### PR TITLE
feat(core, memory): Add tool-call option for saving working memory

### DIFF
--- a/.changeset/beige-buttons-cheat.md
+++ b/.changeset/beige-buttons-cheat.md
@@ -3,4 +3,5 @@
 '@mastra/core': minor
 ---
 
-Added a new option to use tool-calls for saving working memory: new Memory({ workingMemory: { enabled: true, use: "tool-call" } }). This is to support response methods like toDataStream where masking working memory chunks would be more resource intensive and complex
+Added a new option to use tool-calls for saving working memory: new Memory({ workingMemory: { enabled: true, use: "tool-call" } }). This is to support response methods like toDataStream where masking working memory chunks would be more resource intensive and complex.
+To support this `memory` is now passed into tool execute args.

--- a/.changeset/beige-buttons-cheat.md
+++ b/.changeset/beige-buttons-cheat.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': minor
+'@mastra/core': minor
+---
+
+Added a new option to use tool-calls for saving working memory: new Memory({ workingMemory: { enabled: true, use: "tool-call" } }). This is to support response methods like toDataStream where masking working memory chunks would be more resource intensive and complex

--- a/.changeset/mean-eels-stick.md
+++ b/.changeset/mean-eels-stick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Keep default memory db in .mastra/mastra.db, not .mastra/output/memory.db for consistency

--- a/docs/src/pages/docs/reference/memory/Memory.mdx
+++ b/docs/src/pages/docs/reference/memory/Memory.mdx
@@ -132,19 +132,39 @@ const agent = new Agent({
     },
     {
       name: "workingMemory",
-      type: "{ enabled: boolean; template: string }",
+      type: "{ enabled: boolean; template?: string; use?: 'text-stream' | 'tool-call' }",
       description:
-        "Configuration for working memory feature that allows persistent storage of user information across conversations",
+        "Configuration for working memory feature that allows persistent storage of user information across conversations. The 'use' setting determines how working memory updates are handled - either through text stream tags or tool calls.",
       isOptional: true,
       defaultValue:
-        "{ enabled: false, template: '<user><first_name></first_name><last_name></last_name>...</user>' }",
+        "{ enabled: false, template: '<user><first_name></first_name><last_name></last_name>...</user>', use: 'text-stream' }",
     },
   ]}
 />
 
 ### Working Memory
 
