### PR TITLE
docs: fix memory reference links

### DIFF
--- a/docs/src/pages/docs/reference/memory/Memory.mdx
+++ b/docs/src/pages/docs/reference/memory/Memory.mdx
@@ -102,7 +102,7 @@ const memory = new Memory({
 
 ### Related
 
-- [createThread](/reference/memory/createThread.mdx)
-- [getMessages](/reference/memory/getMessages.mdx)
-- [addMessage](/reference/memory/addMessage.mdx)
-- [rememberMessages](/reference/memory/rememberMessages.mdx)
+- [createThread](/docs/reference/memory/createThread.mdx)
+- [getMessages](/docs/reference/memory/getMessages.mdx)
+- [addMessage](/docs/reference/memory/addMessage.mdx)
+- [rememberMessages](/docs/reference/memory/rememberMessages.mdx)

--- a/docs/src/pages/docs/reference/memory/addMessage.mdx
+++ b/docs/src/pages/docs/reference/memory/addMessage.mdx
@@ -125,5 +125,5 @@ When adding tool-related messages, make sure to:
 
 ### Related
 
-- [Memory](/reference/memory/Memory.mdx)
-- [getMessages](/reference/memory/getMessages.mdx)
+- [Memory](/docs/reference/memory/Memory.mdx)
+- [getMessages](/docs/reference/memory/getMessages.mdx)

--- a/docs/src/pages/docs/reference/memory/createThread.mdx
+++ b/docs/src/pages/docs/reference/memory/createThread.mdx
@@ -88,6 +88,6 @@ const thread = await memory.createThread({
 
 ### Related
 
-- [Memory](/reference/memory/Memory.mdx)
-- [getThreadById](/reference/memory/getThreadById.mdx)
-- [getThreadsByResourceId](/reference/memory/getThreadsByResourceId.mdx)
+- [Memory](/docs/reference/memory/Memory.mdx)
+- [getThreadById](/docs/reference/memory/getThreadById.mdx)
+- [getThreadsByResourceId](/docs/reference/memory/getThreadsByResourceId.mdx)

--- a/docs/src/pages/docs/reference/memory/getMessages.mdx
+++ b/docs/src/pages/docs/reference/memory/getMessages.mdx
@@ -148,6 +148,6 @@ The `getMessages` function returns two different message formats:
 
 ### Related
 
-- [Memory](/reference/memory/Memory.mdx)
-- [addMessage](/reference/memory/addMessage.mdx)
-- [rememberMessages](/reference/memory/rememberMessages.mdx)
+- [Memory](/docs/reference/memory/Memory.mdx)
+- [addMessage](/docs/reference/memory/addMessage.mdx)
+- [rememberMessages](/docs/reference/memory/rememberMessages.mdx)

--- a/docs/src/pages/docs/reference/memory/rememberMessages.mdx
+++ b/docs/src/pages/docs/reference/memory/rememberMessages.mdx
@@ -116,5 +116,5 @@ const result = await memory.rememberMessages({
 
 ### Related
 
-- [Memory](/reference/memory/Memory.mdx)
-- [getMessages](/reference/memory/getMessages.mdx)
+- [Memory](/docs/reference/memory/Memory.mdx)
+- [getMessages](/docs/reference/memory/getMessages.mdx)


### PR DESCRIPTION
These were all missing `/docs/`