### PR TITLE
Document new workflow looping APIs

### DIFF
--- a/.changeset/tangy-rules-hunt.md
+++ b/.changeset/tangy-rules-hunt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add documentation for workflow looping APIs

--- a/docs/src/pages/docs/reference/workflows/_meta.ts
+++ b/docs/src/pages/docs/reference/workflows/_meta.ts
@@ -6,6 +6,8 @@ const meta = {
   "step-function": ".step()",
   after: ".after()",
   then: ".then()",
+  until: ".until()",
+  while: ".while()",
   createRun: ".createRun()",
   start: ".start()",
   execute: ".execute()",

--- a/docs/src/pages/docs/reference/workflows/until.mdx
+++ b/docs/src/pages/docs/reference/workflows/until.mdx
@@ -1,0 +1,165 @@
+---
+title: "Reference: Workflow.until() | Looping in Workflows | Mastra Docs"
+description: "Documentation for the `.until()` method in Mastra workflows, which repeats a step until a specified condition becomes true."
+---
+
+# Workflow.until()
+
+The `.until()` method repeats a step until a specified condition becomes true. This creates a loop that continues executing the specified step until the condition is satisfied.
+
+## Usage
+
+```typescript
+workflow
+  .step(incrementStep)
+  .until(condition, incrementStep)
+  .then(finalStep);
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "condition",
+      type: "Function | ReferenceCondition",
+      description: "A function or reference condition that determines when to stop looping",
+      isOptional: false
+    },
+    {
+      name: "step",
+      type: "Step",
+      description: "The step to repeat until the condition is met",
+      isOptional: false
+    }
+  ]}
+/>
+
+## Condition Types
+
+### Function Condition
+
+You can use a function that returns a boolean:
+
+```typescript
+workflow
+  .step(incrementStep)
+  .until(async ({ context }) => {
+    const result = context.getStepResult<{ value: number }>('increment');
+    return (result?.value ?? 0) >= 10; // Stop when value reaches or exceeds 10
+  }, incrementStep)
+  .then(finalStep);
+```
+
+### Reference Condition
+
+You can use a reference-based condition with comparison operators:
+
+```typescript
+workflow
+  .step(incrementStep)
+  .until(
+    {
+      ref: { step: incrementStep, path: 'value' },
+      query: { $gte: 10 }, // Stop when value is greater than or equal to 10
+    },
+    incrementStep
+  )
+  .then(finalStep);
+```
+
+## Comparison Operators
+
+When using reference-based conditions, you can use these comparison operators:
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `$eq`    | Equal to    | `{ $eq: 10 }` |
+| `$ne`    | Not equal to | `{ $ne: 0 }` |
+| `$gt`    | Greater than | `{ $gt: 5 }` |
+| `$gte`   | Greater than or equal to | `{ $gte: 10 }` |
+| `$lt`    | Less than | `{ $lt: 20 }` |
+| `$lte`   | Less than or equal to | `{ $lte: 15 }` |
+
+## Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: "workflow",
+      type: "Workflow",
+      description: "The workflow instance for chaining"
+    }
+  ]}
+/>
+
+## Example
+
+```typescript
+import { Workflow, Step } from '@mastra/core';
+import { z } from 'zod';
+
+// Create a step that increments a counter
+const incrementStep = new Step({
+  id: 'increment',
+  description: 'Increments the counter by 1',
+  outputSchema: z.object({
+    value: z.number(),
+  }),
+  execute: async ({ context }) => {
+    // Get current value from previous execution or start at 0
+    const currentValue =
+      context.getStepResult<{ value: number }>('increment')?.value ||
+      context.getStepResult<{ startValue: number }>('trigger')?.startValue ||
+      0;
+
+    // Increment the value
+    const value = currentValue + 1;
+    console.log(`Incrementing to ${value}`);
+
+    return { value };
+  },
+});
+
+// Create a final step
+const finalStep = new Step({
+  id: 'final',
+  description: 'Final step after loop completes',
+  execute: async ({ context }) => {
+    const finalValue = context.getStepResult<{ value: number }>('increment')?.value;
+    console.log(`Loop completed with final value: ${finalValue}`);
+    return { finalValue };
+  },
+});
+
+// Create the workflow
+const counterWorkflow = new Workflow({
+  name: 'counter-workflow',
+  triggerSchema: z.object({
+    startValue: z.number(),
+    targetValue: z.number(),
+  }),
+});
+
+// Configure the workflow with an until loop
+counterWorkflow
+  .step(incrementStep)
+  .until(async ({ context }) => {
+    const targetValue = context.triggerData.targetValue;
+    const currentValue = context.getStepResult<{ value: number }>('increment')?.value ?? 0;
+    return currentValue >= targetValue;
+  }, incrementStep)
+  .then(finalStep)
+  .commit();
+
+// Execute the workflow
+const run = counterWorkflow.createRun();
+const result = await run.start({ triggerData: { startValue: 0, targetValue: 5 } });
+// Will increment from 0 to 5, then stop and execute finalStep
+```
+
+## Related
+
+- [.while()](./while.mdx) - Loop while a condition is true
+- [Control Flow Guide](../../workflows/control-flow.mdx#loop-control-with-until-and-while)
+- [Workflow Class Reference](./workflow.mdx)

--- a/docs/src/pages/docs/reference/workflows/while.mdx
+++ b/docs/src/pages/docs/reference/workflows/while.mdx
@@ -1,0 +1,168 @@
+---
+title: "Reference: Workflow.while() | Looping in Workflows | Mastra Docs"
+description: "Documentation for the `.while()` method in Mastra workflows, which repeats a step as long as a specified condition remains true."
+---
+
+# Workflow.while()
+
+The `.while()` method repeats a step as long as a specified condition remains true. This creates a loop that continues executing the specified step until the condition becomes false.
+
+## Usage
+
+```typescript
+workflow
+  .step(incrementStep)
+  .while(condition, incrementStep)
+  .then(finalStep);
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "condition",
+      type: "Function | ReferenceCondition",
+      description: "A function or reference condition that determines when to continue looping",
+      isOptional: false
+    },
+    {
+      name: "step",
+      type: "Step",
+      description: "The step to repeat while the condition is true",
+      isOptional: false
+    }
+  ]}
+/>
+
+## Condition Types
+
+### Function Condition
+
+You can use a function that returns a boolean:
+
+```typescript
+workflow
+  .step(incrementStep)
+  .while(async ({ context }) => {
+    const result = context.getStepResult<{ value: number }>('increment');
+    return (result?.value ?? 0) < 10; // Continue as long as value is less than 10
+  }, incrementStep)
+  .then(finalStep);
+```
+
+### Reference Condition
+
+You can use a reference-based condition with comparison operators:
+
+```typescript
+workflow
+  .step(incrementStep)
+  .while(
+    {
+      ref: { step: incrementStep, path: 'value' },
+      query: { $lt: 10 }, // Continue as long as value is less than 10
+    },
+    incrementStep
+  )
+  .then(finalStep);
+```
+
+## Comparison Operators
+
+When using reference-based conditions, you can use these comparison operators:
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `$eq`    | Equal to    | `{ $eq: 10 }` |
+| `$ne`    | Not equal to | `{ $ne: 0 }` |
+| `$gt`    | Greater than | `{ $gt: 5 }` |
+| `$gte`   | Greater than or equal to | `{ $gte: 10 }` |
+| `$lt`    | Less than | `{ $lt: 20 }` |
+| `$lte`   | Less than or equal to | `{ $lte: 15 }` |
+
+## Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: "workflow",
+      type: "Workflow",
+      description: "The workflow instance for chaining"
+    }
+  ]}
+/>
+
+## Example
+
+```typescript
+import { Workflow, Step } from '@mastra/core';
+import { z } from 'zod';
+
+// Create a step that increments a counter
+const incrementStep = new Step({
+  id: 'increment',
+  description: 'Increments the counter by 1',
+  outputSchema: z.object({
+    value: z.number(),
+  }),
+  execute: async ({ context }) => {
+    // Get current value from previous execution or start at 0
+    const currentValue =
+      context.getStepResult<{ value: number }>('increment')?.value ||
+      context.getStepResult<{ startValue: number }>('trigger')?.startValue ||
+      0;
+
+    // Increment the value
+    const value = currentValue + 1;
+    console.log(`Incrementing to ${value}`);
+
+    return { value };
+  },
+});
+
+// Create a final step
+const finalStep = new Step({
+  id: 'final',
+  description: 'Final step after loop completes',
+  execute: async ({ context }) => {
+    const finalValue = context.getStepResult<{ value: number }>('increment')?.value;
+    console.log(`Loop completed with final value: ${finalValue}`);
+    return { finalValue };
+  },
+});
+
+// Create the workflow
+const counterWorkflow = new Workflow({
+  name: 'counter-workflow',
+  triggerSchema: z.object({
+    startValue: z.number(),
+    targetValue: z.number(),
+  }),
+});
+
+// Configure the workflow with a while loop
+counterWorkflow
+  .step(incrementStep)
+  .while(
+    async ({ context }) => {
+      const targetValue = context.triggerData.targetValue;
+      const currentValue = context.getStepResult<{ value: number }>('increment')?.value ?? 0;
+      return currentValue < targetValue;
+    },
+    incrementStep
+  )
+  .then(finalStep)
+  .commit();
+
+// Execute the workflow
+const run = counterWorkflow.createRun();
+const result = await run.start({ triggerData: { startValue: 0, targetValue: 5 } });
+// Will increment from 0 to 4, then stop and execute finalStep
+```
+
+## Related
+
+- [.until()](./until.mdx) - Loop until a condition becomes true
+- [Control Flow Guide](../../workflows/control-flow.mdx#loop-control-with-until-and-while)
+- [Workflow Class Reference](./workflow.mdx)

--- a/docs/src/pages/docs/workflows/control-flow.mdx
+++ b/docs/src/pages/docs/workflows/control-flow.mdx
@@ -9,7 +9,7 @@ When you create a multi-step process, you may need to run steps in parallel, cha
 
 ## Parallel Execution
 
-You can run multiple steps at the same time if they don’t depend on each other. This approach can speed up your workflow when steps perform independent tasks. The code below shows how to add two steps in parallel:
+You can run multiple steps at the same time if they don't depend on each other. This approach can speed up your workflow when steps perform independent tasks. The code below shows how to add two steps in parallel:
 
 ```typescript
 myWorkflow.step(fetchUserData).step(fetchOrderData);
@@ -54,7 +54,7 @@ See the [Branching Paths](../../examples/workflows/branching-paths.mdx) example 
 
 ## Cyclical Dependencies
 
-You can loop back to earlier steps based on conditions, allowing you to repeat tasks until certain results are achieved. The code below shows a workflow that repeats fetchData when a status is “retry”:
+You can loop back to earlier steps based on conditions, allowing you to repeat tasks until certain results are achieved. The code below shows a workflow that repeats fetchData when a status is "retry":
 
 ```typescript
 myWorkflow
@@ -69,9 +69,90 @@ myWorkflow
   });
 ```
 
-If processData returns “success,” finalizeData runs. If it returns “retry,” the workflow loops back to fetchData.
+If processData returns "success," finalizeData runs. If it returns "retry," the workflow loops back to fetchData.
 
 See the [Cyclical Dependencies](../../examples/workflows/cyclical-dependencies.mdx) example for more details.
+
+## Loop Control with `until` and `while`
+
+Mastra provides dedicated methods for creating loops in workflows: `until` and `while`. These methods offer a more intuitive way to implement repetitive tasks compared to manual cyclical dependencies.
+
+### Using `until`
+
+The `until` method repeats a step until a specified condition becomes true. It takes two arguments:
+1. A condition that determines when to stop looping
+2. The step to repeat
+
+```typescript
+workflow
+  .step(incrementStep)
+  .until(async ({ context }) => {
+    // Stop when the value reaches or exceeds 10
+    const result = context.getStepResult<{ value: number }>('increment');
+    return (result?.value ?? 0) >= 10;
+  }, incrementStep)
+  .then(finalStep);
+```
+
+You can also use a reference-based condition:
+
+```typescript
+workflow
+  .step(incrementStep)
+  .until(
+    {
+      ref: { step: incrementStep, path: 'value' },
+      query: { $gte: 10 },
+    },
+    incrementStep
+  )
+  .then(finalStep);
+```
+
+### Using `while`
+
+The `while` method repeats a step as long as a specified condition remains true. It takes the same arguments as `until`:
+1. A condition that determines when to continue looping
+2. The step to repeat
+
+```typescript
+workflow
+  .step(incrementStep)
+  .while(async ({ context }) => {
+    // Continue as long as the value is less than 10
+    const result = context.getStepResult<{ value: number }>('increment');
+    return (result?.value ?? 0) < 10;
+  }, incrementStep)
+  .then(finalStep);
+```
+
+You can also use a reference-based condition:
+
+```typescript
+workflow
+  .step(incrementStep)
+  .while(
+    {
+      ref: { step: incrementStep, path: 'value' },
+      query: { $lt: 10 },
+    },
+    incrementStep
+  )
+  .then(finalStep);
+```
+
+### Comparison Operators
+
+When using reference-based conditions, you can use these comparison operators:
+
+| Operator | Description |
+|----------|-------------|
+| `$eq`    | Equal to    |
+| `$ne`    | Not equal to |
+| `$gt`    | Greater than |
+| `$gte`   | Greater than or equal to |
+| `$lt`    | Less than |
+| `$lte`   | Less than or equal to |
 
 ## Conditions
 

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -768,6 +768,63 @@ describe('Workflow', async () => {
       // @ts-ignore
       expect(results.increment.output).toEqual({ newValue: 10 });
     });
+
+    it('should run a while loop with a condition function', async () => {
+      const increment = vi.fn().mockImplementation(async ({ context }) => {
+        // Get the current value (either from trigger or previous increment)
+        const currentValue =
+          context.getStepResult('increment')?.newValue || context.getStepResult('trigger')?.startValue || 0;
+
+        // Increment the value
+        const newValue = currentValue + 1;
+
+        return { newValue };
+      });
+      const incrementStep = new Step({
+        id: 'increment',
+        description: 'Increments the current value by 1',
+        outputSchema: z.object({
+          newValue: z.number(),
+        }),
+        execute: increment,
+      });
+
+      const final = vi.fn().mockImplementation(async ({ context }) => {
+        return { finalValue: context.getStepResult('increment')?.newValue };
+      });
+      const finalStep = new Step({
+        id: 'final',
+        description: 'Final step that prints the result',
+        execute: final,
+      });
+
+      const counterWorkflow = new Workflow({
+        name: 'counter-workflow',
+        triggerSchema: z.object({
+          target: z.number(),
+          startValue: z.number(),
+        }),
+      });
+
+      counterWorkflow
+        .step(incrementStep)
+        .while(async ({ context }) => {
+          const res = context.getStepResult<{ newValue: number }>('increment');
+          return (res?.newValue ?? 0) < 10;
+        }, incrementStep)
+        .then(finalStep)
+        .commit();
+
+      const run = counterWorkflow.createRun();
+      const { results } = await run.start({ triggerData: { target: 10, startValue: 0 } });
+
+      expect(increment).toHaveBeenCalledTimes(10);
+      expect(final).toHaveBeenCalledTimes(1);
+      // @ts-ignore
+      expect(results.final.output).toEqual({ finalValue: 10 });
+      // @ts-ignore
+      expect(results.increment.output).toEqual({ newValue: 10 });
+    });
   });
 
   describe('Schema Validation', () => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -169,6 +169,7 @@ export class Workflow<
     applyOperator: (op: string, value: any, target: any) => { status: string },
     condition: StepConfig<FallbackStep, CondStep, VarStep, TTriggerSchema>['when'],
     fallbackStep: FallbackStep,
+    loopType?: 'while' | 'until',
   ) {
     const lastStepKey = this.#lastStepStack[this.#lastStepStack.length - 1];
     // If no last step, we can't do anything
@@ -186,7 +187,11 @@ export class Workflow<
       execute: async ({ context }: any) => {
         if (typeof condition === 'function') {
           const result = await condition({ context });
-          return { status: result ? 'complete' : 'continue' };
+          if (loopType === 'while') {
+            return { status: result ? 'continue' : 'complete' };
+          } else {
+            return { status: result ? 'complete' : 'continue' };
+          }
         }
 
         // For query-based conditions, we need to:
@@ -286,7 +291,7 @@ export class Workflow<
       }
     };
 
-    return this.loop(applyOperator, condition, fallbackStep);
+    return this.loop(applyOperator, condition, fallbackStep, 'while');
   }
 
   until<
@@ -313,7 +318,7 @@ export class Workflow<
       }
     };
 
-    return this.loop(applyOperator, condition, fallbackStep);
+    return this.loop(applyOperator, condition, fallbackStep, 'until');
   }
 
   after<TStep extends IAction<any, any, any, any>>(steps: TStep | TStep[]) {


### PR DESCRIPTION
https://linear.app/kepler-crm/issue/MASTRA-2241/document-looping-with-untilwhile-syntax-in-workflows

- documents the `while` and `until` methods
- fixes the `while` method when using a condition function