### PR TITLE
added __registerPrimitives to model.ts

### DIFF
--- a/.changeset/clean-dancers-type.md
+++ b/.changeset/clean-dancers-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added \_\_registerPrimitives to model.ts

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -44,6 +44,18 @@ export class MastraLLM extends MastraLLMBase {
     }
   }
 
+  __registerPrimitives(p: MastraPrimitives) {
+    if (p.telemetry) {
+      this.__setTelemetry(p.telemetry);
+    }
+
+    if (p.logger) {
+      this.__setLogger(p.logger);
+    }
+
+    this.#mastra = p;
+  }
+
   convertTools(tools?: ToolsInput): Record<string, Tool> {
     this.logger.debug('Starting tool conversion for LLM');
     const converted = Object.entries(tools || {}).reduce(


### PR DESCRIPTION
This PR adds __registerPrimitives to model.ts. #mastra is a private variable, so it wasn't being inherited properly.