### PR TITLE
Ifedayo/mastra 1237 add types for triggerdata in machine context

### DIFF
--- a/.changeset/popular-eyes-arrive.md
+++ b/.changeset/popular-eyes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Better types, and correct payload resolution

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -111,7 +111,7 @@ export interface StepConfig<
   TTriggerSchema extends z.ZodType<any>,
 > {
   snapshotOnTimeout?: boolean;
-  when?: Condition<CondStep, TTriggerSchema> | ((args: { context: WorkflowContext }) => Promise<boolean>);
+  when?: Condition<CondStep, TTriggerSchema> | ((args: { context: WorkflowContext<TTriggerSchema> }) => Promise<boolean>);
   variables?: StepInputType<TStep, 'inputSchema'> extends never
     ? Record<string, VariableReference<VarStep, TTriggerSchema>>
     : {
@@ -136,9 +136,9 @@ type StepFailure = {
 export type StepResult<T> = StepSuccess<T> | StepFailure | StepSuspended;
 
 // Update WorkflowContext
-export interface WorkflowContext<TTrigger = any> {
+export interface WorkflowContext<TTrigger extends z.ZodType<any> = any> {
   stepResults: Record<string, StepResult<any>>;
-  triggerData: TTrigger;
+  triggerData: z.infer<TTrigger>;
   attempts: Record<string, number>;
 }
 

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -50,7 +50,7 @@ export type VariableReference<TStep extends StepVariableType<any, any, any, any>
     : TStep extends 'trigger'
       ? {
           step: 'trigger';
-          path: PathsToStringProps<ExtractSchemaType<TTriggerSchema>>;
+          path: PathsToStringProps<ExtractSchemaType<TTriggerSchema>> | '.' | '';
         }
       : {
           step: { id: string };
@@ -66,7 +66,7 @@ export interface BaseCondition<TStep extends StepVariableType<any, any, any, any
     : TStep extends 'trigger'
       ? {
           step: 'trigger';
-          path: PathsToStringProps<ExtractSchemaType<TTriggerSchema>>;
+          path: PathsToStringProps<ExtractSchemaType<TTriggerSchema>> | '.' | '';
         }
       : {
           step: { id: string };

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -186,7 +186,6 @@ describe('Workflow', () => {
 
       const workflow = new Workflow({
         name: 'test-workflow',
-        triggerSchema: z.object({ count: z.number() }),
       });
 
       workflow

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -275,7 +275,7 @@ describe('Workflow', () => {
       });
     });
 
-    it.only('should resolve variables from trigger data', async () => {
+    it('should resolve variables from trigger data', async () => {
       const execute = jest.fn<any>().mockResolvedValue({ result: 'success' });
       const triggerSchema = z.object({
         inputData: z.object({

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -844,7 +844,7 @@ export class Workflow<
       }
 
       // If path is empty or '.', return the entire source data
-      const value = variable.path === '' || variable.path === '.' ? sourceData[key] : get(sourceData, variable.path);
+      const value = variable.path === '' || variable.path === '.' ? sourceData : get(sourceData, variable.path);
 
       this.log(LogLevel.DEBUG, `Resolved variable ${key}`, {
         value,


### PR DESCRIPTION
- Fixes variable resolution when `''` | `'.'` is passed as path
- Apply correct type information on `triggerData` in condition function