### PR TITLE
Else branching with query fix

### DIFF
--- a/.changeset/brown-clouds-listen.md
+++ b/.changeset/brown-clouds-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix for else condition with ref/query syntax

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -973,6 +973,80 @@ describe('Workflow', async () => {
       expect(results.final.output).toEqual({ finalValue: 26 + 7 });
     });
 
+    it('should run the else branch (when query)', async () => {
+      const start = vi.fn().mockImplementation(async ({ context }) => {
+        // Get the current value (either from trigger or previous increment)
+        const currentValue =
+          context.getStepResult('start')?.newValue || context.getStepResult('trigger')?.startValue || 0;
+
+        // Increment the value
+        const newValue = currentValue + 1;
+
+        return { newValue };
+      });
+      const startStep = new Step({
+        id: 'start',
+        description: 'Increments the current value by 1',
+        outputSchema: z.object({
+          newValue: z.number(),
+        }),
+        execute: start,
+      });
+
+      const other = vi.fn().mockImplementation(async ({ context }) => {
+        return { other: 26 };
+      });
+      const otherStep = new Step({
+        id: 'other',
+        description: 'Other step',
+        execute: other,
+      });
+
+      const final = vi.fn().mockImplementation(async ({ context }) => {
+        const startVal = context.getStepResult('start')?.newValue ?? 0;
+        const otherVal = context.getStepResult('other')?.other ?? 0;
+        return { finalValue: startVal + otherVal };
+      });
+      const finalStep = new Step({
+        id: 'final',
+        description: 'Final step that prints the result',
+        execute: final,
+      });
+
+      const counterWorkflow = new Workflow({
+        name: 'counter-workflow',
+        triggerSchema: z.object({
+          startValue: z.number(),
+        }),
+      });
+
+      counterWorkflow
+        .step(startStep)
+        .if({
+          ref: { step: startStep, path: 'newValue' },
+          query: { $lt: 5 },
+        })
+        .then(finalStep)
+        .else()
+        .then(otherStep)
+        .then(finalStep)
+        .commit();
+
+      const run = counterWorkflow.createRun();
+      const { results } = await run.start({ triggerData: { startValue: 6 } });
+
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(other).toHaveBeenCalledTimes(1);
+      expect(final).toHaveBeenCalledTimes(1);
+      // @ts-ignore
+      expect(results.start.output).toEqual({ newValue: 7 });
+      // @ts-ignore
+      expect(results.other.output).toEqual({ other: 26 });
+
+      // @ts-ignore
+      expect(results.final.output).toEqual({ finalValue: 26 + 7 });
+    });
+
     it('should run else-then and a nested if-then branch', async () => {
       const start = vi.fn().mockImplementation(async ({ context }) => {
         // Get the current value (either from trigger or previous increment)

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -371,7 +371,7 @@ export class Workflow<
                 const result = await activeCondition.condition(payload);
                 return !result;
               }
-            : () => Promise.resolve(false),
+            : { not: activeCondition.condition },
       },
     );
 


### PR DESCRIPTION
Fixes an issue with else branch condition evaluation when using a ref/query syntax instead of function condition.

Weird, this was the logic in the branch originally. Must be a bad merge or something. Added a test for that.