### PR TITLE
feat(@mastra/mcp): add support for SSE MCP server connections

### DIFF
--- a/.changeset/famous-glasses-repeat.md
+++ b/.changeset/famous-glasses-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+Added support for SSE MCP servers in the Mastra MCP client

--- a/docs/src/pages/docs/reference/tools/client.mdx
+++ b/docs/src/pages/docs/reference/tools/client.mdx
@@ -19,7 +19,7 @@ constructor({
     capabilities = {},
 }: {
     name: string;
-    server: StdioServerParameters;
+    server: StdioServerParameters | SSEClientParameters;
     capabilities?: ClientCapabilities;
     version?: string;
 })
@@ -43,8 +43,8 @@ constructor({
     },
     {
       name: 'server',
-      type: 'StdioServerParameters',
-      description: 'Configuration parameters for the stdio server connection.',
+      type: 'StdioServerParameters | SSEClientParameters',
+      description: 'Configuration parameters for either a stdio server connection or an SSE server connection.',
     },
     {
       name: 'capabilities',
@@ -95,6 +95,8 @@ Returns an object mapping tool names to their corresponding Mastra tool implemen
 ## Examples
 
 ### Using with Mastra Agent
+
+#### Example with Stdio Server
 
 ```typescript
 import { Agent } from "@mastra/core/agent";
@@ -148,6 +150,26 @@ try {
   // Always disconnect when done
   await fetchClient.disconnect();
 }
+```
+
+#### Example with SSE Server
+
+```typescript
+// Initialize the MCP client using an SSE server
+const sseClient = new MastraMCPClient({
+  name: "sse-client",
+  server: {
+    url: new URL("https://your-mcp-server.com/sse"),
+    // Optional fetch request configuration
+    requestInit: {
+      headers: {
+        "Authorization": "Bearer your-token"
+      }
+    }
+  },
+});
+
+// The rest of the usage is identical to the stdio example
 ```
 
 ## Related Information

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -17,16 +17,27 @@ The `@mastra/mcp` package provides a client implementation for the Model Context
 ```typescript
 import { MastraMCPClient } from '@mastra/mcp';
 
-// Create a client
-const client = new MastraMCPClient({
-  name: 'my-mcp-client',
+// Create a client with stdio server
+const stdioClient = new MastraMCPClient({
+  name: 'my-stdio-client',
   version: '1.0.0', // optional
   server: {
-    // StdioServerParameters
     command: 'your-mcp-server-command',
     args: ['--your', 'args'],
   },
   capabilities: {}, // optional ClientCapabilities
+});
+
+// Or create a client with SSE server
+const sseClient = new MastraMCPClient({
+  name: 'my-sse-client',
+  version: '1.0.0',
+  server: {
+    url: new URL('https://your-mcp-server.com/sse'),
+    requestInit: {
+      headers: { 'Authorization': 'Bearer your-token' }
+    }
+  }
 });
 
 // Connect to the MCP server
@@ -47,9 +58,16 @@ await client.disconnect();
 ### Required Parameters
 
 - `name`: Name of the MCP client instance
-- `server`: StdioServerParameters object containing:
+- `server`: Either a StdioServerParameters or SSEClientParameters object:
+  
+  #### StdioServerParameters
   - `command`: Command to start the MCP server
   - `args`: Array of command arguments
+  
+  #### SSEClientParameters
+  - `url`: URL instance pointing to the SSE server
+  - `requestInit`: Optional fetch request configuration
+  - `eventSourceInit`: Optional EventSource configuration
 
 ### Optional Parameters
 
@@ -61,7 +79,9 @@ await client.disconnect();
 - Standard MCP client implementation
 - Automatic tool conversion to Mastra format
 - Resource discovery and management
-- Stdio-based transport layer
+- Multiple transport layers:
+  - Stdio-based for local servers
+  - SSE-based for remote servers
 - Automatic error handling and logging
 - Tool execution with context
 


### PR DESCRIPTION
This adds support for SSE MCP servers. I updated the reference and readme as well but ex:
```ts
const sseClient = new MastraMCPClient({
  name: 'my-sse-client',
  version: '1.0.0',
  server: {
    url: new URL('https://your-mcp-server.com/sse'),
    requestInit: {
      headers: { 'Authorization': 'Bearer your-token' }
    }
  }
});

```