### PR TITLE
Taofeeq/futr 450 workflow actions sidebar is too long

### DIFF
--- a/packages/admin/src/domains/workflows/components/utils/add-next-step.tsx
+++ b/packages/admin/src/domains/workflows/components/utils/add-next-step.tsx
@@ -19,16 +19,16 @@ export function AddNextStep({ onAddNextStep }: AddNextStepProps) {
     <button
       onClick={onAddNextStep}
       className={cn(blockStyles.default, 'bg-transparent flex w-full min-w-[274px] gap-[10px] !border-dashed p-[10px]')}
-      title="New action"
+      title="New API"
     >
       <div className={cn('flex gap-[6px] rounded-sm bg-[#2C2C2C] p-2')}>
         <Icon name="enrich" className="text-kpl-el-4" />
         <Text size="xs" className="text-kpl-el-4" weight="medium">
-          Action
+          API
         </Text>
       </div>
       <Text className="text-kpl-el-3 max-w-[120px] text-left text-[10px]">
-        Add another event that continues your workflow
+        Add another API that continues your workflow
       </Text>
     </button>
   );

--- a/packages/admin/src/domains/workflows/components/workflow-graph/new-workflow-action.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-graph/new-workflow-action.tsx
@@ -42,17 +42,15 @@ export function NewWorkflowActionBlock() {
             'border-kpl-border-5': selectedBlock?.type === 'action',
           },
         )}
-        title="New action"
+        title="New API"
       >
         <div className={cn('flex gap-[6px] rounded-sm bg-[#2C2C2C] p-2')}>
           <Icon name="enrich" className="text-kpl-el-4" />
           <Text size="xs" className="text-kpl-el-4" weight="medium">
-            Action
+            API
           </Text>
         </div>
-        <Text className="text-kpl-el-3 max-w-[120px] text-left text-[10px]">
-          Select event to continue your workflow
-        </Text>
+        <Text className="text-kpl-el-3 max-w-[120px] text-left text-[10px]">Select API to continue your workflow</Text>
       </button>
     </>
   );

--- a/packages/admin/src/domains/workflows/components/workflow-graph/workflow-event.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-graph/workflow-event.tsx
@@ -48,7 +48,7 @@ export function TriggerBlock({ trigger }: { trigger: WorkflowTrigger }) {
               'border-kpl-border-5': selectedBlock?.type === 'trigger',
             },
           )}
-          title="New action"
+          title="Trigger"
         >
           <div className={cn('flex gap-[6px] rounded-sm bg-[#2C2C2C] p-2')}>
             <Icon name="enrich" className="text-kpl-el-4" />

--- a/packages/admin/src/domains/workflows/components/workflow-graph/workflow-node.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-graph/workflow-node.tsx
@@ -48,16 +48,16 @@ export function ActionNode({ action, handleActionClick }: { handleActionClick: (
                   'border-kpl-border-5': selectedBlock?.block?.id === action?.id,
                 },
               )}
-              title="New action"
+              title="New API"
             >
               <div className={cn('flex gap-[6px] rounded-sm bg-[#2C2C2C] p-2')}>
                 <Icon name="enrich" className="text-kpl-el-4" />
                 <Text size="xs" className="text-kpl-el-4" weight="medium">
-                  Action
+                  API
                 </Text>
               </div>
               <Text className="text-kpl-el-3 max-w-[120px] text-left text-[10px]">
-                Select event to continue your workflow
+                Select API to continue your workflow
               </Text>
             </button>
           </ContextMenuTrigger>

--- a/packages/admin/src/domains/workflows/components/workflow-sidebar/workflow-sidebar-action.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-sidebar/workflow-sidebar-action.tsx
@@ -128,14 +128,18 @@ export function WorkflowSidebarAction({ action, blueprintId }: WorkflowSidebarAc
             {Object.entries(groupByIntegrationName).map(([integrationName, actionList]) => (
               <div key={integrationName} className="space-y-2">
                 <p className="text-xs">{lodashTitleCase(integrationName)} Actions</p>
-                {actionList.map(actionItem => (
-                  <ActionSelector
-                    key={actionItem.type}
-                    isSelected={actionToEdit?.type === actionItem.type}
-                    type={actionItem.type}
-                    onSelectActionEvent={handleCreateAction}
-                  />
-                ))}
+                <div className="space-y-2 max-h-96 overflow-scroll">
+                  <ScrollArea>
+                    {actionList.map(actionItem => (
+                      <ActionSelector
+                        key={actionItem.type}
+                        isSelected={actionToEdit?.type === actionItem.type}
+                        type={actionItem.type}
+                        onSelectActionEvent={handleCreateAction}
+                      />
+                    ))}
+                  </ScrollArea>
+                </div>
               </div>
             ))}
           </div>

--- a/packages/admin/src/domains/workflows/components/workflow-sidebar/workflow-sidebar-action.tsx
+++ b/packages/admin/src/domains/workflows/components/workflow-sidebar/workflow-sidebar-action.tsx
@@ -122,12 +122,12 @@ export function WorkflowSidebarAction({ action, blueprintId }: WorkflowSidebarAc
         <div className="border-kpl-border-1 flex flex-col gap-5 border-b-[0.3px] p-6">
           <div className="mb-5 space-y-1">
             <h1 className="text-xs">Actions</h1>
-            <p className="text-kpl-el-3 text-[11px]">Select an action</p>
+            <p className="text-kpl-el-3 text-[11px]">Select an API</p>
           </div>
           <div className="space-y-10">
             {Object.entries(groupByIntegrationName).map(([integrationName, actionList]) => (
               <div key={integrationName} className="space-y-2">
-                <p className="text-xs">{lodashTitleCase(integrationName)} Actions</p>
+                <p className="text-xs">{lodashTitleCase(integrationName)} APIs</p>
                 <div className="space-y-2 max-h-96 overflow-scroll">
                   <ScrollArea>
                     {actionList.map(actionItem => (


### PR DESCRIPTION
When user has integrations like Asana installed, the sidebar becomes very long because it has a lot of APIs. 
This was fixed by adding a max-height to each grouped APIs, and make it scrollable

Also renamed "Action" to "API" in workflows

<img width="437" alt="Screenshot 2024-09-19 at 3 24 49 PM" src="https://github.com/user-attachments/assets/b1b9e270-2671-4b50-b80b-cf2e29274638">
