### PR TITLE
change manual install agent to match agent created in auto install

### DIFF
--- a/docs/src/pages/guide/getting-started/installation.mdx
+++ b/docs/src/pages/guide/getting-started/installation.mdx
@@ -123,7 +123,7 @@ Then, add the following code to `src/mastra/agents/cat-one.ts`:
 ```ts filename="src/mastra/agents/cat-one.ts" showLineNumbers
 import { Agent } from "@mastra/core";
 
-export const catExpert = new Agent({
+export const catOne = new Agent({
   name: "cat-one",
   model: {
     provider: "OPEN_AI",
@@ -139,10 +139,10 @@ Finally, create the Mastra entry point in `src/mastra/index.ts`:
 
 ```ts filename="src/mastra/index.ts" showLineNumbers
 import { Mastra } from "@mastra/core";
-import { catExpert } from "./agents/cat-one";
+import { catOne } from "./agents/cat-one";
 
 export const mastra = new Mastra({
-  agents: { catExpert },
+  agents: { catOne },
 });
 ```
 
@@ -170,14 +170,14 @@ You can test the agent's endpoint using `curl` or `fetch`:
 <Tabs items={['curl', 'fetch']}>
   <Tabs.Tab>
 ```bash copy
-curl -X POST http://localhost:4111/api/agents/catExpert/text \
+curl -X POST http://localhost:4111/api/agents/catOne/text \
 -H "Content-Type: application/json" \
 -d '{"messages": ["What do cats like to eat?"]}'
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```js copy showLineNumbers
-fetch('http://localhost:4111/api/agents/catExpert/text', {
+fetch('http://localhost:4111/api/agents/catOne/text', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
@@ -205,7 +205,7 @@ If you'd like to directly call agents from the command line, you can create a sc
 import { mastra } from "./mastra";
 
 async function main() {
-  const agent = mastra.getAgent("catExpert");
+  const agent = mastra.getAgent("catOne");
 
   const result = await agent.generate(
     "What do cats like to eat?",

--- a/docs/src/pages/guide/getting-started/installation.mdx
+++ b/docs/src/pages/guide/getting-started/installation.mdx
@@ -112,25 +112,25 @@ Replace `your_openai_api_key` with your actual API key.
 
 ### Create the Agent
 
-First, create the `story-writer` agent file:
+First, create the `cat-one` agent file:
 
 ```bash copy
-touch src/mastra/agents/story-writer.ts
+touch src/mastra/agents/cat-one.ts
 ```
 
-Then, add the following code to `src/mastra/agents/story-writer.ts`:
+Then, add the following code to `src/mastra/agents/cat-one.ts`:
 
-```ts filename="src/mastra/agents/story-writer.ts" showLineNumbers
+```ts filename="src/mastra/agents/cat-one.ts" showLineNumbers
 import { Agent } from "@mastra/core";
 
-export const storyWriterAgent = new Agent({
-  name: "story-writer",
+export const catExpert = new Agent({
+  name: "cat-one",
   model: {
     provider: "OPEN_AI",
     name: "gpt-4o",
     toolChoice: "auto",
   },
-  instructions: `You are a helpful assistant who writes creative stories.`,
+  instructions: `You are a feline expert with comprehensive knowledge of all cat species, from domestic breeds to wild big cats. As a lifelong cat specialist, you understand their behavior, biology, social structures, and evolutionary history in great depth.`,
   tools: {},
 });
 ```
@@ -139,10 +139,10 @@ Finally, create the Mastra entry point in `src/mastra/index.ts`:
 
 ```ts filename="src/mastra/index.ts" showLineNumbers
 import { Mastra } from "@mastra/core";
-import { storyWriterAgent } from "./agents/story-writer";
+import { catExpert } from "./agents/cat-one";
 
 export const mastra = new Mastra({
-  agents: { storyWriter: storyWriterAgent },
+  agents: { catExpert },
 });
 ```
 
@@ -170,20 +170,20 @@ You can test the agent's endpoint using `curl` or `fetch`:
 <Tabs items={['curl', 'fetch']}>
   <Tabs.Tab>
 ```bash copy
-curl -X POST http://localhost:4111/api/agents/storyWriter/text \
+curl -X POST http://localhost:4111/api/agents/catExpert/text \
 -H "Content-Type: application/json" \
--d '{"messages": ["Tell me a story about a courageous astronaut."]}'
+-d '{"messages": ["What do cats like to eat?"]}'
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```js copy showLineNumbers
-fetch('http://localhost:4111/api/agents/storyWriter/text', {
+fetch('http://localhost:4111/api/agents/catExpert/text', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
   },
   body: JSON.stringify({
-    messages: ['Tell me a story about a courageous astronaut.'],
+    messages: ['What do cats like to eat?'],
   }),
 })
   .then(response => response.json())
@@ -205,10 +205,10 @@ If you'd like to directly call agents from the command line, you can create a sc
 import { mastra } from "./mastra";
 
 async function main() {
-  const agent = mastra.getAgent("storyWriter");
+  const agent = mastra.getAgent("catExpert");
 
   const result = await agent.generate(
-    "Write a short story about a robot learning to paint.",
+    "What do cats like to eat?",
   );
 
   console.log("Agent response:", result.text);


### PR DESCRIPTION
Currently the automatic install and manual install in the docs creates two different agents. The automatic install creates a cat expert agent, and the manual install creates a story writer agent. With the current docs, when testing the endpoint or running from the command line, the user would have to make changes to have it work for an automatic install. This PR changes the manual install to match the automatic install.