### PR TITLE
fix(core, deployer, storage): LibSQL database file location consistency

### DIFF
--- a/.changeset/sweet-rats-clap.md
+++ b/.changeset/sweet-rats-clap.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+---
+
+Fixed a bug where mastra.db file location was inconsistently created when running mastra dev vs running a file directly (tsx src/index.ts for ex)

--- a/packages/core/src/storage/libsql/index.ts
+++ b/packages/core/src/storage/libsql/index.ts
@@ -39,6 +39,16 @@ export class LibSQLStore extends MastraStorage {
     });
   }
 
+  // If we're in the .mastra/output directory, use the dir outside .mastra dir
+  // reason we need to do this is libsql relative file paths are based on cwd, not current file path
+  // since mastra dev sets cwd to .mastra/output this means running an agent directly vs running with mastra dev
+  // will put db files in different locations, leading to an inconsistent experience between the two.
+  // Ex: with `file:ex.db`
+  // 1. `mastra dev`: ${cwd}/.mastra/output/ex.db
+  // 2. `tsx src/index.ts`: ${cwd}/ex.db
+  // so if we're in .mastra/output we need to rewrite the file url to be relative to the project root dir
+  // or the experience will be inconsistent
+  // this means `file:` urls are always relative to project root
   protected rewriteDbUrl(url: string): string {
     // If this is a relative file path (starts with file: but not file:/)
     if (url.startsWith('file:') && !url.startsWith('file:/')) {
@@ -47,15 +57,14 @@ export class LibSQLStore extends MastraStorage {
       // Get the relative path part after 'file:'
       const relativePath = url.slice('file:'.length);
 
-      // If we're in a .mastra directory, use the parent directory
       if (cwd.includes('.mastra') && (cwd.endsWith(`output`) || cwd.endsWith(`output/`) || cwd.endsWith(`output\\`))) {
-        const baseDir = join(cwd, `..`, `..`);
+        const baseDir = join(cwd, `..`, `..`); // <- .mastra/output/../../
 
         // Rewrite to be relative to the base directory
         const fullPath = join(baseDir, relativePath);
 
         this.logger.debug(
-          `Initializing LibSQL db with url ${url} with relative file path from inside .mastra directory. Rewriting relative file url to "file:${fullPath}". This ensures it's outside the .mastra directory. If the db is stored inside .mastra it will be deleted when Mastra re-bundles code.`,
+          `Initializing LibSQL db with url ${url} with relative file path from inside .mastra/output directory. Rewriting relative file url to "file:${fullPath}". This ensures it's outside the .mastra/output directory.`,
         );
 
         return `file:${fullPath}`;

--- a/packages/core/src/storage/libsql/index.ts
+++ b/packages/core/src/storage/libsql/index.ts
@@ -49,6 +49,7 @@ export class LibSQLStore extends MastraStorage {
   // so if we're in .mastra/output we need to rewrite the file url to be relative to the project root dir
   // or the experience will be inconsistent
   // this means `file:` urls are always relative to project root
+  // TODO: can we make this easier via bundling? https://github.com/mastra-ai/mastra/pull/2783#pullrequestreview-2662444241
   protected rewriteDbUrl(url: string): string {
     // If this is a relative file path (starts with file: but not file:/)
     if (url.startsWith('file:') && !url.startsWith('file:/')) {

--- a/packages/core/src/storage/libsql/url.test.ts
+++ b/packages/core/src/storage/libsql/url.test.ts
@@ -132,7 +132,7 @@ describe('LibSQLStore URL rewriting', () => {
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         keys: { workflow_name: 'test-workflow', run_id: 'test-1' }
       });
-      expect(record1).not.toBeNull();
+      expect(record1).toBeTruthy();
       if (record1) {
         expect(record1.workflow_name).toBe('test-workflow');
         expect(record1.run_id).toBe('test-1');
@@ -143,7 +143,7 @@ describe('LibSQLStore URL rewriting', () => {
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         keys: { workflow_name: 'test-workflow', run_id: 'test-2' }
       });
-      expect(record2).not.toBeNull();
+      expect(record2).toBeTruthy();
       if (record2) {
         expect(record2.workflow_name).toBe('test-workflow');
         expect(record2.run_id).toBe('test-2');

--- a/packages/core/src/storage/libsql/url.test.ts
+++ b/packages/core/src/storage/libsql/url.test.ts
@@ -69,6 +69,19 @@ describe('LibSQLStore URL rewriting', () => {
       expect(existsSync(join(tmpDir, '.mastra', 'output', 'test.db'))).toBe(false);
       expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
     });
+
+    it('should create db file in .mastra directory when explicitly specified and running from .mastra/output', async () => {
+      const mastraDir = join(tmpDir, '.mastra');
+      const mastraOutputDir = join(mastraDir, 'output');
+      mkdirSync(mastraOutputDir, { recursive: true });
+      process.chdir(mastraOutputDir);
+      const store = new LibSQLStore({ config: { url: 'file:.mastra/test.db' } });
+      await store.init();
+      expect(existsSync(join(tmpDir, 'test.db'))).toBe(false);
+      expect(existsSync(join(mastraDir, 'test.db'))).toBe(true);
+      expect(existsSync(join(mastraOutputDir, 'test.db'))).toBe(false);
+      expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+    });
   });
 
   describe('Database consistency across working directories', () => {

--- a/packages/core/src/storage/libsql/url.test.ts
+++ b/packages/core/src/storage/libsql/url.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join, dirname } from 'node:path';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+import { LibSQLStore } from './index';
+import { TABLE_WORKFLOW_SNAPSHOT } from '../constants';
+
+interface WorkflowSnapshot {
+  workflow_name: string;
+  run_id: string;
+  snapshot: Record<string, any>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+describe('LibSQLStore URL rewriting', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let parentDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), 'mastra-test-libsql-store-url');
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+    mkdirSync(tmpDir);
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    parentDir = join(tmpDir, '..');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Database file creation', () => {
+    it('should create db file in project root when running from project root', async () => {
+      const store = new LibSQLStore({ config: { url: 'file:test.db' } });
+      await store.init();
+      expect(existsSync(join(tmpDir, 'test.db'))).toBe(true);
+      expect(existsSync(join(tmpDir, '.mastra', 'test.db'))).toBe(false);
+      expect(existsSync(join(tmpDir, '.mastra', 'output', 'test.db'))).toBe(false);
+      expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+    });
+
+    it('should create db file in project root when running from .mastra/output', async () => {
+      const mastraOutputDir = join(tmpDir, '.mastra', 'output');
+      mkdirSync(mastraOutputDir, { recursive: true });
+      process.chdir(mastraOutputDir);
+      const store = new LibSQLStore({ config: { url: 'file:test.db' } });
+      await store.init();
+      expect(existsSync(join(tmpDir, 'test.db'))).toBe(true);
+      expect(existsSync(join(tmpDir, '.mastra', 'test.db'))).toBe(false);
+      expect(existsSync(join(tmpDir, '.mastra', 'output', 'test.db'))).toBe(false);
+      expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+    });
+
+    it('should create db file in .mastra directory when explicitly specified', async () => {
+      const mastraDir = join(tmpDir, '.mastra');
+      mkdirSync(mastraDir, { recursive: true });
+      const store = new LibSQLStore({ config: { url: 'file:.mastra/test.db' } });
+      await store.init();
+      expect(existsSync(join(tmpDir, 'test.db'))).toBe(false);
+      expect(existsSync(join(tmpDir, '.mastra', 'test.db'))).toBe(true);
+      expect(existsSync(join(tmpDir, '.mastra', 'output', 'test.db'))).toBe(false);
+      expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+    });
+  });
+
+  describe('Database consistency across working directories', () => {
+    it('should maintain single database file and data consistency when switching working directories', async () => {
+      // First, create and write to the database from project root
+      const store1 = new LibSQLStore({ config: { url: 'file:test.db' } });
+      await store1.init();
+      
+      // Write a test record
+      await store1.batchInsert({
+        tableName: TABLE_WORKFLOW_SNAPSHOT,
+        records: [{
+          workflow_name: 'test-workflow',
+          run_id: 'test-1',
+          snapshot: JSON.stringify({ test: 'data1' }),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        }]
+      });
+
+      // Switch to .mastra/output and write another record
+      const mastraOutputDir = join(tmpDir, '.mastra', 'output');
+      mkdirSync(mastraOutputDir, { recursive: true });
+      process.chdir(mastraOutputDir);
+      
+      const store2 = new LibSQLStore({ config: { url: 'file:test.db' } });
+      await store2.init();
+      
+      await store2.batchInsert({
+        tableName: TABLE_WORKFLOW_SNAPSHOT,
+        records: [{
+          workflow_name: 'test-workflow',
+          run_id: 'test-2',
+          snapshot: JSON.stringify({ test: 'data2' }),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        }]
+      });
+
+      // Verify database file exists only in project root
+      expect(existsSync(join(tmpDir, 'test.db'))).toBe(true);
+      expect(existsSync(join(tmpDir, '.mastra', 'test.db'))).toBe(false);
+      expect(existsSync(join(tmpDir, '.mastra', 'output', 'test.db'))).toBe(false);
+      expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+
+      // Query the database to verify both records exist
+      const record1 = await store2.load<WorkflowSnapshot>({
+        tableName: TABLE_WORKFLOW_SNAPSHOT,
+        keys: { workflow_name: 'test-workflow', run_id: 'test-1' }
+      });
+      expect(record1).not.toBeNull();
+      if (record1) {
+        expect(record1.workflow_name).toBe('test-workflow');
+        expect(record1.run_id).toBe('test-1');
+        expect(record1.snapshot).toEqual({ test: 'data1' });
+      }
+
+      const record2 = await store2.load<WorkflowSnapshot>({
+        tableName: TABLE_WORKFLOW_SNAPSHOT,
+        keys: { workflow_name: 'test-workflow', run_id: 'test-2' }
+      });
+      expect(record2).not.toBeNull();
+      if (record2) {
+        expect(record2.workflow_name).toBe('test-workflow');
+        expect(record2.run_id).toBe('test-2');
+        expect(record2.snapshot).toEqual({ test: 'data2' });
+      }
+    });
+  });
+}); 

--- a/packages/core/src/vector/libsql/index.ts
+++ b/packages/core/src/vector/libsql/index.ts
@@ -47,6 +47,16 @@ export class LibSQLVector extends MastraVector {
     });
   }
 
+  // If we're in the .mastra/output directory, use the dir outside .mastra dir
+  // reason we need to do this is libsql relative file paths are based on cwd, not current file path
+  // since mastra dev sets cwd to .mastra/output this means running an agent directly vs running with mastra dev
+  // will put db files in different locations, leading to an inconsistent experience between the two.
+  // Ex: with `file:ex.db`
+  // 1. `mastra dev`: ${cwd}/.mastra/output/ex.db
+  // 2. `tsx src/index.ts`: ${cwd}/ex.db
+  // so if we're in .mastra/output we need to rewrite the file url to be relative to the project root dir
+  // or the experience will be inconsistent
+  // this means `file:` urls are always relative to project root
   protected rewriteDbUrl(url: string): string {
     // If this is a relative file path (starts with file: but not file:/)
     if (url.startsWith('file:') && !url.startsWith('file:/')) {
@@ -55,15 +65,14 @@ export class LibSQLVector extends MastraVector {
       // Get the relative path part after 'file:'
       const relativePath = url.slice('file:'.length);
 
-      // If we're in a .mastra directory, use the parent directory
       if (cwd.includes('.mastra') && (cwd.endsWith(`output`) || cwd.endsWith(`output/`) || cwd.endsWith(`output\\`))) {
-        const baseDir = join(cwd, `..`, `..`);
+        const baseDir = join(cwd, `..`, `..`); // <- .mastra/output/../../
 
         // Rewrite to be relative to the base directory
         const fullPath = join(baseDir, relativePath);
 
         this.logger.debug(
-          `Initializing LibSQL db with url ${url} with relative file path from inside .mastra directory. Rewriting relative file url to "file:${fullPath}". This ensures it's outside the .mastra directory. If the db is stored inside .mastra it will be deleted when Mastra re-bundles code.`,
+          `Initializing LibSQL db with url ${url} with relative file path from inside .mastra/output directory. Rewriting relative file url to "file:${fullPath}". This ensures it's outside the .mastra/output directory.`,
         );
 
         return `file:${fullPath}`;

--- a/packages/core/src/vector/libsql/index.ts
+++ b/packages/core/src/vector/libsql/index.ts
@@ -57,6 +57,7 @@ export class LibSQLVector extends MastraVector {
   // so if we're in .mastra/output we need to rewrite the file url to be relative to the project root dir
   // or the experience will be inconsistent
   // this means `file:` urls are always relative to project root
+  // TODO: can we make this easier via bundling? https://github.com/mastra-ai/mastra/pull/2783#pullrequestreview-2662444241
   protected rewriteDbUrl(url: string): string {
     // If this is a relative file path (starts with file: but not file:/)
     if (url.startsWith('file:') && !url.startsWith('file:/')) {

--- a/packages/core/src/vector/libsql/url.test.ts
+++ b/packages/core/src/vector/libsql/url.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { LibSQLVector } from './index';
+
+describe('LibSQLVector URL rewriting', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let parentDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), 'mastra-test-libsql-vector-url');
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+    mkdirSync(tmpDir);
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    parentDir = join(tmpDir, '..');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should create db file in project root when cwd is project root', async () => {
+    const vector = new LibSQLVector({
+      connectionUrl: 'file:test.db',
+    });
+
+    // Create an index to ensure the database file is created
+    await vector.createIndex({
+      indexName: 'test_index',
+      dimension: 3,
+    });
+
+    // Check that the database file is created in the project root
+    expect(existsSync(join(tmpDir, 'test.db'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.mastra', 'test.db'))).toBe(false);
+    expect(existsSync(join(tmpDir, '.mastra', 'output', 'test.db'))).toBe(false);
+    expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+  });
+
+  it('should create db file in .mastra directory when cwd is .mastra', async () => {
+    const mastraDir = join(tmpDir, '.mastra');
+    mkdirSync(mastraDir);
+    process.chdir(mastraDir);
+
+    const vector = new LibSQLVector({
+      connectionUrl: 'file:test.db',
+    });
+
+    // Create an index to ensure the database file is created
+    await vector.createIndex({
+      indexName: 'test_index',
+      dimension: 3,
+    });
+
+    // Check that the database file is created in the .mastra directory
+    expect(existsSync(join(tmpDir, 'test.db'))).toBe(false);
+    expect(existsSync(join(mastraDir, 'test.db'))).toBe(true);
+    expect(existsSync(join(mastraDir, 'output', 'test.db'))).toBe(false);
+    expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+  });
+
+  it('should create db file in project root when cwd is .mastra/output', async () => {
+    const outputDir = join(tmpDir, '.mastra', 'output');
+    mkdirSync(outputDir, { recursive: true });
+    process.chdir(outputDir);
+
+    const vector = new LibSQLVector({
+      connectionUrl: 'file:test.db',
+    });
+
+    // Create an index to ensure the database file is created
+    await vector.createIndex({
+      indexName: 'test_index',
+      dimension: 3,
+    });
+
+    // Check that the database file is created in the project root
+    expect(existsSync(join(tmpDir, 'test.db'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.mastra', 'test.db'))).toBe(false);
+    expect(existsSync(join(outputDir, 'test.db'))).toBe(false);
+    expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+  });
+
+  it('should maintain a single database file and data consistency when switching working directories', async () => {
+    // Create a test vector
+    const testVector = [1, 2, 3];
+    const testMetadata = { key: 'value' };
+
+    // First, create the vector store in project root
+    const vector1 = new LibSQLVector({
+      connectionUrl: 'file:test.db',
+    });
+
+    // Create an index and insert a vector
+    await vector1.createIndex({
+      indexName: 'test_index',
+      dimension: 3,
+    });
+
+    await vector1.upsert({
+      indexName: 'test_index',
+      vectors: [testVector],
+      metadata: [testMetadata],
+      ids: ['1'],
+    });
+
+    // Change to .mastra/output directory
+    const outputDir = join(tmpDir, '.mastra', 'output');
+    mkdirSync(outputDir, { recursive: true });
+    process.chdir(outputDir);
+
+    // Create another instance and verify data consistency
+    const vector2 = new LibSQLVector({
+      connectionUrl: 'file:test.db',
+    });
+
+    // Query the vector store
+    const results = await vector2.query({
+      indexName: 'test_index',
+      queryVector: testVector,
+      topK: 1,
+    });
+
+    // Verify that we can retrieve the same data
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('1');
+    expect(results[0].metadata).toEqual(testMetadata);
+
+    // Verify database file location
+    expect(existsSync(join(tmpDir, 'test.db'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.mastra', 'test.db'))).toBe(false);
+    expect(existsSync(join(outputDir, 'test.db'))).toBe(false);
+    expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+  });
+}); 

--- a/packages/core/src/vector/libsql/url.test.ts
+++ b/packages/core/src/vector/libsql/url.test.ts
@@ -89,6 +89,29 @@ describe('LibSQLVector URL rewriting', () => {
     expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
   });
 
+  it('should create db file in .mastra directory when explicitly specified and running from .mastra/output', async () => {
+    const mastraDir = join(tmpDir, '.mastra');
+    const mastraOutputDir = join(mastraDir, 'output');
+    mkdirSync(mastraOutputDir, { recursive: true });
+    process.chdir(mastraOutputDir);
+
+    const vector = new LibSQLVector({
+      connectionUrl: 'file:.mastra/test.db',
+    });
+
+    // Create an index to ensure the database file is created
+    await vector.createIndex({
+      indexName: 'test_index',
+      dimension: 3,
+    });
+
+    // Check that the database file is created in the .mastra directory
+    expect(existsSync(join(tmpDir, 'test.db'))).toBe(false);
+    expect(existsSync(join(mastraDir, 'test.db'))).toBe(true);
+    expect(existsSync(join(mastraOutputDir, 'test.db'))).toBe(false);
+    expect(existsSync(join(parentDir, 'test.db'))).toBe(false);
+  });
+
   it('should maintain a single database file and data consistency when switching working directories', async () => {
     // Create a test vector
     const testVector = [1, 2, 3];

--- a/packages/deployer/public/templates/instrumentation-template.js
+++ b/packages/deployer/public/templates/instrumentation-template.js
@@ -1,16 +1,18 @@
-import { createLogger } from '@mastra/core/logger'
-import { LibSQLStore } from '@mastra/core/storage/libsql'
-import { OTLPStorageExporter } from '@mastra/core/telemetry'
+import { createLogger } from '@mastra/core/logger';
+import { LibSQLStore } from '@mastra/core/storage/libsql';
+import { OTLPStorageExporter } from '@mastra/core/telemetry';
 import {
-  NodeSDK, getNodeAutoInstrumentations, ATTR_SERVICE_NAME, Resource,
+  NodeSDK,
+  getNodeAutoInstrumentations,
+  ATTR_SERVICE_NAME,
+  Resource,
   ParentBasedSampler,
   TraceIdRatioBasedSampler,
   AlwaysOnSampler,
   AlwaysOffSampler,
   OTLPHttpExporter,
 } from '@mastra/core/telemetry/otel-vendor';
-import { telemetry } from './telemetry-config.mjs'
-
+import { telemetry } from './telemetry-config.mjs';
 
 function getSampler(config) {
   if (!config.sampling) {
@@ -34,7 +36,6 @@ function getSampler(config) {
     default:
       return new AlwaysOnSampler();
   }
-
 }
 
 async function getExporter(config) {
@@ -42,17 +43,16 @@ async function getExporter(config) {
     return new OTLPHttpExporter({
       url: config.export.endpoint,
       headers: config.export.headers,
-    })
+    });
   } else if (config.export?.type === 'custom') {
-    return config.export.exporter
+    return config.export.exporter;
   } else {
     const storage = new LibSQLStore({
       config: {
-        // file lives in ./.mastra/output, and we need to write to ./.mastra/mastra.db
-        url: "file:../mastra.db",
+        url: 'file:.mastra/mastra.db',
       },
-    })
-    await storage.init()
+    });
+    await storage.init();
 
     return new OTLPStorageExporter({
       logger: createLogger({
@@ -60,7 +60,7 @@ async function getExporter(config) {
         level: 'silent',
       }),
       storage,
-    })
+    });
   }
 }
 
@@ -82,5 +82,6 @@ sdk.start();
 process.on('SIGTERM', () => {
   sdk.shutdown().catch(() => {
     // do nothing
-  })
+  });
 });
+


### PR DESCRIPTION
When using LibSQL with file-based databases, the location of the database file is determined by the current working directory rather than the location of the code. This causes inconsistency between running agents directly vs running with `mastra dev`:

- When running with `mastra dev`, the cwd is set to `.mastra/output`, so `file:ex.db` creates the database at `.mastra/output/ex.db`
- When running directly with `tsx src/index.ts`, the cwd is the project root, so `file:ex.db` creates the database at `./ex.db`

I updated the URL rewriting logic to ensure consistent database file locations and made it explicit when we want to store a db in .mastra (ex `file:.mastra/mastra.db`)

Added some tests as well to make sure it's all right
