### PR TITLE
[MASTRA-2824] modified evaluation to include output

### DIFF
--- a/.changeset/slimy-apes-open.md
+++ b/.changeset/slimy-apes-open.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Updated evaluate to include agent output

--- a/packages/core/src/eval/evaluation.ts
+++ b/packages/core/src/eval/evaluation.ts
@@ -2,7 +2,7 @@ import type { Agent } from '../agent';
 import { AvailableHooks, executeHook } from '../hooks';
 
 import type { Metric } from './metric';
-import type { TestInfo } from './types';
+import type { TestInfo, EvaluationResult } from './types';
 
 export async function evaluate<T extends Agent>({
   agentName,
@@ -22,7 +22,7 @@ export async function evaluate<T extends Agent>({
   runId?: string;
   testInfo?: TestInfo;
   instructions: string;
-}) {
+}): Promise<EvaluationResult> {
   const runIdToUse = runId || crypto.randomUUID();
 
   const metricResult = await metric.measure(input.toString(), output);
@@ -40,5 +40,5 @@ export async function evaluate<T extends Agent>({
 
   executeHook(AvailableHooks.ON_EVALUATION, traceObject);
 
-  return metricResult;
+  return { ...metricResult, output };
 }

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -1,3 +1,3 @@
 export { Metric, type MetricResult } from './metric';
 export { evaluate } from './evaluation';
-export type { TestInfo } from './types';
+export type { TestInfo, EvaluationResult } from './types';

--- a/packages/core/src/eval/types.ts
+++ b/packages/core/src/eval/types.ts
@@ -1,4 +1,10 @@
+import type { MetricResult } from './metric';
+
 export interface TestInfo {
   testName?: string;
   testPath?: string;
+}
+
+export interface EvaluationResult extends MetricResult {
+  output: string;
 }


### PR DESCRIPTION
This PR adds output to the core evaluate function, so users can have access to output in tests.