### PR TITLE
bump core to 0.1.27-alpha.13

### DIFF
--- a/examples/vnext/src/app/actions.ts
+++ b/examples/vnext/src/app/actions.ts
@@ -57,3 +57,14 @@ export async function testStructuredOutput() {
 
   return recipe?.object;
 }
+
+export async function testSync() {
+  const syncResult = await mastra.sync('mySync', {
+    name: 'John Doe',
+    foo: 'bar',
+    createdAt: new Date(),
+  });
+
+  console.log({ syncResult });
+  return syncResult;
+}

--- a/examples/vnext/src/components/result.tsx
+++ b/examples/vnext/src/components/result.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { testStructuredOutput, testText } from '@/app/actions';
+import { testStructuredOutput, testSync, testText } from '@/app/actions';
 
 function testStream(messages: string[]) {
   return fetch('/api/chat', {
@@ -116,6 +116,13 @@ export default function Result() {
             <div key={index}>{message}</div>
           ))}
         </div>
+      </div>
+
+      <div>
+        <p>Test Sync {`-->`} check logs</p>
+        <button className="bg-blue-500 text-white p-2 rounded" onClick={async () => await testSync()}>
+          Test Sync
+        </button>
       </div>
     </>
   );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/core",
-  "version": "0.1.27-alpha.12",
+  "version": "0.1.27-unstable.1",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/core",
-  "version": "0.1.27-unstable.2",
+  "version": "0.1.27-alpha.13",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -55,7 +55,7 @@
     "xstate": "^5.19.0"
   },
   "peerDependencies": {
-    "zod": "^3.23.8"
+    "zod": "3.23.7"
   },
   "engines": {
     "node": ">=20"
@@ -87,6 +87,7 @@
     "husky": "^9.1.4",
     "jest": "^29.7.0",
     "size-limit": "^11.1.4",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.3",
     "typescript": "5.5.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/core",
-  "version": "0.1.27-unstable.1",
+  "version": "0.1.27-unstable.2",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -153,10 +153,16 @@ export class Mastra<
     params: TSyncs[K]['schema']['_input']
   ): Promise<StripUndefined<TSyncs[K]['outputShema']>['_input']> {
     if (!this.engine) {
+      throw new Error(`Engine is required to run syncs`);
+    }
+
+    const sync = this.syncs?.[key];
+
+    if (!sync) {
       throw new Error(`Sync function ${key as string} not found`);
     }
 
-    const syncFn = this.syncs?.[key]['executor'];
+    const syncFn = sync['executor'];
 
     if (!syncFn) {
       throw new Error(`Sync function ${key as string} not found`);


### PR DESCRIPTION
- **unstable core version**
- **test sync execution from vNext example**
- **new unstable core version**
- **Bump core alpha version -> 13**
