### PR TITLE
Kenny/futr 780 create agent from cli

### DIFF
--- a/packages/cli/src/commands/agents/createNewAgent.ts
+++ b/packages/cli/src/commands/agents/createNewAgent.ts
@@ -1,0 +1,83 @@
+import chalk from 'chalk';
+import { ExecaError } from 'execa';
+import fs from 'fs';
+import inquirer from 'inquirer';
+import path from 'path';
+
+import { toCamelCase } from '../../utils.js';
+
+export async function createNewAgent() {
+  try {
+    const answers = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'name',
+        message: 'What is the name of your agent?',
+        validate: (input: string) => {
+          if (input.trim() === '') {
+            return 'Name cannot be empty';
+          }
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'instructions',
+        message: 'Provide a prompt for your agent:',
+        validate: (input: string) => {
+          if (input.trim() === '') {
+            return 'Prompt cannot be empty';
+          }
+          return true;
+        },
+      },
+    ]);
+
+    const agentCode = `
+export const ${toCamelCase(answers.name)} = new Agent({
+  name: "${toCamelCase(answers.name)}",
+  instructions: "${answers.instructions}",
+  model: {
+    provider: 'ANTHROPIC',
+    name: 'claude-3-5-sonnet-20240620',
+    toolChoice: 'auto',
+  },
+});
+`;
+
+    // Ensure the mastra/agents directory exists
+    const agentsDir = path.join(process.cwd(), 'src', 'mastra', 'agents');
+    if (!fs.existsSync(agentsDir)) {
+      fs.mkdirSync(agentsDir, { recursive: true });
+    }
+
+    const indexPath = path.join(agentsDir, 'agent.ts');
+
+    // If file doesn't exist, create it with initial content
+    if (!fs.existsSync(indexPath)) {
+      fs.writeFileSync(indexPath, '// Mastra Agents\n\n');
+    }
+
+    // Append the new agent to the file
+    fs.appendFileSync(indexPath, agentCode);
+
+    console.log(chalk.green(`\n✓ Agent: ${toCamelCase(answers.name)} created successfully!`));
+    console.log(chalk.blue(`To use: add the agent to index.ts file`));
+
+    return toCamelCase(answers.name);
+  } catch (error) {
+    if (error instanceof ExecaError) {
+      if (error.isCanceled) {
+        console.log(chalk.yellow('\nOperation cancelled'));
+        process.exit(0);
+      }
+    } else if (error instanceof Error && error.name === 'ExitPromptError') {
+      console.log(chalk.yellow('\nPrompt cancelled'));
+      process.exit(0);
+    } else if (error instanceof Error) {
+      console.error(chalk.red('Error creating agent:'), error.message);
+    } else {
+      console.error(chalk.red('Error creating agent:'), error);
+    }
+  }
+}

