### PR TITLE
export CoreMessage types from ai sdk for use in llm generate function

### DIFF
--- a/.changeset/red-zoos-happen.md
+++ b/.changeset/red-zoos-happen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Export CoreMessage Types from ai sdk

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -1,7 +1,28 @@
-import { GenerateObjectResult, GenerateTextResult, LanguageModelV1, StreamObjectResult, StreamTextResult } from 'ai';
+import {
+  CoreMessage as AiCoreMessage,
+  CoreSystemMessage as AiCoreSystemMessage,
+  CoreAssistantMessage as AiCoreAssistantMessage,
+  CoreUserMessage as AiCoreUserMessage,
+  CoreToolMessage as AiCoreToolMessage,
+  GenerateObjectResult,
+  GenerateTextResult,
+  LanguageModelV1,
+  StreamObjectResult,
+  StreamTextResult,
+} from 'ai';
 import { ZodSchema } from 'zod';
 
 export type OpenAIModel = 'gpt-4' | 'gpt-4-turbo' | 'gpt-3.5-turbo' | 'gpt-4o' | 'gpt-4o-mini';
+
+export type CoreMessage = AiCoreMessage;
+
+export type CoreSystemMessage = AiCoreSystemMessage;
+
+export type CoreAssistantMessage = AiCoreAssistantMessage;
+
+export type CoreUserMessage = AiCoreUserMessage;
+
+export type CoreToolMessage = AiCoreToolMessage;
 
 export type OpenAIConfig = {
   provider: 'OPEN_AI';


### PR DESCRIPTION
This PR exports the CoreMessage types in order to properly add types to the llm generate function when using the CoreMessage structure (found in this example: https://mastra.ai/docs/guide/llm-models/01-guide-harry-potter#4-alter-the-system-message)
