### PR TITLE
[MASTRA-2765] added helper to do index building for create and buildindex

### DIFF
--- a/.changeset/social-windows-show.md
+++ b/.changeset/social-windows-show.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Added helper method for both createindex and buildIndex

--- a/.github/workflows/test-memory.yml
+++ b/.github/workflows/test-memory.yml
@@ -6,8 +6,8 @@ on:
     paths:
       - "packages/memory/**"
       - "packages/memory/*/package.json"
-      - "storage/**"
-      - "storage/*/package.json"
+      - "stores/**"
+      - "stores/*/package.json"
       - ".github/workflows/test-memory.yml"
 
 jobs:

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -262,7 +262,7 @@ export class PgVector extends MastraVector {
       }
 
       if (buildIndex) {
-        await this.buildIndex({ indexName, metric, indexConfig });
+        await this.setupIndex({ indexName, metric, indexConfig }, client);
       }
     } catch (error: any) {
       console.error('Failed to create vector table:', error);
@@ -293,52 +293,59 @@ export class PgVector extends MastraVector {
 
     const client = await this.pool.connect();
     try {
-      // Use a different hash prefix for buildIndex locks to avoid conflicts with createIndex
-      const hash = createHash('sha256')
-        .update('build:' + indexName)
-        .digest('hex');
-      const lockId = BigInt('0x' + hash.slice(0, 8)) % BigInt(2 ** 31);
-      const acquired = await client.query('SELECT pg_try_advisory_lock($1)', [lockId]);
+      await this.setupIndex({ indexName, metric, indexConfig }, client);
+    } finally {
+      client.release();
+    }
+  }
 
-      if (!acquired.rows[0].pg_try_advisory_lock) {
-        // Check if index already exists
-        const exists = await client.query(
-          `
+  private async setupIndex({ indexName, metric, indexConfig }: PgDefineIndexParams, client: pg.PoolClient) {
+    // Use a different hash prefix for buildIndex locks to avoid conflicts with createIndex
+    const hash = createHash('sha256')
+      .update('build:' + indexName)
+      .digest('hex');
+    const lockId = BigInt('0x' + hash.slice(0, 8)) % BigInt(2 ** 31);
+    const acquired = await client.query('SELECT pg_try_advisory_lock($1)', [lockId]);
+
+    if (!acquired.rows[0].pg_try_advisory_lock) {
+      // Check if index already exists
+      const exists = await client.query(
+        `
             SELECT 1 FROM pg_class c 
             JOIN pg_namespace n ON n.oid = c.relnamespace
             WHERE c.relname = $1 
             AND n.nspname = 'public'
           `,
-          [`${indexName}_vector_idx`],
-        );
+        [`${indexName}_vector_idx`],
+      );
 
-        if (exists.rows.length > 0) {
-          console.log(`Index ${indexName}_vector_idx already exists, skipping creation`);
-          this.indexCache.delete(indexName); // Still clear cache since we checked
-          return;
-        }
-
-        // Index doesn't exist, wait for lock
-        await client.query('SELECT pg_advisory_lock($1)', [lockId]);
+      if (exists.rows.length > 0) {
+        console.log(`Index ${indexName}_vector_idx already exists, skipping creation`);
+        this.indexCache.delete(indexName); // Still clear cache since we checked
+        return;
       }
 
-      try {
-        await client.query(`DROP INDEX IF EXISTS ${indexName}_vector_idx`);
+      // Index doesn't exist, wait for lock
+      await client.query('SELECT pg_advisory_lock($1)', [lockId]);
+    }
 
-        if (indexConfig.type === 'flat') {
-          this.indexCache.delete(indexName);
-          return;
-        }
+    try {
+      await client.query(`DROP INDEX IF EXISTS ${indexName}_vector_idx`);
 
-        const metricOp =
-          metric === 'cosine' ? 'vector_cosine_ops' : metric === 'euclidean' ? 'vector_l2_ops' : 'vector_ip_ops';
+      if (indexConfig.type === 'flat') {
+        this.indexCache.delete(indexName);
+        return;
+      }
 
-        let indexSQL: string;
-        if (indexConfig.type === 'hnsw') {
-          const m = indexConfig.hnsw?.m ?? 8;
-          const efConstruction = indexConfig.hnsw?.efConstruction ?? 32;
+      const metricOp =
+        metric === 'cosine' ? 'vector_cosine_ops' : metric === 'euclidean' ? 'vector_l2_ops' : 'vector_ip_ops';
 
-          indexSQL = `
+      let indexSQL: string;
+      if (indexConfig.type === 'hnsw') {
+        const m = indexConfig.hnsw?.m ?? 8;
+        const efConstruction = indexConfig.hnsw?.efConstruction ?? 32;
+
+        indexSQL = `
           CREATE INDEX IF NOT EXISTS ${indexName}_vector_idx 
           ON ${indexName} 
           USING hnsw (embedding ${metricOp})
@@ -347,29 +354,26 @@ export class PgVector extends MastraVector {
             ef_construction = ${efConstruction}
           )
         `;
+      } else {
+        let lists: number;
+        if (indexConfig.ivf?.lists) {
+          lists = indexConfig.ivf.lists;
         } else {
-          let lists: number;
-          if (indexConfig.ivf?.lists) {
-            lists = indexConfig.ivf.lists;
-          } else {
-            const size = (await client.query(`SELECT COUNT(*) FROM ${indexName}`)).rows[0].count;
-            lists = Math.max(100, Math.min(4000, Math.floor(Math.sqrt(size) * 2)));
-          }
-          indexSQL = `
+          const size = (await client.query(`SELECT COUNT(*) FROM ${indexName}`)).rows[0].count;
+          lists = Math.max(100, Math.min(4000, Math.floor(Math.sqrt(size) * 2)));
+        }
+        indexSQL = `
           CREATE INDEX IF NOT EXISTS ${indexName}_vector_idx
           ON ${indexName}
           USING ivfflat (embedding ${metricOp})
           WITH (lists = ${lists});
         `;
-        }
-
-        await client.query(indexSQL);
-        this.indexCache.delete(indexName);
-      } finally {
-        await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
       }
+
+      await client.query(indexSQL);
+      this.indexCache.delete(indexName);
     } finally {
-      client.release();
+      await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
     }
   }
 

--- a/stores/vectorize/src/vector/index.test.ts
+++ b/stores/vectorize/src/vector/index.test.ts
@@ -29,12 +29,23 @@ function waitUntilVectorsIndexed(vector: CloudflareVector, indexName: string, ex
   return new Promise((resolve, reject) => {
     const maxAttempts = 60;
     let attempts = 0;
+    let lastCount = 0;
+    let stableCount = 0;
+
     const interval = setInterval(async () => {
       try {
         const stats = await vector.describeIndex(indexName);
         if (stats && stats.count >= expectedCount) {
-          clearInterval(interval);
-          resolve(true);
+          if (stats.count === lastCount) {
+            stableCount++;
+            if (stableCount >= 2) {
+              clearInterval(interval);
+              resolve(true);
+            }
+          } else {
+            stableCount = 1;
+          }
+          lastCount = stats.count;
         }
         attempts++;
         if (attempts >= maxAttempts) {
@@ -205,23 +216,39 @@ describe('CloudflareVector', () => {
 
     describe('Vector update operations', () => {
       const testVectors = [createVector(0, 1.0), createVector(1, 1.0), createVector(2, 1.0)];
-      const indexName = 'test-index' + Date.now();
+      const indexName1 = 'test-index1' + Date.now();
+      const indexName2 = 'test-index2' + Date.now();
+      const indexName3 = 'test-index3' + Date.now();
 
-      beforeEach(async () => {
-        await vectorDB.createIndex({ indexName, dimension: VECTOR_DIMENSION, metric: 'cosine' });
-        await waitUntilReady(vectorDB, indexName);
+      beforeAll(async () => {
+        await vectorDB.createIndex({ indexName: indexName1, dimension: VECTOR_DIMENSION, metric: 'cosine' });
+        await waitUntilReady(vectorDB, indexName1);
+        await vectorDB.createIndex({ indexName: indexName2, dimension: VECTOR_DIMENSION, metric: 'cosine' });
+        await waitUntilReady(vectorDB, indexName2);
+        await vectorDB.createIndex({ indexName: indexName3, dimension: VECTOR_DIMENSION, metric: 'cosine' });
+        await waitUntilReady(vectorDB, indexName3);
       });
 
-      afterEach(async () => {
+      afterAll(async () => {
         try {
-          await vectorDB.deleteIndex(indexName);
+          await vectorDB.deleteIndex(indexName1);
+        } catch (error) {
+          // Ignore errors if index doesn't exist
+        }
+        try {
+          await vectorDB.deleteIndex(indexName2);
+        } catch (error) {
+          // Ignore errors if index doesn't exist
+        }
+        try {
+          await vectorDB.deleteIndex(indexName3);
         } catch (error) {
           // Ignore errors if index doesn't exist
         }
       });
 
       it('should update the vector by id', async () => {
-        const ids = await vectorDB.upsert({ indexName, vectors: testVectors });
+        const ids = await vectorDB.upsert({ indexName: indexName1, vectors: testVectors });
         expect(ids).toHaveLength(3);
 
         const idToBeUpdated = ids[0];
@@ -235,12 +262,12 @@ describe('CloudflareVector', () => {
           metadata: newMetaData,
         };
 
-        await vectorDB.updateIndexById(indexName, idToBeUpdated, update);
+        await vectorDB.updateIndexById(indexName1, idToBeUpdated, update);
 
-        await waitUntilVectorsIndexed(vectorDB, indexName, 3);
+        await waitUntilVectorsIndexed(vectorDB, indexName1, 3);
 
         const results: QueryResult[] = await vectorDB.query({
-          indexName,
+          indexName: indexName1,
           queryVector: newVector,
           topK: 3,
           includeVector: true,
@@ -253,7 +280,7 @@ describe('CloudflareVector', () => {
       }, 500000);
 
       it('should only update vector embeddings by id', async () => {
-        const ids = await vectorDB.upsert({ indexName, vectors: testVectors });
+        const ids = await vectorDB.upsert({ indexName: indexName2, vectors: testVectors });
         expect(ids).toHaveLength(3);
 
         const idToBeUpdated = ids[0];
@@ -263,12 +290,12 @@ describe('CloudflareVector', () => {
           vector: newVector,
         };
 
-        await vectorDB.updateIndexById(indexName, idToBeUpdated, update);
+        await vectorDB.updateIndexById(indexName2, idToBeUpdated, update);
 
-        await waitUntilVectorsIndexed(vectorDB, indexName, 3);
+        await waitUntilVectorsIndexed(vectorDB, indexName2, 3);
 
         const results: QueryResult[] = await vectorDB.query({
-          indexName,
+          indexName: indexName2,
           queryVector: newVector,
           topK: 2,
           includeVector: true,
@@ -281,7 +308,7 @@ describe('CloudflareVector', () => {
       }, 500000);
 
       it('should throw exception when no updates are given', async () => {
-        await expect(vectorDB.updateIndexById(indexName, 'id', {})).rejects.toThrow('No update data provided');
+        await expect(vectorDB.updateIndexById(indexName3, 'id', {})).rejects.toThrow('No update data provided');
       });
     });
 
@@ -431,6 +458,7 @@ describe('CloudflareVector', () => {
       await vectorDB.createMetadataIndex(testIndexName2, 'code', 'string');
       await vectorDB.createMetadataIndex(testIndexName2, 'optionalField', 'string');
       await vectorDB.createMetadataIndex(testIndexName2, 'mixedField', 'string');
+      //      await vectorDB.createMetadataIndex(testIndexName2, 'mixedField', 'number');
 
       await waitForMetadataIndexes(vectorDB, testIndexName2, 10);
 

--- a/stores/vectorize/src/vector/index.test.ts
+++ b/stores/vectorize/src/vector/index.test.ts
@@ -458,7 +458,6 @@ describe('CloudflareVector', () => {
       await vectorDB.createMetadataIndex(testIndexName2, 'code', 'string');
       await vectorDB.createMetadataIndex(testIndexName2, 'optionalField', 'string');
       await vectorDB.createMetadataIndex(testIndexName2, 'mixedField', 'string');
-      //      await vectorDB.createMetadataIndex(testIndexName2, 'mixedField', 'number');
 
       await waitForMetadataIndexes(vectorDB, testIndexName2, 10);
 


### PR DESCRIPTION
Currently there's a connection timeout in CI when running PG concurrency tests. This might be due to the fact that createIndex creates a connection and also calls buildIndex, which creates another connection. Rather than this, we should use the same connection when we do createIndex, rather than do multiple connections.

This PR fixes that by making a helper method for both createIndex and buildIndex, so that building the index doesn't need a separate connection when calling createIndex.