### PR TITLE
feat: rename memory api keys

### DIFF
--- a/.changeset/rare-cougars-remain.md
+++ b/.changeset/rare-cougars-remain.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': minor
+'@mastra/core': patch
+---
+
+Reworked the Memory public API to have more intuitive and simple property names

--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -29,16 +29,17 @@ const memory = new Memory({
   // Optional: Vector store for semantic search
   vector: new PgVector(connectionString),
   
-  // Optional: Thread configuration
-  threads: {
+  // Optional: Memory configuration options
+  options: {
     // Number of recent messages to include (false to disable)
-    injectRecentMessages: 10,
-    
-    // Vector search configuration
-    injectVectorHistorySearch: {
-      includeResults: 3,  // Number of semantic search results
-      includePrevious: 2, // Messages before each result
-      includeNext: 2,     // Messages after each result
+    recentMessages: 10,
+    // Configure vector-based semantic search
+    historySearch: {
+      topK: 3,         // Number of semantic search results
+      messageRange: {   // Messages before and after each result
+        before: 2,
+        after: 2
+      }
     },
   },
   
@@ -51,9 +52,9 @@ const memory = new Memory({
 });
 ```
 
-When you initialize a Mastra instance with this memory configuration, all agents will automatically use these memory settings when you call their `stream()` or `generate()` methods. The thread configuration specified in the `threads` object will be applied to all conversations.
+When you initialize a Mastra instance with this memory configuration, all agents will automatically use these memory settings when you call their `stream()` or `generate()` methods. The memory configuration options specified in the `options` object will be applied to all conversations.
 
-You can override these default settings for individual calls by passing a `thread` option:
+You can override these default settings for individual calls by passing an `options` parameter:
 
 ```typescript
 // Use default memory settings from Memory configuration
@@ -66,13 +67,15 @@ const response1 = await agent.generate("What were we discussing earlier?", {
 const response2 = await agent.generate("What were we discussing earlier?", {
   resourceId: "user_123",
   threadId: "thread_456",
-  thread: {
-    injectRecentMessages: 5,  // Only inject 5 recent messages
-    injectVectorHistorySearch: {
-      includeResults: 2,      // Only get 2 semantic search results
-      includePrevious: 1,     // Include 1 message before each result
-      includeNext: 1,         // Include 1 message after each result
-    }
+  memoryOptions: {
+    recentMessages: 5,  // Only inject 5 recent messages
+    historySearch: {
+      topK: 2,         // Only get 2 semantic search results
+      messageRange: {   // Context around each result
+        before: 1,
+        after: 1
+      }
+    },
   }
 });
 ```
@@ -83,8 +86,8 @@ The same applies to the `stream()` method:
 const stream = await agent.stream("Tell me about our previous conversation", {
   resourceId: "user_123",
   threadId: "thread_456",
-  thread: {
-    injectRecentMessages: 20  // Override to get more context
+  memoryOptions: {
+    recentMessages: 20  // Override to get more context
   }
 });
 ```
@@ -147,13 +150,15 @@ const embeddingOptions = {
 };
 ```
 
-3. Enable vector search in thread configuration:
+3. Enable vector search in memory configuration options:
 ```typescript
-const threadConfig = {
-  injectVectorHistorySearch: {
-    includeResults: 3,    // Number of similar messages to find
-    includePrevious: 2,   // Context before each result
-    includeNext: 2,       // Context after each result
+const optionsConfig = {
+  historySearch: {
+    topK: 3,           // Number of similar messages to find
+    messageRange: {     // Context around each result
+      before: 2,       // Context before each result
+      after: 2         // Context after each result
+    }
   },
 };
 ```
@@ -265,3 +270,13 @@ await memory.deleteThread(thread.id);
 ```
 
 Note that in most cases, you won't need to manage threads manually since the agent's `generate()` and `stream()` methods handle thread management automatically. Manual thread management is primarily useful for advanced use cases or when you need more fine-grained control over the conversation history.
+
+```typescript
+// Use memoryOptions to get more context for this specific request
+await agent.generate("What did we discuss earlier?", {
+  resourceId: "user_123",
+  threadId: "thread_456",
+  memoryOptions: {
+    recentMessages: 20  // Override to get more context
+  }
+});

--- a/examples/memory-libsql/package.json
+++ b/examples/memory-libsql/package.json
@@ -13,7 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "@mastra/core": "workspace:*",
-    "@mastra/memory": "workspace:*"
+    "@mastra/memory": "workspace:*",
+    "@mastra/vector-pg": "workspace:*"
   },
   "version": "0.0.1-alpha.0"
 }

--- a/examples/memory-libsql/src/index.ts
+++ b/examples/memory-libsql/src/index.ts
@@ -50,7 +50,7 @@ async function main() {
       threadId,
       resourceId,
       thread: {
-        injectRecentMessages: 3,
+        recentMessages: 3,
       },
     }),
   );

--- a/examples/memory-libsql/src/mastra/index.ts
+++ b/examples/memory-libsql/src/mastra/index.ts
@@ -11,17 +11,16 @@ const storage = new MastraStorageLibSql({
   },
 });
 
-const vector = new PgVector(`postgresql://postgres:postgres@localhost:5433`);
+const vector = new PgVector(`postgresql://postgres:postgres@localhost:5432`);
 
 const memory = new Memory({
   storage,
   vector,
-  threads: {
-    injectRecentMessages: 100,
-    injectVectorHistorySearch: {
-      includeResults: 2,
-      includeNext: 2,
-      includePrevious: 2,
+  options: {
+    recentMessages: 100,
+    historySearch: {
+      topK: 2,
+      messageRange: { before: 2, after: 2 },
     },
   },
   embeddingOptions: {

--- a/examples/memory-pg/src/index.ts
+++ b/examples/memory-pg/src/index.ts
@@ -50,7 +50,7 @@ async function main() {
       threadId,
       resourceId,
       thread: {
-        injectRecentMessages: 3,
+        recentMessages: 3,
       },
     }),
   );

--- a/examples/memory-pg/src/mastra/index.ts
+++ b/examples/memory-pg/src/mastra/index.ts
@@ -23,12 +23,11 @@ const memory = new Memory({
     password,
   }),
   vector: new PgVector(connectionString),
-  threads: {
-    injectRecentMessages: 10,
-    injectVectorHistorySearch: {
-      includeResults: 3,
-      includePrevious: 2,
-      includeNext: 2,
+  options: {
+    recentMessages: 10,
+    historySearch: {
+      topK: 3,
+      messageRange: { before: 2, after: 2 },
     },
   },
   embeddingOptions: {

--- a/examples/memory-upstashkv/src/index.ts
+++ b/examples/memory-upstashkv/src/index.ts
@@ -50,7 +50,7 @@ async function main() {
       threadId,
       resourceId,
       thread: {
-        injectRecentMessages: 3,
+        recentMessages: 3,
       },
     }),
   );

--- a/examples/memory-upstashkv/src/mastra/index.ts
+++ b/examples/memory-upstashkv/src/mastra/index.ts
@@ -11,12 +11,11 @@ const memory = new Memory({
     token: 'test_token',
   }),
   vector: new PgVector(`postgresql://postgres:postgres@localhost:5433`),
-  threads: {
-    injectRecentMessages: 1,
-    injectVectorHistorySearch: {
-      includeResults: 3,
-      includePrevious: 2,
-      includeNext: 2,
+  options: {
+    recentMessages: 1,
+    historySearch: {
+      topK: 3,
+      messageRange: { before: 2, after: 2 },
     },
   },
   embeddingOptions: {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -680,7 +680,7 @@ export class Agent<
     {
       context,
       threadId: threadIdInFn,
-      thread: memoryConfig,
+      memoryOptions,
       resourceId,
       maxSteps = 5,
       onStepFinish,
@@ -717,7 +717,7 @@ export class Agent<
       messages: messagesToUse,
       context,
       threadId: threadIdInFn,
-      memoryConfig,
+      memoryConfig: memoryOptions,
       resourceId,
       runId: runIdToUse,
       toolsets,
@@ -738,7 +738,7 @@ export class Agent<
 
       const outputText = result.text;
 
-      await after({ result, threadId, memoryConfig, outputText, runId: runIdToUse });
+      await after({ result, threadId, memoryConfig: memoryOptions, outputText, runId: runIdToUse });
 
       return result as unknown as GenerateReturn<Z>;
     }
@@ -756,7 +756,7 @@ export class Agent<
 
     const outputText = JSON.stringify(result.object);
 
-    await after({ result, threadId, memoryConfig, outputText, runId: runIdToUse });
+    await after({ result, threadId, memoryConfig: memoryOptions, outputText, runId: runIdToUse });
 
     return result as unknown as GenerateReturn<Z>;
   }
@@ -766,7 +766,7 @@ export class Agent<
     {
       context,
       threadId: threadIdInFn,
-      thread: memoryConfig,
+      memoryOptions,
       resourceId,
       maxSteps = 5,
       onFinish,
@@ -804,7 +804,7 @@ export class Agent<
       messages: messagesToUse,
       context,
       threadId: threadIdInFn,
-      memoryConfig,
+      memoryConfig: memoryOptions,
       resourceId,
       runId: runIdToUse,
       toolsets,
@@ -826,7 +826,7 @@ export class Agent<
           try {
             const res = JSON.parse(result) || {};
             const outputText = res.text;
-            await after({ result: res, threadId, memoryConfig, outputText, runId: runIdToUse });
+            await after({ result: res, threadId, memoryConfig: memoryOptions, outputText, runId: runIdToUse });
           } catch (e) {
             this.logger.error('Error saving memory on finish', {
               error: e,
@@ -854,7 +854,7 @@ export class Agent<
         try {
           const res = JSON.parse(result) || {};
           const outputText = JSON.stringify(res.object);
-          await after({ result: res, threadId, memoryConfig, outputText, runId: runIdToUse });
+          await after({ result: res, threadId, memoryConfig: memoryOptions, outputText, runId: runIdToUse });
         } catch (e) {
           this.logger.error('Error saving memory on finish', {
             error: e,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -28,7 +28,7 @@ export interface AgentGenerateOptions<Z extends ZodSchema | JSONSchema7 | undefi
   resourceId?: string;
   context?: CoreMessage[];
   threadId?: string;
-  thread?: MemoryConfig;
+  memoryOptions?: MemoryConfig;
   runId?: string;
   onStepFinish?: (step: string) => void;
   maxSteps?: number;
@@ -41,7 +41,7 @@ export interface AgentStreamOptions<Z extends ZodSchema | JSONSchema7 | undefine
   resourceId?: string;
   context?: CoreMessage[];
   threadId?: string;
-  thread?: MemoryConfig;
+  memoryOptions?: MemoryConfig;
   runId?: string;
   onFinish?: (result: string) => Promise<void> | void;
   onStepFinish?: (step: string) => void;

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -44,13 +44,12 @@ export type MessageResponse<T extends 'raw' | 'core_message'> = {
 }[T];
 
 export type MemoryConfig = {
-  injectRecentMessages?: number | false;
-  injectVectorHistorySearch?:
+  recentMessages?: number | false;
+  historySearch?:
     | boolean
     | {
-        includeResults: number;
-        includePrevious: number;
-        includeNext: number;
+        topK: number;
+        messageRange: number | { before: number; after: number };
       };
   // TODO:
   // injectWorkingMemory?: boolean;
@@ -59,13 +58,13 @@ export type MemoryConfig = {
 export type SharedMemoryConfig =
   | {
       storage: MastraStorage;
-      threads?: MemoryConfig;
+      options?: MemoryConfig;
       vector?: MastraVector;
       embeddingOptions?: EmbeddingOptions;
     }
   | {
       storage: MastraStorage;
-      threads?: MemoryConfig;
+      options?: MemoryConfig;
       vector: MastraVector;
       embeddingOptions: EmbeddingOptions;
     };
@@ -82,8 +81,8 @@ export abstract class MastraMemory extends MastraBase {
   embeddingOptions?: EmbeddingOptions;
 
   protected threadConfig: MemoryConfig = {
-    injectRecentMessages: 40,
-    injectVectorHistorySearch: false, // becomes true by default if a vector store is attached
+    recentMessages: 40,
+    historySearch: false, // becomes true by default if a vector store is attached
     // TODO:
     // injectWorkingMemory: true
   };
@@ -93,13 +92,13 @@ export abstract class MastraMemory extends MastraBase {
     this.storage = config.storage;
     if (config.vector) {
       this.vector = config.vector;
-      this.threadConfig.injectVectorHistorySearch = true;
+      this.threadConfig.historySearch = true;
     }
     if (`embeddingOptions` in config) {
       this.embeddingOptions = config.embeddingOptions;
     }
-    if (config.threads) {
-      this.threadConfig = this.getMergedThreadConfig(config.threads);
+    if (config.options) {
+      this.threadConfig = this.getMergedThreadConfig(config.options);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,6 +1215,9 @@ importers:
       '@mastra/memory':
         specifier: workspace:*
         version: link:../../packages/memory
+      '@mastra/vector-pg':
+        specifier: workspace:*
+        version: link:../../vector-stores/pg
 
   examples/memory-pg:
     dependencies:


### PR DESCRIPTION
This PR reworks the new public api for the new Memory class.

Before:
```ts
const memory = new Memory({
  threads: {
    injectRecentMessages: 10,
    
    injectVectorHistorySearch: {
      includeResults: 3,
      includePrevious: 2,
      includeNext: 2,
    },
  },
  storage: ...,
  vector: ...,
});
```

After:
```ts
const memory = new Memory({
  options: {
    recentMessages: 10,
    
    historySearch: {
      topK: 3,
      messageRange: 2 // or { before: 2, after: 2 }
    },
  },
  storage: ...,
  vector: ...,
});
```