### PR TITLE
fix: mastra build due to esbuild not removing types

### DIFF
--- a/.changeset/nasty-poems-shave.md
+++ b/.changeset/nasty-poems-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+fix mastra build errors related to esbuild not removing types

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -59,16 +59,16 @@ async function analyze(
         },
       } satisfies Plugin,
       json(),
+      esbuild({
+        target: 'node20',
+        platform,
+        minify: false,
+      }),
       commonjs({
         strictRequires: 'debug',
         ignoreTryCatch: false,
         transformMixedEsModules: true,
         extensions: ['.js', '.ts'],
-      }),
-      esbuild({
-        target: 'node20',
-        platform,
-        minify: false,
       }),
       removeDeployer(mastraEntry),
       esbuild({


### PR DESCRIPTION
we were seeing errors when bundling where esbuild was not removing
types. The fix is to have the esbuild plugin before the commonjs one