### PR TITLE
Joshua/futr 1154 refactor api separate generate function into generate and

### DIFF
--- a/.changeset/perfect-lamps-rush.md
+++ b/.changeset/perfect-lamps-rush.md
@@ -1,0 +1,7 @@
+---
+'@mastra/dane': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+simplify generate api

--- a/docs/src/pages/agents/00-overview.mdx
+++ b/docs/src/pages/agents/00-overview.mdx
@@ -67,9 +67,7 @@ For more real-time responses, you can stream the agent's response:
 
 ```ts showLineNumbers filename="src/mastra/index.ts" lines={6} copy
 const messages = [{ role: "user", content: "Tell me a story." }];
-const stream = await myAgent.generate(messages, {
-  stream: true,
-});
+const stream = await myAgent.stream(messages);
 
 console.log("Agent:");
 
@@ -102,7 +100,7 @@ const messages = [
   },
 ];
 const response = await myAgent.generate(messages, {
-  schema: schema,
+  output: schema,
 });
 
 console.log("Structured Output:", response.object);
@@ -138,7 +136,7 @@ const messages = [
   },
 ];
 const response = await myAgent.generate(messages, {
-  schema: schema,
+  output: schema,
 });
 
 console.log("Structured Output:", response.object);

--- a/docs/src/pages/agents/02-adding-tools.mdx
+++ b/docs/src/pages/agents/02-adding-tools.mdx
@@ -18,8 +18,8 @@ import { z } from "zod";
 
 const getWeatherInfo = async (city: string) => {
   // Replace with an actual API call to a weather service
-  const data = await fetch(`https://api.example.com/weather?city=${city}`).then((r) =>
-    r.json(),
+  const data = await fetch(`https://api.example.com/weather?city=${city}`).then(
+    (r) => r.json(),
   );
   return data;
 };
@@ -65,7 +65,7 @@ export const weatherAgent = new Agent<typeof tools>({
   },
   tools: {
     weatherInfo,
-  }
+  },
 });
 ```
 
@@ -108,9 +108,9 @@ import { mastra } from "./index";
 
 async function main() {
   const agent = mastra.getAgent("weatherAgent");
-  const response = await agent.generate({
-    messages: ["What's the weather like in New York City today?"],
-  });
+  const response = await agent.generate(
+    "What's the weather like in New York City today?",
+  );
 
   console.log(response.text);
 }

--- a/docs/src/pages/guides/02-chef-michel.mdx
+++ b/docs/src/pages/guides/02-chef-michel.mdx
@@ -1,4 +1,4 @@
-import { Steps } from 'nextra/components';
+import { Steps } from "nextra/components";
 
 # Agents Guide: Building a Chef Assistant
 
@@ -20,17 +20,17 @@ Create a new file `src/mastra/agents/chefAgent.ts` and define your agent:
 
 ```ts copy filename="src/mastra/agents/chefAgent.ts"
 // src/mastra/agents/chefAgent.ts
-import { Agent } from '@mastra/core';
+import { Agent } from "@mastra/core";
 
 export const chefAgent = new Agent({
-  name: 'chef-agent',
+  name: "chef-agent",
   instructions:
-    'You are Michel, a practical and experienced home chef' +
-    'You helps people cook with whatever ingredients they have available.',
+    "You are Michel, a practical and experienced home chef" +
+    "You helps people cook with whatever ingredients they have available.",
   model: {
-    provider: 'OPEN_AI',
-    name: 'gpt-4o',
-    toolChoice: 'auto',
+    provider: "OPEN_AI",
+    name: "gpt-4o",
+    toolChoice: "auto",
   },
 });
 ```
@@ -53,9 +53,9 @@ OPENAI_API_KEY=your_openai_api_key
 In your main file, register the agent:
 
 ```ts filename="src/mastra/index.ts"
-import { Mastra } from '@mastra/core';
+import { Mastra } from "@mastra/core";
 
