### PR TITLE
fix(cli): dev restart errors

### DIFF
--- a/.changeset/thick-pens-fold.md
+++ b/.changeset/thick-pens-fold.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed "instrumentation.mjs" not found, and port 4111 in use errors when rebundling in "mastra dev"

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -84,8 +84,7 @@ async function rebundleAndRestart(dotMastraPath: string, port: number, bundler: 
     // If current server process is running, stop it
     if (currentServerProcess) {
       logger.debug('Stopping current server...');
-      currentServerProcess.kill();
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      currentServerProcess.kill('SIGKILL');
     }
 
     const env = await bundler.loadEnvVars();

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -89,7 +89,8 @@ async function rebundleAndRestart(dotMastraPath: string, port: number, bundler: 
     }
 
     const env = await bundler.loadEnvVars();
-    await startServer(dotMastraPath, port, env);
+
+    await startServer(join(dotMastraPath, 'output'), port, env);
   } finally {
     isRestarting = false;
   }


### PR DESCRIPTION
On latest when I save code in a project I see this:

<img width="723" alt="Screenshot 2025-02-18 at 4 39 31 PM" src="https://github.com/user-attachments/assets/d0523127-7ee1-404f-a414-6acacf722551" />

Turns out we were restarting in `.mastra` instead of the new `.mastra/output`.

After that was fixed I see:
<img width="674" alt="Screenshot 2025-02-18 at 4 39 01 PM" src="https://github.com/user-attachments/assets/0c75de37-eec9-47aa-9e98-d25d63fd22a3" />

I tried to add some graceful process kill handling but found the only way to actually kill it was force killing with `SIGKILL` or `SIGINT`. Killing with one of those also seems to allow us to immediately restart the server intead of waiting 1s
