### PR TITLE
fix(core): optional fields in jsonSchemaToModel

### DIFF
--- a/.changeset/witty-papayas-fall.md
+++ b/.changeset/witty-papayas-fall.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+When converting JSON schemas to Zod schemas, we were sometimes marking optional fields as nullable instead, making them required with a null value, even if the schema didn't mark them as required

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -89,7 +89,7 @@ export function jsonSchemaToModel(jsonSchema: Record<string, any>): ZodObject<an
     if (requiredFields.includes(key)) {
       zodSchema[key] = zodType;
     } else {
-      zodSchema[key] = zodType.nullable();
+      zodSchema[key] = zodType.nullable().optional();
     }
   }
 


### PR DESCRIPTION
I noticed with MCP server tools optional args were being marked as required and throwing errors, this seems to be why: `.nullable` means null must be passed, we also need `.optional` to make the field not required at all.