### PR TITLE
Add missing triggerData to the openapi.json for the POST /api/workflow/{workflowId}/start endpoint

### DIFF
--- a/.changeset/ninety-feet-rescue.md
+++ b/.changeset/ninety-feet-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Add missing triggerData to the openapi.json for the POST /api/workflow/{workflowId}/start endpoint

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -1506,6 +1506,19 @@ export async function createHonoServer(
           schema: { type: 'string' },
         },
       ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                input: { type: 'object' },
+              },
+            },
+          },
+        },
+      },
       responses: {
         200: {
           description: 'Workflow run started',


### PR DESCRIPTION
Add missing triggerData to the openapi.json for the POST /api/workflow/{workflowId}/start endpoint, using the same payload of the [`startAsync`](https://github.com/mastra-ai/mastra/blob/f361eafe6f071f9967ffdc776ff456810ee76664/packages/deployer/src/server/index.ts#L1465-L1477) endpoint.

<img width="1141" alt="Screenshot 2025-03-26 at 02 09 06" src="https://github.com/user-attachments/assets/24c14702-56d4-4902-a99b-c5cf0bb1752a" />

