### PR TITLE
stop polling data when sync is done

### DIFF
--- a/packages/admin/src/domains/onboarding/actions/index.ts
+++ b/packages/admin/src/domains/onboarding/actions/index.ts
@@ -1,6 +1,34 @@
 'use server';
 
+import { Entity } from '@kpl/core';
+
 import { framework } from '@/lib/framework-utils';
+
+export const getEntities = async ({
+  integrationName,
+  connectionId,
+}: {
+  integrationName: string;
+  connectionId: string;
+}) => {
+  const integration = framework?.getIntegration(String(integrationName).toUpperCase());
+  const entityTypes = integration?.entityTypes || {};
+  const entities: Entity[] = [];
+
+  await Promise.all(
+    Object.keys(entityTypes).map(async entityType => {
+      const entity = await framework?.dataLayer.getEntityByConnectionAndType({
+        connectionId,
+        type: entityType,
+      });
+      if (entity) {
+        entities.push(entity);
+      }
+    }),
+  );
+
+  return entities;
+};
 
 export const getSyncedData = async ({
   referenceId,
@@ -32,7 +60,6 @@ export const getSyncedData = async ({
         records: true,
       },
     });
-
     recordCount?.reduce((acc, entity) => {
       acc[entity.type] = entity.records.length;
       return acc;
@@ -40,7 +67,54 @@ export const getSyncedData = async ({
   }
 
   return {
+    connectionId,
     entityTypes,
     entityToRecordCountMap,
   };
+};
+
+export const getSyncedDataByEntity = async ({
+  referenceId,
+  integrationName,
+  entityType,
+}: {
+  referenceId: string;
+  integrationName: string;
+  entityType: string;
+}) => {
+  let connectionId: string | undefined;
+  let recordCount: number | null = null;
+  let lastSyncId: string | null = null;
+  if (referenceId) {
+    const connection = await framework?.dataLayer.getConnectionByReferenceId({
+      referenceId,
+      name: String(integrationName.toUpperCase()),
+    });
+    connectionId = connection?.id;
+  }
+
+  if (connectionId) {
+    const entity = await framework?.dataLayer.getEntityRecordsByConnectionAndType({
+      connectionId,
+      type: entityType,
+    });
+    recordCount = entity?.records.length || 0;
+
+    if (entity?.lastSyncId) {
+      lastSyncId = entity.lastSyncId;
+    }
+  }
+
+  return {
+    recordCount,
+    lastSyncId,
+  };
+};
+
+export const watchEntityTypeStatusAction = async ({ lastSyncId }: { lastSyncId: string }) => {
+  const event = await framework?.watchEvent({
+    id: lastSyncId,
+  });
+
+  return event?.status;
 };

--- a/packages/admin/src/domains/onboarding/components/entity-synced.tsx
+++ b/packages/admin/src/domains/onboarding/components/entity-synced.tsx
@@ -1,0 +1,81 @@
+import { startCase } from 'lodash';
+import React from 'react';
+
+import { Icon } from '@/app/components/icon';
+import NumberAnimator from '@/app/components/number-animator';
+import { IconName } from '@/types/icons';
+
+import { getSyncedDataByEntity, watchEntityTypeStatusAction } from '../actions';
+
+interface EntitySyncedProps {
+  iconName: IconName;
+  referenceId: string | undefined;
+  integrationName: string;
+  label: string;
+  defaultCount: number;
+  canAddLetterS: boolean;
+  entityType: string;
+}
+
+export const EntitySynced = ({
+  iconName,
+  integrationName,
+  referenceId,
+  label,
+  defaultCount,
+  canAddLetterS,
+  entityType,
+}: EntitySyncedProps) => {
+  const [count, setCount] = React.useState(defaultCount);
+
+  React.useEffect(() => {
+    let timeOutId: NodeJS.Timeout;
+    try {
+      const pollForUpdate = async () => {
+        if (referenceId && entityType !== 'ACTION') {
+          const { lastSyncId, recordCount } = await getSyncedDataByEntity({
+            referenceId,
+            entityType,
+            integrationName,
+          });
+
+          if (!lastSyncId) {
+            return pollForUpdate();
+          }
+
+          const status = await watchEntityTypeStatusAction({
+            lastSyncId,
+          });
+
+          if (status !== 'Completed') {
+            pollForUpdate();
+          }
+
+          if (recordCount) {
+            setCount(recordCount);
+          }
+        }
+      };
+
+      timeOutId = setTimeout(pollForUpdate, 1000);
+    } catch (err) {}
+
+    return () => {
+      if (timeOutId) {
+        clearTimeout(timeOutId);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="flex gap-2.5">
+      <div className="flex items-center text-kpl-el-3 bg-[#5F783E]/10 rounded-[3px] w-10 h-10 justify-center ">
+        <Icon name={iconName} width={14} height={14} />
+      </div>
+      <span className="h-10 px-4 flex text-kpl-el-5 text-[13px] font-medium items-center bg-gradient-radial">
+        <NumberAnimator value={count} /> &nbsp;{startCase(label)}
+        {canAddLetterS ? 's' : ''}
+      </span>
+    </div>
+  );
+};

--- a/packages/admin/src/domains/onboarding/components/synced-data.tsx
+++ b/packages/admin/src/domains/onboarding/components/synced-data.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { startCase, throttle } from 'lodash';
 import React from 'react';
 
-import { Icon } from '@/app/components/icon';
-import NumberAnimator from '@/app/components/number-animator';
-
-import { getSyncedData } from '../actions';
 import { SyncedDataItem } from '../types';
+
+import { EntitySynced } from './entity-synced';
 
 interface SyncedDataProps {
   referenceId: string | undefined;
@@ -16,59 +13,23 @@ interface SyncedDataProps {
 }
 
 export const SyncedData = ({ referenceId, integrationName, syncedData }: SyncedDataProps) => {
-  const [data, setData] = React.useState<SyncedDataItem[]>(syncedData);
-
-  React.useEffect(() => {
-    // TODO: watch to check if syncing is complete
-    const pollForUpdates = async () => {
-      if (!referenceId) return;
-
-      const { entityToRecordCountMap } = await getSyncedData({
-        referenceId,
-        integrationName,
-      });
-
-      setData(prevData =>
-        prevData.map(item => {
-          const count = entityToRecordCountMap[item.type];
-          if (count) {
-            return {
-              ...item,
-              count,
-            };
-          }
-          return item;
-        }),
-      );
-    };
-
-    // Throttle the polling function to ensure it doesn't run more frequently than every 5 seconds
-    const throttledPollForUpdates = throttle(pollForUpdates, 5000);
-
-    const intervalId = setInterval(throttledPollForUpdates, 3000);
-
-    return () => {
-      clearInterval(intervalId);
-      throttledPollForUpdates.cancel();
-    };
-  }, [referenceId, integrationName]);
-
   return (
     <div>
       <h4 className="uppercase text-kpl-el-2 text-xs">You&rsquo;ve just synced</h4>
       <div className="space-y-2 mt-3">
-        {data.map(item => {
-          const canAddS = item.count > 1 && item.label[item.label.length - 1].toLowerCase() !== 's';
+        {syncedData.map((item, index) => {
+          const canAddLetterS = item.count > 1 && item.label[item.label.length - 1].toLowerCase() !== 's';
           return (
-            <div className="flex gap-2.5" key={item.label}>
-              <div className="flex items-center text-kpl-el-3 bg-[#5F783E]/10 rounded-[3px] w-10 h-10 justify-center ">
-                <Icon name={item.icon} width={14} height={14} />
-              </div>
-              <span className="h-10 px-4 flex text-kpl-el-5 text-[13px] font-medium items-center bg-gradient-radial">
-                <NumberAnimator value={item.count} /> &nbsp;{startCase(item.label)}
-                {canAddS ? 's' : ''}
-              </span>
-            </div>
+            <EntitySynced
+              key={index}
+              integrationName={integrationName}
+              referenceId={referenceId}
+              iconName={item.icon}
+              defaultCount={item.count}
+              label={item.label}
+              entityType={item.type}
+              canAddLetterS={canAddLetterS}
+            />
           );
         })}
       </div>

--- a/packages/core/src/framework.ts
+++ b/packages/core/src/framework.ts
@@ -399,7 +399,7 @@ export class Framework<C extends Config = Config> {
             return null;
           }
 
-          const lastRun = data?.data?.at?.(0);
+          const lastRun = data?.[0];
 
           if (!lastRun) {
             return null;


### PR DESCRIPTION
We were previously syncing data every 3 seconds. This PR makes sure we don't do that, when the sync is completely done.