### PR TITLE
fix(core): SQLITE_ERROR: table mastra_evals has no column named createdAt

### DIFF
--- a/.changeset/small-oranges-call.md
+++ b/.changeset/small-oranges-call.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Properly serialize any date object when inserting into libsql

--- a/packages/core/src/storage/libsql/index.ts
+++ b/packages/core/src/storage/libsql/index.ts
@@ -138,6 +138,9 @@ export class LibSQLStore extends MastraStorage {
         // returning an undefined value will cause libsql to throw
         return null;
       }
+      if (v instanceof Date) {
+        return v.toISOString();
+      }
       return typeof v === 'object' ? JSON.stringify(v) : v;
     });
     const placeholders = values.map(() => '?').join(', ');
@@ -153,11 +156,7 @@ export class LibSQLStore extends MastraStorage {
       await this.client.execute(
         this.prepareStatement({
           tableName,
-          record: {
-            ...record,
-            createdAt: record.createdAt instanceof Date ? record.createdAt.toISOString() : record.createdAt,
-            updatedAt: record.updatedAt instanceof Date ? record.updatedAt.toISOString() : record.updatedAt,
-          },
+          record,
         }),
       );
     } catch (error) {


### PR DESCRIPTION
In https://github.com/mastra-ai/mastra/pull/2754 we accidentally broke evals insertion. This should fix it by not referencing any specific column names when serializing dates before insertion

```
LibsqlError: SQLITE_ERROR: table mastra_evals has no column n
amed createdAt
    at mapSqliteError (file:///Users/tylerbarnes/code/throwaw
```