### PR TITLE
Easier suspend/resume semantics

### DIFF
--- a/.changeset/small-planets-tell.md
+++ b/.changeset/small-planets-tell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+A better async/await based interface for suspend/resume tracking

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -29,6 +29,7 @@ import type {
   WorkflowState,
 } from './types';
 import {
+  getActivePathsAndStatus,
   getStepResult,
   getSuspendedPaths,
   isErrorEvent,
@@ -110,6 +111,7 @@ export class Machine<
     snapshot?: Snapshot<any>;
   } = {}): Promise<{
     results: Record<string, StepResult<any>>;
+    activePaths: Map<string, { status: string }>;
   }> {
     if (snapshot) {
       // First, let's log the incoming snapshot for debugging
@@ -195,6 +197,10 @@ export class Machine<
           this.#executionSpan?.end();
           resolve({
             results: state.context.steps,
+            activePaths: getActivePathsAndStatus(state.value as Record<string, string>).reduce((acc, curr) => {
+              acc.set(curr.stepId, { status: curr.status });
+              return acc;
+            }, new Map<string, { status: string }>()),
           });
         } catch (error) {
           // If snapshot persistence fails, we should still resolve
@@ -205,6 +211,10 @@ export class Machine<
           this.#executionSpan?.end();
           resolve({
             results: state.context.steps,
+            activePaths: getActivePathsAndStatus(state.value as Record<string, string>).reduce((acc, curr) => {
+              acc.set(curr.stepId, { status: curr.status });
+              return acc;
+            }, new Map<string, { status: string }>()),
           });
         }
       });

--- a/packages/core/src/workflows/workflow-instance.ts
+++ b/packages/core/src/workflows/workflow-instance.ts
@@ -16,6 +16,7 @@ export interface WorkflowResultReturn<T extends z.ZodType<any>> {
     triggerData?: z.infer<T>;
     results: Record<string, StepResult<any>>;
     runId: string;
+    activePaths: Map<string, { status: string }>;
   }>;
 }
 
