### PR TITLE
Add browser tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 
 openapi-ts-error*
 
+.tsup
 .mastra
 memory.db
 

--- a/docs/src/pages/docs/reference/agents/createTool.mdx
+++ b/docs/src/pages/docs/reference/agents/createTool.mdx
@@ -8,7 +8,7 @@ description: Documentation for the createTool function in Mastra, which creates 
 Tools are typed functions that can be executed by agents or workflows, with built-in integration access and parameter validation. Each tool has a schema that defines its inputs, an executor function that implements its logic, and access to configured integrations.
 
 ```ts filename="src/mastra/tools/index.ts" showLineNumbers copy
-import { createTool } from "@mastra/core/logger";
+import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
 const getStockPrice = async (symbol: string) => {

--- a/examples/browser/.env.development
+++ b/examples/browser/.env.development
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-api-key 

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "example-browser",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "mastra dev",
+    "build": "mastra build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.4.1",
+  "dependencies": {
+    "@ai-sdk/openai": "^1.2.1",
+    "@mastra/browser": "workspace:^",
+    "@mastra/core": "workspace:^",
+    "playwright": "^1.49.1",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "mastra": "workspace:^"
+  }
+}

--- a/examples/browser/src/index.ts
+++ b/examples/browser/src/index.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { mastra } from './mastra';
+
+async function main() {
+  const agent = mastra.getAgent('scrapingAgent');
+
+  const result = await agent.generate(
+    `Go to https://news.ycombinator.com/, search for Mastra, hit enter and read the title of the first result.`,
+    {
+      maxSteps: 10,
+      experimental_output: z.object({
+        title: z.string(),
+      }),
+    },
+  );
+
+  console.log(result.object);
+  console.log('done');
+}
+
+main();

--- a/examples/browser/src/mastra/agents/index.ts
+++ b/examples/browser/src/mastra/agents/index.ts
@@ -1,0 +1,35 @@
+import { openai } from '@ai-sdk/openai';
+import { Agent } from '@mastra/core/agent';
+import { createBrowserToolkit } from '@mastra/browser';
+
+export const scrapingAgent = new Agent({
+  name: 'Scraping Agent',
+  instructions: `You are a helpful web browsing assistant that can navigate websites and extract information for users.
+    
+  CAPABILITIES:
+  - Launch a browser (use launch-browser tool)
+  - Open new browser pages (use new-page tool)
+  - Navigate to websites (use navigate tool with a URL)
+  - From the user's instructions get the correct xpaths for the elements you want to interact (use get-elements tool)
+  - Any action ("click", "type", "submit", "scroll", "read") to perform on an element (use element-action tool)
+  - Close individual browser pages (use close-page tool)
+  - Close the entire browser (use close-browser tool)
+  
+  WORKFLOW:
+  1. Always start by launching a browser with launch-browser
+  2. Then open a new page with new-page
+  3. Navigate to the requested URL with navigate-tool
+  4. IMPORTANT: You MUST use get-elements to get the correct xpaths for the elements you want to interact with
+  5. After getting elements, use element-action tool to perform the user actions
+  6. IMPORTANT: If the page has been changed by an action, you MUST use get-elements again to get the new xpaths
+  7. ALWAYS Close the page using close-page when done with your tasks
+  8. ALWAYS Close the browser using close-browser when finished with all tasks
+`,
+  model: openai('gpt-4o-mini'),
+  tools: {
+    ...createBrowserToolkit({
+      // headless: false,
+      model: openai('gpt-4o-mini'),
+    }),
+  },
+});

--- a/examples/browser/src/mastra/index.ts
+++ b/examples/browser/src/mastra/index.ts
@@ -1,0 +1,11 @@
+import { Mastra } from '@mastra/core/mastra';
+import { createLogger } from '@mastra/core/logger';
+import { scrapingAgent } from './agents';
+
+export const mastra = new Mastra({
+  agents: { scrapingAgent },
+  logger: createLogger({
+    name: 'Mastra',
+    level: 'info',
+  }),
+});

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,0 +1,1 @@
+# @mastra/browser

--- a/packages/browser/eslint.config.js
+++ b/packages/browser/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "browser",
-  "version": "1.0.0",
+  "name": "@mastra/browser",
+  "version": "0.0.0",
   "description": "",
   "type": "module",
   "main": "index.js",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "lint": "eslint .",
     "build": "del-cli dist && pnpm build:browser && pnpm build:node",
@@ -30,11 +33,11 @@
   "license": "ISC",
   "packageManager": "pnpm@10.4.1",
   "dependencies": {
-    "@mastra/core": "workspace:*"
+    "@mastra/core": "workspace:*",
+    "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "playwright": "^1.49.0",
-    "zod": "^3.23.8"
+    "playwright": "^1.49.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
@@ -45,7 +48,6 @@
     "get-xpath": "^3.3.0",
     "playwright": "^1.49.1",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.3",
-    "zod": "^3.24.2"
+    "typescript": "^5.7.3"
   }
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "browser",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint .",
+    "build": "del-cli dist && pnpm build:browser && pnpm build:node",
+    "build:watch": "pnpm build:browser --watch && pnpm build:node --watch",
+    "build:browser": "tsup src/browser-tool.ts --target chrome130 --format iife --treeshake=smallest",
+    "build:browser:watch": "pnpm build:browser --watch",
+    "build:node": "tsup src/index.ts --target node20 --format esm,cjs --experimental-dts --treeshake=smallest",
+    "build:node:watch": "pnpm build:node --watch"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.4.1",
+  "dependencies": {
+    "@mastra/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "playwright": "^1.49.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@microsoft/api-extractor": "^7.49.2",
+    "ai": "^4.1.54",
+    "del-cli": "^6.0.0",
+    "eslint": "^9.21.0",
+    "get-xpath": "^3.3.0",
+    "playwright": "^1.49.1",
+    "tsup": "^8.4.0",
+    "typescript": "^5.7.3",
+    "zod": "^3.24.2"
+  }
+}

--- a/packages/browser/src/browser-tool.ts
+++ b/packages/browser/src/browser-tool.ts
@@ -1,0 +1,7 @@
+import { collect } from './browser/collect';
+
+// @ts-ignore
+window.collectDomNodes = function collectDomNodes(rootEl: HTMLElement) {
+  const elements = collect(rootEl);
+  return elements;
+};

