### PR TITLE
Correct typo in LanguageModel-related error

### DIFF
--- a/.changeset/vast-garlics-cry.md
+++ b/.changeset/vast-garlics-cry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Correct typo in LanguageModel-related

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -57,7 +57,7 @@ export class Agent<
     this.instructions = config.instructions;
 
     if (!config.model) {
-      throw new Error(`LanugageModel is required to create an Agent. Please provider the 'model'.`);
+      throw new Error(`LanguageModel is required to create an Agent. Please provide the 'model'.`);
     }
 
     this.llm = new MastraLLM({ model: config.model });


### PR DESCRIPTION
## Fix Typo in LanguageModel Error Message

**Description**
- This PR corrects a typographical error in the LanguageModel error message. The typo has been fixed to ensure clarity and accuracy in error reporting.

**Changes**
- Fixed a minor typo in the error message related to LanguageModel.

**Why This is Needed**
- Improves readability and correctness of error messages.
- Ensures consistency in naming and messaging across the codebase.

**Testing**
- Verified that the corrected error message displays as expected.