### PR TITLE
[MASTRA-2628] Check Evals are valid before inserting into storage

### DIFF
--- a/.changeset/every-bars-stand.md
+++ b/.changeset/every-bars-stand.md
@@ -1,0 +1,7 @@
+---
+'@mastra/evals': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Check for eval values before inserting into storage

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -552,3 +552,33 @@ export function createMastraProxy({ mastra, logger }: { mastra: Mastra; logger: 
     },
   });
 }
+
+export function checkEvalStorageFields(traceObject: any, logger?: Logger) {
+  const missingFields = [];
+  if (!traceObject.input) missingFields.push('input');
+  if (!traceObject.output) missingFields.push('output');
+  if (!traceObject.agentName) missingFields.push('agent_name');
+  if (!traceObject.metricName) missingFields.push('metric_name');
+  if (!traceObject.instructions) missingFields.push('instructions');
+  if (!traceObject.globalRunId) missingFields.push('global_run_id');
+  if (!traceObject.runId) missingFields.push('run_id');
+
+  if (missingFields.length > 0) {
+    if (logger) {
+      logger.warn('Skipping evaluation storage due to missing required fields', {
+        missingFields,
+        runId: traceObject.runId,
+        agentName: traceObject.agentName,
+      });
+    } else {
+      console.warn('Skipping evaluation storage due to missing required fields', {
+        missingFields,
+        runId: traceObject.runId,
+        agentName: traceObject.agentName,
+      });
+    }
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
This PR adds checks for evals before inserting them into storage in order to check that the fields are valid. If the fields are not valid (are undefined, null or empty). The eval is not inserted, with a warning given on what fields are missing.

Context:
There was a bug yesterday where someone using groq got a null output, which caused a SQL error when inserting into evals due to constraint violations.

This was also tested by removing instructions from an agent. This gave a type error, but still allowed me to run the playground and use the agent. After sending a message to the agent, it threw an error due to evals constraints.