### PR TITLE
ci: skip husky hooks in versioning action

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -49,7 +49,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # husky precommit runs linting and typechecking - those are handled by other GH actions already
-          HUSKY_SKIP_HOOKS: 1
           HUSKY: 0
         with:
           title: 'chore: version packages'

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -48,6 +48,8 @@ jobs:
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # husky precommit runs linting and typechecking - those are handled by other GH actions already
+          HUSKY_SKIP_HOOKS: "1"
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages'

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -49,7 +49,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # husky precommit runs linting and typechecking - those are handled by other GH actions already
-          HUSKY_SKIP_HOOKS: "1"
+          HUSKY_SKIP_HOOKS: 1
+          HUSKY: 0
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages'


### PR DESCRIPTION
I removed building packages in https://github.com/mastra-ai/mastra/pull/2951 but we also need to skip these husky hooks since they're also not needed and they require built packages