### PR TITLE
docs: incorrect description of code example

### DIFF
--- a/docs/src/content/docs/workflows/control-flow.mdx
+++ b/docs/src/content/docs/workflows/control-flow.mdx
@@ -47,7 +47,7 @@ In this example:
 
 - stepA leads to stepB, then to stepD.
 - Separately, stepA also triggers stepC, which in turn leads to stepE.
-- Separately, stepD also triggers stepF and stepE in parallel.
+- Separately, stepF is triggered when both stepD and stepE are completed.
 
 See the [Branching Paths](../../examples/workflows/branching-paths.mdx) example for more details.
 


### PR DESCRIPTION
## Description

The way I understand it, passing an array to `.after()` makes multiple items a requirement to what comes after, but the docs was saying something else here.

![image](https://github.com/user-attachments/assets/9d42bba9-ad45-458d-b9ce-34ca130eab48)


## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
