### PR TITLE
Enforce that triggerData is an object

### DIFF
--- a/.changeset/shy-ravens-shop.md
+++ b/.changeset/shy-ravens-shop.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/core': major
+'@mastra/core': minor
 ---
 
 Workflow trigger data should only accept object types

--- a/.changeset/shy-ravens-shop.md
+++ b/.changeset/shy-ravens-shop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': major
+---
+
+Workflow trigger data should only accept object types

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -41,7 +41,7 @@ import type { WorkflowInstance } from './workflow-instance';
 
 export class Machine<
   TSteps extends Step<any, any, any>[] = any,
-  TTriggerSchema extends z.ZodType<any> = any,
+  TTriggerSchema extends z.ZodObject<any> = any,
 > extends EventEmitter {
   logger: Logger;
   #mastra?: MastraPrimitives;
@@ -831,7 +831,7 @@ export class Machine<
     };
   }
 
-  #evaluateCondition<TStep extends StepVariableType<any, any, any, any>, TTriggerSchema extends z.ZodType<any>>(
+  #evaluateCondition<TStep extends StepVariableType<any, any, any, any>, TTriggerSchema extends z.ZodObject<any>>(
     condition: StepCondition<TStep, TTriggerSchema>,
     context: WorkflowContext,
   ): boolean {

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -4,7 +4,7 @@ import type { z } from 'zod';
 import type { IAction, IExecutionContext, MastraPrimitives } from '../action';
 import type { BaseLogMessage, RegisteredLogger } from '../logger';
 
-export interface WorkflowOptions<TTriggerSchema extends z.ZodType<any> = any> {
+export interface WorkflowOptions<TTriggerSchema extends z.ZodObject<any> = any> {
   name: string;
   triggerSchema?: TTriggerSchema;
   retryConfig?: RetryConfig;
@@ -50,7 +50,7 @@ export type RetryConfig = { attempts?: number; delay?: number };
 
 export type VariableReference<
   TStep extends StepVariableType<any, any, any, any>,
-  TTriggerSchema extends z.ZodType<any>,
+  TTriggerSchema extends z.ZodObject<any>,
 > =
   TStep extends IAction<any, any, any, any>
     ? {
@@ -69,7 +69,7 @@ export type VariableReference<
 
 export interface BaseCondition<
   TStep extends StepVariableType<any, any, any, any>,
-  TTriggerSchema extends z.ZodType<any>,
+  TTriggerSchema extends z.ZodObject<any>,
 > {
   ref: TStep extends IAction<any, any, any, any>
     ? {
@@ -115,14 +115,17 @@ export type StepDef<
   }
 >;
 
-export type StepCondition<TStep extends StepVariableType<any, any, any, any>, TTriggerSchema extends z.ZodType<any>> =
+export type StepCondition<
+  TStep extends StepVariableType<any, any, any, any>,
+  TTriggerSchema extends z.ZodObject<any>,
+> =
   | BaseCondition<TStep, TTriggerSchema>
   | SimpleConditionalType
   | { and: StepCondition<TStep, TTriggerSchema>[] }
   | { or: StepCondition<TStep, TTriggerSchema>[] }
   | { not: StepCondition<TStep, TTriggerSchema> };
 
-type Condition<TStep extends StepVariableType<any, any, any, any>, TTriggerSchema extends z.ZodType<any>> =
+type Condition<TStep extends StepVariableType<any, any, any, any>, TTriggerSchema extends z.ZodObject<any>> =
   | BaseCondition<TStep, TTriggerSchema>
   | SimpleConditionalType
   | { and: Condition<TStep, TTriggerSchema>[] }
@@ -133,7 +136,7 @@ export interface StepConfig<
   TStep extends IAction<any, any, any, any>,
   CondStep extends StepVariableType<any, any, any, any>,
   VarStep extends StepVariableType<any, any, any, any>,
-  TTriggerSchema extends z.ZodType<any>,
+  TTriggerSchema extends z.ZodObject<any>,
 > {
   snapshotOnTimeout?: boolean;
   when?:
@@ -170,7 +173,7 @@ type StepFailure = {
 export type StepResult<T> = StepSuccess<T> | StepFailure | StepSuspended | StepWaiting;
 
 // Update WorkflowContext
-export interface WorkflowContext<TTrigger extends z.ZodType<any> = any> {
+export interface WorkflowContext<TTrigger extends z.ZodObject<any> = any> {
   steps: Record<string, StepResult<any>>;
   triggerData: z.infer<TTrigger>;
   attempts: Record<string, number>;
@@ -363,7 +366,7 @@ export interface WorkflowRunState {
   suspendedSteps?: Record<string, string>;
 }
 
-export type WorkflowResumeResult<TTriggerSchema extends z.ZodType<any>> = {
+export type WorkflowResumeResult<TTriggerSchema extends z.ZodObject<any>> = {
   triggerData?: z.infer<TTriggerSchema>;
   results: Record<string, StepResult<any>>;
 };

--- a/packages/core/src/workflows/workflow-instance.ts
+++ b/packages/core/src/workflows/workflow-instance.ts
@@ -20,7 +20,7 @@ export interface WorkflowResultReturn<T extends z.ZodType<any>> {
   }>;
 }
 
-export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTriggerSchema extends z.ZodType<any> = any>
+export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTriggerSchema extends z.ZodObject<any> = any>
   implements WorkflowResultReturn<TTriggerSchema>
 {
   name: string;

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -24,7 +24,7 @@ import { WorkflowInstance } from './workflow-instance';
 import type { WorkflowResultReturn } from './workflow-instance';
 export class Workflow<
   TSteps extends Step<any, any, any>[] = any,
-  TTriggerSchema extends z.ZodType<any> = any,
+  TTriggerSchema extends z.ZodObject<any> = any,
 > extends MastraBase {
   name: string;
   triggerSchema?: TTriggerSchema;

--- a/packages/core/src/workflows/workflow.warning.ts
+++ b/packages/core/src/workflows/workflow.warning.ts
@@ -8,7 +8,7 @@ export * from './index';
 
 export class Workflow<
   TSteps extends Step<any, any, any>[] = any,
-  TTriggerSchema extends z.ZodType<any> = any,
+  TTriggerSchema extends z.ZodObject<any> = any,
 > extends BaseWorkflow<TSteps, TTriggerSchema> {
   constructor(args: WorkflowOptions<TTriggerSchema>) {
     super(args);


### PR DESCRIPTION
Using a primitive type as a trigger in itself doesn't really work. Talked with @abhiaiyer91 about this and we concluded we should probably always make sure that the trigger schema is an object.