### PR TITLE
[MASTRA-2997] added documentation on authorization headers in sse connections

### DIFF
--- a/.changeset/tidy-moose-turn.md
+++ b/.changeset/tidy-moose-turn.md
@@ -2,4 +2,4 @@
 "@mastra/mcp": patch
 ---
 
-[MASTRA-2997] added documentation on authorization headers in sse connections as well as ts checking
+[MASTRA-2997] added documentation on authorization headers in sse connections

--- a/.changeset/tidy-moose-turn.md
+++ b/.changeset/tidy-moose-turn.md
@@ -1,0 +1,5 @@
+---
+"@mastra/mcp": patch
+---
+
+[MASTRA-2997] added documentation on authorization headers in sse connections as well as ts checking

--- a/docs/src/content/reference/tools/client.mdx
+++ b/docs/src/content/reference/tools/client.mdx
@@ -170,10 +170,21 @@ const sseClient = new MastraMCPClient({
   name: "sse-client",
   server: {
     url: new URL("https://your-mcp-server.com/sse"),
-    // Optional fetch request configuration
+    // Optional fetch request configuration - Note: requestInit alone isn't enough for SSE
     requestInit: {
       headers: {
         Authorization: "Bearer your-token",
+      },
+    },
+    // Required for SSE connections with custom headers
+    eventSourceInit: {
+      fetch(input: Request | URL | string, init?: RequestInit) {
+        const headers = new Headers(init?.headers || {});
+        headers.set('Authorization', 'Bearer your-token');
+        return fetch(input, {
+          ...init,
+          headers,
+        });
       },
     },
   },
@@ -181,6 +192,14 @@ const sseClient = new MastraMCPClient({
 
 // The rest of the usage is identical to the stdio example
 ```
+
+### Important Note About SSE Authentication
+
+When using SSE connections with authentication or custom headers, you need to configure both `requestInit` and `eventSourceInit`. This is because SSE connections use the browser's EventSource API, which doesn't support custom headers directly. 
+
+
+The `eventSourceInit` configuration allows you to customize the underlying fetch request used for the SSE connection, ensuring your authentication headers are properly included.
+Without `eventSourceInit`, authentication headers specified in `requestInit` won't be included in the connection request, leading to 401 Unauthorized errors.
 
 ## Related Information
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -14,28 +14,10 @@ import { CallToolResultSchema, ListResourcesResultSchema } from '@modelcontextpr
 
 import { asyncExitHook, gracefulExit } from 'exit-hook';
 
-type EventSourceInit = SSEClientTransportOptions['eventSourceInit'];
-
 // Omit the fields we want to control from the SDK options
-type SSEClientParametersBase = Omit<SSEClientTransportOptions, 'requestInit' | 'eventSourceInit'> & {
+type SSEClientParameters = {
   url: URL;
-};
-
-type SSEClientParameters = SSEClientParametersBase &
-  (
-    | {
-        // No headers case
-        requestInit?: Omit<RequestInit, 'headers'>;
-        eventSourceInit?: EventSourceInit;
-      }
-    | {
-        // With headers case - both must be present
-        requestInit: RequestInit & { headers: RequestInit['headers'] };
-        eventSourceInit: EventSourceInit & {
-          fetch: NonNullable<EventSourceInit>['fetch'];
-        };
-      }
-  );
+} & SSEClientTransportOptions;
 
 export type MastraMCPServerDefinition = StdioServerParameters | SSEClientParameters;
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
A user posted an issue with MCP where custom headers would not show up in their MCP connection. They found the issue was on the MCP sdk side.
```
Currently, there is no way to pass custom headers to the connection requests. You have to override the event source implementation and pass the headers one more time.
```

Added documentation about his findings and the workaround needed to allow custom headers to work.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
