### PR TITLE
feat: install drizzle kit if not present

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,13 +1,51 @@
 import { execa } from 'execa';
+import path from 'path';
+import { PackageJson } from 'type-fest';
 import yoctoSpinner from 'yocto-spinner';
 
+import fsExtra from 'fs-extra/esm';
+
 import { getEnginePath } from '../utils/get-engine-path.js';
+import getPackageManager from '../utils/get-package-manager.js';
 
 const spinner = yoctoSpinner({ text: 'Generating drizzle client\n' });
 
+const checkDrizzleInstallation = async () => {
+  const pkgJsonPath = path.join(process.cwd(), 'package.json');
+  const pkgJson = (await fsExtra.readJSON(pkgJsonPath)) as PackageJson;
+  if (pkgJson.dependencies && !pkgJson.dependencies['drizzle-kit']) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+const installDrizzleKit = async () => {
+  const packageManager = getPackageManager();
+
+  let runCommand = packageManager;
+  if (packageManager === 'npm') {
+    runCommand = `${packageManager} i`;
+  } else {
+    runCommand = `${packageManager} add`;
+  }
+
+  await execa(`${runCommand} drizzle-kit`, {
+    all: true,
+    shell: true,
+    stdio: 'inherit',
+  });
+};
 export async function generate(dbUrl: string) {
   try {
     spinner.start();
+    const isDrizzleInstalled = await checkDrizzleInstallation();
+
+    if (!isDrizzleInstalled) {
+      spinner.text = 'Installing drizzle kit\n';
+      await installDrizzleKit();
+    }
+
     await generateDrizzleClient(dbUrl);
     spinner.success('Drizzle client generated\n');
   } catch (err) {


### PR DESCRIPTION
We check and install `drizzle-kit` if users don't have it installed.

This is required for `generate` to work.