### PR TITLE
fix: fix rollup compiling with bundle externals

### DIFF
--- a/.changeset/fluffy-zoos-build.md
+++ b/.changeset/fluffy-zoos-build.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/deployer': major
+'@mastra/deployer': patch
 ---
 
 fix building externals

--- a/.changeset/fluffy-zoos-build.md
+++ b/.changeset/fluffy-zoos-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': major
+---
+
+fix building externals

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -154,7 +154,7 @@ async function bundleExternals(depsToOptimize: Map<string, string[]>, outputDir:
       if (local === '*') {
         virtualFile.push(`export * from '${dep}';`);
       } else if (local === 'default') {
-        virtualFile.push(`export * from '${dep}';`);
+        virtualFile.push(`export { default } from '${dep}';`);
       } else {
         exportStringBuilder.push(local);
       }


### PR DESCRIPTION
Hello, team, i found a bug with mastra build command,
![image](https://github.com/user-attachments/assets/9280b655-6bf7-449d-94fc-1419534175e6)
The bug is caused by this section:
![image](https://github.com/user-attachments/assets/37fc8afd-1817-43ca-a79e-581e950ebfe6)
If a third party package imported by the way 'import dep from 'dep'',it should be converted to "export { default } from ${dep}", 
In my case, the package 'axios' and 'postgres' all imported with default mode.