### PR TITLE
fix(core): persist libsql db's outside `.mastra` dir

### DIFF
--- a/.changeset/nice-yaks-develop.md
+++ b/.changeset/nice-yaks-develop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed libsql db relative file paths so they're always outside the .mastra directory. If they're inside .mastra they will be deleted when code is re-bundled

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -185,7 +185,7 @@ export class Agent<
       } else {
         thread = await memory.getThreadById({ threadId });
         if (!thread) {
-          this.logger.debug(`Thread not found, creating new thread for agent ${this.name}`, {
+          this.logger.debug(`Thread with id ${threadId} not found, creating new thread for agent ${this.name}`, {
             runId: runId || this.name,
           });
           const title = await this.genTitle(userMessage);
@@ -334,12 +334,12 @@ export class Agent<
 
         if (memory) {
           this.logger.debug(
-            `[Agent:${this.name}] - Memory persistence: store=${this.#mastra?.memory?.constructor.name} threadId=${threadId}`,
+            `[Agent:${this.name}] - Memory persistence: store=${this.getMemory()?.constructor.name} threadId=${threadId}`,
             {
               runId,
               resourceId,
               threadId,
-              memoryStore: this.#mastra?.memory?.constructor.name,
+              memoryStore: this.getMemory()?.constructor.name,
             },
           );
 
@@ -630,12 +630,12 @@ export class Agent<
 
         if (this.getMemory() && resourceId) {
           this.logger.debug(
-            `[Agent:${this.name}] - Memory persistence enabled: store=${this.#mastra?.memory?.constructor.name}, resourceId=${resourceId}`,
+            `[Agent:${this.name}] - Memory persistence enabled: store=${this.getMemory()?.constructor.name}, resourceId=${resourceId}`,
             {
               runId,
               resourceId,
               threadId: threadIdToUse,
-              memoryStore: this.#mastra?.memory?.constructor.name,
+              memoryStore: this.getMemory()?.constructor.name,
             },
           );
           const preExecuteResult = await this.preExecute({


### PR DESCRIPTION
When running `mastra dev` cwd will be inside the `.mastra` dir. 
This becomes a problem because every time code is re-bundled the `.mastra` dir is recreated again, deleting any db files that were written there.

This PR checks if the db url is a relative file path that's not absolute. If it is it rewrites the db url to be based on the parent dir of `.mastra`.
This brings the behaviour in line with how it would work if someone imported their agent into a file and ran it with `tsx src/index.ts`, in that case libsql will put the file in cwd but cwd will be outside `.mastra`