### PR TITLE
fix(@mastra/memory): strip working memory tool calls from history

### DIFF
--- a/.changeset/moody-onions-eat.md
+++ b/.changeset/moody-onions-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Removed working memory tool calls from thread history after the working memory has been updated. This is to prevent updates from polluting the context history and confusing agents. They should only see the most recent copy of working memory

--- a/.changeset/moody-onions-eat.md
+++ b/.changeset/moody-onions-eat.md
@@ -2,4 +2,5 @@
 '@mastra/memory': patch
 ---
 
-Removed working memory tool calls from thread history after the working memory has been updated. This is to prevent updates from polluting the context history and confusing agents. They should only see the most recent copy of working memory
+Removed working memory tool calls from thread history after the working memory has been updated. This is to prevent updates from polluting the context history and confusing agents. They should only see the most recent copy of working memory.
+Also made memory.getWorkingMemory() public since it's useful for testing, debugging, and building UIs. 

--- a/.github/workflows/test-memory.yml
+++ b/.github/workflows/test-memory.yml
@@ -55,14 +55,11 @@ jobs:
       - name: Build core
         run: pnpm build:core
 
-      - name: Build storage packages
-        run: pnpm --filter "@mastra/store-*" build
-
-      - name: Build vector packages
-        run: pnpm --filter "@mastra/vector-*" build
-
       - name: Build vector+store packages
         run: pnpm build:combined-stores
+
+      - name: Build Mastra CLI (used in int tests)
+        run: pnpm build:cli
 
       - name: Build memory
         run: pnpm build:memory

--- a/packages/memory/integration-tests/package.json
+++ b/packages/memory/integration-tests/package.json
@@ -29,6 +29,7 @@
     "@testing-library/react": "^16.2.0",
     "@types/node": "^20.17.27",
     "ai": "^4.2.2",
+    "mastra": "workspace:*",
     "jsdom": "^26.0.0",
     "next": "^15.2.3",
     "react": "^19.0.0",

--- a/packages/memory/integration-tests/package.json
+++ b/packages/memory/integration-tests/package.json
@@ -26,10 +26,8 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.52.1",
     "@testing-library/react": "^16.2.0",
     "@types/node": "^20.17.27",
-    "@vitest/coverage-v8": "^1.6.1",
     "ai": "^4.2.2",
     "jsdom": "^26.0.0",
     "next": "^15.2.3",

--- a/packages/memory/integration-tests/package.json
+++ b/packages/memory/integration-tests/package.json
@@ -3,14 +3,16 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "test": "pnpm test:pg && pnpm test:upstash && pnpm test:libsql",
+    "test": "pnpm test:pg && pnpm test:upstash && pnpm test:libsql && pnpm test:streaming && pnpm test:working-memory",
     "pretest:pg": "docker compose up -d postgres && (for i in $(seq 1 30); do docker compose exec -T postgres pg_isready -U postgres && break || (sleep 1; [ $i -eq 30 ] && exit 1); done)",
     "test:pg": "vitest run ./src/with-pg-storage.test.ts",
     "posttest:pg": "docker compose down --volumes",
     "pretest:upstash": "docker compose up -d redis serverless-redis-http",
     "test:upstash": "vitest run ./src/with-upstash-storage.test.ts",
     "posttest:upstash": "docker compose down --volumes",
-    "test:libsql": "vitest run ./src/with-libsql-storage.test.ts"
+    "test:libsql": "vitest run ./src/with-libsql-storage.test.ts",
+    "test:streaming": "vitest run ./src/streaming-memory.test.ts",
+    "test:working-memory": "vitest run ./src/working-memory.test.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.0",

--- a/packages/memory/integration-tests/src/streaming-memory.test.ts
+++ b/packages/memory/integration-tests/src/streaming-memory.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:net';
+import path from 'node:path';
 import { openai } from '@ai-sdk/openai';
 import { useChat } from '@ai-sdk/react';
 import type { AiMessageType } from '@mastra/core';
@@ -11,7 +12,7 @@ import { Memory } from '@mastra/memory';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { Message } from 'ai';
 import { JSDOM } from 'jsdom';
-import { describe, expect, it, afterEach, beforeEach } from 'vitest';
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 import { z } from 'zod';
 import { weatherAgent } from './mastra/agents/weather';
 
