### PR TITLE
split up workflow docs

### DIFF
--- a/docs/src/pages/docs/workflows/00-overview.mdx
+++ b/docs/src/pages/docs/workflows/00-overview.mdx
@@ -1,119 +1,32 @@
+---
+title: Workflows in Mastra
+---
+
 # Workflows in Mastra
 
-Workflows in Mastra are powerful tools for orchestrating complex sequences of operations. They support loops, branching, parallel execution, error handling, and more.
+Workflows in Mastra help you orchestrate complex sequences of operations with features like branching, parallel execution, resource suspension, and more. 
 
-The most powerful feature of workflows is that you can log the input and output of each step of each run, and send the results to your favorite observability tools. Teams have found this to be a powerful way to monitor and debug their workflows.
+## Why Use Workflows?
 
-## Building a Workflow
+Most AI applications need more than a single call to a language model. You may want to run multiple steps, conditionally skip certain paths, or even pause execution altogether until you receive more data. 
 
-In this overview, we'll create a workflow with dummy steps to demonstrate how workflows are structured and executed in Mastra. We'll cover options for defining steps, different kinds of control flow between steps, conditions, and variables.
+Mastra’s workflow system provides:
 
-### 1. Define Steps
+• A standardized way to define steps and link them together.
+• Support for both simple (linear) and advanced (branching, parallel) paths.
+• Powerful debugging and observability features to track each workflow run.
 
-You can define steps inline or by function reference.
+## Example
 
-#### Option 1: Inline Step Creation
+To create a workflow, you define one or more steps, link them, and then commit the workflow before starting it.
 
-Define steps directly within the workflow using the `.step()` and `.then()` methods.
+Typically, you would call an LLM or other service in some way in some step. But for this example, we'll just double the input value in the first step and increment it in the second.
 
-```typescript showLineNumbers filename="src/mastra/workflows/index.ts" copy
-import { Step, Workflow } from "@mastra/core";
+```typescript
+import { Workflow, Step } from "@mastra/core";
 import { z } from "zod";
 
