### PR TITLE
Add voice routes to hono

### DIFF
--- a/.changeset/fancy-eyes-tease.md
+++ b/.changeset/fancy-eyes-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Add hono routes for agent voice methods speakers, speak and listen

--- a/packages/deployer/src/server/handlers/voice.ts
+++ b/packages/deployer/src/server/handlers/voice.ts
@@ -1,0 +1,92 @@
+import type { Mastra } from '@mastra/core';
+import type { Context } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { Readable } from 'stream';
+
+import { handleError } from './error.js';
+import { validateBody } from './utils.js';
+
+/**
+ * Get available speakers for an agent
+ */
+export async function getSpeakersHandler(c: Context) {
+  try {
+    const mastra: Mastra = c.get('mastra');
+    const agentId = c.req.param('agentId');
+    const agent = mastra.getAgent(agentId);
+
+    if (!agent) {
+      throw new HTTPException(404, { message: 'Agent not found' });
+    }
+
+    if (!agent.voice) {
+      throw new HTTPException(400, { message: 'Agent does not have voice capabilities' });
+    }
+
+    const speakers = await agent.getSpeakers();
+    return c.json(speakers);
+  } catch (error) {
+    return handleError(error, 'Error getting speakers');
+  }
+}
+
+/**
+ * Convert text to speech using the agent's voice provider
+ */
+export async function speakHandler(c: Context) {
+  try {
+    const mastra: Mastra = c.get('mastra');
+    const agentId = c.req.param('agentId');
+    const agent = mastra.getAgent(agentId);
+
+    if (!agent) {
+      throw new HTTPException(404, { message: 'Agent not found' });
+    }
+
+    if (!agent.voice) {
+      throw new HTTPException(400, { message: 'Agent does not have voice capabilities' });
+    }
+
+    const { input, options } = await c.req.json();
+    await validateBody({ input });
+
+    const audioStream = await agent.speak(input, options);
+
+    c.header('Content-Type', `audio/${options.filetype ?? 'mp3'}`);
+    c.header('Transfer-Encoding', 'chunked');
+
+    return c.body(audioStream as any);
+  } catch (error) {
+    return handleError(error, 'Error generating speech');
+  }
+}
+
+/**
+ * Convert speech to text using the agent's voice provider
+ */
+export async function listenHandler(c: Context) {
+  try {
+    const mastra: Mastra = c.get('mastra');
+    const agentId = c.req.param('agentId');
+    const agent = mastra.getAgent(agentId);
+
+    if (!agent) {
+      throw new HTTPException(404, { message: 'Agent not found' });
+    }
+
+    if (!agent.voice) {
+      throw new HTTPException(400, { message: 'Agent does not have voice capabilities' });
+    }
+
+    const audioData = await c.req.arrayBuffer();
+    const audioStream = new Readable();
+    audioStream.push(Buffer.from(audioData));
+    audioStream.push(null);
+
+    const options = c.req.query();
+    const transcription = await agent.listen(audioStream, options);
+    return c.json({ text: transcription });
+  } catch (error) {
+    return handleError(error, 'Error transcribing speech');
+  }
+}

--- a/packages/deployer/src/server/handlers/voice.ts
+++ b/packages/deployer/src/server/handlers/voice.ts
@@ -1,7 +1,7 @@
+import { Readable } from 'stream';
 import type { Mastra } from '@mastra/core';
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { Readable } from 'stream';
 
 import { handleError } from './error.js';
 import { validateBody } from './utils.js';

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -39,6 +39,7 @@ import { generateSystemPromptHandler } from './handlers/prompt.js';
 import { rootHandler } from './handlers/root.js';
 import { getTelemetryHandler } from './handlers/telemetry.js';
 import { executeAgentToolHandler, executeToolHandler, getToolByIdHandler, getToolsHandler } from './handlers/tools.js';
+import { getSpeakersHandler, speakHandler, listenHandler } from './handlers/voice.js';
 import {
   upsertVectors,
   createIndex,
@@ -439,6 +440,178 @@ export async function createHonoServer(
       },
     }),
     generateSystemPromptHandler,
