### PR TITLE
fix typo embed-chunk-array.mdx

### DIFF
--- a/docs/src/content/examples/rag/embedding/embed-chunk-array.mdx
+++ b/docs/src/content/examples/rag/embedding/embed-chunk-array.mdx
@@ -18,7 +18,7 @@ const doc = MDocument.fromText("Your text content...");
 
 const chunks = await doc.chunk();
 
-const { embeddings } = await embed({
+const { embeddings } = await embedMany({
   model: openai.embedding('text-embedding-3-small'),
   values: chunks.map(chunk => chunk.text),
 });


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fix a typo in the docs. Current doc says `embed` https://mastra.ai/examples/rag/embedding/embed-chunk-array when the method should be `embedMany` as your example on Github rightfully states https://github.com/mastra-ai/mastra/blob/main/examples/basics/rag/embed-chunk-array/index.ts

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
