### PR TITLE
updated return type for chunk to properly return type

### DIFF
--- a/.changeset/wild-pens-flash.md
+++ b/.changeset/wild-pens-flash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Update return type for chunk to Chunk[]

--- a/packages/rag/src/document/document.ts
+++ b/packages/rag/src/document/document.ts
@@ -252,7 +252,7 @@ export class MDocument {
     this.chunks = textSplit;
   }
 
-  async chunk(params?: ChunkParams): Promise<MDocument['chunks']> {
+  async chunk(params?: ChunkParams): Promise<Chunk[]> {
     const { strategy: passedStrategy, extract, ...chunkOptions } = params || {};
     // Determine the default strategy based on type if not specified
     const strategy = passedStrategy || this.defaultStrategy();


### PR DESCRIPTION
Currently chunk() returns any. Changed chunk return type from MDocument['chunks'] to be explicitly Chunk[]