-import { chefAgent } from './agents/chefAgent';
+import { chefAgent } from "./agents/chefAgent";
 
 export const mastra = new Mastra({
   agents: { chefAgent },
@@ -74,14 +74,12 @@ export const mastra = new Mastra({
 ```ts filename="src/mastra/index.ts"
 async function main() {
   const query =
-    'In my kitchen I have: pasta, canned tomatoes, garlic, olive oil, and some dried herbs (basil and oregano). What can I make?';
+    "In my kitchen I have: pasta, canned tomatoes, garlic, olive oil, and some dried herbs (basil and oregano). What can I make?";
   console.log(`Query: ${query}`);
 
-  const response = await chefAgent.generate({
-    messages: [{ role: 'user', content: query }],
-  });
+  const response = await chefAgent.generate([{ role: "user", content: query }]);
 
-  console.log('\n👨‍🍳 Chef Michel:', response.text);
+  console.log("\n👨‍🍳 Chef Michel:", response.text);
 }
 
 main();
@@ -105,18 +103,15 @@ async function main() {
     "Now I'm over at my friend's house, and they have: chicken thighs, coconut milk, sweet potatoes, and some curry powder.";
   console.log(`Query: ${query}`);
 
-  const stream = await chefAgent.generate({
-    messages: [{ role: 'user', content: query }],
-    stream: true,
-  });
+  const stream = await chefAgent.stream([{ role: "user", content: query }]);
 
-  console.log('\n Chef Michel: ');
+  console.log("\n Chef Michel: ");
 
   for await (const chunk of stream.textStream) {
     process.stdout.write(chunk);
   }
 
-  console.log('\n\n✅ Recipe complete!');
+  console.log("\n\n✅ Recipe complete!");
 }
 
 main();
@@ -138,10 +133,11 @@ Great! You can make a comforting chicken curry...
 ### Generating a Recipe with Structured Data
 
 ```ts filename="src/mastra/index.ts"
-import { z } from 'zod';
+import { z } from "zod";
 
 async function main() {
-  const query = 'I want to make lasagna, can you generate a lasagna recipe for me?';
+  const query =
+    "I want to make lasagna, can you generate a lasagna recipe for me?";
   console.log(`Query: ${query}`);
 
   // Define the Zod schema
@@ -155,12 +151,12 @@ async function main() {
     steps: z.array(z.string()),
   });
 
-  const response = await chefAgent.generate({
-    messages: [{ role: 'user', content: query }],
-    schema: schema,
-  });
+  const response = await chefAgent.generate(
+    [{ role: "user", content: query }],
+    { output: schema },
+  );
 
-  console.log('\n👨‍🍳 Chef Michel:', response.object);
+  console.log("\n👨‍🍳 Chef Michel:", response.object);
 }
 
 main();
@@ -197,7 +193,7 @@ Query: I want to make lasagna, can you generate a lasagna recipe for me?
 After interacting with the agent, save its memory state:
 
 ```typescript
-await chefAgent.memory.save('chef_memory');
+await chefAgent.memory.save("chef_memory");
 ```
 
 ### Loading the Agent's Memory
@@ -205,7 +201,7 @@ await chefAgent.memory.save('chef_memory');
 Later, you can load the saved memory state:
 
 ```typescript
-await chefAgent.memory.load('chef_memory');
+await chefAgent.memory.load("chef_memory");
 ```
 
 ### Displaying the Agent's Memory
@@ -214,10 +210,10 @@ To view the agent's memory, you can retrieve and log the stored messages:
 
 ```typescript
 const memoryMessages = await chefAgent.memory.getMessages({
-  threadId: 'chef_memory',
+  threadId: "chef_memory",
 });
 
-console.log('Agent Memory:', memoryMessages);
+console.log("Agent Memory:", memoryMessages);
 ```
 
 This will output the stored conversation history and context associated with `chef_memory`.

--- a/docs/src/pages/llm-models/00-overview.mdx
+++ b/docs/src/pages/llm-models/00-overview.mdx
@@ -17,13 +17,13 @@ Mastra provides direct support for Large Language Models (LLMs) through the `LLM
 To start using the `LLM` class, you need to initialize it with the desired model configuration. Here's how you can do it:
 
 ```typescript
-import { Mastra } from '@mastra/core';
+import { Mastra } from "@mastra/core";
 
 const mastra = new Mastra();
 
 const llm = mastra.LLM({
-  provider: 'OPEN_AI',
-  name: 'gpt-4o-mini',
+  provider: "OPEN_AI",
+  name: "gpt-4o-mini",
 });
 ```
 
@@ -39,15 +39,19 @@ Mastra supports major LLM providers out of the box, plus additional providers th
 
 ### Most Popular Providers and Models
 
-| Provider      | Supported Models                                                                                                                                                         |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Provider          | Supported Models                                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **OpenAI**        | `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`, `gpt-4o`, `gpt-4o-mini`                                                                                                         |
 | **Anthropic**     | `claude-3-5-sonnet-20241022`, `claude-3-5-sonnet-20240620`, `claude-3-5-haiku-20241022`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307` |
 | **Google Gemini** | `gemini-1.5-pro-latest`, `gemini-1.5-pro`, `gemini-1.5-flash-latest`, `gemini-1.5-flash`                                                                                 |
 
 A full list of supported models can be found [here](../reference/llm/providers-and-models.mdx).
 
-<Callout> If you don't want to pay for an LLM provider, Google Gemini has a generous free tier for its API.</Callout>
+<Callout>
+  {" "}
+  If you don't want to pay for an LLM provider, Google Gemini has a generous
+  free tier for its API.
+</Callout>
 
 ---
 
@@ -71,7 +75,7 @@ The `generate` function supports three types of message formats:
 You can pass a single string as the message:
 
 ```typescript
-const response = await llm.generate('Tell me a joke.');
+const response = await llm.generate("Tell me a joke.");
 ```
 
 ### 2. Array of Strings
@@ -80,8 +84,8 @@ You can provide an array of strings, which will be converted into user messages:
 
 ```typescript
 const response = await llm.generate([
-  'Hello!',
-  'Can you explain quantum mechanics?',
+  "Hello!",
+  "Can you explain quantum mechanics?",
 ]);
 ```
 
@@ -91,8 +95,8 @@ For finer control, you can pass an array of message objects, specifying the role
 
 ```typescript
 const response = await llm.generate([
-  { role: 'system', content: 'You are a helpful assistant.' },
-  { role: 'user', content: 'What is the meaning of life?' },
+  { role: "system", content: "You are a helpful assistant." },
+  { role: "user", content: "What is the meaning of life?" },
 ]);
 ```
 
@@ -107,7 +111,7 @@ The `generate` function supports four types of output formats:
 Receive a basic text response from the model:
 
 ```typescript
-const response = await llm.generate('What is AI?');
+const response = await llm.generate("What is AI?");
 
 console.log(response.text);
 ```
@@ -117,16 +121,19 @@ console.log(response.text);
 Request a structured response by providing a schema. This is useful when you need the output in a specific format:
 
 ```typescript
-import { z } from 'zod';
+import { z } from "zod";
 
 const mySchema = z.object({
   definition: z.string(),
   examples: z.array(z.string()),
 });
 
-const response = await llm.generate('Define machine learning and give examples.', {
-  schema: mySchema,
-});
+const response = await llm.generate(
+  "Define machine learning and give examples.",
+  {
+    output: mySchema,
+  },
+);
 
 console.log(response.object);
 ```
@@ -136,9 +143,7 @@ console.log(response.object);
 Stream the response in real-time, which is useful for handling longer outputs or providing immediate feedback to users:
 
 ```typescript
-const stream = await llm.generate('Tell me a story about a brave knight.', {
-  stream: true,
-});
+const stream = await llm.stream("Tell me a story about a brave knight.");
 
 for await (const chunk of stream.textStream) {
   process.stdout.write(chunk);
@@ -150,9 +155,8 @@ for await (const chunk of stream.textStream) {
 Stream a structured response using a schema:
 
 ```typescript
-const stream = await llm.generate('Provide live weather data.', {
-  schema: mySchema,
-  stream: true,
+const stream = await llm.stream("Provide live weather data.", {
+  output: mySchema,
 });
 
 for await (const chunk of stream.textStream) {

--- a/examples/agent/src/index.ts
+++ b/examples/agent/src/index.ts
@@ -34,7 +34,7 @@ async function textStream() {
     "Now I'm over at my friend's house, and they have: chicken thighs, coconut milk, sweet potatoes, and some curry powder.";
   console.log(`Query 2: ${query2}`);
 
-  const curryResponse = await agent.generate(query2, { stream: true });
+  const curryResponse = await agent.stream(query2);
 
   console.log('\n👨‍🍳 Chef Michel: ');
 
@@ -53,7 +53,7 @@ async function generateStream() {
     "Now I'm over at my friend's house, and they have: chicken thighs, coconut milk, sweet potatoes, and some curry powder.";
   console.log(`Query 2: ${query2}`);
 
-  const curryResponse = await agent.generate([query2], { stream: true });
+  const curryResponse = await agent.stream([query2]);
 
   console.log('\n👨‍🍳 Chef Michel: ');
 
@@ -72,7 +72,7 @@ async function textObject() {
   console.log(`Query 3: ${query3}`);
 
   const lasagnaResponse = await agent.generate(query3, {
-    schema: z.object({
+    output: z.object({
       ingredients: z.array(
         z.object({
           name: z.string(),
@@ -92,7 +92,7 @@ async function textObjectJsonSchema() {
   console.log(`Query 3: ${query3}`);
 
   const lasagnaResponse = await agent.generate(query3, {
-    schema: {
+    output: {
       type: 'object',
       properties: {
         ingredients: {
@@ -123,7 +123,7 @@ async function generateObject() {
   console.log(`Query 3: ${query3}`);
 
   const lasagnaResponse = await agent.generate([query3], {
-    schema: z.object({
+    output: z.object({
       ingredients: z.array(
         z.object({
           name: z.string(),
@@ -142,8 +142,8 @@ async function streamObject() {
   const query4 = 'I want to make lasagna, can you generate a lasagna recipe for me?';
   console.log(`Query 4: ${query4}`);
 
-  const lasagnaStreamResponse = await agent.generate(query4, {
-    schema: z.object({
+  const lasagnaStreamResponse = await agent.stream(query4, {
+    output: z.object({
       ingredients: z.array(
         z.object({
           name: z.string(),
@@ -152,7 +152,6 @@ async function streamObject() {
       ),
       steps: z.array(z.string()),
     }),
-    stream: true,
   });
 
   console.log('\n👨‍🍳 Chef Michel: ');
@@ -171,9 +170,8 @@ async function generateStreamObject() {
   const query4 = 'I want to make lasagna, can you generate a lasagna recipe for me?';
   console.log(`Query 4: ${query4}`);
 
-  const lasagnaStreamResponse = await agent.generate([query4], {
-    stream: true,
-    schema: z.object({
+  const lasagnaStreamResponse = await agent.stream([query4], {
+    output: z.object({
       ingredients: z.array(
         z.object({
           name: z.string(),

--- a/examples/bird-checker-with-express/src/index.ts
+++ b/examples/bird-checker-with-express/src/index.ts
@@ -68,7 +68,7 @@ app.post('/api/image-metadata', async (req: Request, res: Response) => {
         },
       ],
       {
-        schema: z.object({
+        output: z.object({
           bird: z.boolean(),
           species: z.string(),
           location: z.string(),

--- a/examples/bird-checker-with-nextjs-and-eval/src/lib/mastra/actions.ts
+++ b/examples/bird-checker-with-nextjs-and-eval/src/lib/mastra/actions.ts
@@ -53,7 +53,7 @@ export const promptClaude = async ({
         },
       ],
       {
-        schema: z.object({
+        output: z.object({
           bird: z.boolean(),
           species: z.string(),
           location: z.string(),

--- a/examples/bird-checker-with-nextjs/src/lib/mastra/actions.ts
+++ b/examples/bird-checker-with-nextjs/src/lib/mastra/actions.ts
@@ -50,7 +50,7 @@ export const promptClaude = async ({
         },
       ],
       {
-        schema: z.object({
+        output: z.object({
           bird: z.boolean(),
           species: z.string(),
           location: z.string(),

--- a/examples/crypto-chatbot/app/(chat)/api/chat/route.ts
+++ b/examples/crypto-chatbot/app/(chat)/api/chat/route.ts
@@ -50,13 +50,12 @@ export async function POST(request: Request) {
   const streamingData = new StreamData();
 
   try {
-    const streamResult = await cryptoAgent.generate(userMessages, {
+    const streamResult = await cryptoAgent.stream(userMessages, {
       resourceid: session.user.id,
       threadId: id,
       onFinish: () => {
         streamingData.close();
       },
-      stream: true,
     });
 
     return streamResult.toDataStreamResponse({

--- a/examples/dane/src/mastra/workflows/chat.ts
+++ b/examples/dane/src/mastra/workflows/chat.ts
@@ -58,8 +58,7 @@ const messageOutputStep = new Step({
         messages = [];
       }
 
-      const res = await mastra?.agents?.['dane']?.generate(message, {
-        stream: true,
+      const res = await mastra?.agents?.['dane']?.stream(message, {
         maxSteps: 5,
         resourceid,
         threadId,

--- a/examples/dane/src/mastra/workflows/commit-message.ts
+++ b/examples/dane/src/mastra/workflows/commit-message.ts
@@ -85,7 +85,7 @@ const generateMessage = new Step({
         RETURN THE GUIDELINES YOU ARE USING AS AN ARRAY OF STRINGS ON THE GUIDELINES KEY, AND THE COMMIT MESSAGE ON THE COMMIT MESSAGE KEY
       `,
       {
-        schema: z.object({
+        output: z.object({
           commitMessage: z.string(),
           generated: z.boolean(),
           guidelines: z.array(z.string()),

--- a/examples/dane/src/mastra/workflows/issue-labeler.ts
+++ b/examples/dane/src/mastra/workflows/issue-labeler.ts
@@ -67,7 +67,7 @@ const labelIssue = new Step({
             What label or labels would you assign?
         `,
       {
-        schema: z.object({
+        output: z.object({
           labels: z.array(z.string()),
         }),
       },

--- a/examples/dane/src/mastra/workflows/publish-packages.ts
+++ b/examples/dane/src/mastra/workflows/publish-packages.ts
@@ -29,11 +29,11 @@ const getPacakgesToPublish = new Step({
     const resultObj = await agent.generate(
       `
               ONLY RETURN DATA IF WE HAVE PACKAGES TO PUBLISH. If we do not, return empty arrays.
-              Can you format this for me ${result.text}? 
+              Can you format this for me ${result.text}?
               @mastra/core must be first. @mastra/dane should be listed after packages and integrations.
               `,
       {
-        schema: z.object({
+        output: z.object({
           packages: z.array(z.string()),
           integrations: z.array(z.string()),
           danePackage: z.string(),

--- a/examples/llm/src/mastra/index.ts
+++ b/examples/llm/src/mastra/index.ts
@@ -21,7 +21,7 @@ async function main() {
   console.log(response2.text);
 
   // Streaming responses
-  const stream = await llm.generate(
+  const stream = await llm.stream(
     [
       {
         role: 'system',
@@ -33,7 +33,6 @@ async function main() {
       },
     ],
     {
-      stream: true,
       onStepFinish: step => {
         console.log('Step completed:', step);
       },

--- a/examples/quick-start/src/index.ts
+++ b/examples/quick-start/src/index.ts
@@ -11,7 +11,7 @@ const main = async () => {
 
   try {
     const result = await agentCat.generate('What is the most popular cat species?', {
-      schema: specieSchema,
+      output: specieSchema,
     });
 
     const res = specieSchema.parse(result?.object);

--- a/examples/travel-app/src/app/actions.ts
+++ b/examples/travel-app/src/app/actions.ts
@@ -170,7 +170,7 @@ export async function runAgent(formData: FormData) {
   `;
 
   const result = await travelAnalyzer.generate(messageToAnalyze, {
-    schema: travelSchema,
+    output: travelSchema,
   });
 
   console.log("from travelAnalyzer", result.usage);

--- a/examples/travel-app/src/mastra/workflows/travel-submission.ts
+++ b/examples/travel-app/src/mastra/workflows/travel-submission.ts
@@ -118,7 +118,7 @@ function createArrangementStep({
           runId,
           threadId: sessionId,
           resourceid: `travel-workflow-${userId}`,
-          schema: z.object({
+          output: z.object({
             ids: z.array(z.string()),
             reasoning: z.string(),
           }),

--- a/examples/vnext/src/app/actions.ts
+++ b/examples/vnext/src/app/actions.ts
@@ -23,7 +23,7 @@ export async function testStructuredOutput() {
   const lasagnaAgent = mastra.getAgent('lasagnaAgent');
 
   const recipe = await lasagnaAgent.generate('Generate a lasagna recipe for me', {
-    schema: z.object({
+    output: z.object({
       recipe: z.object({
         name: z.string(),
         ingredients: z.array(

--- a/examples/vnext/src/app/api/chat/route.ts
+++ b/examples/vnext/src/app/api/chat/route.ts
@@ -10,8 +10,7 @@ export async function POST(req: Request) {
 
   const agent = mastra.getAgent('agentOne');
 
-  const streamResult = await agent?.generate(messages, {
-    stream: true,
+  const streamResult = await agent?.stream(messages, {
     onStepFinish: step => {
       console.log({ step });
     },

--- a/examples/vnext/src/app/api/object-stream/route.ts
+++ b/examples/vnext/src/app/api/object-stream/route.ts
@@ -8,8 +8,8 @@ export const maxDuration = 30;
 export async function GET() {
   const testAgent = mastra.getAgent('lasagnaAgent');
 
-  const recipe = await testAgent.generate('Generate a lasagna recipe for me', {
-    schema: z.object({
+  const recipe = await testAgent.stream('Generate a lasagna recipe for me', {
+    output: z.object({
       recipe: z.object({
         name: z.string(),
         ingredients: z.array(
@@ -24,7 +24,6 @@ export async function GET() {
     onStepFinish: step => {
       console.log({ step });
     },
-    stream: true,
   });
 
   console.log('recipe====', JSON.stringify(recipe, null, 2));

--- a/packages/cli/src/templates/express-server.ts
+++ b/packages/cli/src/templates/express-server.ts
@@ -216,8 +216,7 @@ app.post('/api/agents/:agentId/stream', async (req: Request, res: Response) => {
       return;
     }
 
-    const streamResult = await agent.generate(messages, {
-      stream: true,
+    const streamResult = await agent.stream(messages, {
       threadId,
       resourceid,
     });
@@ -257,7 +256,7 @@ app.post('/api/agents/:agentId/text-object', async (req: Request, res: Response)
       return;
     }
 
-    const result = await agent.generate(messages, { schema, threadId, resourceid });
+    const result = await agent.generate(messages, { output: schema, threadId, resourceid });
     res.json(result);
   } catch (error) {
     const apiError = error as ApiError;
@@ -295,7 +294,7 @@ app.post('/api/agents/:agentId/stream-object', async (req: Request, res: Respons
       return;
     }
 
-    const streamResult = await agent.generate(messages, { schema, stream: true, threadId, resourceid });
+    const streamResult = await agent.stream(messages, { output: schema, threadId, resourceid });
 
     streamResult.pipeTextStreamToResponse(res);
   } catch (error) {

--- a/packages/cli/src/templates/netlify.ts
+++ b/packages/cli/src/templates/netlify.ts
@@ -1,3 +1,4 @@
+import { Agent } from '@mastra/core';
 import express, { Request, Response } from 'express';
 import { join } from 'path';
 import serverless from 'serverless-http';
@@ -150,8 +151,7 @@ app.post('/api/agents/:agentId/stream', async (req: Request, res: Response) => {
       return;
     }
 
-    const streamResult = await agent.generate(messages, {
-      stream: true,
+    const streamResult = await agent.stream(messages, {
       threadId,
       resourceid,
     });
@@ -168,7 +168,7 @@ app.post('/api/agents/:agentId/stream', async (req: Request, res: Response) => {
 app.post('/api/agents/:agentId/text-object', async (req: Request, res: Response) => {
   try {
     const agentId = req.params.agentId;
-    const agent = mastra.getAgent(agentId);
+    const agent: Agent = mastra.getAgent(agentId);
     const { messages, schema, threadId, resourceid } = req.body;
 
     const { ok, errorResponse } = await validateBody({
@@ -181,7 +181,7 @@ app.post('/api/agents/:agentId/text-object', async (req: Request, res: Response)
       return;
     }
 
-    const result = await agent.generate(messages, { schema, threadId, resourceid });
+    const result = await agent.generate(messages, { output: schema, threadId, resourceid });
     res.json(result);
   } catch (error) {
     const apiError = error as ApiError;
@@ -196,7 +196,7 @@ app.post('/api/agents/:agentId/text-object', async (req: Request, res: Response)
 app.post('/api/agents/:agentId/stream-object', async (req: Request, res: Response) => {
   try {
     const agentId = req.params.agentId;
-    const agent = mastra.getAgent(agentId);
+    const agent: Agent = mastra.getAgent(agentId);
     const { messages, schema, threadId, resourceid } = req.body;
 
     const { ok, errorResponse } = await validateBody({
@@ -209,7 +209,7 @@ app.post('/api/agents/:agentId/stream-object', async (req: Request, res: Respons
       return;
     }
 
-    const streamResult = await agent.generate(messages, { schema, stream: true, threadId, resourceid });
+    const streamResult = await agent.stream(messages, { output: schema, threadId, resourceid });
 
     streamResult.pipeTextStreamToResponse(res);
   } catch (error) {
@@ -226,7 +226,7 @@ app.post('/api/agents/:agentId/tools/:toolId/execute', async (req: Request, res:
   try {
     const agentId = req.params.agentId;
     const toolId = req.params.toolId;
-    const agent = mastra.getAgent(agentId);
+    const agent: Agent = mastra.getAgent(agentId);
     const tool = Object.values(agent?.tools || {}).find((tool: any) => tool.id === toolId) as any;
     const result = await tool.execute({
       context: {

--- a/packages/cli/src/templates/worker.ts
+++ b/packages/cli/src/templates/worker.ts
@@ -211,7 +211,7 @@ router.post('/api/agents/:agentId/stream', async ({ params, json }: IRequest) =>
       });
     }
 
-    const streamResult = await agent.generate(messages, { stream: true, threadId, resourceid });
+    const streamResult = await agent.stream(messages, { threadId, resourceid });
 
     return streamResult.toDataStreamResponse({
       headers: {
@@ -261,7 +261,7 @@ router.post('/api/agents/:agentId/text-object', async ({ params, json }: IReques
       });
     }
 
-    const result = await agent.generate(messages, { schema, threadId, resourceid });
+    const result = await agent.generate(messages, { output: schema, threadId, resourceid });
     return new Response(JSON.stringify(result), {
       headers: {
         'Content-Type': 'application/json',
@@ -308,7 +308,7 @@ router.post('/api/agents/:agentId/stream-object', async ({ params, json }: IRequ
       });
     }
 
-    const streamResult = await agent.generate(messages, { schema, stream: true, threadId, resourceid });
+    const streamResult = await agent.stream(messages, { output: schema, threadId, resourceid });
 
     return streamResult.toTextStreamResponse({
       headers: {

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -65,9 +65,7 @@ describe('agent', () => {
 
     const agentOne = mastra.getAgent('electionAgent');
 
-    const response = await agentOne.generate('Who won the 2016 US presidential election?', {
-      stream: true,
-    });
+    const response = await agentOne.stream('Who won the 2016 US presidential election?');
 
     const { textStream } = response;
 
@@ -97,7 +95,7 @@ describe('agent', () => {
     const agentOne = mastra.getAgent('electionAgent');
 
     const response = await agentOne.generate('Who won the 2012 US presidential election?', {
-      schema: z.object({
+      output: z.object({
         winner: z.string(),
       }),
     });
@@ -121,7 +119,7 @@ describe('agent', () => {
     const agentOne = mastra.getAgent('electionAgent');
 
     const response = await agentOne.generate('Give me the winners of 2012 and 2016 US presidential elections', {
-      schema: z.array(
+      output: z.array(
         z.object({
           winner: z.string(),
           year: z.string(),
@@ -157,11 +155,10 @@ describe('agent', () => {
 
     const agentOne = mastra.getAgent('electionAgent');
 
-    const response = await agentOne.generate('Who won the 2012 US presidential election?', {
-      schema: z.object({
+    const response = await agentOne.stream('Who won the 2012 US presidential election?', {
+      output: z.object({
         winner: z.string(),
       }),
-      stream: true,
     });
 
     const { partialObjectStream } = response;

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -9,6 +9,7 @@ import {
   UserContent,
 } from 'ai';
 import { randomUUID } from 'crypto';
+import { JSONSchema7 } from 'json-schema';
 import { ZodSchema } from 'zod';
 
 import { MastraPrimitives } from '../action';
@@ -593,7 +594,7 @@ export class Agent<
     };
   }
 
-  async generate<Z extends ZodSchema | undefined = undefined>(
+  async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
     {
       context,
@@ -658,21 +659,13 @@ export class Agent<
       return result as unknown as GenerateReturn<Z>;
     }
 
-    let schema: ZodSchema;
-
-    if (output instanceof ZodSchema) {
-      schema = output;
-    } else {
-      schema = this.llm.__createOutputSchema(output);
-    }
-
     this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm textObject call`, {
       runId: this.name,
     });
     const result = await this.llm.__textObject({
       messages: messageObjects,
       tools: this.tools,
-      structuredOutput: schema,
+      structuredOutput: output,
       convertedTools,
       onStepFinish,
       maxSteps,
@@ -684,7 +677,7 @@ export class Agent<
     return result as unknown as GenerateReturn<Z>;
   }
 
-  async stream<Z extends ZodSchema | undefined = undefined>(
+  async stream<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
     {
       context,
@@ -758,21 +751,13 @@ export class Agent<
       }) as unknown as StreamReturn<Z>;
     }
 
-    let schema: ZodSchema;
-
-    if (output instanceof ZodSchema) {
-      schema = output;
-    } else {
-      schema = this.llm.__createOutputSchema(output);
-    }
-
     this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm streamObject call`, {
       runId: this.name,
     });
     return this.llm.__streamObject({
       messages: messageObjects,
       tools: this.tools,
-      structuredOutput: schema,
+      structuredOutput: output,
       convertedTools,
       onStepFinish,
       onFinish: async result => {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -14,7 +14,7 @@ import { ZodSchema } from 'zod';
 import { MastraPrimitives } from '../action';
 import { MastraBase } from '../base';
 import { LLM } from '../llm';
-import { GenerateReturn, ModelConfig } from '../llm/types';
+import { GenerateReturn, ModelConfig, OutputType, StreamReturn } from '../llm/types';
 import { LogLevel, RegisteredLogger } from '../logger';
 import { ThreadType } from '../memory';
 import { InstrumentClass } from '../telemetry';
@@ -593,32 +593,28 @@ export class Agent<
     };
   }
 
-  async generate<S extends boolean = false, Z extends ZodSchema | undefined = undefined>(
+  async generate<Z extends ZodSchema | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
     {
-      schema,
-      stream,
       context,
       threadId: threadIdInFn,
       resourceid,
       maxSteps = 5,
-      onFinish,
       onStepFinish,
       runId,
       toolsets,
+      output = 'text',
     }: {
       toolsets?: ToolsetsInput;
       resourceid?: string;
       context?: CoreMessage[];
       threadId?: string;
       runId?: string;
-      stream?: S;
-      schema?: Z;
-      onFinish?: (result: string) => Promise<void> | void;
       onStepFinish?: (step: string) => void;
       maxSteps?: number;
+      output?: OutputType | Z;
     } = {},
-  ): Promise<GenerateReturn<S, Z>> {
+  ): Promise<GenerateReturn<Z>> {
     let messagesToUse: UserContent[] = [];
 
     if (Array.isArray(messages)) {
@@ -643,34 +639,100 @@ export class Agent<
 
     const { threadId, messageObjects, convertedTools } = await before();
 
-    if (stream && schema) {
-      this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm streamObject call`, {
+    if (output === 'text') {
+      this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm text call`, {
         runId: this.name,
       });
-      return this.llm.__streamObject({
+
+      const result = await this.llm.__text({
         messages: messageObjects,
         tools: this.tools,
-        structuredOutput: schema,
         convertedTools,
         onStepFinish,
-        onFinish: async result => {
-          try {
-            const res = JSON.parse(result) || {};
-            await after({ result: res, threadId });
-          } catch (e) {
-            this.log(LogLevel.ERROR, 'Error saving memory on finish', {
-              error: e,
-              runId: this.name,
-            });
-          }
-          onFinish?.(result);
-        },
         maxSteps,
         runId,
-      }) as unknown as GenerateReturn<S, Z>;
+      });
+
+      await after({ result, threadId });
+
+      return result as unknown as GenerateReturn<Z>;
     }
 
-    if (stream) {
+    let schema: ZodSchema;
+
+    if (output instanceof ZodSchema) {
+      schema = output;
+    } else {
+      schema = this.llm.__createOutputSchema(output);
+    }
+
+    this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm textObject call`, {
+      runId: this.name,
+    });
+    const result = await this.llm.__textObject({
+      messages: messageObjects,
+      tools: this.tools,
+      structuredOutput: schema,
+      convertedTools,
+      onStepFinish,
+      maxSteps,
+      runId,
+    });
+
+    await after({ result, threadId });
+
+    return result as unknown as GenerateReturn<Z>;
+  }
+
+  async stream<Z extends ZodSchema | undefined = undefined>(
+    messages: string | string[] | CoreMessage[],
+    {
+      context,
+      threadId: threadIdInFn,
+      resourceid,
+      maxSteps = 5,
+      onFinish,
+      onStepFinish,
+      runId,
+      toolsets,
+      output = 'text',
+    }: {
+      toolsets?: ToolsetsInput;
+      resourceid?: string;
+      context?: CoreMessage[];
+      threadId?: string;
+      runId?: string;
+      onFinish?: (result: string) => Promise<void> | void;
+      onStepFinish?: (step: string) => void;
+      maxSteps?: number;
+      output?: OutputType | Z;
+    } = {},
+  ): Promise<StreamReturn<Z>> {
+    let messagesToUse: UserContent[] = [];
+
+    if (Array.isArray(messages)) {
+      messagesToUse = messages.map(content => {
+        if (typeof content === 'string') {
+          return content;
+        }
+        return content.content as string;
+      });
+    } else {
+      messagesToUse = [messages];
+    }
+
+    const { before, after } = this.__primitive({
+      messages: messagesToUse,
+      context,
+      threadId: threadIdInFn,
+      resourceid,
+      runId: runId || this.name,
+      toolsets,
+    });
+
+    const { threadId, messageObjects, convertedTools } = await before();
+
+    if (output === 'text') {
       this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm stream call`, {
         runId: this.name,
       });
@@ -693,43 +755,40 @@ export class Agent<
         },
         maxSteps,
         runId,
-      }) as unknown as GenerateReturn<S, Z>;
+      }) as unknown as StreamReturn<Z>;
     }
 
-    if (schema) {
-      this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm textObject call`, {
-        runId: this.name,
-      });
-      const result = await this.llm.__textObject({
-        messages: messageObjects,
-        tools: this.tools,
-        structuredOutput: schema,
-        convertedTools,
-        onStepFinish,
-        maxSteps,
-        runId,
-      });
+    let schema: ZodSchema;
 
-      await after({ result, threadId });
-
-      return result as unknown as GenerateReturn<S, Z>;
+    if (output instanceof ZodSchema) {
+      schema = output;
+    } else {
+      schema = this.llm.__createOutputSchema(output);
     }
 
-    this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm text call`, {
+    this.log(LogLevel.DEBUG, `Starting agent ${this.name} llm streamObject call`, {
       runId: this.name,
     });
-
-    const result = await this.llm.__text({
+    return this.llm.__streamObject({
       messages: messageObjects,
       tools: this.tools,
+      structuredOutput: schema,
       convertedTools,
       onStepFinish,
+      onFinish: async result => {
+        try {
+          const res = JSON.parse(result) || {};
+          await after({ result: res, threadId });
+        } catch (e) {
+          this.log(LogLevel.ERROR, 'Error saving memory on finish', {
+            error: e,
+            runId: this.name,
+          });
+        }
+        onFinish?.(result);
+      },
       maxSteps,
       runId,
-    });
-
-    await after({ result, threadId });
-
-    return result as unknown as GenerateReturn<S, Z>;
+    }) as unknown as StreamReturn<Z>;
   }
 }

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -39,7 +39,6 @@ import {
   OutputType,
   StreamReturn,
   StructuredOutput,
-  StructuredOutputType,
 } from './types';
 
 @InstrumentClass({

--- a/packages/core/src/llm/llm.test.ts
+++ b/packages/core/src/llm/llm.test.ts
@@ -78,7 +78,7 @@ describe('LLM Class Integration Tests', () => {
         required: ['answer', 'explanation'],
       } as JSONSchema7;
 
-      const response = await llm.generate('What is 2+2?', { schema });
+      const response = await llm.generate('What is 2+2?', { output: schema });
       expect(response.object).toBeDefined();
       expect(response.object.answer).toBe(4);
       expect(typeof response.object.explanation).toBe('string');
@@ -116,9 +116,10 @@ describe('LLM Class Integration Tests', () => {
 
       const response = await llm.generate(
         'Student Sarah Johnson (ID: 78901) is counting from 1 to 5. What are her numbers?',
-        { schema },
+        { output: schema },
       );
       expect(response.object).toBeDefined();
+      console.log('response.object', response.object);
       expect(typeof response.object.student.profile.id).toBe('number');
       expect(response.object.student.profile.id).toBe(78901);
       expect(typeof response.object.student.profile.name).toBe('string');
@@ -144,9 +145,8 @@ describe('LLM Class Integration Tests', () => {
         required: ['answer', 'explanation'],
       } as JSONSchema7;
 
-      const response = await llm.generate('What is 2+2?', {
-        schema,
-        stream: true,
+      const response = await llm.stream('What is 2+2?', {
+        output: schema,
         onFinish: text => {
           chunks.push(text);
           return;

--- a/packages/core/src/llm/llm.test.ts
+++ b/packages/core/src/llm/llm.test.ts
@@ -60,7 +60,8 @@ describe('LLM Class Integration Tests', () => {
         explanation: z.string(),
       });
 
-      const response = await llm.generate('What is 2+2?', { schema });
+      const response = await llm.generate('What is 2+2?', { output: schema });
+
       expect(response.object).toBeDefined();
       expect(response.object.answer).toBe(4);
       expect(typeof response.object.explanation).toBe('string');
@@ -166,8 +167,7 @@ describe('LLM Class Integration Tests', () => {
 
     it('should stream text completion', async () => {
       const chunks: string[] = [];
-      const response = await llm.generate('Count from 1 to 5.', {
-        stream: true,
+      const response = await llm.stream('Count from 1 to 5.', {
         onFinish: text => {
           chunks.push(text);
           return;

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -546,8 +546,10 @@ export type StructuredOutput = {
       };
 };
 
-export type GenerateReturn<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Z extends ZodSchema | JSONSchema7
-  ? GenerateObjectResult<z.infer<Z>>
+export type GenerateReturn<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Z extends
+  | ZodSchema
+  | JSONSchema7
+  ? GenerateObjectResult<any>
   : GenerateTextResult<any, any>;
 
 export type StreamReturn<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Z extends ZodSchema | JSONSchema7

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -11,7 +11,7 @@ import {
   StreamTextResult,
 } from 'ai';
 import { JSONSchema7 } from 'json-schema';
-import { z, ZodSchema } from 'zod';
+import { ZodSchema } from 'zod';
 
 export type OpenAIModel = 'gpt-4' | 'gpt-4-turbo' | 'gpt-3.5-turbo' | 'gpt-4o' | 'gpt-4o-mini';
 

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -11,7 +11,7 @@ import {
   StreamTextResult,
 } from 'ai';
 import { JSONSchema7 } from 'json-schema';
-import { ZodSchema } from 'zod';
+import { z, ZodSchema } from 'zod';
 
 export type OpenAIModel = 'gpt-4' | 'gpt-4-turbo' | 'gpt-3.5-turbo' | 'gpt-4o' | 'gpt-4o-mini';
 
@@ -546,10 +546,12 @@ export type StructuredOutput = {
       };
 };
 
-export type GenerateReturn<S extends boolean, Z> = S extends true
-  ? Z extends ZodSchema | JSONSchema7
-    ? StreamObjectResult<any, any, any>
-    : StreamTextResult<any>
-  : Z extends ZodSchema | JSONSchema7
-    ? GenerateObjectResult<any>
-    : GenerateTextResult<any, any>;
+export type GenerateReturn<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Z extends ZodSchema | JSONSchema7
+  ? GenerateObjectResult<z.infer<Z>>
+  : GenerateTextResult<any, any>;
+
+export type StreamReturn<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Z extends ZodSchema | JSONSchema7
+  ? StreamObjectResult<any, any, any>
+  : StreamTextResult<any>;
+
+export type OutputType = 'text' | StructuredOutput;


### PR DESCRIPTION
- [x] Separate `generate` function into `generate` and `stream`.
- [x] Refactor llm and agents tests. 
- [x] Refactor `generate` examples and in docs.