### PR TITLE
docs(memory):  storage+vector don't need to be configured for defaults

### DIFF
--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -447,7 +447,6 @@ const agent = new Agent({
   model: openai("gpt-4o-mini"),
 
   memory: new Memory({
-    storage: new LibSQLStore({ url: ":memory:" }),
     options: {
       workingMemory: {
         enabled: true, // enables working memory
@@ -467,7 +466,6 @@ const todoAgent = new Agent({
     "You are a TODO list manager. Update the todo list in working memory whenever tasks are added, completed, or modified.",
   model: openai("gpt-4o-mini"),
   memory: new Memory({
-    storage: new LibSQLStore({ url: ":memory:" }),
     options: {
       workingMemory: {
         enabled: true,

--- a/docs/src/pages/docs/reference/memory/Memory.mdx
+++ b/docs/src/pages/docs/reference/memory/Memory.mdx
@@ -23,12 +23,12 @@ import { LibSQLVector } from "@mastra/core/vector/libsql";
 import { Agent } from "@mastra/core/agent";
 
 const memory = new Memory({
-  // Custom storage configuration
+  // Optional storage configuration - libsql will be used by default
   storage: new LibSQLStore({
     url: "file:memory.db",
   }),
 
-  // Custom vector database for semantic search
+  // Optional vector database for semantic search - libsql will be used by default
   vector: new LibSQLVector({
     url: "file:vector.db",
   }),
@@ -70,7 +70,7 @@ const agent = new Agent({
       name: "storage",
       type: "MastraStorage",
       description: "Storage implementation for persisting memory data",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "vector",
@@ -159,8 +159,8 @@ const memory = new Memory({
   options: {
     workingMemory: {
       enabled: true,
-      template: '<user><first_name></first_name><last_name></last_name></user>',
-      use: 'tool-call', // or 'text-stream'
+      template: "<user><first_name></first_name><last_name></last_name></user>",
+      use: "tool-call", // or 'text-stream'
     },
   },
 });
@@ -171,33 +171,6 @@ If no template is provided, the Memory class uses a default template that includ
 ### embedder
 
 By default, Memory uses FastEmbed with the `bge-small-en-v1.5` model, which provides a good balance of performance and model size (~130MB). You only need to specify an embedder if you want to use a different model or provider.
-
-## Additional Notes
-
-### Vector Search Configuration
-
-When using vector search capabilities with custom configuration, ensure you configure both the vector store and appropriate search options. Here's an example:
-
-```typescript copy showLineNumbers
-import { Memory } from "@mastra/memory";
-import { LibSQLStore } from "@mastra/core/storage/libsql";
-import { LibSQLVector } from "@mastra/core/vector/libsql";
-
-const memory = new Memory({
-  storage: new LibSQLStore({
-    url: ":memory:",
-  }),
-  vector: new LibSQLVector({
-    url: ":memory:",
-  }),
-  options: {
-    semanticRecall: {
-      topK: 5,
-      messageRange: 2,
-    },
-  },
-});
-```
 
 ### Related
 

--- a/docs/src/pages/docs/reference/rag/libsql.mdx
+++ b/docs/src/pages/docs/reference/rag/libsql.mdx
@@ -5,7 +5,7 @@ description: Documentation for the LibSQLVector class in Mastra, which provides 
 
 # LibSQLVector Store
 
-The LibSQL storage implementation provides a SQLite-compatible vector search  [LibSQL](https://github.com/tursodatabase/libsql), a fork of SQLite with vector extensions, and [Turso](https://turso.tech/) with vector extensions, offering a lightweight and efficient vector database solution.
+The LibSQL storage implementation provides a SQLite-compatible vector search [LibSQL](https://github.com/tursodatabase/libsql), a fork of SQLite with vector extensions, and [Turso](https://turso.tech/) with vector extensions, offering a lightweight and efficient vector database solution.
 It's part of the `@mastra/core` package and offers efficient vector similarity search with metadata filtering.
 
 ## Installation
@@ -64,7 +64,7 @@ const results = await store.query({
       name: "connectionUrl",
       type: "string",
       description:
-        "LibSQL database URL. Use ':memory:' for in-memory database, 'file:local.db' for local file, or a LibSQL-compatible connection string like 'libsql://your-database.turso.io'.",
+        "LibSQL database URL. Use ':memory:' for in-memory database, 'file:dbname.db' for local file, or a LibSQL-compatible connection string like 'libsql://your-database.turso.io'.",
     },
     {
       name: "authToken",

--- a/docs/src/pages/docs/reference/storage/libsql.mdx
+++ b/docs/src/pages/docs/reference/storage/libsql.mdx
@@ -18,9 +18,9 @@ npm install @mastra/storage-libsql
 ```typescript copy showLineNumbers
 import { LibSQLStore } from "@mastra/core/storage/libsql";
 
-// In-memory database (development)
+// File database (development)
 const storage = new LibSQLStore({
-  url: ":memory:",
+  url: "file:storage.db",
 });
 
 // Persistent database (production)
@@ -37,7 +37,7 @@ const storage = new LibSQLStore({
       name: "url",
       type: "string",
       description:
-        "Database URL. Use ':memory:' for in-memory database or a LibSQL-compatible connection string for persistent storage.",
+        "Database URL. Use ':memory:' for in-memory database, 'file:filename.db' for a file database, or any LibSQL-compatible connection string for persistent storage.",
       isOptional: false,
     },
     {
@@ -53,16 +53,13 @@ const storage = new LibSQLStore({
 
 ### In-Memory vs Persistent Storage
 
-The in-memory configuration (`:memory:`) is useful for:
+The file configuration (`file:storage.db`) is useful for:
 
 - Development and testing
-- Temporary storage that doesn't need to persist
+- Temporary storage
 - Quick prototyping
 
-For production use cases, use a persistent database URL:
-
-- Local file: `file:local.db`
-- Remote LibSQL: `libsql://your-database.turso.io`
+For production use cases, use a persistent database URL: `libsql://your-database.turso.io`
 
 ### Schema Management
 


### PR DESCRIPTION
In https://github.com/mastra-ai/mastra/issues/2712 it was confusing to show setting up an in memory db for memory

1. Using an fs db for local dev is much better
2. To get started these don't need to be configured at all