-The working memory feature allows agents to maintain persistent information across conversations. When enabled, the Memory class will automatically manage XML-based working memory updates through the conversation stream.
+The working memory feature allows agents to maintain persistent information across conversations. When enabled, the Memory class will automatically manage XML-based working memory updates through either text stream tags or tool calls.
+
+There are two modes for handling working memory updates:
+
+1. **text-stream** (default): The agent includes working memory updates directly in its responses using XML-like tags (`<working_memory>...</working_memory>`). These tags are automatically processed and stripped from the visible output.
+
+2. **tool-call**: The agent uses a dedicated tool to update working memory. This mode should be used when working with `toDataStream()` as text-stream mode is not compatible with data streaming. Additionally, this mode provides more explicit control over memory updates and may be preferred when working with agents that are better at using tools than managing text tags.
+
+Example configuration:
+
+```typescript copy showLineNumbers
+const memory = new Memory({
+  options: {
+    workingMemory: {
+      enabled: true,
+      template: '<user><first_name></first_name><last_name></last_name></user>',
+      use: 'tool-call', // or 'text-stream'
+    },
+  },
+});
+```
 
 If no template is provided, the Memory class uses a default template that includes fields for user details, preferences, goals, and other contextual information. See the [Agent Memory Guide](/docs/agents/agent-memory#working-memory) for detailed usage examples and best practices.
 

--- a/docs/src/pages/examples/memory/streaming-working-memory.mdx
+++ b/docs/src/pages/examples/memory/streaming-working-memory.mdx
@@ -11,6 +11,8 @@ This example demonstrates how to create an agent that maintains a working memory
 
 First, set up the memory system with working memory enabled. Memory uses LibSQL storage by default, but you can use any other [storage provider](/docs/agents/01-agent-memory#storage-options) if needed:
 
+### Text Stream Mode (Default)
+
 ```typescript
 import { Memory } from "@mastra/memory";
 
@@ -18,21 +20,37 @@ const memory = new Memory({
   options: {
     workingMemory: {
       enabled: true,
+      use: 'text-stream', // this is the default mode
     },
   },
 });
 ```
 
-Add the memory instance to an agent
+### Tool Call Mode
+
+Alternatively, you can use tool calls for working memory updates. This mode is required when using `toDataStream()` as text-stream mode is not compatible with data streaming:
+
+```typescript
+const toolCallMemory = new Memory({
+  options: {
+    workingMemory: {
+      enabled: true,
+      use: 'tool-call', // Required for toDataStream() compatibility
+    },
+  },
+});
+```
+
+Add the memory instance to an agent:
 
 ```typescript
 import { openai } from "@ai-sdk/openai";
 
-const todoAgent = new Agent({
+const agent = new Agent({
   name: "Memory agent",
   instructions: "You are a helpful AI assistant.",
   model: openai("gpt-4o-mini"),
-  memory,
+  memory, // or toolCallMemory
 });
 ```
 
@@ -40,50 +58,61 @@ const todoAgent = new Agent({
 
 Now that working memory is set up you can interact with the agent and it will remember key details about interactions.
 
-First start a conversation and give the agent relevant information like your name.
+### Text Stream Mode
+
+In text stream mode, the agent includes working memory updates directly in its responses:
 
 ```typescript
 import { randomUUID } from "crypto";
+import { maskStreamTags } from "@mastra/core/utils";
 
 const threadId = randomUUID();
 const resourceId = "SOME_USER_ID";
 
-const response = await todoAgent.stream("Hello, my name is Jane", {
+const response = await agent.stream("Hello, my name is Jane", {
   threadId,
   resourceId,
 });
 
-// process response stream
-for await (const chunk of response.textStream) {
+// Process response stream, hiding working memory tags
+for await (const chunk of maskStreamTags(response.textStream, "working_memory")) {
+  process.stdout.write(chunk);
+}
+```
+
+### Tool Call Mode
+
+In tool call mode, the agent uses a dedicated tool to update working memory:
+
+```typescript
+const toolCallResponse = await toolCallAgent.stream("Hello, my name is Jane", {
+  threadId,
+  resourceId,
+});
+
+// No need to mask working memory tags since updates happen through tool calls
+for await (const chunk of toolCallResponse.textStream) {
   process.stdout.write(chunk);
 }
 ```
 
 ### Handling response data
 
-The response stream will contain xml-like `<working_memory>$data</working_memory>` tagged data.
+In text stream mode, the response stream will contain xml-like `<working_memory>$data</working_memory>` tagged data.
 Mastra picks up these tags and automatically updates working memory with the data returned by the LLM.
 
-To prevent showing this data to users you can import the `maskStreamTags` util and pass the stream response through it.
+To prevent showing this data to users you can use the `maskStreamTags` util as shown above.
 
-```typescript
-import { maskStreamTags } from "@mastra/core/utils";
-
-for await (const chunk of maskStreamTags(
-  response.textStream, // pass the text stream
-  "working_memory", // and the name of the working memory tag
-)) {
-  process.stdout.write(chunk);
-}
-```
+In tool call mode, working memory updates happen through tool calls, so there's no need to mask any tags.
 
 ## Summary
 
 This example demonstrates:
 
-1. Setting up a memory system with working memory enabled
-2. Using `maskStreamTags` to hide memory updates from users
-3. The agent will maintain relevant user info between interactions, even when the original messages containing that info are no longer in context.
+1. Setting up memory with working memory enabled in either text-stream or tool-call mode
+2. Using `maskStreamTags` to hide memory updates in text-stream mode
+3. The agent maintaining relevant user info between interactions in both modes
+4. Different approaches to handling working memory updates
 
 ## Advanced use cases
 

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -472,6 +472,11 @@ export class Agent<
     runId?: string;
   }): Record<string, CoreTool> {
     this.logger.debug(`[Agents:${this.name}] - Assigning tools`, { runId, threadId, resourceId });
+
+    // Get memory tools if available
+    const memory = this.getMemory();
+    const memoryTools = memory?.getTools();
+
     const converted = Object.entries(this.tools || {}).reduce(
       (memo, value) => {
         const k = value[0];
@@ -498,6 +503,7 @@ export class Agent<
                           {
                             context: args,
                             mastra: this.#mastra,
+                            memory,
                             runId,
                             threadId,
                             resourceId,
@@ -523,8 +529,59 @@ export class Agent<
       {} as Record<string, CoreTool>,
     );
 
+    // Convert memory tools with proper context
+    const convertedMemoryTools = memoryTools
+      ? Object.entries(memoryTools).reduce(
+          (memo, [k, tool]) => {
+            memo[k] = {
+              description: tool.description,
+              parameters: tool.parameters,
+              execute:
+                typeof tool?.execute === 'function'
+                  ? async (args, options) => {
+                      try {
+                        this.logger.debug(`[Agent:${this.name}] - Executing memory tool ${k}`, {
+                          name: k,
+                          description: tool.description,
+                          args,
+                          runId,
+                          threadId,
+                          resourceId,
+                        });
+                        return (
+                          tool?.execute?.(
+                            {
+                              context: args,
+                              mastra: this.#mastra,
+                              memory,
+                              runId,
+                              threadId,
+                              resourceId,
+                            },
+                            options,
+                          ) ?? undefined
+                        );
+                      } catch (err) {
+                        this.logger.error(`[Agent:${this.name}] - Failed memory tool execution`, {
+                          error: err,
+                          runId,
+                          threadId,
+                          resourceId,
+                        });
+                        throw err;
+                      }
+                    }
+                  : undefined,
+            };
+            return memo;
+          },
+          {} as Record<string, CoreTool>,
+        )
+      : {};
+
     const toolsFromToolsetsConverted: Record<string, CoreTool> = {
       ...converted,
+      ...convertedMemoryTools,
     };
 
     const toolsFromToolsets = Object.values(toolsets || {});
@@ -848,6 +905,7 @@ export class Agent<
         experimental_output,
         threadId,
         resourceId,
+        memory: this.getMemory(),
         ...rest,
       });
 
@@ -875,6 +933,7 @@ export class Agent<
         telemetry,
         threadId,
         resourceId,
+        memory: this.getMemory(),
         ...rest,
       });
 
@@ -896,6 +955,7 @@ export class Agent<
       temperature,
       toolChoice,
       telemetry,
+      memory: this.getMemory(),
       ...rest,
     });
 