-export const myWorkflow = new Workflow({
-  name: "my-workflow",
-  triggerSchema: z.object({
-    inputValue: z.number(),
-  }),
-});
-
-myWorkflow
-  .step(
-    new Step({
-      id: "stepOne",
-      outputSchema: z.object({
-        doubledValue: z.number(),
-      }),
-      execute: async ({ context }) => {
-        const inputValue = context.machineContext?.getStepPayload<{
-          inputValue: number;
-        }>("trigger")?.inputValue;
-        if (!inputValue) {
-          throw new Error("Input value does not exist");
-        }
-        const doubledValue = inputValue * 2;
-        return { doubledValue };
-      },
-    }),
-  )
-  .then(
-    new Step({
-      id: "stepTwo",
-      outputSchema: z.object({
-        incrementedValue: z.number(),
-      }),
-      execute: async ({ context }) => {
-        const valueToIncrement = context.machineContext?.getStepPayload<{
-          doubledValue: number;
-        }>("stepOne")?.doubledValue;
-
-        if (!valueToIncrement) {
-          throw new Error("Value to increment does not exist");
-        }
-
-        const incrementedValue = valueToIncrement + 1;
-        return { incrementedValue };
-      },
-    }),
-  );
-```
-
-#### Option 2: Define Steps Separately
-
-Define steps separately and then add them to the workflow.
-
-```typescript showLineNumbers filename="src/mastra/workflows/index.ts" copy
-import { Step, Workflow } from "@mastra/core";
-import { z } from "zod";
-
-// Define steps separately
-const stepOne = new Step({
-  id: "stepOne",
-  outputSchema: z.object({
-    doubledValue: z.number(),
-  }),
-  execute: async ({ context }) => {
-    const inputValue = context.machineContext?.getStepPayload<{
-      inputValue: number;
-    }>("trigger")?.inputValue;
-    if (!inputValue) {
-      throw new Error("Input value does not exist");
-    }
-    const doubledValue = inputValue * 2;
-    return { doubledValue };
-  },
-});
-
-const stepTwo = new Step({
-  id: "stepTwo",
-  outputSchema: z.object({
-    incrementedValue: z.number(),
-  }),
-  execute: async ({ context }) => {
-    const valueToIncrement = context.machineContext?.getStepPayload<{
-      doubledValue: number;
-    }>("stepOne")?.doubledValue;
-
-    if (!valueToIncrement) {
-      throw new Error("Value to increment does not exist");
-    }
-
-    const incrementedValue = valueToIncrement + 1;
-    return { incrementedValue };
-  },
-});
-
-// Build the workflow
+// 1. Define the workflow
 const myWorkflow = new Workflow({
   name: "my-workflow",
   triggerSchema: z.object({
@@ -121,263 +34,57 @@ const myWorkflow = new Workflow({
   }),
 });
 
-myWorkflow.step(stepOne).then(stepTwo);
-```
-
-### 2. Control Flow Between Steps
-
-#### Parallel Execution
-
-Use `.step()` to add steps that can run in parallel.
-
-```typescript
-myWorkflow.step(fetchUserData).step(fetchOrderData); // These steps run in parallel
-```
-
-#### Sequential Execution
-
-Use `.then()` to chain steps that depend on the previous step.
-
-```typescript
-myWorkflow.step(fetchOrderData).then(validateData).then(processOrder);
-```
-
-#### Branching and Merging Paths
-
-Use `.after()` to specify dependencies explicitly and to manage branching.
-
-```typescript
-myWorkflow
-  .step(stepA)
-  .then(stepB)
-  .then(stepD)
-  .after(stepA)
-  .step(stepC)
-  .then(stepE)
-  .after([stepD, stepE])
-  .step(stepF);
-```
-
-In this example:
-
-- `stepA` leads to `stepB`, then to `stepD`.
-- Separately, after `stepA`, we start `stepC`, which leads to `stepE`.
-- Once both `stepD` and `stepE` complete, `stepF` runs.
-
-#### Cyclical Dependencies
-
-Workflows can support cyclical dependencies, allowing steps to loop based on conditions.
-
-```typescript
-myWorkflow
-  .step(fetchData)
-  .then(processData)
-  .after(processData)
-  .step(finalizeData, {
-    when: { "processData.status": "success" },
+// 2. Create steps
+const stepOne = new Step({
+  id: "stepOne",
+  execute: async ({ context: { machineContext } }) => ({
+    doubledValue: machineContext.triggerData.inputValue * 2
   })
-  .step(fetchData, {
-    when: { "processData.status": "retry" },
-  });
-```
-
-In this example:
-
-- If `processData` results in a status of `"success"`, `finalizeData` will run.
-- If `processData` results in a status of `"retry"`, the workflow loops back to `fetchData`.
-
-### 3. Conditions
-
-Use the `when` property to define conditions under which a step should execute.
-
-#### Option 1: Function
-
-```typescript
-myWorkflow.step(
-  new Step({
-    id: "processData",
-    execute: async ({ context }) => {
-      // Action logic
-    },
-  }),
-  {
-    when: async ({ context }) => {
-      const fetchData = context?.getStepPayload<{
-        status: string;
-      }>("fetchData");
-      return fetchData?.status === "success";
-    },
-  },
-);
-```
-
-#### Option 2: Query Object
-
-```typescript
-myWorkflow.step(
-  new Step({
-    id: "processData",
-    execute: async ({ context }) => {
-      // Action logic
-    },
-  }),
-  {
-    when: {
-      ref: {
-        step: {
-          id: "fetchData",
-        },
-        path: "status",
-      },
-      query: { $eq: "success" },
-    },
-  },
-);
-```
-
-#### Option 3: Simple Path Comparison (Syntactic Sugar)
-
-```typescript
-myWorkflow.step(
-  new Step({
-    id: "processData",
-    execute: async ({ context }) => {
-      // Action logic
-    },
-  }),
-  {
-    when: {
-      "fetchData.status": "success",
-    },
-  },
-);
-```
-
-### 4. Variables
-
-Variables allow you to pass data between steps.
-
-#### Option 1: Pass the "trigger" to access variables from the triggerSchema
-
-```typescript
-myWorkflow.step(stepOne).then(stepTwo, {
-  variables: {
-    valueToIncrement: {
-      step: "trigger",
-      path: "inputValue",
-    },
-  },
 });
-```
 
-#### Option 2: Pass the previous step to access variables from it's outputSchema
-
-```typescript
-myWorkflow.step(stepOne).then(stepTwo, {
-  variables: {
-    valueToIncrement: {
-      step: stepOne,
-      path: "doubledValue",
-    },
-  },
+const stepTwo = new Step({
+  id: "stepTwo",
+  execute: async ({ context: { machineContext } }) => ({
+    incrementedValue: machineContext.stepResults.stepOne.payload.doubledValue + 1
+  })
 });
+
+// 3. Link and commit steps
+myWorkflow.step(stepOne).then(stepTwo).commit();
+
+// 4. Run the workflow
+const { runId, start } = myWorkflow.createRun({ triggerData: { inputValue: 3 } });
+
+const result = await start();
+console.log("Workflow result:", result.results);
 ```
 
-#### Option 3: Pass the step id of the previous step to access variables from it's outputSchema
+This example shows the essentials: define your workflow, add steps, commit the workflow, then execute it. 
 
-```typescript
-myWorkflow.step(stepOne).then(stepTwo, {
-  variables: {
-    valueToIncrement: {
-      step: {
-        id: "stepOne",
-      },
-      path: "doubledValue",
-    },
-  },
-});
-```
+## Defining Steps
 
-The `valueToIncrement` input for `stepTwo` is fetched from the `doubledValue` output of `stepOne`.
+The basic building block of a workflow [is a step](./steps.mdx). Steps are defined using schemas for inputs and outputs, and can fetch prior step results.
 
-### 5. Finalize the Workflow
+## Control Flow
 
-After defining all steps and their relationships, commit the workflow.
+Workflows let you define a [control flow](./control-flow.mdx) to chain steps together in with parallel steps, branching paths, and more.
 
-```typescript
-myWorkflow.commit();
-```
+## Suspend and Resume
 
-### 6. Add Workflow to Mastra Instance
+When you need to pause execution for external data, user input, or asynchronous events, Mastra supports suspension at any step, persisting the state of the workflow so you can resume it later.
 
-Add the workflow to your Mastra instance.
+## Observability and Debugging
 
-```typescript filename="src/mastra/index.ts" copy
-import { Mastra } from "@mastra/core";
-import { z } from "zod";
+Mastra workflows automatically log the input and output of each step within a workflow run, allowing you to send this data to your preferred logging, telemetry, or observability tools. You can:
 
-import { myWorkflow } from "./workflows";
+• Track the status of each step (e.g., success, error, or suspended).
+• Store run-specific metadata for auditing and post-run analysis.
+• Integrate with third-party observability platforms like Datadog or New Relic by forwarding logs.
 
-export const mastra = new Mastra({
-  workflows: { myWorkflow },
-});
-```
+See the [OTel Configuration](../reference/observability/otel-config.mdx) page for more details.
 
-### 7. Serve the Workflow
+## More Resources
 
-We can now serve the workflow using the `mastra dev` command.
+• Check out our [Workflow Guide](../guides/04-recruiter.mdx) in the Examples section for a hands-on tutorial.
+• Explore the [Workflow Examples](../../examples/workflows/creating-a-workflow.mdx) (including parallel steps, branching paths, cyclical dependencies, calling an LLM, and more).
 
-#### Start the Mastra Server
-
-Open your terminal and run:
-
-```bash copy
-mastra dev
-```
-
-This command will start the server and make your workflow available at:
-
-```
-http://localhost:4111/api/workflows/myWorkflow/execute
-```
-
-### 8. Test the Workflow with cURL
-
-With the server running, you can test your workflow using `curl`:
-
-```bash copy
-curl -X POST http://localhost:4111/api/workflows/myWorkflow/execute \
-  -H "Content-Type: application/json" \
-  -d '{
-    "inputValue": 5
-  }'
-```
-
-Expected Response:
-
-You should receive a JSON response similar to:
-
-```json
-{
-  "results": {
-    "stepOne": {
-      "status": "success",
-      "payload": {
-        "doubledValue": 10
-      }
-    },
-    "stepTwo": {
-      "status": "success",
-      "payload": {
-        "incrementedValue": 11
-      }
-    }
-  },
-  "workflow": "myWorkflow"
-}
-```
-
-This indicates that:
-
-- `stepOne` doubled the input value `5` to `10`.
-- `stepTwo` incremented `10` by `1` to get `11`.

--- a/docs/src/pages/docs/workflows/_meta.js
+++ b/docs/src/pages/docs/workflows/_meta.js
@@ -1,5 +1,7 @@
 const meta = {
   "00-overview": "Overview",
+  "steps": "Steps",
+  "control-flow": "Control Flow",
 };
 
 export default meta;

--- a/docs/src/pages/docs/workflows/control-flow.mdx
+++ b/docs/src/pages/docs/workflows/control-flow.mdx
@@ -1,0 +1,180 @@
+# Control Flow in Workflows
+
+When you create a multi-step process, you may need to run steps in parallel, chain them sequentially, or follow different paths based on outcomes. This page describes how you can manage branching, merging, and conditions to construct workflows that meet your logic requirements. The code snippets show the key patterns for structuring complex control flow.
+
+## Parallel Execution
+
+You can run multiple steps at the same time if they don’t depend on each other. This approach can speed up your workflow when steps perform independent tasks. The code below shows how to add two steps in parallel:
+
+```typescript
+myWorkflow.step(fetchUserData).step(fetchOrderData);
+```
+
+See the [Parallel Steps](../examples/workflows/parallel-steps.mdx) example for more details.
+
+## Sequential Execution
+
+Sometimes you need to run steps in strict order to ensure outputs from one step become inputs for the next. Use .then() to link dependent operations. The code below shows how to chain steps sequentially:
+
+```typescript
+myWorkflow.step(fetchOrderData).then(validateData).then(processOrder);
+```
+
+See the [Sequential Steps](../examples/workflows/sequential-steps.mdx) example for more details.
+
+## Branching and Merging Paths
+
+When different outcomes require different paths, branching is helpful. You can also merge paths later once they complete. The code below shows how to branch after stepA and later converge on stepF:
+
+```typescript
+myWorkflow
+  .step(stepA)
+    .then(stepB)
+    .then(stepD)
+  .after(stepA)
+    .step(stepC)
+    .then(stepE)
+  .after([stepD, stepE])
+    .step(stepF);
+```
+
+In this example:
+
+- stepA leads to stepB, then to stepD.  
+- Separately, stepA also triggers stepC, which in turn leads to stepE.  
+- The workflow waits for both stepD and stepE to finish before proceeding to stepF.
+
+See the [Branching Paths](../examples/workflows/branching-paths.mdx) example for more details.
+
+## Cyclical Dependencies
+
+You can loop back to earlier steps based on conditions, allowing you to repeat tasks until certain results are achieved. The code below shows a workflow that repeats fetchData when a status is “retry”:
+
+```typescript
+myWorkflow
+  .step(fetchData)
+  .then(processData)
+  .after(processData)
+  .step(finalizeData, {
+    when: { "processData.status": "success" },
+  })
+  .step(fetchData, {
+    when: { "processData.status": "retry" },
+  });
+```
+
+If processData returns “success,” finalizeData runs. If it returns “retry,” the workflow loops back to fetchData.
+
+See the [Cyclical Dependencies](../examples/workflows/cyclical-dependencies.mdx) example for more details.
+
+## Conditions
+
+Use the when property to control whether a step runs based on data from previous steps. Below are three ways to specify conditions.
+
+### Option 1: Function
+
+```typescript
+myWorkflow.step(
+  new Step({
+    id: "processData",
+    execute: async ({ context }) => {
+      // Action logic
+    },
+  }),
+  {
+    when: async ({ context }) => {
+      const fetchData = context?.getStepPayload<{ status: string }>("fetchData");
+      return fetchData?.status === "success";
+    },
+  },
+);
+```
+
+### Option 2: Query Object
+
+```typescript
+myWorkflow.step(
+  new Step({
+    id: "processData",
+    execute: async ({ context }) => {
+      // Action logic
+    },
+  }),
+  {
+    when: {
+      ref: {
+        step: {
+          id: "fetchData",
+        },
+        path: "status",
+      },
+      query: { $eq: "success" },
+    },
+  },
+);
+```
+
+### Option 3: Simple Path Comparison
+
+```typescript
+myWorkflow.step(
+  new Step({
+    id: "processData",
+    execute: async ({ context }) => {
+      // Action logic
+    },
+  }),
+  {
+    when: {
+      "fetchData.status": "success",
+    },
+  },
+);
+```
+
+## Renaming Variables
+
+Variables let you pass outputs from one step into another step’s inputs.
+
+### Passing Trigger Data
+
+```typescript
+myWorkflow.step(stepOne).then(stepTwo, {
+  variables: {
+    valueToIncrement: {
+      step: "trigger",
+      path: "inputValue",
+    },
+  },
+});
+```
+
+### Passing Output from a Previous Step
+
+```typescript
+myWorkflow.step(stepOne).then(stepTwo, {
+  variables: {
+    valueToIncrement: {
+      step: stepOne,
+      path: "doubledValue",
+    },
+  },
+});
+```
+
+### Passing Output Using a Step ID
+
+```typescript
+myWorkflow.step(stepOne).then(stepTwo, {
+  variables: {
+    valueToIncrement: {
+      step: {
+        id: "stepOne",
+      },
+      path: "doubledValue",
+    },
+  },
+});
+```
+
+In all these examples, you pick the specific data you want to pass forward. This approach helps decouple steps and keep your workflow logic clear.

--- a/docs/src/pages/docs/workflows/steps.mdx
+++ b/docs/src/pages/docs/workflows/steps.mdx
@@ -1,0 +1,86 @@
+# Defining Steps in a Workflow
+
+When you build a workflow, you typically break down operations into smaller tasks that can be linked and reused. Steps provide a structured way to manage these tasks by defining inputs, outputs, and execution logic. 
+
+The code below shows how to define these steps inline or separately.
+
+## Inline Step Creation
+
+You can create steps directly within your workflow using `.step()` and `.then()`. This code shows how to define, link, and execute two steps in sequence.
+
+```typescript showLineNumbers filename="src/mastra/workflows/index.ts" copy
+import { Step, Workflow } from "@mastra/core";
+import { z } from "zod";
+
+export const myWorkflow = new Workflow({
+  name: "my-workflow",
+  triggerSchema: z.object({
+    inputValue: z.number(),
+  }),
+});
+
+myWorkflow
+  .step(
+    new Step({
+      id: "stepOne",
+      outputSchema: z.object({
+        doubledValue: z.number(),
+      }),
+      execute: async ({ context: { machineContext } }) => ({
+        doubledValue: machineContext.triggerData.inputValue * 2,
+      }),
+    }),
+  )
+  .then(
+    new Step({
+      id: "stepTwo",
+      outputSchema: z.object({
+        incrementedValue: z.number(),
+      }),
+      execute: async ({ context: { machineContext } }) => ({
+        incrementedValue: machineContext.stepResults.stepOne.payload.doubledValue + 1,
+      }),
+    }),
+  );
+```
+
+## Creating Steps Separately
+
+If you prefer to manage your step logic in separate entities, you can define steps outside and then add them to your workflow. This code shows how to define steps independently and link them afterward.
+
+```typescript showLineNumbers filename="src/mastra/workflows/index.ts" copy
+import { Step, Workflow } from "@mastra/core";
+import { z } from "zod";
+
+// Define steps separately
+const stepOne = new Step({
+  id: "stepOne",
+  outputSchema: z.object({
+    doubledValue: z.number(),
+  }),
+  execute: async ({ context: { machineContext } }) => ({
+    doubledValue: machineContext.triggerData.inputValue * 2,
+  }),
+});
+
+const stepTwo = new Step({
+  id: "stepTwo",
+  outputSchema: z.object({
+    incrementedValue: z.number(),
+  }),
+  execute: async ({ context: { machineContext } }) => ({
+    incrementedValue: machineContext.stepResults.stepOne.payload.doubledValue + 1,
+  }),
+});
+
+// Build the workflow
+const myWorkflow = new Workflow({
+  name: "my-workflow",
+  triggerSchema: z.object({
+    inputValue: z.number(),
+  }),
+});
+
+myWorkflow.step(stepOne).then(stepTwo);
+myWorkflow.commit();
+```


### PR DESCRIPTION
There's still a bunch to do for workflows like add suspend resume docs and modify the confusing variable docs. But this is at least a start to get out of this one long page of death problem.