### PR TITLE
feat(core, memory): add default vector db and embedder to Memory

### DIFF
--- a/.changeset/tall-shoes-develop.md
+++ b/.changeset/tall-shoes-develop.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Added a default vector db (libsql) and embedder (fastembed) so that new Memory() can be initialized with zero config

--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -60,7 +60,9 @@ await agent.stream("Can you summarize the search feature requirements?", {
 
 ### Semantic Search
 
-Semantic search is enabled by default using LibSQL for vector storage and FastEmbed for embeddings. This allows your agent to find and recall relevant information from earlier in the conversation:
+Semantic search is enabled by default in Mastra. While FastEmbed (bge-small-en-v1.5) and LibSQL are included by default, you can use any embedder (like OpenAI or Cohere) and vector database (like PostgreSQL, Pinecone, or Chroma) that fits your needs.
+
+This allows your agent to find and recall relevant information from earlier in the conversation:
 
 ```typescript copy showLineNumbers
 const memory = new Memory({
@@ -89,6 +91,22 @@ When semantic search is used:
 2. Similar messages are found using vector similarity search
 3. Surrounding context is included based on `messageRange`
 4. All relevant context is provided to the agent
+
+You can also customize the vector database and embedder:
+
+```typescript copy showLineNumbers
+import { openai } from '@ai-sdk/openai';
+import { PgVector } from '@mastra/pg';
+
+const memory = new Memory({
+  // Use a different vector database (libsql is default)
+  vector: new PgVector({
+    connectionString: "postgresql://user:pass@localhost:5432/db",
+  }),
+  // Or a different embedder (fastembed is default)
+  embedder: openai.embedding('text-embedding-3-small'),
+});
+```
 
 ## Memory Configuration
 

--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -41,7 +41,7 @@ The Memory API uses two main mechanisms to maintain context in conversations, re
 
 ### Recent Message History
 
-The `lastMessages` setting maintains a sliding window of the most recent messages. This ensures your agent always has access to the immediate conversation context:
+By default, Memory keeps track of the 40 most recent messages in a conversation. You can customize this with the `lastMessages` setting:
 
 ```typescript copy showLineNumbers
 const memory = new Memory({
@@ -60,7 +60,7 @@ await agent.stream("Can you summarize the search feature requirements?", {
 
 ### Semantic Search
 
-When vector search is enabled, Memory can find relevant past messages using semantic similarity. This allows your agent to recall information from earlier in the conversation:
+Semantic search is enabled by default using LibSQL for vector storage and FastEmbed for embeddings. This allows your agent to find and recall relevant information from earlier in the conversation:
 
 ```typescript copy showLineNumbers
 const memory = new Memory({
@@ -82,23 +82,37 @@ await agent.stream("What did we decide about the search feature last week?", {
     },
   },
 });
-// The vector search will:
-// 1. Find message_3 as relevant (topK: 10)
-// 2. Include messages [1,2] before and [4,5] after
-// 3. Include all of this context in the agent's response
 ```
+
+When semantic search is used:
+1. The message is converted to a vector embedding
+2. Similar messages are found using vector similarity search
+3. Surrounding context is included based on `messageRange`
+4. All relevant context is provided to the agent
 
 ## Memory Configuration
 
-The Mastra memory system is highly configurable and supports multiple storage backends. Here's a basic configuration example:
+The Mastra memory system is highly configurable and supports multiple storage backends. By default, it uses LibSQL for storage and vector search, and FastEmbed for embeddings.
+
+### Basic Configuration
+
+For most use cases, you can use the default configuration:
 
 ```typescript copy showLineNumbers
-import { openai } from "@ai-sdk/openai";
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory();
+```
+
+### Custom Configuration
+
+For more control, you can customize the storage backend, vector database, and memory options:
+
+```typescript copy showLineNumbers
 import { Memory } from "@mastra/memory";
 import { PostgresStore, PgVector } from "@mastra/pg";
 
 const memory = new Memory({
-  // Required: Storage backend for messages
   storage: new PostgresStore({
     host: "localhost",
     port: 5432,
@@ -106,11 +120,9 @@ const memory = new Memory({
     database: "postgres",
     password: "postgres",
   }),
-
-  // Optional: Vector store for semantic search
-  vector: new PgVector(connectionString),
-
-  // Optional: Memory configuration options
+  vector: new PgVector({
+    connectionString: "postgresql://user:pass@localhost:5432/db",
+  }),
   options: {
     // Number of recent messages to include (false to disable)
     lastMessages: 10,
@@ -120,9 +132,6 @@ const memory = new Memory({
       messageRange: 2, // Messages before and after each result
     },
   },
-
-  // Required if using vector search
-  embedder: openai.embedding("text-embedding-3-small"),
 });
 ```
 

--- a/docs/src/pages/docs/reference/memory/Memory.mdx
+++ b/docs/src/pages/docs/reference/memory/Memory.mdx
@@ -8,10 +8,8 @@ The `Memory` class provides a robust system for managing conversation history an
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 
-const memory = new Memory();
-
 const agent = new Agent({
-  memory,
+  memory: new Memory(),
   ...otherOptions,
 });
 ```
@@ -41,8 +39,9 @@ const memory = new Memory({
 
     // Semantic search configuration
     semanticRecall: {
-      topK: 3,           // Number of similar messages to retrieve
-      messageRange: {    // Messages to include around each result
+      topK: 3, // Number of similar messages to retrieve
+      messageRange: {
+        // Messages to include around each result
         before: 2,
         after: 1,
       },
@@ -51,7 +50,7 @@ const memory = new Memory({
     // Working memory configuration
     workingMemory: {
       enabled: true,
-      template: '<user><first_name></first_name><last_name></last_name></user>',
+      template: "<user><first_name></first_name><last_name></last_name></user>",
     },
   },
 });

--- a/docs/src/pages/docs/reference/memory/Memory.mdx
+++ b/docs/src/pages/docs/reference/memory/Memory.mdx
@@ -1,17 +1,64 @@
 # Memory Class Reference
 
-The `Memory` class provides a robust system for managing conversation history and thread-based message storage in Mastra. It enables persistent storage of conversations, semantic search capabilities, and efficient message retrieval.
+The `Memory` class provides a robust system for managing conversation history and thread-based message storage in Mastra. It enables persistent storage of conversations, semantic search capabilities, and efficient message retrieval. By default, it uses LibSQL for storage and vector search, and FastEmbed for embeddings.
 
-## Usage Example
+## Basic Usage
 
 ```typescript copy showLineNumbers
 import { Memory } from "@mastra/memory";
-import { DefaultStorage } from "@mastra/core/storage";
+import { Agent } from "@mastra/core/agent";
+
+const memory = new Memory();
+
+const agent = new Agent({
+  memory,
+  ...otherOptions,
+});
+```
+
+## Custom Configuration
+
+```typescript copy showLineNumbers
+import { Memory } from "@mastra/memory";
+import { DefaultStorage, DefaultVectorDB } from "@mastra/core/storage";
+import { Agent } from "@mastra/core/agent";
 
 const memory = new Memory({
+  // Custom storage configuration
   storage: new DefaultStorage({
-    url: ":memory:",
+    url: "file:memory.db",
   }),
+
+  // Custom vector database for semantic search
+  vector: new DefaultVectorDB({
+    url: "file:vector.db",
+  }),
+
+  // Memory configuration options
+  options: {
+    // Number of recent messages to include
+    lastMessages: 20,
+
+    // Semantic search configuration
+    semanticRecall: {
+      topK: 3,           // Number of similar messages to retrieve
+      messageRange: {    // Messages to include around each result
+        before: 2,
+        after: 1,
+      },
+    },
+
+    // Working memory configuration
+    workingMemory: {
+      enabled: true,
+      template: '<user><first_name></first_name><last_name></last_name></user>',
+    },
+  },
+});
+
+const agent = new Agent({
+  memory,
+  ...otherOptions,
 });
 ```
 
@@ -35,7 +82,7 @@ const memory = new Memory({
       name: "embedder",
       type: "EmbeddingModel",
       description:
-        "Embedder instance for vector embeddings",
+        "Embedder instance for vector embeddings. Uses FastEmbed (bge-small-en-v1.5) by default",
       isOptional: true,
     },
     {
@@ -103,16 +150,15 @@ If no template is provided, the Memory class uses a default template that includ
 
 ### embedder
 
-The embedder instance to use for generating vector embeddings. This should be an instance of a class that implements the `MastraEmbedder` interface. See the [Embedder Reference](/docs/reference/embedder) for available embedders and their configuration options.
+By default, Memory uses FastEmbed with the `bge-small-en-v1.5` model, which provides a good balance of performance and model size (~130MB). You only need to specify an embedder if you want to use a different model or provider.
 
 ## Additional Notes
 
 ### Vector Search Configuration
 
-When using vector search capabilities, ensure you configure both the vector store and appropriate search options. Here's an example (just using the in-memory store):
+When using vector search capabilities with custom configuration, ensure you configure both the vector store and appropriate search options. Here's an example:
 
 ```typescript copy showLineNumbers
-import { openai } from "@ai-sdk/openai";
 import { Memory } from "@mastra/memory";
 import { DefaultStorage, DefaultVectorDB } from "@mastra/core/storage";
 
@@ -123,7 +169,6 @@ const memory = new Memory({
   vector: new DefaultVectorDB({
     url: ":memory:",
   }),
-  embedder: openai.embedding("text-embedding-3-small"),
   options: {
     semanticRecall: {
       topK: 5,

--- a/docs/src/pages/examples/memory/memory-with-libsql.mdx
+++ b/docs/src/pages/examples/memory/memory-with-libsql.mdx
@@ -1,21 +1,36 @@
 # Memory with LibSQL
 
-This example demonstrates how to use Mastra's memory system with LibSQL. While Memory uses LibSQL as its default storage backend, you can also configure it explicitly for custom settings.
+This example demonstrates how to use Mastra's memory system with LibSQL, which is the default storage and vector database backend.
 
-## Setup
+## Quickstart
 
-First, set up the memory system with vector capabilities:
+Initializing memory with no settings will use LibSQL as the storage and vector database.
+
+```typescript copy showLineNumbers
+import { Memory } from '@mastra/memory';
+import { Agent } from '@mastra/core/agent';
+
+// Initialize memory with LibSQL defaults
+const memory = new Memory();
+
+const memoryAgent = new Agent({
+  name: "Memory Agent",
+  instructions:
+    "You are an AI agent with the ability to automatically recall memories from previous interactions.",
+  model: openai('gpt-4o-mini'),
+  memory,
+});
+```
+
+## Custom Configuration
+
+If you need more control, you can explicitly configure the storage, vector database, and embedder. If you omit either `storage` or `vector`, LibSQL will be used as the default for the omitted option. This lets you use a different provider for just storage or just vector search if needed.
 
 ```typescript
 import { openai } from '@ai-sdk/openai';
-import { Agent } from '@mastra/core/agent';
 import { DefaultStorage, DefaultVectorDB } from "@mastra/core/storage";
-import { Memory } from '@mastra/memory';
 
-// Initialize memory with vector search capabilities
-const memory = new Memory({
-  // The storage configuration is optional as Memory uses LibSQL by default
-  // Only specify it if you need custom configuration
+const customMemory = new Memory({
   storage: new DefaultStorage({
     url: process.env.DATABASE_URL || "file:local.db",
   }),
@@ -29,10 +44,8 @@ const memory = new Memory({
       messageRange: 2,
     },
   },
-  embedder: openai.embedding('text-embedding-3-small'),
 });
 
-// Create an agent with memory capabilities
 const memoryAgent = new Agent({
   name: "Memory Agent",
   instructions:

--- a/docs/src/pages/examples/memory/memory-with-pg.mdx
+++ b/docs/src/pages/examples/memory/memory-with-pg.mdx
@@ -37,7 +37,6 @@ const memory = new Memory({
       messageRange: 2,
     },
   },
-  embedder: openai.embedding("text-embedding-3-small"),
 });
 
 // Create an agent with memory capabilities

--- a/docs/src/pages/examples/memory/memory-with-upstash.mdx
+++ b/docs/src/pages/examples/memory/memory-with-upstash.mdx
@@ -29,7 +29,6 @@ const memory = new Memory({
       messageRange: 2,
     },
   },
-  embedder: openai.embedding("text-embedding-3-small"),
 });
 
 // Create an agent with memory capabilities

--- a/examples/memory-todo-agent/src/mastra/agents/index.ts
+++ b/examples/memory-todo-agent/src/mastra/agents/index.ts
@@ -1,13 +1,8 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
-import { DefaultVectorDB } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 
 const memory = new Memory({
-  vector: new DefaultVectorDB({
-    connectionUrl: 'file:vector.db',
-  }),
-  embedder: openai.embedding('text-embedding-3-small'),
   options: {
     lastMessages: 1,
     semanticRecall: false,

--- a/examples/memory-with-context/src/mastra/agents/index.ts
+++ b/examples/memory-with-context/src/mastra/agents/index.ts
@@ -1,12 +1,8 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
-import { DefaultVectorDB } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 
 const memory = new Memory({
-  vector: new DefaultVectorDB({
-    connectionUrl: 'file:example.db',
-  }),
   options: {
     lastMessages: 4,
     semanticRecall: {
@@ -17,7 +13,6 @@ const memory = new Memory({
       enabled: true,
     },
   },
-  embedder: openai.embedding('text-embedding-3-small'),
 });
 
 export const memoryAgent = new Agent({

--- a/examples/memory-with-libsql/src/mastra/agents/index.ts
+++ b/examples/memory-with-libsql/src/mastra/agents/index.ts
@@ -1,6 +1,5 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
-import { DefaultVectorDB } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 
 const memory = new Memory({
@@ -11,11 +10,6 @@ const memory = new Memory({
       messageRange: 2,
     },
   },
-
-  vector: new DefaultVectorDB({
-    connectionUrl: 'file:example.db',
-  }),
-  embedder: openai.embedding('text-embedding-3-small'),
 });
 
 export const chefAgent = new Agent({

--- a/examples/memory-with-pg/src/mastra/agents/index.ts
+++ b/examples/memory-with-pg/src/mastra/agents/index.ts
@@ -1,5 +1,5 @@
-import { Agent } from '@mastra/core/agent';
 import { openai } from '@ai-sdk/openai';
+import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
 import { PgVector, PostgresStore } from '@mastra/pg';
 
@@ -26,7 +26,6 @@ export const memory = new Memory({
       messageRange: 2,
     },
   },
-  embedder: openai.embedding('text-embedding-3-small'),
 });
 
 export const chefAgent = new Agent({

--- a/examples/memory-with-upstash/src/mastra/index.ts
+++ b/examples/memory-with-upstash/src/mastra/index.ts
@@ -1,4 +1,3 @@
-import { openai } from '@ai-sdk/openai';
 import { Mastra } from '@mastra/core';
 import { Memory } from '@mastra/memory';
 import { PgVector } from '@mastra/pg';
@@ -19,7 +18,6 @@ const memory = new Memory({
       messageRange: 2,
     },
   },
-  embedder: openai.embedding('text-embedding-3-small'),
 });
 
 export const mastra = new Mastra({

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -76,8 +76,8 @@ export abstract class MastraMemory extends MastraBase {
   MAX_CONTEXT_TOKENS?: number;
 
   storage: MastraStorage;
-  vector?: MastraVector;
-  embedder?: EmbeddingModel<string>;
+  vector: MastraVector;
+  embedder: EmbeddingModel<string>;
 
   protected threadConfig: MemoryConfig = {
     lastMessages: 40,
@@ -124,10 +124,6 @@ export abstract class MastraMemory extends MastraBase {
   }
 
   protected async createEmbeddingIndex(): Promise<{ indexName: string }> {
-    if (!this.vector) {
-      throw new Error(`Cannot call MastraMemory.createEmbeddingIndex() without a vector db attached.`);
-    }
-
     const defaultDimensions = 1536;
 
     // AI SDK doesn't expose a way to check how many dimensions a model uses.
@@ -136,28 +132,12 @@ export abstract class MastraMemory extends MastraBase {
       'bge-base-en-v1.5': 768,
     };
 
-    const dimensions = dimensionsByModelId[this.getEmbedder().modelId] || defaultDimensions;
+    const dimensions = dimensionsByModelId[this.embedder.modelId] || defaultDimensions;
     const isDefault = dimensions === defaultDimensions;
     const indexName = isDefault ? 'memory_messages' : `memory_messages_${dimensions}`;
 
     await this.vector.createIndex(indexName, dimensions);
     return { indexName };
-  }
-
-  protected getEmbedder() {
-    if (!this.embedder) {
-      throw new Error(`Cannot use vector features without setting new Memory({ embedder: embedderInstance })
-
-For example:
-
-new Memory({
-  vector,
-  embedder: openai("text-embedding-3-small") // example
-});
-`);
-    }
-
-    return this.embedder;
   }
 
   protected getMergedThreadConfig(config?: MemoryConfig): MemoryConfig {

--- a/packages/core/src/vector/fastembed.ts
+++ b/packages/core/src/vector/fastembed.ts
@@ -18,6 +18,13 @@ function getModelCachePath() {
 // Shared function to generate embeddings using fastembed
 async function generateEmbeddings(values: string[], modelType: 'BGESmallENV15' | 'BGEBaseENV15') {
   try {
+    // NOTE: This dynamic import janky dance is due to some runtimes not having support for the native bindings used by onnxruntime-node
+    // I made a fork of fastembed-js and published it as https://www.npmjs.com/package/fastembed-web
+    // The fork uses onnxruntime-web instead of the node package. Theoretically this fork has greater compatibility while also being less performant.
+    // If we need greater compat for this embedder we can do a dynamic import for fastembed-js and if the import fails we can do a second dynamic import for fastembed-web and try that
+    // I haven't done this yet because I got fastembed-js to work locally and in Mastra Cloud.
+    // If we need this to also work places like Netlify and Vercel and it's not working we will likely need to try using fastembed-web.
+    //
     // Dynamically import fastembed only when this function is called
     // this is to avoid importing fastembed in runtimes that don't support its native bindings
     const fastEmbedImportPath = 'fastembed?d=' + Date.now(); // +? date to prevent esbuild from seeing this as statically analyzable and bundling this as a regular import.

--- a/packages/core/src/vector/fastembed.ts
+++ b/packages/core/src/vector/fastembed.ts
@@ -75,4 +75,4 @@ const fastEmbedProvider = experimental_customProvider({
   },
 });
 
-export const localEmbedder = fastEmbedProvider.textEmbeddingModel;
+export const defaultEmbedder = fastEmbedProvider.textEmbeddingModel;

--- a/packages/core/src/vector/index.ts
+++ b/packages/core/src/vector/index.ts
@@ -1,6 +1,6 @@
 import { MastraBase } from '../base';
 
-export { localEmbedder } from './fastembed';
+export { defaultEmbedder } from './fastembed';
 
 export interface QueryResult {
   id: string;

--- a/packages/memory/integration-tests/.gitignore
+++ b/packages/memory/integration-tests/.gitignore
@@ -1,1 +1,2 @@
 memory.db
+*.db

--- a/packages/memory/integration-tests/src/with-libsql-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-libsql-storage.test.ts
@@ -1,5 +1,4 @@
-import { createOpenAI } from '@ai-sdk/openai';
-import { DefaultStorage, DefaultVectorDB } from '@mastra/core/storage';
+import { DefaultStorage } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 import dotenv from 'dotenv';
 import { describe } from 'vitest';
@@ -8,21 +7,14 @@ import { getResuableTests } from './reusable-tests';
 
 dotenv.config({ path: '.env.test' });
 
-const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
 describe('Memory with LibSQL Integration', () => {
   describe('with explicit storage', () => {
-    const vector = new DefaultVectorDB({
-      connectionUrl: 'file:test.db',
-    });
-
     const memory = new Memory({
       storage: new DefaultStorage({
         config: {
           url: 'file:test.db',
         },
       }),
-      vector,
       options: {
         lastMessages: 10,
         semanticRecall: {
@@ -30,19 +22,13 @@ describe('Memory with LibSQL Integration', () => {
           messageRange: 2,
         },
       },
-      embedder: openai.embedding('text-embedding-3-small'),
     });
 
     getResuableTests(memory);
   });
 
   describe('with default storage', () => {
-    const vector = new DefaultVectorDB({
-      connectionUrl: 'file:test.db',
-    });
-
     const memory = new Memory({
-      vector,
       options: {
         lastMessages: 10,
         semanticRecall: {
@@ -50,7 +36,6 @@ describe('Memory with LibSQL Integration', () => {
           messageRange: 2,
         },
       },
-      embedder: openai.embedding('text-embedding-3-small'),
     });
 
     getResuableTests(memory);

--- a/packages/memory/integration-tests/src/with-pg-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-pg-storage.test.ts
@@ -1,4 +1,3 @@
-import { createOpenAI } from '@ai-sdk/openai';
 import { Memory } from '@mastra/memory';
 import { PostgresStore, PgVector } from '@mastra/pg';
 import dotenv from 'dotenv';
@@ -26,8 +25,6 @@ const parseConnectionString = (url: string) => {
   };
 };
 
-const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
 describe('Memory with PostgresStore Integration', () => {
   const config = parseConnectionString(connectionString);
   const memory = new Memory({
@@ -40,7 +37,6 @@ describe('Memory with PostgresStore Integration', () => {
         messageRange: 2,
       },
     },
-    embedder: openai.embedding('text-embedding-3-small'),
   });
 
   getResuableTests(memory);

--- a/packages/memory/integration-tests/src/with-upstash-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-upstash-storage.test.ts
@@ -1,5 +1,3 @@
-import { createOpenAI } from '@ai-sdk/openai';
-import { DefaultVectorDB } from '@mastra/core/storage';
 import { Memory } from '@mastra/memory';
 import { UpstashStore } from '@mastra/upstash';
 import dotenv from 'dotenv';
@@ -14,19 +12,12 @@ if (!process.env.KV_REST_API_URL || !process.env.KV_REST_API_TOKEN) {
   throw new Error('Required Vercel KV environment variables are not set');
 }
 
-const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
 describe('Memory with UpstashStore Integration', () => {
-  const vector = new DefaultVectorDB({
-    connectionUrl: 'file:test.db',
-  });
-
   const memory = new Memory({
     storage: new UpstashStore({
       url: process.env.KV_REST_API_URL!,
       token: process.env.KV_REST_API_TOKEN!,
     }),
-    vector,
     options: {
       lastMessages: 10,
       semanticRecall: {
@@ -34,7 +25,6 @@ describe('Memory with UpstashStore Integration', () => {
         messageRange: 2,
       },
     },
-    embedder: openai.embedding('text-embedding-3-small'),
   });
 
   getResuableTests(memory);

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -39,17 +39,10 @@ const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
 describe('Working Memory Tests', () => {
   let memory: Memory;
   let thread: any;
-  let vector: DefaultVectorDB;
 
   beforeEach(async () => {
-    // Initialize vector storage
-    vector = new DefaultVectorDB({
-      connectionUrl: 'file:test.db',
-    });
-
     // Create memory instance with working memory enabled
     memory = new Memory({
-      vector,
       options: {
         workingMemory: {
           enabled: true,
@@ -66,7 +59,6 @@ describe('Working Memory Tests', () => {
           messageRange: 2,
         },
       },
-      embedder: openai.embedding('text-embedding-3-small'),
     });
 
     // Reset message counter
@@ -249,7 +241,6 @@ describe('Working Memory Tests', () => {
           url: 'file:test.db',
         },
       }),
-      vector,
       options: {
         workingMemory: {
           enabled: false,
@@ -261,7 +252,6 @@ describe('Working Memory Tests', () => {
           messageRange: 2,
         },
       },
-      embedder: openai.embedding('text-embedding-3-small'),
     });
 
     const thread = await disabledMemory.saveThread({

--- a/packages/memory/integration-tests/vitest.config.ts
+++ b/packages/memory/integration-tests/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    testTimeout: 30000, // 30 seconds
+    testTimeout: 60000,
     hookTimeout: 30000,
     coverage: {
       provider: 'v8',

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -65,11 +65,9 @@ export class Memory extends MastraMemory {
           };
 
     if (selectBy?.vectorSearchString && this.vector) {
-      const embedder = this.getEmbedder();
-
       const { embedding } = await embed({
         value: selectBy.vectorSearchString,
-        model: embedder,
+        model: this.embedder,
       });
 
       const { indexName } = await this.createEmbeddingIndex();
@@ -205,12 +203,11 @@ export class Memory extends MastraMemory {
     this.mutateMessagesToHideWorkingMemory(messages);
 
     if (this.vector) {
-      const embedder = this.getEmbedder();
       const { indexName } = await this.createEmbeddingIndex();
 
       for (const message of messages) {
         if (typeof message.content !== `string`) continue;
-        const { embedding } = await embed({ value: message.content, model: embedder, maxRetries: 3 });
+        const { embedding } = await embed({ value: message.content, model: this.embedder, maxRetries: 3 });
         await this.vector.upsert(
           indexName,
           [embedding],

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -18,7 +18,7 @@ export class Memory extends MastraMemory {
     config: SharedMemoryConfig & {
       /* @deprecated use embedder instead */
       embeddings?: any;
-    },
+    } = {},
   ) {
     const embedderExample = `
 Example: 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -20,34 +20,6 @@ export class Memory extends MastraMemory {
       embeddings?: any;
     } = {},
   ) {
-    const embedderExample = `
-Example: 
-
-  import { openai } from '@ai-sdk/openai';
-
-  new Memory({ 
-    embedder: openai.embedding(\`text-embedding-3-small\`)
-  })
-
-`;
-
-    // Check for deprecated embeddings object
-    if (config.embeddings) {
-      throw new Error(
-        `The \`embeddings\` option is deprecated. Please use \`embedder\` instead.
-${embedderExample}
-`,
-      );
-    }
-
-    if (config.vector && !config.embedder) {
-      throw new Error(
-        `The \`embedder\` option is required when a vector DB is attached to new Memory({ vector })
-
-${embedderExample}`,
-      );
-    }
-
     super({ name: 'Memory', ...config });
 
     const mergedConfig = this.getMergedThreadConfig({


### PR DESCRIPTION
After [some investigation](https://github.com/mastra-ai/mastra/pull/1845) I found that using [fastembed](https://github.com/Anush008/fastembed-js/tree/main) as the default embedder works great locally and in cloud.
Now that we have a default embedder (that requires no API key) that means we can also have a default vector db (libsql of course).

With this PR you can now init memory on an agent without any configuration and you'll get default storage/vectordb/embeddings:
```ts
const agent = new Agent({
  memory: new Memory(),
  [...]
})
```

In this PR I:
- Set the defaults in the `Memory` class, and removed errors related to missing vector/embedder since there will always be one now
- Updated tests to use new defaults instead of openai
- Updated docs/examples/reference

Follow ups:
- pre-download fastembed models in cloud so that they're not downloaded during the first embed call
- possibly use `fastembed-web` as a fallback - for now I will leave this as-is but I left [a note in the code](https://github.com/mastra-ai/mastra/pull/1868/files#diff-97c639e45887d3b518039dbfa61e4fdf40959c6fc382a6209ba72174d1dbcbbfR21-R27) in case we need to do this later