### PR TITLE
feat: deploy docs only on stable versions

### DIFF
--- a/docs/scripts/deploy-docs-prod.sh
+++ b/docs/scripts/deploy-docs-prod.sh
@@ -7,7 +7,7 @@ echo "env: $VERCEL_ENV"
 commit_message=$(git log -1 --pretty=%B)
 
 if [[ "$VERCEL_ENV" == "production" ]]; then
-  if [[ ${commit_message,,} = "chore: version - enter prerelease mode"; then
+  if [[ ${commit_message,,} = "chore: version - enter prerelease mode" ]]; then
     echo "✅ - Build can proceed"
     exit 1;
   else

--- a/docs/scripts/deploy-docs-prod.sh
+++ b/docs/scripts/deploy-docs-prod.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+echo "env: $VERCEL_ENV"
+
+# Check if the commit message contains "chore: version - enter prerelease mode"
+# and only build the docs if it does
+# reference: https://vercel.com/guides/how-do-i-use-the-ignored-build-step-field-on-vercel#with-a-script
+commit_message=$(git log -1 --pretty=%B)
+
+if [[ "$VERCEL_ENV" == "production" ]]; then
+  if [[ ${commit_message,,} = "chore: version - enter prerelease mode"; then
+    echo "✅ - Build can proceed"
+    exit 1;
+  else
+    echo "🛑 - Build cancelled"
+    exit 0;
+  fi
+fi
+
+echo "✅ - Build can proceed"
+exit 1;

--- a/docs/scripts/deploy-docs-prod.sh
+++ b/docs/scripts/deploy-docs-prod.sh
@@ -9,12 +9,12 @@ commit_message=$(git log -1 --pretty=%B)
 if [[ "$VERCEL_ENV" == "production" ]]; then
   if [[ ${commit_message,,} = "chore: version - enter prerelease mode" ]]; then
     echo "✅ - Build can proceed"
-    exit 1;
+    exit 0;
   else
     echo "🛑 - Build cancelled"
-    exit 0;
+    exit 1;
   fi
 fi
 
 echo "✅ - Build can proceed"
-exit 1;
+exit 0;


### PR DESCRIPTION
This PR allows to only deploy the docs project to prod when the commit is `chore: version - enter prerelease mode`. It will still deploy on every PR for previews