### PR TITLE
Extend engine cli commands and update docs

### DIFF
--- a/.changeset/ninety-horses-buy.md
+++ b/.changeset/ninety-horses-buy.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'docs': patch
+---
+
+Adds -f option to engine commands to specify custom docker config. Updates Engine docs.

--- a/docs/src/pages/docs/local-dev/engine.mdx
+++ b/docs/src/pages/docs/local-dev/engine.mdx
@@ -26,8 +26,8 @@ npm install @mastra/engine
 Initialize the Mastra Engine by passing in a database connection URL. This can be done when you set up your main Mastra instance:
 
 ```typescript
-import { Mastra } from '@mastra/core';
-import { PostgresEngine } from '@mastra/engine';
+import { Mastra } from "@mastra/core";
+import { PostgresEngine } from "@mastra/engine";
 
 export const mastra = new Mastra({
   engine: new PostgresEngine({
@@ -60,31 +60,33 @@ With RAG (Retrieval-Augmented Generation), you can store document embeddings in 
 
 The Mastra CLI includes commands to manage your engine and database:
 
-- `mastra engine up`: Sets up your dev environment, starts Docker containers for Postgres, and configures `.env`.
+- `mastra engine add`: Sets up your dev environment, starts Docker containers for Postgres, and configures `.env`.
+- `mastra engine up`: Starts your Docker containers as defined in your docker config file.
 - `mastra engine migrate`: Runs database migrations.
 - `mastra engine generate`: Generates TypeScript types from your database schema.
+- `mastra engine down`: Stops your Docker containers.
 
 ## Example: Using the Mock Engine in Tests
 
 For testing or development, you can use the `MockMastraEngine`:
 
 ```typescript
-import { MockMastraEngine } from '@mastra/core';
+import { MockMastraEngine } from "@mastra/core";
 
-const mockEngine = new MockMastraEngine({ url: 'mock://localhost' });
+const mockEngine = new MockMastraEngine({ url: "mock://localhost" });
 
 // Create an entity
 const entity = await mockEngine.createEntity({
-  name: 'Contacts',
-  connectionId: 'user_123',
+  name: "Contacts",
+  connectionId: "user_123",
 });
 
 // Insert records
 await mockEngine.upsertRecords({
   entityId: entity.id,
   records: [
-    { externalId: 'c1', data: { name: 'Alice' }, entityType: 'Contacts' },
-    { externalId: 'c2', data: { name: 'Bob' }, entityType: 'Contacts' },
+    { externalId: "c1", data: { name: "Alice" }, entityType: "Contacts" },
+    { externalId: "c2", data: { name: "Bob" }, entityType: "Contacts" },
   ],
 });
 
@@ -107,21 +109,25 @@ When running in production:
 ## API Summary
 
 **Entity Management:**
+
 - `createEntity({ name, connectionId })`: Create a new entity
 - `getEntityById({ id })`: Get an entity by ID
 - `getEntity({ name, connectionId })`: Get entity by name and/or connectionId
 - `deleteEntityById({ id })`: Delete an entity and its associated records
 
 **Record Management:**
+
 - `upsertRecords({ entityId, records })`: Insert or update records for an entity
 - `getRecordsByEntityId({ entityId })`: Retrieve all records for an entity
 - `getRecordsByEntityName({ name, connectionId })`: Retrieve all records for an entity by name and connectionId
 - `getRecords({ entityName, connectionId, options })`: Query records with filtering, sorting, and pagination
 
 **Sync Operations:**
+
 - `syncRecords({ name, connectionId, records, lastSyncId })`: Sync incoming data to an entity
 
 **Vector Search (Future)**
+
 - Integrate with vector stores for RAG workflows.
 
 ## Conclusion

--- a/docs/src/pages/docs/reference/cli/engine.mdx
+++ b/docs/src/pages/docs/reference/cli/engine.mdx
@@ -11,17 +11,27 @@ Installs the `@mastra/engine` dependency to your project. The Mastra engine enab
 
 While not required for basic agent interactions, the engine becomes essential when your application needs persistence, background tasks, or vector search capabilities.
 
+This command sets up your development environment by:
+
+1. Creating or updating your environment file with the correct database URL
+2. Configuring the necessary environment variables
+3. Running `docker-compose up` to start required Docker containers
+
 ## `mastra engine generate`
 
 Generates the Drizzle database client and TypeScript types based on your database schema. Requires a valid database connection.
 
 ## `mastra engine up`
 
