### PR TITLE
feat(@mastra/memory): use markdown formatting instead of XML inside working memory tags

### DIFF
--- a/.changeset/chubby-drinks-lead.md
+++ b/.changeset/chubby-drinks-lead.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Updated the internal working memory system to use MD for formatting instead of nested XML - this is more token efficient and makes it more obvious that it's unstructured text

--- a/docs/src/pages/docs/agents/agent-memory.mdx
+++ b/docs/src/pages/docs/agents/agent-memory.mdx
@@ -11,7 +11,7 @@ Agents in Mastra have a sophisticated memory system that stores conversation his
 
 In Mastra, you can organize conversations by a `thread_id`. This allows the system to maintain context and retrieve historical messages that belong to the same discussion.
 
-Mastra also supports the concept of a `resource_id`, which typically represents the user involved in the conversation, ensuring that the agent’s memory and context are correctly associated with the right entity.
+Mastra also supports the concept of a `resource_id`, which typically represents the user involved in the conversation, ensuring that the agent's memory and context are correctly associated with the right entity.
 
 This separation allows you to manage multiple conversations (threads) for a single user or even share conversation context across users if needed.
 
@@ -457,15 +457,15 @@ Inspired by the working memory concept from the MemGPT whitepaper, our implement
 
 #### How It Works
 
-Working memory operates through a system of XML tags and automatic updates:
+Working memory operates through a system of organized data and automatic updates:
 
-1. **Template Structure**: Define what information should be remembered using XML tags. The Memory class comes with a comprehensive default template for user information, or you can create your own template to match your specific needs.
+1. **Template Structure**: Define what information should be remembered using Markdown. The Memory class comes with a comprehensive default template for user information, or you can create your own template to match your specific needs.
 
 2. **Automatic Updates**: The Memory class injects special instructions into the agent's system prompt that tell it to:
 
    - Store relevant information by including `<working_memory>...</working_memory>` tags in its responses
    - Update information proactively when anything changes
-   - Maintain the XML structure while updating values
+   - Maintain the Markdown structure while updating values
    - Keep this process invisible to users
 
 3. **Memory Management**: The system:
