### PR TITLE
docs: remove node-fetch import/ fix link to autoevals 

### DIFF
--- a/docs/src/pages/guide/how-to/02-adding-tools.mdx
+++ b/docs/src/pages/guide/how-to/02-adding-tools.mdx
@@ -9,7 +9,6 @@ Let's use a public API to get the last day's closing stock price for a given sym
 ```typescript filename="src/tools/index.ts"
 import { Agent, createTool } from '@mastra/core';
 import { z } from 'zod';
-import fetch from 'node-fetch';
 
 const getStockPrice = async (symbol) => {
   const data = await fetch(`https://mastra-stock-data.vercel.app/api/stock-data?symbol=${symbol}`).then(r => r.json());

--- a/docs/src/pages/guide/how-to/08-running-evals.mdx
+++ b/docs/src/pages/guide/how-to/08-running-evals.mdx
@@ -4,7 +4,7 @@ Evals are a way to evaluate the performance of your agents. They are essentially
 
 Evals suites run in the cloud, but as tests, it's logical to store them in your codebase.
 
-Mastra recommends using Braintrust's eval framework, [autoevals](https://github.com/braintrusthq/autoevals), to run evals. They have a free tier that should be enough for most use cases.
+Mastra recommends using Braintrust's eval framework, [autoevals](https://github.com/braintrustdata/autoevals), to run evals. They have a free tier that should be enough for most use cases.
 
 Other open-source eval frameworks:
 


### PR DESCRIPTION
- `fetch` as a global has been available since node 18, so let's not add this in the example
- fixed the link to autoevals 