### PR TITLE
Add UNPUBLISHED Status

### DIFF
--- a/packages/admin/mock-data/blueprints/clz8mdxyd00534qm09leywj1s.json
+++ b/packages/admin/mock-data/blueprints/clz8mdxyd00534qm09leywj1s.json
@@ -1,7 +1,7 @@
 {
   "title": "New Workflow",
   "description": null,
-  "status": "DRAFT",
+  "status": "UNPUBLISHED",
   "actions": [
     {
       "id": "s3rtwvx51bxjefyq05kuto83",

--- a/packages/admin/mock-data/config.json
+++ b/packages/admin/mock-data/config.json
@@ -90,7 +90,7 @@
       "id": "clz8mdxyd00534qm09leywj1s",
       "title": "New Workflow",
       "description": null,
-      "status": "DRAFT",
+      "status": "UNPUBLISHED",
       "actions": [
         {
           "id": "s3rtwvx51bxjefyq05kuto83",

--- a/packages/admin/src/domains/workflows/components/workflow-graph/workflow-popup-actions-bar.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-graph/workflow-popup-actions-bar.tsx
@@ -106,7 +106,7 @@ export const WorkflowPopupActionsBar = ({ scale, setScale }: WorkflowPopupAction
     // }
     const updatedBlueprint: Blueprint = {
       ...constructedBlueprint,
-      status: !configurationDone ? 'DRAFT' : constructedBlueprint.status, //turn workflow not properly configured to DRAFT, will remove this when toggle status is done
+      status: !configurationDone ? 'UNPUBLISHED' : constructedBlueprint.status, //turn workflow not properly configured to DRAFT, will remove this when toggle status is done
     };
 
     updateBlueprintInfo({ ...blueprintInfo, status: updatedBlueprint.status });

--- a/packages/admin/src/domains/workflows/utils.ts
+++ b/packages/admin/src/domains/workflows/utils.ts
@@ -38,11 +38,13 @@ import { FormConfigType } from './schema';
 import { filterFieldTypeToOperatorMap, FilterOperator, FilterOpToValueMapEnum } from './types';
 
 export const workflowStatusColorMap: Record<WorkflowStatus, string> = {
-  UNPUBLISHED: '#DFCA7A',
+  DRAFT: '#DFCA7A',
+  UNPUBLISHED: '#FFFFFF33',
   PUBLISHED: '#4BB042',
 } as const;
 
 export const workflowStatusTextMap: Record<WorkflowStatus, string> = {
+  DRAFT: 'Draft',
   UNPUBLISHED: 'Disabled',
   PUBLISHED: 'Live',
 } as const;

--- a/packages/admin/src/domains/workflows/utils.ts
+++ b/packages/admin/src/domains/workflows/utils.ts
@@ -38,12 +38,12 @@ import { FormConfigType } from './schema';
 import { filterFieldTypeToOperatorMap, FilterOperator, FilterOpToValueMapEnum } from './types';
 
 export const workflowStatusColorMap: Record<WorkflowStatus, string> = {
-  DRAFT: '#DFCA7A',
+  UNPUBLISHED: '#DFCA7A',
   PUBLISHED: '#4BB042',
 } as const;
 
 export const workflowStatusTextMap: Record<WorkflowStatus, string> = {
-  DRAFT: 'Draft',
+  UNPUBLISHED: 'Disabled',
   PUBLISHED: 'Live',
 } as const;
 

--- a/packages/admin/src/service/service.blueprintWriter.test.ts
+++ b/packages/admin/src/service/service.blueprintWriter.test.ts
@@ -9,7 +9,7 @@ const exampleBlueprint1 = {
   id: 'blueprint1',
   title: 'New Workflow',
   description: null,
-  status: WorkflowStatusEnum.DRAFT,
+  status: WorkflowStatusEnum.UNPUBLISHED,
   actions: [
     {
       id: 'action1',

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -19,7 +19,7 @@ import {
 } from './schemas';
 
 export const WorkflowStatusEnum = {
-  DRAFT: 'DRAFT',
+  UNPUBLISHED: 'UNPUBLISHED',
   PUBLISHED: 'PUBLISHED',
 } as const;
 

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -19,6 +19,7 @@ import {
 } from './schemas';
 
 export const WorkflowStatusEnum = {
+  DRAFT: 'DRAFT',
   UNPUBLISHED: 'UNPUBLISHED',
   PUBLISHED: 'PUBLISHED',
 } as const;

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -25,12 +25,12 @@ import { FilterOpToValueMapEnum } from './conditions/constants';
 import { FilterOperator } from './conditions/types';
 
 export const workflowStatusColorMap: Record<WorkflowStatus, string> = {
-  DRAFT: '#DFCA7A',
+  UNPUBLISHED: '#DFCA7A',
   PUBLISHED: '#4BB042',
 } as const;
 
 export const workflowStatusTextMap: Record<WorkflowStatus, string> = {
-  DRAFT: 'Draft',
+  UNPUBLISHED: 'Disabled',
   PUBLISHED: 'Live',
 } as const;
 

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -25,11 +25,13 @@ import { FilterOpToValueMapEnum } from './conditions/constants';
 import { FilterOperator } from './conditions/types';
 
 export const workflowStatusColorMap: Record<WorkflowStatus, string> = {
-  UNPUBLISHED: '#DFCA7A',
+  DRAFT: '#DFCA7A',
+  UNPUBLISHED: '#FFFFFF33',
   PUBLISHED: '#4BB042',
 } as const;
 
 export const workflowStatusTextMap: Record<WorkflowStatus, string> = {
+  DRAFT: 'Draft',
   UNPUBLISHED: 'Disabled',
   PUBLISHED: 'Live',
 } as const;


### PR DESCRIPTION
DRAFT status will be used for blueprints the user has started editing, and this status will not be saved/written to the json file

When a user is editing, the blueprint info will be saved to local storage, until user clicks on save button before it's written to the blueprint json file, at which point it'll either have a PUBLISHED/UNPUBLISHED status

a [linear ticket](https://linear.app/kepler-crm/issue/FUTR-122/save-changes-in-workflow-to-localstorage) has been created for the local storage task