### PR TITLE
Change action terminology to "api" in framework. Begin to generate API Client methods as Framework APIs

### DIFF
--- a/integration-generator/generate.ts
+++ b/integration-generator/generate.ts
@@ -302,7 +302,7 @@ async function main() {
             name.charAt(0).toUpperCase() + name.slice(1).toLowerCase()
           }Integration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
                         id: \`\${name}-sync-${entityType}\`,
@@ -312,7 +312,7 @@ async function main() {
             requestParams.length ? requestParams?.join('') : ``
           }  } = event.data;
                             const { referenceId } = event.user;
-                            const proxy = await getProxy({ referenceId })
+                            const proxy = await getApiClient({ referenceId })
 
 
                             const response = await proxy['${pathApi}'].get({

--- a/integration-generator/template.ts
+++ b/integration-generator/template.ts
@@ -138,7 +138,7 @@ export class ${name}Integration extends Integration {
   }
 
 
-  async getProxy({ referenceId }: { referenceId: string }) {
+  async getApiClient({ referenceId }: { referenceId: string }) {
     const connection = await this.dataLayer?.getConnectionByReferenceId({ name: this.name, referenceId })
 
     if (!connection) {

--- a/packages/admin/example.arkw.config.ts
+++ b/packages/admin/example.arkw.config.ts
@@ -98,7 +98,7 @@ export const SLACK_REDIRECT_URI = `https://redirectmeto.com/${new URL(
 export const config: Config = {
   name: 'kepler',
   //logConfig: {}, // TODO: Add this
-  systemActions: [
+  systemApis: [
     {
       type: 'CREATE_NOTE',
       label: 'Create Note',

--- a/packages/admin/src/app/actions-playground/layout.tsx
+++ b/packages/admin/src/app/actions-playground/layout.tsx
@@ -1,4 +1,4 @@
-import { IntegrationAction } from '@arkw/core';
+import { IntegrationApi } from '@arkw/core';
 import { ReactNode } from 'react';
 
 import { framework } from '@/lib/framework-utils';
@@ -7,7 +7,7 @@ import { ActionPlaygroundProvider } from '@/domains/playground/providers/action-
 import { getSerializedFrameworkActions } from '@/domains/workflows/utils';
 
 export default async function WorkflowsParentLayout({ children }: { children: ReactNode }) {
-  const systemActions = framework?.getSystemActions() || [];
+  const systemApis = framework?.getSystemApis() || [];
   const connectedIntegrations =
     (await framework?.connectedIntegrations({
       context: {
@@ -15,17 +15,17 @@ export default async function WorkflowsParentLayout({ children }: { children: Re
       },
     })) || [];
 
-  const connectedIntegrationsActions: Record<string, IntegrationAction<any>> = connectedIntegrations.reduce(
+  const connectedIntegrationsActions: Record<string, IntegrationApi<any>> = connectedIntegrations.reduce(
     (acc: any, { name }: any) => {
-      const actions = framework?.getActionsByIntegration(name);
-      return { ...acc, ...actions };
+      const apis = framework?.getApisByIntegration(name);
+      return { ...acc, ...apis };
     },
     {},
   );
 
-  const allActions = { ...systemActions, ...connectedIntegrationsActions };
+  const allActions = { ...systemApis, ...connectedIntegrationsActions };
 
-  const frameworkActions = Object.values(allActions) as IntegrationAction[];
+  const frameworkActions = Object.values(allActions) as IntegrationApi[];
 
   const serializedFrameworkActions = await getSerializedFrameworkActions({
     frameworkActions,

--- a/packages/admin/src/app/workflows/layout.tsx
+++ b/packages/admin/src/app/workflows/layout.tsx
@@ -1,4 +1,4 @@
-import type { IntegrationAction, IntegrationEvent } from '@arkw/core';
+import type { IntegrationApi, IntegrationEvent } from '@arkw/core';
 import { ReactNode } from 'react';
 
 import { framework } from '@/lib/framework-utils';
@@ -8,7 +8,7 @@ import WorkflowsLayout from '@/domains/workflows/layouts/workflows-layout';
 import { getSerializedFrameworkActions, getSerializedFrameworkEvents } from '@/domains/workflows/utils';
 
 export default async function WorkflowsParentLayout({ children }: { children: ReactNode }) {
-  const systemActions = framework?.getSystemActions();
+  const systemApis = framework?.getSystemApis();
   const systemEvents = framework?.getSystemEvents();
 
   const connectedIntegrations =
@@ -18,9 +18,9 @@ export default async function WorkflowsParentLayout({ children }: { children: Re
       },
     })) || [];
 
-  const connectedIntegrationsActions: Record<string, IntegrationAction<any>> = connectedIntegrations.reduce(
+  const connectedIntegrationsActions: Record<string, IntegrationApi<any>> = connectedIntegrations.reduce(
     (acc, { name }) => {
-      const actions = framework?.getActionsByIntegration(name);
+      const actions = framework?.getApisByIntegration(name);
       return { ...acc, ...actions };
     },
     {},
@@ -33,10 +33,10 @@ export default async function WorkflowsParentLayout({ children }: { children: Re
     {},
   );
 
-  const allActions = { ...systemActions, ...connectedIntegrationsActions };
+  const allActions = { ...systemApis, ...connectedIntegrationsActions };
   const allEvents = { ...systemEvents, ...connectedIntegrationsEvents };
 
-  const frameworkActions = Object.values(allActions) as IntegrationAction[];
+  const frameworkActions = Object.values(allActions) as IntegrationApi[];
   const frameworkEvents = Object.values(allEvents)
     ?.filter(({ triggerProperties }) => triggerProperties)
     ?.map(({ triggerProperties }) => triggerProperties!);

--- a/packages/admin/src/domains/playground/components/action-sclector.tsx
+++ b/packages/admin/src/domains/playground/components/action-sclector.tsx
@@ -1,4 +1,4 @@
-import { frameWorkIcon, RefinedIntegrationAction } from '@arkw/core';
+import { frameWorkIcon, RefinedIntegrationApi } from '@arkw/core';
 
 import Image from 'next/image';
 
@@ -21,7 +21,7 @@ export function ActionSelector({ type, isSelected }: ActionSelectorProps) {
   const { frameworkActions, setSelectedAction } = useActionPlaygroundContext();
   const frameworkAction = frameworkActions.find(action => action.type === type);
 
-  const handleSelectAction = (action: RefinedIntegrationAction) => {
+  const handleSelectAction = (action: RefinedIntegrationApi) => {
     setSelectedAction(action);
   };
 

--- a/packages/admin/src/domains/playground/components/actions-list.tsx
+++ b/packages/admin/src/domains/playground/components/actions-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { RefinedIntegrationAction } from '@arkw/core/dist/types';
+import type { RefinedIntegrationApi } from '@arkw/core/dist/types';
 import { useEffect, useState } from 'react';
 
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -15,9 +15,9 @@ import DynamicForm from './dynamic-form';
 
 export function ActionPlaygroundSidebar() {
   const { frameworkActions, selectedAction } = useActionPlaygroundContext();
-  const [actionToEdit, setActionToEdit] = useState<RefinedIntegrationAction | undefined>(undefined);
+  const [actionToEdit, setActionToEdit] = useState<RefinedIntegrationApi | undefined>(undefined);
 
-  function handleEditActionType(action: RefinedIntegrationAction) {
+  function handleEditActionType(action: RefinedIntegrationApi) {
     setActionToEdit(action);
   }
 
@@ -46,7 +46,7 @@ export function ActionPlaygroundSidebar() {
       ...acc,
       [fwAct.integrationName]: [...(acc[fwAct.integrationName] || []), fwAct],
     };
-  }, {} as { [key: string]: RefinedIntegrationAction[] });
+  }, {} as { [key: string]: RefinedIntegrationApi[] });
 
   return (
     <>

--- a/packages/admin/src/domains/playground/components/dynamic-form.tsx
+++ b/packages/admin/src/domains/playground/components/dynamic-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { RefinedIntegrationAction } from '@arkw/core/dist/types';
+import type { RefinedIntegrationApi } from '@arkw/core/dist/types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import React from 'react';
 import { Control, FieldErrors, useForm } from 'react-hook-form';
@@ -151,7 +151,7 @@ function renderDynamicForm({
   parentField,
 }: {
   schema: ZodSchema;
-  block: RefinedIntegrationAction;
+  block: RefinedIntegrationApi;
   handleFieldChange: ({ key, value }: { key: any; value: any }) => void;
   control: Control<any, any>;
   formValues: any;

--- a/packages/admin/src/domains/playground/providers/action-playground-provider.tsx
+++ b/packages/admin/src/domains/playground/providers/action-playground-provider.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import type { RefinedIntegrationAction } from '@arkw/core';
+import type { RefinedIntegrationApi } from '@arkw/core';
 import React, { createContext, useContext, useMemo, useState } from 'react';
 
 import { getParsedFrameworkActions } from '@/domains/workflows/utils';
 
 export interface ActionPlaygroundContextProps {
-  frameworkActions: RefinedIntegrationAction[];
-  selectedAction: RefinedIntegrationAction | undefined;
-  setSelectedAction: React.Dispatch<React.SetStateAction<RefinedIntegrationAction | undefined>>;
+  frameworkActions: RefinedIntegrationApi[];
+  selectedAction: RefinedIntegrationApi | undefined;
+  setSelectedAction: React.Dispatch<React.SetStateAction<RefinedIntegrationApi | undefined>>;
   payload: Record<string, any>;
   setPayload: React.Dispatch<React.SetStateAction<Record<string, any>>>;
 }
@@ -34,7 +34,7 @@ export const ActionPlaygroundProvider = ({
     return getParsedFrameworkActions(serializedFrameworkActions);
   }, [serializedFrameworkActions]);
 
-  const [selectedAction, setSelectedAction] = useState<RefinedIntegrationAction | undefined>(undefined);
+  const [selectedAction, setSelectedAction] = useState<RefinedIntegrationApi | undefined>(undefined);
 
   const [payload, setPayload] = useState<Record<string, any>>({});
 

--- a/packages/admin/src/domains/workflows/components/workflow-sidebar/action-form.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-sidebar/action-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ActionVariables, WorkflowAction, RefinedIntegrationAction } from '@arkw/core';
+import type { ActionVariables, WorkflowAction, RefinedIntegrationApi } from '@arkw/core';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { mergeWith } from 'lodash';
 import React, { useEffect } from 'react';
@@ -165,7 +165,7 @@ function renderDynamicForm({
   parentField,
 }: {
   schema: ZodSchema;
-  block: RefinedIntegrationAction;
+  block: RefinedIntegrationApi;
   action: WorkflowAction;
   handleFieldChange: ({ key, value, variables }: { key: any; value: any; variables?: ActionVariables }) => void;
   control: Control<any, any>;

--- a/packages/admin/src/domains/workflows/components/workflow-sidebar/workflow-sidebar-action.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-sidebar/workflow-sidebar-action.tsx
@@ -1,4 +1,4 @@
-import type { ActionVariables, RefinedIntegrationAction, WorkflowAction, UpdateAction } from '@arkw/core';
+import type { ActionVariables, RefinedIntegrationApi, WorkflowAction, UpdateAction } from '@arkw/core';
 import { createId } from '@paralleldrive/cuid2';
 import { useEffect, useState } from 'react';
 
@@ -114,7 +114,7 @@ export function WorkflowSidebarAction({ action, blueprintId }: WorkflowSidebarAc
       ...acc,
       [fwAct.integrationName]: [...(acc[fwAct.integrationName] || []), fwAct],
     };
-  }, {} as { [key: string]: RefinedIntegrationAction[] });
+  }, {} as { [key: string]: RefinedIntegrationApi[] });
 
   return (
     <>

--- a/packages/admin/src/domains/workflows/constants.ts
+++ b/packages/admin/src/domains/workflows/constants.ts
@@ -1,7 +1,7 @@
-import type { RefinedIntegrationAction } from '@arkw/core';
+import type { RefinedIntegrationApi } from '@arkw/core';
 
 export type RefinedIntegrationActionLogic = Pick<
-  RefinedIntegrationAction,
+  RefinedIntegrationApi,
   'type' | 'label' | 'icon' | 'description' | 'category'
 >;
 

--- a/packages/admin/src/domains/workflows/context/workflow-context.tsx
+++ b/packages/admin/src/domains/workflows/context/workflow-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { RefinedIntegrationAction, RefinedIntegrationEventTriggerProperties } from '@arkw/core/dist/types';
+import { RefinedIntegrationApi, RefinedIntegrationEventTriggerProperties } from '@arkw/core/dist/types';
 import {
   type NewActionInMiddleProps,
   type UpdateLogicCondtion,
@@ -46,8 +46,8 @@ export interface WorkflowContextProps {
   removeAction: (actionId: string, deleteOnlyBlock?: boolean) => Blueprint;
   updateLogicActionCondition: ({ actionId, condition, isNewCondition }: UpdateLogicCondtion) => Blueprint;
   setActions: (actions: WorkflowContextWorkflowActionsShape) => void;
-  frameworkActions: RefinedIntegrationAction[];
-  frameworkAction?: RefinedIntegrationAction;
+  frameworkActions: RefinedIntegrationApi[];
+  frameworkAction?: RefinedIntegrationApi;
   frameworkEvents: RefinedIntegrationEventTriggerProperties[];
   frameworkEvent?: RefinedIntegrationEventTriggerProperties;
   constructedBlueprint: Blueprint;
@@ -159,7 +159,7 @@ export const WorkflowProvider = ({
 
         const isValid = isActionPayloadValid({
           action: action as WorkflowAction,
-          block: concreteAction as RefinedIntegrationAction,
+          block: concreteAction as RefinedIntegrationApi,
         });
 
         return { id: action.id, isValid };
@@ -267,7 +267,7 @@ export const WorkflowProvider = ({
 
       const isValid = isActionPayloadValid({
         action: newAction as WorkflowAction,
-        block: concreteAction as RefinedIntegrationAction,
+        block: concreteAction as RefinedIntegrationApi,
       });
 
       setActionsValidityObject(prev => ({ ...prev, [action.id]: isValid }));
@@ -292,7 +292,7 @@ export const WorkflowProvider = ({
 
         const isRemovedActionParentValid = isActionPayloadValid({
           action: removedActionParent as WorkflowAction,
-          block: parentConcreteAction as RefinedIntegrationAction,
+          block: parentConcreteAction as RefinedIntegrationApi,
         });
 
         setActionsValidityObject(prev => ({
@@ -418,7 +418,7 @@ export const WorkflowProvider = ({
 
         const isValid = isActionPayloadValid({
           action: removedActionParent as WorkflowAction,
-          block: concreteAction as RefinedIntegrationAction,
+          block: concreteAction as RefinedIntegrationApi,
         });
 
         setActionsValidityObject(prev => ({ ...prev, [removedActionParent.id]: isValid }));
@@ -448,7 +448,7 @@ export const WorkflowProvider = ({
 
       const isValid = isActionPayloadValid({
         action: updatedActions[actionId] as WorkflowAction,
-        block: {} as RefinedIntegrationAction,
+        block: {} as RefinedIntegrationApi,
       });
 
       setActionsValidityObject(prev => ({ ...prev, [actionId]: isValid }));

--- a/packages/admin/src/domains/workflows/utils.ts
+++ b/packages/admin/src/domains/workflows/utils.ts
@@ -11,7 +11,7 @@ import type {
 } from '@arkw/core';
 import type {
   ActionVariable,
-  IntegrationAction,
+  IntegrationApi,
   IntegrationContext,
   IntegrationEventTriggerProperties,
   RefinedIntegrationAction,
@@ -92,7 +92,7 @@ export async function getSerializedFrameworkActions({
   frameworkActions,
   ctx,
 }: {
-  frameworkActions: IntegrationAction[];
+  frameworkActions: IntegrationApi[];
   ctx: IntegrationContext;
 }): Promise<string> {
   const refinedActions = await Promise.all(

--- a/packages/admin/src/domains/workflows/utils.ts
+++ b/packages/admin/src/domains/workflows/utils.ts
@@ -14,7 +14,7 @@ import type {
   IntegrationApi,
   IntegrationContext,
   IntegrationEventTriggerProperties,
-  RefinedIntegrationAction,
+  RefinedIntegrationApi,
   RefinedIntegrationEventTriggerProperties,
   SchemaFieldOptions,
   WorkflowContextAction,
@@ -186,8 +186,8 @@ export async function getSerializedFrameworkEvents({
  * @param serializedFramerworkActions - serialized framework actions
  * @returns parsed framework actions
  */
-export function getParsedFrameworkActions(serializedFramerworkActions: string): RefinedIntegrationAction[] {
-  const parsedActions = superjson.parse<{ data: RefinedIntegrationAction[] }>(serializedFramerworkActions).data;
+export function getParsedFrameworkActions(serializedFramerworkActions: string): RefinedIntegrationApi[] {
+  const parsedActions = superjson.parse<{ data: RefinedIntegrationApi[] }>(serializedFramerworkActions).data;
 
   // resolve zod schema and output schema from parsed events
   return parsedActions.map(action => {
@@ -353,7 +353,7 @@ export const getOutputSchema = ({
   payload,
   blockType,
 }: {
-  block: RefinedIntegrationAction | RefinedIntegrationEventTriggerProperties;
+  block: RefinedIntegrationApi | RefinedIntegrationEventTriggerProperties;
   payload: { value?: unknown } | Record<string, any>;
   blockType: 'action' | 'trigger';
 }) => {
@@ -387,7 +387,7 @@ export const getSchemaClient = ({
   payload,
   blockType,
 }: {
-  block: RefinedIntegrationAction | RefinedIntegrationEventTriggerProperties;
+  block: RefinedIntegrationApi | RefinedIntegrationEventTriggerProperties;
   payload: { value?: unknown } | Record<string, any>;
   blockType: 'action' | 'trigger';
 }) => {
@@ -426,7 +426,7 @@ export const isActionPayloadValid = ({
   block,
 }: {
   action: WorkflowAction;
-  block: RefinedIntegrationAction;
+  block: RefinedIntegrationApi;
 }) => {
   const { type, payload, variables } = action;
 

--- a/packages/asana/.gitignore
+++ b/packages/asana/.gitignore
@@ -1,0 +1,1 @@
+arkw.config.ts

--- a/packages/asana/src/events/AttachmentsForObject.ts
+++ b/packages/asana/src/events/AttachmentsForObject.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const AttachmentsForObject: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-AttachmentCompact`,
@@ -14,7 +14,7 @@ export const AttachmentsForObject: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, parent } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/attachments'].get({

--- a/packages/asana/src/events/AuditLogEvents.ts
+++ b/packages/asana/src/events/AuditLogEvents.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const AuditLogEvents: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-AuditLogEvent`,
@@ -14,7 +14,7 @@ export const AuditLogEvents: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/audit_log_events'].get({

--- a/packages/asana/src/events/CustomFieldSettingsForPortfolio.ts
+++ b/packages/asana/src/events/CustomFieldSettingsForPortfolio.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const CustomFieldSettingsForPortfolio: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-CustomFieldSettingResponse`,
@@ -14,7 +14,7 @@ export const CustomFieldSettingsForPortfolio: EventHandler<AsanaIntegration> = (
   executor: async ({ event, step }: any) => {
     const { portfolio_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/portfolios/{portfolio_gid}/custom_field_settings'].get({

--- a/packages/asana/src/events/CustomFieldSettingsForProject.ts
+++ b/packages/asana/src/events/CustomFieldSettingsForProject.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const CustomFieldSettingsForProject: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-CustomFieldSettingResponse`,
@@ -14,7 +14,7 @@ export const CustomFieldSettingsForProject: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { project_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/projects/{project_gid}/custom_field_settings'].get({

--- a/packages/asana/src/events/CustomFieldsForWorkspace.ts
+++ b/packages/asana/src/events/CustomFieldsForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const CustomFieldsForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-CustomFieldResponse`,
@@ -14,7 +14,7 @@ export const CustomFieldsForWorkspace: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/custom_fields'].get({

--- a/packages/asana/src/events/DependenciesForTask.ts
+++ b/packages/asana/src/events/DependenciesForTask.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const DependenciesForTask: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const DependenciesForTask: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { task_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tasks/{task_gid}/dependencies'].get({

--- a/packages/asana/src/events/DependentsForTask.ts
+++ b/packages/asana/src/events/DependentsForTask.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const DependentsForTask: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const DependentsForTask: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { task_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tasks/{task_gid}/dependents'].get({

--- a/packages/asana/src/events/Events.ts
+++ b/packages/asana/src/events/Events.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Events: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-EventResponse`,
@@ -14,7 +14,7 @@ export const Events: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const {} = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/events'].get({});

--- a/packages/asana/src/events/FavoritesForUser.ts
+++ b/packages/asana/src/events/FavoritesForUser.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const FavoritesForUser: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-AsanaNamedResource`,
@@ -14,7 +14,7 @@ export const FavoritesForUser: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { user_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/users/{user_gid}/favorites'].get({

--- a/packages/asana/src/events/GoalRelationships.ts
+++ b/packages/asana/src/events/GoalRelationships.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const GoalRelationships: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-GoalRelationshipCompact`,
@@ -14,7 +14,7 @@ export const GoalRelationships: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { pretty, fields, supported_goal, resource_subtype } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/goal_relationships'].get({

--- a/packages/asana/src/events/Goals.ts
+++ b/packages/asana/src/events/Goals.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Goals: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-GoalCompact`,
@@ -14,7 +14,7 @@ export const Goals: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { portfolio, project, is_workspace_level, team, workspace, time_periods } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/goals'].get({

--- a/packages/asana/src/events/ItemsForPortfolio.ts
+++ b/packages/asana/src/events/ItemsForPortfolio.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ItemsForPortfolio: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectCompact`,
@@ -14,7 +14,7 @@ export const ItemsForPortfolio: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { portfolio_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/portfolios/{portfolio_gid}/items'].get({

--- a/packages/asana/src/events/ParentGoalsForGoal.ts
+++ b/packages/asana/src/events/ParentGoalsForGoal.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ParentGoalsForGoal: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-GoalForGoalCompact`,
@@ -14,7 +14,7 @@ export const ParentGoalsForGoal: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { goal_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/goals/{goal_gid}/parentGoals'].get({

--- a/packages/asana/src/events/PortfolioMemberships.ts
+++ b/packages/asana/src/events/PortfolioMemberships.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const PortfolioMemberships: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-PortfolioMembershipCompact`,
@@ -14,7 +14,7 @@ export const PortfolioMemberships: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const {} = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/portfolio_memberships'].get({});

--- a/packages/asana/src/events/PortfolioMembershipsForPortfolio.ts
+++ b/packages/asana/src/events/PortfolioMembershipsForPortfolio.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const PortfolioMembershipsForPortfolio: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-PortfolioMembershipCompactForPortfolio`,
@@ -14,7 +14,7 @@ export const PortfolioMembershipsForPortfolio: EventHandler<AsanaIntegration> = 
   executor: async ({ event, step }: any) => {
     const { portfolio_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/portfolios/{portfolio_gid}/portfolio_memberships'].get({

--- a/packages/asana/src/events/Portfolios.ts
+++ b/packages/asana/src/events/Portfolios.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Portfolios: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-PortfolioCompact`,
@@ -14,7 +14,7 @@ export const Portfolios: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, workspace, owner } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/portfolios'].get({

--- a/packages/asana/src/events/ProjectMembershipsForProject.ts
+++ b/packages/asana/src/events/ProjectMembershipsForProject.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ProjectMembershipsForProject: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectMembershipCompact`,
@@ -14,7 +14,7 @@ export const ProjectMembershipsForProject: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { project_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/projects/{project_gid}/project_memberships'].get({

--- a/packages/asana/src/events/ProjectStatusesForProject.ts
+++ b/packages/asana/src/events/ProjectStatusesForProject.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ProjectStatusesForProject: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectStatusCompact`,
@@ -14,7 +14,7 @@ export const ProjectStatusesForProject: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { pretty, fields, limit, offset, project_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/projects/{project_gid}/project_statuses'].get({

--- a/packages/asana/src/events/ProjectTemplates.ts
+++ b/packages/asana/src/events/ProjectTemplates.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ProjectTemplates: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectTemplateCompact`,
@@ -14,7 +14,7 @@ export const ProjectTemplates: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace, team, limit, offset } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/project_templates'].get({

--- a/packages/asana/src/events/ProjectTemplatesForTeam.ts
+++ b/packages/asana/src/events/ProjectTemplatesForTeam.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ProjectTemplatesForTeam: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectTemplateCompact`,
@@ -14,7 +14,7 @@ export const ProjectTemplatesForTeam: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, team_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/teams/{team_gid}/project_templates'].get({

--- a/packages/asana/src/events/Projects.ts
+++ b/packages/asana/src/events/Projects.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Projects: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectCompact`,
@@ -14,7 +14,7 @@ export const Projects: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, workspace, team, archived } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/projects'].get({

--- a/packages/asana/src/events/ProjectsForTask.ts
+++ b/packages/asana/src/events/ProjectsForTask.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ProjectsForTask: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectCompact`,
@@ -14,7 +14,7 @@ export const ProjectsForTask: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { task_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tasks/{task_gid}/projects'].get({

--- a/packages/asana/src/events/ProjectsForTeam.ts
+++ b/packages/asana/src/events/ProjectsForTeam.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ProjectsForTeam: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectCompact`,
@@ -14,7 +14,7 @@ export const ProjectsForTeam: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, archived, team_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/teams/{team_gid}/projects'].get({

--- a/packages/asana/src/events/ProjectsForWorkspace.ts
+++ b/packages/asana/src/events/ProjectsForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const ProjectsForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-ProjectCompact`,
@@ -14,7 +14,7 @@ export const ProjectsForWorkspace: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, archived, workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/projects'].get({

--- a/packages/asana/src/events/SectionsForProject.ts
+++ b/packages/asana/src/events/SectionsForProject.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const SectionsForProject: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-SectionCompact`,
@@ -14,7 +14,7 @@ export const SectionsForProject: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, project_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/projects/{project_gid}/sections'].get({

--- a/packages/asana/src/events/StatusesForObject.ts
+++ b/packages/asana/src/events/StatusesForObject.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const StatusesForObject: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-StatusUpdateCompact`,
@@ -14,7 +14,7 @@ export const StatusesForObject: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { parent, created_since } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/status_updates'].get({

--- a/packages/asana/src/events/SubtasksForTask.ts
+++ b/packages/asana/src/events/SubtasksForTask.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const SubtasksForTask: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const SubtasksForTask: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, task_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tasks/{task_gid}/subtasks'].get({

--- a/packages/asana/src/events/Tags.ts
+++ b/packages/asana/src/events/Tags.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Tags: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TagCompact`,
@@ -14,7 +14,7 @@ export const Tags: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, workspace } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tags'].get({

--- a/packages/asana/src/events/TagsForTask.ts
+++ b/packages/asana/src/events/TagsForTask.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TagsForTask: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TagCompact`,
@@ -14,7 +14,7 @@ export const TagsForTask: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { task_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tasks/{task_gid}/tags'].get({

--- a/packages/asana/src/events/TagsForWorkspace.ts
+++ b/packages/asana/src/events/TagsForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TagsForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TagCompact`,
@@ -14,7 +14,7 @@ export const TagsForWorkspace: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/tags'].get({

--- a/packages/asana/src/events/Tasks.ts
+++ b/packages/asana/src/events/Tasks.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Tasks: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const Tasks: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, assignee, project, section, workspace, completed_since, modified_since } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tasks'].get({

--- a/packages/asana/src/events/TasksForProject.ts
+++ b/packages/asana/src/events/TasksForProject.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TasksForProject: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const TasksForProject: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { project_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/projects/{project_gid}/tasks'].get({

--- a/packages/asana/src/events/TasksForSection.ts
+++ b/packages/asana/src/events/TasksForSection.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TasksForSection: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const TasksForSection: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { section_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/sections/{section_gid}/tasks'].get({

--- a/packages/asana/src/events/TasksForTag.ts
+++ b/packages/asana/src/events/TasksForTag.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TasksForTag: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const TasksForTag: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { tag_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/tags/{tag_gid}/tasks'].get({

--- a/packages/asana/src/events/TasksForUserTaskList.ts
+++ b/packages/asana/src/events/TasksForUserTaskList.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TasksForUserTaskList: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const TasksForUserTaskList: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { user_task_list_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/user_task_lists/{user_task_list_gid}/tasks'].get({

--- a/packages/asana/src/events/TeamMemberships.ts
+++ b/packages/asana/src/events/TeamMemberships.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TeamMemberships: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TeamMembershipCompact`,
@@ -14,7 +14,7 @@ export const TeamMemberships: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { team, user, workspace } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/team_memberships'].get({

--- a/packages/asana/src/events/TeamMembershipsForTeam.ts
+++ b/packages/asana/src/events/TeamMembershipsForTeam.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TeamMembershipsForTeam: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TeamMembershipCompact`,
@@ -14,7 +14,7 @@ export const TeamMembershipsForTeam: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { team_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/teams/{team_gid}/team_memberships'].get({

--- a/packages/asana/src/events/TeamMembershipsForUser.ts
+++ b/packages/asana/src/events/TeamMembershipsForUser.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TeamMembershipsForUser: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TeamMembershipCompact`,
@@ -14,7 +14,7 @@ export const TeamMembershipsForUser: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace, user_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/users/{user_gid}/team_memberships'].get({

--- a/packages/asana/src/events/TeamsForUser.ts
+++ b/packages/asana/src/events/TeamsForUser.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TeamsForUser: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TeamCompact`,
@@ -14,7 +14,7 @@ export const TeamsForUser: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { user_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/users/{user_gid}/teams'].get({

--- a/packages/asana/src/events/TeamsForWorkspace.ts
+++ b/packages/asana/src/events/TeamsForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TeamsForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TeamCompact`,
@@ -14,7 +14,7 @@ export const TeamsForWorkspace: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/teams'].get({

--- a/packages/asana/src/events/TimePeriods.ts
+++ b/packages/asana/src/events/TimePeriods.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const TimePeriods: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TimePeriodCompact`,
@@ -14,7 +14,7 @@ export const TimePeriods: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { start_on, end_on, workspace } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/time_periods'].get({

--- a/packages/asana/src/events/Users.ts
+++ b/packages/asana/src/events/Users.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Users: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-UserCompact`,
@@ -14,7 +14,7 @@ export const Users: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const {} = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/users'].get({});

--- a/packages/asana/src/events/UsersForTeam.ts
+++ b/packages/asana/src/events/UsersForTeam.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const UsersForTeam: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-UserCompact`,
@@ -14,7 +14,7 @@ export const UsersForTeam: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { team_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/teams/{team_gid}/users'].get({

--- a/packages/asana/src/events/UsersForWorkspace.ts
+++ b/packages/asana/src/events/UsersForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const UsersForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-UserCompact`,
@@ -14,7 +14,7 @@ export const UsersForWorkspace: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/users'].get({

--- a/packages/asana/src/events/Webhooks.ts
+++ b/packages/asana/src/events/Webhooks.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Webhooks: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-WebhookResponse`,
@@ -14,7 +14,7 @@ export const Webhooks: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { limit, offset, workspace, resource } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/webhooks'].get({

--- a/packages/asana/src/events/WorkspaceMembershipsForUser.ts
+++ b/packages/asana/src/events/WorkspaceMembershipsForUser.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const WorkspaceMembershipsForUser: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-WorkspaceMembershipCompact`,
@@ -14,7 +14,7 @@ export const WorkspaceMembershipsForUser: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { user_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/users/{user_gid}/workspace_memberships'].get({

--- a/packages/asana/src/events/WorkspaceMembershipsForWorkspace.ts
+++ b/packages/asana/src/events/WorkspaceMembershipsForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const WorkspaceMembershipsForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-WorkspaceMembershipCompact`,
@@ -14,7 +14,7 @@ export const WorkspaceMembershipsForWorkspace: EventHandler<AsanaIntegration> = 
   executor: async ({ event, step }: any) => {
     const { workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/workspace_memberships'].get({

--- a/packages/asana/src/events/Workspaces.ts
+++ b/packages/asana/src/events/Workspaces.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const Workspaces: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-WorkspaceCompact`,
@@ -14,7 +14,7 @@ export const Workspaces: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const {} = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces'].get({});

--- a/packages/asana/src/events/searchTasksForWorkspace.ts
+++ b/packages/asana/src/events/searchTasksForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const searchTasksForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-TaskCompact`,
@@ -14,7 +14,7 @@ export const searchTasksForWorkspace: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/tasks/search'].get({

--- a/packages/asana/src/events/typeaheadForWorkspace.ts
+++ b/packages/asana/src/events/typeaheadForWorkspace.ts
@@ -6,7 +6,7 @@ import { AsanaIntegration } from '..';
 
 export const typeaheadForWorkspace: EventHandler<AsanaIntegration> = ({
   eventKey,
-  integrationInstance: { name, dataLayer, getProxy },
+  integrationInstance: { name, dataLayer, getApiClient },
   makeWebhookUrl,
 }) => ({
   id: `${name}-sync-AsanaNamedResource`,
@@ -14,7 +14,7 @@ export const typeaheadForWorkspace: EventHandler<AsanaIntegration> = ({
   executor: async ({ event, step }: any) => {
     const { workspace_gid } = event.data;
     const { referenceId } = event.user;
-    const proxy = await getProxy({ referenceId });
+    const proxy = await getApiClient({ referenceId });
 
     // @ts-ignore
     const response = await proxy['/workspaces/{workspace_gid}/typeahead'].get({

--- a/packages/asana/src/index.ts
+++ b/packages/asana/src/index.ts
@@ -485,7 +485,7 @@ export class AsanaIntegration extends Integration {
     return openapi as unknown as OpenAPI;
   }
 
-  async getProxy({ referenceId }: { referenceId: string }): Promise<OASClient<NormalizeOAS<typeof openapi>>> {
+  async getApiClient({ referenceId }: { referenceId: string }): Promise<OASClient<NormalizeOAS<typeof openapi>>> {
     const connection = await this.dataLayer?.getConnectionByReferenceId({ name: this.name, referenceId });
 
     if (!connection) {

--- a/packages/asana/src/index.ts
+++ b/packages/asana/src/index.ts
@@ -1,4 +1,4 @@
-import { Integration, IntegrationAuth, IntegrationCredentialType } from '@arkw/core';
+import { Integration, IntegrationAuth, IntegrationCredentialType, OpenAPI } from '@arkw/core';
 import { createClient, OASClient, type NormalizeOAS } from 'fets';
 // import { z } from 'zod';
 // import { AttachmentsForObject } from './events/AttachmentsForObject';
@@ -479,6 +479,10 @@ export class AsanaIntegration extends Integration {
     //   },
     // };
     return this.events;
+  }
+
+  getOpenApiSpec() {
+    return openapi as unknown as OpenAPI;
   }
 
   async getProxy({ referenceId }: { referenceId: string }): Promise<OASClient<NormalizeOAS<typeof openapi>>> {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -93,7 +93,7 @@ export function dev({ integration }: { integration: boolean }) {
         provider: 'postgresql',
         uri: process.env.DATABASE_URL!,
       },
-      systemActions: [],
+      systemApis: [],
       systemEvents: {},
       routeRegistrationPath: '/api/arkw',
       blueprintDirPath: '/mock-data/blueprints',

--- a/packages/cli/src/starter-files/config.ts
+++ b/packages/cli/src/starter-files/config.ts
@@ -3,7 +3,7 @@ import { Config } from '@arkw/core';
 export const config: Config = {
   name: 'PROJECT_NAME',
   //logConfig: {}, // TODO: Add this
-  systemActions: [],
+  systemApis: [],
   systemEvents: {},
   integrations: [],
   db: {

--- a/packages/core/src/framework.ts
+++ b/packages/core/src/framework.ts
@@ -141,7 +141,10 @@ export class Framework {
             displayName: getOperationId,
             label: getOperationId,
             description: "Suh",
-            executor: async () => { },
+            executor: async ({ data, ctx: { referenceId } }) => {
+              const client = await definition.getProxy({ referenceId })
+              return client[path].get()
+            },
             schema: z.object({}),
           } as IntegrationAction
         }
@@ -165,7 +168,10 @@ export class Framework {
               icon: definition.logoUrl,
             },
             description: "Suh",
-            executor: async () => { },
+            executor: async ({ data, ctx: { referenceId } }) => {
+              const client = await definition.getProxy({ referenceId })
+              return client[path].get()
+            },
             schema: z.object({}),
           } as IntegrationAction
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import { DataLayer } from './data-access';
 import { Framework } from './framework';
 import { Integration } from './integration';
-import { IntegrationAction, IntegrationEvent } from './types';
+import { IntegrationApi, IntegrationEvent } from './types';
 
 export interface Config {
   name: string;
@@ -14,7 +14,7 @@ export interface Config {
     uri: string;
   };
   integrations: Integration[];
-  systemActions: Omit<IntegrationAction, 'integrationName'>[];
+  systemApis: Omit<IntegrationApi, 'integrationName'>[];
   systemEvents: Record<string, IntegrationEvent<any>>;
   env?: {
     provider?: 'local' | 'vercel';
@@ -71,11 +71,11 @@ export function createFramework(config: Config) {
     framework.registerIntgeration(integration);
   });
 
-  // Register System actions
-  framework.registerActions({
-    actions: config.systemActions?.map((action) => {
+  // Register System apis
+  framework.registerApis({
+    apis: config.systemApis?.map((api) => {
       return {
-        ...action,
+        ...api,
         integrationName: config.name,
       };
     }),

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -5,6 +5,7 @@ import {
   IntegrationErrors,
   IntegrationEvent,
   MakeWebhookURL,
+  OpenAPI,
 } from './types';
 import { ZodSchema } from 'zod';
 import { IntegrationError } from './utils/errors';
@@ -94,6 +95,10 @@ export class Integration<T = unknown> {
         });
       })
       .filter(Boolean) as EventHandlerReturnType[];
+  }
+
+  getOpenApiSpec(): OpenAPI | undefined {
+    return
   }
 
   registerActions() {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,7 +47,7 @@ export type IntegrationEventTriggerProperties<T = unknown, U = unknown> = {
   isHidden?: boolean;
 };
 
-export interface IntegrationActionExcutorParams<T> {
+export interface IntegrationApiExcutorParams<T> {
   data: T;
 }
 
@@ -60,7 +60,7 @@ export type IntegrationEvent<T extends Integration> = {
   handler?: EventHandler<T>;
 };
 
-export type IntegrationAction<T = unknown, U = unknown> = {
+export type IntegrationApi<T = unknown, U = unknown> = {
   integrationName: string;
   schema:
     | ZodSchema<T>
@@ -78,7 +78,7 @@ export type IntegrationAction<T = unknown, U = unknown> = {
   icon?: frameWorkIcon;
   description: string;
   category?: string;
-  executor: (params: IntegrationActionExcutorParams<T>) => Promise<U>;
+  executor: (params: IntegrationApiExcutorParams<T>) => Promise<U>;
   isHidden?: boolean;
 };
 
@@ -87,13 +87,13 @@ export enum IntegrationErrors {
   MISSING_SCOPES = 'MISSING_SCOPES',
 }
 
-export interface IntegrationActionExcutorParams<T> {
+export interface IntegrationApiExcutorParams<T> {
   data: T;
   ctx: IntegrationContext;
 }
 
-export type RefinedIntegrationAction<T = unknown> = Omit<
-  IntegrationAction,
+export type RefinedIntegrationApi<T = unknown> = Omit<
+  IntegrationApi,
   'getSchemaOptions'
 > & {
   schemaOptions: Record<string, SchemaFieldOptions>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,3 +181,208 @@ export type QueryResult<T> = {
 };
 
 export type Routes = 'connect' | 'callback' | 'inngest' | 'webhook';
+
+// OpenAPI Specification TypeScript Schema
+export interface OpenAPI {
+  openapi: string; // The OpenAPI version (e.g., "3.0.0")
+  info: Info; // Information about the API
+  servers?: Server[]; // List of servers
+  paths: Paths; // Paths and their operations
+  components?: Components; // Reusable components
+  security?: SecurityRequirement[]; // Security requirements
+  tags?: Tag[]; // Tags for API documentation
+  externalDocs?: ExternalDocumentation; // External documentation
+}
+
+interface Info {
+  title: string; // Title of the API
+  version: string; // Version of the API
+  description?: string; // Description of the API
+  termsOfService?: string; // Terms of service
+  contact?: Contact; // Contact information
+  license?: License; // License information
+}
+
+interface Contact {
+  name?: string; // Contact name
+  url?: string; // Contact URL
+  email?: string; // Contact email
+}
+
+interface License {
+  name: string; // License name
+  url?: string; // License URL
+}
+
+interface Server {
+  url: string; // URL of the server
+  description?: string; // Description of the server
+}
+
+interface Paths {
+  [path: string]: PathItem; // Keyed by path (e.g., "/users/{id}")
+}
+
+interface PathItem {
+  summary?: string; // Summary of the path item
+  description?: string; // Description of the path item
+  get?: Operation; // GET operation
+  put?: Operation; // PUT operation
+  post?: Operation; // POST operation
+  delete?: Operation; // DELETE operation
+  options?: Operation; // OPTIONS operation
+  head?: Operation; // HEAD operation
+  patch?: Operation; // PATCH operation
+  trace?: Operation; // TRACE operation
+  servers?: Server[]; // List of servers
+}
+
+interface Operation {
+  summary?: string; // Summary of the operation
+  description?: string; // Description of the operation
+  operationId?: string; // Unique operation ID
+  parameters?: Parameter[]; // List of parameters
+  requestBody?: RequestBody; // Request body
+  responses: Responses; // Responses
+  deprecated?: boolean; // Indicates if the operation is deprecated
+  security?: SecurityRequirement[]; // Security requirements
+  tags?: string[]; // Tags for the operation
+  servers?: Server[]; // List of servers
+}
+
+interface Parameter {
+  name: string; // Name of the parameter
+  in: 'query' | 'header' | 'path' | 'cookie'; // Location of the parameter
+  description?: string; // Description of the parameter
+  required?: boolean; // Indicates if the parameter is required
+  schema: Schema; // Schema defining the parameter
+}
+
+interface RequestBody {
+  description?: string; // Description of the request body
+  content: {
+      [mediaType: string]: MediaType; // Media type of the request body
+  };
+  required?: boolean; // Indicates if the request body is required
+}
+
+interface MediaType {
+  schema: Schema; // Schema defining the media type
+}
+
+interface Responses {
+  [statusCode: string]: Response; // Keyed by status code (e.g., "200")
+}
+
+interface Response {
+  description: string; // Description of the response
+  content?: {
+      [mediaType: string]: MediaType; // Media type of the response
+  };
+  headers?: {
+      [headerName: string]: Header; // Headers for the response
+  };
+  links?: {
+      [linkName: string]: Link; // Links for the response
+  };
+}
+
+interface Header {
+  description?: string; // Description of the header
+  schema: Schema; // Schema defining the header
+}
+
+interface Link {
+  operationRef?: string; // Reference to an operation
+  operationId?: string; // ID of an operation
+  parameters?: {
+      [parameterName: string]: any; // Parameters for the link
+  };
+  requestBody?: any; // Request body for the link
+  description?: string; // Description of the link
+}
+
+interface Schema {
+  type?: string; // Data type (e.g., "string", "integer")
+  format?: string; // Format of the data type (e.g., "date-time")
+  properties?: {
+      [propertyName: string]: Schema; // Properties of the schema
+  };
+  required?: string[]; // Required properties
+  items?: Schema; // Items if the schema is an array
+  enum?: any[]; // Enum values
+  example?: any; // Example value
+  $ref?: string; // Reference to another schema
+}
+
+interface Components {
+  schemas?: {
+      [schemaName: string]: Schema; // Reusable schemas
+  };
+  responses?: {
+      [responseName: string]: Response; // Reusable responses
+  };
+  parameters?: {
+      [parameterName: string]: Parameter; // Reusable parameters
+  };
+  requestBodies?: {
+      [requestBodyName: string]: RequestBody; // Reusable request bodies
+  };
+  headers?: {
+      [headerName: string]: Header; // Reusable headers
+  };
+  securitySchemes?: {
+      [securitySchemeName: string]: SecurityScheme; // Reusable security schemes
+  };
+  links?: {
+      [linkName: string]: Link; // Reusable links
+  };
+  callbacks?: {
+      [callbackName: string]: Callback; // Reusable callbacks
+  };
+}
+
+interface SecurityScheme {
+  type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect'; // Type of security scheme
+  in?: 'query' | 'header' | 'cookie'; // Location of the API key
+  name?: string; // Name of the API key
+  scheme?: string; // HTTP scheme
+  bearerFormat?: string; // Bearer format
+  flows?: OAuthFlows; // OAuth flows
+  openIdConnectUrl?: string; // OpenID Connect URL
+}
+
+interface OAuthFlows {
+  implicit?: OAuthFlow; // OAuth 2.0 implicit flow
+  password?: OAuthFlow; // OAuth 2.0 password flow
+  clientCredentials?: OAuthFlow; // OAuth 2.0 client credentials flow
+  authorizationCode?: OAuthFlow; // OAuth 2.0 authorization code flow
+}
+
+interface OAuthFlow {
+  authorizationUrl?: string; // Authorization URL
+  tokenUrl?: string; // Token URL
+  refreshUrl?: string; // Refresh URL
+  scopes: {
+      [scope: string]: string; // Scopes and their descriptions
+  };
+}
+
+interface SecurityRequirement {
+  [securitySchemeName: string]: string[]; // Security scheme and its required scopes
+}
+
+interface Tag {
+  name: string; // Name of the tag
+  description?: string; // Description of the tag
+  externalDocs?: ExternalDocumentation; // External documentation for the tag
+}
+
+interface ExternalDocumentation {
+  description?: string; // Description of the external documentation
+  url: string; // URL of the external documentation
+}
+
+interface Callback {
+  [callbackName: string]: PathItem; // Callbacks for the API
+}

--- a/packages/core/src/workflows/runner.ts
+++ b/packages/core/src/workflows/runner.ts
@@ -17,7 +17,7 @@ import {
 } from './utils';
 import { FilterOperator } from './conditions/types';
 import {
-  IntegrationAction,
+  IntegrationApi,
   IntegrationContext,
   IntegrationEvent,
 } from '../types';
@@ -303,7 +303,7 @@ export function resolvePayload({
 
 async function runActionsRecursively({
   blueprintActions,
-  frameworkActions,
+  frameworkApis,
   frameworkEvents,
   dataContext,
   blueprintId,
@@ -312,7 +312,7 @@ async function runActionsRecursively({
   blueprintActionKVMap,
 }: {
   blueprintActions: WorkflowAction[];
-  frameworkActions: Record<string, IntegrationAction<any>>;
+  frameworkApis: Record<string, IntegrationApi<any>>;
   frameworkEvents: Record<string, IntegrationEvent<any>>;
   dataContext: any;
   blueprintId: string;
@@ -321,7 +321,7 @@ async function runActionsRecursively({
   blueprintActionKVMap: ReturnType<typeof constructWorkflowContextBluePrint>;
 }): Promise<boolean> {
   for (const action of blueprintActions) {
-    const concreteAction = frameworkActions[action.type];
+    const concreteAction = frameworkApis[action.type];
 
     console.log(
       '==========',
@@ -345,10 +345,10 @@ async function runActionsRecursively({
           blueprintActionKVMap.actions[cond.blockId || ''] ||
           blueprintActionKVMap.trigger;
         const currentConcreteBlock =
-          frameworkActions[refBlock?.type || ''] ||
+          frameworkApis[refBlock?.type || ''] ||
           frameworkEvents[refBlock?.type || '']?.triggerProperties;
 
-        const isAction = !!frameworkActions[refBlock?.type || ''];
+        const isAction = !!frameworkApis[refBlock?.type || ''];
 
         if (!currentConcreteBlock) continue;
 
@@ -381,7 +381,7 @@ async function runActionsRecursively({
 
         const executorResult = await runActionsRecursively({
           blueprintActions: [actionToRun],
-          frameworkActions,
+          frameworkApis,
           frameworkEvents,
           dataContext,
           blueprintId,
@@ -411,7 +411,7 @@ async function runActionsRecursively({
           return await runActionsRecursively({
             blueprintActions: [defaultAction],
             dataContext,
-            frameworkActions,
+            frameworkApis,
             frameworkEvents,
             runId,
             ctx,
@@ -463,7 +463,7 @@ async function runActionsRecursively({
       if (subActions?.length) {
         return await runActionsRecursively({
           blueprintActions: subActions,
-          frameworkActions,
+          frameworkApis,
           frameworkEvents,
           dataContext,
           runId,
@@ -482,12 +482,12 @@ export async function blueprintRunner({
   dataCtx,
   blueprint,
   frameworkEvents,
-  frameworkActions,
+  frameworkApis,
 }: {
   dataCtx: any;
   ctx: IntegrationContext;
   blueprint: Blueprint;
-  frameworkActions: Record<string, IntegrationAction<any>>;
+  frameworkApis: Record<string, IntegrationApi<any>>;
   frameworkEvents: Record<string, IntegrationEvent<any>>;
 }) {
   console.log(`Running blueprint ${blueprint.id}`);
@@ -552,7 +552,7 @@ export async function blueprintRunner({
 
   const ranSuccessfully = await runActionsRecursively({
     blueprintActions: blueprint.actions as any,
-    frameworkActions,
+    frameworkApis,
     ctx,
     frameworkEvents,
     dataContext: fullCtx,

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 import {
   IntegrationContext,
-  RefinedIntegrationAction,
+  RefinedIntegrationApi,
   RefinedIntegrationEventTriggerProperties,
 } from '../types';
 
@@ -104,7 +104,7 @@ export const getOutputSchema = ({
   payload,
   blockType,
 }: {
-  block: RefinedIntegrationAction | RefinedIntegrationEventTriggerProperties;
+  block: RefinedIntegrationApi | RefinedIntegrationEventTriggerProperties;
   payload: { value?: unknown } | Record<string, any>;
   blockType: 'action' | 'trigger';
 }) => {
@@ -145,7 +145,7 @@ export const getOutputSchemaServer = async ({
   blockType,
 }: {
   ctx: IntegrationContext;
-  block: RefinedIntegrationAction | RefinedIntegrationEventTriggerProperties;
+  block: RefinedIntegrationApi | RefinedIntegrationEventTriggerProperties;
   payload: { value?: unknown } | Record<string, any>;
   blockType: 'action' | 'trigger';
 }) => {
@@ -189,7 +189,7 @@ export const getSchemaServer = async ({
   blockType,
 }: {
   ctx: IntegrationContext;
-  block: RefinedIntegrationAction | RefinedIntegrationEventTriggerProperties;
+  block: RefinedIntegrationApi | RefinedIntegrationEventTriggerProperties;
   payload: { value?: unknown } | Record<string, any>;
   blockType: 'action' | 'trigger';
 }) => {
@@ -231,7 +231,7 @@ export const getSchemaClient = ({
   payload,
   blockType,
 }: {
-  block: RefinedIntegrationAction | RefinedIntegrationEventTriggerProperties;
+  block: RefinedIntegrationApi | RefinedIntegrationEventTriggerProperties;
   payload: { value?: unknown } | Record<string, any>;
   blockType: 'action' | 'trigger';
 }) => {

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -46,7 +46,7 @@ const integrationFramework = createFramework({
       actions: { [testIntegrationActionType]: mockIntegrationAction },
     }),
   ],
-  systemActions: mockSystemActions,
+  systemApis: mockSystemActions,
   systemEvents: mockSystemEvents,
   db: {
     provider: 'postgres',

--- a/packages/core/test/runner.test.ts
+++ b/packages/core/test/runner.test.ts
@@ -260,7 +260,7 @@ describe('run blueprint', () => {
   const integrationFramework = createFramework({
     name: testFrameworkName,
     integrations: [],
-    systemActions: [],
+    systemApis: [],
     systemEvents: {},
     db: {
       provider: 'postgres',
@@ -273,7 +273,7 @@ describe('run blueprint', () => {
 
   it('should run a blueprint CONTAINS true or false', async () => {
     let testExecutor = jest.fn();
-    const systemActions = [
+    const systemApis = [
       createMockAction({
         type: 'TEST_FUNC',
         integrationName: CORE_INTEGRATION_NAME,
@@ -288,8 +288,8 @@ describe('run blueprint', () => {
       }),
     });
 
-    integrationFramework.registerActions({
-      actions: systemActions,
+    integrationFramework.registerApis({
+      apis: systemApis,
       integrationName: CORE_INTEGRATION_NAME,
     });
 
@@ -348,7 +348,7 @@ describe('run blueprint', () => {
 
   it('should run a blueprint with condition AND', async () => {
     let testExecutor = jest.fn();
-    const systemActions = [
+    const systemApis = [
       createMockAction({
         type: 'TEST_FUNC',
         integrationName: CORE_INTEGRATION_NAME,
@@ -363,8 +363,8 @@ describe('run blueprint', () => {
       }),
     });
 
-    integrationFramework.registerActions({
-      actions: systemActions,
+    integrationFramework.registerApis({
+      apis: systemApis,
       integrationName: CORE_INTEGRATION_NAME,
     });
     integrationFramework.registerEvents({
@@ -431,7 +431,7 @@ describe('run blueprint', () => {
 
   it('Should filter blueprint using EQUALS and NOT_EQUALS operator', async () => {
     let testExecutor = jest.fn();
-    const systemActions = [
+    const systemApis = [
       createMockAction({
         type: 'TEST_FUNC',
         integrationName: CORE_INTEGRATION_NAME,
@@ -446,8 +446,8 @@ describe('run blueprint', () => {
       }),
     });
 
-    integrationFramework.registerActions({
-      actions: systemActions,
+    integrationFramework.registerApis({
+      apis: systemApis,
       integrationName: CORE_INTEGRATION_NAME,
     });
     integrationFramework.registerEvents({
@@ -523,7 +523,7 @@ describe('run blueprint', () => {
     const testExecutor = jest.fn(() => 'called testExecutor');
     const testExecutor2 = jest.fn();
 
-    const systemActions = [
+    const systemApis = [
       createMockAction({
         type: 'TEST_FUNC',
         integrationName: CORE_INTEGRATION_NAME,
@@ -543,8 +543,8 @@ describe('run blueprint', () => {
       }),
     });
 
-    integrationFramework.registerActions({
-      actions: systemActions,
+    integrationFramework.registerApis({
+      apis: systemApis,
       integrationName: CORE_INTEGRATION_NAME,
     });
     integrationFramework.registerEvents({
@@ -638,7 +638,7 @@ describe('run blueprint', () => {
     const testExecutor = jest.fn(() => 'called testExecutor');
     const testExecutor2 = jest.fn();
 
-    const systemActions = [
+    const systemApis = [
       createMockAction({
         type: 'TEST_FUNC',
         integrationName: CORE_INTEGRATION_NAME,
@@ -658,8 +658,8 @@ describe('run blueprint', () => {
       }),
     });
 
-    integrationFramework.registerActions({
-      actions: systemActions,
+    integrationFramework.registerApis({
+      apis: systemApis,
       integrationName: CORE_INTEGRATION_NAME,
     });
     integrationFramework.registerEvents({
@@ -750,7 +750,7 @@ describe('run blueprint', () => {
     const testExecutor = jest.fn(() => 'called testExecutor');
     const testExecutor2 = jest.fn();
 
-    const systemActions = [
+    const systemApis = [
       createMockAction({
         type: 'TEST_FUNC',
         integrationName: CORE_INTEGRATION_NAME,
@@ -770,8 +770,8 @@ describe('run blueprint', () => {
       }),
     });
 
-    integrationFramework.registerActions({
-      actions: systemActions,
+    integrationFramework.registerApis({
+      apis: systemApis,
       integrationName: CORE_INTEGRATION_NAME,
     });
     integrationFramework.registerEvents({
@@ -866,7 +866,7 @@ describe('run blueprint', () => {
     }));
     const testExecutor2 = jest.fn();
 
-    const systemActions = [
+    const systemApis = [
       createMockAction({
         type: 'TEST_FUNC',
         integrationName: CORE_INTEGRATION_NAME,
@@ -887,8 +887,8 @@ describe('run blueprint', () => {
       }),
     });
 
-    integrationFramework.registerActions({
-      actions: systemActions,
+    integrationFramework.registerApis({
+      apis: systemApis,
       integrationName: CORE_INTEGRATION_NAME,
     });
     integrationFramework.registerEvents({

--- a/packages/google/src/apis/send-email.ts
+++ b/packages/google/src/apis/send-email.ts
@@ -1,4 +1,4 @@
-import { DataLayer, IntegrationAction, extractSchemaOptions } from '@arkw/core';
+import { DataLayer, IntegrationApi, extractSchemaOptions } from '@arkw/core';
 import { z } from 'zod';
 
 // @ts-ignore
@@ -17,7 +17,7 @@ export const SEND_EMAIL = ({
   dataAccess: DataLayer;
   makeClient: MakeClient;
   createEmails: (params: CreateEmailsParams) => Promise<void>;
-}): IntegrationAction<
+}): IntegrationApi<
   z.input<typeof SEND_EMAIL_SCHEMA>,
   {
     status: boolean;
@@ -135,7 +135,7 @@ export const SEND_BULK_EMAIL = ({
   dataAccess: DataLayer;
   makeClient: MakeClient;
   createEmails: (params: CreateEmailsParams) => Promise<void>;
-}): IntegrationAction<
+}): IntegrationApi<
   z.input<typeof SEND_EMAIL_SCHEMA>,
   {
     status: boolean;

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -1,7 +1,7 @@
 import { Connection, IntegrationAuth, Integration, nextHeaders, FilterObject } from '@arkw/core';
 import { z } from 'zod';
 
-import { SEND_BULK_EMAIL, SEND_EMAIL } from './actions/send-email';
+import { SEND_BULK_EMAIL, SEND_EMAIL } from './apis/send-email';
 //@ts-ignore
 import googleIcon from './assets/google.svg';
 import { GoogleClient } from './client';
@@ -41,7 +41,7 @@ export class GoogleIntegration extends Integration<GoogleClient> {
     this.config = config;
   }
 
-  async getProxy({ referenceId }: { referenceId: string }) {
+  async getApiClient({ referenceId }: { referenceId: string }) {
     const c = await this.makeClient({ referenceId });
     const calendar = await c.getCalendarInstance();
     const gmail = await c.getGmailInstance();
@@ -51,8 +51,8 @@ export class GoogleIntegration extends Integration<GoogleClient> {
     };
   }
 
-  registerActions() {
-    this.actions = {
+  registerApis() {
+    this.apis = {
       SEND_EMAIL: SEND_EMAIL({
         dataAccess: this?.dataLayer!,
         name: this.name,
@@ -66,7 +66,7 @@ export class GoogleIntegration extends Integration<GoogleClient> {
         createEmails: this.createEmails.bind(this),
       }),
     };
-    return this.actions;
+    return this.apis;
   }
 
   registerEvents() {

--- a/packages/mailchimp/src/index.ts
+++ b/packages/mailchimp/src/index.ts
@@ -32,7 +32,7 @@ export class MailchimpIntegration extends Integration {
     this.config = config;
   }
 
-  async getProxy({ referenceId }: { referenceId: string }): Promise<typeof sdk> {
+  async getApiClient({ referenceId }: { referenceId: string }): Promise<typeof sdk> {
     const dataInt = await this.dataLayer?.getConnectionByReferenceId({
       referenceId,
       name: this.name,

--- a/packages/rewatch/src/apis/attach-recording.ts
+++ b/packages/rewatch/src/apis/attach-recording.ts
@@ -1,4 +1,4 @@
-import { DataLayer, IntegrationAction } from '@arkw/core';
+import { DataLayer, IntegrationApi } from '@arkw/core';
 import { z } from 'zod';
 
 import { makeRewatchRecords, REWATCH_FIELDS } from '../constants';
@@ -15,7 +15,7 @@ export const ATTACH_RECORDING = ({
   dataAccess: DataLayer;
   makeClient: MakeClient;
   entityType: string;
-}): IntegrationAction<z.infer<typeof videoUploadedPayload>, z.infer<typeof blankSchema>> => ({
+}): IntegrationApi<z.infer<typeof videoUploadedPayload>, z.infer<typeof blankSchema>> => ({
   integrationName: name,
   type: 'ATTACH_RECORDING',
   label: 'Attach recording to attendees',

--- a/packages/rewatch/src/index.ts
+++ b/packages/rewatch/src/index.ts
@@ -1,7 +1,7 @@
 import { Connection, IntegrationAuth, IntegrationCredentialType, Integration } from '@arkw/core';
 import { z } from 'zod';
 
-import { ATTACH_RECORDING } from './actions/attach-recording';
+import { ATTACH_RECORDING } from './apis/attach-recording';
 // @ts-ignore
 import rewatchIcon from './assets/rewatch.svg';
 import { RewatchClient } from './client';
@@ -48,8 +48,8 @@ export class RewatchIntegration extends Integration<RewatchClient> {
     return this.events;
   }
 
-  registerActions() {
-    this.actions = {
+  registerApis() {
+    this.apis = {
       ATTACH_RECORDING: ATTACH_RECORDING({
         makeClient: this.makeClient,
         dataAccess: this?.dataLayer!,
@@ -57,7 +57,7 @@ export class RewatchIntegration extends Integration<RewatchClient> {
         entityType: this.entityTypes.MEETING_RECORDINGS,
       }),
     };
-    return this.actions;
+    return this.apis;
   }
 
   getAuthenticator() {

--- a/packages/slack/src/apis/create-new-channel.ts
+++ b/packages/slack/src/apis/create-new-channel.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 // import slackIcon from '../assets/slack.svg';
-import { DataLayer, IntegrationAction } from '@arkw/core';
+import { DataLayer, IntegrationApi } from '@arkw/core';
 import { z } from 'zod';
 
 // @ts-ignore
@@ -15,7 +15,7 @@ export const CREATE_NEW_CHANNEL = ({
   name: string;
   dataAccess: DataLayer;
   makeClient: MakeClient;
-}): IntegrationAction<z.infer<typeof CREATE_NEW_CHANNEL_SCHEMA>, z.infer<typeof CREATE_NEW_CHANNEL_OUTPUT_SCHEMA>> => ({
+}): IntegrationApi<z.infer<typeof CREATE_NEW_CHANNEL_SCHEMA>, z.infer<typeof CREATE_NEW_CHANNEL_OUTPUT_SCHEMA>> => ({
   integrationName: name,
   executor: async ({ data, ctx: { referenceId } }) => {
     const client = await makeClient({ referenceId });

--- a/packages/slack/src/apis/invite-to-channel.ts
+++ b/packages/slack/src/apis/invite-to-channel.ts
@@ -1,4 +1,4 @@
-import { DataLayer, IntegrationAction } from '@arkw/core';
+import { DataLayer, IntegrationApi } from '@arkw/core';
 import { z } from 'zod';
 
 //@ts-ignore
@@ -13,7 +13,7 @@ export const INVITE_TO_CHANNEL = ({
   name: string;
   dataAccess: DataLayer;
   makeClient: MakeClient;
-}): IntegrationAction<z.infer<typeof INVITE_TO_CHANNEL_SCHEMA>> => ({
+}): IntegrationApi<z.infer<typeof INVITE_TO_CHANNEL_SCHEMA>> => ({
   integrationName: name,
   executor: async ({ data, ctx: { referenceId } }) => {
     const client = await makeClient({ referenceId });

--- a/packages/slack/src/apis/send-message-to-channel.ts
+++ b/packages/slack/src/apis/send-message-to-channel.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 // import slackIcon from '../assets/slack.svg';
-import { DataLayer, IntegrationAction } from '@arkw/core';
+import { DataLayer, IntegrationApi } from '@arkw/core';
 import { z } from 'zod';
 
 // @ts-ignore
@@ -16,7 +16,7 @@ export const SEND_MESSAGE_TO_CHANNEL = ({
   name: string;
   dataAccess: DataLayer;
   makeClient: MakeClient;
-}): IntegrationAction<z.infer<typeof SEND_MESSAGE_TO_CHANNEL_SCHEMA>> => ({
+}): IntegrationApi<z.infer<typeof SEND_MESSAGE_TO_CHANNEL_SCHEMA>> => ({
   integrationName: name,
   executor: async ({ data, ctx: { referenceId } }) => {
     const client = await makeClient({ referenceId });

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,8 +1,8 @@
-import { Connection, IntegrationAction, IntegrationAuth, Integration } from '@arkw/core';
+import { Connection, IntegrationApi, IntegrationAuth, Integration } from '@arkw/core';
 
-import { CREATE_NEW_CHANNEL } from './actions/create-new-channel';
-import { INVITE_TO_CHANNEL } from './actions/invite-to-channel';
-import { SEND_MESSAGE_TO_CHANNEL } from './actions/send-message-to-channel';
+import { CREATE_NEW_CHANNEL } from './apis/create-new-channel';
+import { INVITE_TO_CHANNEL } from './apis/invite-to-channel';
+import { SEND_MESSAGE_TO_CHANNEL } from './apis/send-message-to-channel';
 //@ts-ignore
 import slackIcon from './assets/slack.svg';
 import { SlackClient } from './client';
@@ -40,7 +40,7 @@ export class SlackIntegration extends Integration<SlackClient> {
     return new SlackClient({ token: token.accessToken });
   };
 
-  getActions(): Record<string, IntegrationAction<any>> {
+  registerApis(): Record<string, IntegrationApi<any>> {
     return {
       SEND_MESSAGE_TO_CHANNEL: SEND_MESSAGE_TO_CHANNEL({
         dataAccess: this?.dataLayer!,

--- a/packages/x/src/apis/create-post.ts
+++ b/packages/x/src/apis/create-post.ts
@@ -1,4 +1,4 @@
-import { DataLayer, IntegrationAction } from '@arkw/core';
+import { DataLayer, IntegrationApi } from '@arkw/core';
 import { z } from 'zod';
 
 // @ts-ignore
@@ -13,7 +13,7 @@ export const CREATE_POST = ({
   name: string;
   dataAccess: DataLayer;
   makeClient: MakeClient;
-}): IntegrationAction<z.infer<typeof CREATE_POST_SCHEMA>, z.infer<typeof CREATE_POST_OUTPUT_SCHEMA>> => ({
+}): IntegrationApi<z.infer<typeof CREATE_POST_SCHEMA>, z.infer<typeof CREATE_POST_OUTPUT_SCHEMA>> => ({
   integrationName: name,
   executor: async ({ data, ctx: { referenceId } }) => {
     const client = await makeClient({ referenceId });

--- a/packages/x/src/index.ts
+++ b/packages/x/src/index.ts
@@ -1,6 +1,6 @@
-import { Connection, Integration, IntegrationAction, IntegrationAuth } from '@arkw/core';
+import { Connection, Integration, IntegrationApi, IntegrationAuth } from '@arkw/core';
 
-import { CREATE_POST } from './actions/create-post';
+import { CREATE_POST } from './apis/create-post';
 //@ts-ignore
 import xIcon from './assets/x.svg';
 import { XClient } from './client';
@@ -39,8 +39,8 @@ export class XIntegration extends Integration {
     return new XClient({ token: token.accessToken });
   };
 
-  registerActions(): Record<string, IntegrationAction<any>> {
-    this.actions = {
+  registerApis(): Record<string, IntegrationApi<any>> {
+    this.apis = {
       CREATE_POST: CREATE_POST({
         dataAccess: this?.dataLayer!,
         name: this.name,
@@ -48,7 +48,7 @@ export class XIntegration extends Integration {
       }),
     };
 
-    return this.actions;
+    return this.apis;
   }
 
   async onConnectionCreated({ connection }: { connection: Connection }) {}


### PR DESCRIPTION
- Generate asana
- fix asana builds
- configure asana oauth flow
- Gen actions
- Gen actions
- No more actions, apis
- No more actions, apis
