### PR TITLE
fix: strip query params from fastembed import

### DIFF
--- a/.changeset/nine-kids-clap.md
+++ b/.changeset/nine-kids-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix fastembed imports in mastra cloud for default embedder

--- a/packages/core/src/vector/fastembed.ts
+++ b/packages/core/src/vector/fastembed.ts
@@ -1,5 +1,5 @@
 import { experimental_customProvider } from 'ai';
-// @ts-expect-error no types for this package
+// @ts-ignore no types for this package
 import node_modulesPath from 'node_modules-path';
 import path from 'path';
 
@@ -15,14 +15,13 @@ function getModelCachePath() {
   return cachedPath;
 }
 
-const fastEmbedImportPath = 'fastembed?' + Date.now(); // +? date to prevent esbuild from seeing this as statically analyzable and bundling this as a regular import. top level var so we only get 1 cached import, not a new one per dynamic import (no new Date on each import)
-
 // Shared function to generate embeddings using fastembed
 async function generateEmbeddings(values: string[], modelType: 'BGESmallENV15' | 'BGEBaseENV15') {
   try {
     // Dynamically import fastembed only when this function is called
     // this is to avoid importing fastembed in runtimes that don't support its native bindings
-    const { EmbeddingModel, FlagEmbedding } = await import(fastEmbedImportPath);
+    const fastEmbedImportPath = 'fastembed?d=' + Date.now(); // +? date to prevent esbuild from seeing this as statically analyzable and bundling this as a regular import.
+    const { EmbeddingModel, FlagEmbedding } = await import(fastEmbedImportPath.split(`?`)[0]!); // remove the date to prevent module not found errors in cloud
 
     const model = await FlagEmbedding.init({
       model: EmbeddingModel[modelType],


### PR DESCRIPTION
The import here needs to be non-statically-analyzable so it doesn't get bundled into a require or a top level import. The (hacky) code that's there does that, however, in cloud it seems module imports with query params don't resolve. So this PR strips those off to (hopefully) achieve both goals.

This is part of exploration work so the hackiness is temporary