### PR TITLE
Update endpoints for agents and workflows in docs

### DIFF
--- a/docs/src/pages/guide/agents/00-overview.mdx
+++ b/docs/src/pages/guide/agents/00-overview.mdx
@@ -174,14 +174,14 @@ Mastra provides a CLI command `mastra dev` to run your agents behind an API. By 
 mastra dev
 ```
 
-This will start the server and make your agent available at `http://localhost:3000/agents/my-agent/generate`.
+This will start the server and make your agent available at `http://localhost:4111/agents/my-agent/generate`.
 
 ### Interacting with the Agent
 
 You can interact with the agent using `curl` from the command line:
 
 ```bash
-curl -X POST http://localhost:3000/agents/my-agent/generate \
+curl -X POST http://localhost:4111/agents/my-agent/generate \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/src/pages/guide/agents/00-overview.mdx
+++ b/docs/src/pages/guide/agents/00-overview.mdx
@@ -174,14 +174,14 @@ Mastra provides a CLI command `mastra dev` to run your agents behind an API. By 
 mastra dev
 ```
 
-This will start the server and make your agent available at `http://localhost:4111/agents/my-agent/generate`.
+This will start the server and make your agent available at `http://localhost:4111/api/agents/myAgent/generate`.
 
 ### Interacting with the Agent
 
 You can interact with the agent using `curl` from the command line:
 
 ```bash
-curl -X POST http://localhost:4111/agents/my-agent/generate \
+curl -X POST http://localhost:4111/api/agents/myAgent/generate \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/src/pages/guide/agents/03-chef-michel.mdx
+++ b/docs/src/pages/guide/agents/03-chef-michel.mdx
@@ -20,7 +20,7 @@ Create a new file `src/mastra/agents/chefAgent.ts` and define your agent:
 import { Agent } from "@mastra/core";
 
 export const chefAgent = new Agent({
-  name: "chef-assistant",
+  name: "chef-agent",
   instructions: 'You are Michel, a practical and experienced home chef' +
   'You helps people cook with whatever ingredients they have available.',
   model: {
@@ -257,7 +257,7 @@ This will start a server exposing endpoints to interact with your registered age
 By default, `mastra dev` runs on `http://localhost:4111`. Your Chef Assistant agent will be available at:
 
 ```
-POST http://localhost:4111/agents/chef-assistant/generate
+POST http://localhost:4111/api/agents/chefAgent/generate
 ```
 
 ### **Interacting with the Agent via `curl`**
@@ -265,7 +265,7 @@ POST http://localhost:4111/agents/chef-assistant/generate
 You can interact with the agent using `curl` from the command line:
 
 ```bash
-curl -X POST http://localhost:4111/agents/chef-assistant/generate \
+curl -X POST http://localhost:4111/api/agents/chefAgent/generate \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/src/pages/guide/agents/03-chef-michel.mdx
+++ b/docs/src/pages/guide/agents/03-chef-michel.mdx
@@ -254,10 +254,10 @@ This will start a server exposing endpoints to interact with your registered age
 
 ### **Accessing the Chef Assistant API**
 
-By default, `mastra dev` runs on `http://localhost:3000`. Your Chef Assistant agent will be available at:
+By default, `mastra dev` runs on `http://localhost:4111`. Your Chef Assistant agent will be available at:
 
 ```
-POST http://localhost:3000/agents/chef-assistant/generate
+POST http://localhost:4111/agents/chef-assistant/generate
 ```
 
 ### **Interacting with the Agent via `curl`**
@@ -265,7 +265,7 @@ POST http://localhost:3000/agents/chef-assistant/generate
 You can interact with the agent using `curl` from the command line:
 
 ```bash
-curl -X POST http://localhost:3000/agents/chef-assistant/generate \
+curl -X POST http://localhost:4111/agents/chef-assistant/generate \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/src/pages/guide/agents/04-stock-agent.mdx
+++ b/docs/src/pages/guide/agents/04-stock-agent.mdx
@@ -138,7 +138,7 @@ mastra dev
 This command will start the server and make your agent available at:
 
 ```
-http://localhost:4111/agents/stock-agent/generate
+http://localhost:4111/api/agents/stockAgent/generate
 ```
 
 Make sure that your environment variables are set, especially your OpenAI API key. If you haven't set it yet, you can provide it inline:
@@ -154,7 +154,7 @@ OPENAI_API_KEY=your_openai_api_key mastra dev
 Now that your server is running, you can test your agent's endpoint using `curl`:
 
 ```bash
