### PR TITLE
fix: Example awaits and returns activities

### DIFF
--- a/examples/ai-sdk-useChat/src/mastra/workflows/index.ts
+++ b/examples/ai-sdk-useChat/src/mastra/workflows/index.ts
@@ -141,7 +141,7 @@ const planActivities = new Step({
     }
 
     return {
-      activities: response.text,
+      activities: await response.text,
     };
   },
 });


### PR DESCRIPTION
The examples that comes with create-mastra was not awaiting the LLM response and thus returned empty activities.
The response is now awaited and returned, leading to expected results.

Closes #2495 