### PR TITLE
Joshua/mastra 1232 update doc examples to include dotenv

### DIFF
--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -20,24 +20,24 @@ a project, run:
 
 <Tabs items={["npx", "npm", "yarn", "pnpm"]}>
   <Tabs.Tab>
-  
-```bash copy 
+
+```bash copy
 npx create-mastra@latest
 ```
 
   </Tabs.Tab>
   <Tabs.Tab>
-```bash copy 
+```bash copy
 npm create mastra
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```bash copy 
+```bash copy
 yarn create mastra
 ```
 </Tabs.Tab>
   <Tabs.Tab>
-```bash copy 
+```bash copy
 pnpm create mastra
 ```
 </Tabs.Tab>
@@ -95,7 +95,7 @@ Then, initialize a TypeScript project including the `@mastra/core` package:
 
 ```bash copy npm2yarn
 npm init -y
-npm install typescript tsx @types/node zod --save-dev
+npm install typescript tsx @types/node zod dotenv --save-dev
 npm install @mastra/core@alpha
 npm install -D mastra@alpha
 npx tsc --init
@@ -123,6 +123,9 @@ Then, add the following code to `src/mastra/agents/cat-one.ts`:
 
 ```ts filename="src/mastra/agents/cat-one.ts" showLineNumbers
 import { Agent } from "@mastra/core";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 export const catOne = new Agent({
   name: "cat-one",
@@ -132,7 +135,6 @@ export const catOne = new Agent({
     toolChoice: "auto",
   },
   instructions: `You are a feline expert with comprehensive knowledge of all cat species, from domestic breeds to wild big cats. As a lifelong cat specialist, you understand their behavior, biology, social structures, and evolutionary history in great depth.`,
-  tools: {},
 });
 ```
 

--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -64,7 +64,7 @@ After the prompts, `create-mastra` will set up your project directory with TypeS
 
 Add the API key for your configured LLM provider in your `.env` file.
 
-```env
+```bash filename=".env" copy
 OPENAI_API_KEY=<your-openai-key>
 ```
 
@@ -105,7 +105,7 @@ npx tsc --init
 
 Create a `.env` file in your project root directory and add your API key:
 
-```env
+```bash filename=".env" copy
 OPENAI_API_KEY=<your-openai-key>
 ```
 
@@ -235,7 +235,7 @@ main();
 Then, run the script to test that everything is set up correctly:
 
 ```bash copy
-npx bun src/index.ts
+npx tsx src/index.ts
 ```
 
 This should output the agent's response to your console.

--- a/docs/src/pages/docs/guides/01-harry-potter.mdx
+++ b/docs/src/pages/docs/guides/01-harry-potter.mdx
@@ -1,4 +1,4 @@
-import { Steps } from 'nextra/components';
+import { Steps } from "nextra/components";
 
 # Guide: Harry Potter
 
@@ -22,7 +22,17 @@ Ensure you have the Mastra core package installed:
 npm install @mastra/core
 ```
 
+Also we need to install dotenv to load the environment variables from the `.env` file.
+
+```bash
+npm install dotenv
+```
+
 Set your API key for the LLM provider you intend to use. For OpenAI, set the `OPENAI_API_KEY` environment variable.
+
+```bash filename=".env" copy
+OPENAI_API_KEY=<your-openai-api-key>
+```
 
 <Steps>
 
@@ -31,13 +41,16 @@ Set your API key for the LLM provider you intend to use. For OpenAI, set the `OP
 We'll start by creating a model configuration and initializing the Mastra instance.
 
 ```typescript
-import { CoreMessage, Mastra, type ModelConfig } from '@mastra/core';
+import { CoreMessage, Mastra, type ModelConfig } from "@mastra/core";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const mastra = new Mastra();
 
 const modelConfig: ModelConfig = {
-  provider: 'OPEN_AI',
-  name: 'gpt-4',
+  provider: "OPEN_AI",
+  name: "gpt-4",
 };
 
 const llm = mastra.LLM(modelConfig);
@@ -48,7 +61,7 @@ const llm = mastra.LLM(modelConfig);
 Next, we'll prepare our prompt. We'll ask:
 
 ```typescript
-const prompt = 'What is your favorite room in Hogwarts?';
+const prompt = "What is your favorite room in Hogwarts?";
 ```
 
 ## Test the Response
@@ -58,7 +71,7 @@ We'll use the `generate` method to get the response from the model.
 ```typescript
 const response = await llm.generate(prompt);
 
-console.log('Response:', response.text);
+console.log("Response:", response.text);
 ```
 
 We can't run top-level `await` though, so let's wrap our code in an `async` main function.
@@ -68,16 +81,16 @@ async function main() {
   const mastra = new Mastra();
 
   const modelConfig: ModelConfig = {
-    provider: 'OPEN_AI',
-    name: 'gpt-4',
+    provider: "OPEN_AI",
+    name: "gpt-4",
   };
 
   const llm = mastra.LLM(modelConfig);
-  const prompt = 'What is your favorite room in Hogwarts?';
+  const prompt = "What is your favorite room in Hogwarts?";
 
   const response = await llm.generate(prompt);
 
-  console.log('Response:', response.text);
+  console.log("Response:", response.text);
 }
 
 main();
@@ -106,18 +119,18 @@ To change the perspective, we'll add a system message to specify the persona of 
 ```typescript
 const messages = [
   {
-    role: 'system',
-    content: 'You are Harry Potter.',
+    role: "system",
+    content: "You are Harry Potter.",
   },
   {
-    role: 'user',
-    content: 'What is your favorite room in Hogwarts?',
+    role: "user",
+    content: "What is your favorite room in Hogwarts?",
   },
 ] as CoreMessage[];
 
 const responseHarry = await llm.generate(messages);
 
