### PR TITLE
fix(core, memory): disable embedder by disabling semantic recall

### DIFF
--- a/.changeset/breezy-owls-dance.md
+++ b/.changeset/breezy-owls-dance.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fixed a bug where embeddings were being created for memory even when semanticRecall was turned off

--- a/packages/core/src/vector/fastembed.ts
+++ b/packages/core/src/vector/fastembed.ts
@@ -72,6 +72,14 @@ const memory = new Memory({
 })
 
 Visit https://sdk.vercel.ai/docs/foundations/overview#embedding-models to find an alternate embedding provider
+
+If you do not want to use the Memory semantic recall feature, you can disable it entirely and this error will go away.
+
+const memory = new Memory({
+  options: {
+    semanticRecall: false // <- an embedder will not be required with this set to false
+  }
+})
 `);
     }
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -56,7 +56,7 @@ export class Memory extends MastraMemory {
             messageRange: config?.semanticRecall?.messageRange ?? { before: 2, after: 2 },
           };
 
-    if (selectBy?.vectorSearchString && this.vector) {
+    if (config?.semanticRecall && selectBy?.vectorSearchString && this.vector) {
       const { embedding } = await embed({
         value: selectBy.vectorSearchString,
         model: this.embedder,
@@ -187,14 +187,22 @@ export class Memory extends MastraMemory {
     // }
   }
 
-  async saveMessages({ messages }: { messages: MessageType[] }): Promise<MessageType[]> {
+  async saveMessages({
+    messages,
+    memoryConfig,
+  }: {
+    messages: MessageType[];
+    memoryConfig?: MemoryConfig;
+  }): Promise<MessageType[]> {
     // First save working memory from any messages
     await this.saveWorkingMemory(messages);
 
     // Then strip working memory tags from all messages
     this.mutateMessagesToHideWorkingMemory(messages);
 
-    if (this.vector) {
+    const config = this.getMergedThreadConfig(memoryConfig);
+
+    if (this.vector && config.semanticRecall) {
       const { indexName } = await this.createEmbeddingIndex();
 
       for (const message of messages) {


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/2498
The actual error in that issue is related to the default embedder. The solution is to use a different embedder (eg `openai`) or disable semantic recall. While investigating I discovered turning off `options.semanticRecall` didn't stop memory from creating embeddings though, so this PR fixes that and improves the error message
```
This runtime does not support fastembed-js, which
 is the default embedder in Mastra. 
Scroll up to read import errors. These errors mea
n you can't use the default Mastra embedder on th
is hosting platform.
You can either use Mastra Cloud which supports th
e default embedder, or you can configure an alter
nate provider.

For example if you're using Memory:

import { openai } from "@ai-sdk/openai";

const memory = new Memory({
  embedder: openai.embedding("text-embedding-3-sm
all"), // <- doesn't have to be openai
})

Visit https://sdk.vercel.ai/docs/foundations/over
view#embedding-models to find an alternate embedd
ing provider

```