### PR TITLE
allow setting of telemetry options

### DIFF
--- a/.changeset/clear-seals-tease.md
+++ b/.changeset/clear-seals-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+add option for specifying telemetry settings at generation time

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,26 +1,26 @@
-import { randomUUID } from 'crypto';
 import type {
   AssistantContent,
   CoreAssistantMessage,
   CoreMessage,
   CoreToolMessage,
   CoreUserMessage,
+  LanguageModelV1,
   TextPart,
   ToolCallPart,
   UserContent,
-  LanguageModelV1,
 } from 'ai';
+import { randomUUID } from 'crypto';
 import type { JSONSchema7 } from 'json-schema';
-import { z } from 'zod';
 import type { ZodSchema } from 'zod';
+import { z } from 'zod';
 
 import type { MastraPrimitives } from '../action';
 import { MastraBase } from '../base';
 import type { Metric } from '../eval';
 import { AvailableHooks, executeHook } from '../hooks';
 import type { GenerateReturn, StreamReturn } from '../llm';
-import { MastraLLM } from '../llm/model';
 import type { MastraLLMBase } from '../llm/model';
+import { MastraLLM } from '../llm/model';
 import { RegisteredLogger } from '../logger';
 import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfig, StorageThreadType } from '../memory/types';
@@ -783,6 +783,7 @@ export class Agent<
       temperature,
       toolChoice = 'auto',
       experimental_output,
+      telemetry,
     }: AgentGenerateOptions<Z> = {},
   ): Promise<GenerateReturn<Z>> {
     let messagesToUse: CoreMessage[] = [];
@@ -854,6 +855,7 @@ export class Agent<
         runId: runIdToUse,
         temperature,
         toolChoice,
+        telemetry,
       });
 
       const outputText = result.text;
@@ -873,6 +875,7 @@ export class Agent<
       runId: runIdToUse,
       temperature,
       toolChoice,
+      telemetry,
     });
 
     const outputText = JSON.stringify(result.object);
@@ -898,6 +901,7 @@ export class Agent<
       temperature,
       toolChoice = 'auto',
       experimental_output,
+      telemetry,
     }: AgentStreamOptions<Z> = {},
   ): Promise<StreamReturn<Z>> {
     const runIdToUse = runId || randomUUID();
@@ -994,6 +998,7 @@ export class Agent<
         maxSteps,
         runId: runIdToUse,
         toolChoice,
+        telemetry,
       }) as unknown as StreamReturn<Z>;
     }
 
@@ -1024,6 +1029,7 @@ export class Agent<
       maxSteps,
       runId: runIdToUse,
       toolChoice,
+      telemetry,
     }) as unknown as StreamReturn<Z>;
   }
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV1 } from 'ai';
+import type { LanguageModelV1, TelemetrySettings } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
 
@@ -45,6 +45,7 @@ export interface AgentGenerateOptions<Z extends ZodSchema | JSONSchema7 | undefi
   temperature?: number;
   toolChoice?: 'auto' | 'required';
   experimental_output?: Z;
+  telemetry?: TelemetrySettings;
 }
 
 export interface AgentStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> {
@@ -61,4 +62,5 @@ export interface AgentStreamOptions<Z extends ZodSchema | JSONSchema7 | undefine
   temperature?: number;
   toolChoice?: 'auto' | 'required';
   experimental_output?: Z;
+  telemetry?: TelemetrySettings;
 }

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -1,5 +1,5 @@
-import { createLogger, RegisteredLogger } from './logger';
 import type { Logger } from './logger';
+import { createLogger, RegisteredLogger } from './logger';
 import type { Telemetry } from './telemetry';
 
 export class MastraBase {

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -11,6 +11,7 @@ import type {
   LanguageModelV1,
   StreamObjectResult,
   StreamTextResult,
+  TelemetrySettings,
 } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema } from 'zod';
@@ -82,6 +83,7 @@ export type LLMTextOptions<Z extends ZodSchema | JSONSchema7 | undefined = undef
   maxSteps?: number;
   temperature?: number;
   experimental_output?: Z;
