### PR TITLE
Make hover, and dropdown component  ui cleaner

### DIFF
--- a/packages/admin/src/app/layout.tsx
+++ b/packages/admin/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default async function RootLayout({
   const integrations = await getConfig().then(res => res.integrations);
   return (
     <html lang="en">
-      <body className={`${inter.className}`}>
+      <body className={`dark ${inter.className}`}>
         <AdminLayout integrations={integrations}>{children}</AdminLayout>
       </body>
     </html>


### PR DESCRIPTION
- [x] At the moment, our `shadcn` theme uses light mode. Adding dark class makes us use dark mode.