### PR TITLE
update import path and required versions for agent network docs

### DIFF
--- a/docs/src/pages/docs/reference/networks/agent-network.mdx
+++ b/docs/src/pages/docs/reference/networks/agent-network.mdx
@@ -16,9 +16,12 @@ The `AgentNetwork` class provides a way to create a network of specialized agent
 - **Dynamic Decision Making**: The router decides which agent to call based on the task requirements
 
 ## Usage
+**Warning**: The AgentNetwork is currently available on pre-releases only, you will require the following package versions:
+    - @mastra/core: "0.6.4-alpha.0
+    - mastra: 0.4.3-alpha.1
 
 ```typescript
-import { AgentNetwork } from '@mastra/core';
+import { AgentNetwork } from '@mastra/core/network';
 import { openai } from '@mastra/openai';
 
 // Create specialized agents

--- a/docs/src/pages/docs/reference/networks/agent-network.mdx
+++ b/docs/src/pages/docs/reference/networks/agent-network.mdx
@@ -18,9 +18,7 @@ The `AgentNetwork` class provides a way to create a network of specialized agent
 ## Usage
 > **Pre-release**: The AgentNetwork is currently available on pre-release versions only, 
     you will require the following package versions:
-    
         - @mastra/core: 0.6.4-alpha.0
-        
         - mastra: 0.4.3-alpha.1
 
 ```typescript

--- a/docs/src/pages/docs/reference/networks/agent-network.mdx
+++ b/docs/src/pages/docs/reference/networks/agent-network.mdx
@@ -16,8 +16,8 @@ The `AgentNetwork` class provides a way to create a network of specialized agent
 - **Dynamic Decision Making**: The router decides which agent to call based on the task requirements
 
 ## Usage
-> **Pre-release**: The AgentNetwork is currently available on pre-release versions only, 
-    you will require the following package versions:
+> **Pre-release**: The AgentNetwork is currently available on pre-release versions only, you will require the following package versions:
+
         - @mastra/core: 0.6.4-alpha.0
         - mastra: 0.4.3-alpha.1
 

--- a/docs/src/pages/docs/reference/networks/agent-network.mdx
+++ b/docs/src/pages/docs/reference/networks/agent-network.mdx
@@ -16,9 +16,12 @@ The `AgentNetwork` class provides a way to create a network of specialized agent
 - **Dynamic Decision Making**: The router decides which agent to call based on the task requirements
 
 ## Usage
-**Warning**: The AgentNetwork is currently available on pre-releases only, you will require the following package versions:
-    - @mastra/core: "0.6.4-alpha.0
-    - mastra: 0.4.3-alpha.1
+> **Pre-release**: The AgentNetwork is currently available on pre-release versions only, 
+    you will require the following package versions:
+    
+        - @mastra/core: 0.6.4-alpha.0
+        
+        - mastra: 0.4.3-alpha.1
 
 ```typescript
 import { AgentNetwork } from '@mastra/core/network';


### PR DESCRIPTION
AgentNetwork is really new so docs had a wrong import it seems:

https://mastra.ai/docs/reference/networks/agent-network

@mastra/core -> @mastra/core/networks

added a warning about requiring pre-release versions too