### PR TITLE
New default http based trace exporter

### DIFF
--- a/packages/deployer/public/templates/instrumentation-template.js
+++ b/packages/deployer/public/templates/instrumentation-template.js
@@ -54,19 +54,8 @@ async function getExporter(config) {
   } else if (config.export?.type === 'custom') {
     return config.export.exporter;
   } else {
-    const storage = new LibSQLStore({
-      config: {
-        url: 'file:.mastra/mastra.db',
-      },
-    });
-    await storage.init();
-
-    return new OTLPStorageExporter({
-      logger: createLogger({
-        name: 'telemetry',
-        level: 'silent',
-      }),
-      storage,
+    return new OTLPHttpExporter({
+      url: `http://localhost:${process.env.PORT ?? 4111}/api/telemetry`,
     });
   }
 }

--- a/packages/deployer/src/server/handlers/telemetry.ts
+++ b/packages/deployer/src/server/handlers/telemetry.ts
@@ -1,4 +1,4 @@
-import type { MastraStorage } from '@mastra/core/storage';
+import { TABLE_TRACES, type MastraStorage } from '@mastra/core/storage';
 import type { Telemetry } from '@mastra/core/telemetry';
 import type { Context } from 'hono';
 
@@ -44,5 +44,108 @@ export async function getTelemetryHandler(c: Context) {
     return c.json({ traces });
   } catch (error) {
     return handleError(error, 'Error saving messages');
+  }
+}
+
+export async function storeTelemetryHandler(c: Context) {
+  try {
+    // Parse the incoming body as JSON
+    const body = await c.req.json();
+
+    const mastra = c.get('mastra');
+    const storage: MastraStorage = mastra.getStorage();
+
+    const now = new Date();
+
+    const items = body?.resourceSpans?.[0]?.scopeSpans;
+
+    const allSpans: any[] = items.reduce((acc: any, scopedSpans: any) => {
+      const { scope, spans } = scopedSpans;
+      for (const span of spans) {
+        const {
+          spanId,
+          parentSpanId,
+          traceId,
+          name,
+          kind,
+          attributes,
+          status,
+          events,
+          links,
+          startTimeUnixNano,
+          endTimeUnixNano,
+          ...rest
+        } = span;
+
+        const startTime = Number(BigInt(startTimeUnixNano) / 1000n);
+        const endTime = Number(BigInt(endTimeUnixNano) / 1000n);
+
+        acc.push({
+          id: spanId,
+          parentSpanId,
+          traceId,
+          name,
+          scope: scope.name,
+          kind,
+          status: JSON.stringify(status),
+          events: JSON.stringify(events),
+          links: JSON.stringify(links),
+          attributes: JSON.stringify(
+            attributes.reduce((acc: Record<string, any>, attr: any) => {
+              const valueKey = Object.keys(attr.value)[0];
+              if (valueKey) {
+                acc[attr.key] = attr.value[valueKey];
+              }
+              return acc;
+            }, {}),
+          ),
+          startTime,
+          endTime,
+          other: JSON.stringify(rest),
+          createdAt: now,
+        });
+      }
+      return acc;
+    }, []);
+
+    return storage
+      .__batchInsert({
+        tableName: TABLE_TRACES,
+        records: allSpans,
+      })
+      .then(() => {
+        return c.json(
+          {
+            status: 'success',
+            message: 'Traces received and processed successfully',
+            traceCount: body.resourceSpans?.length || 0,
+          },
+          200,
+        );
+      })
+      .catch(e => {
+        return c.json(
+          {
+            status: 'error',
+            message: 'Failed to process traces',
+            // @ts-ignore
+            error: error.message,
+          },
+          500,
+        );
+      });
+
+    // Return a simple response
+  } catch (error) {
+    console.error('Error processing traces:', error);
+    return c.json(
+      {
+        status: 'error',
+        message: 'Failed to process traces',
+        // @ts-ignore
+        error: error.message,
+      },
+      500,
+    );
   }
 }

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -43,7 +43,7 @@ import {
 } from './handlers/network.js';
 import { generateSystemPromptHandler } from './handlers/prompt.js';
 import { rootHandler } from './handlers/root.js';
-import { getTelemetryHandler } from './handlers/telemetry.js';
+import { getTelemetryHandler, storeTelemetryHandler } from './handlers/telemetry.js';
 import { executeAgentToolHandler, executeToolHandler, getToolByIdHandler, getToolsHandler } from './handlers/tools.js';
 import {
   upsertVectors,
@@ -1297,6 +1297,20 @@ export async function createHonoServer(
       },
     }),
     getTelemetryHandler,
+  );
+
+  app.post(
+    '/api/telemetry',
+    describeRoute({
+      description: 'Store telemetry',
+      tags: ['telemetry'],
+      responses: {
+        200: {
+          description: 'Traces stored',
+        },
+      },
+    }),
+    storeTelemetryHandler,
   );
 
   // Workflow routes


### PR DESCRIPTION
Changes the default exporter to use an API route to POST traces to, and moving the relevant storage exporter logic to that API route