### PR TITLE
Update Google Model Names

### DIFF
--- a/.changeset/popular-news-doubt.md
+++ b/.changeset/popular-news-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Update Google model support in documentation and type definitions to include new Gemini versions

--- a/.changeset/popular-news-doubt.md
+++ b/.changeset/popular-news-doubt.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': minor
----
-
-Update Google model support in documentation and type definitions to include new Gemini versions

--- a/.changeset/three-dryers-hide.md
+++ b/.changeset/three-dryers-hide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Update Google model support in documentation and type definitions to include new Gemini versions

--- a/docs/src/pages/docs/reference/llm/providers-and-models.mdx
+++ b/docs/src/pages/docs/reference/llm/providers-and-models.mdx
@@ -13,7 +13,7 @@ Mastra supports a variety of language models from different providers. There are
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | OpenAI        | `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`, `gpt-4o`, `gpt-4o-mini`                                                                                                         |
 | Anthropic     | `claude-3-5-sonnet-20241022`, `claude-3-5-sonnet-20240620`, `claude-3-5-haiku-20241022`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307` |
-| Google Gemini | `gemini-1.5-pro-latest`, `gemini-1.5-pro`, `gemini-1.5-flash-latest`, `gemini-1.5-flash`                                                                                 |
+| Google Gemini | `gemini-1.5-pro-latest`, `gemini-1.5-pro`, `gemini-1.5-flash-latest`, `gemini-1.5-flash`, `gemini-2.0-flash-exp-latest`, `gemini-2.0-flash-thinking-exp-1219`, `gemini-exp-1206` |
 
 ## Other natively supported providers
 

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -38,7 +38,14 @@ export type OpenAIConfig = {
   apiKey?: string;
 };
 
-export type GoogleModel = 'gemini-1.5-pro-latest' | 'gemini-1.5-pro' | 'gemini-1.5-flash-latest' | 'gemini-1.5-flash';
+export type GoogleModel =
+  | 'gemini-1.5-pro-latest'
+  | 'gemini-1.5-pro'
+  | 'gemini-1.5-flash-latest'
+  | 'gemini-1.5-flash'
+  | 'gemini-2.0-flash-exp-latest'
+  | 'gemini-2.0-flash-thinking-exp-1219'
+  | 'gemini-exp-1206'
 
 export type GoogleConfig = {
   provider: 'GOOGLE';


### PR DESCRIPTION
Update Google model support in documentation and type definitions to include new Gemini versions for 

- gemini-2.0-flash-exp
- gemini-2.0-flash-thinking-exp-1219
- gemini-exp-1206