### PR TITLE
Fix agent memory docs links

### DIFF
--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -13,7 +13,7 @@ Agent memory in Mastra is configured with two named parameters:
 - `threadId` - A unique identifier for the conversation thread.
 - `resourceId` - A unique identifier for the agent's memory context. This is used to group and manage memory for different agents or resources. You can also just set it to `default` for all agents if you don't need to group threads.
 
-You can currently store agent memory in (Postgres)[#using-postgres-for-agent-memory] or (UpstashKV)[#using-redis-for-agent-memory].
+You can currently store agent memory in [Postgres](#using-postgres-for-agent-memory) or [UpstashKV](#using-redis-for-agent-memory).
 
 First, create a new conversation thread:
 


### PR DESCRIPTION
Fix links on https://mastra.ai/docs/agents/01-agent-memory page caused by incorrectly formatted markdown.

![Screenshot 2025-01-25 at 10 05 12](https://github.com/user-attachments/assets/f5138666-f335-401e-a40c-bc21a74bdf45)
