### PR TITLE
Add support for extra api routes

### DIFF
--- a/.changeset/yellow-mugs-lose.md
+++ b/.changeset/yellow-mugs-lose.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+---
+
+Add support for custom api routes in mastra

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         run: pnpm install
 
       - name: Lint
-        run: pnpm turbo --filter "!./examples/*" --filter "!./docs/*" --filter "!./integrations/*" --filter "!@mastra/playground" lint
+        run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/**/*" --filter "!./integrations/**/*" --filter "!@mastra/playground" lint
 
   check-bundle:
     name: Validate build outputs
@@ -70,7 +70,7 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm turbo --filter "!./examples/*" --filter "!./docs" build
+        run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" build
 
       - name: Install test dependencies
         working-directory: ./e2e-tests/pkg-outputs

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -123,6 +123,8 @@
     "fastembed": "^1.14.1",
     "json-schema": "^0.4.0",
     "json-schema-to-zod": "^2.6.0",
+    "hono": "^4.5.1",
+    "hono-openapi": "^0.4.6",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "radash": "^12.1.0",

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4,7 +4,7 @@ import { LogLevel, createLogger, noopLogger } from '../logger';
 import type { Logger } from '../logger';
 import type { MastraMemory } from '../memory/memory';
 import type { AgentNetwork } from '../network';
-import type { ApiRoute, ServerConfig } from '../server/types';
+import type { ServerConfig } from '../server/types';
 import type { MastraStorage } from '../storage';
 import { DefaultProxyStorage } from '../storage/default-proxy-storage';
 import { InstrumentClass, Telemetry } from '../telemetry';
