### PR TITLE
update events and apis playground with reference id select field

### DIFF
--- a/packages/admin/mock-data/blueprints/clz1i01kf000ldvqujk0idrp1.json
+++ b/packages/admin/mock-data/blueprints/clz1i01kf000ldvqujk0idrp1.json
@@ -3,7 +3,7 @@
   "description": "",
   "status": "PUBLISHED",
   "createdAt": "2024-07-25T16:38:49.071Z",
-  "updatedAt": "2024-09-04T09:25:26.296Z",
+  "updatedAt": "2024-09-05T12:35:42.350Z",
   "ownerId": "clvktzwg2000012d2bxppw5em",
   "workspaceId": "clvktzwhf000212d2of5h3xvj",
   "owner": {
@@ -43,14 +43,7 @@
         {
           "id": "f3kfuwmhasjm4p9ateypg6aa",
           "type": "SEND_EMAIL",
-          "variables": {
-            "to": {
-              "to0": {
-                "refBlockId": "ymb8endqno3hi77z9cgzcpd8",
-                "path": "data.email"
-              }
-            }
-          },
+          "variables": {},
           "subActions": [
             {
               "id": "pi6q3xqxtk26wkrawd8ejh67",
@@ -58,26 +51,20 @@
               "parentActionId": "f3kfuwmhasjm4p9ateypg6aa",
               "subActions": [],
               "payload": {
-                "arkwReferenceId": "45678",
-                "to": ["{{to0}}"],
+                "arkwReferenceId": "5678",
+                "to": ["adelekekehinde06@gmail.com"],
                 "subject": "hallo again",
                 "body": "second one sent from oluderutaofeeq@gmail.com"
               },
-              "variables": {
-                "to": {
-                  "to0": {
-                    "refBlockId": "ymb8endqno3hi77z9cgzcpd8",
-                    "path": "data.email"
-                  }
-                }
-              }
+              "variables": {}
             }
           ],
           "parentActionId": "t6bxipp3xztc1jx44yx1b0zj",
           "payload": {
-            "to": ["{{to0}}"],
+            "to": ["adelekekehinde06@gmail.com"],
             "subject": "hallo!",
-            "body": "sent from taofeeq@getkpler.com"
+            "body": "sent from taofeeq@getkpler.com",
+            "arkwReferenceId": "1724771121699"
           }
         }
       ]

