### PR TITLE
[MASTRA-2403] update character and text transformers to add a sliding window overlap

### DIFF
--- a/.changeset/rich-hornets-win.md
+++ b/.changeset/rich-hornets-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Updated overlap for character and text transformer

--- a/packages/rag/src/document/transformers/character.ts
+++ b/packages/rag/src/document/transformers/character.ts
@@ -85,7 +85,7 @@ export class CharacterTransformer extends TextTransformer {
       if (this.lengthFunction(split) <= this.size) {
         chunks.push(split);
       } else {
-        // If a single split is too large, split it further
+        // If a single split is too large, split it further with overlap
         const subChunks = this.__splitChunk(split);
         chunks.push(...subChunks);
       }
@@ -96,24 +96,22 @@ export class CharacterTransformer extends TextTransformer {
 
   private __splitChunk(text: string): string[] {
     const chunks: string[] = [];
-    let currentChunk = '';
+    let currentPosition = 0;
 
-    // Split by characters if no other separator is suitable
-    const chars = text.split('');
+    while (currentPosition < text.length) {
+      let chunkEnd = currentPosition;
+      let currentChunk = '';
 
-    for (const char of chars) {
-      if (this.lengthFunction(currentChunk + char) <= this.size) {
-        currentChunk += char;
-      } else {
-        if (currentChunk) {
-          chunks.push(currentChunk);
-        }
-        currentChunk = char;
+      // Build chunk up to max size
+      while (chunkEnd < text.length && this.lengthFunction(text.slice(currentPosition, chunkEnd + 1)) <= this.size) {
+        chunkEnd++;
       }
-    }
 
-    if (currentChunk) {
+      currentChunk = text.slice(currentPosition, chunkEnd);
       chunks.push(currentChunk);
+
+      // Move position forward by chunk size minus overlap
+      currentPosition += Math.max(1, this.lengthFunction(currentChunk) - this.overlap);
     }
 
     return chunks;


### PR DESCRIPTION
This PR fixes the overlap implementation in the Character Transformer to properly maintain context between chunks. The previous implementation didn't correctly handle overlap when splitting large chunks of text, which could lead to loss of context at chunk boundaries.
