### PR TITLE
fix(core): handle arrays and numbers in memory messages

### DIFF
--- a/.changeset/dark-snails-greet.md
+++ b/.changeset/dark-snails-greet.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an issue where messages that were numbers weren't being stored as strings. Fixed incorrect array access when retrieving memory messages

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -400,6 +400,8 @@ export class Agent<
     let toolCallIds: Array<string> = [];
 
     for (const message of messages) {
+      if (!Array.isArray(message.content)) continue;
+
       if (message.role === 'tool') {
         for (const content of message.content) {
           if (content.type === 'tool-result') {
@@ -420,7 +422,9 @@ export class Agent<
     const messagesBySanitizedContent = messages.map(message => {
       if (message.role !== 'assistant' && message.role !== `tool` && message.role !== `user`) return message;
 
-      if (typeof message.content === 'string') return message;
+      if (!message.content || typeof message.content === 'string' || typeof message.content === 'number') {
+        return message;
+      }
 
       const sanitizedContent = message.content.filter(content => {
         if (content.type === `tool-call`) {

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -155,7 +155,9 @@ export abstract class MastraMemory extends MastraBase {
       content:
         typeof msg.content === 'string' && (msg.content.startsWith('[') || msg.content.startsWith('{'))
           ? JSON.parse((msg as MessageType).content as string)
-          : msg.content,
+          : typeof msg.content === 'number'
+            ? String(msg.content)
+            : msg.content,
     }));
   }
 
@@ -212,6 +214,8 @@ export abstract class MastraMemory extends MastraBase {
 
         if (typeof message.content === 'string') {
           textContent = message.content;
+        } else if (typeof message.content === 'number') {
+          textContent = String(message.content);
         } else if (Array.isArray(message.content)) {
           for (const content of message.content) {
             if (content.type === 'text') {


### PR DESCRIPTION
The missing checks here for if the message content was a number were resulting in an empty string being sent to the llm "" which caused errors.
Not checking if message content was an array before iterating also led to errors. May be related to https://github.com/mastra-ai/mastra/issues/2667