### PR TITLE
Update provider string for Google Gemini

### DIFF
--- a/docs/src/pages/docs/reference/llm/providers-and-models.mdx
+++ b/docs/src/pages/docs/reference/llm/providers-and-models.mdx
@@ -18,7 +18,7 @@ Mastra supports a variety of language models from different providers. There are
 | ------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | OpenAI        | OPEN_AI         | `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`, `gpt-4o-mini`, `gpt-4o-mini`                                                                                                            |
 | Anthropic     | ANTHROPIC       | `claude-3-5-sonnet-20241022`, `claude-3-5-sonnet-20240620`, `claude-3-5-haiku-20241022`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307`         |
-| Google Gemini | GEMINI          | `gemini-1.5-pro-latest`, `gemini-1.5-pro`, `gemini-1.5-flash-latest`, `gemini-1.5-flash`, `gemini-2.0-flash-exp-latest`, `gemini-2.0-flash-thinking-exp-1219`, `gemini-exp-1206` |
+| Google Gemini | GOOGLE          | `gemini-1.5-pro-latest`, `gemini-1.5-pro`, `gemini-1.5-flash-latest`, `gemini-1.5-flash`, `gemini-2.0-flash-exp-latest`, `gemini-2.0-flash-thinking-exp-1219`, `gemini-exp-1206` |
 
 ## Other natively supported providers
 


### PR DESCRIPTION
"provider" should be GOOGLE for Google Gemini according to GoogleConfig. 

export type GoogleConfig = {
  provider: 'GOOGLE';
  name: GoogleModel | (string & {});
  toolChoice?: 'auto' | 'required';
  apiKey?: string;
  baseURL?: string;
  headers?: Record<string, string>;
  fetch?: typeof globalThis.fetch;
};