### PR TITLE
Update mastra cli build priority in dane package publishing

### DIFF
--- a/.changeset/grumpy-books-rush.md
+++ b/.changeset/grumpy-books-rush.md
@@ -1,0 +1,7 @@
+---
+'@mastra/dane': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+update dane publishing

--- a/examples/dane/src/mastra/workflows/publish-packages.ts
+++ b/examples/dane/src/mastra/workflows/publish-packages.ts
@@ -30,7 +30,7 @@ const getPacakgesToPublish = new Step({
       `
               ONLY RETURN DATA IF WE HAVE PACKAGES TO PUBLISH. If we do not, return empty arrays.
               Can you format this for me ${result.text}?
-              @mastra/core must be first. @mastra/dane should be listed after packages and integrations.
+              @mastra/core must be first. mastra must be second. @mastra/dane should be listed after packages and integrations.
               `,
       {
         output: z.object({


### PR DESCRIPTION
- **This PR Updates mastra cli build priority in dane package publishing so that mastra is built before the create-mastra package which has a dependency on mastra so as to fix create-mastra publishing https://github.com/mastra-ai/mastra/actions/runs/12589470365 **
- **changeset**
