### PR TITLE
ci: skip building packages for versioning action

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build
-        run: pnpm build:packages
-
       - name: Create Release Pull Request
         uses: changesets/action@v1
         env:


### PR DESCRIPTION
As far as I can tell building packages here is redundant - I left the pnpm install because I'm not sure if it's needed for the changesets action in the final step or not