### PR TITLE
fix(memory): make it easy for the user to know what to do

### DIFF
--- a/.changeset/sweet-parrots-cry.md
+++ b/.changeset/sweet-parrots-cry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added helpful error when using vector with Memory class - error now contains embedding option example

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -114,7 +114,20 @@ export abstract class MastraMemory extends MastraBase {
 
   protected parseEmbeddingOptions() {
     if (!this.embedding) {
-      throw new Error(`Cannot use vector features without setting new Memory({ embedding: { ... } })`);
+      throw new Error(`Cannot use vector features without setting new Memory({ embedding: { ... } })
+
+For example:
+
+new Memory({
+  storage,
+  vector,
+  embedding: { // <- this is required
+    provider: "OPEN_AI",
+    model: "text-embedding-3-small",
+    maxRetries: 3,
+  }
+});
+`);
     }
 
     return this.embedding;


### PR DESCRIPTION
I was testing scaffolding a new project and went to add memory with storage/vector and ran into this error.
Had to look up what the values were - it'll be easier to just print out a common example for the user like this