### PR TITLE
docs: use corepack

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,6 +11,7 @@ Other dependencies will be installed as part of the setup
 
 From the project root, run the following commands
 
+- **Setup corepack** by running `corepack enable` - allows you to use the correct pnpm version by default
 - **Install the project dependencies** by running `pnpm setup`
 
 ## ADDING A NEW INTEGRATION


### PR DESCRIPTION
Add docs to let people enable corepack so they automatically get the correct pnpm version.

If you switch to other projects that are using yarn or npm, the terminal will get you the correct version.

More info about corepack:
- https://github.com/nodejs/corepack