@@ -118,6 +119,7 @@ export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTrigg
   } = {}): Promise<{
     triggerData?: z.infer<TTriggerSchema>;
     results: Record<string, StepResult<any>>;
+    activePaths: Map<string, { status: string }>;
   }> {
     this.#executionSpan = this.#mastra?.telemetry?.tracer.startSpan(`workflow.${this.name}.execute`, {
       attributes: { componentName: this.name, runId: this.runId },
@@ -184,11 +186,11 @@ export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTrigg
 
     defaultMachine.on('state-update', stateUpdateHandler);
 
-    const { results } = await defaultMachine.execute({ snapshot, stepId, input: machineInput });
+    const { results, activePaths } = await defaultMachine.execute({ snapshot, stepId, input: machineInput });
 
     await this.persistWorkflowSnapshot();
 
-    return { results };
+    return { results, activePaths };
   }
 
   async runMachine(parentStepId: string, input: any) {

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -513,7 +513,7 @@ describe('Workflow', async () => {
 
       const run = workflow.createRun();
 
-      await expect(run.start()).resolves.toEqual({
+      await expect(run.start()).resolves.toMatchObject({
         results: {
           step1: {
             error: 'Step execution failed',
@@ -521,7 +521,6 @@ describe('Workflow', async () => {
           },
         },
         runId: expect.any(String),
-        triggerData: undefined,
       });
     });
 
@@ -547,7 +546,7 @@ describe('Workflow', async () => {
         .commit();
 
       const run = workflow.createRun();
-      await expect(run.start()).resolves.toEqual({
+      await expect(run.start()).resolves.toMatchObject({
         results: {
           step1: {
             status: 'success',
@@ -561,7 +560,6 @@ describe('Workflow', async () => {
           },
         },
         runId: expect.any(String),
-        triggerData: undefined,
       });
     });
   });
@@ -1524,6 +1522,117 @@ describe('Workflow', async () => {
         },
         humanIntervention: { status: 'success', output: { improvedOutput: 'human intervention output' } },
         explainResponse: { status: 'failed', error: 'Step:explainResponse condition check failed' },
+      });
+    });
+
+    it('should handle basic suspend and resume flow with async await syntax', async () => {
+      const getUserInputAction = vi.fn().mockResolvedValue({ userInput: 'test input' });
+      const promptAgentAction = vi
+        .fn()
+        .mockImplementationOnce(async ({ suspend }) => {
+          await suspend();
+          return undefined;
+        })
+        .mockImplementationOnce(() => ({ modelOutput: 'test output' }));
+      const evaluateToneAction = vi.fn().mockResolvedValue({
+        toneScore: { score: 0.8 },
+        completenessScore: { score: 0.7 },
+      });
+      const improveResponseAction = vi.fn().mockResolvedValue({ improvedOutput: 'improved output' });
+      const evaluateImprovedAction = vi.fn().mockResolvedValue({
+        toneScore: { score: 0.9 },
+        completenessScore: { score: 0.8 },
+      });
+
+      const getUserInput = new Step({
+        id: 'getUserInput',
+        execute: getUserInputAction,
+        outputSchema: z.object({ userInput: z.string() }),
+      });
+      const promptAgent = new Step({
+        id: 'promptAgent',
+        execute: promptAgentAction,
+        outputSchema: z.object({ modelOutput: z.string() }),
+      });
+      const evaluateTone = new Step({
+        id: 'evaluateToneConsistency',
+        execute: evaluateToneAction,
+        outputSchema: z.object({
+          toneScore: z.any(),
+          completenessScore: z.any(),
+        }),
+      });
+      const improveResponse = new Step({
+        id: 'improveResponse',
+        execute: improveResponseAction,
+        outputSchema: z.object({ improvedOutput: z.string() }),
+      });
+      const evaluateImproved = new Step({
+        id: 'evaluateImprovedResponse',
+        execute: evaluateImprovedAction,
+        outputSchema: z.object({
+          toneScore: z.any(),
+          completenessScore: z.any(),
+        }),
+      });
+
+      const promptEvalWorkflow = new Workflow({
+        name: 'test-workflow',
+        triggerSchema: z.object({ input: z.string() }),
+      });
+
+      promptEvalWorkflow
+        .step(getUserInput)
+        .then(promptAgent)
+        .then(evaluateTone)
+        .then(improveResponse)
+        .then(evaluateImproved)
+        .commit();
+
+      const mastra = new Mastra({
+        logger,
+        workflows: { 'test-workflow': promptEvalWorkflow },
+      });
+
+      const wf = mastra.getWorkflow('test-workflow');
+      const run = wf.createRun();
+
+      const initialResult = await run.start({ triggerData: { input: 'test' } });
+      expect(initialResult.results.promptAgent.status).toBe('suspended');
+      expect(promptAgentAction).toHaveBeenCalledTimes(1);
+      expect(initialResult.activePaths.size).toBe(1);
+      expect(initialResult.activePaths.get('promptAgent')?.status).toBe('suspended');
+
+      expect(initialResult.results).toEqual({
+        getUserInput: { status: 'success', output: { userInput: 'test input' } },
+        promptAgent: { status: 'suspended' },
+      });
+
+      const newCtx = {
+        userInput: 'test input for resumption',
+      };
+
+      expect(initialResult.results.promptAgent.status).toBe('suspended');
+      expect(promptAgentAction).toHaveBeenCalledTimes(1);
+
+      const resumeResult = await wf.resume({ runId: run.runId, stepId: 'promptAgent', context: newCtx });
+
+      if (!resumeResult) {
+        throw new Error('Resume failed to return a result');
+      }
+
+      expect(resumeResult.results).toEqual({
+        getUserInput: { status: 'success', output: { userInput: 'test input' } },
+        promptAgent: { status: 'success', output: { modelOutput: 'test output' } },
+        evaluateToneConsistency: {
+          status: 'success',
+          output: { toneScore: { score: 0.8 }, completenessScore: { score: 0.7 } },
+        },
+        improveResponse: { status: 'success', output: { improvedOutput: 'improved output' } },
+        evaluateImprovedResponse: {
+          status: 'success',
+          output: { toneScore: { score: 0.9 }, completenessScore: { score: 0.8 } },
+        },
       });
     });
   });


### PR DESCRIPTION
Easier API for suspending and resuming where you can sequentially await a result, check if there are any suspended states and resume them. E.g.

```js
const run = workflow.createRun()
let result = await run.start({...})
if (result.activePaths.get('humanInTheLoopStep')?.status === 'suspended') {
  // do smth
  result = await workflow.resume({ runId: run.runId, stepId: 'humanInTheLoopStep', context: {...} })
}
```