### PR TITLE
Fix after usage with skipped conditions

### DIFF
--- a/.changeset/tender-paws-heal.md
+++ b/.changeset/tender-paws-heal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix after usage with skipped conditions on the awaited steps

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -1,5 +1,5 @@
-import type { Span } from '@opentelemetry/api';
 import EventEmitter from 'node:events';
+import type { Span } from '@opentelemetry/api';
 import { get } from 'radash';
 import sift from 'sift';
 import type { MachineContext, Snapshot } from 'xstate';

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -449,7 +449,7 @@ export class Machine<
             conditionMet = false;
           } else if (conditionMet === WhenConditionReturnValue.CONTINUE_FAILED) {
             // TODO: send another kind of event instead
-            return { type: 'CONDITIONS_SKIPPED' as const };
+            return { type: 'CONDITIONS_SKIP_TO_COMPLETED' as const };
           } else if (conditionMet === WhenConditionReturnValue.LIMBO) {
             return { type: 'CONDITIONS_LIMBO' as const };
           } else if (conditionMet) {
@@ -459,7 +459,9 @@ export class Machine<
             });
             return { type: 'CONDITIONS_MET' as const };
           }
-          return { type: 'CONDITIONS_LIMBO' as const };
+          return this.#workflowInstance.hasSubscribers(stepNode.step.id)
+            ? { type: 'CONDITIONS_SKIPPED' as const }
+            : { type: 'CONDITIONS_LIMBO' as const };
         } else {
           const conditionMet = this.#evaluateCondition(stepConfig.when, context);
           if (!conditionMet) {
@@ -685,9 +687,33 @@ export class Machine<
               },
               {
                 guard: ({ event }: { event: { output: DependencyCheckOutput } }) => {
-                  return event.output.type === 'CONDITIONS_SKIPPED';
+                  return event.output.type === 'CONDITIONS_SKIP_TO_COMPLETED';
                 },
                 target: 'completed',
+              },
+              {
+                guard: ({ event }: { event: { output: DependencyCheckOutput } }) => {
+                  return event.output.type === 'CONDITIONS_SKIPPED';
+                },
+                actions: assign({
+                  steps: ({ context }) => {
+                    const newStep = {
+                      ...context.steps,
+                      [stepNode.step.id]: {
+                        status: 'skipped',
+                      },
+                    };
+
+                    this.logger.debug(`Step ${stepNode.step.id} skipped`, {
+                      stepId: stepNode.step.id,
+                      runId: this.#runId,
+                    });
+
+                    return newStep;
+                  },
+                }),
+
+                target: 'runningSubscribers',
               },
               {
                 guard: ({ event }: { event: { output: DependencyCheckOutput } }) => {

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -264,6 +264,7 @@ export type SubscriberFunctionOutput = {
 export type DependencyCheckOutput =
   | { type: 'CONDITIONS_MET' }
   | { type: 'CONDITIONS_SKIPPED' }
+  | { type: 'CONDITIONS_SKIP_TO_COMPLETED' }
   | { type: 'CONDITION_FAILED'; error: string }
   | { type: 'SUSPENDED' }
   | { type: 'WAITING' }

--- a/packages/core/src/workflows/workflow-instance.ts
+++ b/packages/core/src/workflows/workflow-instance.ts
@@ -203,6 +203,10 @@ export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTrigg
     return { results, activePaths };
   }
 
+  hasSubscribers(stepId: string) {
+    return Object.keys(this.#stepSubscriberGraph).some(key => key.split('&&').includes(stepId));
+  }
+
   async runMachine(parentStepId: string, input: any) {
     const stepStatus = input.steps[parentStepId]?.status;
 

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1524,6 +1524,41 @@ describe('Workflow', async () => {
       expect(result.results.step5).toEqual({ status: 'success', output: { result: 'success5' } });
     });
 
+    it('should run compount subscribers with when conditions', async () => {
+      const step1Action = vi.fn<any>().mockResolvedValue({ result: 'success1' });
+      const step2Action = vi.fn<any>().mockResolvedValue({ result: 'success2' });
+      const step3Action = vi.fn<any>().mockResolvedValue({ result: 'success3' });
+      const step4Action = vi.fn<any>().mockResolvedValue({ result: 'success4' });
+      const step5Action = vi.fn<any>().mockResolvedValue({ result: 'success5' });
+
+      const step1 = new Step({ id: 'step1', execute: step1Action, outputSchema: z.object({ status: z.string() }) });
+      const step2 = new Step({ id: 'step2', execute: step2Action });
+      const step3 = new Step({ id: 'step3', execute: step3Action });
+      const step4 = new Step({ id: 'step4', execute: step4Action });
+      const step5 = new Step({ id: 'step5', execute: step5Action });
+      const workflow = new Workflow({ name: 'test-workflow' });
+      workflow
+        .step(step1, { when: async () => true })
+        .then(step2, { when: async () => false })
+        .after([step1, step2])
+        .step(step3)
+        .then(step4)
+        .then(step5)
+        .commit();
+
+      const run = workflow.createRun();
+      const result = await run.start();
+
+      expect(step1Action).toHaveBeenCalled();
+      expect(step2Action).not.toHaveBeenCalled();
+      expect(step3Action).toHaveBeenCalled();
+      expect(step4Action).toHaveBeenCalled();
+      expect(step5Action).toHaveBeenCalledTimes(1);
+      expect(result.results.step1).toEqual({ status: 'success', output: { result: 'success1' } });
+      expect(result.results.step2).toEqual({ status: 'skipped' });
+      expect(result.results.step5).toEqual({ status: 'success', output: { result: 'success5' } });
+    });
+
     it('should run complex compound subscribers', async () => {
       const step1Action = vi.fn<any>().mockResolvedValue({ result: 'success1' });
       const step2Action = vi.fn<any>().mockResolvedValue({ result: 'success2' });


### PR DESCRIPTION
* Introduces a new `SKIP_TO_COMPLETED` event used for loops where .after() is registered on the looping condition step. We skip that straight into completion and don't check for subscribers anymore since the loop is completed.
* When transitioning to limbo for skipped conditions, we transition to skipped state and run subscribers before moving to the final state if there are subscribers on that stepId