### PR TITLE
[draft] Proposal for removing playground, Swagger UI and OpenAPI from build output

### DIFF
--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -1,9 +1,9 @@
 import { FileService } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
-import * as fsExtra from 'fs-extra';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { BundlerOptions } from '@mastra/core/bundler';
 
 export class BuildBundler extends Bundler {
   constructor() {
@@ -29,13 +29,21 @@ export class BuildBundler extends Bundler {
     await super.prepare(outputDirectory);
   }
 
-  bundle(entryFile: string, outputDirectory: string): Promise<void> {
-    return this._bundle(this.getEntry(), entryFile, outputDirectory);
+  bundle(entryFile: string, outputDirectory: string, options: BundlerOptions): Promise<void> {
+    return this._bundle(this.getEntry(options), entryFile, outputDirectory);
   }
 
-  protected getEntry(): string {
+  protected getEntry(options: BundlerOptions): string {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
-    return readFileSync(join(__dirname, 'templates', 'dev.entry.js'), 'utf8');
+    const devEntryFile = readFileSync(join(__dirname, 'templates', 'dev.entry.js'), 'utf8');
+    return `
+    const options = {
+      playground: ${options.playground},
+      swaggerUI: ${options.swaggerUI},
+      openAPI: ${options.openAPI},
+    }
+    ${devEntryFile}
+    `;
   }
 }

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -6,7 +6,17 @@ import { BuildBundler } from './BuildBundler';
 import { getDeployer } from '@mastra/deployer';
 import { logger } from '../../utils/logger';
 
-export async function build({ dir }: { dir?: string }) {
+export async function build({
+  dir,
+  excludePlayground,
+  excludeSwaggerUI,
+  excludeOpenAPI,
+}: {
+  dir?: string;
+  excludePlayground?: boolean;
+  excludeSwaggerUI?: boolean;
+  excludeOpenAPI?: boolean;
+}) {
   const mastraDir = dir ?? join(process.cwd(), 'src', 'mastra');
   const outputDirectory = join(process.cwd(), '.mastra');
 
@@ -19,7 +29,12 @@ export async function build({ dir }: { dir?: string }) {
     if (!platformDeployer) {
       const deployer = new BuildBundler();
       await deployer.prepare(outputDirectory);
-      await deployer.bundle(mastraEntryFile, outputDirectory);
+
+      await deployer.bundle(mastraEntryFile, outputDirectory, {
+        playground: excludePlayground ? false : true,
+        swaggerUI: excludeSwaggerUI ? false : true,
+        openAPI: excludeOpenAPI ? false : true,
+      });
       return;
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -163,12 +163,20 @@ program
   .command('build')
   .description('Build your Mastra project')
   .option('-d, --dir <path>', 'Path to directory')
+  .option('--exclude-playground', 'Whether to exclude playground routes')
+  .option('--exclude-swaggerUI', 'Whether to exclude swagger UI routes')
+  .option('--exclude-openAPI', 'Whether to exclude Open API spec')
   .action(async args => {
     await analytics.trackCommandExecution({
       command: 'mastra build',
       args,
       execution: async () => {
-        await build({ dir: args.dir });
+        await build({
+          dir: args.dir,
+          excludePlayground: Boolean(args.excludePlayground),
+          excludeSwaggerUI: Boolean(args.excludeSwaggerUI),
+          excludeOpenAPI: Boolean(args.excludeOpenAPI),
+        });
       },
       origin,
     });

--- a/packages/cli/src/templates/dev.entry.js
+++ b/packages/cli/src/templates/dev.entry.js
@@ -6,8 +6,13 @@ import { TABLE_EVALS } from '@mastra/core/storage';
 import { checkEvalStorageFields } from '@mastra/core/utils';
 import { mastra } from '#mastra';
 import { createNodeServer } from '#server';
+
 // @ts-ignore
-await createNodeServer(mastra, { playground: true, swaggerUI: true });
+await createNodeServer(mastra, {
+  playground: options?.playground ?? true,
+  swaggerUI: options?.swaggerUI ?? true,
+  openAPI: options?.openAPI ?? true,
+});
 
 registerHook(AvailableHooks.ON_GENERATION, ({ input, output, metric, runId, agentName, instructions }) => {
   evaluate({

--- a/packages/core/src/bundler/index.ts
+++ b/packages/core/src/bundler/index.ts
@@ -3,10 +3,16 @@ import { parse } from 'dotenv';
 
 import { MastraBase } from '../base';
 
+export type BundlerOptions = {
+  playground?: boolean;
+  swaggerUI?: boolean;
+  openAPI?: boolean;
+};
+
 export interface IBundler {
   loadEnvVars(): Promise<Map<string, string>>;
   getEnvFiles(): Promise<string[]>;
-  bundle(entryFile: string, outputDirectory: string): Promise<void>;
+  bundle(entryFile: string, outputDirectory: string, options?: BundlerOptions): Promise<void>;
   prepare(outputDirectory: string): Promise<void>;
   writePackageJson(outputDirectory: string, dependencies: Map<string, string>): Promise<void>;
 }
@@ -35,5 +41,5 @@ export abstract class MastraBundler extends MastraBase implements IBundler {
   abstract writePackageJson(outputDirectory: string, dependencies: Map<string, string>): Promise<void>;
   abstract writeInstrumentationFile(outputDirectory: string): Promise<void>;
   abstract getEnvFiles(): Promise<string[]>;
-  abstract bundle(entryFile: string, outputDirectory: string): Promise<void>;
+  abstract bundle(entryFile: string, outputDirectory: string, options?: BundlerOptions): Promise<void>;
 }


### PR DESCRIPTION
## Description

> [!NOTE]
> This is a draft PR including a locally tested proposal that, if accepted, needs to take into account the deployers more carefully

This PR adds new command line flags to the mastra build command that allow excluding the playground, Swagger UI, and OpenAPI spec from the build `output` dir.

My strategy was to scope changes to the current build process for regular mastra build output while maintaining backward compatibility. The implementation passes configuration options through the build pipeline to control which components are included at server creation time.

Given how tight the build and deployer APIs are, most of my concerns are around if extending the Builder `bundle` method is the right approach or if it's too risky.

Key changes:

Added CLI flags: --exclude-playground, --exclude-swaggerUI, and --exclude-openAPI
Created a BundlerOptions type to pass these configurations through the build process
Modified the entry file generation to include these options
Updated the server creation process to respect these options

## Related Issue(s)

#3623

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