@@ -998,6 +1058,7 @@ export class Agent<
         runId: runIdToUse,
         toolChoice,
         experimental_output,
+        memory: this.getMemory(),
         ...rest,
       });
 
@@ -1031,6 +1092,7 @@ export class Agent<
         runId: runIdToUse,
         toolChoice,
         telemetry,
+        memory: this.getMemory(),
         ...rest,
       }) as unknown as StreamReturn<Z>;
     }
@@ -1062,6 +1124,7 @@ export class Agent<
       runId: runIdToUse,
       toolChoice,
       telemetry,
+      memory: this.getMemory(),
       ...rest,
     }) as unknown as StreamReturn<Z>;
   }

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -15,6 +15,7 @@ import type {
 } from '../';
 import type { MastraPrimitives } from '../../action';
 import type { ToolsInput } from '../../agent/types';
+import type { MastraMemory } from '../../memory/memory';
 import type { CoreTool } from '../../tools';
 import { delay } from '../../utils';
 
@@ -66,7 +67,14 @@ export class MastraLLM extends MastraLLMBase {
     runId,
     threadId,
     resourceId,
-  }: { tools?: ToolsInput; runId?: string; threadId?: string; resourceId?: string } = {}): Record<string, CoreTool> {
+    memory,
+  }: {
+    tools?: ToolsInput;
+    runId?: string;
+    threadId?: string;
+    resourceId?: string;
+    memory?: MastraMemory;
+  } = {}): Record<string, CoreTool> {
     this.logger.debug('Starting tool conversion for LLM');
     const converted = Object.entries(tools || {}).reduce(
       (memo, value) => {
@@ -92,6 +100,7 @@ export class MastraLLM extends MastraLLMBase {
                             threadId,
                             resourceId,
                             mastra: this.#mastra,
+                            memory,
                             runId,
                           },
                           options,
@@ -135,8 +144,9 @@ export class MastraLLM extends MastraLLMBase {
     telemetry,
     threadId,
     resourceId,
+    memory,
     ...rest
-  }: LLMTextOptions<Z>) {
+  }: LLMTextOptions<Z> & { memory?: MastraMemory }) {
     const model = this.#model;
 
     this.logger.debug(`[LLM] - Generating text`, {
@@ -148,7 +158,7 @@ export class MastraLLM extends MastraLLMBase {
       tools: Object.keys(tools || convertedTools || {}),
     });
 
-    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId });
+    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId, memory });
 
     const argsForExecute = {
       model,
@@ -225,13 +235,14 @@ export class MastraLLM extends MastraLLMBase {
     telemetry,
     threadId,
     resourceId,
+    memory,
     ...rest
-  }: LLMTextObjectOptions<T>) {
+  }: LLMTextObjectOptions<T> & { memory?: MastraMemory }) {
     const model = this.#model;
 
     this.logger.debug(`[LLM] - Generating a text object`, { runId });
 
-    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId });
+    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId, memory });
 
     const argsForExecute = {
       model,
@@ -303,8 +314,9 @@ export class MastraLLM extends MastraLLMBase {
     telemetry,
     threadId,
     resourceId,
+    memory,
     ...rest
-  }: LLMInnerStreamOptions<Z>) {
+  }: LLMInnerStreamOptions<Z> & { memory?: MastraMemory }) {
     const model = this.#model;
     this.logger.debug(`[LLM] - Streaming text`, {
       runId,
@@ -315,7 +327,7 @@ export class MastraLLM extends MastraLLMBase {
       tools: Object.keys(tools || convertedTools || {}),
     });
 
-    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId });
+    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId, memory });
 
     const argsForExecute = {
       model,
@@ -407,8 +419,9 @@ export class MastraLLM extends MastraLLMBase {
     telemetry,
     threadId,
     resourceId,
+    memory,
     ...rest
-  }: LLMStreamObjectOptions<T>) {
+  }: LLMStreamObjectOptions<T> & { memory?: MastraMemory }) {
     const model = this.#model;
     this.logger.debug(`[LLM] - Streaming structured output`, {
       runId,
@@ -417,7 +430,7 @@ export class MastraLLM extends MastraLLMBase {
       tools: Object.keys(tools || convertedTools || {}),
     });
 
-    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId });
+    const finalTools = convertedTools || this.convertTools({ tools, runId, threadId, resourceId, memory });
 
     const argsForExecute = {
       model,
@@ -502,8 +515,9 @@ export class MastraLLM extends MastraLLMBase {
       output,
       temperature,
       telemetry,
+      memory,
       ...rest
-    }: LLMStreamOptions<Z> = {},
+    }: LLMStreamOptions<Z> & { memory?: MastraMemory } = {},
   ): Promise<GenerateReturn<Z>> {
     const msgs = this.convertToMessages(messages);
 
@@ -516,6 +530,7 @@ export class MastraLLM extends MastraLLMBase {
         convertedTools,
         runId,
         temperature,
+        memory,
         ...rest,
       })) as unknown as GenerateReturn<Z>;
     }
