### PR TITLE
feat(@mastra/memory): vnext defaults

### DIFF
--- a/.changeset/clever-regions-strive.md
+++ b/.changeset/clever-regions-strive.md
@@ -1,0 +1,8 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/memory': patch
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Added a new @mastra/memory/vnext that has improved default settings over @mastra/memory. In a future release the vnext settings will become the new defaults (breaking change)

--- a/docs/src/content/docs/agents/agent-memory.mdx
+++ b/docs/src/content/docs/agents/agent-memory.mdx
@@ -17,7 +17,7 @@ npm install @mastra/memory
 
 ```typescript
 import { Agent } from "@mastra/core/agent";
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { openai } from "@ai-sdk/openai";
 
 // Basic memory setup
@@ -31,7 +31,7 @@ const agent = new Agent({
 });
 ```
 
-This basic setup uses default settings, including LibSQL for storage and FastEmbed for embeddings. For detailed setup instructions, see the [Memory Getting Started guide](/docs/memory/getting-started).
+This basic setup uses default settings, including LibSQL for storage and FastEmbed for embeddings. For detailed setup instructions, see the [Memory Getting Started guide](/docs/memory/getting-started). For additional configuration options, see the [Memory Reference](/docs/reference/memory/Memory.mdx).
 
 ## Using Memory in Agent Calls
 

--- a/docs/src/content/docs/memory/overview.mdx
+++ b/docs/src/content/docs/memory/overview.mdx
@@ -24,9 +24,9 @@ npm install @mastra/memory
 
 **2. Create an agent and attach a `Memory` instance:**
 
-```typescript filename="src/mastra/agents/index.ts" {10}
+```typescript filename="src/mastra/agents/index.ts"
 import { Agent } from "@mastra/core/agent";
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { openai } from "@ai-sdk/openai";
 
 export const myMemoryAgent = new Agent({
@@ -73,12 +73,12 @@ const response = await myMemoryAgent.stream("Hello, my name is Alice.", {
 
 ## Conversation History
 
-By default, the `Memory` instance includes the [last 40 messages](../reference/memory/Memory.mdx) from the current Memory thread in each new request. This provides the agent with immediate conversational context.
+By default, the `Memory` instance includes the [last 10 messages](../reference/memory/Memory.mdx) from the current Memory thread in each new request. This provides the agent with immediate conversational context.
 
 ```ts {3}
 const memory = new Memory({
   options: {
-    lastMessages: 10,
+    lastMessages: 20, // Increase from default of 10 if needed
   },
 });
 ```
@@ -90,7 +90,7 @@ const memory = new Memory({
 Conversation history relies on a [storage adapter](/docs/reference/memory/Memory#parameters) to store messages.
 
 ```ts {7-12}
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore } from "@mastra/core/storage/libsql";
 

--- a/docs/src/content/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/docs/memory/semantic-recall.mdx
@@ -17,18 +17,22 @@ It uses vector embeddings of messages for similarity search, integrates with var
 
 ## Quick Start
 
-Semantic recall is enabled by default, so if you give your agent memory it will be included:
+Semantic recall is disabled by default (in vnext) but can be easily enabled:
 
 ```typescript {9}
 import { Agent } from "@mastra/core/agent";
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   name: "SupportAgent",
   instructions: "You are a helpful support agent.",
   model: openai("gpt-4o"),
-  memory: new Memory(),
+  memory: new Memory({
+    options: {
+      semanticRecall: true, // Enable semantic recall. Enabled by default in @mastra/memory, disabled by default in @mastra/memory/vnext
+    },
+  }),
 });
 ```
 
@@ -57,7 +61,7 @@ const agent = new Agent({
 Semantic recall relies on a [storage and vector db](/reference/memory/Memory#parameters) to store messages and their embeddings.
 
 ```ts {8-17}
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore } from "@mastra/core/storage/libsql";
 import { LibSQLVector } from "@mastra/core/vector/libsql";
@@ -74,6 +78,9 @@ const agent = new Agent({
     vector: new LibSQLVector({
       connectionUrl: "file:local.db",
     }),
+    options: {
+      semanticRecall: true, // Don't forget to enable semantic recall
+    },
   }),
 });
 ```
@@ -89,34 +96,25 @@ const agent = new Agent({
 Semantic recall relies an [embedding model](/reference/memory/Memory#embedder) to convert messages into embeddings. By default Mastra uses FastEmbed but you can specify another [embedding model](https://sdk.vercel.ai/docs/ai-sdk-core/embeddings).
 
 ```ts {7}
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { Agent } from "@mastra/core/agent";
 import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   memory: new Memory({
     embedder: openai.embedding("text-embedding-3-small"),
-  }),
-});
-```
-
-### Disabling
-
-There is a performance impact to using semantic recall. New messages are converted into embeddings and used to query a vector database before new messages are sent to the LLM.
-
-Semantic recall is enabled by default but can be disabled when not needed:
-
-```typescript {4}
-const agent = new Agent({
-  memory: new Memory({
     options: {
-      semanticRecall: false,
+      semanticRecall: true,
     },
   }),
 });
 ```
 
-You might want to disable semantic recall in scenarios like:
+### Performance
+
+There is a performance impact to using semantic recall. New messages are converted into embeddings and used to query a vector database before new messages are sent to the LLM.
+
+Semantic recall is disabled by default (in vnext) and you might want to keep it disabled in scenarios like:
 
 - When [conversation history](./getting-started.mdx#conversation-history-last-messages) provide sufficient context for the current conversation.
 - In performance-sensitive applications, like realtime two-way audio, where the added latency of creating embeddings and running vector queries is noticeable.

--- a/docs/src/content/docs/memory/working-memory.mdx
+++ b/docs/src/content/docs/memory/working-memory.mdx
@@ -12,9 +12,9 @@ This is useful for maintaining ongoing state that's always relevant and should a
 
 Here's a minimal example of setting up an agent with working memory:
 
-```typescript {12-15}
+```typescript {12-14}
 import { Agent } from "@mastra/core/agent";
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { openai } from "@ai-sdk/openai";
 
 // Create agent with working memory enabled
@@ -26,7 +26,6 @@ const agent = new Agent({
     options: {
       workingMemory: {
         enabled: true,
-        use: "tool-call", // Recommended setting
       },
     },
   }),

--- a/docs/src/content/examples/memory/memory-with-pg.mdx
+++ b/docs/src/content/examples/memory/memory-with-pg.mdx
@@ -7,7 +7,7 @@ This example demonstrates how to use Mastra's memory system with PostgreSQL as t
 First, set up the memory system with PostgreSQL storage and vector capabilities:
 
 ```typescript
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { PostgresStore, PgVector } from "@mastra/pg";
 import { Agent } from "@mastra/core/agent";
 import { openai } from "@ai-sdk/openai";

