### PR TITLE
follow up: handle loading state improve code block and api result

### DIFF
--- a/packages/admin/src/app/(dashboard)/playground/api/[...api]/page.tsx
+++ b/packages/admin/src/app/(dashboard)/playground/api/[...api]/page.tsx
@@ -2,22 +2,26 @@ import { Separator } from '@radix-ui/react-dropdown-menu';
 
 import { ApiCodeBlock } from '@/domains/playground/components/api-code-block';
 
+import { ApiResultContainer } from '../../components/api/api-result-container';
 import { ApiSchemaBlock } from '../../components/api/api-schema-block';
 import { RunButtonContainer } from '../../components/api/run-button-container';
 
 export default function Page({ params }: { params: { api: Array<string> } }) {
   const [_, api] = params.api;
-  // use the send_email to get the action detail from a list
+
   return (
     <div className="grid h-[calc(100%-1.24rem)] gap-x-[0.62rem] grid-cols-[23.5rem_0.5px_1fr]">
       <ApiSchemaBlock type={api.toUpperCase()} />
       <Separator className="w-[0.5px] bg-arkw-border-1" />
       <div className="flex flex-col gap-5 rounded-[0.375rem]">
-        <div className="basis-[27rem] border-[0.5px] border-arkw-border-1 rounded-[0.25rem] bg-arkw-bg-2">
+        <div className="basis-[27rem] grow-0 relative z-20 border-[0.5px] border-arkw-border-1 rounded-[0.25rem] bg-arkw-bg-2">
           <ApiCodeBlock />
+          <div className="absolute left-0 text-sm rounded-bl-[0.25rem] grid place-items-center rounded-br-[0.25rem] bottom-0 w-full text-center text-arkw-el-3 bg-arkw-bg-13 h-10 py-1 px-4">
+            Code block to use in your app
+          </div>
         </div>
         <RunButtonContainer />
-        <div className="flex-1 p-2  border-[0.5px] border-arkw-border-1 rounded-[0.25rem] bg-arkw-bg-2">Api Result</div>
+        <ApiResultContainer />
       </div>
     </div>
   );

--- a/packages/admin/src/app/(dashboard)/playground/components/api/api-result-container.tsx
+++ b/packages/admin/src/app/(dashboard)/playground/components/api/api-result-container.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useActionPlaygroundContext } from '@/domains/playground/providers/action-playground-provider';
+
+export function ApiResultContainer() {
+  const { apiRunState } = useActionPlaygroundContext();
+  return (
+    <div
+      id="api-result-container"
+      className="flex-1 relative z-20 border-[0.5px] border-arkw-border-1 rounded-[0.25rem] bg-arkw-bg-2"
+    >
+      <div className="absolute text-sm rounded-tl-[0.25rem] grid place-items-center rounded-tr-[0.25rem] top-0 w-full text-center text-arkw-el-3 bg-arkw-bg-13 h-10 py-1 px-4">
+        This is the Output
+      </div>
+      <div className="p-2">
+        {apiRunState === 'success' ? (
+          <p>Api Run Successfully</p>
+        ) : apiRunState === 'fail' ? (
+          <p>Api failed to run</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/app/(dashboard)/playground/components/api/run-button-container.tsx
+++ b/packages/admin/src/app/(dashboard)/playground/components/api/run-button-container.tsx
@@ -16,7 +16,7 @@ export function RunButtonContainer() {
   }, []);
 
   return (
-    <div className="p-2 rounded-xl mx-auto border-arkw-border-2 border-[0.5px] w-fit">
+    <div className="p-2 rounded-xl relative run-button-container mx-auto border-arkw-border-2 border-[0.5px] w-fit">
       <span
         className="bg-[#33616B] h-10 relative justify-center flex items-center gap-1 border-[0.5px] border-[#5699A8] rounded text-sm font-medium text-arkw-el-5 w-[10.25rem] py-2 px-3"
         id="button-container"

--- a/packages/admin/src/app/(dashboard)/playground/components/run-button.tsx
+++ b/packages/admin/src/app/(dashboard)/playground/components/run-button.tsx
@@ -1,18 +1,36 @@
 'use client';
 
+import { Button } from '@/components/ui/button';
+
 import { Icon } from '@/app/components/icon';
 
-function RunApiOrEvent({ context, onClick }: { context: 'api' | 'event'; onClick?: () => void }) {
+function RunApiOrEvent({
+  context,
+  onClick,
+  apiIsRunning,
+}: {
+  context: 'api' | 'event';
+  onClick?: () => void;
+  apiIsRunning?: boolean;
+}) {
   return (
-    <button
+    <Button
+      variant={'ghost'}
       onClick={onClick}
+      disabled={apiIsRunning}
       className="justify-center bg-[#33616B] absolute inset-0 rounded flex items-center gap-1 text-sm font-medium text-arkw-el-5"
     >
       <Icon name="activity" />
-      <span>
-        Run <span className="capitalize">{context}</span>
-      </span>
-    </button>
+      {apiIsRunning ? (
+        <span>
+          Running <span className="capitalize">{context}...</span>
+        </span>
+      ) : (
+        <span>
+          Run <span className="capitalize">{context}</span>
+        </span>
+      )}
+    </Button>
   );
 }
 

--- a/packages/admin/src/app/globals.css
+++ b/packages/admin/src/app/globals.css
@@ -300,3 +300,27 @@ pre.shiki {
   mix-blend-mode: lighten;
   opacity: 0.7;
 }
+
+.run-button-container {
+  &::before {
+    content: '';
+    position: absolute;
+    width: 1px;
+    height: 34px;
+    top: -34px;
+    z-index: 1;
+    left: 50%;
+    background-color: #424242;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -34px;
+    width: 1px;
+    height: 34px;
+    left: 50%;
+    z-index: 1;
+    background-color: #424242;
+  }
+}

--- a/packages/admin/src/domains/playground/components/api-code-block.tsx
+++ b/packages/admin/src/domains/playground/components/api-code-block.tsx
@@ -57,20 +57,26 @@ function ApiCodeBlock() {
   }, [selectedAction, selectedActionPlugin, payload, arkwReferenceId]);
 
   return selectedAction ? (
-    <div className="h-full relative group grid place-items-center max-w-full overflow-auto">
+    <section className="group max-h-[27rem] overflow-scroll">
       <CopyButton
         snippet={snippet}
         classname="absolute z-40 top-4 right-4 w-8 h-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150 ease-in-out"
       />
-      <div
-        className="-left-6 -top-4 api absolute"
-        dangerouslySetInnerHTML={{
-          __html: codeBlock || '',
-        }}
-      />
-    </div>
+      <CodeSnippet codeBlock={codeBlock as string} />
+    </section>
   ) : (
     <></>
+  );
+}
+
+function CodeSnippet({ codeBlock }: { codeBlock?: string }) {
+  return (
+    <div
+      className="api"
+      dangerouslySetInnerHTML={{
+        __html: codeBlock || '',
+      }}
+    />
   );
 }
 

--- a/packages/admin/src/domains/playground/providers/action-playground-provider.tsx
+++ b/packages/admin/src/domains/playground/providers/action-playground-provider.tsx
@@ -5,11 +5,14 @@ import React, { createContext, useContext, useMemo, useState } from 'react';
 
 import { getParsedFrameworkActions } from '@/domains/workflows/utils';
 
+type ApirunState = 'idle' | 'loading' | 'success' | 'fail';
+
 export interface ActionPlaygroundContextProps {
   frameworkActions: RefinedIntegrationApi[];
   selectedAction: RefinedIntegrationApi | undefined;
   setSelectedAction: React.Dispatch<React.SetStateAction<RefinedIntegrationApi | undefined>>;
-
+  apiRunState: ApirunState;
+  setApiRunState: React.Dispatch<React.SetStateAction<ApirunState>>;
   buttonContainer: HTMLDivElement | null;
   setButtonContainer: React.Dispatch<React.SetStateAction<HTMLDivElement | null>>;
   payload: Record<string, any>;
@@ -45,11 +48,15 @@ export const ActionPlaygroundProvider = ({
   const [payload, setPayload] = useState<Record<string, any>>({});
   const [arkwReferenceId, setArkwReferenceId] = useState('');
 
+  const [apiRunState, setApiRunState] = useState<ApirunState>('idle');
+
   const contextValue = useMemo(() => {
     return {
       selectedAction,
       buttonContainer,
       setButtonContainer,
+      apiRunState,
+      setApiRunState,
       frameworkActions,
       setSelectedAction,
       payload,
@@ -57,7 +64,7 @@ export const ActionPlaygroundProvider = ({
       arkwReferenceId,
       setArkwReferenceId,
     };
-  }, [selectedAction, buttonContainer, frameworkActions, payload, arkwReferenceId]);
+  }, [selectedAction, buttonContainer, apiRunState, frameworkActions, payload, arkwReferenceId]);
 
   return <ActionPlaygroundContext.Provider value={contextValue}>{children}</ActionPlaygroundContext.Provider>;
 };

--- a/packages/admin/src/domains/workflows/components/utils/render-header.tsx
+++ b/packages/admin/src/domains/workflows/components/utils/render-header.tsx
@@ -48,7 +48,12 @@ function BlockHeader({
   classname,
 }: BlockHeaderProps) {
   return (
-    <div className={cn('border-arkw-border-1 flex flex-row items-center gap-3 border-b-[0.3px] p-6', classname)}>
+    <div
+      className={cn(
+        'border-arkw-border-1 flex rounded-t-[0.375rem] items-center gap-3 border-b-[0.3px] p-6',
+        classname,
+      )}
+    >
       <div className="flex gap-3 items-center">
         {category === 'path' ? (
           <>

--- a/packages/admin/src/domains/workflows/components/workflow-sidebar/config-forms/multi-select.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-sidebar/config-forms/multi-select.tsx
@@ -95,14 +95,14 @@ function MultiSelect({
       addNewFromSearchValueButtonAction={addNewValue}
       emptyMessage={`No options found.`}
     >
-      <div className="flex w-full flex-col gap-2">
+      <div className="w-full">
         {!selectedValues.length ? (
           <Button
             type="button"
             role="combobox"
             variant={'outline'}
             className={cn(
-              'ring-white/[0.05] bg-transparent text-text-dim h-8 justify-between text-[0.75rem] ring-[0.5px]',
+              'ring-white/[0.05] w-full bg-transparent text-text-dim h-8 justify-between text-[0.75rem] ring-[0.5px]',
             )}
           >
             Add {lodashTitleCase(field.name.split('.').pop() || '')}

--- a/packages/admin/src/domains/workflows/schema.tsx
+++ b/packages/admin/src/domains/workflows/schema.tsx
@@ -122,11 +122,11 @@ export function schemaToFormFieldRenderer<T extends ZodSchema>({
     : (schemaOptions?.options as { label: string; value: string }[]) || fieldConfig.options;
 
   return (
-    <div key={schemaField} className="flex flex-col gap-3">
+    <div key={schemaField} className="flex flex-col gap-1">
       {renderLabel ? (
         renderLabel({ isOptional: Boolean(fieldConfig.isOptional), schemaField })
       ) : (
-        <Label className="flex gap-1 capitalize" htmlFor={schemaField} aria-required={!fieldConfig.isOptional}>
+        <Label className="flex gap-0.5 capitalize" htmlFor={schemaField} aria-required={!fieldConfig.isOptional}>
           {!fieldConfig?.isOptional && <span className="text-red-500">*</span>}
           <Text variant="secondary" className="text-arkw-el-3" size="xs">
             {lodashTitleCase(schemaField.split('.').pop() || '')}


### PR DESCRIPTION
This PR does the ff:

1. handle loading state of running api
2. add descriptive block o code block and result section
<img width="1491" alt="Screenshot 2024-09-08 at 13 03 58" src="https://github.com/user-attachments/assets/10df86cf-9206-4593-bea9-24667147dd51">