--- a/packages/browser/src/browser/collect.ts
+++ b/packages/browser/src/browser/collect.ts
@@ -1,0 +1,103 @@
+import getXPath from 'get-xpath';
+import type { CollectedElement } from '../types';
+import { isElementNode } from './element-node';
+import { isInteractiveElement } from './interactive-element';
+import { isLeafElement } from './leaf-element';
+import { isTextNode } from './text-node';
+import { isActive, isVisible } from './utils';
+
+/**
+ * Collects essential attributes from an element.
+ * @param element The DOM element.
+ * @returns A string of formatted attributes.
+ */
+function collectEssentialAttributes(element: Element): string {
+  const essentialAttributes = [
+    'id',
+    'class',
+    'href',
+    'src',
+    'aria-label',
+    'aria-name',
+    'aria-role',
+    'aria-description',
+    'aria-expanded',
+    'aria-haspopup',
+    'type',
+    'value',
+  ];
+
+  const attrs: string[] = essentialAttributes
+    .map(attr => {
+      const value = element.getAttribute(attr);
+      return value ? `${attr}="${value}"` : '';
+    })
+    .filter(attr => attr !== '');
+
+  Array.from(element.attributes).forEach(attr => {
+    if (attr.name.startsWith('data-')) {
+      attrs.push(`${attr.name}="${attr.value}"`);
+    }
+  });
+
+  return attrs.join(' ');
+}
+
+export function collect(rootEl: Element): CollectedElement[] {
+  const DOMCrawlQueue = [...rootEl.childNodes];
+
+  let shouldAdd = false;
+  const candidateElements: Element[] = [];
+
+  while (DOMCrawlQueue.length > 0) {
+    const node = DOMCrawlQueue.pop();
+
+    if (node && isElementNode(node)) {
+      for (let i = node.childNodes.length - 1; i >= 0; i--) {
+        DOMCrawlQueue.push(node.childNodes[i]!);
+      }
+
+      if (isInteractiveElement(node)) {
+        if (isActive(node) && isVisible(node)) {
+          shouldAdd = true;
+        }
+      }
+      if (isLeafElement(node)) {
+        if (isActive(node) && isVisible(node)) {
+          shouldAdd = true;
+        }
+      }
+    }
+
+    if (shouldAdd && node) {
+      candidateElements.push(node as Element);
+    }
+  }
+
+  const elements: { xpaths: string; output: string }[] = [];
+
+  candidateElements.forEach(elem => {
+    let elemOutput = '';
+
+    if (isTextNode(elem)) {
+      const textContent = elem.textContent?.trim();
+      if (textContent) {
+        elemOutput += `${textContent}\n`;
+      }
+    } else if (isElementNode(elem)) {
+      const tagName = elem.tagName.toLowerCase();
+      const attributes = collectEssentialAttributes(elem);
+      const opening = `<${tagName}${attributes ? ' ' + attributes : ''}>`;
+      const closing = `</${tagName}>`;
+      const textContent = elem.textContent?.trim() || '';
+      elemOutput += `${opening}${textContent}${closing}\n`;
+    }
+
+    elements.push({
+      xpaths: getXPath(elem)!,
+      output: elemOutput,
+    });
+  });
+
+  return elements;
+}

--- a/packages/browser/src/browser/element-node.ts
+++ b/packages/browser/src/browser/element-node.ts
@@ -1,0 +1,3 @@
+export function isElementNode(node: Node): node is Element {
+  return node.nodeType === Node.ELEMENT_NODE;
+}

--- a/packages/browser/src/browser/interactive-element.ts
+++ b/packages/browser/src/browser/interactive-element.ts
@@ -1,0 +1,53 @@
+const interactiveElementTypes = [
+  'A',
+  'BUTTON',
+  'DETAILS',
+  'EMBED',
+  'INPUT',
+  'LABEL',
+  'MENU',
+  'MENUITEM',
+  'OBJECT',
+  'SELECT',
+  'TEXTAREA',
+  'SUMMARY',
+] as const;
+
+const interactiveRoles = [
+  'button',
+  'menu',
+  'menuitem',
+  'link',
+  'checkbox',
+  'radio',
+  'slider',
+  'tab',
+  'tabpanel',
+  'textbox',
+  'combobox',
+  'grid',
+  'listbox',
+  'option',
+  'progressbar',
+  'scrollbar',
+  'searchbox',
+  'switch',
+  'tree',
+  'treeitem',
+  'spinbutton',
+  'tooltip',
+] as const;
+
+const interactiveAriaRoles = ['menu', 'menuitem', 'button'] as const;
+
+export function isInteractiveElement(element: Element): boolean {
+  const elementType = element.tagName;
+  const elementRole = element.getAttribute('role');
+  const elementAriaRole = element.getAttribute('aria-role');
+
+  return !!(
+    (elementType && (interactiveElementTypes as unknown as string[]).includes(elementType)) ||
+    (elementRole && (interactiveRoles as unknown as string[]).includes(elementRole)) ||
+    (elementAriaRole && (interactiveAriaRoles as unknown as string[]).includes(elementAriaRole))
+  );
+}

--- a/packages/browser/src/browser/leaf-element.ts
+++ b/packages/browser/src/browser/leaf-element.ts
@@ -1,0 +1,16 @@
+import { isTextNode } from './text-node';
+
+const leafElementDenyList = ['SVG', 'IFRAME', 'SCRIPT', 'STYLE', 'LINK'];
+
+export function isLeafElement(element: Element) {
+  if (element.textContent === '') {
+    return false;
+  }
+
+  if (element.childNodes.length === 0) {
+    return !leafElementDenyList.includes(element.tagName);
+  }
+
+  // This case ensures that extra context will be included for simple element nodes that contain only text
+  return element.childNodes.length === 1 && isTextNode(element.childNodes[0]!);
+}

--- a/packages/browser/src/browser/text-node.ts
+++ b/packages/browser/src/browser/text-node.ts
@@ -1,0 +1,3 @@
+export function isTextNode(node: Node) {
+  return node.nodeType === Node.TEXT_NODE && Boolean(node.textContent?.trim());
+}

