### PR TITLE
fix(create, init): share getPackageManager() between create and init

### DIFF
--- a/.changeset/loose-loops-wear.md
+++ b/.changeset/loose-loops-wear.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed a bug when detecting package manager during mastra init where npm would run after pnpm already installed, resulting in errors

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -6,6 +6,7 @@ import color from 'picocolors';
 import fs from 'fs/promises';
 
 import { DepsService } from '../../services/service.deps.js';
+import { getPackageManager } from '../utils.js';
 
 const exec = util.promisify(child_process.exec);
 
@@ -33,17 +34,6 @@ const execWithTimeout = async (command: string, timeoutMs = 180000) => {
     throw error;
   }
 };
-
-function getPackageManager(): string {
-  const userAgent = process.env.npm_config_user_agent || `npm`;
-  if (userAgent.includes(`pnpm/`)) {
-    return `pnpm`;
-  } else if (userAgent.includes(`yarn/`)) {
-    return `yarn`;
-  }
-
-  return `npm`;
-}
 
 export const createMastraProject = async () => {
   p.intro(color.inverse('Mastra Create'));

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -3,6 +3,8 @@ import child_process from 'node:child_process';
 import util from 'node:util';
 import color from 'picocolors';
 
+import { getPackageManager } from '../utils';
+
 import {
   createComponentsDir,
   createMastraDir,
@@ -65,7 +67,7 @@ export const init = async ({
     const key = await getAPIKey(llmProvider || 'openai');
 
     const aiSdkPackage = getAISDKPackage(llmProvider);
-    await exec(`npm i ${aiSdkPackage}`);
+    await exec(`${getPackageManager()} i ${aiSdkPackage}`);
 
     s.stop();
     if (!llmApiKey) {

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -1,0 +1,10 @@
+export function getPackageManager(): string {
+  const userAgent = process.env.npm_config_user_agent || `npm`;
+  if (userAgent.includes(`pnpm/`)) {
+    return `pnpm`;
+  } else if (userAgent.includes(`yarn/`)) {
+    return `yarn`;
+  }
+
+  return `npm`;
+}

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -1,10 +1,28 @@
 export function getPackageManager(): string {
-  const userAgent = process.env.npm_config_user_agent || `npm`;
-  if (userAgent.includes(`pnpm/`)) {
-    return `pnpm`;
-  } else if (userAgent.includes(`yarn/`)) {
-    return `yarn`;
+  const userAgent = process.env.npm_config_user_agent || '';
+  const execPath = process.env.npm_execpath || '';
+
+  // Check user agent first
+  if (userAgent.includes('yarn')) {
+    return 'yarn';
+  }
+  if (userAgent.includes('pnpm')) {
+    return 'pnpm';
+  }
+  if (userAgent.includes('npm')) {
+    return 'npm';
   }
 
-  return `npm`;
+  // Fallback to execpath check
+  if (execPath.includes('yarn')) {
+    return 'yarn';
+  }
+  if (execPath.includes('pnpm')) {
+    return 'pnpm';
+  }
+  if (execPath.includes('npm')) {
+    return 'npm';
+  }
+
+  return 'npm'; // Default fallback
 }


### PR DESCRIPTION
Fixes a bug in https://github.com/mastra-ai/mastra/pull/1976 

Running npm after pnpm already installed results in: 
```
Error: Command failed: npm i @ai-sdk/openai
npm error Cannot read properties of null (reading 'matches')
```