### PR TITLE
docs(@mastra/mcp-docs-server): automatic + manual install guides

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,14 @@
+{
+    "mcpServers": {
+      "mastra": {
+        "command": "pnpx",
+        "args": [
+          "tsx",
+          "./packages/mcp-docs-server/src/stdio.ts"
+        ],
+        "env": {
+          "REBUILD_DOCS_ON_START": "true"
+       }
+      }
+    }
+  }

--- a/docs/src/pages/docs/getting-started/_meta.ts
+++ b/docs/src/pages/docs/getting-started/_meta.ts
@@ -1,7 +1,7 @@
 const meta = {
   installation: "Installation",
   "project-structure": "Project Structure",
-  "mcp-docs-server": "Mastra tools for Cursor and Windsurf",
+  "mcp-docs-server": "Agent Code Editor Tools",
 };
 
 export default meta;

--- a/docs/src/pages/docs/getting-started/_meta.ts
+++ b/docs/src/pages/docs/getting-started/_meta.ts
@@ -1,6 +1,7 @@
 const meta = {
   installation: "Installation",
   "project-structure": "Project Structure",
+  "mcp-docs-server": "Mastra tools for Cursor and Windsurf",
 };
 
 export default meta;

--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -77,7 +77,7 @@ After the prompts, `create-mastra` will:
 3. Configure your selected components and LLM provider
 4. Configure the MCP server in your IDE (if selected) for instant access to docs, examples, and help while you code
 
-If you're using a different IDE, you can install the MCP server manually by following the instructions in the [MCP server docs](/docs/getting-started/docs-server).
+**MCP Note:** If you're using a different IDE, you can install the MCP server manually by following the instructions in the [MCP server docs](/docs/getting-started/docs-server). **Also** note that there are additional steps for [Cursor and Windsurf](/docs/getting-started/docs-server#after-adding-the-configuration) to activate the MCP server.
 
 ### Set Up your API Key
 

--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -36,17 +36,17 @@ npx create-mastra@latest
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash copy
-npm create mastra
+npm create mastra@latest
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```bash copy
-yarn create mastra
+yarn create mastra@latest
 ```
 </Tabs.Tab>
   <Tabs.Tab>
 ```bash copy
-pnpm create mastra
+pnpm create mastra@latest
 ```
 </Tabs.Tab>
 </Tabs>
@@ -64,9 +64,20 @@ Select default provider:
   ◯ Anthropic
   ◯ Groq
 Would you like to include example code? No / Yes
