### PR TITLE
fix(stores): add missing ssl property postgres config

### DIFF
--- a/.changeset/pink-hornets-add.md
+++ b/.changeset/pink-hornets-add.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+adds optional ssl property to PostgresConfig

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -9,6 +9,7 @@ import {
 import type { EvalRow, StorageColumn, StorageGetMessagesArg, TABLE_NAMES } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import pgPromise from 'pg-promise';
+import type { ISSLConfig } from 'pg-promise/typescript/pg-subset';
 
 export type PostgresConfig =
   | {
@@ -17,6 +18,7 @@ export type PostgresConfig =
       database: string;
       user: string;
       password: string;
+      ssl?: boolean | ISSLConfig;
     }
   | {
       connectionString: string;
@@ -38,6 +40,7 @@ export class PostgresStore extends MastraStorage {
             database: config.database,
             user: config.user,
             password: config.password,
+            ssl: config.ssl,
           },
     );
   }


### PR DESCRIPTION
## Description

`PostgresConfig` missing `ssl` property

this prevents connections to databases who enforce a secure connection

## Related Issue(s)

Fixes #3400 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
