### PR TITLE
chore(playground-ui): add failed status icon

### DIFF
--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -192,6 +192,8 @@ export function WorkflowTrigger({
                       const statusIcon =
                         status === 'Completed' ? (
                           <div className="w-2 h-2 bg-green-500 rounded-full" />
+                        ) : status === 'Failed' ? (
+                          <div className="w-2 h-2 bg-red-500 rounded-full" />
                         ) : (
                           <div className="w-2 h-2 bg-yellow-500 rounded-full animate-pulse" />
                         );


### PR DESCRIPTION
## Description

Previously, when a workflow failed in playground-ui, the status icon remained as pending.
This update adds a failed status icon to make it easier to identify failed workflows.

<img width="1719" alt="スクリーンショット 2025-04-12 午後10 49 13" src="https://github.com/user-attachments/assets/7a519f35-3647-44e6-b6b4-50874a54dbe3" />


## Related Issue(s)

None

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
