### PR TITLE
fix(@mastra/mcp-docs-server): make dist/stdio.js an executable node script

### DIFF
--- a/.changeset/sharp-moose-doubt.md
+++ b/.changeset/sharp-moose-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-docs-server': patch
+---
+
+Made stdio.js bin executable by node

--- a/packages/mcp-docs-server/package.json
+++ b/packages/mcp-docs-server/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "prepare-docs": "tsx src/prepare-docs/index.ts",
     "prebuild": "pnpm prepare-docs",
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/stdio.js",
     "predev": "pnpm prepare-docs",
     "dev": "fastmcp dev src/index.ts",
     "inspect": "fastmcp inspect src/index.ts",

--- a/packages/mcp-docs-server/src/stdio.ts
+++ b/packages/mcp-docs-server/src/stdio.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { prepare } from './prepare-docs/prepare';
 
 if (process.env.REBUILD_DOCS_ON_START === 'true') {


### PR DESCRIPTION
Forgot to do this in the initial PR!
Fixes:
```
+ npx -y @mastra/mcp-docs-server@latest
/Users/tylerbarnes/.npm/_npx/ed516e8553319255/node_modules/.bin/mcp-docs-server: line 1: import: command not found
/Users/tylerbarnes/.npm/_npx/ed516e8553319255/node_modules/.bin/mcp-docs-server: line 2: syntax error near unexpected token `{'
/Users/tylerbarnes/.npm/_npx/ed516e8553319255/node_modules/.bin/mcp-docs-server: line 2: `if (process.env.REBUILD_DOCS_ON_START === 'true') {'
```