### PR TITLE
Fix overly synchronous and blocking memory behaviour

### DIFF
--- a/.changeset/short-radios-lay.md
+++ b/.changeset/short-radios-lay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+More parallel memory operations

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -204,114 +204,74 @@ export class Agent<
     runId,
   }: {
     resourceId: string;
-    threadId?: string;
+    threadId: string;
     memoryConfig?: MemoryConfig;
     userMessages: CoreMessage[];
     time?: Date;
     keyword?: string;
     runId?: string;
   }) {
-    const userMessage = this.getMostRecentUserMessage(userMessages);
     const memory = this.getMemory();
     if (memory) {
-      const config = memory.getMergedThreadConfig(memoryConfig);
-      let thread: StorageThreadType | null;
-
-      if (!threadId) {
-        this.logger.debug(`No threadId, creating new thread for agent ${this.name}`, {
-          runId: runId || this.name,
-        });
-        const title = config?.threads?.generateTitle ? await this.genTitle(userMessage) : undefined;
-
-        thread = await memory.createThread({
-          threadId,
-          resourceId,
-          memoryConfig,
-          title,
-        });
-      } else {
-        thread = await memory.getThreadById({ threadId });
-        if (!thread) {
-          this.logger.debug(`Thread with id ${threadId} not found, creating new thread for agent ${this.name}`, {
-            runId: runId || this.name,
-          });
-
-          const title = config?.threads?.generateTitle ? await this.genTitle(userMessage) : undefined;
-
-          thread = await memory.createThread({
-            threadId,
-            resourceId,
-            title,
-            memoryConfig,
-          });
-        }
+      const thread = await memory.getThreadById({ threadId });
+      if (!thread) {
+        return { threadId: threadId || '', messages: userMessages };
       }
 
+      const userMessage = this.getMostRecentUserMessage(userMessages);
       const newMessages = userMessage ? [userMessage] : userMessages;
 
-      if (thread) {
-        const messages = newMessages.map(u => {
-          return {
-            id: this.getMemory()?.generateId()!,
-            createdAt: new Date(),
-            threadId: thread.id,
-            ...u,
-            content: u.content as UserContent | AssistantContent,
-            role: u.role as 'user' | 'assistant',
-            type: 'text' as 'text' | 'tool-call' | 'tool-result',
-          };
-        });
-
-        const memoryMessages =
-          threadId && memory
-            ? (
-                await memory.rememberMessages({
-                  threadId,
-                  resourceId,
-                  config: memoryConfig,
-                  vectorMessageSearch: messages
-                    .slice(-1)
-                    .map(m => {
-                      if (typeof m === `string`) {
-                        return m;
-                      }
-                      return m?.content || ``;
-                    })
-                    .join(`\n`),
-                })
-              ).messages
-            : [];
-
-        if (memory) {
-          await memory.saveMessages({ messages, memoryConfig });
-        }
-
-        this.logger.debug('Saved messages to memory', {
-          threadId: thread.id,
-          runId,
-        });
-
-        const memorySystemMessage =
-          memory && threadId ? await memory.getSystemMessage({ threadId, memoryConfig }) : null;
-
+      const messages = newMessages.map(u => {
         return {
-          threadId: thread.id,
-          messages: [
-            memorySystemMessage
-              ? {
-                  role: 'system' as const,
-                  content: memorySystemMessage,
-                }
-              : null,
-            ...this.sanitizeResponseMessages(memoryMessages),
-            ...newMessages,
-          ].filter((message): message is NonNullable<typeof message> => Boolean(message)),
+          id: this.getMemory()?.generateId()!,
+          createdAt: new Date(),
+          threadId: threadId,
+          ...u,
+          content: u.content as UserContent | AssistantContent,
+          role: u.role as 'user' | 'assistant',
+          type: 'text' as 'text' | 'tool-call' | 'tool-result',
         };
-      }
+      });
+
+      const memoryMessages =
+        threadId && memory
+          ? (
+              await memory.rememberMessages({
+                threadId,
+                resourceId,
+                config: memoryConfig,
+                vectorMessageSearch: messages
+                  .slice(-1)
+                  .map(m => {
+                    if (typeof m === `string`) {
+                      return m;
+                    }
+                    return m?.content || ``;
+                  })
+                  .join(`\n`),
+              })
+            ).messages
+          : [];
+
+      this.logger.debug('Saved messages to memory', {
+        threadId,
+        runId,
+      });
+
+      const memorySystemMessage = memory && threadId ? await memory.getSystemMessage({ threadId, memoryConfig }) : null;
 
       return {
-        threadId: (thread as StorageThreadType)?.id || threadId || '',
-        messages: userMessages,
+        threadId: thread.id,
+        messages: [
+          memorySystemMessage
+            ? {
+                role: 'system' as const,
+                content: memorySystemMessage,
+              }
+            : null,
+          ...this.sanitizeResponseMessages(memoryMessages),
+          ...newMessages,
+        ].filter((message): message is NonNullable<typeof message> => Boolean(message)),
       };
     }
 
@@ -621,7 +581,7 @@ export class Agent<
     messages,
   }: {
     runId?: string;
-    threadId?: string;
+    threadId: string;
     memoryConfig?: MemoryConfig;
     messages: CoreMessage[];
     resourceId: string;
@@ -693,6 +653,17 @@ export class Agent<
               memoryStore: this.getMemory()?.constructor.name,
             },
           );
