### PR TITLE
move integrations back to regular dts for speed

### DIFF
--- a/integrations/composio/package.json
+++ b/integrations/composio/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "tsup src/index.ts --format esm --experimental-dts --clean --treeshake",
+    "build": "tsup src/index.ts --format esm --dts --clean --treeshake",
     "build:watch": "pnpm build --watch",
     "lint": "dts lint",
     "size": "size-limit",

--- a/integrations/firecrawl/package.json
+++ b/integrations/firecrawl/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "tsup src/index.ts --format esm --experimental-dts --clean --treeshake",
+    "build": "tsup src/index.ts --format esm --dts --clean --treeshake",
     "build:watch": "pnpm build --watch",
     "lint": "dts lint",
     "size": "size-limit",

--- a/integrations/github/package.json
+++ b/integrations/github/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "cross-env NODE_OPTIONS='--max-old-space-size=8192' tsup src/index.ts --format esm --experimental-dts --clean --treeshake",
+    "build": "cross-env NODE_OPTIONS='--max-old-space-size=8192' tsup src/index.ts --format esm --dts --clean --treeshake",
     "build:watch": "pnpm build --watch",
     "lint": "dts lint",
     "size": "size-limit",

--- a/integrations/ragie/package.json
+++ b/integrations/ragie/package.json
@@ -18,8 +18,8 @@
   },
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "tsup src/index.ts --format esm --experimental-dts --clean --treeshake",
-    "build:dev": "tsup src/index.ts --format esm --experimental-dts --clean --treeshake --watch",
+    "build": "tsup src/index.ts --format esm --dts --clean --treeshake",
+    "build:dev": "tsup src/index.ts --format esm --dts --clean --treeshake --watch",
     "lint": "dts lint",
     "size": "size-limit",
     "start": "dts watch",

--- a/integrations/stabilityai/package.json
+++ b/integrations/stabilityai/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "tsup src/index.ts --format esm --experimental-dts --clean --treeshake",
+    "build": "tsup src/index.ts --format esm --dts --clean --treeshake",
     "build:watch": "pnpm build --watch",
     "lint": "dts lint",
     "size": "size-limit",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "ci:publish": "pnpm publish -r",
-    "build": "pnpm build:packages && pnpm build:combined-stores && pnpm build:stores && pnpm build:integrations && pnpm build:deployers && pnpm build:vector-stores && pnpm build:speech",
+    "build": "pnpm build:packages && pnpm build:combined-stores && pnpm build:stores && pnpm build:deployers && pnpm build:vector-stores && pnpm build:speech && pnpm build:integrations",
     "build:integrations": "pnpm --filter \"./integrations/*\" build",
     "build:packages": "pnpm --filter \"./packages/*\" build",
     "build:vector-stores": "pnpm --filter \"./vector-stores/*\" build",


### PR DESCRIPTION
Dts experimental does a typecheck on these packages and for github it takes 10min so reverting back to regular dts