### PR TITLE
Kenny/futr 761 fix syntax highlighting of code block in docs

### DIFF
--- a/docs/src/pages/guide/how-to/01-creating-agents.mdx
+++ b/docs/src/pages/guide/how-to/01-creating-agents.mdx
@@ -6,18 +6,17 @@ Agents can interact with your data and perform tasks. When using Mastra, an agen
 
 Mastra agents [are configured in your `mastra.config.ts` file](../reference/mastra-config.mdx#agent-configuration-reference) or through the Mastra Admin UI.
 
-```typescript:mastra.config.ts
+```ts filename="mastra.config.ts"
 export const config: Config = {
   ...mastraConfig,
   agents: {
     agentDirPath: '/mastra/agents',
-    ...
   }
 }
 ```
 
-{/*
-```typescript:mastra/agents/gmail-manager.ts
+{/* 
+```typescript
 import { Agent } from "mastra";
 
 export const agent = new Agent({
@@ -37,11 +36,9 @@ export const agent = new Agent({
     "gmailUsersMessagesList": true,
     "chatPostMessage": true
   }
-})
-```
-*/}
+})*/}
 
-```json:mastra/agents/gmail-manager.json
+```json filename="gmail-manager.json"
 {
   "id": "asst_gmail_manager",
   "name": "gmail-manager",
@@ -75,13 +72,11 @@ Good agent instructions should be specific, contextual, and include clear constr
 
 Agents can be equipped with different types of tools:
 
-* functions you write
-* APIs from integrations you install
-* [knowledge sources](./building-knowledge-sources.mdx) you create
-* [workflows](./building-workflows.mdx) you create
+- functions you write
+- APIs from integrations you install
+- [knowledge sources](./building-knowledge-sources.mdx) you create
+- [workflows](./building-workflows.mdx) you create
 
 ## Using the Admin Console
 
 TKTK
-
-

--- a/docs/src/pages/guide/how-to/02-building-workflows.mdx
+++ b/docs/src/pages/guide/how-to/02-building-workflows.mdx
@@ -12,7 +12,7 @@ Workflows provide a way to structure your code to handle these cases. Workflows 
 
 The initial `mastra init` command creates a `blueprints` directory in your project and links it in your `mastra.config.ts` file.
 
-```typescript:mastra.config.ts
+```ts filename="mastra.config.ts"
 export const config: Config = {
   ...mastraConfig,
   workflows: {
@@ -24,7 +24,7 @@ export const config: Config = {
 
 In a file in your `blueprints` directory, you can create a new workflow by adding the following code:
 
-```json:mastra/blueprints/get-mathematicians.json
+```json filename="get-mathematicians.json"
 {
   "title": "Get Mathematicians",
   "status": "PUBLISHED",

--- a/docs/src/pages/guide/how-to/04-logging-and-telemetry.mdx
+++ b/docs/src/pages/guide/how-to/04-logging-and-telemetry.mdx
@@ -14,7 +14,7 @@ TKTK
 
 To send logs to an external service, you can configure a log drain in your `mastra.config.ts` file. Currently, we support [Upstash](https://upstash.com/).
 
-```typescript:mastra.config.ts
+```ts filename="mastra.config.ts"
 export const config: Config = {
   ...mastraConfig,
   logs: {
@@ -31,7 +31,7 @@ export const config: Config = {
 
 Mastra emits tracing data using the OpenTelemetry Node.js SDK and following the OpenTelemetry standard. You can view in a variety of tools (Datadog, Honeycomb, etc.). You can add attributes to the `telemetry` section in your `mastra.config.ts` file.
 
-```typescript:mastra.config.ts
+```ts filename="mastra.config.ts"
 export const config: Config = {
   ...mastraConfig,
   telemetry: {

--- a/docs/src/pages/guide/how-to/06-adding-integrations.mdx
+++ b/docs/src/pages/guide/how-to/06-adding-integrations.mdx
@@ -26,7 +26,7 @@ For example, for Google Calendar, you'd run:
 
 Then, import it into your `mastra-config.ts` file:
 
-```ts
+```ts filename="mastra.config.ts"
 import { GoogleCalendarIntegration } from '@mastra/google-calendar';
 
 // rest of config
@@ -52,7 +52,8 @@ To get a connection from an integration, you need to call `getApiClient` on the 
 
 You can then use the client to query the third-party API.
 
-```ts
+```ts filename="index.ts"
+// Server componenet
 import { Mastra } from '@mastra/core';
 
 import { config } from '../../mastra.config';

--- a/docs/src/pages/guide/reference/mastra-config.mdx
+++ b/docs/src/pages/guide/reference/mastra-config.mdx
@@ -60,7 +60,7 @@ interface VectorProvider {
 - `vectorProvider[].dirPath`: Custom path for provider-specific configurations
 
 ### Example
-```typescript
+```ts filename="mastra.config.ts"
 export const config: Config = {
   agents: {
     agentDirPath: '/mastra-agents',

--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -5,7 +5,7 @@ import { PropertiesTable } from './src/components/properties-table';
 
 const logo = (
   <svg width="119" height="36" viewBox="0 0 119 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="18.0002" cy="18.0002" r="15.2365" stroke="currentColor" stroke-width="1.25409" />
+    <circle cx="18.0002" cy="18.0002" r="15.2365" stroke="currentColor" strokeWidth="1.25409" />
     <ellipse
       cx="18.0008"
       cy="18"
@@ -13,14 +13,14 @@ const logo = (
       ry="10.2193"
       transform="rotate(45 18.0008 18)"
       stroke="currentColor"
-      stroke-width="1.25409"
+      strokeWidth="1.25409"
     />
-    <path d="M11.7793 18.0547H24.3007" stroke="currentColor" stroke-width="1.25409" />
-    <path d="M14.8574 21.2354L21.2192 14.8736" stroke="currentColor" stroke-width="1.25409" />
-    <path d="M21.2207 21.2354L14.8589 14.8736" stroke="currentColor" stroke-width="1.25409" />
+    <path d="M11.7793 18.0547H24.3007" stroke="currentColor" strokeWidth="1.25409" />
+    <path d="M14.8574 21.2354L21.2192 14.8736" stroke="currentColor" strokeWidth="1.25409" />
+    <path d="M21.2207 21.2354L14.8589 14.8736" stroke="currentColor" strokeWidth="1.25409" />
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M7.57571 11.2943C4.93105 13.0681 3.39081 15.4508 3.39081 17.9997C3.39081 20.5486 4.93105 22.9313 7.57571 24.7051C10.2163 26.4762 13.9001 27.592 18.0003 27.592C22.1004 27.592 25.7842 26.4762 28.4248 24.7051C31.0695 22.9313 32.6097 20.5486 32.6097 17.9997C32.6097 15.4508 31.0695 13.0681 28.4248 11.2943C25.7842 9.5232 22.1004 8.40741 18.0003 8.40741C13.9001 8.40741 10.2163 9.5232 7.57571 11.2943ZM6.87715 10.2528C9.75106 8.32521 13.6855 7.15332 18.0003 7.15332C22.315 7.15332 26.2495 8.32521 29.1234 10.2528C31.9932 12.1776 33.8638 14.9046 33.8638 17.9997C33.8638 21.0948 31.9932 23.8218 29.1234 25.7466C26.2495 27.6742 22.315 28.8461 18.0003 28.8461C13.6855 28.8461 9.75106 27.6742 6.87715 25.7466C4.00728 23.8218 2.13672 21.0948 2.13672 17.9997C2.13672 14.9046 4.00728 12.1776 6.87715 10.2528Z"
       fill="currentColor"
     />


### PR DESCRIPTION
Fix lack of syntax highlighting in parts of the docs

before:
![CleanShot 2024-11-13 at 16 50 15@2x](https://github.com/user-attachments/assets/ae604b52-ca99-4a1b-b9d6-24836697e993)

after:
![CleanShot 2024-11-13 at 16 49 49@2x](https://github.com/user-attachments/assets/a6e4bf5a-7f06-4d3a-b2ee-a2204b2294e6)
