### PR TITLE
feat(memory): add DefaultStorage as implicit default for Memory

### DIFF
--- a/docs/src/pages/examples/memory/memory-with-libsql.mdx
+++ b/docs/src/pages/examples/memory/memory-with-libsql.mdx
@@ -1,24 +1,26 @@
 # Memory with LibSQL
 
-This example demonstrates how to use Mastra's memory system with LibSQL as the storage backend.
+This example demonstrates how to use Mastra's memory system with LibSQL. While Memory uses LibSQL as its default storage backend, you can also configure it explicitly for custom settings.
 
 ## Setup
 
-First, set up the memory system with LibSQL storage and vector capabilities:
+First, set up the memory system with vector capabilities:
 
 ```typescript
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
-import { LibSQLStore, DefaultVectorDB } from "@mastra/core/storage";
+import { DefaultStorage, DefaultVectorDB } from "@mastra/core/storage";
 import { Memory } from '@mastra/memory';
 
-// Initialize memory with LibSQL storage and vector search
+// Initialize memory with vector search capabilities
 const memory = new Memory({
-  storage: new LibSQLStore({
+  // The storage configuration is optional as Memory uses LibSQL by default
+  // Only specify it if you need custom configuration
+  storage: new DefaultStorage({
     url: process.env.DATABASE_URL || "file:local.db",
   }),
   vector: new DefaultVectorDB({
-    url: process.env.DATABASE_URL || "file:local.db",
+    connectionUrl: process.env.DATABASE_URL || "file:local.db",
   }),
   options: {
     lastMessages: 10,

--- a/docs/src/pages/examples/memory/streaming-working-memory-advanced.mdx
+++ b/docs/src/pages/examples/memory/streaming-working-memory-advanced.mdx
@@ -11,20 +11,14 @@ This example demonstrates how to create an agent that maintains a todo list usin
 
 Let's break down how to create an agent with working memory capabilities. We'll build a todo list manager that remembers tasks even with minimal context.
 
-### 1. Setting up Memory Storage
+### 1. Setting up Memory
 
-First, we'll configure the memory system using LibSQL storage. You can use any other [storage provider](/docs/agents/01-agent-memory#storage-options) as well.
+First, we'll configure the memory system with a short context window since we'll be using working memory to maintain state. Memory uses LibSQL storage by default, but you can use any other [storage provider](/docs/agents/01-agent-memory#storage-options) if needed:
 
 ```typescript
 import { Memory } from "@mastra/memory";