@@ -35,6 +35,7 @@ export interface Config<
   /**
    * Server middleware functions to be applied to API routes
    * Each middleware can specify a path pattern (defaults to '/api/*')
+   * @deprecated use server.middleware instead
    */
   serverMiddleware?: Array<{
     handler: (c: any, next: () => Promise<void>) => Promise<Response | void>;

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4,6 +4,7 @@ import { LogLevel, createLogger, noopLogger } from '../logger';
 import type { Logger } from '../logger';
 import type { MastraMemory } from '../memory/memory';
 import type { AgentNetwork } from '../network';
+import type { ApiRoute, ServerConfig } from '../server/types';
 import type { MastraStorage } from '../storage';
 import { DefaultProxyStorage } from '../storage/default-proxy-storage';
 import { InstrumentClass, Telemetry } from '../telemetry';
@@ -29,6 +30,7 @@ export interface Config<
   tts?: TTTS;
   telemetry?: OtelConfig;
   deployer?: MastraDeployer;
+  server: ServerConfig;
 
   /**
    * Server middleware functions to be applied to API routes
@@ -69,6 +71,7 @@ export class Mastra<
   #storage?: MastraStorage;
   #memory?: MastraMemory;
   #networks?: TNetworks;
+  #server?: ServerConfig;
 
   /**
    * @deprecated use getTelemetry() instead
@@ -266,6 +269,11 @@ This is a warning for now, but will throw an error in the future
         this.#workflows[key] = workflow;
       });
     }
+
+    if (config?.server) {
+      this.#server = config.server;
+    }
+
     this.setLogger({ logger });
   }
 
@@ -448,6 +456,10 @@ This is a warning for now, but will throw an error in the future
 
   public getNetworks() {
     return Object.values(this.#networks || {});
+  }
+
+  public getServer() {
+    return this.#server;
   }
 
   /**

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -11,26 +11,33 @@ type ParamsFromPath<P extends string> = {
 
 export function registerApiRoute<P extends string>(
   path: P,
-  options: {
-    method: Methods;
-    openapi?: DescribeRouteOptions;
-    handler: Handler<
-      {
-        Variables: {
-          mastra: Mastra;
-        };
+  options: P extends `/api/${string}`
+    ? never
+    : {
+        method: Methods;
+        openapi?: DescribeRouteOptions;
+        handler: Handler<
+          {
+            Variables: {
+              mastra: Mastra;
+            };
+          },
+          P,
+          ParamsFromPath<P>
+        >;
+        middleware?: MiddlewareHandler | MiddlewareHandler[];
       },
-      P,
-      ParamsFromPath<P>
-    >;
-    middleware?: MiddlewareHandler | MiddlewareHandler[];
-  },
-): ApiRoute {
+): P extends `/api/${string}` ? never : ApiRoute {
+  if (path.startsWith('/api/')) {
+    throw new Error('Path must not start with "/api", it\'s reserved for internal API routes');
+  }
+
+  // @ts-expect-error
   return {
     path,
     method: options.method,
     handler: options.handler,
     openapi: options.openapi,
     middleware: options.middleware,
-  };
+  } as ApiRoute;
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,0 +1,36 @@
+import type { Handler, MiddlewareHandler } from 'hono';
+import type { DescribeRouteOptions } from 'hono-openapi';
+import type { Mastra } from '../mastra';
+import type { ApiRoute, Methods } from './types';
+
+// Helper type for inferring parameters from a path
+// Thank you Claude!
+type ParamsFromPath<P extends string> = {
+  [K in P extends `${string}:${infer Param}/${string}` | `${string}:${infer Param}` ? Param : never]: string;
+};
+
+export function registerApiRoute<P extends string>(
+  path: P,
+  options: {
+    method: Methods;
+    openapi?: DescribeRouteOptions;
+    handler: Handler<
+      {
+        Variables: {
+          mastra: Mastra;
+        };
+      },
+      P,
+      ParamsFromPath<P>
+    >;
+    middleware?: MiddlewareHandler | MiddlewareHandler[];
+  },
+): ApiRoute {
+  return {
+    path,
+    method: options.method,
+    handler: options.handler,
+    openapi: options.openapi,
+    middleware: options.middleware,
+  };
+}

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -10,8 +10,11 @@ export type ApiRoute = {
   openapi?: DescribeRouteOptions;
 };
 
+type Middleware = MiddlewareHandler | { path: string; handler: MiddlewareHandler };
+
 export type ServerConfig = {
-  port?: number;
+  // TOOD add support for port
+  // port?: number;
   apiRoutes?: ApiRoute[];
-  middleware?: MiddlewareHandler | Array<MiddlewareHandler>;
+  middleware?: Middleware | Middleware[];
 };

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -1,0 +1,17 @@
+import type { Handler, MiddlewareHandler } from 'hono';
+import type { DescribeRouteOptions } from 'hono-openapi';
+export type Methods = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export type ApiRoute = {
+  path: string;
+  method: Methods;
+  handler: Handler;
+  middleware?: MiddlewareHandler | MiddlewareHandler[];
+  openapi?: DescribeRouteOptions;
+};
+
+export type ServerConfig = {
+  port?: number;
+  apiRoutes?: ApiRoute[];
+  middleware?: MiddlewareHandler | Array<MiddlewareHandler>;
+};

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -6,7 +6,7 @@ import { serveStatic } from '@hono/node-server/serve-static';
 import { swaggerUI } from '@hono/swagger-ui';
 import type { Mastra } from '@mastra/core';
 import { Hono } from 'hono';
-import type { Context } from 'hono';
+import type { Context, MiddlewareHandler } from 'hono';
 
 import { bodyLimit } from 'hono/body-limit';
 import { cors } from 'hono/cors';
@@ -139,6 +139,31 @@ export async function createHonoServer(
     maxSize: 4.5 * 1024 * 1024, // 4.5 MB,
     onError: (c: Context) => c.json({ error: 'Request body too large' }, 413),
   };
+
+  const routes = mastra.getServer()?.apiRoutes;
+
+  if (routes) {
+    for (const route of routes) {
+      const middlewares: MiddlewareHandler[] = [];
+
+      if (route.middleware) {
+        middlewares.push(...(Array.isArray(route.middleware) ? route.middleware : [route.middleware]));
+      }
+      if (route.openapi) {
+        middlewares.push(describeRoute(route.openapi));
+      }
+
+      if (route.method === 'GET') {
+        app.get(route.path, ...middlewares, route.handler);
+      } else if (route.method === 'POST') {
+        app.post(route.path, ...middlewares, route.handler);
+      } else if (route.method === 'PUT') {
+        app.put(route.path, ...middlewares, route.handler);
+      } else if (route.method === 'DELETE') {
+        app.delete(route.path, ...middlewares, route.handler);
+      }
+    }
+  }
 
   // API routes
   app.get(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2983,6 +2983,12 @@ importers:
       fastembed:
         specifier: ^1.14.1
         version: 1.14.1
+      hono:
+        specifier: ^4.5.1
+        version: 4.7.4
+      hono-openapi:
+        specifier: ^0.4.6
+        version: 0.4.6(hono@4.7.4)(openapi-types@12.1.3)(zod@3.24.2)
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
@@ -35372,7 +35378,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.8.4(debug@4.4.0))
+      retry-axios: 2.6.0(axios@1.8.4)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -40137,7 +40143,7 @@ snapshots:
 
   ret@0.4.3: {}
 
-  retry-axios@2.6.0(axios@1.8.4(debug@4.4.0)):
+  retry-axios@2.6.0(axios@1.8.4):
     dependencies:
       axios: 1.8.4(debug@4.4.0)
 


### PR DESCRIPTION
Introduce new server section in Mastra to support server configuration.

```
server: {
    // replaces serverMiddlware
    middleware: [
      async (c, next) => {
        console.log("middleware", c.req.url);
        await next();
      },
    ],
    // collection of routes
    apiRoutes: [
      registerApiRoute("/cool/stuff", {
        method: "GET",
        openapi: {
          description: "Get API status",
          tags: ["system"],
          responses: {
            200: {
              description: "Success",
            },
          },
        },
        handler: (c) => {
          return c.json({ message: "Hello, world!" });
        },
      }),
      registerApiRoute("/cool/posts/:id", {
        method: "GET",
        handler: (c) => {
          const x = c.get("mastra");

          return c.json({ message: "Hello, world!", id: c.req.param("id") });
        },
      }),
    ],
  },
```