### PR TITLE
fix(@mastra/memory, @mastra/core): ensure all new messages are saved atleast 1ms apart

### DIFF
--- a/.changeset/violet-dogs-peel.md
+++ b/.changeset/violet-dogs-peel.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fixed an issue where some user messages and llm messages would have the exact same createdAt date, leading to incorrect message ordering. Added a fix for new messages as well as any that were saved before the fix in the wrong order

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -238,10 +238,11 @@ export class Agent<
 
       const newMessages = ensureAllMessagesAreCoreMessages(userMessages);
 
-      const messages = newMessages.map(u => {
+      const now = Date.now();
+      const messages = newMessages.map((u, index) => {
         return {
           id: this.getMemory()?.generateId()!,
-          createdAt: new Date(),
+          createdAt: new Date(now + index),
           threadId: threadId,
           ...u,
           content: u.content as UserContent | AssistantContent,
@@ -316,6 +317,7 @@ export class Agent<
     if (!response.messages) return [];
     const messagesArray = Array.isArray(response.messages) ? response.messages : [response.messages];
 
+    const now = Date.now();
     return this.sanitizeResponseMessages(messagesArray).map((message: CoreMessage | CoreAssistantMessage, index) => {
       const messageId = randomUUID();
       let toolCallIds: string[] | undefined;
@@ -360,7 +362,7 @@ export class Agent<
         resourceId: resourceId,
         role: message.role as any,
         content: message.content as any,
-        createdAt: new Date(Date.now() + index), // use Date.now() + index to make sure every message is atleast one millisecond apart
+        createdAt: new Date(now + index), // use Date.now() + index to make sure every message is atleast one millisecond apart
         toolCallIds: toolCallIds?.length ? toolCallIds : undefined,
         toolCallArgs: toolCallArgs?.length ? toolCallArgs : undefined,
         toolNames: toolNames?.length ? toolNames : undefined,
@@ -795,11 +797,12 @@ export class Agent<
           try {
             const userMessage = this.getMostRecentUserMessage(messages);
             const newMessages = userMessage ? [userMessage] : messages;
+            const now = Date.now();
             const threadMessages = this.sanitizeResponseMessages(ensureAllMessagesAreCoreMessages(newMessages)).map(
-              u => {
+              (u, index) => {
                 return {
                   id: this.getMemory()?.generateId()!,
-                  createdAt: new Date(),
+                  createdAt: new Date(now + index),
                   threadId: thread.id,
                   resourceId: resourceId,
                   ...u,

--- a/packages/memory/integration-tests/src/reusable-tests.ts
+++ b/packages/memory/integration-tests/src/reusable-tests.ts
@@ -320,6 +320,10 @@ export function getResuableTests(memory: Memory) {
         // Create a unique tool call ID for matching tool calls with results
         const toolCallId = `test-call-${randomUUID()}`;
 
+        let count = 0;
+        const start = Date.now();
+        const getCreatedAt = () => new Date(start + ++count);
+
         // Create an assistant message with a tool call
         const toolCallMessage = {
           id: randomUUID(),
@@ -327,7 +331,7 @@ export function getResuableTests(memory: Memory) {
           resourceId,
           role: 'assistant' as const,
           type: 'text' as const,
-          createdAt: new Date(),
+          createdAt: getCreatedAt(),
           content: [
             { type: 'text' as const, text: 'I will call a tool' },
             {
@@ -340,7 +344,10 @@ export function getResuableTests(memory: Memory) {
         };
 
         // First create a standard text message from the user
-        const userMessage = createTestMessage(thread.id, 'A user message to start the conversation', 'user');
+        const userMessage = {
+          ...createTestMessage(thread.id, 'A user message to start the conversation', 'user'),
+          createdAt: getCreatedAt(),
+        };
 
         // Create a tool result message
         const toolResultMessage = {
@@ -349,7 +356,7 @@ export function getResuableTests(memory: Memory) {
           resourceId,
           role: 'assistant' as const,
           type: 'text' as const,
-          createdAt: new Date(Date.now() + 2000),
+          createdAt: getCreatedAt(),
           content: [
             {
               type: 'tool-result' as const,
@@ -445,6 +452,135 @@ export function getResuableTests(memory: Memory) {
           },
         });
         expect(result.messages[0].content).toEqual(complexMessage);
+      });
+
+      it('should reorder tool calls with multiple messages in between', async () => {
+        // Create a unique tool call ID for matching tool calls with results
+        const toolCallId = `test-call-${randomUUID()}`;
+
+        let count = 0;
+        const start = Date.now();
+        const getCreatedAt = () => new Date(start + ++count * 1000);
+
+        // Create an assistant message with a tool call
+        const toolCallMessage = {
+          id: randomUUID(),
+          threadId: thread.id as string,
+          resourceId,
+          role: 'assistant' as const,
+          type: 'text' as const,
+          createdAt: getCreatedAt(),
+          content: [
+            { type: 'text' as const, text: 'I will call a tool' },
+            {
+              type: 'tool-call' as const,
+              toolCallId,
+              toolName: 'test-tool',
+              args: { test: true },
+            },
+          ],
+        };
+
+        // Create two user messages
+        const userMessage1 = {
+          ...createTestMessage(thread.id, 'First user message in between', 'user'),
+          createdAt: getCreatedAt(),
+        };
+        const userMessage2 = {
+          ...createTestMessage(thread.id, 'Second user message in between', 'user'),
+          createdAt: getCreatedAt(),
+        };
+
+        // Create a tool result message
+        const toolResultMessage = {
+          id: randomUUID(),
+          threadId: thread.id,
+          resourceId,
+          role: 'assistant' as const,
+          type: 'text' as const,
+          createdAt: getCreatedAt(),
+          content: [
+            {
+              type: 'tool-result' as const,
+              toolCallId,
+              toolName: 'test-tool',
+              result: 'test result',
+            },
+          ],
+        };
+
+        // Create messages in the wrong order: tool call, user1, user2, tool result
+        const rawMessages = [toolCallMessage, userMessage1, userMessage2, toolResultMessage];
+        console.log(JSON.stringify({ rawMessages }, null, 2));
+
+        // Verify the reordering function works correctly
+        const reorderedMessages = reorderToolCallsAndResults(rawMessages);
+
+        // Now verify the reordering:
+        // 1. All messages should still be present
+        expect(reorderedMessages.length).toBe(4);
+
+        // 2. User messages should remain in their relative order
+        expect(reorderedMessages[0]).toBe(userMessage1);
+        expect(reorderedMessages[1]).toBe(userMessage2);
+
+        // 3. Tool call should come directly before tool result
+        expect(reorderedMessages[2]).toBe(toolCallMessage);
+        expect(reorderedMessages[3]).toBe(toolResultMessage);
+
+        // PART 2: INTEGRATION TEST
+        const integrationThread = await memory.createThread({
+          resourceId,
+          title: 'Multiple Messages Tool Order Test',
+        });
+
+        // Create copies of our test messages with the correct new threadId
+        const integrationToolCallMessage = {
+          ...toolCallMessage,
+          id: randomUUID(),
+          threadId: integrationThread.id,
+        };
+
+        const integrationUserMessage1 = {
+          ...userMessage1,
+          id: randomUUID(),
+          threadId: integrationThread.id,
+        };
+
+        const integrationUserMessage2 = {
+          ...userMessage2,
+          id: randomUUID(),
+          threadId: integrationThread.id,
+        };
+
+        const integrationToolResultMessage = {
+          ...toolResultMessage,
+          id: randomUUID(),
+          threadId: integrationThread.id,
+        };
+
+        // Save messages in the wrong order intentionally
+        await memory.saveMessages({ messages: [integrationToolCallMessage] });
+        await memory.saveMessages({ messages: [integrationUserMessage1] });
+        await memory.saveMessages({ messages: [integrationUserMessage2] });
+        await memory.saveMessages({ messages: [integrationToolResultMessage] });
+
+        // Retrieve messages through rememberMessages
+        const result = await memory.rememberMessages({
+          threadId: integrationThread.id,
+          config: { lastMessages: 10 },
+        });
+
+        // Check that all messages are present
+        expect(result.messages.length).toBe(4);
+
+        console.log(JSON.stringify({ result: result.messages }, null, 2));
+
+        // Verify message order directly by index
+        expect(result.messages[0].id).toBe(integrationUserMessage1.id);
+        expect(result.messages[1].id).toBe(integrationUserMessage2.id);
+        expect(result.messages[2].id).toBe(integrationToolCallMessage.id);
+        expect(result.messages[3].id).toBe(integrationToolResultMessage.id);
       });
     });
 

--- a/packages/memory/integration-tests/src/reusable-tests.ts
+++ b/packages/memory/integration-tests/src/reusable-tests.ts
@@ -511,7 +511,6 @@ export function getResuableTests(memory: Memory) {
 
         // Create messages in the wrong order: tool call, user1, user2, tool result
         const rawMessages = [toolCallMessage, userMessage1, userMessage2, toolResultMessage];
-        console.log(JSON.stringify({ rawMessages }, null, 2));
 
         // Verify the reordering function works correctly
         const reorderedMessages = reorderToolCallsAndResults(rawMessages);
@@ -573,8 +572,6 @@ export function getResuableTests(memory: Memory) {
 
         // Check that all messages are present
         expect(result.messages.length).toBe(4);
-
-        console.log(JSON.stringify({ result: result.messages }, null, 2));
 
         // Verify message order directly by index
         expect(result.messages[0].id).toBe(integrationUserMessage1.id);

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -126,11 +126,73 @@ export class Memory extends MastraMemory {
       threadConfig: config,
     });
 
+    // Self-heal message ordering to ensure tool calls are directly before tool results
+    const reorderedMessages = this.reorderToolCallsAndResults(rawMessages);
+
     // Parse and convert messages
-    const messages = this.parseMessages(rawMessages);
-    const uiMessages = this.convertToUIMessages(rawMessages);
+    const messages = this.parseMessages(reorderedMessages);
+    const uiMessages = this.convertToUIMessages(reorderedMessages);
 
     return { messages, uiMessages };
+  }
+
+  /**
+   * Self-heals message ordering to ensure tool calls are directly before their corresponding tool results.
+   * Fixes cases where messages may be stored in incorrect order in the database.
+   */
+  private reorderToolCallsAndResults(messages: MessageType[]): MessageType[] {
+    if (!messages.length) return messages;
+    
+    const result = [...messages];
+    
+    // Find all tool result messages
+    for (let i = 0; i < result.length; i++) {
+      const message = result[i];
+      
+      // Skip if not a message with content array
+      if (!message || !Array.isArray(message.content)) continue;
+      
+      // Check each content item for tool results
+      for (const content of message.content) {
+        if (content.type === 'tool-result' && content.toolCallId) {
+          // If this is a tool result, find the corresponding tool call
+          const toolCallId = content.toolCallId;
+          let toolCallIndex = -1;
+          let toolCallMessage = null;
+          
+          // Find the message with matching tool call ID
+          for (let j = 0; j < result.length; j++) {
+            const candidateMessage = result[j];
+            if (!candidateMessage || !Array.isArray(candidateMessage.content)) continue;
+            
+            for (const candidateContent of candidateMessage.content) {
+              if (candidateContent.type === 'tool-call' && candidateContent.toolCallId === toolCallId) {
+                toolCallIndex = j;
+                toolCallMessage = candidateMessage;
+                break;
+              }
+            }
+            
+            if (toolCallIndex !== -1) break;
+          }
+          
+          // If tool call found and it's not directly before the tool result
+          if (toolCallIndex !== -1 && toolCallMessage && toolCallIndex !== i - 1) {
+            // Remove the tool call message from its current position
+            result.splice(toolCallIndex, 1);
+            
+            // Adjust current index if needed (if tool call was before current position)
+            if (toolCallIndex < i) i--;
+            
+            // Insert the tool call message directly before the tool result message
+            result.splice(i, 0, toolCallMessage);
+            i++; // Increment i since we inserted a message
+          }
+        }
+      }
+    }
+    
+    return result;
   }
 
   async rememberMessages({

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -8,6 +8,7 @@ import { Tiktoken } from 'js-tiktoken/lite';
 import o200k_base from 'js-tiktoken/ranks/o200k_base';
 import xxhash from 'xxhash-wasm';
 import { updateWorkingMemoryTool } from './tools/working-memory';
+import { reorderToolCallsAndResults } from './utils';
 
 const encoder = new Tiktoken(o200k_base);
 
@@ -127,72 +128,13 @@ export class Memory extends MastraMemory {
     });
 
     // Self-heal message ordering to ensure tool calls are directly before tool results
-    const reorderedMessages = this.reorderToolCallsAndResults(rawMessages);
+    const reorderedMessages = reorderToolCallsAndResults(rawMessages);
 
     // Parse and convert messages
     const messages = this.parseMessages(reorderedMessages);
     const uiMessages = this.convertToUIMessages(reorderedMessages);
 
     return { messages, uiMessages };
-  }
-
-  /**
-   * Self-heals message ordering to ensure tool calls are directly before their corresponding tool results.
-   * Fixes cases where messages may be stored in incorrect order in the database.
-   */
-  private reorderToolCallsAndResults(messages: MessageType[]): MessageType[] {
-    if (!messages.length) return messages;
-    
-    const result = [...messages];
-    
-    // Find all tool result messages
-    for (let i = 0; i < result.length; i++) {
-      const message = result[i];
-      
-      // Skip if not a message with content array
-      if (!message || !Array.isArray(message.content)) continue;
-      
-      // Check each content item for tool results
-      for (const content of message.content) {
-        if (content.type === 'tool-result' && content.toolCallId) {
-          // If this is a tool result, find the corresponding tool call
-          const toolCallId = content.toolCallId;
-          let toolCallIndex = -1;
-          let toolCallMessage = null;
-          
-          // Find the message with matching tool call ID
-          for (let j = 0; j < result.length; j++) {
-            const candidateMessage = result[j];
-            if (!candidateMessage || !Array.isArray(candidateMessage.content)) continue;
-            
-            for (const candidateContent of candidateMessage.content) {
-              if (candidateContent.type === 'tool-call' && candidateContent.toolCallId === toolCallId) {
-                toolCallIndex = j;
-                toolCallMessage = candidateMessage;
-                break;
-              }
-            }
-            
-            if (toolCallIndex !== -1) break;
-          }
-          
-          // If tool call found and it's not directly before the tool result
-          if (toolCallIndex !== -1 && toolCallMessage && toolCallIndex !== i - 1) {
-            // Remove the tool call message from its current position
-            result.splice(toolCallIndex, 1);
-            
-            // Adjust current index if needed (if tool call was before current position)
-            if (toolCallIndex < i) i--;
-            
-            // Insert the tool call message directly before the tool result message
-            result.splice(i, 0, toolCallMessage);
-            i++; // Increment i since we inserted a message
-          }
-        }
-      }
-    }
-    
-    return result;
   }
 
   async rememberMessages({

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -127,12 +127,14 @@ export class Memory extends MastraMemory {
       threadConfig: config,
     });
 
-    // Self-heal message ordering to ensure tool calls are directly before tool results
-    const reorderedMessages = reorderToolCallsAndResults(rawMessages);
+    // First sort messages by date
+    const orderedByDate = rawMessages.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    // Then reorder tool calls to be directly before their results
+    const reorderedToolCalls = reorderToolCallsAndResults(orderedByDate);
 
     // Parse and convert messages
-    const messages = this.parseMessages(reorderedMessages);
-    const uiMessages = this.convertToUIMessages(reorderedMessages);
+    const messages = this.parseMessages(reorderedToolCalls);
+    const uiMessages = this.convertToUIMessages(reorderedToolCalls);
 
     return { messages, uiMessages };
   }

--- a/packages/memory/src/utils/index.ts
+++ b/packages/memory/src/utils/index.ts
@@ -67,12 +67,19 @@ export function reorderToolCallsAndResults(messages: MessageType[]): MessageType
       continue; // Tool call is already in the correct position
     }
 
-    // Check if tool call is at resultIndex - 2
-    const secondMessagePrev = results[resultIndex - 2];
-    if (secondMessagePrev && isToolCallWithId(secondMessagePrev, toolCallId)) {
-      // Move the tool call to be directly before the tool result
-      results.splice(resultIndex - 2, 1); // Remove from -2 position
-      results.splice(resultIndex - 1, 0, secondMessagePrev); // Insert at the new -1 position
+    // Find the tool call anywhere in the array
+    const toolCallIndex = results.findIndex(message => isToolCallWithId(message, toolCallId));
+
+    if (toolCallIndex !== -1 && toolCallIndex !== resultIndex - 1) {
+      // Store the tool call message
+      const toolCall = results[toolCallIndex];
+      if (!toolCall) continue;
+
+      // Remove the tool call from its current position
+      results.splice(toolCallIndex, 1);
+
+      // Insert right before the tool result
+      results.splice(resultIndex - 1, 0, toolCall);
     }
   }
 

--- a/packages/memory/src/utils/index.ts
+++ b/packages/memory/src/utils/index.ts
@@ -15,6 +15,7 @@ const isToolCallWithId = (message: MessageType | undefined, targetToolCallId: st
 
 /**
  * Self-heals message ordering to ensure tool calls are directly before their matching tool results.
+ * This is needed due to a bug where messages were saved in the wrong order. That bug is fixed, but this code ensures any tool calls saved in the wrong order in the past will still be usable now.
  */
 export function reorderToolCallsAndResults(messages: MessageType[]): MessageType[] {
   if (!messages.length) return messages;

--- a/packages/memory/src/utils/index.ts
+++ b/packages/memory/src/utils/index.ts
@@ -1,0 +1,63 @@
+import type { MessageType } from "@mastra/core/memory";
+
+/**
+ * Self-heals message ordering to ensure tool calls are directly before their corresponding tool results.
+ * Fixes cases where messages may be stored in incorrect order in the database.
+ * This is needed to account for previous versions of memory where the new user message and an assistant message 
+ * had the exact same timestamp. In some cases it would be fine, in others the two messages would have 
+ * their order swapped so it went tool call, user message, tool result.
+ */
+export function reorderToolCallsAndResults(messages: MessageType[]): MessageType[] {
+  if (!messages.length) return messages;
+
+  const result = [...messages];
+
+  // Find all tool result messages
+  for (let i = 0; i < result.length; i++) {
+    const message = result[i];
+
+    // Skip if not a message with content array
+    if (!message || !Array.isArray(message.content)) continue;
+
+    // Check each content item for tool results
+    for (const content of message.content) {
+      if (content.type === 'tool-result' && content.toolCallId) {
+        // If this is a tool result, find the corresponding tool call
+        const toolCallId = content.toolCallId;
+        let toolCallIndex = -1;
+        let toolCallMessage = null;
+
+        // Find the message with matching tool call ID
+        for (let j = 0; j < result.length; j++) {
+          const candidateMessage = result[j];
+          if (!candidateMessage || !Array.isArray(candidateMessage.content)) continue;
+
+          for (const candidateContent of candidateMessage.content) {
+            if (candidateContent.type === 'tool-call' && candidateContent.toolCallId === toolCallId) {
+              toolCallIndex = j;
+              toolCallMessage = candidateMessage;
+              break;
+            }
+          }
+
+          if (toolCallIndex !== -1) break;
+        }
+
+        // If tool call found and it's not directly before the tool result
+        if (toolCallIndex !== -1 && toolCallMessage && toolCallIndex !== i - 1) {
+          // Remove the tool call message from its current position
+          result.splice(toolCallIndex, 1);
+
+          // Adjust current index if needed (if tool call was before current position)
+          if (toolCallIndex < i) i--;
+
+          // Insert the tool call message directly before the tool result message
+          result.splice(i, 0, toolCallMessage);
+          i++; // Increment i since we inserted a message
+        }
+      }
+    }
+  }
+
+  return result;
+} 


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/3603, https://github.com/mastra-ai/mastra/issues/3448, https://discord.com/channels/1309558646228779139/1360536672865091716/1360726058760011857, and https://discord.com/channels/1309558646228779139/1358426023384842368/1358426023384842368

Some places in the code were setting createdAt dates atleast 1ms apart, while other places weren't. This PR adds +index ms when creating dates in loops. I also added a function that will fix any tool calls that were previously saved in the wrong order, and added some tests!