### PR TITLE
feat: allow max context length

### DIFF
--- a/.changeset/orange-pianos-worry.md
+++ b/.changeset/orange-pianos-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add maxContextLength to agent config

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -23,6 +23,7 @@ export interface AgentConfig<
   name: string;
   instructions: string;
   model: LanguageModelV1;
+  maxContextLength?: number;
   tools?: TTools;
   mastra?: MastraPrimitives;
   /** @deprecated This property is deprecated. Use evals instead to add evaluation metrics. */


### PR DESCRIPTION
### Summary
- Added the ability to optionally pass in `maxContextLength` to `Agent`

This is a feature that existed in LangChain + LangSmith workflow, allowing for a *sticky* `systemMessage` (instructions in Mastra terms). Adding this allows for devs to utilize this without having to self implement

### Tests Added
- [x] Added unit tests