### PR TITLE
[MASTRA-2602] Update Vector DB docs and RAG examples

### DIFF
--- a/docs/src/pages/docs/rag/vector-databases.mdx
+++ b/docs/src/pages/docs/rag/vector-databases.mdx
@@ -190,6 +190,84 @@ The dimension size must match the output dimension of your chosen embedding mode
 - OpenAI text-embedding-3-large: 3072 dimensions
 - Cohere embed-multilingual-v3: 1024 dimensions
 
+### Naming Rules of Indexes
+
+Each vector database enforces specific naming conventions for indexes and collections to ensure compatibility and prevent conflicts.
+
+<Tabs items={['Pg Vector', 'Pinecone', 'Qdrant', 'Chroma', 'Astra', 'LibSQL', 'Upstash', 'Cloudflare']}>
+  <Tabs.Tab>
+    Index names must:
+    - Start with a letter or underscore
+    - Contain only letters, numbers, and underscores
+    - Example: `my_index_123` is valid
+    - Example: `my-index` is not valid (contains hyphen)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Index names must:
+    - Use only lowercase letters, numbers, and dashes
+    - Not contain dots (used for DNS routing)
+    - Not use non-Latin characters or emojis
+    - Have a combined length (with project ID) under 52 characters
+      - Example: `my-index-123` is valid
+      - Example: `my.index` is not valid (contains dot)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Collection names must:
+    - Be 1-255 characters long
+    - Not contain any of these special characters:
+      - `< > : " / \ | ? *`
+      - Null character (`\0`)
+      - Unit separator (`\u{1F}`)
+    - Example: `my_collection_123` is valid
+    - Example: `my/collection` is not valid (contains slash)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Collection names must:
+    - Be 3-63 characters long
+    - Start and end with a letter or number
+    - Contain only letters, numbers, underscores, or hyphens
+    - Not contain consecutive periods (..)
+    - Not be a valid IPv4 address
+    - Example: `my-collection-123` is valid
+    - Example: `my..collection` is not valid (consecutive periods)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Collection names must:
+    - Not be empty
+    - Be 48 characters or less
+    - Contain only letters, numbers, and underscores
+    - Example: `my_collection_123` is valid
+    - Example: `my-collection` is not valid (contains hyphen)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Index names must:
+    - Start with a letter or underscore
+    - Contain only letters, numbers, and underscores
+    - Example: `my_index_123` is valid
+    - Example: `my-index` is not valid (contains hyphen)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Namespace names must:
+    - Be 2-100 characters long
+    - Contain only:
+      - Alphanumeric characters (a-z, A-Z, 0-9)
+      - Underscores, hyphens, dots
+    - Not start or end with special characters (_, -, .)
+    - Can be case-sensitive
+    - Example: `MyNamespace123` is valid
+    - Example: `_namespace` is not valid (starts with underscore)
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Index names must:
+    - Start with a letter
+    - Be shorter than 32 characters
+    - Contain only lowercase ASCII letters, numbers, and dashes
+    - Use dashes instead of spaces
+    - Example: `my-index-123` is valid
+    - Example: `My_Index` is not valid (uppercase and underscore)
+  </Tabs.Tab>
+</Tabs>
+
 ### Upserting Embeddings
 
 After creating an index, you can store embeddings along with their basic metadata:

--- a/docs/src/pages/docs/rag/vector-databases.mdx
+++ b/docs/src/pages/docs/rag/vector-databases.mdx
@@ -9,11 +9,7 @@ import { Tabs } from "nextra/components";
 
 After generating embeddings, you need to store them in a database that supports vector similarity search. Mastra provides a consistent interface for storing and querying embeddings across different vector databases.
 
-## Supported databases
-
-### PostgreSQL with PgVector
-
-Best for teams already using PostgreSQL who want to minimize infrastructure complexity:
+## Supported Databases
 
 <Tabs items={['Pg Vector', 'Pinecone', 'Qdrant', 'Chroma', 'Astra', 'LibSQL', 'Upstash', 'Cloudflare']}>
   <Tabs.Tab>
