### PR TITLE
Rework Bundling/Deployer

### DIFF
--- a/.changeset/clean-swans-flow.md
+++ b/.changeset/clean-swans-flow.md
@@ -1,0 +1,10 @@
+---
+'@mastra/deployer-cloudflare': minor
+'@mastra/deployer-netlify': minor
+'@mastra/deployer': minor
+'@mastra/deployer-vercel': minor
+'@mastra/core': minor
+'mastra': minor
+---
+
+Update deployer

--- a/deployers/netlify/src/helpers.ts
+++ b/deployers/netlify/src/helpers.ts
@@ -1,5 +1,4 @@
 async function createNetlifySite({ token, name, scope }: { token: string; name: string; scope?: string }) {
-  console.log(token, name, scope);
   const response = await fetch('https://api.netlify.com/api/v1/sites', {
     method: 'POST',
     headers: {

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -72,7 +72,12 @@ to = "/.netlify/functions/api/:splat"
   }
 
   async bundle(entryFile: string, outputDirectory: string): Promise<void> {
-    return this._bundle(this.getEntry(), entryFile, outputDirectory);
+    return this._bundle(
+      this.getEntry(),
+      entryFile,
+      outputDirectory,
+      join(outputDirectory, this.outputDir, 'netlify', 'functions', 'api'),
+    );
   }
 
   private getEntry(): string {

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -1,6 +1,4 @@
 import { Deployer } from '@mastra/deployer';
-import { getBundler } from '@mastra/deployer/build';
-import virtual from '@rollup/plugin-virtual';
 import { execa } from 'execa';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
@@ -59,7 +57,7 @@ to = "/.netlify/functions/api/:splat"
         './netlify/functions',
       ],
       {
-        cwd: outputDirectory,
+        cwd: join(outputDirectory, this.outputDir),
       },
     );
 
@@ -70,25 +68,11 @@ to = "/.netlify/functions/api/:splat"
   async prepare(outputDirectory: string): Promise<void> {
     await super.prepare(outputDirectory);
 
-    // Prepare the deployment directory
-    if (!existsSync(join(outputDirectory, 'netlify/functions/api'))) {
-      mkdirSync(join(outputDirectory, 'netlify/functions/api'), { recursive: true });
-    }
-    this.writeFiles({ dir: outputDirectory });
+    this.writeFiles({ dir: join(outputDirectory, this.outputDir) });
   }
 
-  async bundle(mastraDir: string, outputDirectory: string): Promise<void> {
-    const bundler = await getBundler({
-      input: '#entry',
-      external: [/^@opentelemetry\//],
-      plugins: [virtual({ '#entry': this.getEntry() })],
-    });
-
-    await bundler.write({
-      inlineDynamicImports: true,
-      file: join(outputDirectory, 'netlify', 'functions', 'api', 'index.mjs'),
-      format: 'es',
-    });
+  async bundle(entryFile: string, outputDirectory: string): Promise<void> {
+    return this._bundle(this.getEntry(), entryFile, outputDirectory);
   }
 
   private getEntry(): string {

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -33,7 +33,7 @@ export class VercelDeployer extends Deployer {
 
   writeFiles(outputDirectory: string): void {
     writeFileSync(
-      join(outputDirectory, 'vercel.json'),
+      join(outputDirectory, this.outputDir, 'vercel.json'),
       JSON.stringify(
         {
           version: 2,
@@ -134,17 +134,8 @@ export const POST = handle(app);
 `;
   }
 
-  async bundle(mastraDir: string, outputDirectory: string): Promise<void> {
-    const bundler = await getBundler({
-      input: '#entry',
-      plugins: [virtual({ '#entry': this.getEntry() })],
-    });
-
-    await bundler.write({
-      inlineDynamicImports: true,
-      file: `${outputDirectory}/index.mjs`,
-      format: 'es',
-    });
+  async bundle(entryFile: string, outputDirectory: string): Promise<void> {
+    return this._bundle(this.getEntry(), entryFile, outputDirectory);
   }
 
   async deploy(outputDirectory: string): Promise<void> {
@@ -155,7 +146,7 @@ export const POST = handle(app);
       '--scope',
       this.teamId as string,
       '--cwd',
-      outputDirectory,
+      join(outputDirectory, this.outputDir),
       '--token',
       this.token,
       'deploy',
@@ -165,7 +156,7 @@ export const POST = handle(app);
 
     // Run the Vercel deploy command
     child_process.execSync(`npx vercel ${commandArgs.join(' ')}`, {
-      cwd: outputDirectory,
+      cwd: join(outputDirectory, this.outputDir),
       env: {
         // ...this.env,
         PATH: process.env.PATH,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,6 @@
     "@dagrejs/dagre": "^1.1.4",
     "@mastra/core": "workspace:^",
     "@mastra/deployer": "workspace:^",
-    "@rollup/plugin-virtual": "^3.0.2",
     "@swc/core": "^1.9.3",
     "chokidar": "^4.0.3",
     "commander": "^12.1.0",

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -36,6 +36,9 @@ export class BuildBundler extends Bundler {
       overwrite: true,
     });
   }
+  bundle(entryFile: string, outputDirectory: string): Promise<void> {
+    return this._bundle(this.getEntry(), entryFile, outputDirectory);
+  }
 
   protected getEntry(): string {
     const __filename = fileURLToPath(import.meta.url);

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -1,17 +1,13 @@
-import { MastraBundler } from '@mastra/core/bundler';
-import { FileService, getBundler } from '@mastra/deployer';
-import virtual from '@rollup/plugin-virtual';
+import { FileService } from '@mastra/deployer/build';
+import { Bundler } from '@mastra/deployer/bundler';
 import * as fsExtra from 'fs-extra';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export class BuildBundler extends MastraBundler {
+export class BuildBundler extends Bundler {
   constructor() {
-    super({
-      name: 'Build',
-      component: 'BUNDLER',
-    });
+    super('Build');
   }
 
   getEnvFiles(): Promise<string[]> {
@@ -22,40 +18,26 @@ export class BuildBundler extends MastraBundler {
       const envFile = fileService.getFirstExistingFile(possibleFiles);
 
       return Promise.resolve([envFile]);
-    } catch (err) {}
+    } catch (err) {
+      // ignore
+    }
 
     return Promise.resolve([]);
   }
 
   async prepare(outputDirectory: string): Promise<void> {
-    await fsExtra.ensureDir(outputDirectory);
-
-    // Clean up the output directory first
-    await fsExtra.emptyDir(outputDirectory);
+    await super.prepare(outputDirectory);
 
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 
-    const playgroundServePath = join(outputDirectory, 'playground');
+    const playgroundServePath = join(outputDirectory, '.build', 'playground');
     await fsExtra.copy(join(dirname(__dirname), 'src/playground/dist'), playgroundServePath, {
       overwrite: true,
     });
   }
 
-  async bundle(mastraDir: string, outputDirectory: string): Promise<void> {
-    const bundler = await getBundler({
-      input: '#entry',
-      plugins: [virtual({ '#entry': this.getEntry() })],
-    });
-
-    await bundler.write({
-      file: `${outputDirectory}/index.mjs`,
-      format: 'es',
-      inlineDynamicImports: true,
-    });
-  }
-
-  private getEntry(): string {
+  protected getEntry(): string {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
     return readFileSync(join(__dirname, 'templates', 'dev.entry.js'), 'utf8');

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -1,13 +1,21 @@
 import { join } from 'node:path';
 
+import { FileService } from '../../services/service.file';
+
 import { BuildBundler } from './BuildBundler';
 
 export async function build({ dir }: { dir?: string }) {
   const mastraDir = dir ?? process.cwd();
   const outputDirectory = join(mastraDir, '.mastra');
   const deployer = new BuildBundler();
+  const fs = new FileService();
+  const mastraEntryFile = fs.getFirstExistingFile([
+    join(mastraDir, 'src', 'mastra', 'index.ts'),
+    join(mastraDir, 'src', 'mastra', 'index.js'),
+  ]);
 
+  console.log(join(mastraDir, 'index.ts'), join(mastraDir, 'index.js'));
   await deployer.prepare(outputDirectory);
 
-  await deployer.bundle(mastraDir, outputDirectory);
+  await deployer.bundle(mastraEntryFile, outputDirectory);
 }

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1,13 +1,16 @@
 import { getDeployer } from '@mastra/deployer';
 import { join } from 'path';
 
+import { FileService } from '../../services/service.file';
 import { logger } from '../../utils/logger';
 
 export async function deploy({ dir }: { dir?: string }) {
   let mastraDir = dir || join(process.cwd(), 'src/mastra');
   try {
     const outputDirectory = join(process.cwd(), '.mastra');
-    const deployer = await getDeployer(mastraDir, outputDirectory);
+    const fs = new FileService();
+    const mastraEntryFile = fs.getFirstExistingFile([join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')]);
+    const deployer = await getDeployer(mastraEntryFile, outputDirectory);
 
     if (!deployer) {
       logger.warn('No deployer found.');
@@ -16,7 +19,7 @@ export async function deploy({ dir }: { dir?: string }) {
 
     try {
       await deployer.prepare(outputDirectory);
-      await deployer.bundle(mastraDir, outputDirectory);
+      await deployer.bundle(mastraEntryFile, outputDirectory);
       try {
         await deployer.deploy(outputDirectory);
       } catch (error) {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -98,7 +98,7 @@ export async function dev({ port, dir, root }: { dir?: string; root?: string; po
   const mastraDir = join(rootDir, dir || 'src/mastra');
   const dotMastraPath = join(rootDir, '.mastra');
 
-  const bundler = new DevBundler();
+  const bundler = new DevBundler(mastraDir);
 
   const env = await bundler.loadEnvVars();
 

--- a/packages/cli/src/utils/get-env.ts
+++ b/packages/cli/src/utils/get-env.ts
@@ -1,4 +1,4 @@
-import dotenv from 'dotenv';
+import { config } from 'dotenv';
 import fs from 'fs';
 import path from 'node:path';
 
@@ -6,7 +6,7 @@ export function getEnv() {
   const projectDir = process.cwd();
   const dotenvPath = path.join(projectDir, '.env.development');
   if (fs.existsSync(dotenvPath)) {
-    dotenv.config({ path: dotenvPath });
+    config({ path: dotenvPath });
   }
   const dbUrl = process.env.DB_URL || '';
   return dbUrl;

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -12,8 +12,6 @@ import { randomUUID } from 'crypto';
 import { JSONSchema7 } from 'json-schema';
 import { z, ZodSchema } from 'zod';
 
-import 'dotenv/config';
-
 import { MastraPrimitives } from '../action';
 import { MastraBase } from '../base';
 import { Metric } from '../eval';

--- a/packages/core/src/bundler/index.ts
+++ b/packages/core/src/bundler/index.ts
@@ -4,7 +4,15 @@ import { readFile } from 'fs/promises';
 
 import { MastraBase } from '../base';
 
-export abstract class MastraBundler extends MastraBase {
+export interface IBundler {
+  loadEnvVars(): Promise<Map<string, string>>;
+  getEnvFiles(): Promise<string[]>;
+  bundle(entryFile: string, outputDirectory: string): Promise<void>;
+  prepare(outputDirectory: string): Promise<void>;
+  writePackageJson(outputDirectory: string, dependencies: Map<string, string>): Promise<void>;
+}
+
+export abstract class MastraBundler extends MastraBase implements IBundler {
   constructor({ name, component = 'BUNDLER' }: { name: string; component?: 'BUNDLER' | 'DEPLOYER' }) {
     super({ component, name });
   }

--- a/packages/core/src/bundler/index.ts
+++ b/packages/core/src/bundler/index.ts
@@ -25,6 +25,7 @@ export abstract class MastraBundler extends MastraBase {
   }
 
   abstract prepare(outputDirectory: string): Promise<void>;
+  abstract writePackageJson(outputDirectory: string, dependencies: Map<string, string>): Promise<void>;
   abstract getEnvFiles(): Promise<string[]>;
-  abstract bundle(mastraDir: string, outputDirectory: string): Promise<void>;
+  abstract bundle(entryFile: string, outputDirectory: string): Promise<void>;
 }

--- a/packages/core/src/bundler/index.ts
+++ b/packages/core/src/bundler/index.ts
@@ -1,4 +1,4 @@
-import dotenv from 'dotenv';
+import { parse } from 'dotenv';
 
 import { readFile } from 'fs/promises';
 
@@ -14,7 +14,7 @@ export abstract class MastraBundler extends MastraBase {
 
     for (const file of await this.getEnvFiles()) {
       const content = await readFile(file, 'utf-8');
-      const config = dotenv.parse(content);
+      const config = parse(content);
 
       Object.entries(config).forEach(([key, value]) => {
         envVars.set(key, value);

--- a/packages/core/src/deployer/index.ts
+++ b/packages/core/src/deployer/index.ts
@@ -1,6 +1,10 @@
-import { MastraBundler } from '../bundler';
+import { type IBundler, MastraBundler } from '../bundler';
 
-export abstract class MastraDeployer extends MastraBundler {
+export interface IDeployer extends IBundler {
+  deploy(outputDirectory: string): Promise<void>;
+}
+
+export abstract class MastraDeployer extends MastraBundler implements IDeployer {
   constructor({ name }: { name: string }) {
     super({ component: 'DEPLOYER', name });
   }

--- a/packages/core/src/embeddings/index.ts
+++ b/packages/core/src/embeddings/index.ts
@@ -6,8 +6,6 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { embed as embedAi, EmbeddingModel, embedMany as embedManyAi } from 'ai';
 import { createVoyage } from 'voyage-ai-provider';
 
-import 'dotenv/config';
-
 import { EmbeddingOptions } from './types';
 
 export * from './types';

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -22,8 +22,6 @@ import { createAnthropicVertex } from 'anthropic-vertex-ai';
 import { JSONSchema7 } from 'json-schema';
 import { z, ZodSchema } from 'zod';
 
-import 'dotenv/config';
-
 import { MastraPrimitives } from '../action';
 import { ToolsInput } from '../agent/types';
 import { MastraBase } from '../base';

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1,5 +1,3 @@
-import 'dotenv/config';
-
 import { Agent } from '../agent';
 import { MastraDeployer } from '../deployer';
 import { LLM } from '../llm';
@@ -275,14 +273,7 @@ export class Mastra<
 
     if (this.agents) {
       Object.keys(this.agents).forEach(key => {
-        const agent = this.agents?.[key];
-        if (agent) {
-          agent.__setLogger(this.logger);
-
-          if (agent.hasOwnMemory()) {
-            agent.getMemory()?.__setLogger(this.logger);
-          }
-        }
+        this.agents?.[key]?.__setLogger(this.logger);
       });
     }
 

--- a/packages/core/src/vector/index.ts
+++ b/packages/core/src/vector/index.ts
@@ -1,7 +1,7 @@
 import { MastraBase } from '../base';
 import { embed, embedMany } from '../embeddings';
-import { EmbeddingOptions } from '../embeddings/types';
-import { EmbedManyResult, EmbedResult } from '../llm/types';
+import type { EmbeddingOptions } from '../embeddings/types';
+import type { EmbedManyResult, EmbedResult } from '../llm/types';
 
 export interface QueryResult {
   id: string;

--- a/packages/deployer/global.d.ts
+++ b/packages/deployer/global.d.ts
@@ -1,1 +1,0 @@
-declare module 'builtins';

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -20,11 +20,19 @@
       "types": "./dist/build/index.d.ts",
       "default": "./dist/build/index.js"
     },
+    "./bundler": {
+      "types": "./dist/bundler/index.d.ts",
+      "default": "./dist/bundler/index.js"
+    },
+    "./analyze": {
+      "types": "./dist/build/analyze.d.ts",
+      "default": "./dist/build/analyze.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/build/index.ts src/server/index.ts --format esm --clean --dts --treeshake",
-    "dev": "pnpm run build:lib --watch",
+    "build": "tsup-node src/index.ts src/build/index.ts src/server/index.ts src/build/bundler.ts src/build/analyze.ts src/bundler/index.ts --format esm --clean --dts --treeshake",
+    "dev": "pnpm run build --watch",
     "pull:openapispec": "node src/server/openapi.script.js",
     "test": "vitest run"
   },

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -1,0 +1,254 @@
+import type { Logger } from '@mastra/core';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import virtual from '@rollup/plugin-virtual';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { rollup, type Plugin } from 'rollup';
+import esbuild from 'rollup-plugin-esbuild';
+
+import { isNodeBuiltin } from './isNodeBuiltin';
+import { aliasHono } from './plugins/hono-alias';
+import { pino } from './plugins/pino';
+import { removeDeployer } from './plugins/remove-deployer';
+
+/**
+ * Analyzes the entry file to identify dependencies that need optimization.
+ * This is the first step of the bundle analysis process.
+ *
+ * @param entry - The entry file path or content
+ * @param mastraEntry - The mastra entry point
+ * @param isVirtualFile - Whether the entry is a virtual file (content string) or a file path
+ * @param platform - Target platform (node or browser)
+ * @param logger - Logger instance for debugging
+ * @returns Map of dependencies to optimize with their exported bindings
+ */
+async function analyze(
+  entry: string,
+  mastraEntry: string,
+  isVirtualFile: boolean,
+  platform: 'node' | 'browser',
+  logger: Logger,
+) {
+  logger.info('Analyzing dependencies...');
+  let virtualPlugin = null;
+  if (isVirtualFile) {
+    virtualPlugin = virtual({
+      '#entry': entry,
+    });
+    entry = '#entry';
+  }
+
+  const optimizerBundler = await rollup({
+    logLevel: 'silent',
+    input: isVirtualFile ? '#entry' : entry,
+    treeshake: true,
+    preserveSymlinks: true,
+    plugins: [
+      virtualPlugin,
+      {
+        name: 'custom-alias-resolver',
+        resolveId(id: string) {
+          if (id === '#server') {
+            return fileURLToPath(import.meta.resolve('@mastra/deployer/server')).replaceAll('\\', '/');
+          }
+          if (id === '#mastra') {
+            return mastraEntry;
+          }
+        },
+      } satisfies Plugin,
+      json(),
+      esbuild({
+        target: 'node20',
+        platform,
+        minify: false,
+      }),
+      removeDeployer(entry),
+      esbuild({
+        target: 'node20',
+        platform,
+        minify: false,
+      }),
+    ].filter(Boolean),
+  });
+
+  const { output } = await optimizerBundler.generate({
+    format: 'esm',
+    inlineDynamicImports: true,
+  });
+
+  await optimizerBundler.close();
+
+  const depsToOptimize = new Map(Object.entries(output[0].importedBindings));
+  for (const dep of depsToOptimize.keys()) {
+    if (isNodeBuiltin(dep)) {
+      depsToOptimize.delete(dep);
+    }
+  }
+
+  return depsToOptimize;
+}
+
+/**
+ * Bundles vendor dependencies identified in the analysis step.
+ * Creates virtual modules for each dependency and bundles them using rollup.
+ *
+ * @param depsToOptimize - Map of dependencies with their exports from analyze step
+ * @param outputDir - Directory where bundled files will be written
+ * @param logger - Logger instance for debugging
+ * @returns Object containing bundle output and reference map for validation
+ */
+async function bundleExternals(depsToOptimize: Map<string, string[]>, outputDir: string, logger: Logger) {
+  logger.info('Optimizing dependencies...');
+  logger.debug(
+    `${Array.from(depsToOptimize.keys())
+      .map(key => `- ${key}`)
+      .join('\n')}`,
+  );
+
+  const reverseVirtualReferenceMap = new Map<string, string>();
+  const virtualDependencies = new Map();
+  for (const [dep, exports] of depsToOptimize.entries()) {
+    const name = dep.replaceAll('/', '-');
+    reverseVirtualReferenceMap.set(name, dep);
+    virtualDependencies.set(dep, {
+      name,
+      virtual: `export { ${exports.join(', ')} } from '${dep}';`,
+    });
+  }
+
+  const bundler = await rollup({
+    logLevel: 'silent',
+    input: Array.from(virtualDependencies.entries()).reduce(
+      (acc, [dep, virtualDep]) => {
+        acc[virtualDep.name] = `#virtual-${dep}`;
+        return acc;
+      },
+      {} as Record<string, string>,
+    ),
+    // this dependency breaks the build, so we need to exclude it
+    // TODO actually fix this so we don't need to exclude it
+    external: ['jsdom'],
+    treeshake: true,
+    preserveSymlinks: true,
+    plugins: [
+      virtual(
+        Array.from(virtualDependencies.entries()).reduce(
+          (acc, [dep, virtualDep]) => {
+            acc[`#virtual-${dep}`] = virtualDep.virtual;
+            return acc;
+          },
+          {} as Record<string, string>,
+        ),
+      ),
+      pino(),
+      commonjs({
+        strictRequires: 'strict',
+        transformMixedEsModules: true,
+        ignoreTryCatch: false,
+      }),
+      nodeResolve({
+        preferBuiltins: true,
+      }),
+      // hono is imported from deployer, so we need to resolve from here instead of the project root
+      aliasHono(),
+      json(),
+    ].filter(Boolean),
+  });
+
+  const { output } = await bundler.write({
+    format: 'esm',
+    dir: outputDir,
+    entryFileNames: '[name].mjs',
+    chunkFileNames: '[name].mjs',
+  });
+
+  await bundler.close();
+
+  return { output, reverseVirtualReferenceMap };
+}
+
+/**
+ * Validates the bundled output by attempting to import each generated module.
+ * Tracks invalid chunks and external dependencies that couldn't be bundled.
+ *
+ * @param output - Bundle output from rollup
+ * @param reverseVirtualReferenceMap - Map to resolve virtual module names back to original deps
+ * @param outputDir - Directory containing the bundled files
+ * @param logger - Logger instance for debugging
+ * @returns Analysis result containing invalid chunks and dependency mappings
+ */
+async function validateOutput(
+  output: any[],
+  reverseVirtualReferenceMap: Map<string, string>,
+  outputDir: string,
+  logger: Logger,
+) {
+  const result = {
+    invalidChunks: new Set<string>(),
+    dependencies: new Map<string, string>(),
+    externalDependencies: new Set<string>(),
+  };
+
+  //const internalFiles = new Set<string>(output.map(file => file.fileName));
+
+  for (const file of output) {
+    if (file.type === 'asset') {
+      continue;
+    }
+
+    try {
+      logger.debug(`Validating if ${file.fileName} is a valid module.`);
+      if (file.isEntry && reverseVirtualReferenceMap.has(file.name)) {
+        result.dependencies.set(reverseVirtualReferenceMap.get(file.name)!, file.fileName);
+      }
+
+      await import(`file:${outputDir}/${file.fileName}`);
+    } catch (err) {
+      result.invalidChunks.add(file.fileName);
+      if (file.isEntry && reverseVirtualReferenceMap.has(file.name)) {
+        result.externalDependencies.add(reverseVirtualReferenceMap.get(file.name)!);
+      }
+
+      // we might need this on other projects but not sure so let's keep it commented out for now
+      // console.log(file.fileName, file.isEntry, file.isDynamicEntry, err);
+      // result.invalidChunks.add(file.fileName);
+      // const externalImports = excludeInternalDeps(file.imports.filter(file => !internalFiles.has(file)));
+      // externalImports.push(...excludeInternalDeps(file.dynamicImports.filter(file => !internalFiles.has(file))));
+      // for (const externalImport of externalImports) {
+      //   result.externalDependencies.add(externalImport);
+      // }
+
+      // if (reverseVirtualReferenceMap.has(file.name)) {
+      //   result.externalDependencies.add(reverseVirtualReferenceMap.get(file.name)!);
+      // }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Main bundle analysis function that orchestrates the three-step process:
+ * 1. Analyze dependencies
+ * 2. Bundle dependencies modules
+ * 3. Validate generated bundles
+ *
+ * This helps identify which dependencies need to be externalized vs bundled.
+ */
+export async function analyzeBundle(
+  entry: string,
+  mastraEntry: string,
+  outputDir: string,
+  platform: 'node' | 'browser',
+  logger: Logger,
+) {
+  const isVirtualFile = entry.includes('\n') || !existsSync(entry);
+
+  const depsToOptimize = await analyze(entry, mastraEntry, isVirtualFile, platform, logger);
+  const { output, reverseVirtualReferenceMap } = await bundleExternals(depsToOptimize, outputDir, logger);
+  const result = await validateOutput(output, reverseVirtualReferenceMap, outputDir, logger);
+
+  return result;
+}

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -64,7 +64,7 @@ async function analyze(
         platform,
         minify: false,
       }),
-      removeDeployer(entry),
+      removeDeployer(mastraEntry),
       esbuild({
         target: 'node20',
         platform,
@@ -87,6 +87,8 @@ async function analyze(
     }
   }
 
+  // todo fix, coulds should add it itself but somehow doesnt
+  depsToOptimize.set('@hono/node-server', ['serve']);
   return depsToOptimize;
 }
 

--- a/packages/deployer/src/build/babel/remove-deployer.ts
+++ b/packages/deployer/src/build/babel/remove-deployer.ts
@@ -3,7 +3,6 @@ import babel from '@babel/core';
 export function removeDeployer() {
   const t = babel.types;
   let mastraClass: string | null = null;
-  let hasReplaced = false;
 
   return {
     name: 'remove-deployer',
@@ -22,9 +21,14 @@ export function removeDeployer() {
           }
         }
       },
-      NewExpression(path) {
-        if (mastraClass && t.isIdentifier(path.node.callee) && path.node.callee.name === mastraClass && !hasReplaced) {
-          hasReplaced = true;
+      NewExpression(path, state) {
+        if (
+          mastraClass &&
+          t.isIdentifier(path.node.callee) &&
+          path.node.callee.name === mastraClass &&
+          !state.hasReplaced
+        ) {
+          state.hasReplaced = true;
           const newMastraObj = t.cloneNode(path.node);
           if (t.isObjectExpression(newMastraObj.arguments[0]) && newMastraObj.arguments[0].properties?.[0]) {
             newMastraObj.arguments[0].properties = newMastraObj.arguments[0].properties.filter(

--- a/packages/deployer/src/build/bundle.ts
+++ b/packages/deployer/src/build/bundle.ts
@@ -78,6 +78,7 @@ function getOptions(inputOptions: NormalizedInputOptions, platform: 'node' | 'br
       }),
       commonjs({
         strictRequires: 'debug',
+        transformMixedEsModules: true,
         // dynamicRequireTargets: ['node_modules/**/@libsql+win32-*/*'],
       }),
       libSqlFix(),

--- a/packages/deployer/src/build/bundle.ts
+++ b/packages/deployer/src/build/bundle.ts
@@ -2,7 +2,7 @@ import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import builtins from 'builtins';
+import { builtinModules } from 'node:module';
 import { join } from 'path';
 import { rollup, watch, type InputOptions, type Plugin, type InputOption } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
@@ -26,7 +26,7 @@ function getOptions(inputOptions: NormalizedInputOptions, platform: 'node' | 'br
     join(root, 'src/mastra/index.js'),
   ]);
 
-  const nodeBuiltins = platform === 'node' ? builtins({ version: '20.0.0' }) : [];
+  const nodeBuiltins = platform === 'node' ? builtinModules : [];
 
   let nodeResolvePlugin =
     platform === 'node'

--- a/packages/deployer/src/build/bundle.ts
+++ b/packages/deployer/src/build/bundle.ts
@@ -77,7 +77,7 @@ function getOptions(inputOptions: NormalizedInputOptions, platform: 'node' | 'br
         ],
       }),
       commonjs({
-        strictRequires: 'debug',
+        strictRequires: 'strict',
         transformMixedEsModules: true,
         // dynamicRequireTargets: ['node_modules/**/@libsql+win32-*/*'],
       }),

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -1,0 +1,126 @@
+import alias from '@rollup/plugin-alias';
+import json from '@rollup/plugin-json';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import { fileURLToPath } from 'node:url';
+import { rollup, type InputOptions, type OutputOptions } from 'rollup';
+import esbuild from 'rollup-plugin-esbuild';
+
+import type { analyzeBundle } from './analyze';
+import { libSqlFix } from './plugins/fix-libsql';
+import { removeDeployer } from './plugins/remove-deployer';
+import { telemetryFix } from './plugins/telemetry-fix';
+
+export async function getInputOptions(
+  entryFile: string,
+  analyzedBundleInfo: Awaited<ReturnType<typeof analyzeBundle>>,
+  platform: 'node' | 'browser',
+): Promise<InputOptions> {
+  let nodeResolvePlugin =
+    platform === 'node'
+      ? nodeResolve({
+          preferBuiltins: true,
+          exportConditions: ['node', 'import', 'require'],
+          mainFields: ['module', 'main'],
+        })
+      : nodeResolve({
+          preferBuiltins: false,
+          exportConditions: ['browser', 'import', 'require'],
+          mainFields: ['module', 'main'],
+          browser: true,
+        });
+
+  return {
+    logLevel: 'silent',
+    treeshake: true,
+    preserveSymlinks: true,
+    external: Array.from(analyzedBundleInfo.externalDependencies),
+    plugins: [
+      telemetryFix(),
+      libSqlFix(),
+      {
+        name: 'alias-optimized-deps',
+        // @ts-ignore
+        resolveId(id) {
+          if (!analyzedBundleInfo.dependencies.has(id)) {
+            return null;
+          }
+
+          const isInvalidChunk = analyzedBundleInfo.invalidChunks.has(analyzedBundleInfo.dependencies.get(id)!);
+          if (isInvalidChunk) {
+            return {
+              id,
+              external: true,
+            };
+          }
+
+          return {
+            id: '.mastra/.build/' + analyzedBundleInfo.dependencies.get(id)!,
+            external: false,
+          };
+        },
+      },
+      alias({
+        entries: [
+          {
+            find: /^\#server$/,
+            replacement: fileURLToPath(import.meta.resolve('@mastra/deployer/server')).replaceAll('\\', '/'),
+          },
+          { find: /^\#mastra$/, replacement: entryFile.replaceAll('\\', '/') },
+        ],
+      }),
+      nodeResolvePlugin,
+      // for debugging
+      // {
+      //   name: 'logger',
+      //   //@ts-ignore
+      //   resolveId(id, ...args) {
+      //     console.log({ id, args });
+      //   },
+      //   // @ts-ignore
+      //   transform(code, id) {
+      //     if (code.includes('class Duplexify ')) {
+      //       console.log({ duplex: id });
+      //     }
+      //   },
+      // },
+      json(),
+      esbuild({
+        target: 'node20',
+        platform,
+        minify: false,
+        define: {
+          'process.env.NODE_ENV': JSON.stringify('production'),
+        },
+      }),
+      removeDeployer(entryFile),
+      // treeshake unused imports
+      esbuild({
+        include: entryFile,
+        target: 'node20',
+        platform,
+        minify: false,
+      }),
+    ].filter(Boolean),
+  } satisfies InputOptions;
+}
+
+export async function createBundler(
+  inputOptions: InputOptions,
+  outputOptions: Partial<OutputOptions> & { dir: string },
+) {
+  const bundler = await rollup(inputOptions);
+
+  return {
+    write: () => {
+      return bundler.write({
+        ...outputOptions,
+        format: 'esm',
+        entryFileNames: '[name].mjs',
+        chunkFileNames: '[name].mjs',
+      });
+    },
+    close: () => {
+      return bundler.close();
+    },
+  };
+}

--- a/packages/deployer/src/build/deployer.ts
+++ b/packages/deployer/src/build/deployer.ts
@@ -4,15 +4,11 @@ import { rollup } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 
 import { removeAllExceptDeployer } from './babel/get-deployer';
-import { FileService } from './fs';
 
-export async function getDeployer(mastraPath: string, outputDir: string) {
-  const fs = new FileService();
-  const file = fs.getFirstExistingFile([`${mastraPath}/index.ts`, `${mastraPath}/index.js`]);
-
+export async function getDeployer(entryFile: string, outputDir: string) {
   const bundle = await rollup({
     input: {
-      deployer: file,
+      deployer: entryFile,
     },
     treeshake: true,
     plugins: [

--- a/packages/deployer/src/build/deps.ts
+++ b/packages/deployer/src/build/deps.ts
@@ -11,9 +11,12 @@ import { createChildProcessLogger } from '../deploy/log.js';
 
 export class Deps extends MastraBase {
   private packageManager: string;
+  private rootDir: string;
 
-  constructor() {
+  constructor(rootDir = process.cwd()) {
     super({ component: 'DEPLOYER', name: 'DEPS' });
+
+    this.rootDir = rootDir;
     this.packageManager = this.getPackageManager();
   }
 
@@ -32,7 +35,7 @@ export class Deps extends MastraBase {
   }
 
   private getPackageManager(): string {
-    const lockFile = this.findLockFile(process.cwd());
+    const lockFile = this.findLockFile(this.rootDir);
     switch (lockFile) {
       case 'pnpm-lock.yaml':
         return 'pnpm';
@@ -47,7 +50,7 @@ export class Deps extends MastraBase {
     }
   }
 
-  public async install({ dir = process.cwd(), packages = [] }: { dir?: string; packages?: string[] }) {
+  public async install({ dir = this.rootDir, packages = [] }: { dir?: string; packages?: string[] }) {
     let runCommand = this.packageManager;
     if (this.packageManager === 'npm') {
       runCommand = `${this.packageManager} i`;
@@ -93,7 +96,7 @@ export class Deps extends MastraBase {
 
   public async checkDependencies(dependencies: string[]): Promise<string> {
     try {
-      const packageJsonPath = path.join(process.cwd(), 'package.json');
+      const packageJsonPath = path.join(this.rootDir, 'package.json');
 
       try {
         await fsPromises.access(packageJsonPath);
@@ -117,7 +120,7 @@ export class Deps extends MastraBase {
 
   public async getProjectName() {
     try {
-      const packageJsonPath = path.join(process.cwd(), 'package.json');
+      const packageJsonPath = path.join(this.rootDir, 'package.json');
       const packageJson = await fsPromises.readFile(packageJsonPath, 'utf-8');
       const pkg = JSON.parse(packageJson);
       return pkg.name;

--- a/packages/deployer/src/build/index.ts
+++ b/packages/deployer/src/build/index.ts
@@ -1,3 +1,6 @@
 export { getBundler, getWatcher } from './bundle';
+export { createBundler, getInputOptions as getBundlerInputOptions } from './bundler';
+export { createWatcher, getInputOptions as getWatcherInputOptions } from './watcher';
+export { analyzeBundle } from './analyze';
 export { FileService } from './fs';
 export { Deps } from './deps';

--- a/packages/deployer/src/build/isNodeBuiltin.ts
+++ b/packages/deployer/src/build/isNodeBuiltin.ts
@@ -1,0 +1,7 @@
+import { builtinModules } from 'node:module';
+
+export function isNodeBuiltin(dep: string): boolean {
+  const [pkg] = dep.split('/');
+
+  return dep.startsWith('node:') || builtinModules.includes(dep) || builtinModules.includes(pkg!);
+}

--- a/packages/deployer/src/build/plugins/hono-alias.ts
+++ b/packages/deployer/src/build/plugins/hono-alias.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import type { Plugin } from 'rollup';
+
+// hono is imported from deployer, so we need to resolve from here instead of the project root
+export function aliasHono(): Plugin {
+  return {
+    name: 'hono-alias',
+    resolveId(id: string) {
+      if (!id.startsWith('@hono/') && !id.startsWith('hono/') && id !== 'hono' && id !== 'hono-openapi') {
+        return;
+      }
+
+      const path = import.meta.resolve(id);
+      return fileURLToPath(path);
+    },
+  } satisfies Plugin;
+}

--- a/packages/deployer/src/build/plugins/pino.ts
+++ b/packages/deployer/src/build/plugins/pino.ts
@@ -1,0 +1,91 @@
+import path from 'path';
+import type { OutputChunk, Plugin } from 'rollup';
+
+export function pino() {
+  let emittedChunks = new Map();
+
+  const workerFiles = [
+    {
+      id: 'thread-stream-worker',
+      file: 'pino-thread-stream-worker',
+    },
+    {
+      id: 'pino-worker',
+      file: 'pino-worker',
+    },
+    {
+      id: 'pino/file',
+      file: 'pino-file',
+    },
+    {
+      id: 'pino-pretty',
+      file: 'pino-pretty',
+    },
+  ];
+
+  const fileReferences = new Map();
+  return {
+    name: 'rollup-plugin-pino',
+
+    async resolveId(id, importee) {
+      if (id === 'pino') {
+        // resolve pino first
+        const resolvedPino = await this.resolve(id, importee);
+
+        await Promise.all(
+          workerFiles.map(async file => {
+            const resolvedEntry = await this.resolve(file.id, resolvedPino.id);
+
+            if (!resolvedEntry) {
+              return null;
+            }
+
+            const reference = this.emitFile({
+              type: 'chunk',
+              id: resolvedEntry.id,
+              name: `${file.file}`,
+            });
+
+            fileReferences.set(file.id, reference);
+          }),
+        );
+      }
+    },
+    renderChunk(code, chunk) {
+      if (chunk.type === 'chunk' && (chunk as OutputChunk).isEntry && fileReferences.size && chunk.name === 'index') {
+        const importRegex = /^(?:import(?:["'\s]*[\w*${}\n\r\t, ]+from\s*)?["'\s].+[;"'\s]*)$/gm;
+
+        const codeToInject = `globalThis.__bundlerPathsOverrides = {
+            ${Array.from(fileReferences.entries())
+              .map(([key, file]) => {
+                return '"' + key + '": import.meta.ROLLUP_FILE_URL_' + file;
+              })
+              .join(',\n')}
+            };`;
+
+        // Find all import matches
+        const matches = Array.from(code.matchAll(importRegex));
+
+        if (matches.length > 0) {
+          // Get the last import's position
+          const lastImport = matches[matches.length - 1];
+          const lastImportEnd = lastImport.index + lastImport[0].length;
+
+          // Insert the code after the last import with a newline
+          const newCode = code.slice(0, lastImportEnd) + '\n\n' + codeToInject + '\n\n' + code.slice(lastImportEnd);
+
+          return {
+            code: newCode,
+            map: null,
+          };
+        }
+
+        // If no imports found, inject at the start of the file
+        return {
+          code: `${codeToInject}\n\n${code}`,
+          map: null,
+        };
+      }
+    },
+  } satisfies Plugin;
+}

--- a/packages/deployer/src/build/watcher.ts
+++ b/packages/deployer/src/build/watcher.ts
@@ -1,0 +1,48 @@
+import type { InputOptions, OutputOptions } from 'rollup';
+import { watch } from 'rollup';
+
+import { getInputOptions as getBundlerInputOptions } from './bundler';
+import { aliasHono } from './plugins/hono-alias';
+
+export async function getInputOptions(entryFile: string, platform: 'node' | 'browser') {
+  const inputOptions = await getBundlerInputOptions(
+    entryFile,
+    {
+      dependencies: new Map(),
+      externalDependencies: new Set(),
+      invalidChunks: new Set(),
+    },
+    platform,
+  );
+
+  //
+  inputOptions.logLevel = 'debug';
+
+  if (Array.isArray(inputOptions.plugins)) {
+    // filter out node-resolve plugin so all node_modules are external
+    inputOptions.plugins = inputOptions.plugins.filter(
+      // @ts-ignore
+      plugin => !plugin || !plugin?.name || plugin.name !== 'node-resolve',
+    );
+
+    inputOptions.plugins.push(aliasHono());
+  }
+
+  console.log(inputOptions);
+
+  return inputOptions;
+}
+
+export async function createWatcher(inputOptions: InputOptions, outputOptions: OutputOptions) {
+  const watcher = await watch({
+    ...inputOptions,
+    output: {
+      ...outputOptions,
+      format: 'esm',
+      entryFileNames: '[name].mjs',
+      chunkFileNames: '[name].mjs',
+    },
+  });
+
+  return watcher;
+}

--- a/packages/deployer/src/build/watcher.ts
+++ b/packages/deployer/src/build/watcher.ts
@@ -15,9 +15,6 @@ export async function getInputOptions(entryFile: string, platform: 'node' | 'bro
     platform,
   );
 
-  //
-  inputOptions.logLevel = 'debug';
-
   if (Array.isArray(inputOptions.plugins)) {
     // filter out node-resolve plugin so all node_modules are external
     inputOptions.plugins = inputOptions.plugins.filter(
@@ -27,8 +24,6 @@ export async function getInputOptions(entryFile: string, platform: 'node' | 'bro
 
     inputOptions.plugins.push(aliasHono());
   }
-
-  console.log(inputOptions);
 
   return inputOptions;
 }

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,0 +1,126 @@
+import { MastraBundler } from '@mastra/core/bundler';
+import virtual from '@rollup/plugin-virtual';
+import { ensureDir } from 'fs-extra';
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { InputOptions, OutputOptions } from 'rollup';
+
+import fsExtra from 'fs-extra/esm';
+
+import { analyzeBundle } from '../build/analyze';
+import { createBundler as createBundlerUtil, getInputOptions } from '../build/bundler';
+import { Deps } from '../build/deps';
+import { FileService } from '../build/fs';
+
+export abstract class Bundler extends MastraBundler {
+  protected analyzeOutputDir = '.build';
+  protected outputDir = 'output';
+
+  constructor(name: string) {
+    super({ name, component: 'BUNDLER' });
+  }
+
+  protected abstract getEntry(): string;
+
+  async prepare(outputDirectory: string): Promise<void> {
+    await ensureDir(join(outputDirectory, this.analyzeOutputDir));
+    await ensureDir(join(outputDirectory, this.outputDir));
+
+    // Clean up the output directory first
+    await fsExtra.emptyDir(outputDirectory);
+  }
+
+  async writePackageJson(outputDirectory: string, dependencies: Map<string, string>) {
+    this.logger.debug(`Writing project's package.json`);
+    await ensureDir(outputDirectory);
+    const pkgPath = join(outputDirectory, 'package.json');
+
+    await writeFile(
+      pkgPath,
+      JSON.stringify(
+        {
+          name: 'server',
+          version: '1.0.0',
+          description: '',
+          type: 'module',
+          main: 'index.mjs',
+          scripts: {
+            start: 'node ./index.mjs',
+          },
+          author: 'Mastra',
+          license: 'ISC',
+          dependencies: Object.fromEntries(dependencies),
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  protected createBundler(inputOptions: InputOptions, outputOptions: Partial<OutputOptions> & { dir: string }) {
+    return createBundlerUtil(inputOptions, outputOptions);
+  }
+
+  protected async analyze(entry: string, mastraFile: string, outputDirectory: string) {
+    return await analyzeBundle(entry, mastraFile, join(outputDirectory, this.analyzeOutputDir), 'node', this.logger);
+  }
+
+  protected async installDependencies(outputDirectory: string, rootDir = process.cwd()) {
+    const deps = new Deps(rootDir);
+    deps.__setLogger(this.logger);
+
+    await deps.install({ dir: join(outputDirectory, this.outputDir) });
+  }
+
+  async bundle(mastraDir: string, outputDirectory: string): Promise<void> {
+    this.logger.info('Start bundling Mastra');
+    const fileService = new FileService();
+    const mastraEntryFile = fileService.getFirstExistingFile([
+      join(mastraDir, 'src/mastra/index.ts'),
+      join(mastraDir, 'src/mastra/index.js'),
+    ]);
+
+    const inputFileOrVirtual = this.getEntry();
+    const isVirtual = inputFileOrVirtual.includes('\n') || existsSync(inputFileOrVirtual);
+
+    const analyzedBundleInfo = await analyzeBundle(
+      inputFileOrVirtual,
+      mastraEntryFile,
+      join(outputDirectory, this.analyzeOutputDir),
+      'node',
+      this.logger,
+    );
+
+    this.writePackageJson(
+      join(outputDirectory, this.outputDir),
+      Array.from(analyzedBundleInfo.externalDependencies).reduce((acc, dep) => {
+        acc.set(dep, 'latest');
+        return acc;
+      }, new Map<string, string>()),
+    );
+
+    const inputOptions: InputOptions = await getInputOptions(mastraEntryFile, analyzedBundleInfo, 'node');
+
+    if (isVirtual) {
+      inputOptions.input = { index: '#entry' };
+
+      if (Array.isArray(inputOptions.plugins)) {
+        inputOptions.plugins.unshift(virtual({ '#entry': this.getEntry() }));
+      } else {
+        inputOptions.plugins = [virtual({ '#entry': this.getEntry() })];
+      }
+    } else {
+      inputOptions.input = { index: inputFileOrVirtual };
+    }
+
+    const bundler = await this.createBundler(inputOptions, { dir: join(outputDirectory, this.outputDir) });
+
+    await bundler.write();
+    this.logger.info('Bundling Mastra done');
+
+    this.logger.info('Installing dependencies');
+    await this.installDependencies(outputDirectory);
+    this.logger.info('Done installing dependencies');
+  }
+}

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -80,7 +80,12 @@ export abstract class Bundler extends MastraBundler {
     await deps.install({ dir: join(outputDirectory, this.outputDir) });
   }
 
-  protected async _bundle(serverFile: string, mastraEntryFile: string, outputDirectory: string): Promise<void> {
+  protected async _bundle(
+    serverFile: string,
+    mastraEntryFile: string,
+    outputDirectory: string,
+    bundleLocation: string = join(outputDirectory, this.outputDir),
+  ): Promise<void> {
     this.logger.info('Start bundling Mastra');
     const isVirtual = serverFile.includes('\n') || existsSync(serverFile);
 
@@ -115,7 +120,7 @@ export abstract class Bundler extends MastraBundler {
       inputOptions.input = { index: serverFile };
     }
 
-    const bundler = await this.createBundler(inputOptions, { dir: join(outputDirectory, this.outputDir) });
+    const bundler = await this.createBundler(inputOptions, { dir: bundleLocation });
 
     await bundler.write();
     this.logger.info('Bundling Mastra done');

--- a/packages/deployer/src/deploy/base.ts
+++ b/packages/deployer/src/deploy/base.ts
@@ -1,18 +1,14 @@
-import { MastraDeployer } from '@mastra/core/deployer';
-import { emptyDir, ensureDir } from 'fs-extra';
-import { join } from 'path';
-
-import { writeFile } from 'fs/promises';
+import { type IDeployer } from '@mastra/core/deployer';
 
 import { Deps } from '../build/deps.js';
 import { FileService } from '../build/fs';
+import { Bundler } from '../bundler';
 
-export abstract class Deployer extends MastraDeployer {
+export abstract class Deployer extends Bundler implements IDeployer {
   deps: Deps = new Deps();
-  override name: string = '';
 
   constructor(args: { name: string }) {
-    super(args);
+    super(args.name, 'DEPLOYER');
 
     this.deps.__setLogger(this.logger);
   }
@@ -30,39 +26,5 @@ export abstract class Deployer extends MastraDeployer {
     return Promise.resolve([]);
   }
 
-  async prepare(outputDirectory: string) {
-    this.logger.info(`Preparing ${outputDirectory}...`);
-    await ensureDir(outputDirectory);
-
-    // Clean up the output directory first
-    await emptyDir(outputDirectory);
-  }
-
-  async writePackageJson(outputDirectory: string, dependencies: Map<string, string>) {
-    this.logger.debug(`Writing package.json`);
-    const pkgPath = join(outputDirectory, 'package.json');
-
-    await writeFile(
-      pkgPath,
-      JSON.stringify(
-        {
-          name: 'server',
-          version: '1.0.0',
-          description: '',
-          type: 'module',
-          main: 'index.mjs',
-          scripts: {
-            start: 'node ./index.mjs',
-          },
-          author: 'Mastra',
-          license: 'ISC',
-          dependencies: Object.fromEntries(dependencies),
-        },
-        null,
-        2,
-      ),
-    );
-
-    await writeFile(pkgPath, JSON.stringify(dependencies, null, 2));
-  }
+  abstract deploy(outputDirectory: string): Promise<void>;
 }

--- a/packages/deployer/src/deploy/base.ts
+++ b/packages/deployer/src/deploy/base.ts
@@ -17,33 +17,6 @@ export abstract class Deployer extends MastraDeployer {
     this.deps.__setLogger(this.logger);
   }
 
-  async writePackageJson(outputDirectory: string) {
-    this.logger.debug(`Writing package.json`);
-    const pkgPath = join(outputDirectory, 'package.json');
-
-    await writeFile(
-      pkgPath,
-      JSON.stringify(
-        {
-          name: 'server',
-          version: '1.0.0',
-          description: '',
-          type: 'module',
-          main: 'index.mjs',
-          scripts: {
-            start: 'node ./index.mjs',
-            build: 'echo "Already built"',
-          },
-          author: 'Mastra',
-          license: 'ISC',
-          dependencies: {},
-        },
-        null,
-        2,
-      ),
-    );
-  }
-
   getEnvFiles(): Promise<string[]> {
     const possibleFiles = ['.env.production', '.env'];
 
@@ -63,7 +36,33 @@ export abstract class Deployer extends MastraDeployer {
 
     // Clean up the output directory first
     await emptyDir(outputDirectory);
+  }
 
-    await this.writePackageJson(outputDirectory);
+  async writePackageJson(outputDirectory: string, dependencies: Map<string, string>) {
+    this.logger.debug(`Writing package.json`);
+    const pkgPath = join(outputDirectory, 'package.json');
+
+    await writeFile(
+      pkgPath,
+      JSON.stringify(
+        {
+          name: 'server',
+          version: '1.0.0',
+          description: '',
+          type: 'module',
+          main: 'index.mjs',
+          scripts: {
+            start: 'node ./index.mjs',
+          },
+          author: 'Mastra',
+          license: 'ISC',
+          dependencies: Object.fromEntries(dependencies),
+        },
+        null,
+        2,
+      ),
+    );
+
+    await writeFile(pkgPath, JSON.stringify(dependencies, null, 2));
   }
 }

--- a/packages/deployer/src/index.ts
+++ b/packages/deployer/src/index.ts
@@ -1,3 +1,3 @@
 export * from './deploy';
-export * from './build';
+export { getBundler, getWatcher, Deps, FileService } from './build';
 export { getDeployer } from './build/deployer';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2041,9 +2041,6 @@ importers:
       '@mastra/deployer':
         specifier: workspace:^
         version: link:../deployer
-      '@rollup/plugin-virtual':
-        specifier: ^3.0.2
-        version: 3.0.2(rollup@4.32.1)
       '@swc/core':
         specifier: ^1.9.3
         version: 1.10.11(@swc/helpers@0.5.15)

--- a/vector-stores/pg/src/index.ts
+++ b/vector-stores/pg/src/index.ts
@@ -1,5 +1,5 @@
-import { Filter } from '@mastra/core/filter';
-import { IndexStats, QueryResult, MastraVector } from '@mastra/core/vector';
+import type { Filter } from '@mastra/core/filter';
+import { type IndexStats, type QueryResult, MastraVector } from '@mastra/core/vector';
 import pg from 'pg';
 
 import { PGFilterTranslator } from './filter';


### PR DESCRIPTION
We're updating deployer/bundler again to accomedate with the node ecosystem. There are many edge cases when hoisting dependencies to esm.

New approach:
- Analyze dependencies
- Create vendor packages for each dependency
- Try out these compiled packages
- On failure, mark as external
- Install external files
- Run compiled entry

TODO (later)
- [ ] cleanup unused files