+Turn your IDE into a Mastra expert? (Installs MCP server)
+  ◯ Skip for now
+  ◯ Cursor
+  ◯ Windsurf
 ```
 
-After the prompts, `create-mastra` will set up your project directory with TypeScript, install dependencies, and configure your selected components and LLM provider.
+After the prompts, `create-mastra` will:
+
+1. Set up your project directory with TypeScript
+2. Install dependencies
+3. Configure your selected components and LLM provider
+4. Configure the MCP server in your IDE (if selected) for instant access to docs, examples, and help while you code
+
+If you're using a different IDE, you can install the MCP server manually by following the instructions in the [MCP server docs](/docs/getting-started/docs-server).
 
 ### Set Up your API Key
 

--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -77,7 +77,7 @@ After the prompts, `create-mastra` will:
 3. Configure your selected components and LLM provider
 4. Configure the MCP server in your IDE (if selected) for instant access to docs, examples, and help while you code
 
-**MCP Note:** If you're using a different IDE, you can install the MCP server manually by following the instructions in the [MCP server docs](/docs/getting-started/docs-server). **Also** note that there are additional steps for [Cursor and Windsurf](/docs/getting-started/docs-server#after-adding-the-configuration) to activate the MCP server.
+**MCP Note:** If you're using a different IDE, you can install the MCP server manually by following the instructions in the [MCP server docs](/docs/getting-started/mcp-docs-server). **Also** note that there are additional steps for [Cursor and Windsurf](/docs/getting-started/mcp-docs-server#after-configuration) to activate the MCP server.
 
 ### Set Up your API Key
 

--- a/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
@@ -6,46 +6,48 @@ description: "Learn how to use the Mastra MCP documentation server in your IDE t
 # Mastra Tools for your agentic IDE
 
 `@mastra/mcp-docs-server` provides direct access to Mastra's complete knowledge base in Cursor, Windsurf, Cline, or any other IDE that supports MCP.
-It has documentation, code examples, technical blog posts / feature announcements, and package changelogs which your IDE can read to help you build with Mastra.
 
-## How it works
+It has access to documentation, code examples, technical blog posts / feature announcements, and package changelogs which your IDE can read to help you build with Mastra.
 
 The MCP server tools have been designed to allow an agent to query the specific information it needs to complete a Mastra related task - for example: adding a Mastra feature to an agent, scaffolding a new project, or helping you understand how something works.
 
-Once it's installed you can send the agent prompts and assume in understands Mastra.
+## How it works
 
-Add features:
+Once it's installed in your IDE you can write prompts and assume the agent will understand everything about Mastra.
+
+### Add features
 
 - "Add evals to my agent and write tests"
-- "Write me a workflow that does the following [...]"
-- "Make a new tool that allows my agent to [...]"
+- "Write me a workflow that does the following `[task]`"
+- "Make a new tool that allows my agent to access `[3rd party API]`"
 
-Ask about integrations:
+### Ask about integrations
 
-- "Does Mastra work with the AI SDK? How can I use it in my [React/Svelte/etc] project?"
+- "Does Mastra work with the AI SDK?
+  How can I use it in my `[React/Svelte/etc]` project?"
 - "What's the latest Mastra news around MCP?"
-- "Does Mastra support [provider]'s speech and voice API? Show me an example in my code of how I can use it."
+- "Does Mastra support `[provider]` speech and voice APIs? Show me an example in my code of how I can use it."
 
-Debug or updating existing code:
+### Debug or updating existing code
 
 - "I'm running into a bug with agent memory, have there been any related changes or bug fixes recently?"
-- "How does working memory behave in Mastra and how can I use it to do [task]?"
-- "I saw there are new workflow features, explain them to me and then update [workflow] to use them."
+- "How does working memory behave in Mastra and how can I use it to do `[task]`? It doesn't seem to work the way I expect."
+- "I saw there are new workflow features, explain them to me and then update `[workflow]` to use them."
 
-And more - if you have a question, try asking your IDE and let it look it up for you.
+**And more** - if you have a question, try asking your IDE and let it look it up for you.
 
 ## Automatic Installation
 
 Run `pnpm create mastra@latest` and select Cursor or Windsurf when prompted to install the MCP server. For other IDEs, or if you already have a Mastra project, install the MCP server by following the instructions below.
 
-## Installation
+## Manual Installation
 
 - **Cursor**: Edit `.cursor/mcp.json` in your project root, or `~/.cursor/mcp.json` for global configuration
 - **Windsurf**: Edit `~/.codeium/windsurf/mcp_config.json` (only supports global configuration)
 
 Add the following configuration:
 
-MacOS/Linux:
+### MacOS/Linux
 
 ```json
 {
@@ -58,7 +60,7 @@ MacOS/Linux:
 }
 ```
 
-Windows:
+### Windows
 
 ```json
 {
@@ -71,16 +73,16 @@ Windows:
 }
 ```
 
-## After adding the configuration
+## After Configuration
 
-In Cursor:
+### Cursor
 
 1. Open Cursor settings
 2. Navigate to MCP settings
 3. Click "enable" on the Mastra MCP server
 4. If you have an agent chat open, you'll need to re-open it or start a new chat to use the MCP server
 
-In Windsurf:
+### Windsurf
 
 1. Fully quit and re-open Windsurf
 2. If tool calls start failing, go to Windsurfs MCP settings and re-start the MCP server. This is a common Windsurf MCP issue and isn't related to Mastra. Right now Cursor's MCP server is more stable than Windsurfs is.

--- a/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
@@ -136,7 +136,3 @@ Track updates for Mastra and `@mastra/*` packages:
    - Verify the tool exists and is properly configured
    - Update to the latest version of your IDE
 
-## Using in Your Code
-
-If you're building a Mastra application and want to use the documentation server programmatically in an agent, check out our guide on [Model Context Protocol (MCP)](/docs/tools/mcp-guide).
-

--- a/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
@@ -133,8 +133,6 @@ Track updates for Mastra and `@mastra/*` packages:
    - On Windows, make sure to use the Windows-specific configuration
 
 2. **Tool Calls Failing**
-   - Restart the MCP server
-   - Check your internet connection
-   - Verify the tool exists and is properly configured
+   - Restart the MCP server and/or your IDE
    - Update to the latest version of your IDE
 

--- a/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
@@ -1,0 +1,142 @@
+---
+title: "Mastra Tools for Cursor, Windsurf, and other IDE's | Getting Started | Mastra Docs"
+description: "Learn how to use the Mastra MCP documentation server in your IDE to turn it into an agentic Mastra expert."
+---
+
+# Mastra Tools for your agentic IDE
+
+`@mastra/mcp-docs-server` provides direct access to Mastra's complete knowledge base in Cursor, Windsurf, Cline, or any other IDE that supports MCP.
+It has documentation, code examples, technical blog posts / feature announcements, and package changelogs which your IDE can read to help you build with Mastra.
+
+## How it works
+
+The MCP server tools have been designed to allow an agent to query the specific information it needs to complete a Mastra related task - for example: adding a Mastra feature to an agent, scaffolding a new project, or helping you understand how something works.
+
+Once it's installed you can send the agent prompts and assume in understands Mastra.
+
+Add features:
+
+- "Add evals to my agent and write tests"
+- "Write me a workflow that does the following [...]"
+- "Make a new tool that allows my agent to [...]"
+
+Ask about integrations:
+
+- "Does Mastra work with the AI SDK? How can I use it in my [React/Svelte/etc] project?"
+- "What's the latest Mastra news around MCP?"
+- "Does Mastra support [provider]'s speech and voice API? Show me an example in my code of how I can use it."
+
+Debug or updating existing code:
+
+- "I'm running into a bug with agent memory, have there been any related changes or bug fixes recently?"
+- "How does working memory behave in Mastra and how can I use it to do [task]?"
+- "I saw there are new workflow features, explain them to me and then update [workflow] to use them."
+
+And more - if you have a question, try asking your IDE and let it look it up for you.
+
+## Automatic Installation
+
+Run `pnpm create mastra@latest` and select Cursor or Windsurf when prompted to install the MCP server. For other IDEs, or if you already have a Mastra project, install the MCP server by following the instructions below.
+
+## Installation
+
+- **Cursor**: Edit `.cursor/mcp.json` in your project root, or `~/.cursor/mcp.json` for global configuration
+- **Windsurf**: Edit `~/.codeium/windsurf/mcp_config.json` (only supports global configuration)
+
+Add the following configuration:
+
+MacOS/Linux:
+
+```json
+{
+  "mcpServers": {
+    "mastra": {
+      "command": "npx",
+      "args": ["-y", "@mastra/mcp-docs-server@latest"]
+    }
+  }
+}
+```
+
+Windows:
+
+```json
+{
+  "mcpServers": {
+    "mastra": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server@latest"]
+    }
+  }
+}
+```
+
+After adding the configuration:
+
+In Cursor:
+
+1. Open Cursor settings
+2. Navigate to MCP settings
+3. Click "enable" on the Mastra MCP server
+4. If you have an agent chat open, you'll need to re-open it or start a new chat to use the MCP server
+
+In Windsurf:
+
+1. Fully quit and re-open Windsurf
+2. If tool calls start failing, go to Windsurfs MCP settings and re-start the MCP server. This is a common Windsurf MCP issue and isn't related to Mastra. Right now Cursor's MCP server is more stable than Windsurfs is.
+
+In both IDEs it may take a minute for the MCP server to start the first time as it needs to download the package from npm.
+
+## Available Agent Tools
+
+### Documentation
+
+Access Mastra's complete documentation:
+
+- Getting started / installation
+- Guides and tutorials
+- API references
+
+### Examples
+
+Browse code examples:
+
+- Complete project structures
+- Implementation patterns
+- Best practices
+
+### Blog Posts
+
+Search the blog for:
+
+- Technical posts
+- Changelog and feature announcements
+- AI news and updates
+
+### Package Changes
+
+Track updates for Mastra and `@mastra/*` packages:
+
+- Bug fixes
+- New features
+- Breaking changes
+
+## Common Issues
+
+1. **Server Not Starting**
+
+   - Ensure npx is installed and working
+   - Check for conflicting MCP servers
+   - Verify your configuration file syntax
+   - On Windows, make sure to use the Windows-specific configuration
+
+2. **Tool Calls Failing**
+   - Restart the MCP server
+   - Check your internet connection
+   - Verify the tool exists and is properly configured
+   - Update to the latest version of your IDE
+
+## Using in Your Code
+
+If you're building a Mastra application and want to use the documentation server programmatically in an agent, check out our guide on [Model Context Protocol (MCP)](/docs/tools/mcp-guide).
+

--- a/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
@@ -71,7 +71,7 @@ Windows:
 }
 ```
 
-After adding the configuration:
+## After adding the configuration
 
 In Cursor:
 

--- a/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
@@ -85,7 +85,7 @@ Add the following configuration:
 ### Windsurf
 
 1. Fully quit and re-open Windsurf
-2. If tool calls start failing, go to Windsurfs MCP settings and re-start the MCP server. This is a common Windsurf MCP issue and isn't related to Mastra. Right now Cursor's MCP server is more stable than Windsurfs is.
+2. If tool calls start failing, go to Windsurfs MCP settings and re-start the MCP server. This is a common Windsurf MCP issue and isn't related to Mastra. Right now Cursor's MCP implementation is more stable than Windsurfs is.
 
 In both IDEs it may take a minute for the MCP server to start the first time as it needs to download the package from npm.
 

--- a/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/pages/docs/getting-started/mcp-docs-server.mdx
@@ -28,7 +28,7 @@ Once it's installed in your IDE you can write prompts and assume the agent will 
 - "What's the latest Mastra news around MCP?"
 - "Does Mastra support `[provider]` speech and voice APIs? Show me an example in my code of how I can use it."
 
-### Debug or updating existing code
+### Debug or update existing code
 
 - "I'm running into a bug with agent memory, have there been any related changes or bug fixes recently?"
 - "How does working memory behave in Mastra and how can I use it to do `[task]`? It doesn't seem to work the way I expect."


### PR DESCRIPTION
Documentation for the new docs mcp server: https://github.com/mastra-ai/mastra/pull/2966

Also added a `.cursor/mcp.json` to the repo so we can use it during development.