### PR TITLE
prefix all storage table names with mastra_

### DIFF
--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -11,10 +11,10 @@ export type TABLE_NAMES =
   | typeof MastraStorage.TABLE_THREADS;
 
 export abstract class MastraStorage extends MastraBase {
-  static readonly TABLE_WORKFLOW_SNAPSHOT = 'workflow_snapshot';
-  static readonly TABLE_EVALS = 'evals';
-  static readonly TABLE_MESSAGES = 'messages';
-  static readonly TABLE_THREADS = 'threads';
+  static readonly TABLE_WORKFLOW_SNAPSHOT = 'mastra_workflow_snapshot';
+  static readonly TABLE_EVALS = 'mastra_evals';
+  static readonly TABLE_MESSAGES = 'mastra_messages';
+  static readonly TABLE_THREADS = 'mastra_threads';
 
   hasInit = false;
 

--- a/packages/core/src/storage/libsql.test.ts
+++ b/packages/core/src/storage/libsql.test.ts
@@ -39,18 +39,18 @@ describe('MastraStorageLibSql', () => {
 
   beforeEach(async () => {
     // Clear tables before each test
-    await storage.clearTable({ tableName: 'workflow_snapshot' });
-    await storage.clearTable({ tableName: 'evals' });
-    await storage.clearTable({ tableName: 'messages' });
-    await storage.clearTable({ tableName: 'threads' });
+    await storage.clearTable({ tableName: 'mastra_workflow_snapshot' });
+    await storage.clearTable({ tableName: 'mastra_evals' });
+    await storage.clearTable({ tableName: 'mastra_messages' });
+    await storage.clearTable({ tableName: 'mastra_threads' });
   });
 
   afterAll(async () => {
     // Clear tables after tests
-    await storage.clearTable({ tableName: 'workflow_snapshot' });
-    await storage.clearTable({ tableName: 'evals' });
-    await storage.clearTable({ tableName: 'messages' });
-    await storage.clearTable({ tableName: 'threads' });
+    await storage.clearTable({ tableName: 'mastra_workflow_snapshot' });
+    await storage.clearTable({ tableName: 'mastra_evals' });
+    await storage.clearTable({ tableName: 'mastra_messages' });
+    await storage.clearTable({ tableName: 'mastra_threads' });
   });
 
   describe('Thread Operations', () => {
@@ -236,7 +236,7 @@ describe('MastraStorageLibSql', () => {
     beforeAll(async () => {
       // Create workflow_snapshot table
       await storage.createTable({
-        tableName: 'workflow_snapshot',
+        tableName: 'mastra_workflow_snapshot',
         schema: {
           workflow_name: { type: 'text', nullable: false },
           run_id: { type: 'text', nullable: false },

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -406,7 +406,7 @@ export class PostgresStore extends MastraStorage {
         [workflowName, runId, JSON.stringify(snapshot), new Date(), new Date()],
       );
     } catch (error) {
-      console.error('Error inserting into workflow_snapshot:', error);
+      console.error('Error inserting into mastra_workflow_snapshot:', error);
       throw error;
     }
   }

--- a/storage/pg/src/pg.test.ts
+++ b/storage/pg/src/pg.test.ts
@@ -42,9 +42,9 @@ describe('PostgresStore', () => {
 
   beforeEach(async () => {
     // Clear tables before each test
-    await store.clearTable({ tableName: 'workflow_snapshot' });
-    await store.clearTable({ tableName: 'messages' });
-    await store.clearTable({ tableName: 'threads' });
+    await store.clearTable({ tableName: 'mastra_workflow_snapshot' });
+    await store.clearTable({ tableName: 'mastra_messages' });
+    await store.clearTable({ tableName: 'mastra_threads' });
   });
 
   describe('Thread Operations', () => {


### PR DESCRIPTION
Before the storage refactor these were all prefixed https://linear.app/kepler-crm/issue/MASTRA-1696/prefix-table-names-with-mastra-identifiers