### PR TITLE
feat: bundle design tokens as CJS in playground UI for tailwind usage

### DIFF
--- a/.changeset/plain-bananas-fry.md
+++ b/.changeset/plain-bananas-fry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+bundle tokens as CJS in playground UI for tailwind usage

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -16,7 +16,16 @@
         "default": "./dist/index.es.js"
       }
     },
-    "./style.css": "./dist/style.css"
+    "./style.css": "./dist/style.css",
+    "./tokens": {
+      "import": {
+        "types": "./dist/tokens.d.ts",
+        "default": "./dist/tokens.es.js"
+      },
+      "require": {
+        "default": "./dist/tokens.cjs.js"
+      }
+    }
   },
   "scripts": {
     "dev": "vite",

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -23,7 +23,8 @@
         "default": "./dist/tokens.es.js"
       },
       "require": {
-        "default": "./dist/tokens.cjs.js"
+        "default": "./dist/tokens.cjs.js",
+        "types": "./dist/tokens.d.ts"
       }
     }
   },

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -28,10 +28,14 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'MastraPlayground',
-      formats: ['es'],
-      fileName: format => `index.${format}.js`,
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
+      },
+      formats: ['es', 'cjs'],
+      fileName: (format, entryName) => {
+        return `${entryName}.${format}.js`;
+      },
     },
     sourcemap: true,
     // Reduce bloat from legacy polyfills.


### PR DESCRIPTION
## Description

The goal is to be able to use the design tokens in the playground-ui AND in the cli/playground one. The problem is that playground-ui is bundled as ESM and the tailwind config of cli/playground only supports cjs.

This PR introduces an additional "token" entry to the playground-ui vite config file so that we can compile it to ESM and CJS.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
