### PR TITLE
Agent registration order of operations

### DIFF
--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -105,6 +105,23 @@ export class Mastra<
 
     this.syncs = (config?.syncs || {}) as TSyncs;
 
+
+    if (config?.syncs && !config?.engine) {
+      throw new Error('Engine is required to run syncs');
+    }
+
+    this.syncs = (config?.syncs || {}) as TSyncs;
+
+    if (config?.engine) {
+      this.engine = config.engine;
+    }
+
+    if (config?.vectors) {
+      this.vectors = config.vectors;
+    }
+
+    this.memory = config?.memory;
+
     /*
     Agents
     */
@@ -130,22 +147,6 @@ export class Mastra<
     }
 
     this.agents = agents as TAgents;
-
-    if (config?.syncs && !config?.engine) {
-      throw new Error('Engine is required to run syncs');
-    }
-
-    this.syncs = (config?.syncs || {}) as TSyncs;
-
-    if (config?.engine) {
-      this.engine = config.engine;
-    }
-
-    if (config?.vectors) {
-      this.vectors = config.vectors;
-    }
-
-    this.memory = config?.memory;
 
     /*
     Workflows


### PR DESCRIPTION
This PR fixes a potential initialization issue by reordering class property assignments:

1. Ensures core dependencies (syncs, engine, vectors, memory) are initialized on the Mastra class before any agent registration occurs
2. Moves initialization code above the agent registration block to guarantee that when _registerPrimitives() is called, all required dependencies are properly set
3. Prevents scenarios where agents could reference uninitialized class properties

Before this change, agents could potentially reference uninitialized dependencies during registration since the property assignments happened after agent setup.

Before:

<img width="627" alt="Screenshot 2024-12-17 at 2 11 31 PM" src="https://github.com/user-attachments/assets/6188302f-c439-438d-9d21-2c9d9d0a04e4" />

After:

<img width="624" alt="Screenshot 2024-12-17 at 2 13 00 PM" src="https://github.com/user-attachments/assets/fa12c0b5-defc-4375-919c-bd734aabdf99" />
