### PR TITLE
ci: skip husky and add gh token when committing mcp-docs-server package version bump

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Bump docs prerelease version
+      - name: Bump mcp-docs-server prerelease version
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # husky precommit runs linting and typechecking - those are handled by other GH actions already
+          HUSKY: 0
         run: |
           cd packages/mcp-docs-server
           pnpm version prerelease --preid alpha --no-git-tag-version


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/actions/runs/13906224830/job/38909780000