@@ -33,6 +29,10 @@ Best for teams already using PostgreSQL who want to minimize infrastructure comp
 
   ```
 
+  ### Using PostgreSQL with pgvector
+
+  PostgreSQL with the pgvector extension is a good solution for teams already using PostgreSQL who want to minimize infrastructure complexity. 
+  For detailed setup instructions and best practices, see the [official pgvector repository](https://github.com/pgvector/pgvector).
 </Tabs.Tab>
 <Tabs.Tab>
   ```ts filename="vector-store.ts" showLineNumbers copy

--- a/docs/src/pages/docs/rag/vector-databases.mdx
+++ b/docs/src/pages/docs/rag/vector-databases.mdx
@@ -190,7 +190,7 @@ The dimension size must match the output dimension of your chosen embedding mode
 - OpenAI text-embedding-3-large: 3072 dimensions
 - Cohere embed-multilingual-v3: 1024 dimensions
 
-### Naming Rules of Indexes
+### Naming Rules for Databases
 
 Each vector database enforces specific naming conventions for indexes and collections to ensure compatibility and prevent conflicts.
 

--- a/docs/src/pages/examples/rag/rerank/rerank-rag.mdx
+++ b/docs/src/pages/examples/rag/rerank/rerank-rag.mdx
@@ -35,7 +35,7 @@ POSTGRES_CONNECTION_STRING=your_connection_string_here
 
 Then, import the necessary dependencies:
 
-```typescript copy showLineNumbers filename="src/mastra/index.ts"
+```typescript copy showLineNumbers filename="index.ts"
 import { openai } from "@ai-sdk/openai";
 import { Mastra } from "@mastra/core";
 import { Agent } from "@mastra/core/agent";
@@ -48,7 +48,7 @@ import { embedMany } from "ai";
 
 Using createVectorQueryTool imported from @mastra/rag, you can create a tool that can query the vector database and re-rank results:
 
