### PR TITLE
fix: ignore json issues for client-js workflow watch

### DIFF
--- a/.changeset/sixty-candles-matter.md
+++ b/.changeset/sixty-candles-matter.md
@@ -1,0 +1,8 @@
+---
+'@mastra/client-js': patch
+'mastra': patch
+'create-mastra': patch
+'@mastra/playground-ui': patch
+---
+
+Fix parsing chunk in client-js workflow watch method sometimes failing, disrupting the stream process

--- a/.changeset/sixty-candles-matter.md
+++ b/.changeset/sixty-candles-matter.md
@@ -1,8 +1,5 @@
 ---
 '@mastra/client-js': patch
-'mastra': patch
-'create-mastra': patch
-'@mastra/playground-ui': patch
 ---
 
 Fix parsing chunk in client-js workflow watch method sometimes failing, disrupting the stream process

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -157,7 +157,15 @@ export class Workflow extends BaseResource {
           for (const chunk of chunks) {
             if (chunk) {
               // Only process non-empty chunks
-              yield JSON.parse(chunk);
+              if (typeof chunk === 'string') {
+                try {
+                  const parsedChunk = JSON.parse(chunk);
+                  yield parsedChunk;
+                } catch (error) {
+                  // Silently ignore parsing errors to maintain stream processing
+                  // This allows the stream to continue even if one record is malformed
+                }
+              }
             }
           }
         } catch (error) {

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -161,7 +161,7 @@ export class Workflow extends BaseResource {
                 try {
                   const parsedChunk = JSON.parse(chunk);
                   yield parsedChunk;
-                } catch (error) {
+                } catch {
                   // Silently ignore parsing errors to maintain stream processing
                   // This allows the stream to continue even if one record is malformed
                 }


### PR DESCRIPTION
## Description

This PR fixes could not parse error occurring in client-js workflow watch method, disrupting the stream process

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
