### PR TITLE
updated pg filtering and updated docs and example

### DIFF
--- a/.changeset/big-fireants-wave.md
+++ b/.changeset/big-fireants-wave.md
@@ -1,0 +1,6 @@
+---
+'@mastra/rag': patch
+'docs': patch
+---
+
+Updated pg filter function and updated docs and example

--- a/docs/src/pages/examples/rag/filter-rag.mdx
+++ b/docs/src/pages/examples/rag/filter-rag.mdx
@@ -130,6 +130,13 @@ await vectorStore.upsert(
   chunks?.map((chunk: any) => ({
     text: chunk.text,
     ...chunk.metadata,
+    nested: {
+      keywords: chunk.metadata.excerptKeywords
+        .replace("KEYWORDS:", "")
+        .split(",")
+        .map((k) => k.trim()),
+      id: index,
+    },
   })),
 );
 ```
@@ -139,21 +146,23 @@ await vectorStore.upsert(
 Function to generate responses based on retrieved context:
 
 ```typescript copy showLineNumbers{65} filename="src/mastra/index.ts"
-async function generateResponse(
-  query: string,
-  filter: {
-    keyword: string;
-    operator: string;
-    value: string;
-  },
-) {
-  const { keyword, operator, value } = filter;
+async function generateResponse(query: string, filter: any) {
+  const buildFilterString = (f: any): string => {
+    if ("type" in f) {
+      return `type:${f.type} condition with filters: [${f.filters
+        .map(buildFilterString)
+        .join(", ")}]`;
+    }
+    return `keyword: ${f.keyword} operator: ${f.operator} value: ${f.value}`;
+  };
+  const filterDescription = buildFilterString(filter);
   const prompt = `
       Please answer the following question:
       ${query}
 
-      Please base your answer only on the context provided in the tool using this keyword: ${keyword}, this operator: ${operator}, and this value: ${value}.
-      If the context doesn't contain enough information to fully answer the question, please state that explicitly.
+    Please base your answer only on the context provided in the tool using these filter conditions:
+    ${filterDescription}
+    If the context doesn't contain enough information to fully answer the question, please state that explicitly.
       `;
 
   // Call the agent to generate a response
@@ -165,15 +174,11 @@ async function generateResponse(
 
 ## Example Usage
 
-```typescript copy showLineNumbers{87} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{89} filename="src/mastra/index.ts"
 async function answerQueries(
   queries: {
     query: string;
-    filter: {
-      keyword: string;
-      operator: string;
-      value: string;
-    };
+    filter: any;
   }[],
 ) {
   for (const { query, filter } of queries) {
@@ -192,27 +197,118 @@ const queries = [
   {
     query: "What adaptation strategies are mentioned?",
     filter: {
-      keyword: "excerptKeywords",
+      keyword: "nested.keywords",
       operator: "ilike",
-      value: `%adaptation%`,
-    },
+      value: "adaptation"
+    }
   },
   {
-    query: "How do temperatures affect crop yields specifically?",
-    filter: { keyword: "excerptKeywords", operator: "ilike", value: `%crop%` },
-  },
-  {
-    query: "What are the future challenges?",
+    query: "Show me recent sections",
     filter: {
-      keyword: "excerptKeywords",
-      operator: "ilike",
-      value: `%technologies%`,
-    },
+      keyword: "nested.id",
+      operator: "gt",
+      value: "2"
+    }
   },
+  {
+    query: "Find sections about drought and irrigation",
+    filter: {
+      type: "$and",
+      filters: [
+        {
+          keyword: "text",
+          operator: "ilike",
+          value: "drought"
+        },
+        {
+          keyword: "text",
+          operator: "ilike",
+          value: "irrigation"
+        }
+      ]
+    }
+  },
+  {
+    query: "Find sections about wheat or rice",
+    filter: {
+      type: "$or",
+      filters: [
+        {
+          keyword: "text",
+          operator: "ilike",
+          value: "wheat"
+        },
+        {
+          keyword: "text",
+          operator: "ilike",
+          value: "rice"
+        }
+      ]
+    }
+  }
 ];
 
 await answerQueries(queries);
 ```
+
+### Filter Types
+
+PGVector supports these filter types:
+
+1. Basic comparison operators:
+```typescript
+{
+  "path.to.field": {
+    eq: "value",     // Equals
+    neq: "value",    // Not equals
+    gt: 25,          // Greater than
+    gte: 25,         // Greater than or equal
+    lt: 25,          // Less than
+    lte: 25          // Less than or equal
+  }
+}
+```
+
+2. Text search operators:
+```typescript
+{
+  "path.to.field": {
+    like: "value",    // Case-sensitive pattern matching
+    ilike: "value"    // Case-insensitive pattern matching
+  }
+}
+```
+
+3. Collection operators:
+```typescript
+{
+  "path.to.field": {
+    in: ["value1", "value2"],     // Match any value in array
+    contains: "value",            // JSONB containment
+    exists: true                  // Check if field exists
+  }
+}
+```
+
+4. Logical operators:
+```typescript
+{
+  type: "$and",  // or "$or"
+  filters: [
+    { "path.to.field": { ilike: "value1" } },
+    { "path.to.field": { ilike: "value2" } }
+  ]
+}
+```
+
+### Available Operators
+
+PGVector implements the following operators:
+
+- Basic: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`
+- Text: `like`, `ilike`
+- Collection: `in`, `contains`, `exists`
+- Logical: `$and`, `$or`
 
 <br />
 <br />

--- a/packages/rag/src/pg/filter.ts
+++ b/packages/rag/src/pg/filter.ts
@@ -1,4 +1,17 @@
-export type OperatorType = 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'like' | 'ilike' | 'in' | 'contains' | 'exists';
+export type OperatorType =
+  | 'eq'
+  | 'neq'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'like'
+  | 'ilike'
+  | 'in'
+  | 'contains'
+  | 'exists'
+  | '$and'
+  | '$or';
 
 // Type guard to check if an operator is valid
 export function isValidOperator(operator: string): operator is OperatorType {
@@ -17,15 +30,17 @@ type FilterOperatorMap = {
 
 // Helper functions to create operators
 const createBasicOperator = (symbol: string) => {
+  const isLikeOperator = symbol.toLowerCase().includes('like');
   return (key: string, paramIndex: number): FilterOperator => ({
-    sql: `metadata->>'${key}' ${symbol} $${paramIndex}`,
+    sql: `metadata#>>'{${key.replace(/\./g, ',')}}' ${symbol} $${paramIndex}`,
     needsValue: true,
+    transformValue: isLikeOperator ? (value: string) => `%${value}%` : undefined,
   });
 };
 
 const createNumericOperator = (symbol: string) => {
   return (key: string, paramIndex: number): FilterOperator => ({
-    sql: `(metadata->>'${key}')::numeric ${symbol} $${paramIndex}`,
+    sql: `(metadata#>>'{${key.replace(/\./g, ',')}}')::numeric ${symbol} $${paramIndex}`,
     needsValue: true,
   });
 };