--- a/packages/browser/src/browser/tsconfig.json
+++ b/packages/browser/src/browser/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.node.json",
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable"]
+  },
+  "include": ["./*"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/browser/src/browser/utils.ts
+++ b/packages/browser/src/browser/utils.ts
@@ -1,0 +1,80 @@
+/*
+ * Checks if an element is visible and therefore relevant for LLMs to consider. We check:
+ * - Size
+ * - Display properties
+ * - Opacity
+ * If the element is a child of a previously hidden element, it should not be included, so we don't consider downstream effects of a parent element here
+ */
+export function isVisible(element: Element): boolean {
+  const rect = element.getBoundingClientRect();
+  // Ensure the element is within the viewport
+  if (rect.width === 0 || rect.height === 0 || rect.top < 0 || rect.top > window.innerHeight) {
+    return false;
+  }
+  if (!isTopElement(element, rect)) {
+    return false;
+  }
+
+  const visible = element.checkVisibility({
+    checkOpacity: true,
+    checkVisibilityCSS: true,
+  });
+
+  return visible;
+}
+
+export function isTextVisible(element: Element): boolean {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const rect = range.getBoundingClientRect();
+
+  if (rect.width === 0 || rect.height === 0 || rect.top < 0 || rect.top > window.innerHeight) {
+    return false;
+  }
+  const parent = element.parentElement;
+  if (!parent) {
+    return false;
+  }
+
+  const visible = parent.checkVisibility({
+    checkOpacity: true,
+    checkVisibilityCSS: true,
+  });
+
+  return visible;
+}
+
+export function isTopElement(elem: Element, rect: DOMRect): boolean {
+  const points = [
+    { x: rect.left + rect.width * 0.25, y: rect.top + rect.height * 0.25 },
+    { x: rect.left + rect.width * 0.75, y: rect.top + rect.height * 0.25 },
+    { x: rect.left + rect.width * 0.25, y: rect.top + rect.height * 0.75 },
+    { x: rect.left + rect.width * 0.75, y: rect.top + rect.height * 0.75 },
+    { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+  ];
+
+  return points.some(point => {
+    const topEl = document.elementFromPoint(point.x, point.y);
+    let current = topEl;
+    while (current && current !== document.body) {
+      if (current.isSameNode(elem)) {
+        return true;
+      }
+      current = current.parentElement;
+    }
+
+    return false;
+  });
+}
+
+export function isActive(element: Element): boolean {
+  if (
+    element.hasAttribute('disabled') ||
+    element.hasAttribute('hidden') ||
+    element.getAttribute('aria-disabled') === 'true'
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,0 +1,36 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { LanguageModelV1 } from 'ai';
+import { elementActionTool } from './tools/action';
+import { closeBrowserTool } from './tools/close-browser';
+import { closePageTool } from './tools/close-page';
+import { getElementsTool } from './tools/get-elements';
+import { launchBrowserTool } from './tools/launch';
+import { navigateTool } from './tools/navigate';
+import { newPageTool } from './tools/new-page';
+import type { ToolContext } from './tools/types';
+
+type BrowserToolkitOptions = Parameters<typeof launchBrowserTool>[0] & {
+  model: LanguageModelV1;
+  batchSize?: number;
+};
+
+export function createBrowserToolkit({ model, batchSize, ...options }: BrowserToolkitOptions) {
+  const context: ToolContext = {
+    browser: null,
+    context: null,
+    page: null,
+  };
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const domUtilsPath = join(__dirname, 'browser-tool.global.js');
+
+  return {
+    launchBrowser: launchBrowserTool(options, context),
+    newPage: newPageTool({ domUtilsPath }, context),
+    navigate: navigateTool(context),
+    getElement: getElementsTool({ model, batchSize }, context),
+    actionTool: elementActionTool(context),
+    closePage: closePageTool(context),
+    closeBrowser: closeBrowserTool(context),
+  };
+}

--- a/packages/browser/src/tools/action.ts
+++ b/packages/browser/src/tools/action.ts
@@ -1,0 +1,93 @@
+import { createTool } from '@mastra/core/tools';
+import type { Tool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { ToolContext } from './types';
+
+const inputSchema = z.object({
+  actions: z.array(
+    z.object({
+      selector: z.string().describe('xPath selector of the element to do an action on'),
+      action: z.enum(['click', 'type', 'submit', 'scroll', 'read', 'wait']),
+      value: z.string().optional().describe('value to type if the action is type'),
+    }),
+  ),
+});
+
+const outputSchema = z.object({
+  results: z.array(
+    z.object({
+      message: z.string(),
+      content: z.string().optional(),
+    }),
+  ),
+});
+
+export function elementActionTool(globalContext: ToolContext): Tool<typeof inputSchema, typeof outputSchema> {
+  return createTool({
+    id: 'element-action',
+    description: 'Performs an action on an element',
+    inputSchema,
+    outputSchema,
+    execute: async ({ context }) => {
+      try {
+        if (!globalContext?.page) {
+          return { results: [{ message: 'No page is currently open' }] };
+        }
+
+        const results: { message: string; content?: string }[] = [];
+
+        // Process each action in the array
+        for (const { selector, action, value } of context.actions) {
+          // Find the element using the XPath selector
+          const element = globalContext.page.locator(`xpath=${selector}`);
+
+          if ((await element.count()) === 0) {
+            results.push({ message: `Element with selector "${selector}" not found` });
+            continue;
+          }
+
+          // Perform the requested action
+          switch (action) {
+            case 'click':
+              await element.click();
+              results.push({ message: `Successfully clicked element with selector "${selector}"` });
+              break;
+            case 'type':
+              if (!value) {
+                results.push({ message: 'Error: Value is required for type action' });
+                break;
+              }
+
+              await element.fill(value);
+              results.push({ message: `Successfully typed "${value}" into element with selector "${selector}"` });
+              break;
+            case 'submit':
+              await element.press('Enter');
+              results.push({ message: `Successfully submitted form with selector "${selector}"` });
+              break;
+            case 'scroll':
+              await element.scrollIntoViewIfNeeded();
+              results.push({ message: `Successfully scrolled to element with selector "${selector}"` });
+              break;
+            case 'read':
+              const text = await element.textContent();
+              results.push({
+                message: `Successfully read content from element with selector "${selector}"`,
+                content: text || '',
+              });
+              break;
+            default:
+              results.push({ message: `Unsupported action: ${action}` });
+          }
+        }
+
+        return { results };
+      } catch (e) {
+        if (e instanceof Error) {
+          return { results: [{ message: `Error: ${e.message}` }] };
+        }
+        return { results: [{ message: 'An unknown error occurred' }] };
+      }
+    },
+  });
+}

--- a/packages/browser/src/tools/close-browser.ts
+++ b/packages/browser/src/tools/close-browser.ts
@@ -1,0 +1,35 @@
+import { createTool } from '@mastra/core/tools';
+import type { Tool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { ToolContext } from './types';
+
+const inputSchema = z.object({});
+
+export function closeBrowserTool(globalContext: ToolContext): Tool<typeof inputSchema> {
+  return createTool({
+    id: 'close-browser',
+    description: 'Closes the browser instance completely',
+    inputSchema,
+    execute: async ({ mastra }) => {
+      try {
+        if (!globalContext?.browser) {
+          return { message: 'No browser is currently open' };
+        }
+
+        mastra?.logger?.debug('[browser] close browser');
+        await globalContext.context?.close();
+        await globalContext.browser?.close();
+        globalContext.context = null;
+        globalContext.browser = null;
+        globalContext.page = null;
+
+        return { message: 'Browser closed successfully' };
+      } catch (e) {
+        if (e instanceof Error) {
+          return { message: `Error closing page: ${e.message}` };
+        }
+        return { message: 'An unknown error occurred while closing the page' };
+      }
+    },
+  });
+}

--- a/packages/browser/src/tools/close-page.ts
+++ b/packages/browser/src/tools/close-page.ts
@@ -1,0 +1,30 @@
+import { createTool } from '@mastra/core/tools';
+import type { Tool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { ToolContext } from './types';
+
+const inputSchema = z.object({});
+
+export function closePageTool(globalContext: ToolContext): Tool<typeof inputSchema> {
+  return createTool({
+    id: 'close-page',
+    description: 'Closes the currently open browser page',
+    inputSchema,
+    execute: async ({ mastra }) => {
+      try {
+        if (!globalContext?.page) {
+          return { message: 'No page is currently open' };
+        }
+
+        mastra?.logger?.debug('[browser] close page');
+        await globalContext.page.close();
+        return { message: 'Page closed successfully' };
+      } catch (e) {
+        if (e instanceof Error) {
+          return { message: `Error closing page: ${e.message}` };
+        }
+        return { message: 'An unknown error occurred while closing the page' };
+      }
+    },
+  });
+}

--- a/packages/browser/src/tools/get-elements.ts
+++ b/packages/browser/src/tools/get-elements.ts
@@ -1,0 +1,121 @@
+import { Agent } from '@mastra/core/agent';
+import type { Mastra } from '@mastra/core/mastra';
+import { createTool } from '@mastra/core/tools';
+import type { Tool } from '@mastra/core/tools';
+import type { LanguageModelV1 } from 'ai';
+import { z } from 'zod';
+import type { CollectedElement } from '../types';
+import type { ToolContext } from './types';
+
+type GetElementInput = {
+  queries: string[];
+  elements: CollectedElement[];
+};
+
+const DEFAULT_BATCH_SIZE = 250;
+
+const inputSchema = z.object({
+  queries: z.array(z.string()).describe('The user queries to find the correct elements'),
+});
+
+const outputSchema = z.union([
+  z.object({
+    elements: z.array(z.string()),
+  }),
+  z.object({
+    message: z.string(),
+  }),
+]);
+
+export function getElementsTool(
+  { model, batchSize: CHUNK_SIZE = DEFAULT_BATCH_SIZE }: { model: LanguageModelV1; batchSize?: number },
+  globalContext: ToolContext,
+): Tool<typeof inputSchema, typeof outputSchema> {
+  const cache = new Map<string, CollectedElement[]>();
+
+  async function getElements(agent: Agent, { queries, elements }: GetElementInput) {
+    if (elements.length === 0) {
+      return [];
+    }
+
+    const prompt = `Give me the correct xpaths for the elements that matches the query, each query is divided by a |: ${queries.join('|')}
+
+IMPORTANT: Only use xpaths you can find list below, do not make up your own xpaths.
+
+list of XPaths with their text inputs:
+${elements
+  .map(el => {
+    return `${el.xpaths}: ${el.output}`;
+  })
+  .join('\n')}`;
+
+    const element = await agent.generate(prompt, {
+      output: z.object({
+        xpaths: z.array(z.string()),
+      }),
+    });
+
+    return element.object.xpaths;
+  }
+
+  return createTool({
+    id: 'get-elements',
+    description: 'From an agent instruction, get the list of xpath elements to interact with on the current page.',
+    inputSchema,
+    outputSchema,
+    // @ts-ignore
+    execute: async ({ context, mastra }) => {
+      try {
+        if (!globalContext?.page) {
+          return { message: 'Error: Page is not open, try the new-page tool first' };
+        }
+
+        const url = globalContext.page.url();
+        if (!cache.has(url)) {
+          const elements = await globalContext.page.evaluate(() => {
+            // @ts-ignore
+            return window.collectDomNodes(document.body);
+          });
+
+          cache.set(url, elements);
+        }
+
+        const elements = cache.get(url)!;
+
+        const findElementSubAgent = new Agent({
+          name: 'find-element',
+          instructions:
+            'Given a list of xpath and texts, based on the query, return the correct xpaths. Only use xpaths you can find in the instructions.',
+          model,
+        });
+
+        if (mastra) {
+          findElementSubAgent.__registerMastra(mastra as unknown as Mastra);
+        }
+
+        const allXpaths = new Set<string>();
+        for (let i = 0; i < elements.length; i += CHUNK_SIZE) {
+          const xpaths = await getElements(findElementSubAgent, {
+            elements: elements.slice(i, i + CHUNK_SIZE),
+            queries: context.queries,
+          });
+
+          if (xpaths) {
+            xpaths.forEach(x => allXpaths.add(x));
+          }
+        }
+
+        if (allXpaths.size === 0) {
+          return { message: 'No elements found' };
+        }
+
+        return { elements: Array.from(allXpaths) };
+      } catch (e) {
+        if (e instanceof Error) {
+          return { message: `Error: ${e.message}`, found: false };
+        }
+        return { message: 'An unknown error occurred', found: false };
+      }
+    },
+  });
+}

--- a/packages/browser/src/tools/launch.ts
+++ b/packages/browser/src/tools/launch.ts
@@ -1,0 +1,55 @@
+import { createTool } from '@mastra/core/tools';
+import type { Tool } from '@mastra/core/tools';
+import type { LaunchOptions } from 'playwright';
+import { chromium, devices } from 'playwright';
+import { z } from 'zod';
+import type { ToolContext } from './types';
+
+type DeviceDescriptor = (typeof devices)[keyof typeof devices];
+
+interface BrowserArgs extends LaunchOptions {
+  device?: DeviceDescriptor;
+}
+
+const inputSchema = z.object({});
+const outputSchema = z.object({
+  message: z.string(),
+});
+
+type InputSchema = typeof inputSchema;
+type OutputSchema = typeof outputSchema;
+
+export function launchBrowserTool(
+  { device, ...args }: BrowserArgs = {
+    headless: false,
+    slowMo: 1000,
+    device: devices['Desktop Chrome'],
+  },
+  globalContext: ToolContext,
+): Tool<InputSchema, OutputSchema> {
+  return createTool({
+    id: 'launch-browser',
+    description: 'Launches a browser',
+    inputSchema,
+    outputSchema,
+    execute: async ({ mastra }) => {
+      try {
+        if (!globalContext.browser) {
+          globalContext.browser = await chromium.launch(args);
+        }
+
+        mastra?.logger?.debug('[browser] launching browser');
+        const context = await globalContext.browser.newContext(device);
+
+        globalContext.context = context;
+        return { message: 'Browser is open' };
+      } catch (e) {
+        if (e instanceof Error) {
+          return { message: `Error: ${e.message}` };
+        }
+
+        return { message: 'Error: unknown error' };
+      }
+    },
+  });
+}

--- a/packages/browser/src/tools/navigate.ts
+++ b/packages/browser/src/tools/navigate.ts
@@ -1,0 +1,39 @@
+import { createTool } from '@mastra/core/tools';
+import type { Tool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { ToolContext } from './types';
+
+const inputSchema = z.object({
+  url: z.string().url(),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+});
+
+export function navigateTool(globalContext: ToolContext): Tool<typeof inputSchema, typeof outputSchema> {
+  return createTool({
+    id: 'navigate-tool',
+    description: 'Navigates to a website',
+    inputSchema,
+    outputSchema,
+    execute: async ({ context, mastra }) => {
+      try {
+        if (!globalContext.page) {
+          return { message: 'Error: no page is currently open' };
+        }
+
+        mastra?.logger?.debug(`[browser] navigating to ${context.url}`);
+        await globalContext.page.goto(context.url, {
+          waitUntil: 'domcontentloaded',
+        });
+        return { message: `Navigated to page ${context.url}` };
+      } catch (e) {
+        if (e instanceof Error) {
+          return { message: `Error: ${e.message}` };
+        }
+        return { message: 'Error' };
+      }
+    },
+  });
+}

--- a/packages/browser/src/tools/new-page.ts
+++ b/packages/browser/src/tools/new-page.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { createTool } from '@mastra/core/tools';
+import type { Tool } from '@mastra/core/tools';
+import { z } from 'zod';
+import type { ToolContext } from './types';
+
+const inputSchema = z.object({});
+
+export function newPageTool(
+  {
+    domUtilsPath,
+  }: {
+    domUtilsPath: string;
+  },
+  globalContext: ToolContext,
+): Tool<typeof inputSchema> {
+  const domUtils = readFileSync(domUtilsPath, 'utf-8');
+
+  return createTool({
+    id: 'new-page',
+    description: 'Opens a new page in the browser',
+    inputSchema,
+    execute: async ({ mastra }) => {
+      try {
+        if (!globalContext.context) {
+          return { message: 'Error: Browser is not open, try the launch-browser tool first.' };
+        }
+
+        mastra?.logger?.debug('[browser] open new page');
+        const page = await globalContext.context.newPage();
+        mastra?.logger?.debug(`[browser] adding init script ${domUtilsPath}`);
+        await page.addInitScript({
+          content: domUtils,
+        });
+        globalContext.page = page;
+        return { message: 'New page is open' };
+      } catch (e) {
+        if (e instanceof Error) {
+          return { message: `Error: ${e.message}` };
+        }
+        return { message: 'Error' };
+      }
+    },
+  });
+}

--- a/packages/browser/src/tools/types.ts
+++ b/packages/browser/src/tools/types.ts
@@ -1,0 +1,7 @@
+import type { Browser, BrowserContext, Page } from 'playwright';
+
+export interface ToolContext {
+  browser: Browser | null;
+  context: BrowserContext | null;
+  page: Page | null;
+}

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -1,0 +1,4 @@
+export type CollectedElement = {
+  xpaths: string;
+  output: string;
+};

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/index.ts", "src/tools/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/browser/*"]
+}

--- a/packages/core/src/tools/index.warning.ts
+++ b/packages/core/src/tools/index.warning.ts
@@ -6,7 +6,7 @@ import type { ToolAction, ToolExecutionContext } from './types';
 export * from './tool';
 
 export class Tool<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
+  TSchemaIn extends z.ZodSchema,
   TSchemaOut extends z.ZodSchema | undefined = undefined,
   TContext extends ToolExecutionContext<TSchemaIn> = ToolExecutionContext<TSchemaIn>,
 > extends BaseTool<TSchemaIn, TSchemaOut, TContext> {

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -2,9 +2,8 @@ import type { z } from 'zod';
 
 import type { Mastra } from '../mastra';
 import type { ToolAction, ToolExecutionContext } from './types';
-
 export class Tool<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
+  TSchemaIn extends z.ZodSchema,
   TSchemaOut extends z.ZodSchema | undefined = undefined,
   TContext extends ToolExecutionContext<TSchemaIn> = ToolExecutionContext<TSchemaIn>,
   TOptions extends unknown = unknown,
@@ -12,7 +11,7 @@ export class Tool<
 {
   id: string;
   description: string;
-  inputSchema?: TSchemaIn;
+  inputSchema: TSchemaIn;
   outputSchema?: TSchemaOut;
   execute: (
     context: TContext,
@@ -31,7 +30,7 @@ export class Tool<
 }
 
 export function createTool<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
+  TSchemaIn extends z.ZodSchema,
   TSchemaOut extends z.ZodSchema | undefined = undefined,
   TContext extends ToolExecutionContext<TSchemaIn> = ToolExecutionContext<TSchemaIn>,
 >(opts: ToolAction<TSchemaIn, TSchemaOut, TContext>) {

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -17,12 +17,13 @@ export interface ToolExecutionContext<TSchemaIn extends z.ZodSchema | undefined 
 }
 
 export interface ToolAction<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
+  TSchemaIn extends z.ZodSchema,
   TSchemaOut extends z.ZodSchema | undefined = undefined,
   TContext extends ToolExecutionContext<TSchemaIn> = ToolExecutionContext<TSchemaIn>,
   TOptions extends unknown = unknown,
 > extends IAction<string, TSchemaIn, TSchemaOut, TContext, TOptions> {
   description: string;
+  inputSchema: TSchemaIn;
   execute: (
     context: TContext,
     options?: TOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,7 +239,7 @@ importers:
         version: link:../../packages/core
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.0
         version: 3.24.2
@@ -361,7 +361,7 @@ importers:
         version: link:../../../../packages/core
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.1
         version: 3.24.2
@@ -703,7 +703,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -746,7 +746,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -765,7 +765,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -784,7 +784,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.1
         version: 3.24.2
@@ -799,7 +799,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/rag/embed-text-chunk:
     dependencies:
@@ -811,7 +811,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/rag/embed-text-with-cohere:
     dependencies:
@@ -823,7 +823,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/rag/filter-rag:
     dependencies:
@@ -841,7 +841,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -863,7 +863,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -882,7 +882,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -901,7 +901,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/rag/insert-embedding-in-libsql:
     dependencies:
@@ -916,7 +916,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/rag/insert-embedding-in-pgvector:
     dependencies:
@@ -931,7 +931,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/rag/insert-embedding-in-pinecone:
     dependencies:
@@ -946,7 +946,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/rag/metadata-extraction:
     dependencies:
@@ -971,7 +971,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -990,7 +990,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       dotenv:
         specifier: ^16.4.7
@@ -1009,7 +1009,7 @@ importers:
         version: link:../../../../packages/rag
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
 
   examples/basics/workflows/calling-agent-from-workflow:
     dependencies:
@@ -1087,7 +1087,7 @@ importers:
         version: link:../../packages/core
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.0
         version: 3.24.2
@@ -1324,7 +1324,7 @@ importers:
         version: 0.10.0(utf-8-validate@6.0.5)
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0-rc-45804af1-20241021)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0-rc-45804af1-20241021)(zod@3.24.2)
       bcrypt-ts:
         specifier: ^5.0.3
         version: 5.0.3
@@ -1673,7 +1673,7 @@ importers:
         version: link:../../packages/memory
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       chalk:
         specifier: ^5.3.0
         version: 5.4.1
@@ -1877,7 +1877,7 @@ importers:
         version: link:../../packages/memory
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       '@types/node':
         specifier: ^22.10.1
@@ -1960,7 +1960,7 @@ importers:
         version: 1.1.2(@types/react@19.0.10)(react@19.0.0)
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2075,7 +2075,7 @@ importers:
         version: link:../../packages/core
       ai:
         specifier: latest
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
     devDependencies:
       '@types/node':
         specifier: ^22.10.5
@@ -2200,7 +2200,7 @@ importers:
         version: link:../../packages/core
       composio-core:
         specifier: ^0.3.2
-        version: 0.3.3(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(@swc/core@1.10.18(@swc/helpers@0.5.15))(@types/node@22.13.4)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(bufferutil@4.0.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(pdf-parse@1.1.1)(playwright@1.50.1)(react@19.0.0)(redis@4.7.0)(sswr@2.1.0(svelte@5.20.2))(svelte@5.20.2)(typescript@5.7.3)(utf-8-validate@6.0.5)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.3.3(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(@swc/core@1.10.18(@swc/helpers@0.5.15))(@types/node@22.13.4)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(bufferutil@4.0.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@7.0.3)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(pdf-parse@1.1.1)(playwright@1.50.1)(react@19.0.0)(redis@4.7.0)(sswr@2.1.0(svelte@5.20.2))(svelte@5.20.2)(typescript@5.7.3)(utf-8-validate@6.0.5)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       zod:
         specifier: ^3.24.0
         version: 3.24.2
@@ -2511,25 +2511,59 @@ importers:
     dependencies:
       '@vitest/eslint-plugin':
         specifier: ^1.1.25
-        version: 1.1.31(@typescript-eslint/utils@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.6(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.13.5)(jiti@2.4.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2)(utf-8-validate@6.0.5))(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 1.1.31(@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.6(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.13.5)(jiti@2.4.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2)(utf-8-validate@6.0.5))(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       eslint-plugin-import-x:
         specifier: ^4.6.1
-        version: 4.6.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
+        version: 4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-react:
         specifier: ^7.37.4
-        version: 7.37.4(eslint@9.20.1(jiti@2.4.2))
+        version: 7.37.4(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
-        version: 5.1.0(eslint@9.20.1(jiti@2.4.2))
+        version: 5.1.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-testing-library:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
+        version: 7.1.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       globals:
         specifier: ^15.14.0
         version: 15.15.0
       typescript-eslint:
         specifier: ^8.20.0
-        version: 8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
+        version: 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+
+  packages/browser:
+    dependencies:
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../_config
+      '@microsoft/api-extractor':
+        specifier: ^7.49.2
+        version: 7.50.0(@types/node@22.13.5)
+      del-cli:
+        specifier: ^6.0.0
+        version: 6.0.0
+      eslint:
+        specifier: ^9.21.0
+        version: 9.21.0(jiti@2.4.2)
+      get-xpath:
+        specifier: ^3.3.0
+        version: 3.3.0
+      playwright:
+        specifier: ^1.49.1
+        version: 1.50.1
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(@microsoft/api-extractor@7.50.0(@types/node@22.13.5))(@swc/core@1.10.18(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
 
   packages/cli:
     dependencies:
@@ -2816,10 +2850,10 @@ importers:
         version: 10.4.20(postcss@8.5.2)
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
-        version: 5.1.0(eslint@9.20.1(jiti@2.4.2))
+        version: 5.1.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-react-refresh:
         specifier: ^0.4.14
-        version: 0.4.19(eslint@9.20.1(jiti@2.4.2))
+        version: 0.4.19(eslint@9.21.0(jiti@2.4.2))
       postcss:
         specifier: ^8.4.49
         version: 8.5.2
@@ -2879,7 +2913,7 @@ importers:
         version: 1.30.0
       ai:
         specifier: ^4.1.53
-        version: 4.1.53(react@19.0.0)(zod@3.24.2)
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       cohere-ai:
         specifier: ^7.15.4
         version: 7.15.4(encoding@0.1.13)
@@ -7058,12 +7092,20 @@ packages:
     resolution: {integrity: sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.12.0':
+    resolution: {integrity: sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/eslintrc@3.2.0':
     resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.0':
+    resolution: {integrity: sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@8.57.1':
@@ -7074,12 +7116,20 @@ packages:
     resolution: {integrity: sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@9.21.0':
+    resolution: {integrity: sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/object-schema@2.1.6':
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/plugin-kit@0.2.6':
     resolution: {integrity: sha512-+0TjwR1eAUdZtvv/ir1mGX+v0tUoR3VEPB8Up0LLJC+whRW0GgBBtpbOkg/a/U4Dxa6l5a3l9AJ1aWIQVyoWJA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.2.7':
+    resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@faker-js/faker@8.4.1':
@@ -7245,6 +7295,10 @@ packages:
 
   '@humanwhocodes/retry@0.4.1':
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.2':
+    resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
   '@iarna/toml@2.2.5':
@@ -10037,6 +10091,10 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
 
+  '@sindresorhus/merge-streams@2.3.0':
+    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -11412,8 +11470,8 @@ packages:
       zod:
         optional: true
 
-  ai@4.1.53:
-    resolution: {integrity: sha512-krLPk+OKLmVGRmsxI+FhbwETiuHFPESVI/Fl8ao/AAYjF2TYr0QFdPSQ8Fk9gWHUi47H+ZDnvJx05Xp/z4UccA==}
+  ai@4.1.54:
+    resolution: {integrity: sha512-VcUZhNEC9i1OpdhDaz1cF0IllgMqhwoUdqHQT1U3dKvS9KnOa9qvEtUUAilA+VHI/1LSZF4VzGhXPC7QMT9NMg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -12913,9 +12971,18 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  del-cli@6.0.0:
+    resolution: {integrity: sha512-9nitGV2W6KLFyya4qYt4+9AKQFL+c0Ehj5K7V7IwlxTc6RMCfQUGY9E9pLG6e8TQjtwXpuiWIGGZb3mfVxyZkw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   del@6.1.1:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
     engines: {node: '>=10'}
+
+  del@8.0.0:
+    resolution: {integrity: sha512-R6ep6JJ+eOBZsBr9esiNN1gxFbZE4Q2cULkUSFumGYecAiS6qodDvcPx/sFuWHMNul7DWmrtoEOpYSm7o6tbSA==}
+    engines: {node: '>=18'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -13807,6 +13874,16 @@ packages:
       jiti:
         optional: true
 
+  eslint@9.21.0:
+    resolution: {integrity: sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
@@ -14494,6 +14571,9 @@ packages:
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
+  get-xpath@3.3.0:
+    resolution: {integrity: sha512-AKbHVEHSlSDS9AJDmjfSxV010xSVRFzkS4UkGCb8CaGvorp83GCuKwcmzF/64CVp3M5wjgy9tc6y1uR2V+c5Xw==}
+
   gh-release-fetch@4.0.3:
     resolution: {integrity: sha512-TOiP1nwLsH5shG85Yt6v6Kjq5JU/44jXyEpbcfPgmj3C829yeXIlx9nAEwQRaxtRF3SJinn2lz7XUkfG9W/U4g==}
     engines: {node: ^14.18.0 || ^16.13.0 || >=18.0.0}
@@ -14578,6 +14658,10 @@ packages:
   globby@13.2.2:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  globby@14.1.0:
+    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
+    engines: {node: '>=18'}
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
@@ -14940,6 +15024,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.3:
+    resolution: {integrity: sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==}
+    engines: {node: '>= 4'}
+
   image-meta@0.2.1:
     resolution: {integrity: sha512-K6acvFaelNxx8wc2VjbIzXKDVB0Khs0QT35U6NkGfTdCmjLNcO2945m7RFNR9/RPVFm48hq7QPzK8uGH18HCGw==}
 
@@ -15231,6 +15319,10 @@ packages:
   is-path-cwd@2.2.0:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
     engines: {node: '>=6'}
+
+  is-path-cwd@3.0.0:
+    resolution: {integrity: sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -16401,6 +16493,10 @@ packages:
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -17732,6 +17828,10 @@ packages:
   path-type@5.0.0:
     resolution: {integrity: sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==}
     engines: {node: '>=12'}
+
+  path-type@6.0.0:
+    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
+    engines: {node: '>=18'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -20025,6 +20125,25 @@ packages:
       typescript:
         optional: true
 
+  tsup@8.4.0:
+    resolution: {integrity: sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: ^5.7.3
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -20986,7 +21105,6 @@ packages:
   yaeti@0.0.6:
     resolution: {integrity: sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==}
     engines: {node: '>=0.10.32'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -23968,6 +24086,11 @@ snapshots:
       eslint: 9.20.1(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.21.0(jiti@2.4.2))':
+    dependencies:
+      eslint: 9.21.0(jiti@2.4.2)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint/config-array@0.19.2':
@@ -23979,6 +24102,10 @@ snapshots:
       - supports-color
 
   '@eslint/core@0.11.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.12.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -24010,15 +24137,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.0':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0(supports-color@8.1.1)
+      espree: 10.3.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.20.0': {}
+
+  '@eslint/js@9.21.0': {}
 
   '@eslint/object-schema@2.1.6': {}
 
   '@eslint/plugin-kit@0.2.6':
     dependencies:
       '@eslint/core': 0.11.0
+      levn: 0.4.1
+
+  '@eslint/plugin-kit@0.2.7':
+    dependencies:
+      '@eslint/core': 0.12.0
       levn: 0.4.1
 
   '@faker-js/faker@8.4.1': {}
@@ -24214,6 +24362,8 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.1': {}
+
+  '@humanwhocodes/retry@0.4.2': {}
 
   '@iarna/toml@2.2.5': {}
 
@@ -28778,6 +28928,8 @@ snapshots:
 
   '@sindresorhus/is@5.6.0': {}
 
+  '@sindresorhus/merge-streams@2.3.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sindresorhus/slugify@2.2.1':
@@ -29708,6 +29860,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      debug: 4.4.0(supports-color@8.1.1)
+      eslint: 9.20.1(jiti@2.4.2)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare-lite: 1.4.0
+      semver: 7.7.1
+      tsutils: 3.21.0(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -29734,6 +29905,23 @@ snapshots:
       '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
       eslint: 9.20.1(jiti@2.4.2)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.24.1
+      '@typescript-eslint/type-utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1
+      eslint: 9.21.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -29791,6 +29979,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.24.1
+      '@typescript-eslint/types': 8.24.1
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1
+      debug: 4.4.0(supports-color@8.1.1)
+      eslint: 9.21.0(jiti@2.4.2)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -29835,6 +30035,17 @@ snapshots:
       '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.20.1(jiti@2.4.2)
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      debug: 4.4.0(supports-color@8.1.1)
+      eslint: 9.21.0(jiti@2.4.2)
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -29936,6 +30147,17 @@ snapshots:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       eslint: 9.20.1(jiti@2.4.2)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@2.4.2))
+      '@typescript-eslint/scope-manager': 8.24.1
+      '@typescript-eslint/types': 8.24.1
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -30287,10 +30509,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.31(@typescript-eslint/utils@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.6(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.13.5)(jiti@2.4.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2)(utf-8-validate@6.0.5))(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/eslint-plugin@1.1.31(@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.6(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.13.5)(jiti@2.4.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2)(utf-8-validate@6.0.5))(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
-      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
-      eslint: 9.20.1(jiti@2.4.2)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.7.3
       vitest: 3.0.6(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.13.5)(jiti@2.4.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2)(utf-8-validate@6.0.5))(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -30730,7 +30952,7 @@ snapshots:
       react: 19.0.0
       zod: 3.24.2
 
-  ai@4.1.53(react@19.0.0)(zod@3.24.2):
+  ai@4.1.54(react@19.0.0)(zod@3.24.2):
     dependencies:
       '@ai-sdk/provider': 1.0.10
       '@ai-sdk/provider-utils': 2.1.11(zod@3.24.2)
@@ -30742,7 +30964,7 @@ snapshots:
       react: 19.0.0
       zod: 3.24.2
 
-  ai@4.1.53(react@19.0.0-rc-45804af1-20241021)(zod@3.24.2):
+  ai@4.1.54(react@19.0.0-rc-45804af1-20241021)(zod@3.24.2):
     dependencies:
       '@ai-sdk/provider': 1.0.10
       '@ai-sdk/provider-utils': 2.1.11(zod@3.24.2)
@@ -31405,6 +31627,11 @@ snapshots:
       esbuild: 0.24.2
       load-tsconfig: 0.2.5
 
+  bundle-require@5.1.0(esbuild@0.25.0):
+    dependencies:
+      esbuild: 0.25.0
+      load-tsconfig: 0.2.5
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -31876,7 +32103,7 @@ snapshots:
 
   commondir@1.0.1: {}
 
-  composio-core@0.3.3(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(@swc/core@1.10.18(@swc/helpers@0.5.15))(@types/node@22.13.4)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(bufferutil@4.0.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(pdf-parse@1.1.1)(playwright@1.50.1)(react@19.0.0)(redis@4.7.0)(sswr@2.1.0(svelte@5.20.2))(svelte@5.20.2)(typescript@5.7.3)(utf-8-validate@6.0.5)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
+  composio-core@0.3.3(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(@swc/core@1.10.18(@swc/helpers@0.5.15))(@types/node@22.13.4)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(bufferutil@4.0.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@7.0.3)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(pdf-parse@1.1.1)(playwright@1.50.1)(react@19.0.0)(redis@4.7.0)(sswr@2.1.0(svelte@5.20.2))(svelte@5.20.2)(typescript@5.7.3)(utf-8-validate@6.0.5)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
     dependencies:
       '@ai-sdk/openai': 0.0.36(zod@3.24.2)
       '@e2b/code-interpreter': 0.0.8(bufferutil@4.0.9)(utf-8-validate@6.0.5)
@@ -31897,7 +32124,7 @@ snapshots:
       enumify: 2.0.0
       hono: 4.7.2
       inquirer: 10.2.2
-      langchain: 0.2.20(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(axios@1.7.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2))(pdf-parse@1.1.1)(playwright@1.50.1)(redis@4.7.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+      langchain: 0.2.20(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(axios@1.7.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@7.0.3)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2))(pdf-parse@1.1.1)(playwright@1.50.1)(redis@4.7.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       open: 8.4.2
       openai: 4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)
       pusher-js: 8.4.0-rc2
@@ -32485,6 +32712,11 @@ snapshots:
 
   defu@6.1.4: {}
 
+  del-cli@6.0.0:
+    dependencies:
+      del: 8.0.0
+      meow: 13.2.0
+
   del@6.1.1:
     dependencies:
       globby: 11.1.0
@@ -32495,6 +32727,15 @@ snapshots:
       p-map: 4.0.0
       rimraf: 3.0.2
       slash: 3.0.0
+
+  del@8.0.0:
+    dependencies:
+      globby: 14.1.0
+      is-glob: 4.0.3
+      is-path-cwd: 3.0.0
+      is-path-inside: 4.0.0
+      p-map: 7.0.3
+      slash: 5.1.0
 
   delayed-stream@1.0.0: {}
 
@@ -32722,7 +32963,7 @@ snapshots:
       '@rollup/plugin-replace': 5.0.7(rollup@3.29.5)
       '@rollup/plugin-terser': 0.4.4(rollup@3.29.5)
       '@types/jest': 29.5.14
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       ansi-escapes: 4.3.2
       asyncro: 3.0.0
@@ -33690,6 +33931,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    optional: true
+
+  eslint-plugin-import-x@4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
+    dependencies:
+      '@types/doctrine': 0.0.9
+      '@typescript-eslint/scope-manager': 8.24.1
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      debug: 4.4.0(supports-color@8.1.1)
+      doctrine: 3.0.0
+      enhanced-resolve: 5.18.1
+      eslint: 9.21.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      get-tsconfig: 4.10.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      stable-hash: 0.0.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@8.57.1):
     dependencies:
@@ -33812,7 +34074,7 @@ snapshots:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       jest: 29.7.0(@types/node@22.13.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.10.18(@swc/helpers@0.5.15))(@types/node@22.13.4)(typescript@5.7.3))
     transitivePeerDependencies:
       - supports-color
@@ -33880,9 +34142,13 @@ snapshots:
     dependencies:
       eslint: 9.20.1(jiti@2.4.2)
 
-  eslint-plugin-react-refresh@0.4.19(eslint@9.20.1(jiti@2.4.2)):
+  eslint-plugin-react-hooks@5.1.0(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.20.1(jiti@2.4.2)
+      eslint: 9.21.0(jiti@2.4.2)
+
+  eslint-plugin-react-refresh@0.4.19(eslint@9.21.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.21.0(jiti@2.4.2)
 
   eslint-plugin-react@7.37.4(eslint@8.57.1):
     dependencies:
@@ -33928,6 +34194,28 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-plugin-react@7.37.4(eslint@9.21.0(jiti@2.4.2)):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.1
+      eslint: 9.21.0(jiti@2.4.2)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.8
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
   eslint-plugin-tailwindcss@3.18.0(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.10.18(@swc/helpers@0.5.15))(@types/node@20.17.19)(typescript@5.7.3))):
     dependencies:
       fast-glob: 3.3.3
@@ -33942,11 +34230,11 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-testing-library@7.1.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3):
+  eslint-plugin-testing-library@7.1.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
-      eslint: 9.20.1(jiti@2.4.2)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -34025,6 +34313,47 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.1
+      '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.2.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.21.0(jiti@2.4.2):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@2.4.2))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.19.2
+      '@eslint/core': 0.12.0
+      '@eslint/eslintrc': 3.3.0
+      '@eslint/js': 9.21.0
+      '@eslint/plugin-kit': 0.2.7
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.2
       '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
@@ -34878,6 +35207,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-xpath@3.3.0: {}
+
   gh-release-fetch@4.0.3:
     dependencies:
       '@xhmikosr/downloader': 13.0.1
@@ -34986,6 +35317,15 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
+
+  globby@14.1.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 2.3.0
+      fast-glob: 3.3.3
+      ignore: 7.0.3
+      path-type: 6.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.3.0
 
   globrex@0.1.2: {}
 
@@ -35421,6 +35761,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.3: {}
+
   image-meta@0.2.1: {}
 
   immediate@3.0.6: {}
@@ -35752,6 +36094,8 @@ snapshots:
   is-observable@2.1.0: {}
 
   is-path-cwd@2.2.0: {}
+
+  is-path-cwd@3.0.0: {}
 
   is-path-inside@3.0.3: {}
 
@@ -36828,7 +37172,7 @@ snapshots:
       dotenv: 16.4.7
       winston: 3.17.0
 
-  langchain@0.2.20(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(axios@1.7.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2))(pdf-parse@1.1.1)(playwright@1.50.1)(redis@4.7.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
+  langchain@0.2.20(@aws-sdk/credential-provider-node@3.750.0)(@notionhq/client@2.2.16(encoding@0.1.13))(@pinecone-database/pinecone@4.1.0)(assemblyai@4.9.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(axios@1.7.9)(chromadb@1.10.4(cohere-ai@7.15.4(encoding@0.1.13))(encoding@0.1.13)(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.4.1)(html-to-text@9.0.5)(ignore@7.0.3)(jsdom@20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5))(mammoth@1.9.0)(mongodb@6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4))(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2))(pdf-parse@1.1.1)(playwright@1.50.1)(redis@4.7.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
     dependencies:
       '@langchain/core': 0.2.36(openai@4.85.2(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2))
       '@langchain/openai': 0.2.11(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))
@@ -36854,7 +37198,7 @@ snapshots:
       d3-dsv: 3.0.1
       fast-xml-parser: 4.4.1
       html-to-text: 9.0.5
-      ignore: 5.3.2
+      ignore: 7.0.3
       jsdom: 20.0.3(bufferutil@4.0.9)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.5)
       mammoth: 1.9.0
       mongodb: 6.13.0(@aws-sdk/credential-providers@3.750.0)(socks@2.8.4)
@@ -37525,6 +37869,8 @@ snapshots:
   memorystream@0.3.1: {}
 
   meow@12.1.1: {}
+
+  meow@13.2.0: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -39076,6 +39422,8 @@ snapshots:
   path-type@4.0.0: {}
 
   path-type@5.0.0: {}
+
+  path-type@6.0.0: {}
 
   pathe@1.1.2: {}
 
@@ -42028,6 +42376,35 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.4.0(@microsoft/api-extractor@7.50.0(@types/node@22.13.5))(@swc/core@1.10.18(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.0)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.0
+      debug: 4.4.0(supports-color@8.1.1)
+      esbuild: 0.25.0
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0)
+      resolve-from: 5.0.0
+      rollup: 4.34.8
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.11
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.50.0(@types/node@22.13.5)
+      '@swc/core': 1.10.18(@swc/helpers@0.5.15)
+      postcss: 8.5.3
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsutils@3.21.0(typescript@5.7.3):
     dependencies:
       tslib: 1.14.1
@@ -42149,6 +42526,16 @@ snapshots:
       '@typescript-eslint/parser': 8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.20.1(jiti@2.4.2)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1263,6 +1263,28 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
 
+  examples/browser:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^1.2.1
+        version: 1.2.1(zod@3.24.2)
+      '@mastra/browser':
+        specifier: workspace:^
+        version: link:../../packages/browser
+      '@mastra/core':
+        specifier: workspace:^
+        version: link:../../packages/core
+      playwright:
+        specifier: ^1.49.1
+        version: 1.50.1
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+    devDependencies:
+      mastra:
+        specifier: workspace:^
+        version: link:../../packages/cli
+
   examples/crypto-chatbot:
     dependencies:
       '@ai-sdk/openai':
@@ -2536,6 +2558,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../core
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -2543,6 +2568,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: ^7.49.2
         version: 7.50.0(@types/node@22.13.5)
+      ai:
+        specifier: ^4.1.54
+        version: 4.1.54(react@19.0.0)(zod@3.24.2)
       del-cli:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2561,9 +2589,6 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
-      zod:
-        specifier: ^3.24.2
-        version: 3.24.2
 
   packages/cli:
     dependencies:


### PR DESCRIPTION
Adding @mastra/browser package for browser utils.

How to use it:
```
import { createBrowserToolbelt } from '@mastra/browser'

export const agent = new Agent({
  name: Scraper',
  instructions: `You are a helpful web browsing assistant that can navigate websites and extract information for users.
    
    CAPABILITIES:
    - Launch a browser (use launch-browser tool)
    - Open new browser pages (use new-page tool)
    - Navigate to websites (use navigate tool with a URL)
    - Get elements on the page (use get-elements tool)
    - Any action ("click", "type", "submit", "scroll", "read", "wait") to perform on an element (use element-action tool)
    - Close individual browser pages (use close-page tool)
    - Close the entire browser (use close-browser tool)
    
    WORKFLOW:
    1. Always start by launching a browser with launch-browser
    2. Then open a new page with new-page
    3. Navigate to the requested URL with navigate-tool
    4. IMPORTANT: You MUST use get-elements to get the xpath selectors for the current page
    5. After getting elements, use element-action tool to perform the user actions
    6. Close the page using close-page when done with it
    7. Close the browser using close-browser when finished with all tasks
`,
  model: openai('gpt-4o-mini'),
  tools: {
    ...createBrowserToolbelt()
  },
})
```