### PR TITLE
feat: allow passing memory to individual agents

### DIFF
--- a/.changeset/red-ladybugs-tease.md
+++ b/.changeset/red-ladybugs-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added the ability to pass a configured Memory class instance directly to new Agent instances instead of passing memory to Mastra

--- a/examples/memory-pg/src/mastra/agents/index.ts
+++ b/examples/memory-pg/src/mastra/agents/index.ts
@@ -1,4 +1,37 @@
 import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
+import { PostgresStore } from '@mastra/store-pg';
+import { PgVector } from '@mastra/vector-pg';
+
+const host = `localhost`;
+const port = 5432;
+const user = `postgres`;
+const database = `postgres`;
+const password = `postgres`;
+const connectionString = `postgresql://${user}:${password}@${host}:${port}`;
+
+export const memory = new Memory({
+  storage: new PostgresStore({
+    host,
+    port,
+    user,
+    database,
+    password,
+  }),
+  vector: new PgVector(connectionString),
+  options: {
+    recentMessages: 10,
+    historySearch: {
+      topK: 3,
+      messageRange: { before: 2, after: 2 },
+    },
+  },
+  embeddingOptions: {
+    provider: 'OPEN_AI',
+    model: 'text-embedding-ada-002',
+    maxRetries: 3,
+  },
+});
 
 export const chefAgent = new Agent({
   name: 'chefAgent',
@@ -9,6 +42,7 @@ export const chefAgent = new Agent({
     name: 'gpt-4o',
     toolChoice: 'auto',
   },
+  memory,
 });
 
 export const memoryAgent = new Agent({
@@ -20,4 +54,5 @@ export const memoryAgent = new Agent({
     name: 'gpt-4o',
     toolChoice: 'auto',
   },
+  memory,
 });

--- a/examples/memory-pg/src/mastra/index.ts
+++ b/examples/memory-pg/src/mastra/index.ts
@@ -1,43 +1,9 @@
 import { Mastra } from '@mastra/core';
-import { Memory } from '@mastra/memory';
-import { PostgresStore } from '@mastra/store-pg';
-import { PgVector } from '@mastra/vector-pg';
 
 import 'dotenv/config';
 
 import { chefAgent, memoryAgent } from './agents';
 
-const host = `localhost`;
-const port = 5432;
-const user = `postgres`;
-const database = `postgres`;
-const password = `postgres`;
-const connectionString = `postgresql://${user}:${password}@${host}:${port}`;
-
-const memory = new Memory({
-  storage: new PostgresStore({
-    host,
-    port,
-    user,
-    database,
-    password,
-  }),
-  vector: new PgVector(connectionString),
-  options: {
-    recentMessages: 10,
-    historySearch: {
-      topK: 3,
-      messageRange: { before: 2, after: 2 },
-    },
-  },
-  embeddingOptions: {
-    provider: 'OPEN_AI',
-    model: 'text-embedding-ada-002',
-    maxRetries: 3,
-  },
-});
-
 export const mastra = new Mastra({
   agents: { chefAgent, memoryAgent },
-  memory,
 });

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -21,7 +21,7 @@ import { AvailableHooks, executeHook } from '../hooks';
 import { LLM } from '../llm';
 import { GenerateReturn, ModelConfig, StreamReturn } from '../llm/types';
 import { LogLevel, RegisteredLogger } from '../logger';
-import { MemoryConfig, StorageThreadType } from '../memory';
+import { MastraMemory, MemoryConfig, StorageThreadType } from '../memory';
 import { InstrumentClass } from '../telemetry';
 import { CoreTool, ToolAction } from '../tools/types';
 
@@ -40,6 +40,7 @@ export class Agent<
   readonly instructions: string;
   readonly model: ModelConfig;
   #mastra?: MastraPrimitives;
+  #memory?: MastraMemory;
   tools: TTools;
   metrics: TMetrics;
 
@@ -68,6 +69,17 @@ export class Agent<
     if (config.metrics) {
       this.metrics = config.metrics;
     }
+
+    if (config.memory) {
+      this.#memory = config.memory;
+    }
+  }
+
+  public hasOwnMemory(): boolean {
+    return Boolean(this.#memory);
+  }
+  public getMemory(): MastraMemory | undefined {
+    return this.#memory ?? this.#mastra?.memory;
   }
 
   __registerPrimitives(p: MastraPrimitives) {
@@ -154,7 +166,8 @@ export class Agent<
     runId?: string;
   }) {
     const userMessage = this.getMostRecentUserMessage(userMessages);
-    if (this.#mastra?.memory) {
+    const memory = this.getMemory();
+    if (memory) {
       let thread: StorageThreadType | null;
       if (!threadId) {
         this.logger.debug(`No threadId, creating new thread for agent ${this.name}`, {
@@ -162,19 +175,19 @@ export class Agent<
         });
         const title = await this.genTitle(userMessage);
 
-        thread = await this.#mastra.memory.createThread({
+        thread = await memory.createThread({
           threadId,
           resourceId,
           title,
         });
       } else {
-        thread = await this.#mastra.memory.getThreadById({ threadId });
+        thread = await memory.getThreadById({ threadId });
         if (!thread) {
           this.logger.debug(`Thread not found, creating new thread for agent ${this.name}`, {
             runId: runId || this.name,
           });
           const title = await this.genTitle(userMessage);
-          thread = await this.#mastra.memory.createThread({
+          thread = await memory.createThread({
             threadId,
             resourceId,
             title,
@@ -235,9 +248,9 @@ export class Agent<
         }
 
         const memoryMessages =
-          threadId && this.#mastra.memory
+          threadId && memory
             ? (
-                await this.#mastra.memory.rememberMessages({
+                await memory.rememberMessages({
                   threadId,
                   config: memoryConfig,
                   vectorMessageSearch: messages
@@ -253,7 +266,9 @@ export class Agent<
               ).messages
             : [];
 
-        await this.#mastra.memory.saveMessages({ messages, memoryConfig });
+        if (memory) {
+          await memory.saveMessages({ messages, memoryConfig });
+        }
 
         this.log(LogLevel.DEBUG, 'Saved messages to memory', {
           threadId: thread.id,
@@ -293,10 +308,12 @@ export class Agent<
 
         const responseMessagesWithoutIncompleteToolCalls = this.sanitizeResponseMessages(ms);
 
-        if (this.#mastra?.memory) {
+        const memory = this.getMemory();
+
+        if (memory) {
           this.log(LogLevel.DEBUG, 'Saving response to memory', { threadId, runId });
 
-          await this.#mastra.memory.saveMessages({
+          await memory.saveMessages({
             memoryConfig,
             messages: responseMessagesWithoutIncompleteToolCalls.map((message: CoreMessage | CoreAssistantMessage) => {
               const messageId = randomUUID();
@@ -551,7 +568,7 @@ export class Agent<
         let coreMessages = messages;
         let threadIdToUse = threadId;
 
-        if (this.#mastra?.memory && resourceId) {
+        if (this.getMemory() && resourceId) {
           const preExecuteResult = await this.preExecute({
             resourceId,
             runId,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -200,7 +200,7 @@ export class Agent<
       if (thread) {
         const messages = newMessages.map(u => {
           return {
-            id: this.#mastra?.memory?.generateId()!,
+            id: this.getMemory()?.generateId()!,
             createdAt: new Date(),
             threadId: thread.id,
             ...u,
@@ -592,7 +592,7 @@ export class Agent<
 
         if (
           (toolsets && Object.keys(toolsets || {}).length > 0) ||
-          (this.#mastra?.memory && resourceId) ||
+          (this.getMemory() && resourceId) ||
           this.#mastra?.engine
         ) {
           convertedTools = this.convertTools({
@@ -645,7 +645,7 @@ export class Agent<
           result: resToLog,
           threadId,
         });
-        if (this.#mastra?.memory && resourceId) {
+        if (this.getMemory() && resourceId) {
           try {
             this.logger.debug(`Saving assistant message in memory for agent ${this.name}`, {
               runId,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
 
 import type { MastraPrimitives } from '../action';
+import type { MastraMemory } from '../memory';
 import type { Metric } from '../eval';
 import type { CoreMessage, ModelConfig, OutputType } from '../llm/types';
 import { MemoryConfig } from '../memory';
@@ -21,6 +22,7 @@ export interface AgentConfig<
   tools?: TTools;
   mastra?: MastraPrimitives;
   metrics?: TMetrics;
+  memory?: MastraMemory;
 }
 
 export interface AgentGenerateOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -178,7 +178,7 @@ export class Mastra<
           telemetry: this.telemetry,
           engine: this.engine,
           storage: this.storage,
-          memory: agent.getMemory(),
+          memory: agent.getMemory() || this.memory,
           agents: agents,
           tts: this.tts,
           vectors: this.vectors,

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -146,7 +146,6 @@ export class Mastra<
         });
         this.memory.__setTelemetry(this.telemetry);
       }
-      console.log(`set memory on mastra`);
     }
 
     if (config?.tts) {
@@ -318,7 +317,6 @@ export class Mastra<
     }
 
     if (this.memory) {
-      console.log(`setting memory on logger`);
       this.memory.__setLogger(this.logger);
     }
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -178,7 +178,7 @@ export class Mastra<
           telemetry: this.telemetry,
           engine: this.engine,
           storage: this.storage,
-          memory: this.memory,
+          memory: agent.getMemory(),
           agents: agents,
           tts: this.tts,
           vectors: this.vectors,
@@ -299,7 +299,13 @@ export class Mastra<
 
     if (this.agents) {
       Object.keys(this.agents).forEach(key => {
-        this.agents?.[key]?.__setLogger(this.logger);
+        const agent = this.agents?.[key];
+        if (agent) {
+          agent.__setLogger(this.logger);
+          if (agent.hasOwnMemory()) {
+            agent.getMemory()?.__setLogger(this.logger);
+          }
+        }
       });
     }
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -146,6 +146,7 @@ export class Mastra<
         });
         this.memory.__setTelemetry(this.telemetry);
       }
+      console.log(`set memory on mastra`);
     }
 
     if (config?.tts) {
@@ -178,7 +179,7 @@ export class Mastra<
           telemetry: this.telemetry,
           engine: this.engine,
           storage: this.storage,
-          memory: agent.getMemory() || this.memory,
+          memory: this.memory,
           agents: agents,
           tts: this.tts,
           vectors: this.vectors,
@@ -302,6 +303,7 @@ export class Mastra<
         const agent = this.agents?.[key];
         if (agent) {
           agent.__setLogger(this.logger);
+
           if (agent.hasOwnMemory()) {
             agent.getMemory()?.__setLogger(this.logger);
           }
@@ -316,6 +318,7 @@ export class Mastra<
     }
 
     if (this.memory) {
+      console.log(`setting memory on logger`);
       this.memory.__setLogger(this.logger);
     }
 


### PR DESCRIPTION
Before this change users would pass memory to Mastra:

```ts
export const mastra = new Mastra({
  agents: { chefAgent, memoryAgent },
  memory: new Memory()
});
```

Now that we have automatic memory management, this is likely not flexible enough for regular use cases. There's a good chance users will need different memory configs for each agent.

With this change you can now also do this:

```ts
export const agent = new Agent({
  ...agentConfig,
  memory: new Memory()
})
```