-import { DefaultStorage } from "@mastra/core/storage";
 
 const memory = new Memory({
-  storage: new DefaultStorage({
-    config: {
-      url: "file:example.db",
-    },
-  }),
   options: {
     lastMessages: 1, // working memory means we can have a shorter context window and still maintain conversational coherence
     workingMemory: {
@@ -40,7 +34,6 @@ Next, we'll define a template that shows the agent how to structure the todo lis
 
 ```typescript
 const memory = new Memory({
-  storage,
   options: {
     lastMessages: 1,
     workingMemory: {

--- a/docs/src/pages/examples/memory/streaming-working-memory.mdx
+++ b/docs/src/pages/examples/memory/streaming-working-memory.mdx
@@ -9,19 +9,12 @@ This example demonstrates how to create an agent that maintains a working memory
 
 ## Setup
 
-First, set up the memory system with LibSQL storage (or any other [storage provider](/docs/agents/01-agent-memory#storage-options)
-and a working memory template for the todo list:
+First, set up the memory system with working memory enabled. Memory uses LibSQL storage by default, but you can use any other [storage provider](/docs/agents/01-agent-memory#storage-options) if needed:
 
 ```typescript
 import { Memory } from "@mastra/memory";
-import { DefaultStorage } from "@mastra/core/storage";
 
 const memory = new Memory({
-  storage: new DefaultStorage({
-    config: {
-      url: "file:example.db",
-    },
-  }),
   options: {
     workingMemory: {
       enabled: true,

--- a/examples/memory-todo-agent/src/mastra/agents/index.ts
+++ b/examples/memory-todo-agent/src/mastra/agents/index.ts
@@ -1,14 +1,9 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
-import { DefaultStorage, DefaultVectorDB } from '@mastra/core/storage';
+import { DefaultVectorDB } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 
 const memory = new Memory({
-  storage: new DefaultStorage({
-    config: {
-      url: 'file:example.db',
-    },
-  }),
   vector: new DefaultVectorDB({
     connectionUrl: 'file:vector.db',
   }),

--- a/examples/memory-with-context/src/mastra/agents/index.ts
+++ b/examples/memory-with-context/src/mastra/agents/index.ts
@@ -1,14 +1,9 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
-import { DefaultStorage, DefaultVectorDB } from '@mastra/core/storage';
+import { DefaultVectorDB } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 
 const memory = new Memory({
-  storage: new DefaultStorage({
-    config: {
-      url: 'file:example.db',
-    },
-  }),
   vector: new DefaultVectorDB({
     connectionUrl: 'file:example.db',
   }),

--- a/examples/memory-with-libsql/src/mastra/agents/index.ts
+++ b/examples/memory-with-libsql/src/mastra/agents/index.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
-import { DefaultStorage, DefaultVectorDB } from '@mastra/core/storage';
+import { DefaultVectorDB } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 
 const memory = new Memory({
@@ -12,11 +12,6 @@ const memory = new Memory({
     },
   },
 
-  storage: new DefaultStorage({
-    config: {
-      url: 'file:example.db',
-    },
-  }),
   vector: new DefaultVectorDB({
     connectionUrl: 'file:example.db',
   }),

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -88,6 +88,7 @@ export const createMastraProject = async () => {
   await exec(`echo .mastra >> .gitignore`);
   await exec(`echo .env.development >> .gitignore`);
   await exec(`echo .env >> .gitignore`);
+  await exec(`echo *.db >> .gitignore`);
   s.stop('.gitignore added');
 
   p.outro('Project created successfully');

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -11,7 +11,7 @@ import {
 } from 'ai';
 
 import { MastraBase } from '../base';
-import { MastraStorage, StorageGetMessagesArg } from '../storage';
+import { DefaultStorage, MastraStorage, StorageGetMessagesArg } from '../storage';
 import { deepMerge } from '../utils';
 import { MastraVector } from '../vector';
 
@@ -59,8 +59,11 @@ export type MemoryConfig = {
 };
 
 export type SharedMemoryConfig = {
-  storage: MastraStorage;
+  /* @default new DefaultStorage({ config: { url: "file:memory.db" } }) */
+  storage?: MastraStorage;
+
   options?: MemoryConfig;
+
   vector?: MastraVector;
   embedder?: EmbeddingModel<string>;
 };
@@ -83,7 +86,13 @@ export abstract class MastraMemory extends MastraBase {
 
   constructor(config: { name: string } & SharedMemoryConfig) {
     super({ component: 'MEMORY', name: config.name });
-    this.storage = config.storage;
+    this.storage =
+      config.storage ||
+      new DefaultStorage({
+        config: {
+          url: 'file:memory.db',
+        },
+      });
     if (config.vector) {
       this.vector = config.vector;
       this.threadConfig.semanticRecall = true;
@@ -112,7 +121,6 @@ export abstract class MastraMemory extends MastraBase {
 For example:
 
 new Memory({
-  storage,
   vector,
   embedder: openai("text-embedding-3-small") // example
 });

--- a/packages/core/src/storage/README.md
+++ b/packages/core/src/storage/README.md
@@ -16,6 +16,7 @@ The storage package provides a flexible and extensible storage system for Mastra
    - Concrete implementation using LibSQL/SQLite
    - Supports both in-memory and file-based storage
    - Implements atomic transactions for data integrity
+   - Used automatically by Memory if no storage is provided
 
 ### Supported Tables
 
@@ -47,6 +48,21 @@ The storage system manages four primary tables:
 ## Usage
 
 ### Basic Setup
+
+When using Memory, DefaultStorage is used automatically if no storage is provided:
+
+```typescript
+import { Memory } from '@mastra/memory';
+
+const memory = new Memory({
+  options: {
+    lastMessages: 10,
+    semanticRecall: true
+  }
+});
+```
+
+For direct storage usage or custom configurations:
 
 ```typescript
 import { DefaultStorage } from '@mastra/core/storage';

--- a/packages/memory/integration-tests/.gitignore
+++ b/packages/memory/integration-tests/.gitignore
@@ -1,1 +1,1 @@
-test.db
+memory.db

--- a/packages/memory/integration-tests/src/with-libsql-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-libsql-storage.test.ts
@@ -11,26 +11,48 @@ dotenv.config({ path: '.env.test' });
 const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 describe('Memory with LibSQL Integration', () => {
-  const vector = new DefaultVectorDB({
-    connectionUrl: 'file:test.db',
+  describe('with explicit storage', () => {
+    const vector = new DefaultVectorDB({
+      connectionUrl: 'file:test.db',
+    });
+
+    const memory = new Memory({
+      storage: new DefaultStorage({
+        config: {
+          url: 'file:test.db',
+        },
+      }),
+      vector,
+      options: {
+        lastMessages: 10,
+        semanticRecall: {
+          topK: 3,
+          messageRange: 2,
+        },
+      },
+      embedder: openai.embedding('text-embedding-3-small'),
+    });
+
+    getResuableTests(memory);
   });
 
-  const memory = new Memory({
-    storage: new DefaultStorage({
-      config: {
-        url: 'file:test.db',
-      },
-    }),
-    vector,
-    options: {
-      lastMessages: 10,
-      semanticRecall: {
-        topK: 3,
-        messageRange: 2,
-      },
-    },
-    embedder: openai.embedding('text-embedding-3-small'),
-  });
+  describe('with default storage', () => {
+    const vector = new DefaultVectorDB({
+      connectionUrl: 'file:test.db',
+    });
 
-  getResuableTests(memory);
+    const memory = new Memory({
+      vector,
+      options: {
+        lastMessages: 10,
+        semanticRecall: {
+          topK: 3,
+          messageRange: 2,
+        },
+      },
+      embedder: openai.embedding('text-embedding-3-small'),
+    });
+
+    getResuableTests(memory);
+  });
 });

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -49,11 +49,6 @@ describe('Working Memory Tests', () => {
 
     // Create memory instance with working memory enabled
     memory = new Memory({
-      storage: new DefaultStorage({
-        config: {
-          url: 'file:test.db',
-        },
-      }),
       vector,
       options: {
         workingMemory: {


### PR DESCRIPTION
This PR updates the Memory class to automatically use DefaultStorage when no storage is provided, simplifying the configuration experience for users.

- Modified Memory class to use DefaultStorage by default with 'file:memory.db' as the connection URL
- Updated documentation to reflect the new default storage behavior
- Added *.db to .gitignore in create-mastra template

I'll add default vector as well in a later PR but that requires more investigation first