### PR TITLE
Fix Workflow `createRun` options argument & trigger data requirement

### DIFF
--- a/docs/src/pages/docs/reference/workflows/createRun.mdx
+++ b/docs/src/pages/docs/reference/workflows/createRun.mdx
@@ -1,15 +1,15 @@
 # createRun
 
-The createRun method initializes a new workflow run instance. It generates a unique run ID for tracking and returns a start function that begins workflow execution when called.
+The createRun method initializes a new workflow run instance. It generates a unique run ID (or you can pass in your own custom ID) for tracking and returns a start function that begins workflow execution when called.
 
 ## Usage
 
 ```typescript
-const { runId, start } = workflow.createRun({ 
+const { runId, start } = workflow.createRun({
   triggerData: { inputValue: 42 },
   metadata: {
-    requestId: "abc-123" 
-  }
+    requestId: "abc-123",
+  },
 });
 
 const result = await start();
@@ -23,8 +23,8 @@ const result = await start();
       name: "config",
       type: "object",
       description: "Configuration options for the workflow run",
-      isOptional: true
-    }
+      isOptional: true,
+    },
   ]}
 />
 
@@ -36,14 +36,14 @@ const result = await start();
       name: "triggerData",
       type: "Record<string, any>",
       description: "Initial data passed to trigger the workflow execution",
-      isOptional: true
+      isOptional: true,
     },
     {
-      name: "metadata", 
+      name: "metadata",
       type: "Record<string, any>",
       description: "Additional metadata to associate with this run",
-      isOptional: true
-    }
+      isOptional: true,
+    },
   ]}
 />
 
@@ -54,13 +54,13 @@ const result = await start();
     {
       name: "runId",
       type: "string",
-      description: "Unique identifier for tracking this workflow run"
+      description: "Unique identifier for tracking this workflow run",
     },
     {
       name: "start",
       type: "() => Promise<WorkflowResult>",
-      description: "Function that begins workflow execution when called"
-    }
+      description: "Function that begins workflow execution when called",
+    },
   ]}
 />
 
@@ -76,7 +76,7 @@ try {
   if (error instanceof ValidationError) {
     // Handle validation errors
     console.log(error.type); // 'circular_dependency' | 'no_terminal_path' | 'unreachable_step'
-    console.log(error.details); 
+    console.log(error.details);
   }
 }
 ```