--- a/packages/cli/src/commands/agents/createNewAgent.ts
+++ b/packages/cli/src/commands/agents/createNewAgent.ts
@@ -62,8 +62,6 @@ export const ${toCamelCase(answers.name)} = new Agent({
     fs.appendFileSync(indexPath, agentCode);
 
     console.log(chalk.green(`\n✓ Agent: ${toCamelCase(answers.name)} created successfully!`));
-    console.log(chalk.blue(`To use: add the agent to index.ts file`));
-
     return toCamelCase(answers.name);
   } catch (error) {
     if (error instanceof ExecaError) {

--- a/packages/cli/src/commands/agents/listAgents.ts
+++ b/packages/cli/src/commands/agents/listAgents.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+
+import * as fs from 'fs/promises';
+
+export async function listAgents(): Promise<string[]> {
+  try {
+    const agentFilePath = path.join(process.cwd(), 'src', 'mastra', 'agents', 'agent.ts');
+
+    const fileContent = await fs.readFile(agentFilePath, 'utf-8');
+
+    const agentRegex = /export\s+const\s+(\w+)\s*=\s*new\s+Agent\s*\(\s*{\s*name:\s*["']([^"']+)["']/g;
+
+    const agentNames: string[] = [];
+    let match;
+
+    while ((match = agentRegex.exec(fileContent)) !== null) {
+      agentNames.push(match[2]);
+    }
+
+    return agentNames;
+  } catch (error) {
+    console.error('Error reading agent file:', error);
+    return [];
+  }
+}

--- a/packages/cli/src/commands/agents/updateAgentFile.ts
+++ b/packages/cli/src/commands/agents/updateAgentFile.ts
@@ -1,0 +1,57 @@
+import path from 'path';
+import prettier from 'prettier';
+
+import fs from 'fs/promises';
+
+export async function updateAgentIndexFile(newAgentName: string) {
+  const indexPath = path.join(process.cwd(), 'src', 'mastra', 'index.ts');
+
+  try {
+    const content = await fs.readFile(indexPath, 'utf-8');
+
+    const importMatch = content.match(/import\s*{([^}]+)}\s*from\s*'\.\/agents\/agent'/);
+    const existingAgents = importMatch
+      ? importMatch[1]
+          .split(',')
+          .map(a => a.trim())
+          .filter(a => a)
+      : [];
+
+    if (!existingAgents.includes(newAgentName)) {
+      existingAgents.push(newAgentName);
+    }
+
+    const newImport = `import { ${existingAgents.join(', ')} } from './agents/agent';`;
+
+    let updatedContent = importMatch
+      ? content.replace(/import\s*{[^}]+}\s*from\s*'\.\/agents\/agent';/, newImport)
+      : newImport + '\n' + content;
+
+    const agentsMatch = updatedContent.match(/agents:\s*\[(.*?)\]/);
+
+    if (agentsMatch) {
+      const currentAgents = agentsMatch[1]
+        .split(',')
+        .map(a => a.trim())
+        .filter(a => a);
+      if (!currentAgents.includes(newAgentName)) {
+        currentAgents.push(newAgentName);
+        const newAgentsArray = `agents: [${currentAgents.join(', ')}]`;
+        const updatedWithAgent = updatedContent.replace(/agents:\s*\[[^\]]+\]/, newAgentsArray);
+        updatedContent = updatedWithAgent;
+      }
+    }
+
+    const formattedContent = await prettier.format(updatedContent, {
+      parser: 'typescript',
+      singleQuote: true,
+    });
+
+    await fs.writeFile(indexPath, formattedContent);
+
+    return formattedContent;
+  } catch (err) {
+    console.error('Error updating index file:', err);
+    throw err;
+  }
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -66,10 +66,7 @@ import { Mastra, createLogger } from '@mastra/core';
 import { agentOne, agentTwo } from './agents/agent';
 
 export const mastra = new Mastra({
-  tools: {},
-  syncs: {},
   agents: [agentOne, agentTwo],
-  integrations: [],
   logger: createLogger({
     type: 'CONSOLE',
     level: 'INFO',
@@ -96,7 +93,7 @@ export const agentOne = new Agent({
   instructions: 'You know about basketball, specifically the NBA. You are a sports analyst.',
   model: {
     provider: 'ANTHROPIC',
-    name: 'claude-3-haiku-20240307',
+    name: 'claude-3-5-sonnet-20240620',
     toolChoice: 'auto',
   },
 });
@@ -107,7 +104,7 @@ export const agentTwo = new Agent({
   model: {
     provider: 'GROQ',
     name: 'llama3-groq-70b-8192-tool-use-preview',
-    toolChoice: 'required',
+    toolChoice: 'auto',
   },
 });
     `,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,9 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import figlet from 'figlet';
 
+import { createNewAgent } from './commands/agents/createNewAgent.js';
+import { listAgents } from './commands/agents/listAgents.js';
+import { updateAgentIndexFile } from './commands/agents/updateAgentFile.js';
 import { build, dev } from './commands/dev.js';
 import { generate } from './commands/generate.js';
 import { init } from './commands/init.js';
@@ -20,7 +23,6 @@ program
   .description(`mastra CLI ${version}`)
   .action(() => {
     console.log(chalk.bold(figlet.textSync('Mastra')));
-    console.log(`version: ${version}`);
   });
 
 program
@@ -81,6 +83,28 @@ engine
       console.error('Please add DB_URL to your .env file');
       console.info(`Run ${chalk.blueBright('Mastra engine up')} to get started with a pg db`);
     }
+  });
+
+const agent = program.command('agent').description('Manage the mastra agent');
+
+agent
+  .command('new')
+  .description('Create a new agent')
+  .action(async () => {
+    const result = await createNewAgent();
+    if (!result) return;
+    await updateAgentIndexFile(result);
+  });
+
+agent
+  .command('list')
+  .description('List all agents')
+  .action(async () => {
+    const agents = await listAgents();
+    console.log('Agents:');
+    agents.forEach((agent, index) => {
+      console.log(`${index + 1}. ${chalk.blueBright(agent)}`);
+    });
   });
 
 program.parse(process.argv);

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -146,3 +146,29 @@ export function sanitizeForDockerName(name: string): string {
 
   return sanitized;
 }
+
+export const toCamelCase = (str: string): string => {
+  // If string is already camelCase with no spaces, return as is
+  if (/^[a-z][a-zA-Z0-9]*$/.test(str) && !str.includes(' ')) {
+    return str;
+  }
+
+  return str
+    .split(' ')
+    .filter(word => word.length > 0)
+    .map((word, index) => {
+      // If word contains hyphen, return as is
+      if (word.includes('-')) {
+        return word;
+      }
+
+      // If word is already camelCase, preserve its case
+      if (/^[a-z][a-zA-Z0-9]*$/.test(word)) {
+        return index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1);
+      }
+
+      // Otherwise convert to camelCase
+      return index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.toLowerCase().slice(1);
+    })
+    .join('');
+};


### PR DESCRIPTION
We needed a way to boostrap agent quickly with the cli. this enables devs get up and running with little effort.

This PR introduces that change plus a `mastra agent list` command to see all available agents.

![CleanShot 2024-11-25 at 16 22 27@2x](https://github.com/user-attachments/assets/19787f53-acfc-44a6-9bb5-285e74ead744)
