### PR TITLE
create run if none exists on resume

### DIFF
--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -721,7 +721,8 @@ export class Workflow<
       return activeRun.resume({ stepId, context: resumeContext });
     }
 
-    throw new Error(`Workflow run ${runId} not found`);
+    const run = this.createRun({ runId });
+    return run.resume({ stepId, context: resumeContext });
   }
 
   watch(onTransition: (state: WorkflowRunState) => void): () => void {


### PR DESCRIPTION
https://linear.app/kepler-crm/issue/MASTRA-2612/fix-resume-backwards-compat

Creates a run if none exists when calling resume from the workflow instance.