### PR TITLE
Update npmjs link in integrations.mdx

### DIFF
--- a/docs/src/pages/docs/local-dev/integrations.mdx
+++ b/docs/src/pages/docs/local-dev/integrations.mdx
@@ -120,7 +120,7 @@ Consider using a `.env` file or another secure method to manage sensitive creden
 
 Mastra provides several built-in integrations; primarily API-key based integrations that do not require OAuth. Some available integrations including Github, Stripe, Resend, Firecrawl, and more.
 
-Check [Mastra's codebase](https://github.com/mastra-ai/mastra/tree/main/integrations) or [npm packages](https://www.npmjs.com/settings/mastra/packages) for a full list of available integrations.
+Check [Mastra's codebase](https://github.com/mastra-ai/mastra/tree/main/integrations) or [npm packages](https://www.npmjs.com/search?q=%22%40mastra%22) for a full list of available integrations.
 
 ## Conclusion
 


### PR DESCRIPTION
The existing link pushes to a login page (guessing it's for maintainers?)

I expect an open public link will be most helpful.

This is just a simple search page for `@mastra`

Embedded question -- only some of these are in the mastra repo currently but I think many were previously. 

How should we treat an integration on npm that no longer appears in the mastra repo?