@@ -86,4 +86,7 @@ try {
 - [Workflow Class Reference](./workflow.mdx)
 - [Step Class Reference](./step.mdx)
 - See the [Creating a Workflow](../../examples/workflows/creating-a-workflow.mdx) example for complete usage
+
+```
+
 ```

--- a/docs/src/pages/examples/workflows/branching-paths.mdx
+++ b/docs/src/pages/examples/workflows/branching-paths.mdx
@@ -75,7 +75,9 @@ myWorkflow
   .then(stepFour)
   .commit();
 
-const result = await myWorkflow.execute({ triggerData: { inputValue: 3 } });
+const result = await myWorkflow
+  .createRun({ triggerData: { inputValue: 3 } })
+  .start();
 ```
 
 <br />

--- a/docs/src/pages/examples/workflows/parallel-steps.mdx
+++ b/docs/src/pages/examples/workflows/parallel-steps.mdx
@@ -73,7 +73,9 @@ myWorkflow
   .then(stepFour) // chain two
   .commit();
 
-const result = await myWorkflow.execute({ triggerData: { inputValue: 3 } });
+const result = await myWorkflow
+  .createRun({ triggerData: { inputValue: 3 } })
+  .start();
 ```
 
 <br />

--- a/examples/basics/workflows/workflow-with-branching-paths/index.ts
+++ b/examples/basics/workflows/workflow-with-branching-paths/index.ts
@@ -47,4 +47,6 @@ const myWorkflow = new Workflow({
 
 myWorkflow.step(stepOne).then(stepTwo).after(stepOne).step(stepThree).then(stepFour).commit();
 
-const result = await myWorkflow.execute({ triggerData: { inputValue: 3 } });
+const result = await myWorkflow
+  .createRun({ triggerData: { inputValue: 3 } })
+  .start();

--- a/examples/workflow-with-separate-steps/src/mastra/workflows/index.ts
+++ b/examples/workflow-with-separate-steps/src/mastra/workflows/index.ts
@@ -46,4 +46,6 @@ const myWorkflow = new Workflow({
 
 myWorkflow.step(stepOne).then(stepTwo).step(stepThree).then(stepFour).commit();
 
-const result = await myWorkflow.execute({ triggerData: { inputValue: 3 } });
+const result = await myWorkflow
+  .createRun({ triggerData: { inputValue: 3 } })
+  .start();

--- a/packages/cli/src/templates/express-server.ts
+++ b/packages/cli/src/templates/express-server.ts
@@ -422,7 +422,7 @@ app.post('/api/workflows/:workflowId/execute', async (req: Request, res: Respons
   try {
     const workflowId = req.params.workflowId;
     const workflow = mastra.getWorkflow(workflowId);
-    const result = await workflow.execute({ triggerData: req.body });
+    const result = await workflow.createRun({ triggerData: req.body }).start();
     res.json({
       results: result?.results ?? {},
       workflow: workflowId,

--- a/packages/cli/src/templates/netlify.ts
+++ b/packages/cli/src/templates/netlify.ts
@@ -291,7 +291,7 @@ app.post('/api/workflows/:workflowId/execute', async (req: Request, res: Respons
   try {
     const workflowId = req.params.workflowId;
     const workflow = mastra.getWorkflow(workflowId);
-    const result = await workflow.execute(req.body);
+    const result = await workflow.createRun(req.body).start();
     res.json(result);
   } catch (error) {
     const apiError = error as ApiError;

--- a/packages/cli/src/templates/worker.ts
+++ b/packages/cli/src/templates/worker.ts
@@ -438,7 +438,7 @@ router.post('/workflows/:workflowId/execute', async ({ params, json, mastra }: I
     const workflowId = decodeURIComponent(params.workflowId);
     const workflow = mastra.getWorkflow(workflowId);
     const body = await json();
-    const result = await workflow.execute(body);
+    const result = await workflow.createRun(body).start();
 
     return new Response(JSON.stringify(result), {
       headers: {

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { IAction, IExecutionContext } from '../action';
 import { BaseLogMessage, RegisteredLogger } from '../logger';
+import { Snapshot } from 'xstate';
 
 export interface StepExecutionContext<
   TSchemaIn extends z.ZodSchema | undefined = undefined,
@@ -145,6 +146,23 @@ type StepFailure = {
 };
 
 export type StepResult<T> = StepSuccess<T> | StepFailure | StepSuspended | StepWaiting;
+
+interface WorkflowRunOptions {
+  runId?: string;
+  stepId?: string;
+  snapshot?: Snapshot<any>;
+}
+
+// Trigger data is required when a workflow has a trigger schema
+export interface WorkflowRunOptionsWithTrigger<TTriggerSchema extends z.ZodTypeAny>
+  extends WorkflowRunOptions {
+  triggerData: z.infer<TTriggerSchema>;
+}
+
+// Type helper using a conditional type to handle cases where a triggerSchema is present or absent
+export type WorkflowExecuteParams<TTriggerSchema extends z.ZodTypeAny> = TTriggerSchema extends z.ZodTypeAny
+  ? [options: WorkflowRunOptionsWithTrigger<TTriggerSchema>]
+  : [options?: WorkflowRunOptions];
 
 // Update WorkflowContext
 export interface WorkflowContext<TTrigger extends z.ZodType<any> = any> {

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -21,7 +21,7 @@ describe('Workflow', () => {
 
       workflow.step(step1).commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(execute).toHaveBeenCalled();
       expect(result.results['step1']).toEqual({
@@ -47,7 +47,7 @@ describe('Workflow', () => {
 
       workflow.step(step1).step(step2).commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(step1Action).toHaveBeenCalled();
       expect(step2Action).toHaveBeenCalled();
@@ -78,7 +78,7 @@ describe('Workflow', () => {
 
       workflow.step(step1).then(step2).commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(executionOrder).toEqual(['step1', 'step2']);
       expect(result.results).toEqual({
@@ -138,7 +138,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      const result = await workflow.execute({ triggerData: { status: 'pending' } });
+      const result = await workflow.createRun({ triggerData: { status: 'pending' } }).start();
 
       expect(step1Action).toHaveBeenCalled();
       expect(step2Action).toHaveBeenCalled();
@@ -163,7 +163,7 @@ describe('Workflow', () => {
 
       workflow.step(step1).then(step2).commit();
 
-      const result = await workflow.execute().catch(err => err);
+      const result = await workflow.createRun().start().catch(err => err);
 
       expect(step1Action).toHaveBeenCalled();
       expect(step2Action).not.toHaveBeenCalled();
@@ -195,7 +195,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(step1Action).toHaveBeenCalled();
       expect(step2Action).toHaveBeenCalled();
@@ -232,7 +232,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(step2Action).toHaveBeenCalled();
       expect(result.results.step1).toEqual({
@@ -270,7 +270,7 @@ describe('Workflow', () => {
         .then(step2)
         .commit();
 
-      const result = await workflow.execute({ triggerData: { inputData: 'test-input' } });
+      const result = await workflow.createRun({ triggerData: { inputData: 'test-input' } }).start();
 
       expect(result.results.step1).toEqual({ status: 'success', payload: { result: 'success' } });
       expect(result.results.step2).toEqual({ status: 'success', payload: { result: 'success' } });
@@ -327,9 +327,9 @@ describe('Workflow', () => {
 
       workflow.step(step1).then(step2).commit();
 
-      const result = await workflow.execute({
+      const result = await workflow.createRun({
         triggerData: { inputValue: 'test-input' },
-      });
+      }).start();
 
       expect(step1Action).toHaveBeenCalled();
       expect(step2Action).toHaveBeenCalled();
@@ -354,9 +354,9 @@ describe('Workflow', () => {
 
       workflow.step(step1).commit();
 
-      const results = await workflow.execute({
+      const results = await workflow.createRun({
         triggerData: { inputData: 'test-input' },
-      });
+      }).start();
 
       const baseContext = {
         attempts: { step1: 3 },
@@ -407,7 +407,7 @@ describe('Workflow', () => {
         getStepPayload: expect.any(Function),
       };
 
-      await workflow.execute({ triggerData: { inputData: { nested: { value: 'test' } } } });
+      await workflow.createRun({ triggerData: { inputData: { nested: { value: 'test' } } } }).start();
 
       expect(execute).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -453,7 +453,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      const results = await workflow.execute();
+      const results = await workflow.createRun().start();
 
       const baseContext = {
         attempts: { step1: 3, step2: 3 },
@@ -499,7 +499,7 @@ describe('Workflow', () => {
 
       workflow.step(step1).commit();
 
-      await expect(workflow.execute()).resolves.toEqual({
+      await expect(workflow.createRun().start()).resolves.toEqual({
         results: {
           step1: {
             error: 'Step execution failed',
@@ -532,7 +532,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      await expect(workflow.execute()).resolves.toEqual({
+      await expect(workflow.createRun().start()).resolves.toEqual({
         results: {
           step1: {
             status: 'success',
@@ -629,7 +629,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(step2Action).toHaveBeenCalled();
       expect(step3Action).not.toHaveBeenCalled();
@@ -670,12 +670,12 @@ describe('Workflow', () => {
       // ).rejects.toThrow();
 
       // Should pass validation
-      await workflow.execute({
+      await workflow.createRun({
         triggerData: {
           required: 'test',
           nested: { value: 42 },
         },
-      });
+      }).start();
     });
   });
 
@@ -706,7 +706,7 @@ describe('Workflow', () => {
 
       workflow.step(step1).then(step2).then(step3).step(step4).then(step5).commit();
 
-      await workflow.execute();
+      await workflow.createRun().start();
 
       expect(action1).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -783,7 +783,7 @@ describe('Workflow', () => {
       const workflow = new Workflow({ name: 'test-workflow' });
       workflow.step(step1).then(step2).then(step3).step(step4).then(step5).commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(result.results.step1).toEqual({ status: 'success', payload: { result: 'success1' } });
       expect(result.results.step2).toEqual({ status: 'success', payload: { result: 'success2' } });
@@ -822,7 +822,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(result.results.step1).toEqual({ status: 'success', payload: { result: 'success' } });
       expect(result.results.step2).toEqual({ status: 'suspended' });
@@ -845,7 +845,7 @@ describe('Workflow', () => {
       const workflow = new Workflow({ name: 'test-workflow' });
       workflow.step(step1).then(step2).then(step5).after(step1).step(step3).then(step4).then(step5).commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(step1Action).toHaveBeenCalled();
       expect(step2Action).toHaveBeenCalled();
@@ -887,7 +887,7 @@ describe('Workflow', () => {
         .then(step5)
         .commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(step1Action).toHaveBeenCalled();
       expect(step2Action).toHaveBeenCalled();
@@ -910,7 +910,7 @@ describe('Workflow', () => {
       const workflow = new Workflow({ name: 'test-workflow' });
       workflow.step(step1).step(step3).after(step1).step(step3).after(step3).step(step1).commit();
 
-      const result = await workflow.execute();
+      const result = await workflow.createRun().start();
 
       expect(step1Action).toHaveBeenCalled();
 
@@ -955,7 +955,7 @@ describe('Workflow', () => {
         .step(randomTool)
         .commit();
 
-      await workflow.execute();
+      await workflow.createRun().start();
 
       expect(syncAction).toHaveBeenCalled();
       expect(step1Action).toHaveBeenCalled();

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -289,9 +289,10 @@ export class Workflow<
             {
               ...options,
               triggerData: (options as WorkflowRunOptionsWithTrigger<NonNullable<TTriggerSchema>>).triggerData,
+              runId,
             },
           ]
-        : [{ ...options }]
+        : [{ ...options, runId }]
     ) as WorkflowExecuteParams<TTriggerSchema>;
 
     return {


### PR DESCRIPTION
The docs currently describe the intended Workflow usage as 

```ts
const myWorkflow = new Workflow({
  name: 'my-workflow',
  triggerSchema: z.object({
    input: z.number(),
  }),
});
 
const { runId, start } = myWorkflow.createRun({ 
  triggerData: { input: 90 } 
});
 
const res = await start();
```

However it doesn't appear triggerData can actually be passed through `createRun`. You also call `myWorkflow.execute()` with no options argument, when it seems the intended use is if a `triggerSchema` exists then it should be required to be passed through. 

- fixed types to require trigger data to be passed through if it is defined
- removed all `workflow.execute()` calls and switched to `workflow.create().start()` syntax in docs, templates, and tests
- make the `execute` method private
- now allows a custom `runId`s to be passed into `createRun()`

Now, if trigger schema is undefined, `workflow.createRun()` can be called with no args. If the schema is defined, then `workflow.create({ triggerData: {...} })` will be required.

I'm not sure if this is the best approach to the types, so might be worth a look over.