### PR TITLE
Make sure workflows are registered in Mastra

### DIFF
--- a/.changeset/good-elephants-admire.md
+++ b/.changeset/good-elephants-admire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add error when workflow is not registered in Mastra

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -238,6 +238,10 @@ export class Workflow<
     const runId = crypto.randomUUID();
     this.#runId = runId;
 
+    if (!this.#mastra) {
+      throw new Error('Mastra not initialized, please register the workflow with a Mastra instance.');
+    }
+
     return {
       runId,
       start: async ({ triggerData } = {}) => this.execute({ triggerData }),


### PR DESCRIPTION
Just like agents, workflows should be registered to get all necessary defaults