### PR TITLE
feat: Qdrant vector store support

### DIFF
--- a/.github/workflows/.publish.yaml
+++ b/.github/workflows/.publish.yaml
@@ -24,6 +24,10 @@ jobs:
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
+      qdrant:
+        image: qdrant/qdrant
+        ports:
+          - 6333:6333
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/src/pages/guide/how-to/04-knowledge-sources.mdx
+++ b/docs/src/pages/guide/how-to/04-knowledge-sources.mdx
@@ -84,6 +84,17 @@ await store.upsert({ vectors, metadata, namespace });
 const results = await store.query({ vector, limit, namespace });
 ```
 
+### Qdrant Storage
+
+```typescript
+import { QdrantVector } from '@mastra/rag';
+
+const store = new QdrantVector('http://localhost:6333/');
+
+await store.upsert({ vectors, metadata, namespace });
+const results = await store.query({ vector, limit, namespace });
+```
+
 ## Configuration
 
 Add vector store configuration to your Mastra config:

--- a/docs/src/pages/guide/reference/local-dev/mastra-class.mdx
+++ b/docs/src/pages/guide/reference/local-dev/mastra-class.mdx
@@ -36,7 +36,7 @@ The Mastra class is the core entry point for your application. It manages agents
     {
       name: 'vectors',
       type: 'Record<string, MastraVector>',
-      description: 'Vector store instance, used for semantic search and vector-based tools (eg Pinecone or PgVector)',
+      description: 'Vector store instance, used for semantic search and vector-based tools (eg Pinecone, PgVector or Qdrant)',
       isOptional: true
     },
     {

--- a/docs/src/pages/guide/reference/rag/qdrant.mdx
+++ b/docs/src/pages/guide/reference/rag/qdrant.mdx
@@ -1,0 +1,165 @@
+## Qdrant
+
+[Qdrant](http://qdrant.tech/) is a vector similarity search engine. It provides a production-ready service with a convenient API to store, search, and manage vectors with additional payload and extended filtering support.
+
+### Constructor Options
+
+<PropertiesTable
+  content={[
+    {
+      name: 'url',
+      type: 'string',
+      description: 'REST URL of the Qdrant instance. Eg. https://xyz-example.eu-central.aws.cloud.qdrant.io:6333',
+    },
+    {
+      name: 'apiKey',
+      type: 'string',
+      description: 'Optional Qdrant API key',
+    },
+    {
+      name: 'https',
+      type: 'boolean',
+      description: 'Whether to use TLS when setting up the connection. Recommended.',
+    },
+  ]}
+/>
+
+### Methods
+
+#### createIndex()
+
+<PropertiesTable
+  content={[
+    {
+      name: 'indexName',
+      type: 'string',
+      description: 'Name of the index to create',
+    },
+    {
+      name: 'dimension',
+      type: 'number',
+      description: 'Vector dimension size',
+    },
+    {
+      name: 'metric',
+      type: "'cosine' | 'euclidean' | 'dotproduct'",
+      isOptional: true,
+      defaultValue: 'cosine',
+      description: 'Distance metric for similarity search',
+    },
+  ]}
+/>
+
+#### upsert()
+
+<PropertiesTable
+  content={[
+    {
+      name: 'vectors',
+      type: 'number[][]',
+      description: 'Array of embedding vectors',
+    },
+    {
+      name: 'metadata',
+      type: 'Record<string, any>[]',
+      isOptional: true,
+      description: 'Metadata for each vector',
+    },
+    {
+      name: 'namespace',
+      type: 'string',
+      isOptional: true,
+      description: 'Optional namespace for organization',
+    },
+  ]}
+/>
+
+#### query()
+
+<PropertiesTable
+  content={[
+    {
+      name: 'vector',
+      type: 'number[]',
+      description: 'Query vector to find similar vectors',
+    },
+    {
+      name: 'topK',
+      type: 'number',
+      isOptional: true,
+      defaultValue: '10',
+      description: 'Number of results to return',
+    },
+    {
+      name: 'filter',
+      type: 'Record<string, any>',
+      isOptional: true,
+      description: 'Metadata filters for the query',
+    },
+  ]}
+/>
+
+#### listIndexes()
+
+Returns an array of index names as strings.
+
+#### describeIndex()
+
+<PropertiesTable
+  content={[
+    {
+      name: 'indexName',
+      type: 'string',
+      description: 'Name of the index to describe',
+    },
+  ]}
+/>
+
+Returns:
+
+```typescript
+interface IndexStats {
+  dimension: number;
+  count: number;
+  metric: 'cosine' | 'euclidean' | 'dotproduct';
+}
+```
+
+#### deleteIndex()
+
+<PropertiesTable
+  content={[
+    {
+      name: 'indexName',
+      type: 'string',
+      description: 'Name of the index to delete',
+    },
+  ]}
+/>
+
+### Response Types
+
+Query results are returned in this format:
+
+```typescript
+interface QueryResult {
+  id: string;
+  score: number;
+  metadata: Record<string, any>;
+}
+```
+
+### Error Handling
+
+The store throws typed errors that can be caught:
+
+```typescript
+try {
+  await store.query(queryVector);
+} catch (error) {
+  if (error instanceof VectorStoreError) {
+    console.log(error.code); // 'connection_failed' | 'invalid_dimension' | etc
+    console.log(error.details); // Additional error context
+  }
+}
+```

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -34,6 +34,7 @@
     "@mastra/core": "workspace:^",
     "@paralleldrive/cuid2": "^2.2.2",
     "@pinecone-database/pinecone": "^3.0.3",
+    "@qdrant/js-client-rest": "^1.12.0",
     "date-fns": "^4.1.0",
     "dotenv": "^16.3.1",
     "drizzle-orm": "^0.36.1",

--- a/packages/rag/src/index.ts
+++ b/packages/rag/src/index.ts
@@ -1,3 +1,4 @@
 export * from './document';
 export * from './pg';
 export * from './pinecone';
+export * from './qdrant';

--- a/packages/rag/src/qdrant/index.test.ts
+++ b/packages/rag/src/qdrant/index.test.ts
@@ -1,0 +1,119 @@
+// To setup a Qdrant server, run:
+// docker run -p 6333:6333 qdrant/qdrant
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+
+import { QdrantVector } from './index';
+
+describe('Qdrant Integration Tests', () => {
+  let qdrant: QdrantVector;
+  const testCollectionName = 'test-collection-' + Date.now();
+  const dimension = 3;
+
+  beforeAll(async () => {
+    qdrant = new QdrantVector('http://localhost:6333/');
+    await qdrant.createIndex(testCollectionName, dimension);
+  });
+
+  afterAll(async () => {
+    await qdrant.deleteIndex(testCollectionName);
+  }, 50000);
+
+  describe('Index Operations', () => {
+    it('should list collections including ours', async () => {
+      const indexes = await qdrant.listIndexes();
+      expect(indexes).toContain(testCollectionName);
+    }, 50000);
+
+    it('should describe index with correct properties', async () => {
+      const stats = await qdrant.describeIndex(testCollectionName);
+      expect(stats.dimension).toBe(dimension);
+      expect(stats.metric).toBe('cosine');
+      expect(typeof stats.count).toBe('number');
+    }, 50000);
+  });
+
+  describe('Vector Operations', () => {
+    const testVectors = [
+      [1.0, 0.0, 0.0],
+      [0.0, 1.0, 0.0],
+      [0.0, 0.0, 1.0],
+    ];
+    const testMetadata = [{ label: 'x-axis' }, { label: 'y-axis' }, { label: 'z-axis' }];
+    let vectorIds: string[];
+
+    it('should upsert vectors with metadata', async () => {
+      vectorIds = await qdrant.upsert(testCollectionName, testVectors, testMetadata);
+      expect(vectorIds).toHaveLength(3);
+    }, 50000);
+
+    it('should query vectors and return nearest neighbors', async () => {
+      const queryVector = [1.0, 0.1, 0.1];
+      const results = await qdrant.query(testCollectionName, queryVector, 3);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].score).toBeGreaterThan(0);
+      expect(results[0].metadata).toBeDefined();
+    }, 50000);
+
+    it('should query vectors with metadata filter', async () => {
+      const queryVector = [0.0, 1.0, 0.0];
+      const filter = {
+        must: [{ key: 'label', match: { value: 'y-axis' } }],
+      };
+
+      const results = await qdrant.query(testCollectionName, queryVector, 1, filter);
+
+      expect(results).toHaveLength(1);
+      expect(results?.[0]?.metadata?.label).toBe('y-axis');
+    }, 50000);
+  });
+
+  describe('Error Handling', () => {
+    it('should handle non-existent index query gracefully', async () => {
+      const nonExistentIndex = 'non-existent-index';
+      await expect(qdrant.query(nonExistentIndex, [1, 0, 0])).rejects.toThrow();
+    }, 50000);
+
+    it('should handle incorrect dimension vectors', async () => {
+      const wrongDimVector = [[1, 0]]; // 2D vector for 3D index
+      await expect(qdrant.upsert(testCollectionName, wrongDimVector)).rejects.toThrow();
+    }, 50000);
+  });
+
+  describe('Performance Tests', () => {
+    it('should handle batch upsert of 1000 vectors', async () => {
+      const batchSize = 1000;
+      const vectors = Array(batchSize)
+        .fill(null)
+        .map(() =>
+          Array(dimension)
+            .fill(null)
+            .map(() => Math.random()),
+        );
+      const metadata = vectors.map((_, i) => ({ id: i }));
+
+      const start = Date.now();
+      const ids = await qdrant.upsert(testCollectionName, vectors, metadata);
+      const duration = Date.now() - start;
+
+      expect(ids).toHaveLength(batchSize);
+      console.log(`Batch upsert of ${batchSize} vectors took ${duration}ms`);
+    }, 300000);
+
+    it('should perform multiple concurrent queries', async () => {
+      const queryVector = [1, 0, 0];
+      const numQueries = 10;
+
+      const start = Date.now();
+      const promises = Array(numQueries)
+        .fill(null)
+        .map(() => qdrant.query(testCollectionName, queryVector));
+
+      const results = await Promise.all(promises);
+      const duration = Date.now() - start;
+
+      expect(results).toHaveLength(numQueries);
+      console.log(`${numQueries} concurrent queries took ${duration}ms`);
+    }, 50000);
+  });
+});

--- a/packages/rag/src/qdrant/index.ts
+++ b/packages/rag/src/qdrant/index.ts
@@ -1,0 +1,107 @@
+import { MastraVector, QueryResult, IndexStats } from '@mastra/core';
+import { QdrantClient, Schemas } from '@qdrant/js-client-rest';
+
+const BATCH_SIZE = 256;
+const DISTANCE_MAPPING: Record<string, Schemas['Distance']> = {
+  cosine: 'Cosine',
+  euclidean: 'Euclid',
+  dotproduct: 'Dot',
+};
+
+export class QdrantVector extends MastraVector {
+  private client: QdrantClient;
+
+  constructor(url: string, apiKey?: string, https?: boolean) {
+    super();
+
+    this.client = new QdrantClient({
+      url,
+      apiKey,
+      https,
+    });
+  }
+
+  async upsert(
+    indexName: string,
+    vectors: number[][],
+    metadata?: Record<string, any>[],
+    ids?: string[],
+  ): Promise<string[]> {
+    const pointIds = ids || vectors.map(() => crypto.randomUUID());
+
+    const records = vectors.map((vector, i) => ({
+      id: pointIds[i],
+      vector: vector,
+      payload: metadata?.[i] || {},
+    }));
+
+    for (let i = 0; i < records.length; i += BATCH_SIZE) {
+      const batch = records.slice(i, i + BATCH_SIZE);
+      await this.client.upsert(indexName, {
+        // @ts-expect-error
+        points: batch,
+        wait: true,
+      });
+    }
+
+    return pointIds;
+  }
+
+  async createIndex(
+    indexName: string,
+    dimension: number,
+    metric: 'cosine' | 'euclidean' | 'dotproduct' = 'cosine',
+  ): Promise<void> {
+    await this.client.createCollection(indexName, {
+      vectors: {
+        // @ts-expect-error
+        size: dimension,
+        // @ts-expect-error
+        distance: DISTANCE_MAPPING[metric],
+      },
+    });
+  }
+
+  async query(
+    indexName: string,
+    queryVector: number[],
+    topK: number = 10,
+    filter?: Record<string, any>,
+  ): Promise<QueryResult[]> {
+    const results = (
+      await this.client.query(indexName, {
+        query: queryVector,
+        limit: topK,
+        filter: filter,
+        with_payload: true,
+      })
+    ).points;
+
+    return results.map(match => ({
+      id: match.id as string,
+      score: match.score || 0,
+      metadata: match.payload as Record<string, any>,
+    }));
+  }
+
+  async listIndexes(): Promise<string[]> {
+    const response = await this.client.getCollections();
+    return response.collections.map(collection => collection.name) || [];
+  }
+
+  async describeIndex(indexName: string): Promise<IndexStats> {
+    const { config, points_count } = await this.client.getCollection(indexName);
+
+    const distance = config.params.vectors?.distance as Schemas['Distance'];
+    return {
+      dimension: config.params.vectors?.size as number,
+      count: points_count || 0,
+      // @ts-expect-error
+      metric: Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance),
+    };
+  }
+
+  async deleteIndex(indexName: string): Promise<void> {
+    await this.client.deleteCollection(indexName);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1183,7 +1183,7 @@ importers:
         version: 9.5.1
       dts-cli:
         specifier: ^2.0.5
-        version: 2.0.5(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.0))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.0))(@jest/transform@29.7.0)(@jest/types@29.6.3)(@swc/core@1.9.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(@types/node@22.9.1)(canvas@2.11.2(encoding@0.1.13))(esbuild@0.19.12)
+        version: 2.0.5(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.0))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.0))(@jest/transform@29.7.0)(@jest/types@29.6.3)(@swc/core@1.9.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(@types/node@22.9.1)(canvas@2.11.2(encoding@0.1.13))
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -1208,6 +1208,9 @@ importers:
       '@pinecone-database/pinecone':
         specifier: ^3.0.3
         version: 3.0.3
+      '@qdrant/js-client-rest':
+        specifier: ^1.12.0
+        version: 1.12.0(typescript@5.6.3)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1250,13 +1253,13 @@ importers:
         version: 0.28.1
       dts-cli:
         specifier: ^2.0.5
-        version: 2.0.5(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.0))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.0))(@jest/transform@29.7.0)(@jest/types@29.6.3)(@swc/core@1.9.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(@types/node@22.9.1)(canvas@2.11.2(encoding@0.1.13))
+        version: 2.0.5(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.0))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.0))(@jest/transform@29.7.0)(@jest/types@29.6.3)(@swc/core@1.9.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(@types/node@22.9.1)(canvas@2.11.2(encoding@0.1.13))(esbuild@0.19.12)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.9.3(@swc/helpers@0.5.15))(@types/node@22.9.1)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.24.0)(jest@29.7.0(@types/node@22.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.9.3(@swc/helpers@0.5.15))(@types/node@22.9.1)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.19.12)(jest@29.7.0(@types/node@22.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.9.3(@swc/helpers@0.5.15))(@types/node@22.9.1)(typescript@5.6.3)))(typescript@5.6.3)
 
 packages:
 


### PR DESCRIPTION
## Description

This PR adds support for Qdrant - https://qdrant.tech/ to be used as a vector store in Mastra for RAG.

## Testing
- I've Q&A tested the `QdrantVector` class externally since I ran into build issues throughout yesterday.
- Added integration tests. You need a Qdrant instance running using: `docker run -p 6333:6333 qdrant/qdrant`.