@@ -510,13 +510,16 @@ const todoAgent = new Agent({
       workingMemory: {
         enabled: true,
 
-        // optional XML-like template to encourage agent to store specific kinds of info.
+        // optional Markdown template to encourage agent to store specific kinds of info.
         // if you leave this out a default template will be used
-        template: `<todos>
-  <in-progress></in-progress>
-  <pending></pending>
-  <completed></completed>
-</todos>`,
+        template: `# Todo List
+## In Progress
+- 
+## Pending
+- 
+## Completed
+- 
+`,
       },
       lastMessages: 1, // Only keep the last message in context
     },
@@ -526,11 +529,15 @@ const todoAgent = new Agent({
 
 ### Handling Memory Updates in Streaming
 
-When an agent responds, it includes working memory updates directly in its response stream. These updates appear as XML blocks in the text:
+When an agent responds, it includes working memory updates directly in its response stream. These updates appear as tagged blocks in the text:
 
 ```typescript copy showLineNumbers
 // Raw agent response stream:
-Let me help you with that! <working_memory><user><first_name>John</first_name>...</user></working_memory> Based on your question...
+Let me help you with that! <working_memory># User Information
+- **First Name**: John
+- **Last Name**:
+- **Location**:
+...</working_memory> Based on your question...
 ```
 
 To prevent these memory blocks from being visible to users while still allowing the system to process them, use the `maskStreamTags` utility:

--- a/docs/src/pages/docs/reference/memory/Memory.mdx
+++ b/docs/src/pages/docs/reference/memory/Memory.mdx
@@ -51,7 +51,11 @@ const memory = new Memory({
     // Working memory configuration
     workingMemory: {
       enabled: true,
-      template: "<user><first_name></first_name><last_name></last_name></user>",
+      template: `
+# User
+- First Name:
+- Last Name:
+`,
     },
   },
 });
@@ -134,10 +138,10 @@ const agent = new Agent({
       name: "workingMemory",
       type: "{ enabled: boolean; template?: string; use?: 'text-stream' | 'tool-call' }",
       description:
-        "Configuration for working memory feature that allows persistent storage of user information across conversations. The 'use' setting determines how working memory updates are handled - either through text stream tags or tool calls.",
+        "Configuration for working memory feature that allows persistent storage of user information across conversations. The 'use' setting determines how working memory updates are handled - either through text stream tags or tool calls. Working memory uses Markdown format to structure and store continuously relevant information.",
       isOptional: true,
       defaultValue:
-        "{ enabled: false, template: '<user><first_name></first_name><last_name></last_name>...</user>', use: 'text-stream' }",
+        "{ enabled: false, template: '# User Information\\n- **First Name**:\\n- **Last Name**:\\n...', use: 'text-stream' }",
     },
     {
       name: "threads",
@@ -167,14 +171,14 @@ const memory = new Memory({
   options: {
     workingMemory: {
       enabled: true,
-      template: "<user><first_name></first_name><last_name></last_name></user>",
+      template: "# User\n- **First Name**:\n- **Last Name**:",
       use: "tool-call", // or 'text-stream'
     },
   },
 });
 ```
 
-If no template is provided, the Memory class uses a default template that includes fields for user details, preferences, goals, and other contextual information. See the [Agent Memory Guide](/docs/agents/agent-memory#working-memory) for detailed usage examples and best practices.
+If no template is provided, the Memory class uses a default template that includes fields for user details, preferences, goals, and other contextual information in Markdown format. See the [Agent Memory Guide](/docs/agents/agent-memory#working-memory) for detailed usage examples and best practices.
 
 ### embedder
 

--- a/docs/src/pages/examples/memory/streaming-working-memory-advanced.mdx
+++ b/docs/src/pages/examples/memory/streaming-working-memory-advanced.mdx
@@ -30,7 +30,7 @@ const memory = new Memory({
 
 ### 2. Defining the Working Memory Template
 
-Next, we'll define a template that shows the agent how to structure the todo list data. The template uses XML-like tags to represent the data structure. This helps the agent understand what information to track for each todo item.
+Next, we'll define a template that shows the agent how to structure the todo list data. The template uses Markdown to represent the data structure. This helps the agent understand what information to track for each todo item.
 
 ```typescript
 const memory = new Memory({
@@ -39,10 +39,13 @@ const memory = new Memory({
     workingMemory: {
       enabled: true,
       template: `
-<todolist>
-  <info>this is an example list - replace it with whatever the user needs</info>
-  <item status="ACTIVE" title="Example" due="Feb 7 3028" started="Feb 7 2025">example description</item>
-</todolist>
+# Todo List
+## Item Status
+- Active items:
+  - Example (Due: Feb 7 3028, Started: Feb 7 2025)
+    - Description: This is an example task
+## Completed
+- None yet
 `,
     },
   },

--- a/docs/src/pages/examples/memory/streaming-working-memory.mdx
+++ b/docs/src/pages/examples/memory/streaming-working-memory.mdx
@@ -20,7 +20,7 @@ const memory = new Memory({
   options: {
     workingMemory: {
       enabled: true,
-      use: 'text-stream', // this is the default mode
+      use: "text-stream", // this is the default mode
     },
   },
 });
@@ -35,7 +35,7 @@ const toolCallMemory = new Memory({
   options: {
     workingMemory: {
       enabled: true,
-      use: 'tool-call', // Required for toDataStream() compatibility
+      use: "tool-call", // Required for toDataStream() compatibility
     },
   },
 });
@@ -75,7 +75,10 @@ const response = await agent.stream("Hello, my name is Jane", {
 });
 
 // Process response stream, hiding working memory tags
-for await (const chunk of maskStreamTags(response.textStream, "working_memory")) {
+for await (const chunk of maskStreamTags(
+  response.textStream,
+  "working_memory",
+)) {
   process.stdout.write(chunk);
 }
 ```
@@ -98,7 +101,7 @@ for await (const chunk of toolCallResponse.textStream) {
 
 ### Handling response data
 
-In text stream mode, the response stream will contain xml-like `<working_memory>$data</working_memory>` tagged data.
+In text stream mode, the response stream will contain `<working_memory>$data</working_memory>` tagged data where `$data` is Markdown-formatted content.
 Mastra picks up these tags and automatically updates working memory with the data returned by the LLM.
 
 To prevent showing this data to users you can use the `maskStreamTags` util as shown above.

--- a/examples/memory-todo-agent/src/mastra/agents/index.ts
+++ b/examples/memory-todo-agent/src/mastra/agents/index.ts
@@ -9,10 +9,13 @@ const memory = new Memory({
     workingMemory: {
       enabled: true,
       template: `
-<todolist>
-  <info>this is an example list - replace it with whatever the user needs</info>
-  <item status="ACTIVE" due="Feb 7 3028" title="Example" started="Feb 7 2025">example</item>
-</todolist>
+# Todo List
+## Active Items
+- Example (Due: Feb 7 3028, Started: Feb 7 2025)
+  - Description: This is an example task - replace with whatever the user needs
+
+## Completed Items
+- None yet
 `,
     },
   },

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -29,6 +29,7 @@ const createTestMessage = (threadId: string, content: string, role: 'user' | 'as
     role,
     type: 'text',
     createdAt: new Date(Date.now() + messageCounter * 1000),
+    resourceId,
   };
 };
 
@@ -46,12 +47,12 @@ describe('Working Memory Tests', () => {
       options: {
         workingMemory: {
           enabled: true,
-          template: `<user>
-  <first_name></first_name>
-  <last_name></last_name>
-  <location></location>
-  <interests></interests>
-</user>`,
+          template: `# User Information
+- **First Name**: 
+- **Last Name**: 
+- **Location**: 
+- **Interests**: 
+`,
         },
         lastMessages: 10,
         semanticRecall: {
@@ -89,13 +90,18 @@ describe('Working Memory Tests', () => {
     });
 
     // Get working memory
-    // @ts-expect-error
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<first_name>Tyler</first_name>');
-    expect(workingMemory).toContain('<location>San Francisco</location>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      // Check for specific Markdown format
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: Tyler');
+      expect(workingMemory).toContain('**Location**: San Francisco');
+    }
   });
 
   it('should handle LLM responses with working memory', async () => {
+    // This test still uses XML format for backward compatibility testing
     const messages = [
       createTestMessage(thread.id, 'Hi, my name is Tyler'),
       {
@@ -104,8 +110,16 @@ describe('Working Memory Tests', () => {
         role: 'assistant',
         type: 'text',
         content:
-          "Hello Tyler! I'll remember your name.\n<working_memory><user><first_name>Tyler</first_name></user></working_memory>",
+          `Hello Tyler! I'll remember your name.
+<working_memory>
+# User Information
+- **First Name**: Tyler
+- **Last Name**: 
+- **Location**: 
+- **Interests**: 
+</working_memory>`,
         createdAt: new Date(),
+        resourceId,
       },
       createTestMessage(thread.id, 'I live in San Francisco'),
       {
@@ -114,16 +128,29 @@ describe('Working Memory Tests', () => {
         role: 'assistant',
         type: 'text',
         content:
-          "Great city! I'll update my memory about you.\n<working_memory><user><first_name>Tyler</first_name><location>San Francisco</location></user></working_memory>",
+          `Great city! I'll update my memory about you.
+<working_memory>
+# User Information
+- **First Name**: Tyler
+- **Last Name**: 
+- **Location**: San Francisco
+- **Interests**: 
+</working_memory>`,
         createdAt: new Date(),
+        resourceId,
       },
     ] as MessageType[];
 
     await memory.saveMessages({ messages });
 
+    // Content checks should verify Markdown format
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<first_name>Tyler</first_name>');
-    expect(workingMemory).toContain('<location>San Francisco</location>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: Tyler');
+      expect(workingMemory).toContain('**Location**: San Francisco');
+    }
 
     // Verify the messages are saved without working memory tags
     const remembered = await memory.rememberMessages({
@@ -141,9 +168,12 @@ describe('Working Memory Tests', () => {
 
   it('should initialize with default working memory template', async () => {
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<user>');
-    expect(workingMemory).toContain('<first_name>');
-    expect(workingMemory).toContain('</user>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      // Should match our Markdown template
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('First Name');
+    }
   });
 
   it('should update working memory from assistant messages', async () => {
@@ -151,17 +181,25 @@ describe('Working Memory Tests', () => {
       createTestMessage(thread.id, 'Hi, my name is John and I live in New York'),
       createTestMessage(
         thread.id,
-        'Nice to meet you! Let me update my memory.\n<working_memory><user><first_name>John</first_name><location>New York</location></user></working_memory>',
+        `Nice to meet you! Let me update my memory.
+<working_memory>
+# User Information
+- **First Name**: John
+- **Last Name**: 
+- **Location**: New York
+- **Interests**: 
+</working_memory>`,
         'assistant',
       ),
     ];
 
     await memory.saveMessages({ messages });
 
-    // Get thread and check metadata
+    // Get thread and check metadata - verify specific Markdown format
     const updatedThread = await memory.getThreadById({ threadId: thread.id });
-    expect(updatedThread?.metadata?.workingMemory).toContain('<first_name>John</first_name>');
-    expect(updatedThread?.metadata?.workingMemory).toContain('<location>New York</location>');
+    expect(updatedThread?.metadata?.workingMemory).toContain('# User Information');
+    expect(updatedThread?.metadata?.workingMemory).toContain('**First Name**: John');
+    expect(updatedThread?.metadata?.workingMemory).toContain('**Location**: New York');
   });
 
   it('should accumulate working memory across multiple messages', async () => {
@@ -171,7 +209,14 @@ describe('Working Memory Tests', () => {
         createTestMessage(thread.id, 'Hi, my name is John'),
         createTestMessage(
           thread.id,
-          'Hello John!\n<working_memory><user><first_name>John</first_name></user></working_memory>',
+          `Hello John!
+<working_memory>
+# User Information
+- **First Name**: John
+- **Last Name**: 
+- **Location**: 
+- **Interests**: 
+</working_memory>`,
           'assistant',
         ),
       ],
@@ -183,7 +228,14 @@ describe('Working Memory Tests', () => {
         createTestMessage(thread.id, 'I live in New York'),
         createTestMessage(
           thread.id,
-          'Great city!\n<working_memory><user><first_name>John</first_name><location>New York</location></user></working_memory>',
+          `Great city!
+<working_memory>
+# User Information
+- **First Name**: John
+- **Last Name**: 
+- **Location**: New York
+- **Interests**: 
+</working_memory>`,
           'assistant',
         ),
       ],
@@ -195,16 +247,27 @@ describe('Working Memory Tests', () => {
         createTestMessage(thread.id, 'I love playing tennis'),
         createTestMessage(
           thread.id,
-          'Tennis is fun!\n<working_memory><user><first_name>John</first_name><location>New York</location><interests>tennis</interests></user></working_memory>',
+          `Tennis is fun!
+<working_memory>
+# User Information
+- **First Name**: John
+- **Last Name**: 
+- **Location**: New York
+- **Interests**: tennis
+</working_memory>`,
           'assistant',
         ),
       ],
     });
 
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<first_name>John</first_name>');
-    expect(workingMemory).toContain('<location>New York</location>');
-    expect(workingMemory).toContain('<interests>tennis</interests>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: John');
+      expect(workingMemory).toContain('**Location**: New York');
+      expect(workingMemory).toContain('**Interests**: tennis');
+    }
   });
 
   it('should hide working memory tags in remembered messages', async () => {
@@ -212,7 +275,14 @@ describe('Working Memory Tests', () => {
       createTestMessage(thread.id, 'Hi, my name is John'),
       createTestMessage(
         thread.id,
-        'Hello John!\n<working_memory><user><first_name>John</first_name></user></working_memory>',
+        `Hello John!
+<working_memory>
+# User Information
+- **First Name**: John
+- **Last Name**: 
+- **Location**: 
+- **Interests**: 
+</working_memory>`,
         'assistant',
       ),
     ];
@@ -240,7 +310,10 @@ describe('Working Memory Tests', () => {
       options: {
         workingMemory: {
           enabled: false,
-          template: `<user><first_name></first_name></user>`,
+          template: `# User Information
+- **First Name**: 
+- **Last Name**:
+`,
         },
         lastMessages: 10,
         semanticRecall: {
@@ -258,7 +331,12 @@ describe('Working Memory Tests', () => {
       createTestMessage(thread.id, 'Hi, my name is John'),
       createTestMessage(
         thread.id,
-        'Hello John!\n<working_memory><user><first_name>John</first_name></user></working_memory>',
+        `Hello John!
+<working_memory>
+# User Information
+- **First Name**: John
+- **Last Name**: 
+</working_memory>`,
         'assistant',
       ),
     ];
@@ -285,7 +363,10 @@ describe('Working Memory Tests', () => {
       options: {
         workingMemory: {
           enabled: true,
-          template: `<user><first_name></first_name><location></location></user>`,
+          template: `# User Information
+- **First Name**: 
+- **Location**: 
+`,
           use: 'tool-call',
         },
         lastMessages: 10,
@@ -316,8 +397,9 @@ describe('Working Memory Tests', () => {
 
     // Verify working memory was saved in tool-call mode
     const toolCallWorkingMemory = await toolCallMemory.getThreadById({ threadId: toolCallThread.id });
-    expect(toolCallWorkingMemory?.metadata?.workingMemory).toContain('<first_name>John</first_name>');
-    expect(toolCallWorkingMemory?.metadata?.workingMemory).toContain('<location>New York</location>');
+    expect(toolCallWorkingMemory?.metadata?.workingMemory).toContain('# User Information');
+    expect(toolCallWorkingMemory?.metadata?.workingMemory).toContain('**First Name**: John');
+    expect(toolCallWorkingMemory?.metadata?.workingMemory).toContain('**Location**: New York');
 
     // Create memory instance with working memory in text-stream mode
     const textStreamMemory = new Memory({
@@ -329,7 +411,10 @@ describe('Working Memory Tests', () => {
       options: {
         workingMemory: {
           enabled: true,
-          template: `<user><first_name></first_name><location></location></user>`,
+          template: `# User Information
+- **First Name**: 
+- **Location**: 
+`,
           use: 'text-stream',
         },
         lastMessages: 10,
@@ -360,8 +445,9 @@ describe('Working Memory Tests', () => {
 
     // Verify working memory was saved in text-stream mode
     const textStreamWorkingMemory = await textStreamMemory.getThreadById({ threadId: textStreamThread.id });
-    expect(textStreamWorkingMemory?.metadata?.workingMemory).toContain('<first_name>Tyler</first_name>');
-    expect(textStreamWorkingMemory?.metadata?.workingMemory).toContain('<location>San Francisco</location>');
+    expect(textStreamWorkingMemory?.metadata?.workingMemory).toContain('# User Information');
+    expect(textStreamWorkingMemory?.metadata?.workingMemory).toContain('**First Name**: Tyler');
+    expect(textStreamWorkingMemory?.metadata?.workingMemory).toContain('**Location**: San Francisco');
   });
 
   it('should handle LLM responses with working memory using tool calls', async () => {
@@ -395,8 +481,13 @@ describe('Working Memory Tests', () => {
     });
 
     const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<first_name>Tyler</first_name>');
-    expect(workingMemory).toContain('<location>San Francisco</location>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      // Check for specific Markdown format
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: Tyler');
+      expect(workingMemory).toContain('**Location**: San Francisco');
+    }
   });
 
   it("shouldn't pollute context with working memory tool call args, only the system instruction working memory should exist", async () => {
@@ -410,7 +501,10 @@ describe('Working Memory Tests', () => {
         workingMemory: {
           enabled: true,
           use: 'tool-call',
-          template: `<user><first_name></first_name><location></location></user>`,
+          template: `# User Information
+- **First Name**: 
+- **Location**: 
+`,
         },
         lastMessages: 5,
       },
@@ -431,8 +525,13 @@ describe('Working Memory Tests', () => {
     });
 
     let workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<first_name>Tyler</first_name>');
-    expect(workingMemory?.toLowerCase()).toContain('<location>submarine under the sea</location>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: Tyler');
+      expect(workingMemory?.toLowerCase()).toContain('**location**:');
+      expect(workingMemory?.toLowerCase()).toContain('submarine under the sea');
+    }
 
     await agent.generate('I changed my name to Jim', {
       threadId: thread.id,
@@ -440,8 +539,13 @@ describe('Working Memory Tests', () => {
     });
 
     workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<first_name>Jim</first_name>');
-    expect(workingMemory?.toLowerCase()).toContain('<location>submarine under the sea</location>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: Jim');
+      expect(workingMemory?.toLowerCase()).toContain('**location**:');
+      expect(workingMemory?.toLowerCase()).toContain('submarine under the sea');
+    }
 
     await agent.generate('I moved to Vancouver Island', {
       threadId: thread.id,
@@ -449,8 +553,12 @@ describe('Working Memory Tests', () => {
     });
 
     workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toContain('<first_name>Jim</first_name>');
-    expect(workingMemory).toContain('<location>Vancouver Island</location>');
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: Jim');
+      expect(workingMemory).toContain('**Location**: Vancouver Island');
+    }
 
     const history = await memory.query({
       threadId: thread.id,
@@ -473,13 +581,150 @@ describe('Working Memory Tests', () => {
       }
     }
 
-    expect(memoryArgs).not.toContain(`<first_name>Tyler</first_name>`);
-    expect(memoryArgs).not.toContain('<location>submarine under the sea</location>');
-    expect(memoryArgs).not.toContain('<first_name>Jim</first_name>');
-    expect(memoryArgs).not.toContain('<location>Vancouver Island</location>');
+    expect(memoryArgs).not.toContain(`Tyler`);
+    expect(memoryArgs).not.toContain('submarine under the sea');
+    expect(memoryArgs).not.toContain('Jim');
+    expect(memoryArgs).not.toContain('Vancouver Island');
     expect(memoryArgs).toEqual([]);
 
     workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-    expect(workingMemory).toBe(`<user><first_name>Jim</first_name><location>Vancouver Island</location></user>`);
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      // Format-specific assertion that checks for Markdown format
+      expect(workingMemory).toContain('# User Information');
+      expect(workingMemory).toContain('**First Name**: Jim');
+      expect(workingMemory).toContain('**Location**: Vancouver Island');
+    }
+  });
+
+  it('should handle working memory in Markdown format', async () => {
+    // Create memory instance with Markdown-formatted working memory
+    const markdownMemory = new Memory({
+      storage: new DefaultStorage({
+        config: {
+          url: 'file:test.db',
+        },
+      }),
+      options: {
+        workingMemory: {
+          enabled: true,
+          template: `# User Info
+- **First Name**: 
+- **Last Name**: 
+- **Location**: 
+`,
+          use: 'text-stream',
+        },
+        lastMessages: 10,
+      },
+    });
+
+    const markdownThread = await markdownMemory.saveThread({
+      thread: createTestThread('Markdown Working Memory Thread'),
+    });
+
+    // Simulate working memory update using Markdown
+    const messages = [
+      createTestMessage(markdownThread.id, 'Hi, my name is Alice and I live in Boston'),
+      createTestMessage(
+        markdownThread.id,
+        `Nice to meet you Alice!
+<working_memory>
+# User Info
+- **First Name**: Alice
+- **Last Name**: 
+- **Location**: Boston
+</working_memory>`,
+        'assistant',
+      ),
+    ];
+
+    await markdownMemory.saveMessages({ messages });
+
+    // Get thread and check metadata
+    const updatedThread = await markdownMemory.getThreadById({ threadId: markdownThread.id });
+    expect(updatedThread?.metadata?.workingMemory).toContain('# User Info');
+    expect(updatedThread?.metadata?.workingMemory).toContain('**First Name**: Alice');
+    expect(updatedThread?.metadata?.workingMemory).toContain('**Location**: Boston');
+
+    // Verify that linebreaks are preserved for Markdown format
+    const workingMemory = await markdownMemory.getWorkingMemory({ threadId: markdownThread.id });
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      expect(workingMemory).toContain('\n');
+      expect(workingMemory.split('\n').length).toBeGreaterThan(1);
+    }
+  });
+
+  // Test for backward compatibility with XML format
+  it('should handle conversion from XML to Markdown format', async () => {
+    // First, create a thread with XML-formatted working memory
+    const xmlMemory = new Memory({
+      storage: new DefaultStorage({
+        config: {
+          url: 'file:test.db',
+        },
+      }),
+      options: {
+        workingMemory: {
+          enabled: true,
+          template: `<user>
+  <first_name></first_name>
+  <last_name></last_name>
+  <location></location>
+</user>`,
+        },
+      },
+    });
+
+    const xmlThread = await xmlMemory.saveThread({
+      thread: createTestThread('XML to Markdown Thread'),
+    });
+
+    // Update with XML format
+    await xmlMemory.saveMessages({
+      messages: [
+        createTestMessage(xmlThread.id, 'My name is Bob'),
+        createTestMessage(
+          xmlThread.id,
+          `Hello Bob!
+<working_memory><user><first_name>Bob</first_name></user></working_memory>`,
+          'assistant',
+        ),
+      ],
+    });
+
+    // Now create a new Memory instance with Markdown format that will read the existing thread
+    const markdownMemory = new Memory({
+      storage: new DefaultStorage({
+        config: {
+          url: 'file:test.db',
+        },
+      }),
+      options: {
+        workingMemory: {
+          enabled: true,
+          template: `# User Info
+- **First Name**: 
+- **Last Name**: 
+- **Location**: 
+`,
+        },
+      },
+    });
+
+    // The system instructions in getWorkingMemoryWithInstruction should guide the LLM to convert
+    const systemMessage = await markdownMemory.getSystemMessage({ threadId: xmlThread.id });
+    expect(systemMessage).toContain('If the working memory was previously in XML format, convert it to Markdown');
+
+    // Verify the data in working memory can be accessed regardless of format
+    const workingMemory = await markdownMemory.getWorkingMemory({ threadId: xmlThread.id });
+    expect(workingMemory).not.toBeNull();
+    if (workingMemory) {
+      expect(workingMemory).toContain('Bob');
+    }
+    
+    // The template in systemMessage should be markdown even though the stored memory is XML
+    expect(systemMessage).toContain('Use Markdown for all data');
   });
 });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -332,15 +332,6 @@ export class Memory extends MastraMemory {
       this.threadConfig.workingMemory.template ||
       this.defaultWorkingMemoryTemplate;
 
-    // For backward compatibility - if it contains XML tags, use the old compression
-    if (memory.includes('><')) {
-      return memory
-        .split(`>\n`)
-        .map(c => c.trim()) // remove extra whitespace
-        .join(`>`); // and linebreaks
-    }
-
-    // For Markdown, just trim whitespace but preserve linebreaks as they're important
     return memory.trim();
   }
 
@@ -442,7 +433,7 @@ Notes:
 - This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
 - REMEMBER: the way you update your working memory is by outputting the entire "<working_memory>text</working_memory>" block in your response. The system will pick this up and store it for you. The user will not see it.
 - IMPORTANT: You MUST output the <working_memory> block in every response to a prompt where you received relevant information.
-- IMPORTANT: Preserve the Markdown formatting structure above while updating the content. If the working memory was previously in XML format, convert it to Markdown while preserving the information.`;
+- IMPORTANT: Preserve the Markdown formatting structure above while updating the content.`;
   }
 
   private getWorkingMemoryToolInstruction(workingMemoryBlock: string) {
@@ -465,7 +456,7 @@ Notes:
 - Do not remove empty sections - you must include the empty sections along with the ones you're filling in
 - REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the entire Markdown content. The system will store it for you. The user will not see it.
 - IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information.
-- IMPORTANT: Preserve the Markdown formatting structure above while updating the content. If the working memory was previously in XML format, convert it to Markdown while preserving the information.`;
+- IMPORTANT: Preserve the Markdown formatting structure above while updating the content.`;
   }
 
   public getTools(config?: MemoryConfig): Record<string, CoreTool> {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -462,6 +462,7 @@ Notes:
 - Update memory whenever referenced information changes
 - If you're unsure whether to store something, store it (eg if the user tells you information about themselves, call updateWorkingMemory immediately to update it)
 - This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
+- Do not remove empty sections - you must include the empty sections along with the ones you're filling in
 - REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the entire Markdown content. The system will store it for you. The user will not see it.
 - IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information.
 - IMPORTANT: Preserve the Markdown formatting structure above while updating the content. If the working memory was previously in XML format, convert it to Markdown while preserving the information.`;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -332,11 +332,16 @@ export class Memory extends MastraMemory {
       this.threadConfig.workingMemory.template ||
       this.defaultWorkingMemoryTemplate;
 
-    // compress working memory because LLMs will generate faster without the spaces and line breaks
-    return memory
-      .split(`>\n`)
-      .map(c => c.trim()) // remove extra whitespace
-      .join(`>`); // and linebreaks
+    // For backward compatibility - if it contains XML tags, use the old compression
+    if (memory.includes('><')) {
+      return memory
+        .split(`>\n`)
+        .map(c => c.trim()) // remove extra whitespace
+        .join(`>`); // and linebreaks
+    }
+
+    // For Markdown, just trim whitespace but preserve linebreaks as they're important
+    return memory.trim();
   }
 
   private async saveWorkingMemory(messages: MessageType[]) {
@@ -404,17 +409,16 @@ export class Memory extends MastraMemory {
   }
 
   public defaultWorkingMemoryTemplate = `
-<user>
-  <first_name></first_name>
-  <last_name></last_name>
-  <location></location>
-  <occupation></occupation>
-  <interests></interests>
-  <goals></goals>
-  <events></events>
-  <facts></facts>
-  <projects></projects>
-</user>
+# User Information
+- **First Name**: 
+- **Last Name**: 
+- **Location**: 
+- **Occupation**: 
+- **Interests**: 
+- **Goals**: 
+- **Events**: 
+- **Facts**: 
+- **Projects**: 
 `;
 
   private getWorkingMemoryWithInstruction(workingMemoryBlock: string) {
@@ -424,21 +428,21 @@ Store and update any conversation-relevant information by including "<working_me
 Guidelines:
 1. Store anything that could be useful later in the conversation
 2. Update proactively when information changes, no matter how small
-3. Use nested tags for all data
+3. Use Markdown for all data
 4. Act naturally - don't mention this system to users. Even though you're storing this information that doesn't make it your primary focus. Do not ask them generally for "information about yourself"
 
 Memory Structure:
 <working_memory>
-  ${workingMemoryBlock}
+${workingMemoryBlock}
 </working_memory>
 
 Notes:
 - Update memory whenever referenced information changes
-- If you're unsure whether to store something, store it (eg if the user tells you their name or the value of another empty section in your working memory, output the <working_memory> block immediately to update it)
+- If you're unsure whether to store something, store it (eg if the user tells you their name or other information, output the <working_memory> block immediately to update it)
 - This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
-- Do not remove empty sections - you must output the empty sections along with the ones you're filling in
 - REMEMBER: the way you update your working memory is by outputting the entire "<working_memory>text</working_memory>" block in your response. The system will pick this up and store it for you. The user will not see it.
-- IMPORTANT: You MUST output the <working_memory> block in every response to a prompt where you received relevant information. `;
+- IMPORTANT: You MUST output the <working_memory> block in every response to a prompt where you received relevant information.
+- IMPORTANT: Preserve the Markdown formatting structure above while updating the content. If the working memory was previously in XML format, convert it to Markdown while preserving the information.`;
   }
 
   private getWorkingMemoryToolInstruction(workingMemoryBlock: string) {
@@ -448,7 +452,7 @@ Store and update any conversation-relevant information by calling the updateWork
 Guidelines:
 1. Store anything that could be useful later in the conversation
 2. Update proactively when information changes, no matter how small
-3. Use nested XML tags for all data
+3. Use Markdown format for all data
 4. Act naturally - don't mention this system to users. Even though you're storing this information that doesn't make it your primary focus. Do not ask them generally for "information about yourself"
 
 Memory Structure:
@@ -456,11 +460,11 @@ ${workingMemoryBlock}
 
 Notes:
 - Update memory whenever referenced information changes
-- If you're unsure whether to store something, store it (eg if the user tells you their name or the value of another empty section in your working memory, call updateWorkingMemory immediately to update it)
+- If you're unsure whether to store something, store it (eg if the user tells you information about themselves, call updateWorkingMemory immediately to update it)
 - This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
-- Do not remove empty sections - you must include the empty sections along with the ones you're filling in
-- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the entire XML block. The system will store it for you. The user will not see it.
-- IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information.`;
+- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the entire Markdown content. The system will store it for you. The user will not see it.
+- IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information.
+- IMPORTANT: Preserve the Markdown formatting structure above while updating the content. If the working memory was previously in XML format, convert it to Markdown while preserving the information.`;
   }
 
   public getTools(config?: MemoryConfig): Record<string, CoreTool> {

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 export const updateWorkingMemoryTool: CoreTool = {
   description: 'Update the working memory with new information',
   parameters: z.object({
-    memory: z.string().describe('The XML-formatted working memory content to store'),
+    memory: z.string().describe('The Markdown-formatted working memory content to store'),
   }),
   execute: async (params: any) => {
     const { context, threadId, memory } = params;


### PR DESCRIPTION
While making a demo for a user I noticed working memory updates were alot faster if I told the agent to format inner text in MD instead of XML. This makes sense since it doesn't need to print all the extra tags/tokens.
I also talked with a user who was confused and thought the xml working memory data was meant to be stored in a structured format for db access/filtering (tags as columns or something like that). Using MD instead should make it more obvious that this is unstructured text and make it less confusing.