### PR TITLE
docs: Add installation instructions for @ai-sdk/openai

### DIFF
--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -2377,7 +2377,7 @@ Then, initialize a TypeScript project including the `@mastra/core` package:
 ```bash copy
 npm init -y
 npm install typescript tsx @types/node mastra --save-dev
-npm install @mastra/core zod
+npm install @mastra/core zod @ai-sdk/openai
 npx tsc --init
 ```
   </Tabs.Tab>
@@ -3065,7 +3065,7 @@ Initialize a new Node.js project and install the required dependencies:
 
 ```bash
 npm init -y
-npm install @mastra/core zod
+npm install @mastra/core zod @ai-sdk/openai
 ```
 
 Set Up Environment Variables

--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -114,7 +114,7 @@ Then, initialize a TypeScript project including the `@mastra/core` package:
 ```bash copy
 npm init -y
 npm install typescript tsx @types/node mastra --save-dev
-npm install @mastra/core zod
+npm install @mastra/core zod @ai-sdk/openai
 npx tsc --init
 ```
   </Tabs.Tab>

--- a/docs/src/pages/docs/guides/02-stock-agent.mdx
+++ b/docs/src/pages/docs/guides/02-stock-agent.mdx
@@ -42,7 +42,7 @@ Initialize a new Node.js project and install the required dependencies:
 
 ```bash
 npm init -y
-npm install @mastra/core zod
+npm install @mastra/core zod @ai-sdk/openai
 ```
 
 Set Up Environment Variables


### PR DESCRIPTION
In the docs, the installation instructions for @ai-sdk/openai were missing, so I added the it.