### PR TITLE
Add Cloudflare Worker environment variable auto-population

### DIFF
--- a/.changeset/ready-dolls-enter.md
+++ b/.changeset/ready-dolls-enter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-cloudflare': patch
+---
+
+Enable process env syncing to cloudflare workers

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -61,8 +61,8 @@ export class CloudflareDeployer extends Deployer {
     const wranglerConfig: Record<string, any> = {
       name: cfWorkerName,
       main: './index.mjs',
-      compatibility_date: '2024-12-02',
-      compatibility_flags: ['nodejs_compat'],
+      compatibility_date: '2025-04-01',
+      compatibility_flags: ['nodejs_compat', 'nodejs_compat_populate_process_env'],
       observability: {
         logs: {
           enabled: true,
@@ -86,11 +86,6 @@ import { createHonoServer } from '#server';
 
 export default {
   fetch: async (request, env, context) => {
-    // fixes process.env
-    Object.keys(env).forEach(key => {
-      process.env[key] = env[key]
-    })
-
     const app = await createHonoServer(mastra)
     return app.fetch(request, env, context);
   }


### PR DESCRIPTION
Fixes #3438

This change adds the `nodejs_compat_populate_process_env` flag to the Cloudflare Worker's compatibility flags, which automatically populates `process.env` with values from the `env` object. As a result, the manual code that previously copied each key from `env` to `process.env` could be removed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mastra-ai/mastra/pull/3439?shareId=52e1095e-0cb9-4925-824d-d46b6def9681).