### PR TITLE
Fix retry mechanism for workflow steps

### DIFF
--- a/.changeset/small-monkeys-speak.md
+++ b/.changeset/small-monkeys-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Better retry mechanisms

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -1,5 +1,5 @@
-import EventEmitter from 'node:events';
 import type { Span } from '@opentelemetry/api';
+import EventEmitter from 'node:events';
 import { get } from 'radash';
 import sift from 'sift';
 import type { MachineContext, Snapshot } from 'xstate';
@@ -22,6 +22,7 @@ import type {
   StepDef,
   StepGraph,
   StepNode,
+  StepResolverOutput,
   StepResult,
   StepVariableType,
   WorkflowActionParams,
@@ -312,6 +313,8 @@ export class Machine<
     return {
       resolverFunction: fromPromise(async ({ input }: { input: ResolverFunctionInput }) => {
         const { stepNode, context } = input;
+        const attemptCount = context.attempts[stepNode.step.id];
+
         const resolvedData = this.#resolveVariables({
           stepConfig: stepNode.config,
           context,
@@ -325,28 +328,57 @@ export class Machine<
 
         const logger = this.logger;
         let mastraProxy = undefined;
+
         if (this.#mastra) {
           mastraProxy = createMastraProxy({ mastra: this.#mastra, logger });
         }
-        const result = await stepNode.config.handler({
-          context: resolvedData,
-          suspend: async (payload?: any) => {
-            await this.#workflowInstance.suspend(stepNode.step.id, this);
-            if (this.#actor) {
-              // Update context with current result
-              context.steps[stepNode.step.id] = {
-                status: 'suspended',
-                suspendPayload: payload,
-              };
-              this.logger.debug(`Sending SUSPENDED event for step ${stepNode.step.id}`);
-              this.#actor?.send({ type: 'SUSPENDED', suspendPayload: payload, stepId: stepNode.step.id });
-            } else {
-              this.logger.debug(`Actor not available for step ${stepNode.step.id}`);
-            }
-          },
-          runId: this.#runId,
-          mastra: mastraProxy as MastraUnion | undefined,
-        });
+
+        let result = undefined;
+
+        try {
+          result = await stepNode.config.handler({
+            context: resolvedData,
+            suspend: async (payload?: any) => {
+              await this.#workflowInstance.suspend(stepNode.step.id, this);
+              if (this.#actor) {
+                // Update context with current result
+                context.steps[stepNode.step.id] = {
+                  status: 'suspended',
+                  suspendPayload: payload,
+                };
+                this.logger.debug(`Sending SUSPENDED event for step ${stepNode.step.id}`);
+                this.#actor?.send({ type: 'SUSPENDED', suspendPayload: payload, stepId: stepNode.step.id });
+              } else {
+                this.logger.debug(`Actor not available for step ${stepNode.step.id}`);
+              }
+            },
+            runId: this.#runId,
+            mastra: mastraProxy as MastraUnion | undefined,
+          });
+        } catch (error) {
+          this.logger.debug(`Step ${stepNode.step.id} failed`, {
+            stepId: stepNode.step.id,
+            error,
+            runId: this.#runId,
+          });
+
+          this.logger.debug(`Attempt count for step ${stepNode.step.id}`, {
+            attemptCount,
+            attempts: context.attempts,
+            runId: this.#runId,
+            stepId: stepNode.step.id,
+          });
+
+          if (!attemptCount || attemptCount < 0) {
+            return {
+              type: 'STEP_FAILED' as const,
+              error: error instanceof Error ? error.message : `Step:${stepNode.step.id} failed with error: ${error}`,
+              stepId: stepNode.step.id,
+            };
+          }
+
+          return { type: 'STEP_WAITING' as const, stepId: stepNode.step.id };
+        }
 
         this.logger.debug(`Step ${stepNode.step.id} result`, {
           stepId: stepNode.step.id,
@@ -355,35 +387,19 @@ export class Machine<
         });
 
         return {
-          stepId: stepNode.step.id,
+          type: 'STEP_SUCCESS' as const,
           result,
+          stepId: stepNode.step.id,
         };
       }),
       conditionCheck: fromPromise(async ({ input }: { input: { context: WorkflowContext; stepNode: StepNode } }) => {
         const { context, stepNode } = input;
         const stepConfig = stepNode.config;
-        const attemptCount = context.attempts[stepNode.step.id];
 
         this.logger.debug(`Checking conditions for step ${stepNode.step.id}`, {
           stepId: stepNode.step.id,
           runId: this.#runId,
         });
-
-        this.logger.debug(`Attempt count for step ${stepNode.step.id}`, {
-          attemptCount,
-          attempts: context.attempts,
-          runId: this.#runId,
-          stepId: stepNode.step.id,
-        });
-
-        // if step has no attempts left, suspend or fail
-        if (!attemptCount || attemptCount < 0) {
-          // TODO: INSTEAD OF SUSPENDING, LEAVE THE STEP IN THE PENDING STATE, AND UPDATE CONTEXT TO SIGNIFY COMPLETION
-          if (stepConfig?.snapshotOnTimeout) {
-            return { type: 'SUSPENDED' as const, stepId: stepNode.step.id };
-          }
-          return { type: 'CONDITION_FAILED' as const, error: `Step:${stepNode.step.id} condition check failed` };
-        }
 
         if (!stepConfig?.when) {
           return { type: 'CONDITIONS_MET' as const };
@@ -411,11 +427,14 @@ export class Machine<
             },
             mastra: this.#mastra,
           });
+
           if (conditionMet === WhenConditionReturnValue.ABORT) {
             conditionMet = false;
           } else if (conditionMet === WhenConditionReturnValue.CONTINUE_FAILED) {
             // TODO: send another kind of event instead
             return { type: 'CONDITIONS_SKIPPED' as const };
+          } else if (conditionMet === WhenConditionReturnValue.LIMBO) {
+            return { type: 'CONDITIONS_LIMBO' as const };
           } else if (conditionMet) {
             this.logger.debug(`Condition met for step ${stepNode.step.id}`, {
               stepId: stepNode.step.id,
@@ -423,10 +442,7 @@ export class Machine<
             });
             return { type: 'CONDITIONS_MET' as const };
           }
-          if (!attemptCount || attemptCount < 0) {
-            return { type: 'CONDITION_FAILED' as const, error: `Step:${stepNode.step.id} condition check failed` };
-          }
-          return { type: 'WAITING' as const, stepId: stepNode.step.id };
+          return { type: 'CONDITIONS_LIMBO' as const };
         } else {
           const conditionMet = this.#evaluateCondition(stepConfig.when, context);
           if (!conditionMet) {
@@ -656,6 +672,29 @@ export class Machine<
               },
               {
                 guard: ({ event }: { event: { output: DependencyCheckOutput } }) => {
+                  return event.output.type === 'CONDITIONS_LIMBO';
+                },
+                target: 'limbo',
+                actions: assign({
+                  steps: ({ context }) => {
+                    const newStep = {
+                      ...context.steps,
+                      [stepNode.step.id]: {
+                        status: 'skipped',
+                      },
+                    };
+
+                    this.logger.debug(`Step ${stepNode.step.id} skipped`, {
+                      stepId: stepNode.step.id,
+                      runId: this.#runId,
+                    });
+
+                    return newStep;
+                  },
+                }),
+              },
+              {
+                guard: ({ event }: { event: { output: DependencyCheckOutput } }) => {
                   return event.output.type === 'CONDITION_FAILED';
                 },
                 target: 'failed',
@@ -700,6 +739,23 @@ export class Machine<
             [stepNode.step.id]: {
               target: 'pending',
             },
+          },
+        },
+        limbo: {
+          // no target, will stay in limbo indefinitely
+          entry: () => {
+            this.logger.debug(`Step ${stepNode.step.id} limbo`, {
+              stepId: stepNode.step.id,
+              timestamp: new Date().toISOString(),
+              runId: this.#runId,
+            });
+          },
+          exit: () => {
+            this.logger.debug(`Step ${stepNode.step.id} finished limbo`, {
+              stepId: stepNode.step.id,
+              timestamp: new Date().toISOString(),
+              runId: this.#runId,
+            });
           },
         },
         suspended: {
@@ -756,19 +812,71 @@ export class Machine<
               context,
               stepNode,
             }),
-            onDone: {
-              target: 'runningSubscribers',
-              actions: [
-                ({ event }: { event: any }) =>
-                  this.logger.debug(`Step ${stepNode.step.id} finished executing`, {
-                    stepId: stepNode.step.id,
-                    output: event.output,
-                    runId: this.#runId,
+            onDone: [
+              {
+                guard: ({ event }: { event: { output: StepResolverOutput } }) => {
+                  return event.output.type === 'STEP_FAILED';
+                },
+                target: 'failed',
+                actions: assign({
+                  steps: ({ context, event }) => {
+                    if (event.output.type !== 'STEP_FAILED') return context.steps;
+
+                    const newStep = {
+                      ...context.steps,
+                      [stepNode.step.id]: {
+                        status: 'failed',
+                        error: event.output.error,
+                      },
+                    };
+
+                    this.logger.debug(`Step ${stepNode.step.id} failed`, {
+                      error: event.output.error,
+                      stepId: stepNode.step.id,
+                    });
+
+                    return newStep;
+                  },
+                }),
+              },
+              {
+                guard: ({ event }: { event: { output: StepResolverOutput } }) => {
+                  return event.output.type === 'STEP_SUCCESS';
+                },
+                actions: [
+                  ({ event }: { event: { output: StepResolverOutput } }) => {
+                    this.logger.debug(`Step ${stepNode.step.id} finished executing`, {
+                      stepId: stepNode.step.id,
+                      output: event.output,
+                      runId: this.#runId,
+                    });
+                  },
+                  { type: 'updateStepResult', params: { stepId: stepNode.step.id } },
+                  { type: 'spawnSubscribers', params: { stepId: stepNode.step.id } },
+                ],
+                target: 'runningSubscribers',
+              },
+              {
+                guard: ({ event }: { event: { output: StepResolverOutput } }) => {
+                  return event.output.type === 'STEP_WAITING';
+                },
+                target: 'waiting',
+                actions: [
+                  { type: 'decrementAttemptCount', params: { stepId: stepNode.step.id } },
+                  assign({
+                    steps: ({ context, event }) => {
+                      if (event.output.type !== 'STEP_WAITING') return context.steps;
+                      return {
+                        ...context.steps,
+                        [stepNode.step.id]: {
+                          status: 'waiting',
+                        },
+                      };
+                    },
                   }),
-                { type: 'updateStepResult', params: { stepId: stepNode.step.id } },
-                { type: 'spawnSubscribers', params: { stepId: stepNode.step.id } },
-              ],
-            },
+                ],
+              },
+            ],
             onError: {
               target: 'failed',
               actions: [{ type: 'setStepError', params: { stepId: stepNode.step.id } }],

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -99,6 +99,7 @@ export enum WhenConditionReturnValue {
   CONTINUE = 'continue',
   CONTINUE_FAILED = 'continue_failed',
   ABORT = 'abort',
+  LIMBO = 'limbo',
 }
 
 export type StepDef<
@@ -109,7 +110,6 @@ export type StepDef<
 > = Record<
   TStepId,
   {
-    snapshotOnTimeout?: boolean;
     when?:
       | Condition<any, any>
       | ((args: { context: WorkflowContext; mastra?: Mastra }) => Promise<boolean | WhenConditionReturnValue>);
@@ -141,7 +141,6 @@ export interface StepConfig<
   VarStep extends StepVariableType<any, any, any, any>,
   TTriggerSchema extends z.ZodObject<any>,
 > {
-  snapshotOnTimeout?: boolean;
   when?:
     | Condition<CondStep, TTriggerSchema>
     | ((args: {
@@ -173,7 +172,11 @@ type StepFailure = {
   error: string;
 };
 
-export type StepResult<T> = StepSuccess<T> | StepFailure | StepSuspended | StepWaiting;
+type StepSkipped = {
+  status: 'skipped';
+};
+
+export type StepResult<T> = StepSuccess<T> | StepFailure | StepSuspended | StepWaiting | StepSkipped;
 
 // Update WorkflowContext
 export interface WorkflowContext<TTrigger extends z.ZodObject<any> = any> {
@@ -221,12 +224,20 @@ export type DependencyCheckOutput =
   | { type: 'CONDITIONS_SKIPPED' }
   | { type: 'CONDITION_FAILED'; error: string }
   | { type: 'SUSPENDED' }
-  | { type: 'WAITING' };
+  | { type: 'WAITING' }
+  | { type: 'CONDITIONS_LIMBO' };
+
+export type StepResolverOutput =
+  | { type: 'STEP_SUCCESS'; output: unknown }
+  | { type: 'STEP_FAILED'; error: string }
+  | { type: 'STEP_WAITING' };
+
+
 
 export type WorkflowActors = {
   resolverFunction: {
     input: ResolverFunctionInput;
-    output: ResolverFunctionOutput;
+    output: StepResolverOutput;
   };
   conditionCheck: {
     input: { context: WorkflowContext; stepId: string };
@@ -347,7 +358,7 @@ export interface WorkflowRunState {
     steps: Record<
       string,
       {
-        status: 'success' | 'failed' | 'suspended' | 'waiting';
+        status: 'success' | 'failed' | 'suspended' | 'waiting' | 'skipped';
         payload?: any;
         error?: string;
       }

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -47,6 +47,10 @@ export function isFinalState(status: string): boolean {
   return ['completed', 'failed'].includes(status);
 }
 
+export function isLimboState(status: string): boolean {
+  return status === 'limbo';
+}
+
 export function recursivelyCheckForFinalState({
   value,
   suspendedPaths,
@@ -57,8 +61,8 @@ export function recursivelyCheckForFinalState({
   path: string;
 }): boolean {
   if (typeof value === 'string') {
-    // if the value is a final state or it has previouslyreached a suspended state, return true
-    return isFinalState(value) || suspendedPaths.has(path);
+    // if the value is a final state or limbo state or it has previously reached a suspended state, return true
+    return isFinalState(value) || isLimboState(value) || suspendedPaths.has(path);
   }
   return Object.keys(value).every(key =>
     recursivelyCheckForFinalState({ value: value[key]!, suspendedPaths, path: path ? `${path}.${key}` : key }),

--- a/packages/core/src/workflows/workflow-instance.ts
+++ b/packages/core/src/workflows/workflow-instance.ts
@@ -172,6 +172,7 @@ export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTrigg
       stepGraph,
       executionSpan: this.#executionSpan,
       startStepId,
+      retryConfig: this.#retryConfig,
     });
 
     this.#machines[startStepId] = defaultMachine;
@@ -213,7 +214,7 @@ export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTrigg
     const subscriberKeys = Object.keys(this.#stepSubscriberGraph).filter(key => key.split('&&').includes(parentStepId));
 
     subscriberKeys.forEach(key => {
-      if (['success', 'failure'].includes(stepStatus) && this.#isCompoundKey(key)) {
+      if (['success', 'failure', 'skipped'].includes(stepStatus) && this.#isCompoundKey(key)) {
         this.#compoundDependencies[key]![parentStepId] = true;
       }
     });

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -329,6 +329,7 @@ describe('Workflow', async () => {
           expect(step1Result).toEqual({ value: 'step1-result' });
 
           // Verify that failed steps return undefined
+          // @ts-ignore
           const failedStep = context?.getStepResult<never>('non-existent-step');
           expect(failedStep).toBeUndefined();
 

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -10,7 +10,7 @@ import { Telemetry } from '../telemetry';
 import { createTool } from '../tools';
 
 import { Step } from './step';
-import type { WorkflowContext, WorkflowResumeResult } from './types';
+import { WhenConditionReturnValue, type WorkflowContext, type WorkflowResumeResult } from './types';
 import { Workflow } from './workflow';
 
 const storage = new DefaultStorage({
@@ -1362,9 +1362,9 @@ describe('Workflow', async () => {
   });
 
   describe('Retry', () => {
-    it('should retry a step', async () => {
+    it('should retry a step default 3 times', async () => {
       const step1 = new Step({ id: 'step1', execute: vi.fn<any>().mockResolvedValue({ result: 'success' }) });
-      const step2 = new Step({ id: 'step2', execute: vi.fn<any>().mockResolvedValue({ result: 'success 2' }) });
+      const step2 = new Step({ id: 'step2', execute: vi.fn<any>().mockRejectedValue(new Error('Step failed')) });
 
       const mastra = new Mastra({
         logger: createLogger({
@@ -1374,30 +1374,51 @@ describe('Workflow', async () => {
 
       const workflow = new Workflow({
         name: 'test-workflow',
-
-        retryConfig: { attempts: 3, delay: 10 },
         mastra,
       });
 
       workflow
         .step(step1)
-        .then(step2, {
-          snapshotOnTimeout: true,
-          when: async () => {
-            return await new Promise(resolve => {
-              setTimeout(() => {
-                resolve(false);
-              }, 100);
-            });
-          },
-        })
+        .then(step2)
         .commit();
 
       const run = workflow.createRun();
       const result = await run.start();
 
       expect(result.results.step1).toEqual({ status: 'success', output: { result: 'success' } });
-      expect(result.results.step2).toEqual({ status: 'suspended' });
+      expect(result.results.step2).toEqual({ status: 'failed', error: 'Step failed' });
+      expect(step1.execute).toHaveBeenCalledTimes(1);
+      expect(step2.execute).toHaveBeenCalledTimes(4); // 3 retries + 1 initial call
+    });
+
+    it('should retry a step with a custom retry config', async () => {
+      const step1 = new Step({ id: 'step1', execute: vi.fn<any>().mockResolvedValue({ result: 'success' }) });
+      const step2 = new Step({ id: 'step2', execute: vi.fn<any>().mockRejectedValue(new Error('Step failed')) });
+
+      const mastra = new Mastra({
+        logger: createLogger({
+          name: 'Workflow',
+        }),
+      });
+
+      const workflow = new Workflow({
+        name: 'test-workflow',
+        mastra,
+        retryConfig: { attempts: 5, delay: 200 },
+      });
+
+      workflow
+        .step(step1)
+        .then(step2)
+        .commit();
+
+      const run = workflow.createRun();
+      const result = await run.start();
+
+      expect(result.results.step1).toEqual({ status: 'success', output: { result: 'success' } });
+      expect(result.results.step2).toEqual({ status: 'failed', error: 'Step failed' });
+      expect(step1.execute).toHaveBeenCalledTimes(1);
+      expect(step2.execute).toHaveBeenCalledTimes(6); // 5 retries + 1 initial call
     });
   });
 
@@ -1966,6 +1987,7 @@ describe('Workflow', async () => {
                   stepId: suspended.stepId,
                   context: newCtx,
                 });
+
                 resolve(resumed as any);
               } catch (error) {
                 reject(error);
@@ -1976,8 +1998,9 @@ describe('Workflow', async () => {
       });
 
       const initialResult = await started;
+
       expect(initialResult.results.humanIntervention.status).toBe('suspended');
-      expect(initialResult.results.explainResponse.status).toBe('failed');
+      expect(initialResult.results.explainResponse.status).toBe('skipped');
       expect(humanInterventionAction).toHaveBeenCalledTimes(2);
       expect(explainResponseAction).not.toHaveBeenCalled();
 
@@ -1993,7 +2016,7 @@ describe('Workflow', async () => {
           output: { toneScore: { score: 0.8 }, completenessScore: { score: 0.7 } },
         },
         humanIntervention: { status: 'success', output: { improvedOutput: 'human intervention output' } },
-        explainResponse: { status: 'failed', error: 'Step:explainResponse condition check failed' },
+        explainResponse: { status: 'skipped' },
       });
     });
 
@@ -2143,7 +2166,7 @@ describe('Workflow', async () => {
       expect(improvedResponseResult?.results.humanIntervention.status).toBe('suspended');
       expect(improvedResponseResult?.results.improveResponse.status).toBe('success');
       expect(improvedResponseResult?.results.evaluateImprovedResponse.status).toBe('success');
-      expect(improvedResponseResult?.results.explainResponse.status).toBe('failed');
+      expect(improvedResponseResult?.results.explainResponse.status).toBe('skipped');
       expect(humanInterventionAction).toHaveBeenCalledTimes(2);
       expect(explainResponseAction).not.toHaveBeenCalled();
 
@@ -2164,7 +2187,7 @@ describe('Workflow', async () => {
           output: { toneScore: { score: 0.9 }, completenessScore: { score: 0.8 } },
         },
         humanIntervention: { status: 'success', output: { improvedOutput: 'human intervention output' } },
-        explainResponse: { status: 'failed', error: 'Step:explainResponse condition check failed' },
+        explainResponse: { status: 'skipped' },
       });
     });
 
@@ -2312,7 +2335,6 @@ describe('Workflow', async () => {
       const step1 = new Step({
         id: 'step1',
         execute: async ({ mastra }) => {
-          console.log({ mastra });
           telemetry = mastra?.telemetry;
         },
       });


### PR DESCRIPTION
https://linear.app/kepler-crm/issue/MASTRA-2295/move-retry-logic-from-when-condition-to-step-execution

- pulls retry logic out of conditions into steps themselves
- defines new `skipped` status to denote a failed condition