### PR TITLE
fix nested import paths

### DIFF
--- a/.changeset/cold-boxes-end.md
+++ b/.changeset/cold-boxes-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix multi slash imports during bundling

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -306,7 +306,10 @@ async function validateOutput(
     } catch (err) {
       result.invalidChunks.add(file.fileName);
       if (file.isEntry && reverseVirtualReferenceMap.has(file.name)) {
-        result.externalDependencies.add(reverseVirtualReferenceMap.get(file.name)!);
+        const reference = reverseVirtualReferenceMap.get(file.name)!;
+        const dep = reference.startsWith('@') ? reference.split('/').slice(0, 2) : reference.split('/')[0];
+
+        result.externalDependencies.add(dep);
       }
 
       // we might need this on other projects but not sure so let's keep it commented out for now

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -307,9 +307,9 @@ async function validateOutput(
       result.invalidChunks.add(file.fileName);
       if (file.isEntry && reverseVirtualReferenceMap.has(file.name)) {
         const reference = reverseVirtualReferenceMap.get(file.name)!;
-        const dep = reference.startsWith('@') ? reference.split('/').slice(0, 2) : reference.split('/')[0];
+        const dep = reference.startsWith('@') ? reference.split('/').slice(0, 2).join('/') : reference.split('/')[0];
 
-        result.externalDependencies.add(dep);
+        result.externalDependencies.add(dep!);
       }
 
       // we might need this on other projects but not sure so let's keep it commented out for now


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fix nested / imports like firebase-admin/firestore when bundling fails and makes these imports external

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes #3262

## Type of Change

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
