### PR TITLE
fix(core, pg): ensure correct tool call and result message order when using Memory semanticRecall

### DIFF
--- a/.changeset/chatty-jobs-speak.md
+++ b/.changeset/chatty-jobs-speak.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+Ensure proper message sort order for tool calls and results when using Memory semanticRecall feature

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -326,56 +326,58 @@ export class Agent<
 
           await memory.saveMessages({
             memoryConfig,
-            messages: responseMessagesWithoutIncompleteToolCalls.map((message: CoreMessage | CoreAssistantMessage) => {
-              const messageId = randomUUID();
-              let toolCallIds: string[] | undefined;
-              let toolCallArgs: Record<string, unknown>[] | undefined;
-              let toolNames: string[] | undefined;
-              let type: 'text' | 'tool-call' | 'tool-result' = 'text';
+            messages: responseMessagesWithoutIncompleteToolCalls.map(
+              (message: CoreMessage | CoreAssistantMessage, index) => {
+                const messageId = randomUUID();
+                let toolCallIds: string[] | undefined;
+                let toolCallArgs: Record<string, unknown>[] | undefined;
+                let toolNames: string[] | undefined;
+                let type: 'text' | 'tool-call' | 'tool-result' = 'text';
 
-              if (message.role === 'tool') {
-                toolCallIds = (message as CoreToolMessage).content.map(content => content.toolCallId);
-                type = 'tool-result';
-              }
-              if (message.role === 'assistant') {
-                const assistantContent = (message as CoreAssistantMessage).content as Array<TextPart | ToolCallPart>;
+                if (message.role === 'tool') {
+                  toolCallIds = (message as CoreToolMessage).content.map(content => content.toolCallId);
+                  type = 'tool-result';
+                }
+                if (message.role === 'assistant') {
+                  const assistantContent = (message as CoreAssistantMessage).content as Array<TextPart | ToolCallPart>;
 
-                const assistantToolCalls = assistantContent
-                  .map(content => {
-                    if (content.type === 'tool-call') {
-                      return {
-                        toolCallId: content.toolCallId,
-                        toolArgs: content.args,
-                        toolName: content.toolName,
-                      };
-                    }
-                    return undefined;
-                  })
-                  ?.filter(Boolean) as Array<{
-                  toolCallId: string;
-                  toolArgs: Record<string, unknown>;
-                  toolName: string;
-                }>;
+                  const assistantToolCalls = assistantContent
+                    .map(content => {
+                      if (content.type === 'tool-call') {
+                        return {
+                          toolCallId: content.toolCallId,
+                          toolArgs: content.args,
+                          toolName: content.toolName,
+                        };
+                      }
+                      return undefined;
+                    })
+                    ?.filter(Boolean) as Array<{
+                    toolCallId: string;
+                    toolArgs: Record<string, unknown>;
+                    toolName: string;
+                  }>;
 
-                toolCallIds = assistantToolCalls?.map(toolCall => toolCall.toolCallId);
+                  toolCallIds = assistantToolCalls?.map(toolCall => toolCall.toolCallId);
 
-                toolCallArgs = assistantToolCalls?.map(toolCall => toolCall.toolArgs);
-                toolNames = assistantToolCalls?.map(toolCall => toolCall.toolName);
-                type = assistantContent?.[0]?.type as 'text' | 'tool-call' | 'tool-result';
-              }
+                  toolCallArgs = assistantToolCalls?.map(toolCall => toolCall.toolArgs);
+                  toolNames = assistantToolCalls?.map(toolCall => toolCall.toolName);
+                  type = assistantContent?.[0]?.type as 'text' | 'tool-call' | 'tool-result';
+                }
 
-              return {
-                id: messageId,
-                threadId: threadId,
-                role: message.role as any,
-                content: message.content as any,
-                createdAt: new Date(),
-                toolCallIds: toolCallIds?.length ? toolCallIds : undefined,
-                toolCallArgs: toolCallArgs?.length ? toolCallArgs : undefined,
-                toolNames: toolNames?.length ? toolNames : undefined,
-                type,
-              };
-            }),
+                return {
+                  id: messageId,
+                  threadId: threadId,
+                  role: message.role as any,
+                  content: message.content as any,
+                  createdAt: new Date(Date.now() + index), // use Date.now() + index to make sure every message is atleast one millisecond apart
+                  toolCallIds: toolCallIds?.length ? toolCallIds : undefined,
+                  toolCallArgs: toolCallArgs?.length ? toolCallArgs : undefined,
+                  toolNames: toolNames?.length ? toolNames : undefined,
+                  type,
+                };
+              },
+            ),
           });
         }
       }
@@ -398,8 +400,7 @@ export class Agent<
             toolResultIds.push(content.toolCallId);
           }
         }
-      }
-      if (message.role === 'assistant' || message.role === 'user') {
+      } else if (message.role === 'assistant' || message.role === 'user') {
         for (const content of message.content) {
           if (typeof content !== `string`) {
             if (content.type === `tool-call`) {

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -411,11 +411,11 @@ export class PostgresStore extends MastraStorage {
           WITH ordered_messages AS (
             SELECT 
               *,
-              ROW_NUMBER() OVER (ORDER BY "createdAt") as row_num
+              ROW_NUMBER() OVER (ORDER BY "createdAt" DESC) as row_num
             FROM "${MastraStorage.TABLE_MESSAGES}"
             WHERE thread_id = $1
           )
-          SELECT DISTINCT ON (m.id)
+          SELECT
             m.id, 
             m.content, 
             m.role, 
@@ -435,7 +435,7 @@ export class PostgresStore extends MastraStorage {
               (m.row_num <= target.row_num + $4 AND m.row_num > target.row_num)
             )
           )
-          ORDER BY m.id, m."createdAt"
+          ORDER BY m."createdAt" DESC
           `,
           [
             threadId,


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/2012

There were 2 problems: 
1. sometimes we were setting the exact same date on multiple messages, meaning sorting them later by date might get the order wrong - now they're always atleast 1ms apart to preserve sort order by date
2. we were sorting by id and created date for PG vector results, which sometimes messed up tool call order