@@ -118,13 +119,22 @@ describe('Memory Streaming Tests', () => {
     const threadId = randomUUID();
     const resourceId = 'test-resource';
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       port = await getAvailablePort();
 
-      mastraServer = spawn('pnpm', ['mastra', 'dev', '--port', port.toString()], {
-        stdio: 'pipe',
-        detached: true, // Run in a new process group so we can kill it and children
-      });
+      mastraServer = spawn(
+        'pnpm',
+        [
+          path.resolve(import.meta.dirname, `..`, `..`, `..`, `cli`, `dist`, `index.js`),
+          'dev',
+          '--port',
+          port.toString(),
+        ],
+        {
+          stdio: 'pipe',
+          detached: true, // Run in a new process group so we can kill it and children
+        },
+      );
 
       // Wait for server to be ready
       await new Promise<void>((resolve, reject) => {
@@ -144,7 +154,7 @@ describe('Memory Streaming Tests', () => {
       });
     });
 
-    afterEach(() => {
+    afterAll(() => {
       // Kill the server and its process group
       if (mastraServer?.pid) {
         try {

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -370,25 +370,29 @@ describe('Working Memory Tests', () => {
   });
 
   it('should handle LLM responses with working memory using tool calls', async () => {
+    const memory = new Memory({
+      storage: new DefaultStorage({
+        config: {
+          url: 'file:test.db',
+        },
+      }),
+      options: {
+        workingMemory: {
+          enabled: true,
+          use: 'tool-call',
+        },
+        lastMessages: 5,
+      },
+    });
+
     const agent = new Agent({
       name: 'Memory Test Agent',
       instructions: 'You are a helpful AI agent. Always add working memory tags to remember user information.',
       model: openai('gpt-4o'),
-      memory: new Memory({
-        storage: new DefaultStorage({
-          config: {
-            url: 'file:test.db',
-          },
-        }),
-        options: {
-          workingMemory: {
-            enabled: true,
-            use: 'tool-call',
-          },
-          lastMessages: 5,
-        },
-      }),
+      memory,
     });
+
+    const thread = await memory.createThread(createTestThread(`Tool call working memory test`));
 
     await agent.generate('Hi, my name is Tyler and I live in San Francisco', {
       threadId: thread.id,
@@ -400,5 +404,93 @@ describe('Working Memory Tests', () => {
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<first_name>Tyler</first_name>');
     expect(workingMemory).toContain('<location>San Francisco</location>');
+  });
+
+  it("shouldn't pollute context with working memory tool call args, only the system instruction working memory should exist", async () => {
+    const memory = new Memory({
+      storage: new DefaultStorage({
+        config: {
+          url: 'file:test.db',
+        },
+      }),
+      options: {
+        workingMemory: {
+          enabled: true,
+          use: 'tool-call',
+          template: `<user><first_name></first_name><location></location></user>`,
+        },
+        lastMessages: 5,
+      },
+    });
+
+    const agent = new Agent({
+      name: 'Memory Test Agent',
+      instructions: 'You are a helpful AI agent. Always add working memory tags to remember user information.',
+      model: openai('gpt-4o'),
+      memory,
+    });
+
+    const thread = await memory.createThread(createTestThread(`Tool call working memory context pollution test`));
+
+    await agent.generate('Hi, my name is Tyler and I live in a submarine under the sea', {
+      threadId: thread.id,
+      resourceId,
+    });
+
+    // @ts-expect-error
+    let workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
+    expect(workingMemory).toContain('<first_name>Tyler</first_name>');
+    expect(workingMemory?.toLowerCase()).toContain('<location>submarine under the sea</location>');
+
+    await agent.generate('I changed my name to Jim', {
+      threadId: thread.id,
+      resourceId,
+    });
+
+    // @ts-expect-error
+    workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
+    expect(workingMemory).toContain('<first_name>Jim</first_name>');
+    expect(workingMemory?.toLowerCase()).toContain('<location>submarine under the sea</location>');
+
+    await agent.generate('I moved to Vancouver Island', {
+      threadId: thread.id,
+      resourceId,
+    });
+
+    // @ts-expect-error
+    workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
+    expect(workingMemory).toContain('<first_name>Jim</first_name>');
+    expect(workingMemory).toContain('<location>Vancouver Island</location>');
+
+    const history = await memory.query({
+      threadId: thread.id,
+      resourceId,
+      selectBy: {
+        last: 20,
+      },
+    });
+
+    const memoryArgs: string[] = [];
+
+    for (const message of history.messages) {
+      if (message.role === `assistant`) {
+        for (const part of message.content) {
+          if (typeof part === `string`) continue;
+          if (part.type === `tool-call` && part.toolName === `updateWorkingMemory`) {
+            memoryArgs.push((part.args as any).memory);
+          }
+        }
+      }
+    }
+
+    expect(memoryArgs).not.toContain(`<first_name>Tyler</first_name>`);
+    expect(memoryArgs).not.toContain('<location>submarine under the sea</location>');
+    expect(memoryArgs).not.toContain('<first_name>Jim</first_name>');
+    expect(memoryArgs).not.toContain('<location>Vancouver Island</location>');
+    expect(memoryArgs).toEqual([]);
+
+    // @ts-expect-error
+    workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
+    expect(workingMemory).toBe(`<user><first_name>Jim</first_name><location>Vancouver Island</location></user>`);
   });
 });

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -121,8 +121,6 @@ describe('Working Memory Tests', () => {
 
     await memory.saveMessages({ messages });
 
-    // Get the working memory
-    // @ts-expect-error
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<first_name>Tyler</first_name>');
     expect(workingMemory).toContain('<location>San Francisco</location>');
@@ -142,7 +140,6 @@ describe('Working Memory Tests', () => {
   });
 
   it('should initialize with default working memory template', async () => {
-    // @ts-expect-error
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<user>');
     expect(workingMemory).toContain('<first_name>');
@@ -204,7 +201,6 @@ describe('Working Memory Tests', () => {
       ],
     });
 
-    // @ts-expect-error
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<first_name>John</first_name>');
     expect(workingMemory).toContain('<location>New York</location>');
@@ -270,7 +266,6 @@ describe('Working Memory Tests', () => {
     await disabledMemory.saveMessages({ messages });
 
     // Working memory should be null when disabled
-    // @ts-expect-error
     const workingMemory = await disabledMemory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toBeNull();
 
@@ -399,8 +394,6 @@ describe('Working Memory Tests', () => {
       resourceId,
     });
 
-    // Get working memory
-    // @ts-expect-error
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<first_name>Tyler</first_name>');
     expect(workingMemory).toContain('<location>San Francisco</location>');
@@ -437,7 +430,6 @@ describe('Working Memory Tests', () => {
       resourceId,
     });
 
-    // @ts-expect-error
     let workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<first_name>Tyler</first_name>');
     expect(workingMemory?.toLowerCase()).toContain('<location>submarine under the sea</location>');
@@ -447,7 +439,6 @@ describe('Working Memory Tests', () => {
       resourceId,
     });
 
-    // @ts-expect-error
     workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<first_name>Jim</first_name>');
     expect(workingMemory?.toLowerCase()).toContain('<location>submarine under the sea</location>');
@@ -457,7 +448,6 @@ describe('Working Memory Tests', () => {
       resourceId,
     });
 
-    // @ts-expect-error
     workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toContain('<first_name>Jim</first_name>');
     expect(workingMemory).toContain('<location>Vancouver Island</location>');
@@ -489,7 +479,6 @@ describe('Working Memory Tests', () => {
     expect(memoryArgs).not.toContain('<location>Vancouver Island</location>');
     expect(memoryArgs).toEqual([]);
 
-    // @ts-expect-error
     workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
     expect(workingMemory).toBe(`<user><first_name>Jim</first_name><location>Vancouver Island</location></user>`);
   });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -321,7 +321,7 @@ export class Memory extends MastraMemory {
     return null;
   }
 
-  protected async getWorkingMemory({ threadId }: { threadId: string }): Promise<string | null> {
+  public async getWorkingMemory({ threadId }: { threadId: string }): Promise<string | null> {
     if (!this.threadConfig.workingMemory?.enabled) return null;
 
     // Get thread from storage

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -282,7 +282,6 @@ export class Memory extends MastraMemory {
   protected mutateMessagesToHideWorkingMemory(messages: MessageType[]) {
     const workingMemoryRegex = /<working_memory>([^]*?)<\/working_memory>/g;
 
-    const deletedToolCallIds = new Set<string>();
     for (const [index, message] of messages.entries()) {
       if (typeof message?.content === `string`) {
         message.content = message.content.replace(workingMemoryRegex, ``).trim();
@@ -292,13 +291,9 @@ export class Memory extends MastraMemory {
             content.text = content.text.replace(workingMemoryRegex, ``).trim();
           }
 
-          if (content.type === `tool-call` && content.toolName === `updateWorkingMemory`) {
-            deletedToolCallIds.add(content.toolCallId);
-            delete messages[index];
-          } else if (
-            content.type === `tool-result` &&
-            content.toolName === `updateWorkingMemory` &&
-            deletedToolCallIds.has(content.toolCallId)
+          if (
+            (content.type === `tool-call` || content.type === `tool-result`) &&
+            content.toolName === `updateWorkingMemory`
           ) {
             delete messages[index];
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2370,7 +2370,7 @@ importers:
         version: 7.52.1(@types/node@20.17.27)
       '@rollup/plugin-image':
         specifier: ^3.0.3
-        version: 3.0.3(rollup@3.29.5)
+        version: 3.0.3(rollup@4.36.0)
       '@size-limit/preset-small-lib':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
@@ -2434,7 +2434,7 @@ importers:
         version: 7.52.1(@types/node@20.17.27)
       '@rollup/plugin-image':
         specifier: ^3.0.3
-        version: 3.0.3(rollup@4.36.0)
+        version: 3.0.3(rollup@3.29.5)
       '@size-limit/preset-small-lib':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
@@ -3491,18 +3491,12 @@ importers:
         specifier: ^3.24.2
         version: 3.24.2
     devDependencies:
-      '@microsoft/api-extractor':
-        specifier: ^7.52.1
-        version: 7.52.1(@types/node@20.17.27)
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/node':
         specifier: ^20.17.27
         version: 20.17.27
-      '@vitest/coverage-v8':
-        specifier: ^1.6.1
-        version: 1.6.1(vitest@1.6.1(@edge-runtime/vm@3.2.0)(@types/node@20.17.27)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(terser@5.39.0))
       ai:
         specifier: ^4.2.2
         version: 4.2.2(react@19.0.0)(zod@3.24.2)
@@ -11381,11 +11375,6 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/coverage-v8@1.6.1':
-    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
-    peerDependencies:
-      vitest: 1.6.1
-
   '@vitest/eslint-plugin@1.1.38':
     resolution: {integrity: sha512-KcOTZyVz8RiM5HyriiDVrP1CyBGuhRxle+lBsmSs6NTJEO/8dKVAq+f5vQzHj1/Kc7bYXSDO6yBe62Zx0t5iaw==}
     peerDependencies:
@@ -15719,10 +15708,6 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
@@ -16452,9 +16437,6 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -30245,25 +30227,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@edge-runtime/vm@3.2.0)(@types/node@20.17.27)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(terser@5.39.0))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.0(supports-color@8.1.1)
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      picocolors: 1.1.1
-      std-env: 3.8.1
-      strip-literal: 2.1.1
-      test-exclude: 6.0.0
-      vitest: 1.6.1(@edge-runtime/vm@3.2.0)(@types/node@20.17.27)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(terser@5.39.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/eslint-plugin@1.1.38(@typescript-eslint/utils@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.9(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.17.27)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@typescript-eslint/utils': 8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
@@ -33316,7 +33279,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@8.57.1)(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -33327,7 +33290,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@8.57.1)(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -33338,7 +33301,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.23.0(jiti@2.4.2)))(eslint@9.23.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -33434,7 +33397,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@8.57.1)(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -33463,7 +33426,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@8.57.1)(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -33492,7 +33455,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.23.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.23.0(jiti@2.4.2)))(eslint@9.23.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.23.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -35730,14 +35693,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.0(supports-color@8.1.1)
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.1.7:
     dependencies:
       html-escaper: 2.0.2
@@ -36839,12 +36794,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  magicast@0.3.5:
-    dependencies:
-      '@babel/parser': 7.26.10
-      '@babel/types': 7.26.10
-      source-map-js: 1.2.1
 
   make-dir@3.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3568,6 +3568,9 @@ importers:
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+      mastra:
+        specifier: workspace:*
+        version: link:../../cli
       next:
         specifier: ^15.2.3
         version: 15.2.3(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
Having all the working memory tool call args in context can confuse the LLM and make it think some of those updates are current. The only copy of working memory it should see is in the system prompt