### PR TITLE
Update heading level of "Working memory" in 01-agent-memory.mdx

### DIFF
--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -405,7 +405,7 @@ await memory.deleteThread(thread.id);
 
 Note that in most cases, you won't need to manage threads manually since the agent's `generate()` and `stream()` methods handle thread management automatically. Manual thread management is primarily useful for advanced use cases or when you need more fine-grained control over the conversation history.
 
-### Working Memory
+## Working Memory
 
 Working memory is a powerful feature that allows agents to maintain persistent information across conversations, even with minimal context. This is particularly useful for remembering user preferences, personal details, or any other contextual information that should persist throughout interactions.
 


### PR DESCRIPTION
The heading "Working memory" was previously under "Manually Managing Threads" which does not make sense. It should be in a separate section.