### PR TITLE
Improve workflow types

### DIFF
--- a/.changeset/all-garlics-bow.md
+++ b/.changeset/all-garlics-bow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improve typinges for getStepResult and workflow results

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -398,16 +398,18 @@ export class Machine<
           let conditionMet = await stepConfig.when({
             context: {
               ...context,
-              getStepResult: ((stepId: string) => {
-                if (stepId === 'trigger') {
+              getStepResult: ((stepId: string | Step<any, any, any, any>) => {
+                const resolvedStepId = typeof stepId === 'string' ? stepId : stepId.id;
+
+                if (resolvedStepId === 'trigger') {
                   return context.triggerData;
                 }
-                const result = context.steps[stepId];
+                const result = context.steps[resolvedStepId];
                 if (result && result.status === 'success') {
                   return result.output;
                 }
                 return undefined;
-              }) as WorkflowContext<TTriggerSchema>['getStepResult'],
+              }) satisfies WorkflowContext<TTriggerSchema>['getStepResult'],
             },
             mastra: this.#mastra,
           });
@@ -479,16 +481,18 @@ export class Machine<
 
     const resolvedData: Record<string, any> = {
       ...context,
-      getStepResult: ((stepId: string) => {
-        if (stepId === 'trigger') {
+      getStepResult: ((stepId: string | Step<any, any, any, any>) => {
+        const resolvedStepId = typeof stepId === 'string' ? stepId : stepId.id;
+
+        if (resolvedStepId === 'trigger') {
           return context.triggerData;
         }
-        const result = context.steps[stepId];
+        const result = context.steps[resolvedStepId];
         if (result && result.status === 'success') {
           return result.output;
         }
         return undefined;
-      }) as WorkflowContext<TTriggerSchema>['getStepResult'],
+      }) satisfies WorkflowContext<TTriggerSchema>['getStepResult'],
     };
 
     for (const [key, variable] of Object.entries(stepConfig.data)) {

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -22,13 +22,13 @@ import type {
   StepDef,
   StepGraph,
   StepNode,
-  StepResult,
   StepVariableType,
   WorkflowActionParams,
   WorkflowActions,
   WorkflowActors,
   WorkflowContext,
   WorkflowEvent,
+  WorkflowRunResult,
   WorkflowState,
 } from './types';
 import { WhenConditionReturnValue } from './types';
@@ -113,10 +113,7 @@ export class Machine<
     stepId?: string;
     input?: any;
     snapshot?: Snapshot<any>;
-  } = {}): Promise<{
-    results: Record<string, StepResult<any>>;
-    activePaths: Map<string, { status: string; suspendPayload?: any }>;
-  }> {
+  } = {}): Promise<Pick<WorkflowRunResult<TTriggerSchema, TSteps>, 'results' | 'activePaths'>> {
     if (snapshot) {
       // First, let's log the incoming snapshot for debugging
       this.logger.debug(`Workflow snapshot received`, { runId: this.#runId, snapshot });

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -4,6 +4,7 @@ import type { z } from 'zod';
 import type { IAction, IExecutionContext, MastraUnion } from '../action';
 import type { BaseLogMessage, RegisteredLogger } from '../logger';
 import type { Mastra } from '../mastra';
+import type { Step } from './step';
 
 export interface WorkflowOptions<TTriggerSchema extends z.ZodObject<any> = any> {
   name: string;
@@ -181,7 +182,10 @@ export interface WorkflowContext<TTrigger extends z.ZodObject<any> = any> {
   steps: Record<string, StepResult<any>>;
   triggerData: z.infer<TTrigger>;
   attempts: Record<string, number>;
-  getStepResult: <T = unknown>(stepId: string) => T | undefined;
+  getStepResult<T>(stepId: string): T;
+  getStepResult<T extends Step<any, any, any, any>>(
+    stepId: T,
+  ): T['outputSchema'] extends undefined ? unknown : z.infer<NonNullable<T['outputSchema']>>;
 }
 
 export interface WorkflowLogMessage extends BaseLogMessage {

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -221,21 +221,6 @@ export interface WorkflowContext<
   ): T['outputSchema'] extends undefined ? unknown : z.infer<NonNullable<T['outputSchema']>>;
 }
 
-export interface WorkflowContext2<
-  TTrigger extends z.ZodObject<any> = any,
-  TSteps extends StepAction<string, any, any, any>[] = StepAction<string, any, any, any>[],
-> {
-  mastra?: MastraUnion;
-  steps: StepsRecord<TSteps>;
-  triggerData: z.infer<TTrigger>;
-  attempts: Record<string, number>;
-  // getStepResult<T>(stepId: string): T;
-  getStepResult<T extends keyof StepsRecord<TSteps>>(stepId: T): z.infer<StepsRecord<TSteps>[T]['outputSchema']>;
-  // getStepResult<T extends Step<any, any, any, any>>(
-  //   stepId: T,
-  // ): T['outputSchema'] extends undefined ? unknown : z.infer<NonNullable<T['outputSchema']>>;
-}
-
 export interface WorkflowLogMessage extends BaseLogMessage {
   type: typeof RegisteredLogger.WORKFLOW;
   workflowName: string;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -176,6 +176,25 @@ type StepFailure = {
 
 export type StepResult<T> = StepSuccess<T> | StepFailure | StepSuspended | StepWaiting;
 
+// Define a type for mapping step IDs to their respective steps[]
+export type StepsRecord<T extends readonly Step<any, any, z.ZodType<any> | undefined>[]> = {
+  [K in T[number]['id']]: Extract<T[number], { id: K }>;
+};
+
+export interface WorkflowRunResult<
+  T extends z.ZodType<any>,
+  TSteps extends Step<string, any, z.ZodType<any> | undefined>[],
+> {
+  triggerData?: z.infer<T>;
+  results: {
+    [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown>
+      : StepResult<z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>>;
+  };
+  runId: string;
+  activePaths: Map<string, { status: string; suspendPayload?: any }>;
+}
+
 // Update WorkflowContext
 export interface WorkflowContext<TTrigger extends z.ZodObject<any> = any> {
   mastra?: MastraUnion;

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -694,7 +694,7 @@ describe('Workflow', async () => {
       counterWorkflow
         .step(incrementStep)
         .until(async ({ context }) => {
-          const res = context.getStepResult<{ newValue: number }>('increment');
+          const res = context.getStepResult('increment');
           return (res?.newValue ?? 0) >= 12;
         }, incrementStep)
         .then(finalStep)

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -674,9 +674,13 @@ describe('Workflow', async () => {
         execute: increment,
       });
 
-      const final = vi.fn().mockImplementation(async ({ context }) => {
-        return { finalValue: context.getStepResult('increment')?.newValue };
-      });
+      const final = vi
+        .fn()
+        .mockImplementation(
+          async ({ context }: { context: WorkflowContext<any, [typeof incrementStep, typeof finalStep]> }) => {
+            return { finalValue: context.getStepResult(incrementStep).newValue };
+          },
+        );
       const finalStep = new Step({
         id: 'final',
         description: 'Final step that prints the result',
@@ -702,8 +706,6 @@ describe('Workflow', async () => {
 
       const run = counterWorkflow.createRun();
       const { results } = await run.start({ triggerData: { target: 10, startValue: 0 } });
-
-      results;
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);
@@ -734,7 +736,7 @@ describe('Workflow', async () => {
       });
 
       const final = vi.fn().mockImplementation(async ({ context }) => {
-        return { finalValue: context.getStepResult('increment')?.newValue };
+        return { finalValue: context.getStepResult(incrementStep).newValue };
       });
       const finalStep = new Step({
         id: 'final',

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -255,7 +255,8 @@ describe('Workflow', async () => {
         .step(step1)
         .then(step2, {
           when: async ({ context }) => {
-            const step1Result = context.getStepResult<{ count: number }>('step1');
+            const step1Result = context.getStepResult(step1);
+
             return step1Result ? step1Result.count > 3 : false;
           },
         })

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -683,7 +683,7 @@ describe('Workflow', async () => {
         execute: final,
       });
 
-      const counterWorkflow = new Workflow({
+      const counterWorkflow = new Workflow<[typeof incrementStep, typeof finalStep]>({
         name: 'counter-workflow',
         triggerSchema: z.object({
           target: z.number(),
@@ -702,6 +702,8 @@ describe('Workflow', async () => {
 
       const run = counterWorkflow.createRun();
       const { results } = await run.start({ triggerData: { target: 10, startValue: 0 } });
+
+      results;
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -174,7 +174,7 @@ export class Workflow<
     VarStep extends StepVariableType<any, any, any, any>,
   >(
     applyOperator: (op: string, value: any, target: any) => { status: string },
-    condition: StepConfig<FallbackStep, CondStep, VarStep, TTriggerSchema>['when'],
+    condition: StepConfig<FallbackStep, CondStep, VarStep, TTriggerSchema, TSteps>['when'],
     fallbackStep: FallbackStep,
     loopType?: 'while' | 'until',
   ) {
@@ -305,7 +305,10 @@ export class Workflow<
     FallbackStep extends StepAction<any, any, any, any>,
     CondStep extends StepVariableType<any, any, any, any>,
     VarStep extends StepVariableType<any, any, any, any>,
-  >(condition: StepConfig<FallbackStep, CondStep, VarStep, TTriggerSchema>['when'], fallbackStep: FallbackStep) {
+  >(
+    condition: StepConfig<FallbackStep, CondStep, VarStep, TTriggerSchema, TSteps>['when'],
+    fallbackStep: FallbackStep,
+  ) {
     const applyOperator = (operator: string, value: any, target: any) => {
       switch (operator) {
         case '$eq':

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -24,8 +24,9 @@ import { WhenConditionReturnValue } from './types';
 import { isVariableReference, updateStepInHierarchy } from './utils';
 import type { WorkflowResultReturn } from './workflow-instance';
 import { WorkflowInstance } from './workflow-instance';
+
 export class Workflow<
-  TSteps extends Step<any, any, any>[] = any,
+  TSteps extends Step<string, any, any>[] = Step<string, any, any>[],
   TTriggerSchema extends z.ZodObject<any> = any,
 > extends MastraBase {
   name: string;
@@ -405,8 +406,8 @@ export class Workflow<
    * @throws Error if trigger schema validation fails
    */
 
-  createRun(): WorkflowResultReturn<TTriggerSchema> {
-    const run = new WorkflowInstance({
+  createRun(): WorkflowResultReturn<TTriggerSchema, TSteps> {
+    const run = new WorkflowInstance<TSteps, TTriggerSchema>({
       logger: this.logger,
       name: this.name,
       mastra: this.#mastra,


### PR DESCRIPTION
Update workflow types by anotating the workflow class

```
const counterWorkflow = new Workflow<[typeof incrementStep, typeof finalStep]>({
  name: 'counter-workflow',
  triggerSchema: z.object({
    target: z.number(),
    startValue: z.number(),
  }),
});
```

Now these functions get payload typed
```
counterWorkflow
  .step(incrementStep)
  .until(async ({ context }) => {
    const res = context.getStepResult('increment');
    return (res.newValue) >= 12;
  }, incrementStep)
  .then(finalStep)
  .commit();
```
