### PR TITLE
fix(core): ensure telemetry proxy doesn't turn sync methods into async methods

### DIFF
--- a/.changeset/brave-dots-smash.md
+++ b/.changeset/brave-dots-smash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Prevent telemetry proxy from converting sync methods to async


### PR DESCRIPTION
Before this fix telemetry was making all methods return a promise. This change should retain the original behaviour for async methods but also handle any synchronous methods