--- a/docs/src/content/reference/memory/Memory.mdx
+++ b/docs/src/content/reference/memory/Memory.mdx
@@ -5,7 +5,7 @@ The `Memory` class provides a robust system for managing conversation history an
 ## Basic Usage
 
 ```typescript copy showLineNumbers
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { Agent } from "@mastra/core/agent";
 
 const agent = new Agent({
@@ -14,10 +14,27 @@ const agent = new Agent({
 });
 ```
 
+## Improved Memory Defaults
+
+Based on extensive user feedback and testing, we've created an improved configuration for Memory with more efficient defaults. This implementation is available now via the `/vnext` import path and will become the standard in a future release.
+
+```typescript copy showLineNumbers
+import { Memory } from "@mastra/memory/vnext";
+```
+
+The key improvements in the defaults:
+
+- **Smaller context window**: Reduced `lastMessages` from 40 to 10, providing a better balance between context and token usage
+- **Disabled semantic recall by default**: Many users weren't aware this feature was active and incurring embedding costs
+- **Disabled thread title generation**: This removes unnecessary latency when creating new threads  
+- **Using tool-calls for working memory**: More reliable than text-stream mode, especially with structured data streams
+
+You can still enable any of these features through configuration when needed.
+
 ## Custom Configuration
 
 ```typescript copy showLineNumbers
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { LibSQLStore } from "@mastra/core/storage/libsql";
 import { LibSQLVector } from "@mastra/core/vector/libsql";
 import { Agent } from "@mastra/core/agent";
@@ -39,13 +56,11 @@ const memory = new Memory({
     lastMessages: 20,
 
     // Semantic search configuration
-    semanticRecall: {
-      topK: 3, // Number of similar messages to retrieve
-      messageRange: {
-        // Messages to include around each result
-        before: 2,
-        after: 1,
-      },
+    semanticRecall: true,
+    
+    // Title generation for threads
+    threads: {
+      generateTitle: true,
     },
 
     // Working memory configuration
@@ -70,21 +85,16 @@ const agent = new Agent({
 
 The working memory feature allows agents to maintain persistent information across conversations. When enabled, the Memory class will automatically manage working memory updates through either text stream tags or tool calls.
 
-There are two modes for handling working memory updates:
-
-1. **text-stream** (default): The agent includes working memory updates directly in its responses using XML tags containing Markdown (`<working_memory># User \n ## Preferences...</working_memory>`). These tags are automatically processed and stripped from the visible output.
-
-2. **tool-call**: The agent uses a dedicated tool to update working memory. This mode should be used when working with `toDataStream()` as text-stream mode is not compatible with data streaming. Additionally, this mode provides more explicit control over memory updates and may be preferred when working with agents that are better at using tools than managing text tags.
-
 Example configuration:
 
 ```typescript copy showLineNumbers
+import { Memory } from "@mastra/memory/vnext";
+
 const memory = new Memory({
   options: {
     workingMemory: {
       enabled: true,
       template: "# User\n- **First Name**:\n- **Last Name**:",
-      use: "tool-call", // or 'text-stream'
     },
   },
 });
@@ -99,12 +109,12 @@ By default, Memory uses FastEmbed with the `bge-small-en-v1.5` model, which prov
 For environments where local embedding isn't supported, you can use an API-based embedder:
 
 ```typescript {6}
