### PR TITLE
(fix) Support union types on jsonSchemaToModel func

### DIFF
--- a/.changeset/tricky-kids-relax.md
+++ b/.changeset/tricky-kids-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Updated the jsonSchemaPropertiesToTSTypes function to properly handle JSON Schema definitions where type can be an array of strings. Previously, the function only handled single string types, but according to the JSON Schema specification, type can be an array of possible types.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -19,6 +19,16 @@ export function jsonSchemaPropertiesToTSTypes(value: any): z.ZodTypeAny {
     return z.object({});
   }
 
+  // Handle case where type is an array of strings
+  if (Array.isArray(value.type)) {
+    const types = value.type.map((type: string) => {
+      return jsonSchemaPropertiesToTSTypes({ ...value, type });
+    });
+    return z.union(types).describe(
+      (value.description || '') + (value.examples ? `\nExamples: ${value.examples.join(', ')}` : '')
+    );
+  }
+
   let zodType;
   switch (value.type) {
     case 'string':


### PR DESCRIPTION
# Handle array of types in JSON Schema conversion

## Description
Updated the `jsonSchemaPropertiesToTSTypes` function to properly handle JSON Schema definitions where `type` can be an array of strings. Previously, the function only handled single string types, but according to the JSON Schema specification, `type` can be an array of possible types.

## Changes
- Added support for array of types in `jsonSchemaPropertiesToTSTypes`
- Creates a Zod union type when multiple types are specified
- Preserves descriptions and examples on the union type

## Example
The following JSON Schema can now be properly converted:

```json
{
  "type": "object",
  "properties": {
    "mixedField": {
      "type": ["string", "null"],
      "description": "A field that can be either a string or null",
      "examples": ["example text", null]
    },
    "multiType": {
      "type": ["number", "string", "boolean"],
      "description": "A field that accepts multiple types"
    }
  }
}
```

Will be converted to the equivalent Zod schema:

```typescript
z.object({
  mixedField: z.union([
    z.string(),
    z.null()
  ]).describe("A field that can be either a string or null\nExamples: example text, null"),
  multiType: z.union([
    z.number(),
    z.string(),
    z.boolean()
  ]).describe("A field that accepts multiple types")
})
```