### PR TITLE
fix(@mastra/core, @mastra/memory): allow explicitly disabling vector store

### DIFF
--- a/.changeset/floppy-oranges-laugh.md
+++ b/.changeset/floppy-oranges-laugh.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Allowed explicitly disabling vector/embedder in Memory by passing vector: false or options.semanticRecall: false

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -58,7 +58,7 @@ export type SharedMemoryConfig = {
 
   options?: MemoryConfig;
 
-  vector?: MastraVector;
+  vector?: MastraVector | false;
   embedder?: EmbeddingModel<string>;
 
   processors?: MemoryProcessor[];


### PR DESCRIPTION
Before this, even with semantic recall disabled, the default vector store and embedder would be attached to the memory instance.
This PR allows Memory to have no vector/embedder by turning off semantic recall or by setting vector to false

```ts
new Memory({
  vector: false,
  // or
  options: { semanticRecall: false }
})
```

We'll be changing the defaults anyway but this should help short term by allowing folks to fully opt-out of vector/embedding with Memory. Long term with new defaults this will still be useful because when we set `semanticRecall: false` in the new defaults, this logic will make sure no default vector store is attached.