### PR TITLE
(fix): Fix duplicate null types in JSON Schema generation

### DIFF
--- a/.changeset/fix-null-type-schema.md
+++ b/.changeset/fix-null-type-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed JSON Schema generation for null types to prevent duplicate null entries in type arrays 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -107,7 +107,10 @@ export function jsonSchemaToModel(jsonSchema: Record<string, any>): ZodObject<an
       zodType = zodType.describe(value.description);
     }
 
-    if (requiredFields.includes(key)) {
+    // Add check for null type requiring the field
+    const isTypeRequired = value.type === 'null';
+
+    if (requiredFields.includes(key) || isTypeRequired) {
       zodSchema[key] = zodType;
     } else {
       zodSchema[key] = zodType.nullable().optional();


### PR DESCRIPTION
## Problem
When converting Zod schemas back to JSON Schema, fields with `type: "null"` were being processed incorrectly, resulting in invalid JSON Schema output like `{ "type": ["null", "null"] }`. This happens because these fields were being made both nullable and optional, effectively duplicating the null type in the array of possible types.

## Solution
Added a check to detect when a field's type is explicitly "null" and make it required in those cases, preventing the additional nullable modifier from being applied. This ensures the generated JSON Schema remains valid and accurately represents the intended type structure.

Example:
```json
// Before (invalid)
{
  "myField": {
    "type": ["null", "null"]
  }
}

// After (valid)
{
  "myField": {
    "type": "null"
  }
}
```

## Changes
- Added `isTypeRequired` check in `jsonSchemaToModel` to detect explicit null types
- Modified field generation logic to skip nullable/optional modifiers for null-typed fields

This fix ensures proper JSON Schema generation while maintaining backward compatibility with existing schema definitions.