### PR TITLE
fix(@mastra/composio): tool id length + app filtering

### DIFF
--- a/.changeset/thin-impalas-battle.md
+++ b/.changeset/thin-impalas-battle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/composio': patch
+---
+
+Fixed composio tool ID length errors. Fixed composio app filtering

--- a/integrations/composio/src/index.ts
+++ b/integrations/composio/src/index.ts
@@ -74,7 +74,8 @@ export class ComposioIntegration extends Integration<ComposioToolsetParams> {
       ...(useCase && { useCase: useCase }),
       ...(actions && { actions: actions?.join(',') }),
       ...(usecaseLimit && { usecaseLimit: usecaseLimit }),
-      filterByAvailableApps: true,
+      // only filter by available if apps: [] is not included. Composio does not allow both args at the same time
+      filterByAvailableApps: !apps?.length,
     });
 
     const tools: Record<string, ToolAction<any, any, any, any>> = {};

--- a/integrations/composio/src/index.ts
+++ b/integrations/composio/src/index.ts
@@ -43,15 +43,19 @@ export class ComposioIntegration extends Integration<ComposioToolsetParams> {
 
   private generateTool(schema: Record<string, any>) {
     const parameters = jsonSchemaToModel(schema.parameters);
+
+    // use name as ID - if we use description as id, long descriptions will cause API errors - the id can't be longer than 63 chars
+    const id = schema.name;
+
     return createTool({
-      id: schema.description,
+      id,
       description: schema.description,
       inputSchema: parameters,
       execute: async ({ context }) => {
         try {
           const d = await this.client
             .getEntity(this.config.entityId!)
-            .execute(schema.name, context || {}, undefined, this.config.connectedAccountId!);
+            .execute(id, context || {}, undefined, this.config.connectedAccountId!);
           return d;
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
Fixes:
1. We were using the tool description as the ID - when the description was over 63 chars this would cause llm providers to throw errors.
2. App filters didn't work because `filterByAvailableApps` was hardcoded to true and that option can't be true when `apps` option is also used