### PR TITLE
Kenny/futr 929 update init to add default option

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -12,13 +12,13 @@ import {
   writeIndexFile,
 } from './utils.js';
 
-const s = yoctoSpinner({ text: 'Initializing project\n' });
+const s = yoctoSpinner();
 
 export async function init({
   directory,
-  addExample,
+  addExample = false,
   components,
-  llmProvider,
+  llmProvider = 'openai',
   showSpinner,
 }: {
   directory: string;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -113,7 +113,7 @@ program
   .command('init')
   .description('Initialize a new Mastra project')
   .option('--default', 'Quick start with defaults(src, OpenAI, no examples)')
-  .option('-d, --dir <directory>', 'Directory for Mastra files to (defaults to src/mastra)')
+  .option('-d, --dir <directory>', 'Directory for Mastra files to (defaults to src/)')
   .option('-c, --components <components>', 'Comma-separated list of components (agents, tools, workflows)')
   .option('-l, --llm <model-provider>', 'Default model provider (openai, anthropic, or groq))')
   .option('-e, --example', 'Include example code')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -132,7 +132,7 @@ program
       return;
     }
     //TODO: validate args
-    const componentsArr = args.components.split(',');
+    const componentsArr = args.components ? args.components.split(',') : [];
     init({
       directory: args.dir,
       components: componentsArr,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,7 +34,7 @@ const mastraText = retro(`
 
 program
   .version(`${version}`)
-  .description(`mastra CLI ${version}`)
+  .description(`Mastra CLI ${version}`)
   .action(() => {
     console.log(mastraText);
   });
@@ -113,11 +113,11 @@ program
   .command('init')
   .description('Initialize a new Mastra project')
   .option('--default', 'Quick start with defaults(src, OpenAI, no examples)')
-  .option('-d, --dir <directory>', 'Directory to add mastra related files to (defaults to src/mastra)')
-  .option('-c, --components <components>', 'Mastra components to setup: agents, tools, workflows')
-  .option('-l, --llm <model-provider>', 'Default model provider to use, defaults to OpenAI')
-  .option('-e, --example', 'Add code samples')
-  .option('-ne, --no-example', "Don't add code samples")
+  .option('-d, --dir <directory>', 'Directory for Mastra files to (defaults to src/mastra)')
+  .option('-c, --components <components>', 'Comma-separated list of components (agents, tools, workflows)')
+  .option('-l, --llm <model-provider>', 'Default model provider (openai, anthropic, or groq))')
+  .option('-e, --example', 'Include example code')
+  .option('-ne, --no-example', 'Skip example code')
   .action(args => {
     if (!Object.keys(args).length) return interactivePrompt();
 
@@ -189,7 +189,7 @@ engine
     }
   });
 
-const agent = program.command('agent').description('Manage the mastra agent');
+const agent = program.command('agent').description('Manage Mastra agents');
 
 agent
   .command('new')


### PR DESCRIPTION
This PR adds fallback defaults for options that aren't provided when running the init command. for example, if a user does
`npx mastra init --dir src --llm openai` without adding the `--components` flag, we handle it with sane defaults.