### PR TITLE
Inject step metadata into `execute` function

### DIFF
--- a/.changeset/busy-worms-win.md
+++ b/.changeset/busy-worms-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Inject step metadata into execute fn

--- a/packages/core/src/workflows/machine.ts
+++ b/packages/core/src/workflows/machine.ts
@@ -389,6 +389,13 @@ export class Machine<
             },
             runId: this.#runId,
             mastra: mastraProxy as MastraUnion | undefined,
+            metadata: {
+              inputSchema: stepNode.step.inputSchema,
+              outputSchema: stepNode.step.outputSchema,
+              id: stepNode.step.id,
+              description: stepNode.step.description,
+              payload: stepNode.step.payload,
+            },
           });
         } catch (error) {
           this.logger.debug(`Step ${stepNode.step.id} failed`, {

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -7,7 +7,7 @@ export class Step<
   TStepId extends string = any,
   TSchemaIn extends z.ZodSchema | undefined = undefined,
   TSchemaOut extends z.ZodSchema | undefined = undefined,
-  TContext extends StepExecutionContext<TSchemaIn> = StepExecutionContext<TSchemaIn>,
+  TContext extends StepExecutionContext<TSchemaIn, TSchemaOut> = StepExecutionContext<TSchemaIn, TSchemaOut>,
 > implements StepAction<TStepId, TSchemaIn, TSchemaOut, TContext>
 {
   id: TStepId;
@@ -42,7 +42,7 @@ export function createStep<
   TId extends string,
   TSchemaIn extends z.ZodSchema | undefined,
   TSchemaOut extends z.ZodSchema | undefined,
-  TContext extends StepExecutionContext<TSchemaIn>,
+  TContext extends StepExecutionContext<TSchemaIn, TSchemaOut> = StepExecutionContext<TSchemaIn, TSchemaOut>,
 >(opts: StepAction<TId, TSchemaIn, TSchemaOut, TContext>) {
   return new Step(opts);
 }

--- a/packages/core/src/workflows/workflow-instance.ts
+++ b/packages/core/src/workflows/workflow-instance.ts
@@ -575,7 +575,10 @@ export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTrigg
 
     // NOTE: destructuring rest breaks some injected runtime fields, like runId
     // TODO: investigate why that is exactly
-    const handler = async ({ context, ...rest }: ActionContext<TSteps[number]['inputSchema']>) => {
+    const handler = async ({
+      context,
+      ...rest
+    }: ActionContext<TSteps[number]['inputSchema'], TSteps[number]['outputSchema']>) => {
       const targetStep = this.#steps[stepId];
       if (!targetStep) throw new Error(`Step not found`);
 
@@ -601,7 +604,10 @@ export class WorkflowInstance<TSteps extends Step<any, any, any>[] = any, TTrigg
 
     // Only trace handler if telemetry is available
 
-    const finalHandler = ({ context, ...rest }: ActionContext<TSteps[number]['inputSchema']>) => {
+    const finalHandler = ({
+      context,
+      ...rest
+    }: ActionContext<TSteps[number]['inputSchema'], TSteps[number]['outputSchema']>) => {
       if (this.#executionSpan) {
         return executeStep(handler, `workflow.${this.name}.step.${stepId}`, {
           componentName: this.name,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -598,7 +598,10 @@ export class Workflow<
 
     // NOTE: destructuring rest breaks some injected runtime fields, like runId
     // TODO: investigate why that is exactly
-    const handler = async ({ context, ...rest }: ActionContext<TSteps[number]['inputSchema']>) => {
+    const handler = async ({
+      context,
+      ...rest
+    }: ActionContext<TSteps[number]['inputSchema'], TSteps[number]['outputSchema']>) => {
       const targetStep = this.#steps[stepId];
       if (!targetStep) throw new Error(`Step not found`);
 
@@ -625,7 +628,10 @@ export class Workflow<
 
     // Only trace handler if telemetry is available
 
-    const finalHandler = ({ context, ...rest }: ActionContext<TSteps[number]['inputSchema']>) => {
+    const finalHandler = ({
+      context,
+      ...rest
+    }: ActionContext<TSteps[number]['inputSchema'], TSteps[number]['outputSchema']>) => {
       if (this.getExecutionSpan(rest?.runId as string)) {
         return executeStep(handler, `workflow.${this.name}.step.${stepId}`, {
           componentName: this.name,


### PR DESCRIPTION
https://linear.app/kepler-crm/issue/MASTRA-2453/expose-step-config-in-step-execution-scope