### PR TITLE
feat: create pg_data volume

### DIFF
--- a/packages/cli/src/files/starter-docker-compose.yaml
+++ b/packages/cli/src/files/starter-docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
     volumes:
-      - ./db:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/data
 
   inngest:
     build:
@@ -25,3 +25,6 @@ services:
       - '--no-discovery'
       - '-u'
       - ${INNGEST_SERVE_URL:-http://host.docker.internal:3000/api/integrations/inngest}
+
+volumes:
+  pgdata:


### PR DESCRIPTION
This PR updates the docker compose file and creates ` pg_data` volume which is used to store the provisioned postres data