-console.log('Response as Harry Potter:', responseHarry.text);
+console.log("Response as Harry Potter:", responseHarry.text);
 ```
 
 Output:
@@ -133,11 +146,11 @@ Response as Harry Potter: My favorite room in Hogwarts is definitely the Gryffin
 Now, let's change the system message to have the model respond as Draco Malfoy.
 
 ```typescript
-messages[0].content = 'You are Draco Malfoy.';
+messages[0].content = "You are Draco Malfoy.";
 
 const responseDraco = await llm.generate(messages);
 
-console.log('Response as Draco Malfoy:', responseDraco.text);
+console.log("Response as Draco Malfoy:", responseDraco.text);
 ```
 
 Output:
@@ -168,7 +181,7 @@ main();
 Run the script again:
 
 ```bash copy
-OPENAI_API_KEY=<your-openai-api-key> npx tsx src/mastra/index.ts
+npx tsx src/mastra/index.ts
 ```
 
 **Output:**

--- a/docs/src/pages/docs/guides/02-chef-michel.mdx
+++ b/docs/src/pages/docs/guides/02-chef-michel.mdx
@@ -19,7 +19,6 @@ In this guide, we'll walk through creating a "Chef Assistant" agent that helps u
 Create a new file `src/mastra/agents/chefAgent.ts` and define your agent:
 
 ```ts copy filename="src/mastra/agents/chefAgent.ts"
-// src/mastra/agents/chefAgent.ts
 import { Agent } from '@mastra/core';
 
 export const chefAgent = new Agent({
@@ -41,8 +40,7 @@ export const chefAgent = new Agent({
 
 Create a `.env` file in your project root and add your OpenAI API key:
 
-```env
-# .env
+```bash filename=".env" copy
 OPENAI_API_KEY=your_openai_api_key
 ```
 

--- a/docs/src/pages/docs/guides/03-stock-agent.mdx
+++ b/docs/src/pages/docs/guides/03-stock-agent.mdx
@@ -1,4 +1,4 @@
-import { Steps } from 'nextra/components';
+import { Steps } from "nextra/components";
 
 # Stock Agent
 
@@ -34,14 +34,14 @@ Initialize a new Node.js project and install the required dependencies:
 
 ```bash
 npm init -y
-npm install @mastra/core zod
+npm install @mastra/core zod dotenv
 ```
 
-Set Up Environment Variables\*\*
+Set Up Environment Variables
 
 Create a `.env` file at the root of your project to store your OpenAI API key.
 
-```env:.env
+```bash filename=".env" copy
 OPENAI_API_KEY=your_openai_api_key
 ```
 
@@ -59,12 +59,14 @@ touch src/agents/stockAgent.ts src/tools/stockPrices.ts src/index.ts
 Next, we'll create a tool that fetches the last day's closing stock price for a given symbol.
 
 ```ts filename="src/tools/stockPrices.ts"
-import { createTool } from '@mastra/core';
-import { z } from 'zod';
+import { createTool } from "@mastra/core";
+import { z } from "zod";
 
 const getStockPrice = async (symbol: string) => {
-  const data = await fetch(`https://mastra-stock-data.vercel.app/api/stock-data?symbol=${symbol}`).then(r => r.json());
-  return data.prices['4. close'];
+  const data = await fetch(
+    `https://mastra-stock-data.vercel.app/api/stock-data?symbol=${symbol}`,
+  ).then((r) => r.json());
+  return data.prices["4. close"];
 };
 
 export const stockPrices = createTool({
@@ -74,7 +76,7 @@ export const stockPrices = createTool({
   }),
   description: `Fetches the last day's closing stock price for a given symbol`,
   execute: async ({ context: { symbol } }) => {
-    console.log('Using tool to fetch stock price for', symbol);
+    console.log("Using tool to fetch stock price for", symbol);
     return {
       symbol,
       currentPrice: await getStockPrice(symbol),
@@ -114,15 +116,18 @@ export const stockAgent = new Agent<typeof tools>({
 
 We need to initialize the Mastra instance with our agent and tool.
 
-````ts filename="src/index.ts"
-import { Mastra } from '@mastra/core';
+```ts filename="src/index.ts"
+import { Mastra } from "@mastra/core";
+import dotenv from "dotenv";
 
 import { stockAgent } from "./agents/stockAgent";
+
+dotenv.config();
 
 export const mastra = new Mastra({
   agents: { stockAgent },
 });
-````
+```
 
 ## Serve the Application
 
@@ -131,7 +136,7 @@ Instead of running the application directly, we'll use the `mastra dev` command 
 In your terminal, start the Mastra server by running:
 
 ```bash
-mastra dev --dir src 
+mastra dev --dir src
 ```
 
 This command will start the server and make your agent available at:


### PR DESCRIPTION
#### Problem
If you run follow our guide examples, but decide to use `tsx` as your compiler. It won't work without setting up `donenv`.

```Note: If you use `bun` to run any of our guide examples. You won't run into this problem because `bun` loads `.env` before running the file.```

#### Solution
- Include `dotenv` setup at part of the guide examples / installation setup.
- Use `tsx` instead of `bun` to run our guide examples. 