### PR TITLE
fix: error creating project due to npm dependency resolution

### DIFF
--- a/.changeset/silver-seahorses-march.md
+++ b/.changeset/silver-seahorses-march.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+fix error when installing zod in starter

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -284,7 +284,7 @@ export const initializeMinimal = async () => {
   s.start('Creating project');
 
   await exec(`npm init -y`);
-  await exec(`npm i zod@3.23.7 typescript tsx @types/node --save-dev >> output.txt`);
+  await exec(`npm i zod typescript tsx @types/node --save-dev`);
 
   s.message('Installing dependencies');
 


### PR DESCRIPTION
Context:

There was an error with zod as a `dep` and that was because we pinned a specific version in our installation for starter template. Now we don't. 