### PR TITLE
fix(memory): prevent incomplete tool errors

### DIFF
--- a/.changeset/thick-bobcats-double.md
+++ b/.changeset/thick-bobcats-double.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fixed incomplete tool call errors when including memory message history in context

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -586,7 +586,7 @@ export class Agent<
     let coreMessages: CoreMessage[] = [];
     let threadIdToUse = threadId;
 
-    this.log(LogLevel.INFO, `Saving user messages in memory for agent ${this.name}`, { runId });
+    this.log(LogLevel.DEBUG, `Saving user messages in memory for agent ${this.name}`, { runId });
     const saveMessageResponse = await this.saveMemory({
       threadId,
       resourceId,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -264,7 +264,7 @@ export class Agent<
              For the end date, return the date 1 day after the end of the time period.
              Today's date is ${new Date().toISOString()} and the time is ${new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })} ${memorySystemMessage ? `\n\n${memorySystemMessage}` : ''}`,
             } as any,
-            ...memoryMessages,
+            ...this.sanitizeResponseMessages(memoryMessages),
             ...newMessages,
           ],
         };
@@ -375,10 +375,9 @@ export class Agent<
     }
   }
 
-  sanitizeResponseMessages(
-    messages: Array<CoreToolMessage | CoreAssistantMessage>,
-  ): Array<CoreToolMessage | CoreAssistantMessage> {
+  sanitizeResponseMessages(messages: Array<CoreMessage>): Array<CoreMessage> {
     let toolResultIds: Array<string> = [];
+    let toolCallIds: Array<string> = [];
 
     for (const message of messages) {
       if (message.role === 'tool') {
@@ -388,20 +387,34 @@ export class Agent<
           }
         }
       }
+      if (message.role === 'assistant' || message.role === 'user') {
+        for (const content of message.content) {
+          if (typeof content !== `string`) {
+            if (content.type === `tool-call`) {
+              toolCallIds.push(content.toolCallId);
+            }
+          }
+        }
+      }
     }
 
     const messagesBySanitizedContent = messages.map(message => {
-      if (message.role !== 'assistant') return message;
+      if (message.role !== 'assistant' && message.role !== `tool` && message.role !== `user`) return message;
 
       if (typeof message.content === 'string') return message;
 
-      const sanitizedContent = message.content.filter(content =>
-        content.type === 'tool-call'
-          ? toolResultIds.includes(content.toolCallId)
-          : content.type === 'text'
-            ? content.text.length > 0
-            : true,
-      );
+      const sanitizedContent = message.content.filter(content => {
+        if (content.type === `tool-call`) {
+          return toolResultIds.includes(content.toolCallId);
+        }
+        if (content.type === `text`) {
+          return content.text.trim() !== ``;
+        }
+        if (content.type === `tool-result`) {
+          return toolCallIds.includes(content.toolCallId);
+        }
+        return true;
+      });
 
       return {
         ...message,
@@ -409,7 +422,25 @@ export class Agent<
       };
     });
 
-    return messagesBySanitizedContent.filter(message => message.content.length > 0);
+    return messagesBySanitizedContent.filter(message => {
+      if (typeof message.content === `string`) {
+        return message.content !== '';
+      }
+
+      if (Array.isArray(message.content)) {
+        return (
+          message.content.length &&
+          message.content.every(c => {
+            if (c.type === `text`) {
+              return c.text && c.text !== '';
+            }
+            return true;
+          })
+        );
+      }
+
+      return true;
+    }) as Array<CoreMessage>;
   }
 
   convertTools({

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -422,7 +422,25 @@ export class Agent<
       };
     });
 
-    return messagesBySanitizedContent.filter(message => message.content.length > 0) as CoreMessage[];
+    return messagesBySanitizedContent.filter(message => {
+      if (typeof message.content === `string`) {
+        return message.content !== '';
+      }
+
+      if (Array.isArray(message.content)) {
+        return (
+          message.content.length &&
+          message.content.every(c => {
+            if (c.type === `text`) {
+              return c.text && c.text !== '';
+            }
+            return true;
+          })
+        );
+      }
+
+      return true;
+    }) as Array<CoreMessage>;
   }
 
   convertTools({

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -422,25 +422,7 @@ export class Agent<
       };
     });
 
-    return messagesBySanitizedContent.filter(message => {
-      if (typeof message.content === `string`) {
-        return message.content !== '';
-      }
-
-      if (Array.isArray(message.content)) {
-        return (
-          message.content.length &&
-          message.content.every(c => {
-            if (c.type === `text`) {
-              return c.text && c.text !== '';
-            }
-            return true;
-          })
-        );
-      }
-
-      return true;
-    }) as Array<CoreMessage>;
+    return messagesBySanitizedContent.filter(message => message.content.length > 0) as CoreMessage[];
   }
 
   convertTools({

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -40,7 +40,7 @@ export class Memory extends MastraMemory {
           vector?: number[];
         }[] = null;
 
-    this.logger.info(`Memory query() with:`, {
+    this.logger.debug(`Memory query() with:`, {
       threadId,
       selectBy,
       threadConfig,
@@ -130,7 +130,7 @@ export class Memory extends MastraMemory {
       threadConfig: config,
     });
 
-    this.logger.info(`Remembered message history includes ${messages.messages.length} messages.`);
+    this.logger.debug(`Remembered message history includes ${messages.messages.length} messages.`);
     return messages;
   }
 


### PR DESCRIPTION
As the rolling message window updates, it can get into a state where there's a missing tool call, but a tool result is included. This causes LLM APIs to reject the request.
I used the existing `agent.sanitizeResponseMessages` to fix this, updated that method to account for a couple more cases, and added a test