### PR TITLE
fix: get framework to load and work with next 15

### DIFF
--- a/packages/admin/src/lib/framework-utils.ts
+++ b/packages/admin/src/lib/framework-utils.ts
@@ -19,11 +19,10 @@ async function loadConfig() {
 
 async function getFramework() {
   try {
-    await loadConfig();
-
-    const { config } = require('../../temp-mastra-config.ts');
+    const { config } = await import(process.env.CONFIG_PATH!);
 
     const framework = Mastra.init(config);
+
     return { framework, config };
   } catch (error) {
     console.error('Error loading config:', error);


### PR DESCRIPTION
fix for next15 breakin config import

you need to start the dev server with `pnpm start:dev`