+  );
+
+  app.get(
+    '/api/agents/:agentId/speakers',
+    describeRoute({
+      description: 'Get available speakers for an agent',
+      tags: ['agents'],
+      parameters: [
+        {
+          name: 'agentId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {
+        200: {
+          description: 'List of available speakers',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  description: 'Speaker information depending on the voice provider',
+                  properties: {
+                    voiceId: { type: 'string' },
+                  },
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+        },
+        400: {
+          description: 'Agent does not have voice capabilities',
+        },
+        404: {
+          description: 'Agent not found',
+        },
+      },
+    }),
+    getSpeakersHandler,
+  );
+
+  app.post(
+    '/api/agents/:agentId/speak',
+    bodyLimit(bodyLimitOptions),
+    describeRoute({
+      description: "Convert text to speech using the agent's voice provider",
+      tags: ['agents'],
+      parameters: [
+        {
+          name: 'agentId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                text: {
+                  type: 'string',
+                  description: 'Text to convert to speech',
+                },
+                options: {
+                  type: 'object',
+                  description: 'Provider-specific options for speech generation',
+                  properties: {
+                    speaker: {
+                      type: 'string',
+                      description: 'Speaker ID to use for speech generation',
+                    },
+                  },
+                  additionalProperties: true,
+                },
+              },
+              required: ['text'],
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: 'Audio stream',
+          content: {
+            'audio/mpeg': {
+              schema: {
+                format: 'binary',
+                description: 'Audio stream containing the generated speech',
+              },
+            },
+            'audio/*': {
+              schema: {
+                format: 'binary',
+                description: 'Audio stream depending on the provider',
+              },
+            },
+          },
+        },
+        400: {
+          description: 'Agent does not have voice capabilities or invalid request',
+        },
+        404: {
+          description: 'Agent not found',
+        },
+      },
+    }),
+    speakHandler,
+  );
+
+  app.post(
+    '/api/agents/:agentId/listen',
+    bodyLimit({
+      ...bodyLimitOptions,
+      maxSize: 10 * 1024 * 1024, // 10 MB for audio files
+    }),
+    describeRoute({
+      description:
+        "Convert speech to text using the agent's voice provider. Additional provider-specific options can be passed as query parameters.",
+      tags: ['agents'],
+      parameters: [
+        {
+          name: 'agentId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'audio/mpeg': {
+            schema: {
+              format: 'binary',
+              description:
+                'Audio data stream to transcribe (supports various formats depending on provider like mp3, wav, webm, flac)',
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: 'Transcription result',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  text: {
+                    type: 'string',
+                    description: 'Transcribed text',
+                  },
+                },
+              },
+            },
+          },
+        },
+        400: {
+          description: 'Agent does not have voice capabilities or invalid request',
+        },
+        404: {
+          description: 'Agent not found',
+        },
+      },
+    }),
+    listenHandler,
   );
 
   app.post(

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -39,7 +39,6 @@ import { generateSystemPromptHandler } from './handlers/prompt.js';
 import { rootHandler } from './handlers/root.js';
 import { getTelemetryHandler } from './handlers/telemetry.js';
 import { executeAgentToolHandler, executeToolHandler, getToolByIdHandler, getToolsHandler } from './handlers/tools.js';
-import { getSpeakersHandler, speakHandler, listenHandler } from './handlers/voice.js';
 import {
   upsertVectors,
   createIndex,
@@ -48,6 +47,7 @@ import {
   describeIndex,
   deleteIndex,
 } from './handlers/vector.js';
+import { getSpeakersHandler, speakHandler, listenHandler } from './handlers/voice.js';
 import {
   executeWorkflowHandler,
   getWorkflowByIdHandler,


### PR DESCRIPTION
Adds the following routes to hono server:
- GET speakers
- POST speak
- POST listen

GET speakers:
```
# Example request
curl --location 'http://localhost:4111/api/agents/weatherAgent/speakers'
```
![image](https://github.com/user-attachments/assets/49a1ecd9-82aa-4aac-a917-66ba389591f3)

POST speak 
```
# Example request
curl --location 'http://localhost:4111/api/agents/weatherAgent/speak' \
--header 'Content-Type: application/json' \
--data '{
    "input": "hello world",
    "options": {
        "speaker": "coral"
    }
}'
```

POST listen
```
# Example request
curl -X POST -F "audio=@download.mp3" http://localhost:4111/api/agents/weatherAgent/listen?filetype=mp3
```
<img width="847" alt="image" src="https://github.com/user-attachments/assets/bb54d7d7-352d-4713-a024-765eb5c357b9" />

