### PR TITLE
Integration redirectURI core preset

### DIFF
--- a/packages/admin/example.future.config.ts
+++ b/packages/admin/example.future.config.ts
@@ -92,7 +92,7 @@ if (!dbUrl || !redirectHost) {
 
 export const redirectPath = '/api/integrations/connect/callback';
 
-export const REDIRECT_URI = new URL(redirectPath, redirectHost).toString();
+//Custom redirect URI for slack local development
 export const SLACK_REDIRECT_URI = `https://redirectmeto.com/${new URL(redirectPath, redirectHost).toString()}`;
 
 // THIS IS YOUR PROJECTS CONFIG
@@ -200,7 +200,6 @@ export const config: Config = {
       config: {
         CLIENT_ID: process.env.MAILCHIMP_CLIENT_ID!,
         CLIENT_SECRET: process.env.MAILCHIMP_CLIENT_SECRET!,
-        REDIRECT_URI,
       },
     }),
     new RewatchIntegration(),
@@ -209,14 +208,12 @@ export const config: Config = {
         CLIENT_ID: process.env.SLACK_CLIENT_ID!,
         CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET!,
         REDIRECT_URI: SLACK_REDIRECT_URI,
-        // SLACK_PROXY_REDIRECT_URI='https://redirectmeto.com/http://localhost:3000/api/integrations/connect/callback'
       },
     }),
     new GoogleIntegration({
       config: {
         CLIENT_ID: process.env.GOOGLE_CLIENT_ID!,
         CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET!,
-        REDIRECT_URI,
         TOPIC: process.env.GOOGLE_MAIL_TOPIC!,
       },
     }),

