### PR TITLE
[MASTRA-2662] Fix compound subscribers edge case

### DIFF
--- a/.changeset/dirty-donkeys-nail.md
+++ b/.changeset/dirty-donkeys-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix compound subscriber bug

--- a/packages/core/src/workflows/workflow-instance.ts
+++ b/packages/core/src/workflows/workflow-instance.ts
@@ -359,7 +359,7 @@ export class WorkflowInstance<
           return;
         }
 
-        this.#initializeCompoundDependencies();
+        this.#resetCompoundDependency(key);
 
         const machine = new Machine({
           logger: this.logger,
@@ -643,6 +643,19 @@ export class WorkflowInstance<
         );
       }
     });
+  }
+
+  #resetCompoundDependency(key: string) {
+    if (this.#isCompoundKey(key)) {
+      const requiredSteps = key.split('&&');
+      this.#compoundDependencies[key] = requiredSteps.reduce(
+        (acc, step) => {
+          acc[step] = false;
+          return acc;
+        },
+        {} as Record<string, boolean>,
+      );
+    }
   }
 
   #makeStepDef<TStepId extends TSteps[number]['id'], TSteps extends Step<any, any, any>[]>(


### PR DESCRIPTION
## Description

When a compound subscriber is defined after a previous subscriber (having overlapping stepIDs), the second subscriber does not run due to the dependencies array prematurely getting cleared.

## Related Issue(s)
Closes #3151 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
