### PR TITLE
Fix: Update mastra dev reference link

### DIFF
--- a/docs/src/pages/docs/local-dev/mastra-dev.mdx
+++ b/docs/src/pages/docs/local-dev/mastra-dev.mdx
@@ -74,7 +74,7 @@ The Tools playground allows you to test your custom tools in isolation:
 
 ## REST API Endpoints
 
-`mastra dev` also spins up REST API routes for your agents and workflows via the local [Mastra Server](/docs/deployment/server). This allows you to test your API endpoints before deployment. See [Mastra Dev reference](http://localhost:3000/docs/reference/cli/dev#routes) for more details about all endpoints.
+`mastra dev` also spins up REST API routes for your agents and workflows via the local [Mastra Server](/docs/deployment/server). This allows you to test your API endpoints before deployment. See [Mastra Dev reference](/docs/reference/cli/dev#routes) for more details about all endpoints.
 
 You can then leverage the [Mastra Client](/docs/deployment/client) SDK to interact with your served REST API routes seamlessly.
 


### PR DESCRIPTION
- Updated the mastra dev reference link to be relative instead of having it point to localhost:3000