--- a/packages/admin/src/app/(dashboard)/actions-playground/layout.tsx
+++ b/packages/admin/src/app/(dashboard)/actions-playground/layout.tsx
@@ -8,14 +8,9 @@ import { getSerializedFrameworkActions } from '@/domains/workflows/utils';
 
 export default async function WorkflowsParentLayout({ children }: { children: ReactNode }) {
   const systemApis = framework?.getSystemApis() || [];
-  const connectedIntegrations =
-    (await framework?.connectedIntegrations({
-      context: {
-        referenceId: `1`,
-      },
-    })) || [];
+  const availableIntegrations = framework?.availableIntegrations()?.map(({ integration }) => integration) || [];
 
-  const connectedIntegrationsActions: Record<string, IntegrationApi<any>> = connectedIntegrations.reduce(
+  const availableIntegrationsApis: Record<string, IntegrationApi<any>> = availableIntegrations.reduce(
     (acc: any, { name }: any) => {
       const apis = framework?.getApisByIntegration(name);
       return { ...acc, ...apis };
@@ -23,13 +18,13 @@ export default async function WorkflowsParentLayout({ children }: { children: Re
     {},
   );
 
-  const allActions = { ...systemApis, ...connectedIntegrationsActions };
+  const allActions = { ...systemApis, ...availableIntegrationsApis };
 
   const frameworkActions = Object.values(allActions) as IntegrationApi[];
 
   const serializedFrameworkActions = await getSerializedFrameworkActions({
     frameworkActions,
-    ctx: { referenceId: '1' },
+    ctx: { referenceId: '' },
   });
 
   return (

--- a/packages/admin/src/app/(dashboard)/events-playground/layout.tsx
+++ b/packages/admin/src/app/(dashboard)/events-playground/layout.tsx
@@ -9,28 +9,20 @@ import { getSerializedFrameworkEvents } from '@/domains/workflows/utils';
 export default async function WorkflowsParentLayout({ children }: { children: ReactNode }) {
   const systemEvents = framework?.getSystemEvents();
 
-  const connectedIntegrations =
-    (await framework?.connectedIntegrations({
-      context: {
-        referenceId: `1`,
-      },
-    })) || [];
+  const availableIntegrations = framework?.availableIntegrations()?.map(({ integration }) => integration) || [];
 
-  const connectedIntegrationsRefinedEvents = connectedIntegrations.reduce<RefinedIntegrationEvent[]>(
-    (acc, { name }) => {
-      const events = framework?.getEventsByIntegration(name) ?? {};
-      const refinedEvents: RefinedIntegrationEvent[] = Object.entries(events).map(([k, v]) => {
-        return {
-          ...v,
-          key: k,
-          label: k,
-          integrationName: name,
-        };
-      });
-      return [...acc, ...refinedEvents];
-    },
-    [],
-  );
+  const availableIntegrationsEvents = availableIntegrations.reduce<RefinedIntegrationEvent[]>((acc, { name }) => {
+    const events = framework?.getEventsByIntegration(name) ?? {};
+    const refinedEvents: RefinedIntegrationEvent[] = Object.entries(events).map(([k, v]) => {
+      return {
+        ...v,
+        key: k,
+        label: k,
+        integrationName: name,
+      };
+    });
+    return [...acc, ...refinedEvents];
+  }, []);
 
   const refinedSystemEvents: RefinedIntegrationEvent[] = Object.entries(systemEvents ?? {}).map(([k, v]) => {
     return {
@@ -40,11 +32,11 @@ export default async function WorkflowsParentLayout({ children }: { children: Re
     };
   });
 
-  const frameworkEvents = [...refinedSystemEvents, ...connectedIntegrationsRefinedEvents];
+  const frameworkEvents = [...refinedSystemEvents, ...availableIntegrationsEvents];
 
   const serializedFrameworkEvents = await getSerializedFrameworkEvents({
     frameworkEvents,
-    ctx: { referenceId: `1` },
+    ctx: { referenceId: `` },
   });
 
   return (

--- a/packages/admin/src/domains/playground/components/action-detail.tsx
+++ b/packages/admin/src/domains/playground/components/action-detail.tsx
@@ -13,7 +13,7 @@ import { codeToHtml } from 'shiki/bundle/web';
 import { useActionPlaygroundContext } from '../providers/action-playground-provider';
 
 function ActionDetail() {
-  const { selectedAction, payload } = useActionPlaygroundContext();
+  const { selectedAction, payload, arkwReferenceId } = useActionPlaygroundContext();
   const selectedActionPlugin = selectedAction?.integrationName;
   const [codeBlock, setCodeBlock] = useState<string | null>(null);
   const [_, CopyFn, isCodeBlockCopied] = useCopyToClipboard();
@@ -40,7 +40,7 @@ function ActionDetail() {
                 ${stringifiedPayload.substring(1, stringifiedPayload.length - 1)}
               },
               ctx:{
-                referenceId: '1'
+                referenceId: ${arkwReferenceId}
               }
           },
         });
@@ -58,7 +58,7 @@ function ActionDetail() {
 
     setSnippet(snippet);
     getCodeBlock().then(html => setCodeBlock(html));
-  }, [selectedAction, selectedActionPlugin, payload]);
+  }, [selectedAction, selectedActionPlugin, payload, arkwReferenceId]);
 
   return selectedAction ? (
     <div className="px-8 h-full grid place-items-center max-w-full overflow-auto">

--- a/packages/admin/src/domains/playground/components/actions-list.tsx
+++ b/packages/admin/src/domains/playground/components/actions-list.tsx
@@ -48,10 +48,6 @@ export function ActionPlaygroundSidebar() {
     };
   }, {} as { [key: string]: RefinedIntegrationApi[] });
 
-  console.log({
-    groupByIntegrationName,
-  });
-
   return (
     <>
       {/*this renders the list of action blocks to select from*/}

--- a/packages/admin/src/domains/playground/components/event-detail.tsx
+++ b/packages/admin/src/domains/playground/components/event-detail.tsx
@@ -13,7 +13,7 @@ import { codeToHtml } from 'shiki/bundle/web';
 import { useEventPlaygroundContext } from '../providers/event-playground-provider';
 
 function EventDetail() {
-  const { selectedEvent, payload } = useEventPlaygroundContext();
+  const { selectedEvent, payload, arkwReferenceId } = useEventPlaygroundContext();
   const [codeBlock, setCodeBlock] = useState<string | null>(null);
   const [_, CopyFn, isCodeBlockCopied] = useCopyToClipboard();
   const [snippet, setSnippet] = useState<string>('');
@@ -39,7 +39,7 @@ function EventDetail() {
             },
           },
           user: {
-            referenceId: 1,
+            referenceId: ${arkwReferenceId},
           },
         });
 
@@ -56,7 +56,7 @@ function EventDetail() {
 
     setSnippet(snippet);
     getCodeBlock().then(html => setCodeBlock(html));
-  }, [selectedEvent, payload]);
+  }, [selectedEvent, payload, arkwReferenceId]);
 
   return selectedEvent ? (
     <div className="px-8 h-full grid place-items-center max-w-full overflow-auto">

--- a/packages/admin/src/domains/playground/components/event-dynamic-form.tsx
+++ b/packages/admin/src/domains/playground/components/event-dynamic-form.tsx
@@ -7,7 +7,9 @@ import React from 'react';
 import { Control, FieldErrors, useForm } from 'react-hook-form';
 import { z, ZodSchema } from 'zod';
 
+import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 
 import { constructObjFromStringPath } from '@/lib/object';
@@ -15,6 +17,8 @@ import { toast } from '@/lib/toast';
 
 import { getWorkflowFormFieldMap } from '@/domains/workflows/components/utils/constants';
 import BlockHeader from '@/domains/workflows/components/utils/render-header';
+import ReferenceSelect from '@/domains/workflows/components/workflow-sidebar/config-forms/reference-select';
+import { useFrameworkEvent } from '@/domains/workflows/hooks/use-framework-event';
 import { schemaToFormFieldRenderer } from '@/domains/workflows/schema';
 
 import { useEventPlaygroundContext } from '../providers/event-playground-provider';
@@ -23,36 +27,103 @@ import { triggerFrameworkEvent } from '../server-actions/trigger-framework-event
 import TriggerEvent from './event-runner';
 
 function EventDynamicForm<T extends ZodSchema>() {
-  const { selectedEvent, setSelectedEvent, setPayload } = useEventPlaygroundContext();
+  const { selectedEvent, setSelectedEvent, arkwReferenceId, setArkwReferenceId } = useEventPlaygroundContext();
 
-  const discriminatedUnionSchemaOptions = (selectedEvent?.schema as any)?._def?.options;
+  const { frameworkEvent, isLoading } = useFrameworkEvent({
+    eventKey: selectedEvent?.key!,
+    integrationName: selectedEvent?.integrationName!,
+    referenceId: arkwReferenceId,
+  });
+
+  if (!selectedEvent) {
+    return null;
+  }
+
+  const title = selectedEvent.label;
+  // icon comes from framework
+  const icon = '';
+
+  return (
+    <ScrollArea className="h-full w-full" viewportClassName="kepler-actions-form-scroll-area">
+      <div className="flex flex-col h-full">
+        <BlockHeader
+          title={title as string}
+          icon={
+            icon || {
+              alt: 'dashboard icon',
+              icon: 'dashboard',
+            }
+          }
+          category={'trigger'}
+          handleEditBlockType={() => setSelectedEvent(undefined)}
+        />
+        <div className="mt-5 px-6">
+          <Text weight="medium" className="text-arkw-el-3">
+            Inputs
+          </Text>
+        </div>
+        <section className="flex flex-col gap-5 pt-6">
+          <div className="flex flex-col gap-3 px-6">
+            <Label className="capitalize flex gap-1" htmlFor="arkwReferenceId" aria-required={true}>
+              <span className="text-red-500">*</span>
+              <Text variant="secondary" className="text-arkw-el-3" size="xs">
+                Reference ID to use execute the event
+              </Text>
+            </Label>
+
+            <ReferenceSelect
+              selected={arkwReferenceId}
+              onSelect={({ value }: { value: any }) => {
+                setArkwReferenceId(value);
+              }}
+              integrationName={selectedEvent?.integrationName!}
+            />
+          </div>
+          {isLoading ? (
+            <div className="flex flex-col gap-5 px-6">
+              <div className="flex flex-col gap-3">
+                <Skeleton className="h-3 w-28" />
+                <Skeleton className="h-8 w-full" />
+              </div>
+              <div className="flex flex-col gap-3">
+                <Skeleton className="h-3 w-28" />
+                <Skeleton className="h-8 w-full" />
+              </div>
+              <div className="flex flex-col gap-3">
+                <Skeleton className="h-3 w-28" />
+                <Skeleton className="h-8 w-full" />
+              </div>
+            </div>
+          ) : (
+            <InnerEventDynamicForm block={frameworkEvent!} />
+          )}
+        </section>
+      </div>
+    </ScrollArea>
+  );
+}
+
+function InnerEventDynamicForm<T extends ZodSchema>({ block }: { block: RefinedIntegrationEvent }) {
+  const { setPayload, payload, arkwReferenceId } = useEventPlaygroundContext();
 
   const {
     control,
     handleSubmit,
     setValue,
     watch,
-    reset,
     formState: { errors },
   } = useForm<z.infer<T>>({
-    resolver: zodResolver(selectedEvent?.schema as any),
+    resolver: zodResolver(block?.schema as any),
     // defaultValues: {}
   });
 
   const formValues = watch();
 
-  if (!selectedEvent || !selectedEvent?.schema) {
+  if (!block || !block?.schema) {
     return null;
   }
 
-  const schema = selectedEvent.schema;
-  typeof selectedEvent?.schema === `function`
-    ? selectedEvent?.schema({ ctx: { referenceId: `1` } })
-    : selectedEvent.schema;
-
-  const title = selectedEvent.label;
-  // icon comes from framework
-  const icon = '';
+  const schema = block?.schema;
 
   function handleFieldChange({ key, value }: { key: keyof z.infer<T>; value: any }) {
     const newFormValues = mergeWith(formValues, constructObjFromStringPath(key as string, value));
@@ -61,15 +132,14 @@ function EventDynamicForm<T extends ZodSchema>() {
   }
 
   async function handleTriggerEvent() {
-    const parser = selectedEvent?.schema;
     let values = formValues;
 
     try {
       await triggerFrameworkEvent({
-        eventKey: selectedEvent?.key!,
+        eventKey: block?.key!,
         payload: values,
-        referenceId: '1',
-        integrationName: selectedEvent?.integrationName!,
+        referenceId: arkwReferenceId,
+        integrationName: block?.integrationName!,
       });
       toast.success('Event triggered successfully');
     } catch (error) {
@@ -79,44 +149,24 @@ function EventDynamicForm<T extends ZodSchema>() {
   }
 
   return (
-    <ScrollArea className="h-full w-full" viewportClassName="kepler-actions-form-scroll-area">
-      <div className="flex flex-col h-full">
-        <form onSubmit={handleSubmit(() => {})} className="flex h-full flex-col">
-          <BlockHeader
-            title={title as string}
-            icon={
-              icon || {
-                alt: 'dashboard icon',
-                icon: 'dashboard',
-              }
-            }
-            category={'trigger'}
-            handleEditBlockType={() => setSelectedEvent(undefined)}
-          />
-          <div className="mt-5 px-6">
-            <Text weight="medium" className="text-arkw-el-3">
-              Inputs
-            </Text>
-          </div>
-          <section className="flex flex-col gap-5 p-6 pb-0 h-full">
-            {renderDynamicForm({
-              schema: schema as ZodSchema,
-              block: selectedEvent,
-              handleFieldChange,
-              control,
-              formValues,
-              errors,
-            })}
-          </section>
-          <TriggerEvent
-            className=""
-            onTriggerEvent={async () => {
-              await handleTriggerEvent();
-            }}
-          />
-        </form>
-      </div>
-    </ScrollArea>
+    <>
+      <form onSubmit={handleSubmit(() => {})} className="flex flex-col gap-5 px-6 pb-0 h-full">
+        {renderDynamicForm({
+          schema: schema as ZodSchema,
+          block,
+          handleFieldChange,
+          control,
+          formValues,
+          errors,
+        })}
+      </form>
+      <TriggerEvent
+        className="px-6"
+        onTriggerEvent={async () => {
+          await handleTriggerEvent();
+        }}
+      />
+    </>
   );
 }
 

--- a/packages/admin/src/domains/playground/components/events-list.tsx
+++ b/packages/admin/src/domains/playground/components/events-list.tsx
@@ -21,8 +21,6 @@ export function EventPlaygroundSidebar() {
     setEventToEdit(event);
   }
 
-  console.log(frameworkEvents);
-
   useEffect(() => {
     if (selectedEvent) {
       handleEditEventType(selectedEvent);

--- a/packages/admin/src/domains/playground/providers/action-playground-provider.tsx
+++ b/packages/admin/src/domains/playground/providers/action-playground-provider.tsx
@@ -11,6 +11,8 @@ export interface ActionPlaygroundContextProps {
   setSelectedAction: React.Dispatch<React.SetStateAction<RefinedIntegrationApi | undefined>>;
   payload: Record<string, any>;
   setPayload: React.Dispatch<React.SetStateAction<Record<string, any>>>;
+  arkwReferenceId: string;
+  setArkwReferenceId: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const ActionPlaygroundContext = createContext({} as ActionPlaygroundContextProps);
@@ -37,6 +39,7 @@ export const ActionPlaygroundProvider = ({
   const [selectedAction, setSelectedAction] = useState<RefinedIntegrationApi | undefined>(undefined);
 
   const [payload, setPayload] = useState<Record<string, any>>({});
+  const [arkwReferenceId, setArkwReferenceId] = useState('');
 
   const contextValue: ActionPlaygroundContextProps = useMemo(() => {
     return {
@@ -45,8 +48,10 @@ export const ActionPlaygroundProvider = ({
       setSelectedAction,
       payload,
       setPayload,
+      arkwReferenceId,
+      setArkwReferenceId,
     };
-  }, [selectedAction, frameworkActions, payload]);
+  }, [selectedAction, frameworkActions, payload, arkwReferenceId]);
 
   return <ActionPlaygroundContext.Provider value={contextValue}>{children}</ActionPlaygroundContext.Provider>;
 };

--- a/packages/admin/src/domains/playground/providers/event-playground-provider.tsx
+++ b/packages/admin/src/domains/playground/providers/event-playground-provider.tsx
@@ -11,6 +11,8 @@ export interface EventPlaygroundContextProps {
   setSelectedEvent: React.Dispatch<React.SetStateAction<RefinedIntegrationEvent | undefined>>;
   payload: Record<string, any>;
   setPayload: React.Dispatch<React.SetStateAction<Record<string, any>>>;
+  arkwReferenceId: string;
+  setArkwReferenceId: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const EventPlaygroundContext = createContext({} as EventPlaygroundContextProps);
@@ -37,6 +39,7 @@ export const EventPlaygroundProvider = ({
   const [selectedEvent, setSelectedEvent] = useState<RefinedIntegrationEvent | undefined>(undefined);
 
   const [payload, setPayload] = useState<Record<string, any>>({});
+  const [arkwReferenceId, setArkwReferenceId] = useState('');
 
   const contextValue: EventPlaygroundContextProps = useMemo(() => {
     return {
@@ -45,8 +48,10 @@ export const EventPlaygroundProvider = ({
       setSelectedEvent,
       payload,
       setPayload,
+      arkwReferenceId,
+      setArkwReferenceId,
     };
-  }, [selectedEvent, frameworkEvents, payload]);
+  }, [selectedEvent, frameworkEvents, payload, arkwReferenceId]);
 
   return <EventPlaygroundContext.Provider value={contextValue}>{children}</EventPlaygroundContext.Provider>;
 };

--- a/packages/admin/src/domains/workflows/components/workflow-graph/workflow-event.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-graph/workflow-event.tsx
@@ -12,6 +12,7 @@ import last from 'lodash/last';
 
 import { useWorkflowContext } from '../../context/workflow-context';
 import { extractConditions } from '../../utils';
+import { FrameworkIcon } from '../utils/action-selector';
 
 import { WorkflowGraphAddBlock } from './workflow-graph-add-block';
 
@@ -83,7 +84,7 @@ export function TriggerBlock({ trigger }: { trigger: WorkflowTrigger }) {
       >
         <div className={cn(blockStyles.header)}>
           <span className={cn('border-arkw-border-2 bg-arkw-bg-9 rounded-sm border-[0.4px] border-solid p-2', {})}>
-            {/* <FrameworkIcon icon={icon} className="text-current" /> */}
+            <FrameworkIcon icon={{ icon: 'dashboard', alt: 'dashboard' }} className="text-current" />
           </span>
           <Text size="xs" weight="medium" className="text-arkw-el-6 capitalize">
             {label}

--- a/packages/admin/src/domains/workflows/components/workflow-sidebar/action-form.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-sidebar/action-form.tsx
@@ -180,14 +180,20 @@ function InnerDynamicForm<T extends ZodSchema>({ block, action, onUpdateAction, 
     if (key === discriminatedUnionSchemaDiscriminator) {
       reset({ [key]: value });
       const newFormValues = constructObjFromStringPath(key as string, value);
-      onBlur?.({ payload: { ...newFormValues }, variables: variables ? { [key]: variables } : undefined });
+      onBlur?.({
+        payload: { ...newFormValues, arkwReferenceId: action?.payload?.arkwReferenceId },
+        variables: variables ? { [key]: variables } : undefined,
+      });
     } else {
       setValue<any>(key, value);
       if (attemptedPublish) {
         trigger();
       }
       const newFormValues = mergeWith(formValues, constructObjFromStringPath(key as string, value));
-      onBlur?.({ payload: { ...newFormValues }, variables: variables ? { [key]: variables } : undefined });
+      onBlur?.({
+        payload: { ...newFormValues, arkwReferenceId: action?.payload?.arkwReferenceId },
+        variables: variables ? { [key]: variables } : undefined,
+      });
     }
   }
 

--- a/packages/admin/src/domains/workflows/components/workflow-sidebar/config-forms/multi-select.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-sidebar/config-forms/multi-select.tsx
@@ -48,7 +48,7 @@ function MultiSelect({
   const allOptions = options.length ? options : [];
 
   const variableSelections = useMemo(() => {
-    return selectedValues.filter(value => value.id.includes('{{') && value.id.includes('}}'));
+    return selectedValues?.filter(value => value?.id?.includes('{{') && value?.id?.includes('}}'));
   }, [selectedValues]);
 
   const totalVariablesSelection = variableSelections.length;
@@ -112,7 +112,7 @@ function MultiSelect({
                     setSelectedValues(selectedValues.filter(selectedValue => selectedValue.id !== value.id));
                     onSelect({
                       key: field.name,
-                      value: selectedValues.filter(selectedValue => selectedValue.id !== value.id),
+                      value: selectedValues.filter(selectedValue => selectedValue.id !== value.id)?.map(({ id }) => id),
                     });
                   }}
                   icon="cancel"

--- a/packages/admin/src/domains/workflows/hooks/use-framework-event.ts
+++ b/packages/admin/src/domains/workflows/hooks/use-framework-event.ts
@@ -1,0 +1,49 @@
+import { RefinedIntegrationEvent } from '@arkw/core';
+import { useEffect, useState } from 'react';
+
+import { getFrameworkEvent } from '../actions';
+import { getParsedFrameworkEvents } from '../utils';
+
+export const useFrameworkEvent = ({
+  eventKey,
+  integrationName,
+  referenceId = '',
+}: {
+  eventKey: string;
+  integrationName: string;
+  referenceId: string;
+}) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [frameworkEvent, setFrameworkEvent] = useState<RefinedIntegrationEvent | null>(null);
+
+  useEffect(() => {
+    const getApi = async () => {
+      if (!eventKey || !integrationName) {
+        setFrameworkEvent(null);
+        setIsLoading(false);
+        return;
+      }
+      try {
+        const serializedApi = await getFrameworkEvent({ eventKey, integrationName, referenceId });
+        if (serializedApi) {
+          const api = getParsedFrameworkEvents(serializedApi);
+          setFrameworkEvent(api?.[0] || null);
+        } else {
+          setFrameworkEvent(null);
+        }
+        setIsLoading(false);
+      } catch (err) {
+        console.log(`Eror getting event for ${eventKey}=`, err);
+        setFrameworkEvent(null);
+        setIsLoading(false);
+      }
+    };
+
+    getApi();
+  }, [eventKey, integrationName, referenceId]);
+
+  return {
+    frameworkEvent,
+    isLoading,
+  };
+};


### PR DESCRIPTION
This PR does the following
- [x] update events and apis playground with reference id select field
- [x] fix multi select breaking the app in workflow if user unselects an item with the 'x' icon and attempts to save/publish or come back the edited api block
- [x] fix workflow api block reference id sometimes getting overridden  