### PR TITLE
ci: remove non-package from changeset

### DIFF
--- a/.changeset/thirty-sloths-guess.md
+++ b/.changeset/thirty-sloths-guess.md
@@ -1,6 +1,5 @@
 ---
 "@mastra/core": patch
-"examples-agent-network": patch
 ---
 
 AgentStep -> Agent as a workflow step (WIP)


### PR DESCRIPTION
https://github.com/mastra-ai/mastra/actions/runs/14179771783/job/39722953592

```
🦋  error Error: Found mixed changeset thirty-sloths-guess
🦋  error Found ignored packages: examples-agent-network
🦋  error Found not ignored packages: @mastra/core
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
```