-```typescript copy showLineNumbers{8} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{8} filename="index.ts"
 const vectorQueryTool = createVectorQueryTool({
   vectorStoreName: "pgVector",
   indexName: "embeddings",
@@ -63,7 +63,7 @@ const vectorQueryTool = createVectorQueryTool({
 
 Set up the Mastra agent that will handle the responses:
 
-```typescript copy showLineNumbers{17} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{17} filename="index.ts"
 export const ragAgent = new Agent({
   name: "RAG Agent",
   instructions: `You are a helpful assistant that answers questions based on the provided context. Keep your answers concise and relevant.
@@ -80,7 +80,7 @@ export const ragAgent = new Agent({
 
 Instantiate PgVector and Mastra with the components:
 
-```typescript copy showLineNumbers{29} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{29} filename="index.ts"
 const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
 
 export const mastra = new Mastra({
@@ -94,7 +94,7 @@ const agent = mastra.getAgent("ragAgent");
 
 Create a document and process it into chunks:
 
-```typescript copy showLineNumbers{38} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{38} filename="index.ts"
 const doc1 = MDocument.fromText(`
 market data shows price resistance levels.
 technical charts display moving averages.
@@ -128,7 +128,7 @@ const chunks = await doc1.chunk({
 
 Generate embeddings for the chunks and store them in the vector database:
 
-```typescript copy showLineNumbers{66} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{66} filename="index.ts"
 const { embeddings } = await embedMany({
   model: openai.embedding("text-embedding-3-small"),
   values: chunks.map(chunk => chunk.text),
@@ -151,7 +151,7 @@ await vectorStore.upsert({
 
 Try different queries to see how the re-ranking affects results:
 
-```typescript copy showLineNumbers{82} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{82} filename="index.ts"
 const queryOne = 'explain technical trading analysis';
 const answerOne = await agent.generate(queryOne);
 console.log('\nQuery:', queryOne);

--- a/docs/src/pages/examples/rag/usage/cleanup-rag.mdx
+++ b/docs/src/pages/examples/rag/usage/cleanup-rag.mdx
@@ -42,7 +42,7 @@ POSTGRES_CONNECTION_STRING=your_connection_string_here
 
 Then, import the necessary dependencies:
 
-```typescript copy showLineNumbers filename="src/mastra/index.ts"
+```typescript copy showLineNumbers filename="index.ts"
 import { openai } from '@ai-sdk/openai';
 import { Mastra } from "@mastra/core";
 import { Agent } from "@mastra/core/agent";
@@ -57,7 +57,7 @@ import { embedMany } from "ai";
 
 Using createVectorQueryTool imported from @mastra/rag, you can create a tool that can query the vector database.
 
-```typescript copy showLineNumbers{8} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{8} filename="index.ts"
 const vectorQueryTool = createVectorQueryTool({
   vectorStoreName: "pgVector",
   indexName: "embeddings",
@@ -69,7 +69,7 @@ const vectorQueryTool = createVectorQueryTool({
 
 Using createDocumentChunkerTool imported from @mastra/rag, you can create a tool that chunks the document and sends the chunks to your agent.
 
-```typescript copy showLineNumbers{14} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{14} filename="index.ts"
 const doc = MDocument.fromText(yourText);
 
 const documentChunkerTool = createDocumentChunkerTool({
@@ -87,7 +87,7 @@ const documentChunkerTool = createDocumentChunkerTool({
 
 Set up a single Mastra agent that can handle both querying and cleaning:
 
-```typescript copy showLineNumbers{26} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{26} filename="index.ts"
 const ragAgent = new Agent({
   name: "RAG Agent",
   instructions: `You are a helpful assistant that handles both querying and cleaning documents.
@@ -108,7 +108,7 @@ const ragAgent = new Agent({
 
 Instantiate PgVector and Mastra with the components:
 
-```typescript copy showLineNumbers{41} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{41} filename="index.ts"
 const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
 
 export const mastra = new Mastra({
@@ -122,7 +122,7 @@ const agent = mastra.getAgent('ragAgent');
 
 Chunk the initial document and create embeddings:
 
-```typescript copy showLineNumbers{49} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{49} filename="index.ts"
 const chunks = await doc.chunk({
   strategy: "recursive",
   size: 256,
@@ -152,7 +152,7 @@ await vectorStore.upsert({
 
 Let's try querying the raw data to establish a baseline:
 
-```typescript copy showLineNumbers{73} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{73} filename="index.ts"
 // Generate response using the original embeddings
 const query = 'What are all the technologies mentioned for space exploration?';
 const originalResponse = await agent.generate(query);
@@ -164,7 +164,7 @@ console.log('Response:', originalResponse.text);
 
 After seeing the initial results, we can clean the data to improve quality:
 
-```typescript copy showLineNumbers{79} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{79} filename="index.ts"
 const chunkPrompt = `Use the tool provided to clean the chunks. Make sure to filter out irrelevant information that is not space related and remove duplicates.`;
 
 const newChunks = await agent.generate(chunkPrompt);
@@ -200,7 +200,7 @@ await vectorStore.upsert({
 
 Query the data again after cleaning to observe any differences in the response:
 
-```typescript copy showLineNumbers{109} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{109} filename="index.ts"
 // Query again with cleaned embeddings
 const cleanedResponse = await agent.generate(query);
 console.log('\nQuery:', query);

--- a/docs/src/pages/examples/rag/usage/cot-rag.mdx
+++ b/docs/src/pages/examples/rag/usage/cot-rag.mdx
@@ -36,7 +36,7 @@ POSTGRES_CONNECTION_STRING=your_connection_string_here
 
 Then, import the necessary dependencies:
 
-```typescript copy showLineNumbers filename="src/mastra/index.ts"
+```typescript copy showLineNumbers filename="index.ts"
 import { openai } from "@ai-sdk/openai";
 import { Mastra } from "@mastra/core";
 import { Agent } from "@mastra/core/agent";
@@ -49,7 +49,7 @@ import { embedMany } from "ai";
 
 Using createVectorQueryTool imported from @mastra/rag, you can create a tool that can query the vector database.
 
-```typescript copy showLineNumbers{8} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{8} filename="index.ts"
 const vectorQueryTool = createVectorQueryTool({
   vectorStoreName: "pgVector",
   indexName: "embeddings",
@@ -61,7 +61,7 @@ const vectorQueryTool = createVectorQueryTool({
 
 Set up the Mastra agent with chain-of-thought prompting instructions:
 
-```typescript copy showLineNumbers{14} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{14} filename="index.ts"
 export const ragAgent = new Agent({
   name: "RAG Agent",
   instructions: `You are a helpful assistant that answers questions based on the provided context.
@@ -95,7 +95,7 @@ Remember: Explain how you're using the retrieved information to reach your concl
 
 Instantiate PgVector and Mastra with all components:
 
-```typescript copy showLineNumbers{36} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{36} filename="index.ts"
 const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
 
 export const mastra = new Mastra({
@@ -109,7 +109,7 @@ const agent = mastra.getAgent("ragAgent");
 
 Create a document and process it into chunks:
 
-```typescript copy showLineNumbers{44} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{44} filename="index.ts"
 const doc = MDocument.fromText(
   `The Impact of Climate Change on Global Agriculture...`,
 );
@@ -126,7 +126,7 @@ const chunks = await doc.chunk({
 
 Generate embeddings for the chunks and store them in the vector database:
 
-```typescript copy showLineNumbers{55} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{55} filename="index.ts"
 const { embeddings } = await embedMany({
   values: chunks.map(chunk => chunk.text),
   model: openai.embedding("text-embedding-3-small"),
@@ -148,7 +148,7 @@ await vectorStore.upsert({
 
 Try different queries to see how the agent breaks down its reasoning:
 
-```typescript copy showLineNumbers{83} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{83} filename="index.ts"
 const answerOne = await agent.generate('What are the main adaptation strategies for farmers?');
 console.log('\nQuery:', 'What are the main adaptation strategies for farmers?');
 console.log('Response:', answerOne.text);

--- a/docs/src/pages/examples/rag/usage/cot-workflow-rag.mdx
+++ b/docs/src/pages/examples/rag/usage/cot-workflow-rag.mdx
@@ -35,7 +35,7 @@ POSTGRES_CONNECTION_STRING=your_connection_string_here
 
 Import the necessary dependencies:
 
-```typescript copy showLineNumbers filename="src/mastra/index.ts"
+```typescript copy showLineNumbers filename="index.ts"
 import { openai } from "@ai-sdk/openai";
 import { Mastra } from "@mastra/core";
 import { Agent } from "@mastra/core/agent";
@@ -50,7 +50,7 @@ import { z } from "zod";
 
 First, define the workflow with its trigger schema:
 
-```typescript copy showLineNumbers{10} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{10} filename="index.ts"
 export const ragWorkflow = new Workflow({
   name: "rag-workflow",
   triggerSchema: z.object({
@@ -63,7 +63,7 @@ export const ragWorkflow = new Workflow({
 
 Create a tool for querying the vector database:
 
-```typescript copy showLineNumbers{17} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{17} filename="index.ts"
 const vectorQueryTool = createVectorQueryTool({
   vectorStoreName: "pgVector",
   indexName: "embeddings",
@@ -75,7 +75,7 @@ const vectorQueryTool = createVectorQueryTool({
 
 Set up the Mastra agent:
 
-```typescript copy showLineNumbers{23} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{23} filename="index.ts"
 export const ragAgent = new Agent({
   name: "RAG Agent",
   instructions: `You are a helpful assistant that answers questions based on the provided context.`,
@@ -92,7 +92,7 @@ The workflow is divided into multiple steps for chain-of-thought reasoning:
 
 ### 1. Context Analysis Step
 
-```typescript copy showLineNumbers{32} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{32} filename="index.ts"
 const analyzeContext = new Step({
   id: "analyzeContext",
   outputSchema: z.object({
@@ -118,7 +118,7 @@ const analyzeContext = new Step({
 
 ### 2. Thought Breakdown Step
 
-```typescript copy showLineNumbers{54} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{54} filename="index.ts"
 const breakdownThoughts = new Step({
   id: "breakdownThoughts",
   outputSchema: z.object({
@@ -148,7 +148,7 @@ const breakdownThoughts = new Step({
 
 ### 3. Connection Step
 
-```typescript copy showLineNumbers{80} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{80} filename="index.ts"
 const connectPieces = new Step({
   id: "connectPieces",
   outputSchema: z.object({
@@ -177,7 +177,7 @@ const connectPieces = new Step({
 
 ### 4. Conclusion Step
 
-```typescript copy showLineNumbers{105} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{105} filename="index.ts"
 const drawConclusions = new Step({
   id: "drawConclusions",
   outputSchema: z.object({
@@ -206,7 +206,7 @@ const drawConclusions = new Step({
 
 ### 5. Final Answer Step
 
-```typescript copy showLineNumbers{130} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{130} filename="index.ts"
 const finalAnswer = new Step({
   id: "finalAnswer",
   outputSchema: z.object({
@@ -242,7 +242,7 @@ const finalAnswer = new Step({
 
 Connect all the steps in the workflow:
 
-```typescript copy showLineNumbers{160} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{160} filename="index.ts"
 ragWorkflow
   .step(analyzeContext)
   .then(breakdownThoughts)
@@ -257,7 +257,7 @@ ragWorkflow.commit();
 
 Instantiate PgVector and Mastra with all components:
 
-```typescript copy showLineNumbers{169} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{169} filename="index.ts"
 const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
 
 export const mastra = new Mastra({
@@ -271,7 +271,7 @@ export const mastra = new Mastra({
 
 Process and chunks the document:
 
-```typescript copy showLineNumbers{177} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{177} filename="index.ts"
 const doc = MDocument.fromText(`The Impact of Climate Change on Global Agriculture...`);
 
 const chunks = await doc.chunk({
@@ -286,7 +286,7 @@ const chunks = await doc.chunk({
 
 Generate and store embeddings:
 
-```typescript copy showLineNumbers{186} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{186} filename="index.ts"
 const { embeddings } = await embedMany({
   model: openai.embedding('text-embedding-3-small'),
   values: chunks.map(chunk => chunk.text),
@@ -308,7 +308,7 @@ await vectorStore.upsert({
 
 Here's how to execute the workflow with a query:
 
-```typescript copy showLineNumbers{202} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{202} filename="index.ts"
 const query = 'What are the main adaptation strategies for farmers?';
 
 console.log('\nQuery:', query);

--- a/docs/src/pages/examples/rag/usage/filter-rag.mdx
+++ b/docs/src/pages/examples/rag/usage/filter-rag.mdx
@@ -41,7 +41,7 @@ POSTGRES_CONNECTION_STRING=your_connection_string_here
 
 Then, import the necessary dependencies:
 
-```typescript copy showLineNumbers filename="src/mastra/index.ts"
+```typescript copy showLineNumbers filename="index.ts"
 import { openai } from '@ai-sdk/openai';
 import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
@@ -54,7 +54,7 @@ import { embedMany } from 'ai';
 
 Using createVectorQueryTool imported from @mastra/rag, you can create a tool that enables metadata filtering:
 
-```typescript copy showLineNumbers{9} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{9} filename="index.ts"
 const vectorQueryTool = createVectorQueryTool({
   id: 'vectorQueryTool',
   vectorStoreName: "pgVector",
@@ -68,7 +68,7 @@ const vectorQueryTool = createVectorQueryTool({
 
 Create a document and process it into chunks with metadata:
 
-```typescript copy showLineNumbers{17} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{17} filename="index.ts"
 const doc = MDocument.fromText(`The Impact of Climate Change on Global Agriculture...`);
 
 const chunks = await doc.chunk({
@@ -86,7 +86,7 @@ const chunks = await doc.chunk({
 
 Transform chunks into metadata that can be filtered:
 
-```typescript copy showLineNumbers{31} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{31} filename="index.ts"
 const chunkMetadata = chunks?.map((chunk: any, index: number) => ({
   text: chunk.text,
   ...chunk.metadata,
@@ -108,7 +108,7 @@ The agent requires both the vector query tool and a system prompt containing:
 - Metadata structure for available filter fields
 - Vector store prompt for filter operations and syntax
 
-```typescript copy showLineNumbers{43} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{43} filename="index.ts"
 export const ragAgent = new Agent({
   name: 'RAG Agent',
   model: openai('gpt-4o-mini'),
@@ -149,7 +149,7 @@ The agent's instructions are designed to:
 
 Instantiate PgVector and Mastra with the components:
 
-```typescript copy showLineNumbers{69} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{69} filename="index.ts"
 const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
 
 export const mastra = new Mastra({
@@ -163,7 +163,7 @@ const agent = mastra.getAgent('ragAgent');
 
 Generate embeddings and store them with metadata:
 
-```typescript copy showLineNumbers{78} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{78} filename="index.ts"
 const { embeddings } = await embedMany({
   model: openai.embedding('text-embedding-3-small'),
   values: chunks.map(chunk => chunk.text),
@@ -189,7 +189,7 @@ The `upsert` operation stores both the vector embeddings and their associated me
 
 Try different queries using metadata filters:
 
-```typescript copy showLineNumbers{96} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{96} filename="index.ts"
 const queryOne = 'What are the adaptation strategies mentioned?';
 const answerOne = await agent.generate(queryOne);
 console.log('\nQuery:', queryOne);

--- a/docs/src/pages/examples/rag/usage/graph-rag.mdx
+++ b/docs/src/pages/examples/rag/usage/graph-rag.mdx
@@ -38,7 +38,7 @@ POSTGRES_CONNECTION_STRING=your_connection_string_here
 
 Then, import the necessary dependencies:
 
-```typescript copy showLineNumbers filename="src/mastra/index.ts"
+```typescript copy showLineNumbers filename="index.ts"
 import { openai } from "@ai-sdk/openai";
 import { Mastra } from "@mastra/core";
 import { Agent } from "@mastra/core/agent";
@@ -51,7 +51,7 @@ import { embedMany } from "ai";
 
 Using createGraphRAGTool imported from @mastra/rag, you can create a tool that queries the vector database and converts the results into a knowledge graph:
 
-```typescript copy showLineNumbers{8} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{8} filename="index.ts"
 const graphRagTool = createGraphRAGTool({
   vectorStoreName: "pgVector",
   indexName: "embeddings",
@@ -67,7 +67,7 @@ const graphRagTool = createGraphRAGTool({
 
 Set up the Mastra agent that will handle the responses:
 
-```typescript copy showLineNumbers{19} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{19} filename="index.ts"
 const ragAgent = new Agent({
   name: "GraphRAG Agent",
   instructions: `You are a helpful assistant that answers questions based on the provided context. Format your answers as follows:
@@ -91,7 +91,7 @@ If the context doesn't contain enough information to fully answer the question, 
 
 Instantiate PgVector and Mastra with the components:
 
-```typescript copy showLineNumbers{36} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{36} filename="index.ts"
 const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
 
 export const mastra = new Mastra({
@@ -105,7 +105,7 @@ const agent = mastra.getAgent("ragAgent");
 
 Create a document and process it into chunks:
 
-```typescript copy showLineNumbers{45} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{45} filename="index.ts"
 const doc = MDocument.fromText(`
 # Riverdale Heights: Community Development Study
 // ... text content ...
@@ -123,7 +123,7 @@ const chunks = await doc.chunk({
 
 Generate embeddings for the chunks and store them in the vector database:
 
-```typescript copy showLineNumbers{56} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{56} filename="index.ts"
 const { embeddings } = await embedMany({
   model: openai.embedding("text-embedding-3-small"),
   values: chunks.map(chunk => chunk.text),
@@ -145,7 +145,7 @@ await vectorStore.upsert({
 
 Try different queries to explore relationships in the data:
 
-```typescript copy showLineNumbers{82} filename="src/mastra/index.ts"
+```typescript copy showLineNumbers{82} filename="index.ts"
 const queryOne = "What are the direct and indirect effects of early railway decisions on Riverdale Heights' current state?";
 const answerOne = await ragAgent.generate(queryOne);
 console.log('\nQuery:', queryOne);


### PR DESCRIPTION
This PR adds more details on vector db naming schemas for indexes, and updated RAG example filenames in docs