-Sets up your development environment by:
+Runs `docker-compose up` to start required Docker containers.
 
-1. Running `docker-compose up` to start required Docker containers
-2. Creating or updating your environment file with the correct database URL
-3. Configuring the necessary environment variables
+- Accepts a `-f` or `--file` option for a custom Docker config file path.
+
+## `mastra engine down`
+
+Runs `docker-compose down` to stop required Docker containers.
+
+- Accepts a `-f` or `--file` option for a custom Docker config file path.
 
 ## `mastra engine migrate`
 

--- a/examples/dane/.gitignore
+++ b/examples/dane/.gitignore
@@ -1,3 +1,4 @@
 output.txt
 node_modules
 dist/
+.env*

--- a/packages/cli/src/commands/engine/down.ts
+++ b/packages/cli/src/commands/engine/down.ts
@@ -2,12 +2,13 @@ import yoctoSpinner from 'yocto-spinner';
 
 import { DockerService } from '../../services/service.docker.js';
 
-export async function down() {
+export async function down(composePath?: string) {
   const spinner = yoctoSpinner({ text: 'Shutting down docker container\n' });
   spinner.start();
   try {
     const dockerService = new DockerService();
-    await dockerService.stopDockerContainer('mastra-pg.docker-compose.yaml');
+    const composeFile = dockerService.getComposeFile(composePath);
+    await dockerService.stopDockerContainer(composeFile);
     spinner.success('Docker container shut down successfully\n');
   } catch (error) {
     spinner.error('Failed to shut down Docker container\n');

--- a/packages/cli/src/commands/engine/up.ts
+++ b/packages/cli/src/commands/engine/up.ts
@@ -2,12 +2,13 @@ import yoctoSpinner from 'yocto-spinner';
 
 import { DockerService } from '../../services/service.docker.js';
 
-export async function up() {
+export async function up(composePath?: string) {
   const spinner = yoctoSpinner({ text: 'Starting docker container\n' });
   spinner.start();
   try {
     const dockerService = new DockerService();
-    await dockerService.startDockerContainer('mastra-pg.docker-compose.yaml');
+    const composeFile = dockerService.getComposeFile(composePath);
+    await dockerService.startDockerContainer(composeFile);
     spinner.success('Docker containers started successfully\n');
   } catch (error) {
     spinner.error('Failed to start Docker containers\n');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -167,12 +167,13 @@ engine
 engine
   .command('up')
   .description('Runs docker-compose up to start docker containers')
-  .action(async () => {
+  .option('-f, --file <path>', 'Path to docker-compose file')
+  .action(async args => {
     await analytics.trackCommandExecution({
       command: 'engine up',
-      args: {},
+      args,
       execution: async () => {
-        await up();
+        await up(args.file);
       },
     });
   });
@@ -180,12 +181,13 @@ engine
 engine
   .command('down')
   .description('Runs docker-compose down to shut down docker containers')
-  .action(async () => {
+  .option('-f, --file <path>', 'Path to docker-compose file')
+  .action(async args => {
     await analytics.trackCommandExecution({
       command: 'engine down',
       args: {},
       execution: async () => {
-        await down();
+        await down(args.file);
       },
     });
   });

--- a/packages/cli/src/services/service.docker.ts
+++ b/packages/cli/src/services/service.docker.ts
@@ -1,4 +1,5 @@
 import { execa } from 'execa';
+import fs from 'fs';
 import path from 'path';
 import { check } from 'tcp-port-used';
 import { fileURLToPath } from 'url';
@@ -141,5 +142,25 @@ export class DockerService {
         { replace: `${postgresPort}`, search: 'REPLACE_DB_PORT' },
       ],
     });
+  }
+
+  getComposeFile(composePath: string) {
+    const fileService = new FileService();
+    let composeFile: string;
+    if (composePath) {
+      if (!fs.existsSync(composePath)) {
+        throw new Error(`Docker compose file not found: ${composePath}`);
+      }
+      composeFile = composePath;
+    } else {
+      composeFile = fileService.getFirstExistingFile([
+        'mastra-pg.docker-compose.yaml',
+        'mastra-pg.docker-compose.yml',
+        'docker-compose.yaml',
+        'docker-compose.yml',
+      ]);
+    }
+
+    return composeFile;
   }
 }


### PR DESCRIPTION
This adds a -f or --file option to the engine commands of the CLI. This is needed if a user wants to create a custom docker file or rename the one created by mastra (to perhaps combine it with other docker containers).