### PR TITLE
updated docs to rename mastra serve to mastra dev

### DIFF
--- a/docs/src/pages/guide/agents/00-overview.mdx
+++ b/docs/src/pages/guide/agents/00-overview.mdx
@@ -82,7 +82,7 @@ for await (const chunk of stream.textStream) {
 
 Agents can return structured data by providing a JSON Schema or using a Zod schema.
 
-#### Using JSON Schema
+### Using JSON Schema
 
 ```typescript
 const schema = {
@@ -108,7 +108,7 @@ const response = await myAgent.generate(messages, {
 console.log("Structured Output:", response.object);
 ```
 
-#### Using Zod
+### Using Zod
 
 You can also use Zod schemas for type-safe structured outputs.
 
@@ -164,19 +164,19 @@ const memoryMessages = await myAgent.memory.getMessages({
 console.log("Agent Memory:", memoryMessages);
 ```
 
-## \*\*5. Running Agents
+## **5. Running Agents**
 
-Mastra provides a CLI command `mastra serve` to run your agents behind an API. By default, this looks for exported agents in files in the `src/mastra/agents` directory.
+Mastra provides a CLI command `mastra dev` to run your agents behind an API. By default, this looks for exported agents in files in the `src/mastra/agents` directory.
 
-### **Starting the Server**
+### Starting the Server
 
 ```bash
-mastra serve
+mastra dev
 ```
 
 This will start the server and make your agent available at `http://localhost:3000/agents/my-agent/generate`.
 
-### **Interacting with the Agent**
+### Interacting with the Agent
 
 You can interact with the agent using `curl` from the command line:
 

--- a/docs/src/pages/guide/agents/01-agent-memory.mdx
+++ b/docs/src/pages/guide/agents/01-agent-memory.mdx
@@ -26,7 +26,7 @@ console.log("Agent Memory:", memoryMessages);
 
 This is the simplest way to use agent memory -- with the default in-memory storage. It's suitable for local development, testing, or backend processes outside the context of a user session and request/response cycle.
 
-Especially if you're using `mastra serve` or otherwise running agents behind an API, you'll want to use a more persistent memory backend.
+Especially if you're using `mastra dev` or otherwise running agents behind an API, you'll want to use a more persistent memory backend.
 
 ## 2. Using Mastra Engine
 

--- a/docs/src/pages/guide/agents/03-chef-michel.mdx
+++ b/docs/src/pages/guide/agents/03-chef-michel.mdx
@@ -242,19 +242,19 @@ This resets the agent's memory to an empty state.
 
 ## **Step 7: Running the Agent Server**
 
-### **Using `mastra serve`**
+### **Using `mastra dev`**
 
-You can run your agent as a service using the `mastra serve` command:
+You can run your agent as a service using the `mastra dev` command:
 
 ```bash
-mastra serve
+mastra dev
 ```
 
 This will start a server exposing endpoints to interact with your registered agents.
 
 ### **Accessing the Chef Assistant API**
 
-By default, `mastra serve` runs on `http://localhost:3000`. Your Chef Assistant agent will be available at:
+By default, `mastra dev` runs on `http://localhost:3000`. Your Chef Assistant agent will be available at:
 
 ```
 POST http://localhost:3000/agents/chef-assistant/generate

--- a/docs/src/pages/guide/agents/04-stock-agent.mdx
+++ b/docs/src/pages/guide/agents/04-stock-agent.mdx
@@ -127,12 +127,12 @@ export const mastra = new Mastra({
 
 ## **5. Serve the Application**
 
-Instead of running the application directly, we'll use the `mastra serve` command to start the server. This will expose your agent via REST API endpoints, allowing you to interact with it over HTTP.
+Instead of running the application directly, we'll use the `mastra dev` command to start the server. This will expose your agent via REST API endpoints, allowing you to interact with it over HTTP.
 
 In your terminal, start the Mastra server by running:
 
 ```bash
-mastra serve
+mastra dev
 ```
 
 This command will start the server and make your agent available at:
@@ -144,7 +144,7 @@ http://localhost:3000/agents/stock-agent/generate
 Make sure that your environment variables are set, especially your OpenAI API key. If you haven't set it yet, you can provide it inline:
 
 ```bash
-OPENAI_API_KEY=your_openai_api_key mastra serve
+OPENAI_API_KEY=your_openai_api_key mastra dev
 ```
 
 ---

--- a/docs/src/pages/guide/getting-started/installation.mdx
+++ b/docs/src/pages/guide/getting-started/installation.mdx
@@ -53,7 +53,7 @@ On initialization, you'll be guided through the following prompts:
   - Tools
   - Workflows
 - **Select a default LLM provider**: Choose from supported providers like OpenAI, Anthropic, or Google Gemini.
-- **Include example code**: **Select `Yes` to include example code.** This will add sample agents, tools, and workflows to your project, allowing you to test and run `mastra serve` immediately.
+- **Include example code**: **Select `Yes` to include example code.** This will add sample agents, tools, and workflows to your project, allowing you to test and run `mastra dev` immediately.
 
 ### Set Up Your API Key
 
@@ -153,7 +153,7 @@ export const mastra = new Mastra({
 });
 ```
 
-This registers your agent with Mastra so that `mastra serve` can discover and serve it.
+This registers your agent with Mastra so that `mastra dev` can discover and serve it.
 
 If you're using Anthropic, set the `ANTHROPIC_API_KEY`. If you're using Google Gemini,
 set the `GOOGLE_GENERATIVE_AI_API_KEY`.
@@ -165,7 +165,7 @@ set the `GOOGLE_GENERATIVE_AI_API_KEY`.
 Mastra provides commands to serve your agents via REST endpoints. Run the following command to start the Mastra server:
 
 ```bash copy
-OPENAI_API_KEY=<your-openai-api-key> mastra serve
+OPENAI_API_KEY=<your-openai-api-key> mastra dev
 ```
 
 This command creates REST API endpoints for your agents.

--- a/docs/src/pages/guide/reference/local-dev/mastra-cli.mdx
+++ b/docs/src/pages/guide/reference/local-dev/mastra-cli.mdx
@@ -97,7 +97,7 @@ Runs database migrations to keep your schema up to date.
 
 ### Server
 
-#### `mastra serve`
+#### `mastra dev`
 
 Starts a development server that creates REST API endpoints for your agents and workflows:
 

--- a/docs/src/pages/guide/workflows/00-overview.mdx
+++ b/docs/src/pages/guide/workflows/00-overview.mdx
@@ -303,14 +303,14 @@ myWorkflow.commit();
 
 ### **8. Serve the Workflow**
 
-We can now serve the workflow using the `mastra serve` command.
+We can now serve the workflow using the `mastra dev` command.
 
 #### **Start the Mastra Server**
 
 Open your terminal and run:
 
 ```bash
-mastra serve
+mastra dev
 ```
 
 This command will start the server and make your workflow available at:


### PR DESCRIPTION
This PR updates docs to change `mastra serve` to `mastra dev`, as `serve` is deprecated in favor of `dev`. Also updates agents overview navigation (displayed below)

Before:

<img width="287" alt="image" src="https://github.com/user-attachments/assets/4a7a6b18-b714-462d-beee-b987b276f75e" />

After:
<img width="299" alt="image" src="https://github.com/user-attachments/assets/5eb028e6-2045-4fb2-9eaa-fdbdf4e69552" />
