### PR TITLE
fix(core): correctly infer object output types

### DIFF
--- a/.changeset/swift-shrimps-follow.md
+++ b/.changeset/swift-shrimps-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent.generate() so it properly infers the return type based on output: schema | string and experimental_output: schema

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -780,12 +780,13 @@ export class Agent<
 
   async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
-    args?: AgentGenerateOptions<Z> & { output?: 'text'; experimental_output?: undefined },
+    args?: AgentGenerateOptions<Z> & { output?: 'text'; experimental_output?: never },
   ): Promise<GenerateTextResult<any, any>>;
   async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
-    args?: AgentGenerateOptions<Z> & ({ output: Z } | { experimental_output: Z; output?: undefined }),
-  ): Promise<GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : any>>;
+    args?: AgentGenerateOptions<Z> &
+      ({ output: Z; experimental_output?: never } | { experimental_output: Z; output?: never }),
+  ): Promise<GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : unknown>>;
   async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
     {
@@ -803,7 +804,7 @@ export class Agent<
       experimental_output,
       telemetry,
     }: AgentGenerateOptions<Z> = {},
-  ): Promise<GenerateTextResult<any, any> | GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : any>> {
+  ): Promise<GenerateTextResult<any, any> | GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : unknown>> {
     let messagesToUse: CoreMessage[] = [];
 
     if (typeof messages === `string`) {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -5,6 +5,8 @@ import type {
   CoreMessage,
   CoreToolMessage,
   CoreUserMessage,
+  GenerateObjectResult,
+  GenerateTextResult,
   LanguageModelV1,
   TextPart,
   ToolCallPart,
@@ -778,6 +780,14 @@ export class Agent<
 
   async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
+    args?: AgentGenerateOptions<Z> & { output?: 'text'; experimental_output?: undefined },
+  ): Promise<GenerateTextResult<any, any>>;
+  async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
+    messages: string | string[] | CoreMessage[],
+    args?: AgentGenerateOptions<Z> & ({ output: Z } | { experimental_output: Z }),
+  ): Promise<GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : any>>;
+  async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
+    messages: string | string[] | CoreMessage[],
     {
       context,
       threadId: threadIdInFn,
@@ -787,13 +797,13 @@ export class Agent<
       onStepFinish,
       runId,
       toolsets,
-      output = 'text' as const,
+      output = 'text',
       temperature,
       toolChoice = 'auto',
       experimental_output,
       telemetry,
     }: AgentGenerateOptions<Z> = {},
-  ): Promise<GenerateReturn<Z>> {
+  ): Promise<GenerateTextResult<any, any> | GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : any>> {
     let messagesToUse: CoreMessage[] = [];
 
     if (typeof messages === `string`) {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -784,7 +784,7 @@ export class Agent<
   ): Promise<GenerateTextResult<any, any>>;
   async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],
-    args?: AgentGenerateOptions<Z> & ({ output: Z } | { experimental_output: Z }),
+    args?: AgentGenerateOptions<Z> & ({ output: Z } | { experimental_output: Z; output?: undefined }),
   ): Promise<GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : any>>;
   async generate<Z extends ZodSchema | JSONSchema7 | undefined = undefined>(
     messages: string | string[] | CoreMessage[],


### PR DESCRIPTION
<img width="962" alt="Screenshot 2025-02-26 at 4 03 16 PM" src="https://github.com/user-attachments/assets/a9905639-60ab-425f-8e05-0d541a132e81" />

<img width="1104" alt="Screenshot 2025-02-26 at 4 07 06 PM" src="https://github.com/user-attachments/assets/7f5f801a-5cad-42a0-b501-1c1653782fe0" />


<img width="1004" alt="Screenshot 2025-02-26 at 4 06 57 PM" src="https://github.com/user-attachments/assets/55864afd-ffe3-4cdf-82a4-0e7988a7821e" />
<img width="597" alt="Screenshot 2025-02-26 at 4 10 27 PM" src="https://github.com/user-attachments/assets/f531bd82-e59b-401a-aeca-ba03b8b9ca15" />