-import { Memory } from "@mastra/memory";
+import { Memory } from "@mastra/memory/vnext";
 import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   memory: new Memory({
-    embedder: openai.embedding("text-embedding-3-small"), // Adds network request
+    embedder: openai.embedding("text-embedding-3-small"),
   }),
 });
 ```
@@ -153,7 +163,7 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
       description:
         "Number of most recent messages to retrieve. Set to false to disable.",
       isOptional: true,
-      defaultValue: "40",
+      defaultValue: "40 (10 in vNext)",
     },
     {
       name: "semanticRecall",
@@ -161,7 +171,7 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
       description:
         "Enable semantic search in message history. Automatically enabled when vector store is provided.",
       isOptional: true,
-      defaultValue: "false (true if vector store provided)",
+      defaultValue: "true (false in vNext)",
     },
     {
       name: "topK",
@@ -186,7 +196,7 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
         "Configuration for working memory feature that allows persistent storage of user information across conversations. The 'use' setting determines how working memory updates are handled - either through text stream tags or tool calls. Working memory uses Markdown format to structure and store continuously relevant information.",
       isOptional: true,
       defaultValue:
-        "{ enabled: false, template: '# User Information\\n- **First Name**:\\n- **Last Name**:\\n...', use: 'text-stream' }",
+        "{ enabled: false, template: '# User Information\\n- **First Name**:\\n- **Last Name**:\\n...', use: 'text-stream' (use: 'tool-call' in vNext) }",
     },
     {
       name: "threads",
@@ -194,7 +204,7 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
       description:
         "Settings related to memory thread creation. `generateTitle` will cause the thread.title to be generated from an llm summary of the users first message.",
       isOptional: true,
-      defaultValue: "{ generateTitle: true }",
+      defaultValue: "{ generateTitle: true } (false in vNext)",
     },
   ]}
 />

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -124,7 +124,7 @@ export function jsonSchemaToModel(jsonSchema: Record<string, any>): ZodObject<an
 /**
  * Deep merges two objects, recursively merging nested objects and arrays
  */
-export function deepMerge<T extends object = object>(target: T, source: Partial<T>): T {
+export function deepMerge<T extends object = object>(target: T, source?: Partial<T>): T {
   const output = { ...target };
 
   if (!source) return output;

--- a/packages/memory/integration-tests/package.json
+++ b/packages/memory/integration-tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "test": "pnpm test:pg && pnpm test:upstash && pnpm test:libsql && pnpm test:streaming && pnpm test:working-memory",
+    "test": "pnpm test:pg && pnpm test:upstash && pnpm test:libsql && pnpm test:streaming && pnpm test:working-memory && pnpm test:vnext",
     "pretest:pg": "docker compose up -d postgres && (for i in $(seq 1 30); do docker compose exec -T postgres pg_isready -U postgres && break || (sleep 1; [ $i -eq 30 ] && exit 1); done)",
     "test:pg": "vitest run ./src/with-pg-storage.test.ts",
     "posttest:pg": "docker compose down --volumes",
@@ -12,6 +12,7 @@
     "posttest:upstash": "docker compose down --volumes",
     "test:libsql": "vitest run ./src/with-libsql-storage.test.ts",
     "test:streaming": "vitest run ./src/streaming-memory.test.ts",
+    "test:vnext": "vitest run ./src/vnext-memory.test.ts",
     "test:working-memory": "vitest run ./src/working-memory.test.ts",
     "pretest:pg:perf": "docker compose up -d postgres && (for i in $(seq 1 30); do docker compose exec -T postgres pg_isready -U postgres && break || (sleep 1; [ $i -eq 30 ] && exit 1); done)",
     "test:pg:perf": "vitest run ./src/performance-testing/with-pg-storage.test.ts",

--- a/packages/memory/integration-tests/src/vnext-memory.test.ts
+++ b/packages/memory/integration-tests/src/vnext-memory.test.ts
@@ -1,0 +1,76 @@
+import type { MemoryConfig } from '@mastra/core/memory';
+import { Memory as OriginalMemory } from '@mastra/memory';
+import { Memory as VNextMemory } from '@mastra/memory/vnext';
+import { describe, expect, it } from 'vitest';
+
+describe('vNext Memory', () => {
+  it('should have different defaults from the original Memory', () => {
+    const originalMemory = new OriginalMemory();
+    const vNextMemory = new VNextMemory();
+
+    // Access the configuration via getMergedThreadConfig()
+    const originalConfig = originalMemory.getMergedThreadConfig();
+    const vNextConfig = vNextMemory.getMergedThreadConfig();
+
+    // Check that vNext defaults are different from original defaults
+    expect(originalConfig).not.toStrictEqual(vNextConfig);
+
+    // Check specific default values for vNext
+    expect(vNextConfig.workingMemory!.enabled).toBe(false);
+    expect(vNextConfig.semanticRecall).toBe(false);
+    expect(vNextConfig.threads!.generateTitle).toBe(false);
+    expect(vNextConfig.lastMessages).toBe(10);
+    expect(vNextConfig.workingMemory!.use).toBe('tool-call');
+  });
+
+  it('should allow overriding the default settings', () => {
+    // Create vNext memory with custom settings that override defaults
+    const customConfig: Partial<MemoryConfig> = {
+      workingMemory: {
+        enabled: true,
+      },
+      semanticRecall: true,
+      threads: {
+        generateTitle: true,
+      },
+      lastMessages: 20,
+    };
+
+    const customVNextMemory = new VNextMemory({
+      options: customConfig,
+    });
+
+    // Access the configuration via getMergedThreadConfig()
+    const mergedConfig = customVNextMemory.getMergedThreadConfig();
+
+    // Verify the custom settings were applied
+    expect(mergedConfig.workingMemory!.enabled).toBe(true);
+    expect(mergedConfig.semanticRecall).toBe(true);
+    expect(mergedConfig.threads!.generateTitle).toBe(true);
+    expect(mergedConfig.lastMessages).toBe(20);
+
+    // Check that non-overridden settings keep their default values
+    expect(mergedConfig.workingMemory!.use).toBe('tool-call');
+  });
+
+  it('should correctly merge deep nested settings', () => {
+    // Test partial overrides of nested objects
+    const partialOverrideMemory = new VNextMemory({
+      options: {
+        workingMemory: {
+          // Only override 'enabled', keep other workingMemory defaults
+          enabled: true,
+        },
+      },
+    });
+
+    // Access the configuration via getMergedThreadConfig()
+    const mergedConfig = partialOverrideMemory.getMergedThreadConfig();
+
+    // Verify the partial override worked
+    expect(mergedConfig.workingMemory!.enabled).toBe(true);
+    expect(mergedConfig.workingMemory!.use).toBe('tool-call');
+    expect(mergedConfig.workingMemory!.template).toBeDefined();
+  });
+});
+

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -26,11 +26,21 @@
         "default": "./dist/processors/index.cjs"
       }
     },
+    "./vnext": {
+      "import": {
+        "types": "./dist/vnext.d.ts",
+        "default": "./dist/vnext.js"
+      },
+      "require": {
+        "types": "./dist/vnext.d.cts",
+        "default": "./dist/vnext.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "build": "pnpm run check && tsup src/index.ts src/processors/index.ts --format esm,cjs --experimental-dts --clean --treeshake=smallest --splitting",
+    "build": "pnpm run check && tsup src/index.ts src/processors/index.ts src/vnext.ts --format esm,cjs --experimental-dts --clean --treeshake=smallest --splitting",
     "build:watch": "pnpm build --watch",
     "test:integration": "cd integration-tests && pnpm run test",
     "test:unit": "pnpm vitest run ./src/*",

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -11,6 +11,19 @@ import { updateWorkingMemoryTool } from './tools/working-memory';
 
 const encoder = new Tiktoken(o200k_base);
 
+export const defaultWorkingMemoryTemplate = `
+# User Information
+- **First Name**: 
+- **Last Name**: 
+- **Location**: 
+- **Occupation**: 
+- **Interests**: 
+- **Goals**: 
+- **Events**: 
+- **Facts**: 
+- **Projects**: 
+`;
+
 /**
  * Concrete implementation of MastraMemory that adds support for thread configuration
  * and message injection.
@@ -465,18 +478,7 @@ export class Memory extends MastraMemory {
     return this.getWorkingMemoryWithInstruction(workingMemory);
   }
 
-  public defaultWorkingMemoryTemplate = `
-# User Information
-- **First Name**: 
-- **Last Name**: 
-- **Location**: 
-- **Occupation**: 
-- **Interests**: 
-- **Goals**: 
-- **Events**: 
-- **Facts**: 
-- **Projects**: 
-`;
+  public defaultWorkingMemoryTemplate = defaultWorkingMemoryTemplate;
 
   private getWorkingMemoryWithInstruction(workingMemoryBlock: string) {
     return `WORKING_MEMORY_SYSTEM_INSTRUCTION:

