### PR TITLE
fix langfuse directions

### DIFF
--- a/docs/src/pages/docs/reference/observability/providers/langfuse.mdx
+++ b/docs/src/pages/docs/reference/observability/providers/langfuse.mdx
@@ -30,11 +30,10 @@ import { LangfuseExporter } from "langfuse-vercel";
 export const mastra = new Mastra({
   // ... other config
   telemetry: {
-    serviceName: "your-service-name",
+    serviceName: "ai", // this must be set to "ai" so that the LangfuseExporter thinks it's an AI SDK trace
     enabled: true,
     export: {
       type: "custom",
-      traceName: "ai",
       exporter: new LangfuseExporter({
         publicKey: process.env.LANGFUSE_PUBLIC_KEY,
         secretKey: process.env.LANGFUSE_SECRET_KEY,


### PR DESCRIPTION
I wasn't seeing any traces in langfuse until I switched to setting serviceName to "ai" to satisfy their logic here: https://github.com/langfuse/langfuse-js/blob/a626f4631bb537afbb2c8b84d6b5078a73d8cb61/langfuse-vercel/src/LangfuseExporter.ts#L255