+  telemetry?: TelemetrySettings;
 } & Run;
 
 export type LLMTextObjectOptions<T> = LLMTextOptions & {
@@ -98,6 +100,7 @@ export type LLMStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = und
   output?: OutputType | Z;
   temperature?: number;
   experimental_output?: Z;
+  telemetry?: TelemetrySettings;
 };
 
 export type LLMInnerStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {
@@ -110,6 +113,7 @@ export type LLMInnerStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined 
   temperature?: number;
   toolChoice?: 'auto' | 'required';
   experimental_output?: Z;
+  telemetry?: TelemetrySettings;
 } & Run;
 
 export type LLMStreamObjectOptions<T> = LLMInnerStreamOptions & {

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -1,16 +1,16 @@
-import { generateText, generateObject, jsonSchema, streamText, streamObject, Output } from 'ai';
-import type { LanguageModel, Schema, CoreMessage } from 'ai';
+import type { CoreMessage, LanguageModel, Schema } from 'ai';
+import { generateObject, generateText, jsonSchema, Output, streamObject, streamText } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
-import { z } from 'zod';
 import type { ZodSchema } from 'zod';
+import { z } from 'zod';
 
 import type {
   GenerateReturn,
-  LLMTextOptions,
   LLMInnerStreamOptions,
   LLMStreamObjectOptions,
   LLMStreamOptions,
   LLMTextObjectOptions,
+  LLMTextOptions,
   StreamReturn,
 } from '../';
 import type { MastraPrimitives } from '../../action';
@@ -117,6 +117,7 @@ export class MastraLLM extends MastraLLMBase {
     toolChoice = 'auto',
     onStepFinish,
     experimental_output,
+    telemetry,
   }: LLMTextOptions<Z>) {
     const model = this.#model;
 
@@ -178,7 +179,10 @@ export class MastraLLM extends MastraLLMBase {
     return await generateText({
       messages,
       ...argsForExecute,
-      experimental_telemetry: this.experimental_telemetry,
+      experimental_telemetry: {
+        ...this.experimental_telemetry,
+        ...telemetry,
+      },
       experimental_output: schema
         ? Output.object({
             schema,
@@ -197,6 +201,7 @@ export class MastraLLM extends MastraLLMBase {
     runId,
     temperature,
     toolChoice = 'auto',
+    telemetry,
   }: LLMTextObjectOptions<T>) {
     const model = this.#model;
 
@@ -252,7 +257,10 @@ export class MastraLLM extends MastraLLMBase {
       ...argsForExecute,
       output: output as any,
       schema,
-      experimental_telemetry: this.experimental_telemetry,
+      experimental_telemetry: {
+        ...this.experimental_telemetry,
+        ...telemetry,
+      },
     });
   }
 
@@ -267,6 +275,7 @@ export class MastraLLM extends MastraLLMBase {
     temperature,
     toolChoice = 'auto',
     experimental_output,
+    telemetry,
   }: LLMInnerStreamOptions<Z>) {
     const model = this.#model;
     this.logger.debug(`[LLM] - Streaming text`, {
@@ -339,7 +348,10 @@ export class MastraLLM extends MastraLLMBase {
     return await streamText({
       messages,
       ...argsForExecute,
-      experimental_telemetry: this.experimental_telemetry,
+      experimental_telemetry: {
+        ...this.experimental_telemetry,
+        ...telemetry,
+      },
       experimental_output: schema
         ? Output.object({
             schema,
@@ -359,6 +371,7 @@ export class MastraLLM extends MastraLLMBase {
     runId,
     temperature,
     toolChoice = 'auto',
+    telemetry,
   }: LLMStreamObjectOptions<T>) {
     const model = this.#model;
     this.logger.debug(`[LLM] - Streaming structured output`, {
@@ -430,7 +443,10 @@ export class MastraLLM extends MastraLLMBase {
       ...argsForExecute,
       output: output as any,
       schema,
-      experimental_telemetry: this.experimental_telemetry,
+      experimental_telemetry: {
+        ...this.experimental_telemetry,
+        ...telemetry,
+      },
     });
   }
 
@@ -444,6 +460,7 @@ export class MastraLLM extends MastraLLMBase {
       runId,
       output = 'text',
       temperature,
+      telemetry,
     }: LLMStreamOptions<Z> = {},
   ): Promise<GenerateReturn<Z>> {
     const msgs = this.convertToMessages(messages);
@@ -468,6 +485,7 @@ export class MastraLLM extends MastraLLMBase {
       tools,
       convertedTools,
       runId,
+      telemetry,
     })) as unknown as GenerateReturn<Z>;
   }
 
@@ -482,6 +500,7 @@ export class MastraLLM extends MastraLLMBase {
       runId,
       output = 'text',
       temperature,
+      telemetry,
     }: LLMStreamOptions<Z> = {},
   ) {
     const msgs = this.convertToMessages(messages);
@@ -496,6 +515,7 @@ export class MastraLLM extends MastraLLMBase {
         convertedTools,
         runId,
         temperature,
+        telemetry,
       })) as unknown as StreamReturn<Z>;
     }
 
@@ -509,6 +529,7 @@ export class MastraLLM extends MastraLLMBase {
       convertedTools,
       runId,
       temperature,
+      telemetry,
     })) as unknown as StreamReturn<Z>;
   }
 }


### PR DESCRIPTION
This is a proof of concept of something I'd like to be able to do with Mastra: set telemetry settings at generation time. E.g.,

```typescript
      const res = await mastra.getAgent("cannon").stream(messages, {
          telemetryOptions: {
              functionId: "my-awesome-function", // Trace name
              metadata: {
                  langfuseTraceId: "trace-123", // Langfuse trace
                  tags: ["story", "cat"], // Custom tags
                  userId: "user-123", // Langfuse user
                  sessionId: "session-456", // Langfuse session
                  foo: "bar", // Any custom attribute recorded in metadata
              },
          },
      });
```

Effectively it's giving me more control over the telemetry options passed to the AI SDK, which is required for traces to have these bits of information in Langfuse (https://langfuse.com/docs/integrations/vercel-ai-sdk#pass-custom-attributes).

Feedback welcome--happy to clean up this PR if this is a direction you are open to! 