### PR TITLE
fix(core): error when threadId is passed in but no resourceId

### DIFF
--- a/.changeset/violet-regions-eat.md
+++ b/.changeset/violet-regions-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Throw error when resourceId is not provided but Memory is configured and a threadId was passed

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -646,7 +646,15 @@ export class Agent<
         let coreMessages = messages;
         let threadIdToUse = threadId;
 
-        if (this.getMemory() && resourceId) {
+        const memory = this.getMemory();
+
+        if (threadId && memory && !resourceId) {
+          throw new Error(
+            `A resourceId must be provided when passing a threadId and using Memory. Saw threadId ${threadId} but resourceId is ${resourceId}`,
+          );
+        }
+
+        if (memory && resourceId) {
           this.logger.debug(
             `[Agent:${this.name}] - Memory persistence enabled: store=${this.getMemory()?.constructor.name}, resourceId=${resourceId}`,
             {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -32,11 +32,9 @@ export interface AgentConfig<
   voice?: CompositeVoice;
 }
 
-export interface AgentGenerateOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> {
+export type AgentGenerateOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {
   toolsets?: ToolsetsInput;
-  resourceId?: string;
   context?: CoreMessage[];
-  threadId?: string;
   memoryOptions?: MemoryConfig;
   runId?: string;
   onStepFinish?: (step: string) => void;
@@ -46,13 +44,11 @@ export interface AgentGenerateOptions<Z extends ZodSchema | JSONSchema7 | undefi
   toolChoice?: 'auto' | 'required';
   experimental_output?: Z;
   telemetry?: TelemetrySettings;
-}
+} & ({ resourceId?: undefined; threadId?: undefined } | { resourceId: string; threadId: string });
 
-export interface AgentStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> {
+export type AgentStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {
   toolsets?: ToolsetsInput;
-  resourceId?: string;
   context?: CoreMessage[];
-  threadId?: string;
   memoryOptions?: MemoryConfig;
   runId?: string;
   onFinish?: (result: string) => unknown;
@@ -63,4 +59,4 @@ export interface AgentStreamOptions<Z extends ZodSchema | JSONSchema7 | undefine
   toolChoice?: 'auto' | 'required';
   experimental_output?: Z;
   telemetry?: TelemetrySettings;
-}
+} & ({ resourceId?: undefined; threadId?: undefined } | { resourceId: string; threadId: string });


### PR DESCRIPTION
A user on discord ran into this papercut - they passed in a threadId and configured memory but they didn't pass a resourceId. As a result memory silently didn't do anything. This PR throws an error in that case to make it more obvious