### PR TITLE
updated filtering for vector query

### DIFF
--- a/.changeset/wise-swans-shout.md
+++ b/.changeset/wise-swans-shout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Update filter for vector query to work with more stores

--- a/.changeset/wise-swans-shout.md
+++ b/.changeset/wise-swans-shout.md
@@ -1,5 +1,6 @@
 ---
 '@mastra/rag': patch
+'docs': patch
 ---
 
 Update filter for vector query to work with more stores

--- a/docs/src/pages/examples/rag/filter-rag.mdx
+++ b/docs/src/pages/examples/rag/filter-rag.mdx
@@ -47,7 +47,7 @@ const vectorQueryTool = createVectorQueryTool({
     maxRetries: 3,
   },
   topK: 3,
-  useFilter: true,
+  vectorFilterType: 'pg',
 });
 ```
 
@@ -137,11 +137,12 @@ async function generateResponse(
     value: string;
   },
 ) {
+  const { keyword, operator, value } = filter;
   const prompt = `
       Please answer the following question:
       ${query}
 
-      Please base your answer only on the context provided in the tool using this filter ${filter}. 
+      Please base your answer only on the context provided in the tool using this keyword: ${keyword}, this operator: ${operator}, and this value: ${value}.
       If the context doesn't contain enough information to fully answer the question, please state that explicitly.
       `;
 

--- a/examples/basics/rag/filter-rag/index.ts
+++ b/examples/basics/rag/filter-rag/index.ts
@@ -10,7 +10,7 @@ const vectorQueryTool = createVectorQueryTool({
     maxRetries: 3,
   },
   topK: 3,
-  useFilter: true,
+  vectorFilterType: 'pg',
 });
 
 export const ragAgent = new Agent({
@@ -87,11 +87,12 @@ async function generateResponse(
     value: string;
   },
 ) {
+  const { keyword, operator, value } = filter;
   const prompt = `
       Please answer the following question:
       ${query}
 
-      Please base your answer only on the context provided in the tool using this filter ${filter}. 
+      Please base your answer only on the context provided in the tool using this keyword: ${keyword}, this operator: ${operator}, and this value: ${value}.
       If the context doesn't contain enough information to fully answer the question, please state that explicitly.
       `;
 

--- a/packages/rag/src/pg/index.ts
+++ b/packages/rag/src/pg/index.ts
@@ -42,12 +42,15 @@ export class PgVector extends MastraVector {
       if (filter) {
         const conditions = Object.entries(filter).map(([key, condition]) => {
           // If condition is not a FilterCondition object, assume it's an equality check
-          if (!condition || typeof condition !== 'object' || !('operator' in condition)) {
+          if (!condition || typeof condition !== 'object') {
             filterValues.push(condition);
             return `metadata->>'${key}' = $${filterValues.length}`;
           }
 
-          const { operator, value } = condition;
+          const [[operator, value] = []] = Object.entries(condition ?? {});
+          if (!operator || value === undefined) {
+            throw new Error(`Invalid operator or value for key: ${key}`);
+          }
           if (!isValidOperator(operator)) {
             throw new Error(`Unsupported operator: ${operator}`);
           }


### PR DESCRIPTION
This PR updates the filtering for vector query to allow for different filter structures from different vector stores. 

Note: More work needs to be done to properly get filters correct for each vector store. Possibly adding a filter option when generating that can be passed to the tool, rather than having it done in the prompt.