### PR TITLE
fix(playground-ui): enum trigger schema cannot submit

### DIFF
--- a/.changeset/purple-yaks-attend.md
+++ b/.changeset/purple-yaks-attend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+enum-type trigger schemas could not be submitted in the Playground UI has been resolved.

--- a/packages/playground-ui/src/components/ui/autoform/components/SelectField.tsx
+++ b/packages/playground-ui/src/components/ui/autoform/components/SelectField.tsx
@@ -12,7 +12,7 @@ export const SelectField: React.FC<AutoFormFieldProps> = ({ field, inputProps, e
         const syntheticEvent = {
           target: {
             value,
-            name: field.key,
+            name: inputProps.name,
           },
         } as React.ChangeEvent<HTMLInputElement>;
         props.onChange(syntheticEvent);


### PR DESCRIPTION
## Description

When the trigger schema is an enum, couldn't submit due to a validation error.

<img width="1464" alt="スクリーンショット 2025-04-14 午後8 58 33" src="https://github.com/user-attachments/assets/193c9408-ff04-42dc-9cf7-7c927b1d36d6" />

After the fix, the form was submitted successfully.

<img width="1464" alt="スクリーンショット 2025-04-14 午後9 10 48" src="https://github.com/user-attachments/assets/b872fad5-91ff-4da7-872c-b799f67f5133" />


## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
