### PR TITLE
fix port mapping bug

### DIFF
--- a/packages/cli/src/starter-files/docker-compose-pg-inngest.yaml
+++ b/packages/cli/src/starter-files/docker-compose-pg-inngest.yaml
@@ -3,7 +3,7 @@ services:
     image: postgres:13
     container_name: 'REPLACE_PROJECT_NAME-db'
     ports:
-      - 'REPLACE_DB_PORT:REPLACE_DB_PORT'
+      - 'REPLACE_DB_PORT:5432'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
@@ -18,7 +18,7 @@ services:
     container_name: 'REPLACE_PROJECT_NAME-inngest'
     image: inngest:latest
     ports:
-      - 'REPLACE_INNGEST_PORT:REPLACE_INNGEST_PORT'
+      - 'REPLACE_INNGEST_PORT:8288'
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     command:

--- a/packages/cli/src/starter-files/docker-compose-pg-only.yaml
+++ b/packages/cli/src/starter-files/docker-compose-pg-only.yaml
@@ -3,7 +3,7 @@ services:
     image: postgres:13
     container_name: 'REPLACE_PROJECT_NAME-db'
     ports:
-      - 'REPLACE_DB_PORT:REPLACE_DB_PORT'
+      - 'REPLACE_DB_PORT:5432'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}


### PR DESCRIPTION
The second port number is the container internal port. which needs to be hardcoded to 5432 for postgres or 8288 for inngest.