-curl -X POST http://localhost:4111/agents/stock-agent/generate \
+curl -X POST http://localhost:4111/api/agents/stockAgent/generate \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/src/pages/guide/agents/04-stock-agent.mdx
+++ b/docs/src/pages/guide/agents/04-stock-agent.mdx
@@ -138,7 +138,7 @@ mastra dev
 This command will start the server and make your agent available at:
 
 ```
-http://localhost:3000/agents/stock-agent/generate
+http://localhost:4111/agents/stock-agent/generate
 ```
 
 Make sure that your environment variables are set, especially your OpenAI API key. If you haven't set it yet, you can provide it inline:
@@ -154,7 +154,7 @@ OPENAI_API_KEY=your_openai_api_key mastra dev
 Now that your server is running, you can test your agent's endpoint using `curl`:
 
 ```bash
-curl -X POST http://localhost:3000/agents/stock-agent/generate \
+curl -X POST http://localhost:4111/agents/stock-agent/generate \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/src/pages/guide/getting-started/installation.mdx
+++ b/docs/src/pages/guide/getting-started/installation.mdx
@@ -170,14 +170,14 @@ You can test the agent's endpoint using `curl` or `fetch`:
 <Tabs items={['curl', 'fetch']}>
   <Tabs.Tab>
 ```bash copy
-curl -X POST http://localhost:4111/agent/story-writer/text \
+curl -X POST http://localhost:4111/api/agents/storyWriter/text \
 -H "Content-Type: application/json" \
 -d '{"messages": ["Tell me a story about a courageous astronaut."]}'
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```js copy showLineNumbers
-fetch('http://localhost:4111/agent/story-writer/text', {
+fetch('http://localhost:4111/api/agents/storyWriter/text', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/docs/src/pages/guide/reference/local-dev/mastra-cli.mdx
+++ b/docs/src/pages/guide/reference/local-dev/mastra-cli.mdx
@@ -114,7 +114,7 @@ Example usage:
 mastra serve
 
 # Make a request to an agent
-curl -X POST http://localhost:4111/agent/my-agent/text \
+curl -X POST http://localhost:4111/api/agents/:agentId/text \
 -H "Content-Type: application/json" \
 -d '{"messages": ["Your prompt here"]}'
 ```

--- a/docs/src/pages/guide/workflows/00-overview.mdx
+++ b/docs/src/pages/guide/workflows/00-overview.mdx
@@ -301,7 +301,17 @@ After defining all steps and their relationships, commit the workflow.
 myWorkflow.commit();
 ```
 
-### **8. Serve the Workflow**
+### **8. Add Workflow to Mastra Instance**
+
+Add the workflow to your Mastra instance. 
+
+```typescript
+export const mastra = new Mastra({
+  workflows: { myWorkflow },
+});
+```
+
+### **9. Serve the Workflow**
 
 We can now serve the workflow using the `mastra dev` command.
 
@@ -316,15 +326,15 @@ mastra dev
 This command will start the server and make your workflow available at:
 
 ```
-http://localhost:4111/workflows/my-workflow/execute
+http://localhost:4111/api/workflows/myWorkflow/execute
 ```
 
-### **9. Test the Workflow with cURL**
+### **10. Test the Workflow with cURL**
 
 With the server running, you can test your workflow using `curl`:
 
 ```bash
-curl -X POST http://localhost:4111/workflows/my-workflow/execute \
+curl -X POST http://localhost:4111/api/workflows/myWorkflow/execute \
   -H "Content-Type: application/json" \
   -d '{
     "inputValue": 5

--- a/docs/src/pages/guide/workflows/00-overview.mdx
+++ b/docs/src/pages/guide/workflows/00-overview.mdx
@@ -316,7 +316,7 @@ mastra dev
 This command will start the server and make your workflow available at:
 
 ```
-http://localhost:3000/workflows/my-workflow/execute
+http://localhost:4111/workflows/my-workflow/execute
 ```
 
 ### **9. Test the Workflow with cURL**
@@ -324,7 +324,7 @@ http://localhost:3000/workflows/my-workflow/execute
 With the server running, you can test your workflow using `curl`:
 
 ```bash
-curl -X POST http://localhost:3000/workflows/my-workflow/execute \
+curl -X POST http://localhost:4111/workflows/my-workflow/execute \
   -H "Content-Type: application/json" \
   -d '{
     "inputValue": 5


### PR DESCRIPTION
Changing localhost port in docs to match what we currently use when running `mastra dev`, and updated endpoints to match format we use in express (/api/agents/:agentId/)