@@ -53,20 +68,26 @@ export const FILTER_OPERATORS: FilterOperatorMap = {
 
   // IN array of values
   in: (key: string, paramIndex: number): FilterOperator => ({
-    sql: `metadata->>'${key}' = ANY($${paramIndex})`,
+    sql: `metadata#>>'{${key.split('.').join(',')}}' = ANY($${paramIndex}::text[])`,
     needsValue: true,
+    transformValue: (value: string) => (Array.isArray(value) ? value : value.split(',')),
   }),
   // JSONB contains
   contains: (key: string, paramIndex: number): FilterOperator => ({
     sql: `metadata @> $${paramIndex}::jsonb`,
     needsValue: true,
-    transformValue: (value: any) => JSON.stringify({ [key]: value }),
+    transformValue: (value: any) => {
+      const parts = key.split('.');
+      return JSON.stringify(parts.reduceRight((value, key) => ({ [key]: value }), value));
+    },
   }),
   // Key exists
   exists: (key: string): FilterOperator => ({
     sql: `metadata ? '${key}'`,
     needsValue: false,
   }),
+  $and: (key: string) => ({ sql: `(${key})`, needsValue: false }),
+  $or: (key: string) => ({ sql: `(${key})`, needsValue: false }),
 };
 
 type FilterCondition = {

--- a/packages/rag/src/pg/index.ts
+++ b/packages/rag/src/pg/index.ts
@@ -37,44 +37,49 @@ export class PgVector extends MastraVector {
   ): Promise<QueryResult[]> {
     const client = await this.pool.connect();
     try {
-      let filterQuery = '';
       let filterValues: any[] = [minScore];
       const vectorStr = `[${queryVector.join(',')}]`;
 
-      if (filter) {
-        const conditions = Object.entries(filter).map(([key, condition]) => {
-          // If condition is not a FilterCondition object, assume it's an equality check
-          if (!condition || typeof condition !== 'object') {
-            filterValues.push(condition);
-            return `metadata->>'${key}' = $${filterValues.length}`;
-          }
+      const buildCondition = (key: string, value: any): string => {
+        // Handle logical operators ($and/$or)
+        if (key === '$and' || key === '$or') {
+          const conditions = value.map((f: Filter) =>
+            Object.entries(f)
+              .map(([k, v]) => buildCondition(k, v))
+              .join(' AND '),
+          );
+          const operatorFn = FILTER_OPERATORS[key];
+          return operatorFn(conditions.join(` ${key === '$or' ? 'OR' : 'AND'} `), 0).sql;
+        }
 
-          const [[operator, value] = []] = Object.entries(condition ?? {});
-          if (!operator || value === undefined) {
-            throw new Error(`Invalid operator or value for key: ${key}`);
-          }
-          if (!isValidOperator(operator)) {
-            throw new Error(`Unsupported operator: ${operator}`);
-          }
-          // Get operation function
+        // If condition is not a FilterCondition object, assume it's an equality check
+        if (!value || typeof value !== 'object') {
+          filterValues.push(value);
+          return `metadata#>>'{${key}}' = $${filterValues.length}`;
+        }
+
+        // Handle operator conditions
+        const [[operator, operatorValue] = []] = Object.entries(value);
+        if (operator && isValidOperator(operator)) {
           const operatorFn = FILTER_OPERATORS[operator];
-
           const operatorResult = operatorFn(key, filterValues.length + 1);
-
-          // Handle operator cases and check if value is needed
           if (operatorResult.needsValue) {
-            // Transform value if needed
-            const transformedValue = operatorResult.transformValue ? operatorResult.transformValue(value) : value;
+            const transformedValue = operatorResult.transformValue
+              ? operatorResult.transformValue(operatorValue)
+              : operatorValue;
             filterValues.push(transformedValue);
           }
-
-          // return sql condition
           return operatorResult.sql;
-        });
-        if (conditions.length > 0) {
-          filterQuery = 'AND ' + conditions.join(' AND ');
         }
-      }
+
+        return ''; // Handle unexpected cases
+      };
+
+      const filterQuery = filter
+        ? Object.entries(filter)
+            .map(([key, value]) => buildCondition(key, value))
+            .join(' AND ')
+        : 'true';
 
       const query = `
             WITH vector_scores AS (
@@ -84,7 +89,7 @@ export class PgVector extends MastraVector {
                     metadata
                     ${includeVector ? ', embedding' : ''}
                 FROM ${indexName}
-                WHERE true ${filterQuery}
+                WHERE ${filterQuery}
             )
             SELECT *
             FROM vector_scores


### PR DESCRIPTION
This PR updates the pg filter function when querying data. It now supports nested filtering and logical chaining. It also updates the example docs to show the different operators, as well as makes the example queries more basic to show off the concept.