### PR TITLE
Improve dependency analyzer to support * imports

### DIFF
--- a/.changeset/curvy-wombats-clap.md
+++ b/.changeset/curvy-wombats-clap.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'mastra': patch
+---
+
+Enable \* imports in analyze bundle

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -1,5 +1,3 @@
-import { MastraBundler } from '@mastra/core/bundler';
-import type { getWatcher } from '@mastra/deployer';
 import { FileService } from '@mastra/deployer';
 import { createWatcher, getWatcherInputOptions, writeTelemetryConfig } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
@@ -40,7 +38,7 @@ export class DevBundler extends Bundler {
     });
   }
 
-  async watch(entryFile: string, outputDirectory: string): ReturnType<typeof getWatcher> {
+  async watch(entryFile: string, outputDirectory: string): ReturnType<typeof createWatcher> {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 

--- a/packages/deployer/src/index.ts
+++ b/packages/deployer/src/index.ts
@@ -1,3 +1,3 @@
 export * from './deploy';
-export { getBundler, getWatcher, Deps, FileService } from './build';
+export { Deps, FileService } from './build';
 export { getDeployer } from './build/deployer';


### PR DESCRIPTION
Add support for * imports to the dependency analyzer

For example
```
import * as x from 'my-dep'
```

* imports needed some special care so we write them directly to the virtual file