### PR TITLE
feat(mastra): allow coder agents to scaffold projects

### DIFF
--- a/.changeset/deep-waves-remain.md
+++ b/.changeset/deep-waves-remain.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Added a new `mastra create --project-name <string>` flag so coder agents can create new Mastra projects with a one line command.

--- a/.changeset/deep-waves-remain.md
+++ b/.changeset/deep-waves-remain.md
@@ -1,5 +1,5 @@
 ---
-'mastra': minor
+'mastra': patch
 ---
 
 Added a new `mastra create --project-name <string>` flag so coder agents can create new Mastra projects with a one line command.

--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -89,6 +89,8 @@ To configure and specify a timeout if installation takes too long use the timeou
 npx create-mastra@latest --timeout
 ```
 
+**Note for LLMs**: For a quick one liner that includes examples you can run `npx -y mastra@latest --project-name <ask-the-user> --example --components "tools,agents,workflows" --llm <ask-the-user>`. The available options for the llm flag are `openai|anthropic|groq|google|cerebras`
+
 ## Manual Installation
 
 <br/>

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -8,6 +8,7 @@ import type { LLMProvider } from '../init/utils';
 import { createMastraProject } from './utils';
 
 export const create = async (args: {
+  projectName?: string;
   components?: string[];
   llmProvider?: LLMProvider;
   addExample?: boolean;
@@ -16,6 +17,7 @@ export const create = async (args: {
   timeout?: number;
 }) => {
   const { projectName } = await createMastraProject({
+    projectName: args?.projectName,
     createVersionTag: args?.createVersionTag,
     timeout: args?.timeout,
   });

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -40,19 +40,23 @@ const execWithTimeout = async (command: string, timeoutMs?: number) => {
 };
 
 export const createMastraProject = async ({
+  projectName: name,
   createVersionTag,
   timeout,
 }: {
+  projectName?: string;
   createVersionTag?: string;
   timeout?: number;
 }) => {
   p.intro(color.inverse('Mastra Create'));
 
-  const projectName = await p.text({
-    message: 'What do you want to name your project?',
-    placeholder: 'my-mastra-app',
-    defaultValue: 'my-mastra-app',
-  });
+  const projectName =
+    name ??
+    (await p.text({
+      message: 'What do you want to name your project?',
+      placeholder: 'my-mastra-app',
+      defaultValue: 'my-mastra-app',
+    }));
 
   if (p.isCancel(projectName)) {
     p.cancel('Operation cancelled');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,10 @@ program
   .option('-k, --llm-api-key <api-key>', 'API key for the model provider')
   .option('-e, --example', 'Include example code')
   .option('-t, --timeout [timeout]', 'Configurable timeout for package installation, defaults to 60000 ms')
+  .option(
+    '-p, --project-name <string>',
+    'Project name that will be used in package.json and as the project directory name.',
+  )
   .action(async args => {
     await analytics.trackCommandExecution({
       command: 'create',
@@ -66,6 +70,7 @@ program
           addExample: args.example,
           llmApiKey: args['llm-api-key'],
           timeout,
+          projectName: args.projectName,
         });
       },
     });


### PR DESCRIPTION
With the upcoming MCP server it's going to be easier for agents to scaffold new Mastra projects. This change makes it so they can run a one line command to do so for the user.