### PR TITLE
Fix events registration and usage in workflows

### DIFF
--- a/.changeset/cuddly-beers-join.md
+++ b/.changeset/cuddly-beers-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix workflow events discovery

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -3047,7 +3047,7 @@ describe('Workflow', async () => {
       });
     });
 
-    it('should handle basic event based resume flow', async () => {
+    it('should handle basic event based resume flow with events registered on workflow', async () => {
       const getUserInputAction = vi.fn().mockResolvedValue({ userInput: 'test input' });
       const promptAgentAction = vi
         .fn()
@@ -3086,12 +3086,76 @@ describe('Workflow', async () => {
       });
 
       const wf = mastra.getWorkflow('test-workflow');
+      const run = wf.createRun();
+
+      const initialResult = await run.start({ triggerData: { input: 'test' } });
+      expect(initialResult.activePaths.size).toBe(1);
+      expect(initialResult.results).toEqual({
+        getUserInput: { status: 'success', output: { userInput: 'test input' } },
+        __testev_event: { status: 'suspended' },
+      });
+      expect(getUserInputAction).toHaveBeenCalledTimes(1);
+
+      const firstResumeResult = await run.resumeWithEvent('testev', {
+        catName: 'test input for resumption',
+      });
+
+      if (!firstResumeResult) {
+        throw new Error('Resume failed to return a result');
+      }
+
+      expect(firstResumeResult.activePaths.size).toBe(1);
+      expect(firstResumeResult.results).toEqual({
+        getUserInput: { status: 'success', output: { userInput: 'test input' } },
+        promptAgent: { status: 'success', output: { test: 'yes' } },
+        __testev_event: {
+          status: 'success',
+          output: {
+            executed: true,
+            resumedEvent: {
+              catName: 'test input for resumption',
+            },
+          },
+        },
+      });
+    });
+
+    it('should handle event based resume flow with events registered on run', async () => {
+      const getUserInputAction = vi.fn().mockResolvedValue({ userInput: 'test input' });
+      const promptAgentAction = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          return { test: 'yes' };
+        })
+        .mockImplementationOnce(() => ({ modelOutput: 'test output' }));
+      const getUserInput = new Step({
+        id: 'getUserInput',
+        execute: getUserInputAction,
+        outputSchema: z.object({ userInput: z.string() }),
+      });
+      const promptAgent = new Step({
+        id: 'promptAgent',
+        execute: promptAgentAction,
+        outputSchema: z.object({ modelOutput: z.string() }),
+      });
+
+      const promptEvalWorkflow = new Workflow({
+        name: 'test-workflow',
+        triggerSchema: z.object({ input: z.string() }),
+      });
+
+      promptEvalWorkflow.step(getUserInput).afterEvent('testev').step(promptAgent).commit();
+
+      const mastra = new Mastra({
+        logger,
+        workflows: { 'test-workflow': promptEvalWorkflow },
+      });
+
+      const wf = mastra.getWorkflow('test-workflow');
       const run = wf.createRun({
         events: {
           testev: {
-            schema: z.object({
-              catName: z.string(),
-            }),
+            schema: z.object({ catName: z.string() }),
           },
         },
       });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -926,7 +926,10 @@ export class Workflow<
       onFinish: () => {
         this.#runs.delete(run.runId);
       },
-      events,
+      events: {
+        ...this.events,
+        ...events,
+      },
     });
     this.#runs.set(run.runId, run);
     return {
@@ -1189,7 +1192,7 @@ export class Workflow<
       return activeRun.resume({ stepId, context: resumeContext, container });
     }
 
-    const run = this.createRun({ runId });
+    const run = this.createRun({ runId, events: this.events });
     return run.resume({ stepId, context: resumeContext, container });
   }
 
@@ -1211,7 +1214,8 @@ export class Workflow<
 
   async resumeWithEvent(runId: string, eventName: string, data: any) {
     this.logger.warn(`Please use 'resumeWithEvent' on the 'createRun' call instead, resumeWithEvent is deprecated`);
-    const event = this.events?.[eventName];
+    const run = this.#runs.get(runId);
+    const event = this.events?.[eventName] ?? run?.events?.[eventName];
     if (!event) {
       throw new Error(`Event ${eventName} not found`);
     }

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -869,10 +869,11 @@ export class Workflow<
   }
 
   afterEvent(eventName: string) {
-    const event = this.events?.[eventName];
-    if (!event) {
-      throw new Error(`Event ${eventName} not found`);
-    }
+    // if the event was defined on run, it won't exist at this point
+    // const event = this.events?.[eventName];
+    // if (!event) {
+    //   throw new Error(`Event ${eventName} not found`);
+    // }
 
     const lastStep = this.#steps[this.#lastStepStack[this.#lastStepStack.length - 1] ?? ''];
     if (!lastStep) {
@@ -912,6 +913,8 @@ export class Workflow<
     runId?: string;
     events?: Record<string, { schema: z.ZodObject<any> }>;
   } = {}): WorkflowResultReturn<TResultSchema, TTriggerSchema, TSteps> {
+    this.events = { ...this.events, ...events };
+
     const run = new WorkflowInstance<TSteps, TTriggerSchema, TResultSchema>({
       logger: this.logger,
       name: this.name,
@@ -926,10 +929,7 @@ export class Workflow<
       onFinish: () => {
         this.#runs.delete(run.runId);
       },
-      events: {
-        ...this.events,
-        ...events,
-      },
+      events: this.events,
     });
     this.#runs.set(run.runId, run);
     return {


### PR DESCRIPTION
## Description

When `events` are registered on the `Workflow` class, and an attempt is made to resume the workflow using the `resumeWithEvent` method on a run, we run into `Event not found` errors due to a bug with the runs not getting injected into the `events` collection of the run.

https://linear.app/kepler-crm/issue/MASTRA-3046/workflows-events-issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
