### PR TITLE
Fix mastra init in non npm packageManager project

### DIFF
--- a/.changeset/crazy-wolves-mate.md
+++ b/.changeset/crazy-wolves-mate.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'create-mastra': patch
+---
+
+Fix init in non npm project

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -15,6 +15,7 @@ import {
   writeIndexFile,
 } from './utils';
 import type { Components, LLMProvider } from './utils';
+import { DepsService } from '../../services/service.deps';
 
 const s = p.spinner();
 
@@ -67,7 +68,8 @@ export const init = async ({
     const key = await getAPIKey(llmProvider || 'openai');
 
     const aiSdkPackage = getAISDKPackage(llmProvider);
-    const pm = getPackageManager();
+    const depsService = new DepsService();
+    const pm = depsService.packageManager;
     const installCommand = getPackageManagerInstallCommand(pm);
     await exec(`${pm} ${installCommand} ${aiSdkPackage}`);
 

--- a/packages/cli/src/services/service.deps.ts
+++ b/packages/cli/src/services/service.deps.ts
@@ -7,7 +7,7 @@ import fsExtra from 'fs-extra/esm';
 import type { PackageJson } from 'type-fest';
 
 export class DepsService {
-  private packageManager: string;
+  readonly packageManager: string;
 
   constructor() {
     this.packageManager = this.getPackageManager();


### PR DESCRIPTION
- **Fix mastra init in non npm packageManager**
- **changeset**

When mastra init is ran standalone, today we still try to discover the package manager in the create install command which might be wrong, as it init could be the entry point. At this point in init, we'll want to use the lockfile to decipher what type of project manager is used in the project
