### PR TITLE
[Docs] Remove duplicate section in agent memory docs

### DIFF
--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -10,6 +10,7 @@ Agents in Mastra have a memory that stores conversation history and contextual i
 ## Using Agent Memory
 
 Agent memory in Mastra is configured with two named parameters:
+
 - `threadId` - A unique identifier for the conversation thread.
 - `resourceId` - A unique identifier for the agent's memory context. This is used to group and manage memory for different agents or resources. You can also just set it to `default` for all agents if you don't need to group threads.
 
@@ -29,10 +30,13 @@ const thread = await mastra.memory?.createThread({
 Now, let's start adding messages to the thread:
 
 ```typescript
-const responseOne = await myAgent.generate("Tell me about the project requirements.", {
-  resourceid: "memory_id",
-  threadId: thread.id,
-});
+const responseOne = await myAgent.generate(
+  "Tell me about the project requirements.",
+  {
+    resourceid: "memory_id",
+    threadId: thread.id,
+  },
+);
 
 const responseTwo = await myAgent.generate("What are the next steps?", {
   resourceid: "memory_id",
@@ -40,9 +44,9 @@ const responseTwo = await myAgent.generate("What are the next steps?", {
 });
 ```
 
-Notice that you don't need to explicitly save the messages to memory, or pass the response from the first call to the second. 
+Notice that you don't need to explicitly save the messages to memory, or pass the response from the first call to the second.
 
-Each generate call automatically preserves the conversation context in memory. 
+Each generate call automatically preserves the conversation context in memory.
 
 ### Inserting Messages to Memory
 
@@ -71,16 +75,6 @@ const messages = await mastra.memory.getMessages({
 });
 ```
 
-### Retrieving Messages From Memory
-
-To check the current messages in memory at any point:
-
-```typescript
-const messages = await mastra.memory.getMessages({
-  threadId: thread.id,
-});
-```
-
 Retrieves all messages from the specified thread in chronological order.
 
 ### Retrieving Context Window
@@ -90,9 +84,9 @@ You can use memory to retrieve messages within a specific time range:
 ```typescript
 const messages = await mastra.memory.getContextWindow({
   threadId: thread.id,
-  startDate: new Date('2024-01-01'),
-  endDate: new Date('2024-01-31'),
-  format: 'raw'
+  startDate: new Date("2024-01-01"),
+  endDate: new Date("2024-01-31"),
+  format: "raw",
 });
 ```
 
@@ -102,11 +96,11 @@ You can optionally limit the total tokens in the context window by configuring m
 const upstashKVMemory = new UpstashKVMemory({
   url: process.env.UPSTASH_REDIS_REST_URL!,
   token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-  maxTokens: 4000 // Limit total tokens in context window
+  maxTokens: 4000, // Limit total tokens in context window
 });
 ```
 
-When maxTokens is set, messages are filtered by date range and then processed from newest to oldest until the token limit is reached. 
+When maxTokens is set, messages are filtered by date range and then processed from newest to oldest until the token limit is reached.
 
 This maintains the context window size while preserving the most recent conversation history.
 


### PR DESCRIPTION
This PR removes a duplicate section `Retrieving Messages From Memory` on the https://mastra.ai/docs/agents/01-agent-memory page.

![Screenshot 2025-01-25 at 10 26 53](https://github.com/user-attachments/assets/95a93ad0-f014-46ab-a218-5a7f79047754)