--- a/packages/core/src/framework.ts
+++ b/packages/core/src/framework.ts
@@ -105,9 +105,9 @@ export class Framework {
     const { name } = definition;
     definition.attachDataLayer({ dataLayer: this.dataLayer });
 
-    definition.attachCorePresets({
-      corePresets: { redirectURI: this.makeRedirectURI() },
-    });
+    definition.corePresets = {
+      redirectURI: this.makeRedirectURI(),
+    };
 
     this.integrations.set(name, definition);
 
@@ -333,7 +333,7 @@ export class Framework {
   };
 
   makeRedirectURI = () => {
-    return encodeURI(`${this?.config?.systemHostURL}${this.routes.callback}`);
+    return new URL(this.routes.callback, this.config.systemHostURL).toString();
   };
 
   runBlueprint = async ({

--- a/packages/core/src/framework.ts
+++ b/packages/core/src/framework.ts
@@ -105,6 +105,10 @@ export class Framework {
     const { name } = definition;
     definition.attachDataLayer({ dataLayer: this.dataLayer });
 
+    definition.attachCorePresets({
+      corePresets: { redirectURI: this.makeRedirectURI() },
+    });
+
     this.integrations.set(name, definition);
 
     definition.registerEvents();
@@ -324,8 +328,12 @@ export class Framework {
 
   makeWebhookUrl = ({ event, name }: { name: string; event: string }) => {
     return encodeURI(
-      `${this?.config?.systemHostURL}${this?.config?.routeRegistrationPath}/webhook?name=${name}&event=${event}`
+      `${this?.config?.systemHostURL}${this.routes.webhook}?name=${name}&event=${event}`
     );
+  };
+
+  makeRedirectURI = () => {
+    return encodeURI(`${this?.config?.systemHostURL}${this.routes.callback}`);
   };
 
   runBlueprint = async ({

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -78,10 +78,6 @@ export class Integration<T = unknown> {
     this.dataLayer = dataLayer;
   }
 
-  attachCorePresets({ corePresets }: { corePresets: CoreIntegrationPresets }) {
-    this.corePresets = corePresets;
-  }
-
   getEventHandlers({
     makeWebhookUrl,
   }: {

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -23,6 +23,10 @@ export type IntegrationConfig = {
   [key: string]: any;
 };
 
+export type CoreIntegrationPresets = {
+  redirectURI: string;
+};
+
 /**
  * @params T - The type of the client that the integration provides
  */
@@ -35,6 +39,9 @@ export class Integration<T = unknown> {
   events: Record<string, IntegrationEvent<any>> = {};
   actions: Record<string, IntegrationAction<any>> = {};
   entityTypes: Record<string, string> = {};
+  corePresets: CoreIntegrationPresets = {
+    redirectURI: '',
+  };
 
   constructor(config: IntegrationConfig) {
     if (!config?.name) {
@@ -69,6 +76,10 @@ export class Integration<T = unknown> {
 
   attachDataLayer({ dataLayer }: { dataLayer: DataLayer }) {
     this.dataLayer = dataLayer;
+  }
+
+  attachCorePresets({ corePresets }: { corePresets: CoreIntegrationPresets }) {
+    this.corePresets = corePresets;
   }
 
   getEventHandlers({
@@ -174,6 +185,9 @@ export class Integration<T = unknown> {
     });
 
     try {
+      /* 
+      Internal integration test, we won't need to redirect
+      */
       const authenticator = this.getAuthenticator();
       const bearer = await authenticator.getAuthToken({
         connectionId: connection?.id!,

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -185,9 +185,6 @@ export class Integration<T = unknown> {
     });
 
     try {
-      /* 
-      Internal integration test, we won't need to redirect
-      */
       const authenticator = this.getAuthenticator();
       const bearer = await authenticator.getAuthToken({
         connectionId: connection?.id!,

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -20,7 +20,6 @@ import {
 type GoogleConfig = {
   CLIENT_ID: string;
   CLIENT_SECRET: string;
-  REDIRECT_URI: string;
   TOPIC: string;
   [key: string]: any;
 };
@@ -453,7 +452,7 @@ export class GoogleIntegration extends Integration<GoogleClient> {
         return this.onConnectionCreated({ connection });
       },
       config: {
-        REDIRECT_URI: this.config.REDIRECT_URI,
+        REDIRECT_URI: this.config.REDIRECT_URI || this.corePresets.redirectURI,
         CLIENT_ID: this.config.CLIENT_ID,
         CLIENT_SECRET: this.config.CLIENT_SECRET,
         SERVER: 'https://accounts.google.com',

--- a/packages/mailchimp/src/index.ts
+++ b/packages/mailchimp/src/index.ts
@@ -12,7 +12,6 @@ import { mailchimpSync } from './events/sync';
 type MailchimpConfig = {
   CLIENT_ID: string;
   CLIENT_SECRET: string;
-  REDIRECT_URI: string;
   [key: string]: any;
 };
 
@@ -143,7 +142,6 @@ export class MailchimpIntegration extends Integration {
   }
 
   getAuthenticator() {
-    console.log(this.config);
     return new IntegrationAuth({
       dataAccess: this.dataLayer!,
       onConnectionCreated: connection => {
@@ -154,7 +152,7 @@ export class MailchimpIntegration extends Integration {
         AUTH_TYPE: this.config.authType,
         CLIENT_ID: this.config.CLIENT_ID,
         CLIENT_SECRET: this.config.CLIENT_SECRET,
-        REDIRECT_URI: this.config.REDIRECT_URI,
+        REDIRECT_URI: this.config.REDIRECT_URI || this.corePresets.redirectURI,
         SERVER: MAILCHIMP_HOST,
         AUTHORIZATION_ENDPOINT: '/oauth2/authorize',
         TOKEN_ENDPOINT: '/oauth2/token',

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -11,7 +11,6 @@ import { SLACK_INTEGRATION_NAME } from './constants';
 type SlackConfig = {
   CLIENT_ID: string;
   CLIENT_SECRET: string;
-  REDIRECT_URI: string;
   [key: string]: any;
 };
 
@@ -87,7 +86,7 @@ export class SlackIntegration extends Integration<SlackClient> {
       config: {
         CLIENT_ID: this.config.CLIENT_ID,
         CLIENT_SECRET: this.config.CLIENT_SECRET,
-        REDIRECT_URI: this.config.REDIRECT_URI,
+        REDIRECT_URI: this.config.REDIRECT_URI || this.corePresets.redirectURI,
         AUTH_TYPE: this.config.authType,
         SERVER: 'https://slack.com',
         DISCOVERY_ENDPOINT: '/.well-known/openid-configuration',


### PR DESCRIPTION
This PR allows the framework to configure core presets like redirectURI and make available for integrations,

This PR also accounts for  the possible necessity for the integration's authenticator REDIRECT_URI to be overidden