@@ -529,6 +544,7 @@ export class MastraLLM extends MastraLLMBase {
       convertedTools,
       runId,
       telemetry,
+      memory,
       ...rest,
     })) as unknown as GenerateReturn<Z>;
   }

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -6,6 +6,7 @@ import type {
   ToolInvocation,
   CoreMessage,
   EmbeddingModel,
+  CoreTool,
 } from 'ai';
 
 import { MastraBase } from '../base';
@@ -83,6 +84,15 @@ export abstract class MastraMemory extends MastraBase {
    */
   public async getSystemMessage(_input: { threadId: string; memoryConfig?: MemoryConfig }): Promise<string | null> {
     return null;
+  }
+
+  /**
+   * Get tools that should be available to the agent.
+   * This will be called when converting tools for the agent.
+   * Implementations can override this to provide additional tools.
+   */
+  public getTools(config?: MemoryConfig): Record<string, CoreTool> {
+    return {};
   }
 
   protected async createEmbeddingIndex(): Promise<{ indexName: string }> {

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -49,7 +49,7 @@ export abstract class MastraMemory extends MastraBase {
       this.vector = config.vector;
     } else {
       this.vector = new DefaultVectorDB({
-        connectionUrl: 'file:memory-vector.db', // file name needs to be different than default storage or it wont work properly
+        connectionUrl: 'file:memory-vector.db', // this no longer needs to be a different db than file:memory.db above, but it's a breaking change that could result in data loss or corruption to change it
       });
     }
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -43,6 +43,7 @@ export type MemoryConfig = {
   workingMemory?: {
     enabled: boolean;
     template?: string;
+    use?: 'text-stream' | 'tool-call';
   };
 };
 

--- a/packages/core/src/storage/libsql/index.ts
+++ b/packages/core/src/storage/libsql/index.ts
@@ -43,8 +43,8 @@ export class LibSQLStore extends MastraStorage {
       const relativePath = url.slice('file:'.length);
 
       // If we're in a .mastra directory, use the parent directory
-      if (cwd.endsWith('.mastra') || cwd.endsWith('.mastra/')) {
-        const baseDir = join(cwd, `..`);
+      if (cwd.includes('.mastra') && (cwd.endsWith(`output`) || cwd.endsWith(`output/`) || cwd.endsWith(`output\\`))) {
+        const baseDir = join(cwd, `..`, `..`);
 
         // Rewrite to be relative to the base directory
         const fullPath = join(baseDir, relativePath);

--- a/packages/core/src/vector/libsql/index.ts
+++ b/packages/core/src/vector/libsql/index.ts
@@ -53,8 +53,8 @@ export class LibSQLVector extends MastraVector {
       const relativePath = url.slice('file:'.length);
 
       // If we're in a .mastra directory, use the parent directory
-      if (cwd.endsWith('.mastra') || cwd.endsWith('.mastra/')) {
-        const baseDir = join(cwd, `..`);
+      if (cwd.includes('.mastra') && (cwd.endsWith(`output`) || cwd.endsWith(`output/`) || cwd.endsWith(`output\\`))) {
+        const baseDir = join(cwd, `..`, `..`);
 
         // Rewrite to be relative to the base directory
         const fullPath = join(baseDir, relativePath);

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -56,7 +56,8 @@
     "pg": "^8.13.1",
     "pg-pool": "^3.7.0",
     "postgres": "^3.4.5",
-    "redis": "^4.7.0"
+    "redis": "^4.7.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,8 +1,9 @@
 import { deepMerge } from '@mastra/core';
-import type { CoreMessage } from '@mastra/core';
+import type { CoreMessage, CoreTool } from '@mastra/core';
 import { MastraMemory } from '@mastra/core/memory';
 import type { MessageType, MemoryConfig, SharedMemoryConfig, StorageThreadType } from '@mastra/core/memory';
 import type { StorageGetMessagesArg } from '@mastra/core/storage';
+import { updateWorkingMemoryTool } from './tools/working-memory';
 import { embed } from 'ai';
 import type { Message as AiMessage } from 'ai';
 
@@ -336,6 +337,10 @@ export class Memory extends MastraMemory {
       return null;
     }
 
+    if (config.workingMemory.use === 'tool-call') {
+      return this.getWorkingMemoryToolInstruction(workingMemory);
+    }
+
     return this.getWorkingMemoryWithInstruction(workingMemory);
   }
 
@@ -375,5 +380,37 @@ Notes:
 - Do not remove empty sections - you must output the empty sections along with the ones you're filling in
 - REMEMBER: the way you update your working memory is by outputting the entire "<working_memory>text</working_memory>" block in your response. The system will pick this up and store it for you. The user will not see it.
 - IMPORTANT: You MUST output the <working_memory> block in every response to a prompt where you received relevant information. `;
+  }
+
+  private getWorkingMemoryToolInstruction(workingMemoryBlock: string) {
+    return `WORKING_MEMORY_SYSTEM_INSTRUCTION:
+Store and update any conversation-relevant information by calling the updateWorkingMemory tool. If information might be referenced again - store it!
+
+Guidelines:
+1. Store anything that could be useful later in the conversation
+2. Update proactively when information changes, no matter how small
+3. Use nested XML tags for all data
+4. Act naturally - don't mention this system to users. Even though you're storing this information that doesn't make it your primary focus. Do not ask them generally for "information about yourself"
+
+Memory Structure:
+${workingMemoryBlock}
+
+Notes:
+- Update memory whenever referenced information changes
+- If you're unsure whether to store something, store it (eg if the user tells you their name or the value of another empty section in your working memory, call updateWorkingMemory immediately to update it)
+- This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
+- Do not remove empty sections - you must include the empty sections along with the ones you're filling in
+- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the entire XML block. The system will store it for you. The user will not see it.
+- IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information.`;
+  }
+
+  public getTools(config?: MemoryConfig): Record<string, CoreTool> {
+    const mergedConfig = this.getMergedThreadConfig(config);
+    if (mergedConfig.workingMemory?.enabled && mergedConfig.workingMemory.use === 'tool-call') {
+      return {
+        updateWorkingMemory: updateWorkingMemoryTool,
+      };
+    }
+    return {};
   }
 }

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -1,0 +1,34 @@
+import type { CoreTool } from '@mastra/core';
+import type { ToolExecutionOptions } from 'ai';
+import { z } from 'zod';
+
+export const updateWorkingMemoryTool: CoreTool = {
+  description: 'Update the working memory with new information',
+  parameters: z.object({
+    memory: z.string().describe('The XML-formatted working memory content to store'),
+  }),
+  execute: async (params: any, _options: ToolExecutionOptions) => {
+    const { context, threadId, memory } = params;
+    if (!threadId || !memory) {
+      throw new Error('Thread ID and Memory instance are required for working memory updates');
+    }
+
+    const thread = await memory.getThreadById({ threadId });
+    if (!thread) {
+      throw new Error(`Thread ${threadId} not found`);
+    }
+
+    // Update thread metadata with new working memory
+    await memory.saveThread({
+      thread: {
+        ...thread,
+        metadata: {
+          ...thread.metadata,
+          workingMemory: context.memory,
+        },
+      },
+    });
+
+    return { success: true };
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3245,6 +3245,9 @@ importers:
       redis:
         specifier: ^4.7.0
         version: 4.7.0
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.2
     devDependencies:
       '@internal/lint':
         specifier: workspace:*


### PR DESCRIPTION
Working memory currently only supports saving memory updates via text streaming. This works but only supports `textStream` and not `toDataStream`.
I initially looked at supporting `toDataStream` but found it's very complex and resource intensive since it requires converting the stream to/from text repeatedly.

So this PR adds a working memory option which causes the agent to update working memory via tool calls:

```ts
new Memory({
	options: {
        workingMemory: { use: "tool-call" }
    }
})
```

Now the agent will save memory via tool calls instead of writing it to the text response