### PR TITLE
Fix exports map in @mastra/evals

### DIFF
--- a/.changeset/six-beers-lick.md
+++ b/.changeset/six-beers-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fix exports for @mastra/evals

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "build": "tsup src/index.ts src/metrics/llm/index.ts src/metrics/nlp/index.ts --format esm --experimental-dts --clean --treeshake",
+    "build": "tsup src/index.ts src/metrics/llm/index.ts src/metrics/nlp/index.ts --format esm --dts --clean --treeshake",
     "build:watch": "pnpm build --watch",
     "test": "vitest"
   },

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -4,33 +4,32 @@
   "description": "",
   "type": "module",
   "main": "dist/index.js",
-  "module": "dist/evals.esm.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/evals.esm.js"
+        "default": "./dist/index.js"
       }
     },
     "./nlp": {
       "import": {
         "types": "./dist/metrics/nlp/index.d.ts",
-        "default": "./dist/nlp.esm.js"
+        "default": "./dist/metrics/nlp/index.js"
       }
     },
     "./llm": {
       "import": {
         "types": "./dist/metrics/llm/index.d.ts",
-        "default": "./dist/llm.esm.js"
+        "default": "./dist/metrics/llm/index.js"
       }
     },
     "./package.json": "./package.json"
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "build": "pnpm check && tsup src/index.ts src/metrics/llm/index.ts src/metrics/nlp/index.ts --format esm --dts --clean --treeshake",
-    "dev": "tsup src/index.ts src/metrics/llm/index.ts src/metrics/nlp/index.ts --format esm --dts --watch",
+    "build": "tsup src/index.ts src/metrics/llm/index.ts src/metrics/nlp/index.ts --format esm --experimental-dts --clean --treeshake",
+    "build:watch": "pnpm build --watch",
     "test": "vitest"
   },
   "keywords": [],


### PR DESCRIPTION
Our exports map in evals was still pointing to old code