### PR TITLE
updated storage overview docs

### DIFF
--- a/docs/src/components/schema-table.tsx
+++ b/docs/src/components/schema-table.tsx
@@ -92,7 +92,6 @@ export const SchemaTable: React.FC<SchemaTableProps> = ({ columns = [] }) => {
               <MDXText>{column.description ?? ""}</MDXText>
               {column.example && (
                 <div className="mt-1 flex flex-col gap-1">
-                  Example:
                   <MDXExample>
                     {JSON.stringify(column.example, null, 2)}
                   </MDXExample>
@@ -113,7 +112,9 @@ const MDXExample = ({ children }: { children: string }) => {
     <div className="my-2">
       {components.pre && components.code && (
         <components.pre>
-          <components.code>{children}</components.code>
+          <components.code>
+            <div className="pl-5">{children}</div>
+          </components.code>
         </components.pre>
       )}
     </div>

--- a/docs/src/pages/docs/storage/overview.mdx
+++ b/docs/src/pages/docs/storage/overview.mdx
@@ -10,12 +10,14 @@ import { SchemaTable } from '@/components/schema-table'
 
 # MastraStorage
 
-MastraStorage provides a unified interface for managing
+`MastraStorage` provides a unified interface for managing:
 
-- **`Workflow Tracking`**: allowing users to suspend and resume workflow runs.
-- **`Memory`**: threads and messages per resourceId in your application
-- **`Traces`**: OpenTelemetry traces from all components of Mastra
-- **`Eval Datasets`**: as evals are run, the scores and reasons are stored in datasets.
+- **Suspended Workflows**: the serialized state of suspended workflows (so they can be resumed later)
+- **Memory**: threads and messages per `resourceId` in your application
+- **Traces**: OpenTelemetry traces from all components of Mastra
+- **Eval Datasets**: scores and scoring reasons from eval runs
+
+<br />
 
 <div>
   {useTheme().resolvedTheme === 'dark' ? (

--- a/docs/src/pages/docs/storage/overview.mdx
+++ b/docs/src/pages/docs/storage/overview.mdx
@@ -12,10 +12,10 @@ import { SchemaTable } from '@/components/schema-table'
 
 MastraStorage provides a unified interface for managing
 
-- Workflow Tracking, allowing users to suspend and resume workflow runs.
-- Memory, threads and messages per resourceId in your application
-- Traces - OpenTelemetry traces from all components of Mastra
-- Eval Datasets - as evals are run, the scores and reasons are stored in datasets.
+- **`Workflow Tracking`**: allowing users to suspend and resume workflow runs.
+- **`Memory`**: threads and messages per resourceId in your application
+- **`Traces`**: OpenTelemetry traces from all components of Mastra
+- **`Eval Datasets`**: as evals are run, the scores and reasons are stored in datasets.
 
 <div>
   {useTheme().resolvedTheme === 'dark' ? (
@@ -58,6 +58,7 @@ const mastra = new Mastra({
   <Tabs.Tab>
 Stores conversation messages and their metadata. Each message belongs to a thread and contains the actual content along with metadata about the sender role and message type.
 
+<br />
 <SchemaTable
   columns={[
     {
@@ -107,6 +108,7 @@ Stores conversation messages and their metadata. Each message belongs to a threa
   <Tabs.Tab>
 Groups related messages together and associates them with a resource. Contains metadata about the conversation.
 
+<br />
 <SchemaTable
   columns={[
     {
@@ -133,7 +135,7 @@ Groups related messages together and associates them with a resource. Contains m
     {
       name: "metadata",
       type: "text",
-      description: "Custom thread metadata as stringified JSON.",
+      description: "Custom thread metadata as stringified JSON. Example:",
       example: {
         category: "support",
         priority: 1
@@ -156,6 +158,7 @@ Groups related messages together and associates them with a resource. Contains m
   <Tabs.Tab>
 When `suspend` is called on a workflow, its state is saved in the following format. When `resume` is called, that state is rehydrated.
 
+<br />
 <SchemaTable
   columns={[
     {
@@ -173,7 +176,7 @@ When `suspend` is called on a workflow, its state is saved in the following form
     {
       name: "snapshot",
       type: "text",
-      description: "Serialized workflow state as JSON.",
+      description: "Serialized workflow state as JSON. Example:",
       example: {
         value: { currentState: 'running' },
         context: {
@@ -204,6 +207,7 @@ When `suspend` is called on a workflow, its state is saved in the following form
   <Tabs.Tab>
 Stores eval results from running metrics against agent outputs.
 
+<br />
 <SchemaTable
   columns={[
     {
@@ -221,7 +225,7 @@ Stores eval results from running metrics against agent outputs.
     {
       name: "result",
       type: "jsonb",
-      description: "Eval result data that includes score and details.",
+      description: "Eval result data that includes score and details. Example:",
       example: {
         score: 0.95,
         details: {
@@ -277,6 +281,7 @@ Stores eval results from running metrics against agent outputs.
   <Tabs.Tab>
 Captures OpenTelemetry traces for monitoring and debugging.
 
+<br />
 <SchemaTable
   columns={[
     {
@@ -325,7 +330,7 @@ Captures OpenTelemetry traces for monitoring and debugging.
     {
       name: "status",
       type: "jsonb",
-      description: "JSON object with `code` (UNSET=0, ERROR=1, OK=2) and optional `message`",
+      description: "JSON object with `code` (UNSET=0, ERROR=1, OK=2) and optional `message`. Example:",
       example: {
         code: 1,
         message: "HTTP request failed with status 500"
@@ -344,7 +349,7 @@ Captures OpenTelemetry traces for monitoring and debugging.
     {
       name: "other",
       type: "text",
-      description: "Additional OpenTelemetry span fields as stringified JSON",
+      description: "Additional OpenTelemetry span fields as stringified JSON. Example:",
       example: {
         droppedAttributesCount: 2,
         droppedEventsCount: 1,


### PR DESCRIPTION
This PR makes some visual changes to the storage overview page.

Overview Section:
Added monotext to `MastraStorage` and added bold and colons for bullet points.
Added line break between overview and image
Before:
![image](https://github.com/user-attachments/assets/07a1d572-2401-448c-b747-6e09bceccf10)

After:
![image](https://github.com/user-attachments/assets/0a96ac75-ffb5-4d2c-bf0a-175d60e3d16b)

Schema Table:
Added line break between description and table, and changed example to include padding.
Before:
![image](https://github.com/user-attachments/assets/bd630119-55a9-469e-9ca3-d5cf2d183dbb)

After:
![image](https://github.com/user-attachments/assets/517ef5ed-dd05-4b2c-9146-f6f5d4bc766b)
