### PR TITLE
fix structured output preview not correct

### DIFF
--- a/packages/cli/admin/src/app/(dashboard)/agents/create/page.tsx
+++ b/packages/cli/admin/src/app/(dashboard)/agents/create/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
           <h1 className="text-base">Create New Agent</h1>
         </div>
       </div>
-      <section className="grid flex-1 overflow-hidden gap-x-[0.62rem] grid-cols-[30rem_30rem]">
+      <section className="grid flex-1 overflow-hidden gap-x-[0.62rem] grid-cols-[31rem_31rem]">
         <AgentInfoForm />
         <ScrollArea className="flex-1">
           <div className="px-[1.31rem] pb-4 space-y-10 ">

--- a/packages/cli/admin/src/app/(dashboard)/agents/edit/[id]/page.tsx
+++ b/packages/cli/admin/src/app/(dashboard)/agents/edit/[id]/page.tsx
@@ -38,7 +38,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
           <h1 className="text-base">{agent.name}</h1>
         </div>
       </div>
-      <section className="grid flex-1 overflow-hidden gap-x-[0.62rem] grid-cols-[30rem_30rem]">
+      <section className="grid flex-1 overflow-hidden gap-x-[0.62rem] grid-cols-[31rem_31rem]">
         <AgentInfoForm />
         <ScrollArea className="flex-1">
           <div className="px-[1.31rem] pb-4 space-y-10 ">

--- a/packages/cli/admin/src/domains/agents/components/agent-structured-output-item.tsx
+++ b/packages/cli/admin/src/domains/agents/components/agent-structured-output-item.tsx
@@ -50,77 +50,80 @@ export const AgentStructuredOutputItem = ({
   };
 
   return (
-    <div className="space-y-2 flex gap-2 items-center">
-      {isLastStructuredOutput ? (
-        <IconButton
-          icon="plus-icon"
-          onClick={() => {
-            addNewKey();
-          }}
-          className="cursor-pointer px-0"
-          title="Add new output item"
-          size="sm"
-        />
-      ) : (
-        <div className="w-4"></div>
-      )}
-      <div className="flex items-center gap-2">
-        <Input
-          value={structuredOutput.name}
-          onChange={e => {
-            updateKeyName(e.target.value, structuredOutput.id);
-          }}
-          className="w-52"
-          placeholder="Enter item key"
-          customSize="sm"
-          autoCapitalize="off"
-          autoCorrect="off"
-          autoComplete="off"
-          type="text"
-        />
-
-        <Select
-          value={structuredOutput.type || ''}
-          onValueChange={value => {
-            updateKeyType(value as StructuredOutputType, structuredOutput.id);
-          }}
-        >
-          <SelectTrigger className="w-[150px]">
-            <SelectValue placeholder="Select a type" />
-          </SelectTrigger>
-          <SelectContent>
-            {[...structuredOutputTypes].map(item => (
-              <SelectItem key={item} value={item}>
-                {toTitleCase(item)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <IconButton
-          icon="trash"
-          onClick={() => {
-            removeKey(structuredOutput.id);
-          }}
-          className="cursor-pointer px-0 ml-2 text-mastra-el-3"
-          size="sm"
-        />
-
-        {childrenOutputs?.length ? (
+    <>
+      <div className="space-y-2 flex gap-2 items-center">
+        {isLastStructuredOutput ? (
           <IconButton
-            icon="down-caret"
+            icon="plus-icon"
             onClick={() => {
-              setCollapse(!collapse);
+              addNewKey();
             }}
-            className={cn('cursor-pointer px-0 transition-transform', collapse && 'rotate-180')}
+            className="cursor-pointer px-0"
+            title="Add new output item"
             size="sm"
           />
-        ) : null}
+        ) : (
+          <div className="w-4" />
+        )}
+        <div className="flex items-center gap-2">
+          <Input
+            value={structuredOutput.name}
+            onChange={e => {
+              updateKeyName(e.target.value, structuredOutput.id);
+            }}
+            className="w-52"
+            placeholder="Enter item key"
+            customSize="sm"
+            autoCapitalize="off"
+            autoCorrect="off"
+            autoComplete="off"
+            type="text"
+          />
+
+          <Select
+            value={structuredOutput.type || ''}
+            onValueChange={value => {
+              updateKeyType(value as StructuredOutputType, structuredOutput.id);
+            }}
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue placeholder="Select a type" />
+            </SelectTrigger>
+            <SelectContent>
+              {[...structuredOutputTypes].map(item => (
+                <SelectItem key={item} value={item}>
+                  {toTitleCase(item)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <IconButton
+            icon="trash"
+            onClick={() => {
+              removeKey(structuredOutput.id);
+            }}
+            className="cursor-pointer px-0 ml-2 text-mastra-el-3"
+            size="sm"
+          />
+
+          {childrenOutputs?.length || structuredOutput.type === 'array' ? (
+            <IconButton
+              icon="down-caret"
+              onClick={() => {
+                setCollapse(!collapse);
+              }}
+              className={cn('cursor-pointer px-0 transition-transform', collapse && 'rotate-180')}
+              size="sm"
+            />
+          ) : null}
+        </div>
       </div>
       {collapse ? null : (
         <div className="space-y-2">
           {structuredOutput.type === 'array' ? (
             <div className="flex items-center gap-2">
+              <div className="w-4" />
               <p className="text-xs w-52 text-right pr-2 text-mastra-el-6/80 italic">Array item type</p>
               <Select
                 value={structuredOutput.arrayItemType || ''}
@@ -143,6 +146,7 @@ export const AgentStructuredOutputItem = ({
           ) : null}
           {childrenOutputs?.map((chOutput, chIndex) => (
             <div className="flex items-center gap-2" key={chOutput.id}>
+              <div className="w-3" />
               <div className="w-1 h-1 rounded-full bg-white ml-2" />
               <Input
                 value={chOutput.name}
@@ -177,7 +181,7 @@ export const AgentStructuredOutputItem = ({
                 onClick={() => {
                   removeChildKey(chOutput.id);
                 }}
-                className="cursor-pointer px-0"
+                className="cursor-pointer px-0 ml-2 text-mastra-el-3"
                 size="sm"
               />
 
@@ -196,6 +200,6 @@ export const AgentStructuredOutputItem = ({
           ))}
         </div>
       )}
-    </div>
+    </>
   );
 };

--- a/packages/cli/admin/src/domains/agents/utils.ts
+++ b/packages/cli/admin/src/domains/agents/utils.ts
@@ -139,5 +139,7 @@ export const constructStrucuturedOutputArr = (structuredResponse: StructuredResp
     recurseDip(structuredResponse);
   }
 
+  console.log({ structuredOutput, childrenOutput });
+
   return { structuredOutput, childrenOutput };
 };


### PR DESCRIPTION
for this JSON:
```
{
	"question": {
		"type": "string"
	},
	"answer": {
		"type": "string"
	},
	"athletes": {
		"type": "array",
		"items" : {
			"type": "string"
		}
	}
}
```

previous view, not showing the array item type:
<img width="444" alt="Screenshot 2024-11-13 at 2 08 52 PM" src="https://github.com/user-attachments/assets/ccff2a3d-c336-4c3b-9273-f62a49e2d301">

correct view, showing the array item type:
<img width="444" alt="Screenshot 2024-11-13 at 2 08 02 PM" src="https://github.com/user-attachments/assets/70ad8a56-1d00-45a4-9aab-c7ee9486207e">







