### PR TITLE
Update curl to Test Workflow Example

### DIFF
--- a/docs/src/pages/docs/workflows/00-overview.mdx
+++ b/docs/src/pages/docs/workflows/00-overview.mdx
@@ -111,9 +111,7 @@ Or use the API (requires running `mastra dev`):
 curl --location 'http://localhost:4111/api/workflows/myWorkflow/execute' \
      --header 'Content-Type: application/json' \
      --data '{
-       "triggerData": {
-         "inputValue": 45
-       }
+       "inputValue": 45
      }'
 ```
 


### PR DESCRIPTION
While following this [workflow example ](https://mastra.ai/docs/workflows/00-overview)
The user will get the wrong output for **"doubledValue"** and **"incrementedValue"**.

`{
   "triggerData":{
      "triggerData":{
         "inputValue":45
      }
   },
   "results":{
      "stepOne":{
         "status":"success",
         "output":{
            "doubledValue":null
         }
      },
      "stepTwo":{
         "status":"success",
         "output":{
            "incrementedValue":null
         }
      }
   },
   "runId":"edfe93b1-ab09-418a-83ae-bf2cef96ccd2"
}`

This fix the input passed via the API call.