### PR TITLE
fix(playground): broken link to docs

### DIFF
--- a/packages/cli/src/playground/src/components/ui/sidebar.tsx
+++ b/packages/cli/src/playground/src/components/ui/sidebar.tsx
@@ -81,7 +81,7 @@ export const Sidebar = () => {
           </a>
           <div className="w-1 h-1 bg-gray-300/60 rounded-full" />
           <a
-            href="https://mastra.ai/docs/guide"
+            href="https://mastra.ai/docs"
             target="_blank"
             rel="noopener"
             className="text-sm text-gray-300/60 hover:text-gray-100"


### PR DESCRIPTION
- Fixing a broken link to Mastra.ai docs in the Sidebar of the Playground app.