### PR TITLE
Enable the weather example to function with non-English languages

### DIFF
--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -2893,6 +2893,7 @@ export const weatherAgent = new Agent({
 
 Your primary function is to help users get weather details for specific locations. When responding:
 - Always ask for a location if none is provided
+- If the location name isn’t in English, please translate it
 - Include relevant details like humidity, wind conditions, and precipitation
 - Keep responses concise but informative
 
@@ -23643,6 +23644,7 @@ const weatherAgent = new Agent({
   instructions: `You are a helpful weather assistant that provides accurate weather information.
 Your primary function is to help users get weather details for specific locations. When responding:
 - Always ask for a location if none is provided
+- If the location name isn’t in English, please translate it
 - Include relevant details like humidity, wind conditions, and precipitation
 - Keep responses concise but informative
 Use the weatherTool to fetch current weather data.`,

--- a/docs/src/pages/docs/getting-started/installation.mdx
+++ b/docs/src/pages/docs/getting-started/installation.mdx
@@ -312,6 +312,7 @@ export const weatherAgent = new Agent({
 
 Your primary function is to help users get weather details for specific locations. When responding:
 - Always ask for a location if none is provided
+- If the location name isn’t in English, please translate it
 - Include relevant details like humidity, wind conditions, and precipitation
 - Keep responses concise but informative
 

--- a/docs/src/pages/examples/agents/using-a-tool.mdx
+++ b/docs/src/pages/examples/agents/using-a-tool.mdx
@@ -114,6 +114,7 @@ const weatherAgent = new Agent({
   instructions: `You are a helpful weather assistant that provides accurate weather information.
 Your primary function is to help users get weather details for specific locations. When responding:
 - Always ask for a location if none is provided
+- If the location name isn’t in English, please translate it
 - Include relevant details like humidity, wind conditions, and precipitation
 - Keep responses concise but informative
 Use the weatherTool to fetch current weather data.`,

--- a/examples/ai-sdk-useChat/src/mastra/agents/index.ts
+++ b/examples/ai-sdk-useChat/src/mastra/agents/index.ts
@@ -10,6 +10,7 @@ export const weatherAgent = new Agent({
 
       Your primary function is to help users get weather details for specific locations. When responding:
       - Always ask for a location if none is provided
+      - If the location name isn’t in English, please translate it
       - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
       - Include relevant details like humidity, wind conditions, and precipitation
       - Keep responses concise but informative

--- a/examples/basics/agents/using-a-tool/index.ts
+++ b/examples/basics/agents/using-a-tool/index.ts
@@ -99,7 +99,7 @@ const weatherAgent = new Agent({
   name: 'Weather Agent',
   instructions: `You are a helpful weather assistant that provides accurate weather information.
 Your primary function is to help users get weather details for specific locations. When responding:
-- Always ask for a location if none is provided - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
+- Always ask for a location if none is provided - If the location name isn’t in English, please translate it - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
 - Include relevant details like humidity, wind conditions, and precipitation
 - Keep responses concise but informative
 Use the weatherTool to fetch current weather data.`,

--- a/examples/weather-agent/src/mastra/agents/index.ts
+++ b/examples/weather-agent/src/mastra/agents/index.ts
@@ -9,6 +9,7 @@ export const weatherAgent = new Agent({
 
 Your primary function is to help users get weather details for specific locations. When responding:
 - Always ask for a location if none is provided
+- If the location name isn’t in English, please translate it
 - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
 - Include relevant details like humidity, wind conditions, and precipitation
 - Keep responses concise but informative

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -65,6 +65,7 @@ export async function writeAgentSample(llmProvider: LLMProvider, destPath: strin
 
       Your primary function is to help users get weather details for specific locations. When responding:
       - Always ask for a location if none is provided
+      - If the location name isn’t in English, please translate it
       - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
       - Include relevant details like humidity, wind conditions, and precipitation
       - Keep responses concise but informative


### PR DESCRIPTION
This is a quick suggestion by a non-native English speaker! When passing non-English prompt like "今日の東京の天気は？" (this means "What's the weather in Tokyo today?" in Japanese language), the example app fails with the following error:
```
ERROR [2025-03-18 11:35:00.589 +0900] (weatherTool): Failed tool execution
    runId: "weatherAgent"
    description: "Get current weather for a location"
    args: {
      "location": "東京"
    }
    error: {}
```

This pull request resolves this issue not only for Japanese but also other non-English languages. 