+
+          let thread = threadIdToUse ? await memory.getThreadById({ threadId: threadIdToUse }) : undefined;
+          if (!thread) {
+            thread = await memory.createThread({
+              threadId: threadIdToUse,
+              resourceId,
+              memoryConfig,
+            });
+          }
+          threadIdToUse = thread.id;
+
           const preExecuteResult = await this.preExecute({
             resourceId,
             runId,
@@ -769,15 +740,54 @@ export class Agent<
           result: resToLog,
           threadId,
         });
-        if (this.getMemory() && resourceId) {
+        const memory = this.getMemory();
+        const thread = await memory?.getThreadById({ threadId });
+        if (memory && resourceId && thread) {
           try {
-            await this.saveResponse({
-              result,
-              threadId,
-              resourceId,
-              memoryConfig,
-              runId,
+            const userMessage = this.getMostRecentUserMessage(messages);
+            const newMessages = userMessage ? [userMessage] : messages;
+            const threadMessages = newMessages.map(u => {
+              return {
+                id: this.getMemory()?.generateId()!,
+                createdAt: new Date(),
+                threadId: thread.id,
+                ...u,
+                content: u.content as UserContent | AssistantContent,
+                role: u.role as 'user' | 'assistant',
+                type: 'text' as 'text' | 'tool-call' | 'tool-result',
+              };
             });
+
+            await Promise.all([
+              (async () => {
+                await memory.saveMessages({ messages: threadMessages, memoryConfig });
+                await this.saveResponse({
+                  result,
+                  threadId,
+                  resourceId,
+                  memoryConfig,
+                  runId,
+                });
+              })(),
+              (async () => {
+                if (!thread.title?.startsWith('New Thread')) {
+                  return;
+                }
+
+                const config = memory.getMergedThreadConfig(memoryConfig);
+                const title = config?.threads?.generateTitle ? await this.genTitle(userMessage) : undefined;
+                if (!title) {
+                  return;
+                }
+
+                return memory.createThread({
+                  threadId: thread.id,
+                  resourceId,
+                  memoryConfig,
+                  title,
+                });
+              })(),
+            ]);
           } catch (e) {
             this.logger.error('Error saving response', {
               error: e,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -196,7 +196,7 @@ export class Agent<
     return title;
   }
 
-  async saveMemory({
+  async fetchMemory({
     threadId,
     memoryConfig,
     resourceId,
@@ -590,7 +590,7 @@ export class Agent<
     let threadIdToUse = threadId;
 
     this.logger.debug(`Saving user messages in memory for agent ${this.name}`, { runId });
-    const saveMessageResponse = await this.saveMemory({
+    const saveMessageResponse = await this.fetchMemory({
       threadId,
       resourceId,
       userMessages: messages,


### PR DESCRIPTION
* Creating a thread in preExecute before hook and de-coupling that from `saveMemory()` logic in `packages/core/src/agent/index.ts`
* `saveMemory()` is now called `fetchMemory` because it no longer saves any messages, just fetches all the memory context required
* We no longer generate the thread title in a blocking way, we do that in the `after` hook in parallel with saving all the user and llm output messages
* Saving of new user messages is no longer a blocking operation in `saveMemory` but rather happens in the `after` hook in parallel, no longer blocking the actual LLM call. 
