### PR TITLE
ci: make mem0 example private

### DIFF
--- a/examples/memory-with-mem0/package.json
+++ b/examples/memory-with-mem0/package.json
@@ -2,6 +2,7 @@
   "name": "memory-with-mem0",
   "version": "1.0.0",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "mastra dev"


### PR DESCRIPTION
This failed https://github.com/mastra-ai/mastra/actions/runs/14090416967/job/39465436662 cause the new Mem0 example isn't private, so it tried to publish it