### PR TITLE
fix(@mastra/core, @mastra/memory): Memory + useChat + client tools

### DIFF
--- a/.changeset/social-ghosts-take.md
+++ b/.changeset/social-ghosts-take.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fixed a bug where useChat with client side tool calling and Memory would not work. Added docs for using Memory with useChat()

--- a/docs/src/pages/docs/agents/01-agent-memory.mdx
+++ b/docs/src/pages/docs/agents/01-agent-memory.mdx
@@ -317,6 +317,50 @@ The memory system will automatically:
 3. Inject relevant historical context into new conversations
 4. Maintain conversation threads and context
 
+## useChat()
+
+When using `useChat` from the AI SDK, you must send only the latest message or you will encounter message ordering bugs.
+
+If the `useChat()` implementation for your framework supports `experimental_prepareRequestBody`, you can do the following:
+
+```ts
+const { messages } = useChat({
+  api: "api/chat",
+  experimental_prepareRequestBody({ messages, id }) {
+    return { message: messages.at(-1), id };
+  },
+});
+```
+
+This will only ever send the latest message to the server.
+In your chat server endpoint you can then pass a threadId and resourceId when calling stream or generate and the agent will have access to the memory thread messages:
+
+```ts
+const { messages } = await request.json();
+
+const stream = await myAgent.stream(messages, {
+  threadId,
+  resourceId,
+});
+
+return stream.toDataStreamResponse();
+```
+
+If the `useChat()` for your framework (svelte for example) doesn't support `experimental_prepareRequestBody`, you can pick and use the last message before calling stream or generate:
+
+```ts
+const { messages } = await request.json();
+
+const stream = await myAgent.stream([messages.at(-1)], {
+  threadId,
+  resourceId,
+});
+
+return stream.toDataStreamResponse();
+```
+
+See the [AI SDK documentation on message persistence](https://sdk.vercel.ai/docs/ai-sdk-ui/chatbot-message-persistence) for more information.
+
 ## Manually Managing Threads
 
 While threads are automatically managed when using agent methods, you can also manually manage threads using the memory API directly. This is useful for advanced use cases like:

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -469,16 +469,28 @@ export class Agent<
     });
 
     return messagesBySanitizedContent.filter(message => {
-      if (message.role === `assistant`) {
-        if (Array.isArray(message.content)) {
-          for (const part of message.content) {
-            if (part.type === `tool-call` && dupeToolCalls.has(part.toolCallId)) {
-              dupeToolCalls.delete(part.toolCallId);
-              return false;
-            }
+      if (typeof message.content === `string`) {
+        return message.content !== '';
+      }
+
+      if (Array.isArray(message.content)) {
+        for (const part of message.content) {
+          if (part.type === `tool-call` && dupeToolCalls.has(part.toolCallId)) {
+            dupeToolCalls.delete(part.toolCallId);
+            return false;
           }
         }
+        return (
+          message.content.length &&
+          message.content.every(c => {
+            if (c.type === `text`) {
+              return c.text && c.text !== '';
+            }
+            return true;
+          })
+        );
       }
+
       return true;
     }) as Array<CoreMessage>;
   }

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -417,7 +417,6 @@ export class Agent<
   sanitizeResponseMessages(messages: Array<CoreMessage>): Array<CoreMessage> {
     let toolResultIds: Array<string> = [];
     let toolCallIds: Array<string> = [];
-    let dupeToolCalls = new Set<string>();
 
     for (const message of messages) {
       if (!Array.isArray(message.content)) continue;
@@ -432,9 +431,6 @@ export class Agent<
         for (const content of message.content) {
           if (typeof content !== `string`) {
             if (content.type === `tool-call`) {
-              if (toolCallIds.includes(content.toolCallId)) {
-                dupeToolCalls.add(content.toolCallId);
-              }
               toolCallIds.push(content.toolCallId);
             }
           }
@@ -474,12 +470,6 @@ export class Agent<
       }
 
       if (Array.isArray(message.content)) {
-        for (const part of message.content) {
-          if (part.type === `tool-call` && dupeToolCalls.has(part.toolCallId)) {
-            dupeToolCalls.delete(part.toolCallId);
-            return false;
-          }
-        }
         return (
           message.content.length &&
           message.content.every(c => {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -856,7 +856,7 @@ export class Agent<
           content: messages,
         },
       ];
-    } else {
+    } else if (Array.isArray(messages)) {
       messagesToUse = messages.map(message => {
         if (typeof message === `string`) {
           return {
@@ -866,6 +866,8 @@ export class Agent<
         }
         return message;
       });
+    } else {
+      messagesToUse = [messages];
     }
 
     const runIdToUse = runId || randomUUID();

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -71,7 +71,7 @@ export class Memory extends MastraMemory {
             messageRange: config?.semanticRecall?.messageRange ?? { before: 2, after: 2 },
           };
 
-    if (config?.semanticRecall && selectBy?.vectorSearchString && this.vector) {
+    if (config?.semanticRecall && selectBy?.vectorSearchString && this.vector && !!selectBy.vectorSearchString) {
       const { embedding } = await embed({
         value: selectBy.vectorSearchString,
         model: this.embedder,
@@ -239,7 +239,7 @@ export class Memory extends MastraMemory {
       const { indexName } = await this.createEmbeddingIndex();
 
       for (const message of messages) {
-        if (typeof message.content !== `string`) continue;
+        if (typeof message.content !== `string` || message.content === '') continue;
         const { embedding } = await embed({ value: message.content, model: this.embedder, maxRetries: 3 });
         await this.vector.upsert({
           indexName,


### PR DESCRIPTION
Fixes https://discord.com/channels/1309558646228779139/1347999511280222279/1348735064590127209

When using `useChat` it sends the full message list to the server on each request. Since memory also includes the full chat history this means the chat history would get mixed up or doubled. When pairing this with client side tool calling, incomplete tool message errors would happen because the message history included the original saved tool call (which had no separate tool result) + the new client side injected tool call which included a result - meaning the message history would include the initial tool call and then the same tool call with a result.

These issues are fixed and I updated the documentation to show how to use `useChat` with memory.