### PR TITLE
feat(core, memory): add ability to validate resourceId owns thread 

### DIFF
--- a/.changeset/tough-carrots-enter.md
+++ b/.changeset/tough-carrots-enter.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Added the ability to ensure the accessed thread in memory.query() is for the right resource id. ex memory.query({ threadId, resourceId }). If the resourceId doesn't own the thread it will throw an error.

--- a/docs/src/pages/docs/reference/memory/query.mdx
+++ b/docs/src/pages/docs/reference/memory/query.mdx
@@ -60,6 +60,13 @@ const { messages } = await memory.query({
       isOptional: false,
     },
     {
+      name: "resourceId",
+      type: "string",
+      description:
+        "Optional ID of the resource that owns the thread. If provided, validates thread ownership",
+      isOptional: true,
+    },
+    {
       name: "selectBy",
       type: "object",
       description: "Options for filtering messages",

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -258,6 +258,7 @@ export class Agent<
             ? (
                 await memory.rememberMessages({
                   threadId,
+                  resourceId,
                   config: memoryConfig,
                   vectorMessageSearch: messages
                     .slice(-1)

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -137,10 +137,12 @@ export abstract class MastraMemory extends MastraBase {
 
   abstract rememberMessages({
     threadId,
+    resourceId,
     vectorMessageSearch,
     config,
   }: {
     threadId: string;
+    resourceId?: string;
     vectorMessageSearch?: string;
     config?: MemoryConfig;
   }): Promise<{
@@ -297,6 +299,7 @@ export abstract class MastraMemory extends MastraBase {
    */
   abstract query({
     threadId,
+    resourceId,
     selectBy,
   }: StorageGetMessagesArg): Promise<{ messages: CoreMessage[]; uiMessages: AiMessageType[] }>;
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -22,6 +22,7 @@ export interface WorkflowRow {
 
 export type StorageGetMessagesArg = {
   threadId: string;
+  resourceId?: string;
   selectBy?: {
     vectorSearchString?: string;
     last?: number | false;


### PR DESCRIPTION
Closes https://github.com/mastra-ai/mastra/issues/2708
```ts
try {
	const thread = await memory.query({ threadId, resourceId })
} catch (e) {
	logger.error(`Thread ${threadId} is not owned by resource ${resourceId}`)
}
```