### PR TITLE
fix: add overview redirect

### DIFF
--- a/docs/src/components/showcase-grid.tsx
+++ b/docs/src/components/showcase-grid.tsx
@@ -38,25 +38,25 @@ export const ShowcaseGrid = () => {
     {
       title: 'Audiofeed',
       description: 'Audiofeed repurposes your content into audio and video.',
-      image: '/showcase/audio-feed.png',
+      image: '/docs/showcase/audio-feed.png',
       link: 'https://audiofeed.ai',
     },
     {
       title: 'Bird Checker',
       description: 'Bird Checker is a bird identification app.',
-      image: '/showcase/bird-checker.png',
+      image: '/docs/showcase/bird-checker.png',
       link: 'https://bird-checker.vercel.app',
     },
     {
       title: 'OpenAPI Spec Writer',
       description: 'Generate an open api spec from your documentation url.',
-      image: '/showcase/open-api-spec-writer.png',
+      image: '/docs/showcase/open-api-spec-writer.png',
       link: 'https://openapi-spec-writer.vercel.app',
     },
     {
       title: 'Crypto Chatbot',
       description: 'You can ask about current crypto prices and trends in the cryptocurrency market.',
-      image: '/showcase/crypto-chatbot.png',
+      image: '/docs/showcase/crypto-chatbot.png',
       link: 'https://crypto-chatbot-xi.vercel.app/',
     },
   ];

--- a/docs/src/pages/_meta.js
+++ b/docs/src/pages/_meta.js
@@ -8,6 +8,10 @@ const meta = {
     title: 'Showcase',
     type: 'page',
   },
+  overview: {
+    title: 'Docs',
+    type: 'page',
+  },
   guides: {
     title: 'Guides',
     collapsed: false,

--- a/docs/src/pages/overview.mdx
+++ b/docs/src/pages/overview.mdx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/router';
+
+export default function Overview() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/');
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Remove the `guide` suffix from the `docs` url.