### PR TITLE
Remove ascii art

### DIFF
--- a/.changeset/healthy-timers-promise.md
+++ b/.changeset/healthy-timers-promise.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+show cli options rather than ascii art

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,6 @@
     "express": "^4.21.1",
     "figlet": "^1.8.0",
     "fs-extra": "^11.2.0",
-    "gradient-string": "^3.0.0",
     "is-port-reachable": "^4.0.0",
     "memfs": "^4.14.0",
     "picocolors": "^1.1.1",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 import * as p from '@clack/prompts';
 import { Command } from 'commander';
-import { retro } from 'gradient-string';
 import color from 'picocolors';
 
 import { createNewAgent } from './commands/agents/create-new-agent.js';
@@ -25,21 +24,7 @@ const program = new Command();
 
 const version = await getPackageVersion();
 
-const mastraText = retro(`
-███╗   ███╗ █████╗ ███████╗████████╗██████╗  █████╗ 
-████╗ ████║██╔══██╗██╔════╝╚══██╔══╝██╔══██╗██╔══██╗
-██╔████╔██║███████║███████╗   ██║   ██████╔╝███████║
-██║╚██╔╝██║██╔══██║╚════██║   ██║   ██╔══██╗██╔══██║
-██║ ╚═╝ ██║██║  ██║███████║   ██║   ██║  ██║██║  ██║
-╚═╝     ╚═╝╚═╝  ╚═╝╚══════╝   ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝
-`);
-
-program
-  .version(`${version}`, '-v, --version')
-  .description(`Mastra CLI ${version}`)
-  .action(() => {
-    logger.log(mastraText);
-  });
+program.version(`${version}`, '-v, --version').description(`Mastra CLI ${version}`);
 
 program
   .command('init')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1512,9 +1512,6 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
-      gradient-string:
-        specifier: ^3.0.0
-        version: 3.0.0
       is-port-reachable:
         specifier: ^4.0.0
         version: 4.0.0
@@ -6402,9 +6399,6 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
-  '@types/tinycolor2@1.4.6':
-    resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
-
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
@@ -8983,10 +8977,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  gradient-string@3.0.0:
-    resolution: {integrity: sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==}
-    engines: {node: '>=14'}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -12465,18 +12455,12 @@ packages:
   tiny-worker@2.3.0:
     resolution: {integrity: sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==}
 
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
-
   tinyexec@0.3.1:
     resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
-
-  tinygradient@1.1.5:
-    resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
 
   title@4.0.1:
     resolution: {integrity: sha512-xRnPkJx9nvE5MF6LkB5e8QJjE2FW8269wTu/LQdf7zZqBgPly0QJPf/CWAo7srj5so4yXfoLEdCFgurlpi47zg==}
@@ -19317,8 +19301,6 @@ snapshots:
     dependencies:
       '@types/node': 22.10.1
 
-  '@types/tinycolor2@1.4.6': {}
-
   '@types/tough-cookie@4.0.5': {}
 
   '@types/triple-beam@1.3.5': {}
@@ -22560,11 +22542,6 @@ snapshots:
   gpt-tokenizer@2.6.2: {}
 
   graceful-fs@4.2.11: {}
-
-  gradient-string@3.0.0:
-    dependencies:
-      chalk: 5.3.0
-      tinygradient: 1.1.5
 
   graphemer@1.4.0: {}
 
@@ -27362,19 +27339,12 @@ snapshots:
       esm: 3.2.25
     optional: true
 
-  tinycolor2@1.6.0: {}
-
   tinyexec@0.3.1: {}
 
   tinyglobby@0.2.10:
     dependencies:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
-
-  tinygradient@1.1.5:
-    dependencies:
-      '@types/tinycolor2': 1.4.6
-      tinycolor2: 1.6.0
 
   title@4.0.1:
     dependencies:


### PR DESCRIPTION
Remove the `ascii` art that shows up when you run `mastra`

now, we show the option:
![CleanShot 2024-12-09 at 12 54 05@2x](https://github.com/user-attachments/assets/51cab527-5cf2-407b-ae32-07bb76f96088)
