### PR TITLE
Update example.future.config.ts redirectHost variable

### DIFF
--- a/packages/admin/example.future.config.ts
+++ b/packages/admin/example.future.config.ts
@@ -84,7 +84,7 @@ const RECORD_SCHEMA = z.discriminatedUnion('entityType', [
 ]);
 
 export const dbUrl = process.env.DB_URL;
-export const redirectHost = process.env.KEPLER_URL;
+export const redirectHost = process.env.APP_URL;
 
 if (!dbUrl || !redirectHost) {
   throw new Error('Missing required environment variables');


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ac93f4c7-96b6-49c1-88bc-ed7d94948657)

We seem to have copied `KEPLER_URL` when we were porting some features.