### PR TITLE
chore: add changesets for package moves

### DIFF
--- a/.changeset/move-astra.md
+++ b/.changeset/move-astra.md
@@ -1,0 +1,12 @@
+---
+"@mastra/astra": minor
+"@mastra/vector-astra": minor
+---
+
+Move Astra package from `@mastra/vector-astra` to `@mastra/astra`.
+
+- Move package to `stores/astra`
+- Reorganize source files into `src/vector`
+- Add deprecation notice to old package
+- Update documentation and examples
+- No breaking changes in functionality

--- a/.changeset/move-pg.md
+++ b/.changeset/move-pg.md
@@ -1,0 +1,13 @@
+---
+"@mastra/pg": minor
+"@mastra/store-pg": minor
+"@mastra/vector-pg": minor
+---
+
+Combine PostgreSQL packages into `@mastra/pg`.
+
+- Move and combine packages to `stores/pg`
+- Reorganize source files into `src/vector` and `src/store`
+- Add deprecation notices to old packages
+- Update documentation and examples
+- No breaking changes in functionality

--- a/.changeset/move-pinecone.md
+++ b/.changeset/move-pinecone.md
@@ -1,0 +1,12 @@
+---
+"@mastra/pinecone": minor
+"@mastra/vector-pinecone": minor
+---
+
+Move Pinecone package from `@mastra/vector-pinecone` to `@mastra/pinecone`.
+
+- Move package to `stores/pinecone`
+- Reorganize source files into `src/vector`
+- Add deprecation notice to old package
+- Update documentation and examples
+- No breaking changes in functionality

--- a/.changeset/move-qdrant.md
+++ b/.changeset/move-qdrant.md
@@ -1,0 +1,12 @@
+---
+"@mastra/qdrant": minor
+"@mastra/vector-qdrant": minor
+---
+
+Move Qdrant package from `@mastra/vector-qdrant` to `@mastra/qdrant`.
+
+- Move package to `stores/qdrant`
+- Reorganize source files into `src/vector`
+- Add deprecation notice to old package
+- Update documentation and examples
+- No breaking changes in functionality

--- a/.changeset/move-upstash.md
+++ b/.changeset/move-upstash.md
@@ -1,0 +1,13 @@
+---
+"@mastra/upstash": minor
+"@mastra/store-upstash": minor
+"@mastra/vector-upstash": minor
+---
+
+Combine Upstash packages into `@mastra/upstash`.
+
+- Move and combine packages to `stores/upstash`
+- Reorganize source files into `src/vector` and `src/store`
+- Add deprecation notices to old packages
+- Update documentation and examples
+- No breaking changes in functionality


### PR DESCRIPTION
Generated by windsurf:

Add changesets for all package moves:

- Add changeset for moving Qdrant package
- Add changeset for moving Pinecone package
- Add changeset for moving Astra package
- Add changeset for moving Upstash packages
- Add changeset for moving PostgreSQL packages

All changes are marked as minor since we are pre-v1.