### PR TITLE
fix: memory?.getTools is not a function on alpha

### DIFF
--- a/.changeset/mighty-rats-run.md
+++ b/.changeset/mighty-rats-run.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added optional chaining to a memory function call that may not exist

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -3,7 +3,8 @@ import util from 'node:util';
 import * as p from '@clack/prompts';
 import color from 'picocolors';
 
-import { getPackageManager, getPackageManagerInstallCommand } from '../utils';
+import { DepsService } from '../../services/service.deps';
+import { getPackageManagerInstallCommand } from '../utils';
 
 import {
   createComponentsDir,
@@ -15,7 +16,6 @@ import {
   writeIndexFile,
 } from './utils';
 import type { Components, LLMProvider } from './utils';
-import { DepsService } from '../../services/service.deps';
 
 const s = p.spinner();
 

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -490,7 +490,7 @@ export class Agent<
 
     // Get memory tools if available
     const memory = this.getMemory();
-    const memoryTools = memory?.getTools();
+    const memoryTools = memory?.getTools?.();
 
     let mastraProxy = undefined;
     const logger = this.logger;


### PR DESCRIPTION
When I bump to latest alpha for core but not memory I get this error. Once we release users will get it too if they only bump core