### PR TITLE
fix(@mastra/core): exclude more methods from tracing

### DIFF
--- a/.changeset/bumpy-fans-tickle.md
+++ b/.changeset/bumpy-fans-tickle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+exclude \_\_primitive, getMemory, hasOwnMemory from traces since they create noisy traces

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -46,7 +46,7 @@ export * from './types';
 
 @InstrumentClass({
   prefix: 'agent',
-  excludeMethods: ['__setTools', '__setLogger', '__setTelemetry', 'log'],
+  excludeMethods: ['hasOwnMemory', 'getMemory', '__primitive', '__setTools', '__setLogger', '__setTelemetry', 'log'],
 })
 export class Agent<
   TTools extends ToolsInput = ToolsInput,


### PR DESCRIPTION
This should clean these up:
![image (2)](https://github.com/user-attachments/assets/550b4efa-8a02-4b08-af61-9a63ce2a9ce1)
