### PR TITLE
update assistant-ui example: makeMarkdownText was moved to a different package in assistant-ui project

### DIFF
--- a/examples/assistant-ui/components/MyAssistant.tsx
+++ b/examples/assistant-ui/components/MyAssistant.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Thread } from '@assistant-ui/react';
-import { makeMarkdownText } from '@assistant-ui/react-markdown';
+import { makeMarkdownText } from '@assistant-ui/react-ui';
 
 const MarkdownText = makeMarkdownText();
 

--- a/examples/assistant-ui/package.json
+++ b/examples/assistant-ui/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^0.0.72",
     "@assistant-ui/react": "^0.7.68",
-    "@assistant-ui/react-markdown": "^0.7.0",
+    "@assistant-ui/react-ui": "^0.1.6",
     "@mastra/client-js": "0.1.0-alpha.7",
     "next": "15.0.3",
     "react": "^18",


### PR DESCRIPTION
new location: https://github.com/assistant-ui/assistant-ui/blob/main/packages/react-ui/src/ui/markdown/markdown-text.tsx#L86
deprecation notice: https://github.com/assistant-ui/assistant-ui/blob/main/packages/react-markdown/src/index.ts#L14-L15