### PR TITLE
fix(@mastra/core): only allow memory on Agents, not on Mastra

### DIFF
--- a/.changeset/sweet-spoons-wink.md
+++ b/.changeset/sweet-spoons-wink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Memory can no longer be added to new Mastra(), only to new Agent() - this is for simplicity as each agent will typically need its own memory settings

--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -292,13 +292,17 @@ const memory = new Memory({
 Once configured, the memory system is automatically used by agents. Here's how to use it:
 
 ```typescript copy showLineNumbers
-// Initialize Mastra with memory
+// Initialize Agent with memory
+const myAgent = new Agent({
+  memory,
+  // other agent options
+});
+// Add agent to mastra
 const mastra = new Mastra({
   agents: { myAgent },
-  memory,
 });
 
-// Memory is automatically used in agent interactions
+// Memory is automatically used in agent interactions when resourceId and threadId are added
 const response = await myAgent.generate(
   "What were we discussing earlier about performance?",
   {

--- a/examples/crypto-chatbot/mastra/agents/index.ts
+++ b/examples/crypto-chatbot/mastra/agents/index.ts
@@ -1,4 +1,6 @@
 import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
+import { PostgresStore } from '@mastra/pg';
 import { openai } from '@ai-sdk/openai';
 import { systemPrompt } from '@/ai/prompts';
 import {
@@ -6,6 +8,14 @@ import {
   getHistoricalCryptoPrices,
   searchCryptoCoins,
 } from '../tools';
+
+const connectionString = process.env.POSTGRES_URL!;
+
+const memory = new Memory({
+  storage: new PostgresStore({
+    connectionString,
+  }),
+});
 
 export const createCryptoAgent = (modelProvider: any, modelName: any) => {
   let model;
@@ -21,6 +31,7 @@ export const createCryptoAgent = (modelProvider: any, modelName: any) => {
     name: 'cryptoAgent',
     instructions: systemPrompt,
     model,
+    memory,
     tools: {
       searchCryptoCoins,
       getCryptoPrice,

--- a/examples/crypto-chatbot/mastra/index.ts
+++ b/examples/crypto-chatbot/mastra/index.ts
@@ -1,16 +1,6 @@
 import { Mastra } from '@mastra/core';
 import { createLogger } from '@mastra/core/logger';
-import { Memory } from '@mastra/memory';
-import { PostgresStore } from '@mastra/pg';
 import { createCryptoAgent } from './agents';
-
-const connectionString = process.env.POSTGRES_URL!;
-
-const memory = new Memory({
-  storage: new PostgresStore({
-    connectionString,
-  }),
-});
 
 export const createMastra = ({
   modelProvider,
@@ -20,7 +10,6 @@ export const createMastra = ({
   modelName: string;
 }) =>
   new Mastra({
-    memory,
     agents: { cryptoAgent: createCryptoAgent(modelProvider, modelName) },
     logger: createLogger({
       name: 'CONSOLE',

--- a/examples/dane/src/mastra/agents/index.ts
+++ b/examples/dane/src/mastra/agents/index.ts
@@ -7,6 +7,7 @@ import { fsTool } from '../tools/fs.js';
 import { imageTool } from '../tools/image.js';
 import { readPDF } from '../tools/pdf.js';
 
+import { memory } from './memory.js';
 import { getBaseModelConfig } from './model.js';
 
 export const daneCommitMessage = new Agent({
@@ -19,6 +20,7 @@ export const daneCommitMessage = new Agent({
     FIGURE OUT THE BEST TOP LEVEL SEMANTIC MATCH TO USE AS THE SCOPE.
     `,
   model: getBaseModelConfig(),
+  memory,
 });
 
 export const daneIssueLabeler = new Agent({
@@ -28,6 +30,7 @@ export const daneIssueLabeler = new Agent({
     You help engineers label their issues.
     `,
   model: getBaseModelConfig(),
+  memory,
 });
 
 export const daneLinkChecker = new Agent({
@@ -43,6 +46,7 @@ export const daneLinkChecker = new Agent({
     - Link to relevant documentation
     `,
   model: getBaseModelConfig(),
+  memory,
 });
 
 export const daneChangeLog = new Agent({
@@ -59,6 +63,7 @@ export const daneChangeLog = new Agent({
     - Use consistent formatting for code references
     `,
   model: getBaseModelConfig(),
+  memory,
 });
 
 export const dane = new Agent({
@@ -100,6 +105,7 @@ export const dane = new Agent({
     * Tell the user what you are doing.
     `,
   model: getBaseModelConfig(),
+  memory,
   tools: {
     fsTool,
     execaTool,

--- a/examples/dane/src/mastra/agents/memory.ts
+++ b/examples/dane/src/mastra/agents/memory.ts
@@ -1,0 +1,11 @@
+import { Memory } from '@mastra/memory';
+import { UpstashStore } from '@mastra/upstash';
+
+export const memory = new Memory({
+  storage: new UpstashStore({
+    url: 'http://localhost:8079',
+    token: `example_token`,
+    // TODO: do we need to implement this in Memory?
+    // maxTokens: 39000,
+  }),
+});

--- a/examples/dane/src/mastra/agents/new-contributor.ts
+++ b/examples/dane/src/mastra/agents/new-contributor.ts
@@ -1,5 +1,6 @@
 import { Agent } from '@mastra/core/agent';
 
+import { memory } from './memory.js';
 import { getBaseModelConfig } from './model.js';
 
 export const daneNewContributor = new Agent({
@@ -11,4 +12,5 @@ export const daneNewContributor = new Agent({
     `,
   model: getBaseModelConfig(),
   tools: {},
+  memory,
 });

--- a/examples/dane/src/mastra/agents/package-publisher.ts
+++ b/examples/dane/src/mastra/agents/package-publisher.ts
@@ -2,6 +2,7 @@ import { Agent } from '@mastra/core/agent';
 
 import { pnpmChangesetStatus, pnpmBuild, pnpmChangesetPublish, activeDistTag } from '../tools/pnpm.js';
 
+import { memory } from './memory.js';
 import { getBaseModelConfig } from './model.js';
 
 const packages_llm_text = `
@@ -186,6 +187,7 @@ export const danePackagePublisher = new Agent({
       - Validate package.json configurations before publishing
       `,
   model: getBaseModelConfig(),
+  memory,
   tools: {
     pnpmChangesetStatus,
     pnpmBuild,

--- a/examples/dane/src/mastra/index.ts
+++ b/examples/dane/src/mastra/index.ts
@@ -1,7 +1,5 @@
 import { Mastra } from '@mastra/core';
 import { DefaultStorage } from '@mastra/core/storage';
-import { Memory } from '@mastra/memory';
-import { UpstashStore } from '@mastra/upstash';
 
 import { dane, daneChangeLog, daneCommitMessage, daneIssueLabeler, daneLinkChecker } from './agents/index.js';
 import { daneNewContributor } from './agents/new-contributor.js';
@@ -27,14 +25,6 @@ export const mastra = new Mastra({
     config: {
       url: ':memory:',
     },
-  }),
-  memory: new Memory({
-    storage: new UpstashStore({
-      url: 'http://localhost:8079',
-      token: `example_token`,
-      // TODO: do we need to implement this in Memory?
-      // maxTokens: 39000,
-    }),
   }),
   workflows: {
     message: messageWorkflow,

--- a/examples/memory-with-upstash/src/mastra/agents/index.ts
+++ b/examples/memory-with-upstash/src/mastra/agents/index.ts
@@ -1,8 +1,27 @@
-import { Agent } from '@mastra/core';
 import { openai } from '@ai-sdk/openai';
+import { Agent } from '@mastra/core';
+import { Memory } from '@mastra/memory';
+import { PgVector } from '@mastra/pg';
+import { UpstashStore } from '@mastra/upstash';
+
+const memory = new Memory({
+  storage: new UpstashStore({
+    url: 'http://localhost:8089',
+    token: 'test_token',
+  }),
+  vector: new PgVector(`postgresql://postgres:postgres@localhost:5433`),
+  options: {
+    lastMessages: 1,
+    semanticRecall: {
+      topK: 3,
+      messageRange: 2,
+    },
+  },
+});
 
 export const chefAgent = new Agent({
   name: 'chefAgent',
+  memory,
   instructions:
     'You are Michel, a practical and experienced home chef who helps people cook great meals with whatever ingredients they have available. Your first priority is understanding what ingredients and equipment the user has access to, then suggesting achievable recipes. You explain cooking steps clearly and offer substitutions when needed, maintaining a friendly and encouraging tone throughout.',
   model: openai('gpt-4o'),
@@ -10,6 +29,7 @@ export const chefAgent = new Agent({
 
 export const memoryAgent = new Agent({
   name: 'Memory Agent',
+  memory,
   instructions:
     "You are an AI agent with the ability to automatically recall memories from previous interactions. You may have conversations that last hours, days, months, or years. If you don't know it already you should ask for the users name and some info about them.",
   model: openai('gpt-4o'),

--- a/examples/memory-with-upstash/src/mastra/index.ts
+++ b/examples/memory-with-upstash/src/mastra/index.ts
@@ -1,26 +1,7 @@
 import { Mastra } from '@mastra/core';
-import { Memory } from '@mastra/memory';
-import { PgVector } from '@mastra/pg';
-import { UpstashStore } from '@mastra/upstash';
 
 import { chefAgent, memoryAgent } from './agents';
 
-const memory = new Memory({
-  storage: new UpstashStore({
-    url: 'http://localhost:8089',
-    token: 'test_token',
-  }),
-  vector: new PgVector(`postgresql://postgres:postgres@localhost:5433`),
-  options: {
-    lastMessages: 1,
-    semanticRecall: {
-      topK: 3,
-      messageRange: 2,
-    },
-  },
-});
-
 export const mastra = new Mastra({
   agents: { chefAgent, memoryAgent },
-  memory,
 });

--- a/examples/travel-app/src/mastra/agents/index.ts
+++ b/examples/travel-app/src/mastra/agents/index.ts
@@ -1,4 +1,5 @@
 import { anthropic } from "@ai-sdk/anthropic";
+import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 
 import {
@@ -8,11 +9,17 @@ import {
   searchFlights,
   searchHotels,
 } from "../tools";
+import { storage } from "./storage";
+
+const memory = new Memory({
+  storage,
+});
 
 export const travelAgent = new Agent({
   name: "travelAgent",
   instructions: `You are an expert travel agent responsible for finding a flight, hotel, and three attractions for a user. You will be given a set of user preferences along with some tools and you will need to find the best options for them. Be as concise as possible with your response.`,
   model: anthropic("claude-3-5-sonnet-20240620"),
+  memory,
   tools: {
     searchFlights,
     searchHotels,
@@ -27,4 +34,5 @@ export const travelAnalyzer = new Agent({
   instructions:
     "You are an expert travel agent responsible for finding a flight, hotel, and three attractions for a user. You will be given a set of user preferences along with some data to find the best options for them.",
   model: anthropic("claude-3-5-sonnet-20240620"),
+  memory,
 });

--- a/examples/travel-app/src/mastra/agents/storage.ts
+++ b/examples/travel-app/src/mastra/agents/storage.ts
@@ -1,0 +1,7 @@
+import { PostgresStore } from "@mastra/pg";
+
+const url = "postgresql://postgres:postgres@localhost:5433/mastra";
+
+export const storage = new PostgresStore({
+  connectionString: url,
+});

--- a/examples/travel-app/src/mastra/index.ts
+++ b/examples/travel-app/src/mastra/index.ts
@@ -1,22 +1,12 @@
 import { Mastra } from "@mastra/core";
 import { createLogger } from "@mastra/core/logger";
-import { Memory } from "@mastra/memory";
-import { PostgresStore } from "@mastra/pg";
 
 import { travelAgent, travelAnalyzer } from "./agents";
 import { syncCsvDataWorkflow } from "./workflows/attractions";
-
-const url = "postgresql://postgres:postgres@localhost:5433/mastra";
-
-const storage = new PostgresStore({
-  connectionString: url,
-});
+import { storage } from "./agents/storage";
 
 export const mastra = new Mastra({
   workflows: { syncCsvDataWorkflow },
-  memory: new Memory({
-    storage,
-  }),
   storage,
   agents: { travelAgent, travelAnalyzer },
   logger: createLogger({

--- a/examples/workflow-with-memory/src/mastra/agents/index.ts
+++ b/examples/workflow-with-memory/src/mastra/agents/index.ts
@@ -1,8 +1,16 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
+import { PostgresStore } from '@mastra/pg';
+
+const connectionString = process.env.POSTGRES_URL!;
+const memory = new Memory({
+  storage: new PostgresStore({ connectionString }),
+});
 
 export const catOne = new Agent({
   name: 'cat-one',
+  memory,
   instructions:
     'You are a feline expert with comprehensive knowledge of all cat species, from domestic breeds to wild big cats. As a lifelong cat specialist, you understand their behavior, biology, social structures, and evolutionary history in great depth.',
   model: openai('gpt-4o'),

--- a/examples/workflow-with-memory/src/mastra/index.ts
+++ b/examples/workflow-with-memory/src/mastra/index.ts
@@ -1,18 +1,10 @@
 import { Mastra } from '@mastra/core';
 import { createLogger } from '@mastra/core/logger';
-import { Memory } from '@mastra/memory';
-import { PostgresStore } from '@mastra/pg';
 
 import { catOne } from './agents/index';
 import { sequentialWorkflow, parallelWorkflow, branchedWorkflow, cyclicalWorkflow } from './workflows';
 
-const connectionString = process.env.POSTGRES_URL!;
-const memory = new Memory({
-  storage: new PostgresStore({ connectionString }),
-});
-
 export const mastra = new Mastra({
-  memory: memory,
   agents: { catOne },
   logger: createLogger({
     name: 'Mastra',

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -18,7 +18,6 @@ export interface Config<
   TTTS extends Record<string, MastraTTS> = Record<string, MastraTTS>,
   TLogger extends Logger = Logger,
 > {
-  memory?: MastraMemory;
   agents?: TAgents;
   storage?: MastraStorage;
   vectors?: TVectors;
@@ -27,6 +26,9 @@ export interface Config<
   tts?: TTTS;
   telemetry?: OtelConfig;
   deployer?: MastraDeployer;
+
+  // @deprecated add memory to your Agent directly instead
+  memory?: MastraMemory;
 }
 
 @InstrumentClass({
@@ -145,14 +147,18 @@ export class Mastra<
       this.vectors = config.vectors;
     }
 
-    if (config?.memory) {
-      this.memory = config.memory;
-      if (this.telemetry) {
-        this.memory = this.telemetry.traceClass(config.memory, {
-          excludeMethods: ['__setTelemetry', '__getTelemetry'],
-        });
-        this.memory.__setTelemetry(this.telemetry);
-      }
+    if (config && `memory` in config) {
+      throw new Error(`
+  Memory should be added to Agents, not to Mastra.
+
+Instead of:
+  new Mastra({ memory: new Memory() })
+
+do:
+  new Agent({ memory: new Memory() })
+
+
+`);
     }
 
     if (config?.tts) {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -147,8 +147,18 @@ export class Mastra<
       this.vectors = config.vectors;
     }
 
+    if (config?.memory) {
+      this.memory = config.memory;
+      if (this.telemetry) {
+        this.memory = this.telemetry.traceClass(config.memory, {
+          excludeMethods: ['__setTelemetry', '__getTelemetry'],
+        });
+        this.memory.__setTelemetry(this.telemetry);
+      }
+    }
+
     if (config && `memory` in config) {
-      throw new Error(`
+      this.logger.warn(`
   Memory should be added to Agents, not to Mastra.
 
 Instead of:
@@ -157,7 +167,7 @@ Instead of:
 do:
   new Agent({ memory: new Memory() })
 
-
+This is a warning for now, but will throw an error in the future
 `);
     }
 


### PR DESCRIPTION
This is to simplify the API - in most cases each agent will need its own memory settings.
For now I deprecated the TS types and threw an error explaining what to do.