--- a/packages/memory/src/vnext.ts
+++ b/packages/memory/src/vnext.ts
@@ -1,0 +1,29 @@
+import type { MemoryConfig, SharedMemoryConfig } from '@mastra/core/memory';
+import { deepMerge } from '@mastra/core/utils';
+import { defaultWorkingMemoryTemplate, Memory as MainMemory } from './index';
+
+const newDefaults: MemoryConfig = {
+  workingMemory: {
+    enabled: false,
+    template: defaultWorkingMemoryTemplate,
+    use: 'tool-call',
+  },
+  semanticRecall: false,
+  threads: {
+    generateTitle: false,
+  },
+  lastMessages: 10,
+};
+
+export class Memory extends MainMemory {
+  constructor(config: SharedMemoryConfig = {}) {
+    super({
+      ...config,
+      options: deepMerge<MemoryConfig>(
+        newDefaults,
+        // merge any user config ontop
+        config.options,
+      ),
+    });
+  }
+}

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -97,7 +97,15 @@ export function MastraRuntimeProvider({
         topK,
         topP,
         instructions,
-        ...(memory ? { threadId, resourceId: agentId } : {}),
+        ...(memory ? { 
+          threadId, 
+          resourceId: agentId,
+          memoryOptions: {
+            threads: {
+              generateTitle: true,
+            }
+          }
+        } : {}),
       });
 
       if (!response.body) {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -85,13 +85,15 @@ export async function getThreadByIdHandler({
   }
 }
 
+type SaveMessagesArg = Parameters<MastraMemory['saveMessages']>[0];
 export async function saveMessagesHandler({
   mastra,
   agentId,
   body,
 }: Pick<MemoryContext, 'mastra' | 'agentId'> & {
   body: {
-    messages: Parameters<MastraMemory['saveMessages']>[0]['messages'];
+    messages: SaveMessagesArg['messages'];
+    memoryConfig?: SaveMessagesArg['memoryConfig'];
   };
 }) {
   try {
@@ -115,7 +117,10 @@ export async function saveMessagesHandler({
       createdAt: message.createdAt ? new Date(message.createdAt) : new Date(),
     }));
 
-    const result = await memory.saveMessages({ messages: processedMessages, memoryConfig: {} });
+    const result = await memory.saveMessages({
+      messages: processedMessages,
+      memoryConfig: body.memoryConfig || {},
+    });
     return result;
   } catch (error) {
     return handleError(error, 'Error saving messages');


### PR DESCRIPTION
This PR introduces a new export of the Memory class with more efficient defaults based on user feedback. 

- `import { Memory } from "@mastra/memory/vnext"`
- Reduced lastMessages from 40 to 10
- Disabled semanticRecall by default to avoid unexpected embedding/RAG happening on each new message
- Disabled threads.generateTitle by default to reduce latency
- Changed workingMemory.use default to 'tool-call' since we should make tool calling the only way to update working memory

I added some tests to make sure overriding settings is working properly. I updated playground and server routes so that the playground opts in to generating the thread title. I also updated docs to show importing from vnext instead.