### PR TITLE
fix: MCP alpha "MCP error -32601: Method not found" + typo

### DIFF
--- a/.changeset/slick-moles-end.md
+++ b/.changeset/slick-moles-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed an error in the @mastra/mcp alpha release where client.setLoggingLevel led to errors in clients that don't support it

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -74,7 +74,6 @@ export class MastraMCPClient extends MastraBase {
           originalOnClose();
         }
       };
-      await this.client.setLoggingLevel(`critical`);
       asyncExitHook(
         async () => {
           this.logger.debug(`Disconnecting ${this.name} MCP server`);

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -67,8 +67,12 @@ export class MastraMCPClient extends MastraBase {
     try {
       await this.client.connect(this.transport);
       this.isConnected = true;
+      const originalOnClose = this.client.onclose;
       this.client.onclose = () => {
         this.isConnected = false;
+        if (typeof originalOnClose === `function`) {
+          originalOnClose();
+        }
       };
       await this.client.setLoggingLevel(`critical`);
       asyncExitHook(

--- a/packages/mcp/src/configuration.ts
+++ b/packages/mcp/src/configuration.ts
@@ -107,7 +107,7 @@ To fix this you have three different options:
       await mcpClient.connect();
     } catch (e) {
       this.mcpClientsById.delete(name);
-      this.logger.error(`MCPConfiguraiton errored connecting to MCP server ${name}`);
+      this.logger.error(`MCPConfiguration errored connecting to MCP server ${name}`);
       throw e;
     }
 


### PR DESCRIPTION
I'm getting this error "MCP error -32601: Method not found" in the alpha because I added `await this.client.setLoggingLevel(`critical`);` while I was debugging and forgot to remove it. Not all servers support this