### PR TITLE
perf: remove unnnecessary llm call

### DIFF
--- a/.changeset/five-rules-doubt.md
+++ b/.changeset/five-rules-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed an extra llm call that was needed for the old Memory API but is no longer needed

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -218,43 +218,6 @@ export class Agent<
           };
         });
 
-        const contextCallMessages: CoreMessage[] = [
-          {
-            role: 'system',
-            content: `\n
-             Analyze this message to determine if the user is referring to a previous conversation with the LLM.
-             Specifically, identify if the user wants to reference specific information from that chat or if they want the LLM to use the previous chat messages as context for the current conversation.
-             Extract any date ranges mentioned in the user message that could help identify the previous chat.
-             Return dates in ISO format.
-             If no specific dates are mentioned but time periods are (like "last week" or "past month"), calculate the appropriate date range.
-             For the end date, return the date 1 day after the end of the time period.
-             Today's date is ${new Date().toISOString()}`,
-          },
-          ...newMessages,
-        ];
-
-        let context;
-
-        try {
-          context = await this.llm.__textObject<{ usesContext: boolean; startDate: Date; endDate: Date }>({
-            messages: contextCallMessages,
-            structuredOutput: z.object({
-              usesContext: z.boolean(),
-              startDate: z.date(),
-              endDate: z.date(),
-            }),
-          });
-
-          this.logger.debug('Text Object result', {
-            contextObject: JSON.stringify(context.object, null, 2),
-            runId: runId || this.name,
-          });
-        } catch (e) {
-          if (e instanceof Error) {
-            this.log(LogLevel.DEBUG, `No context found: ${e.message}`);
-          }
-        }
-
         const memoryMessages =
           threadId && memory
             ? (


### PR DESCRIPTION
89838899a92cf9d337df632eb4f1274f4bc7d38a added a llm call to check if there was any relevant context in memory, before loading messages from memory.

30322ce4746b0abc4eb36ad1de85acba5b759386 removed the the context check and defaulted to always loading messages from memory. But, crucially, missed removing the (now) unnecessary llm call to check for context.