### PR TITLE
feat: send mcp name on error

### DIFF
--- a/.changeset/brave-hornets-refuse.md
+++ b/.changeset/brave-hornets-refuse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+send mcp name on error connecting to it

--- a/packages/mcp/src/configuration.ts
+++ b/packages/mcp/src/configuration.ts
@@ -117,7 +117,7 @@ To fix this you have three different options:
       this.logger.error(`MCPConfiguration errored connecting to MCP server ${name}`, {
         error: e instanceof Error ? e.message : String(e),
       });
-      throw e;
+      throw new Error(`Failed to connect to MCP server ${name}: ${e instanceof Error ? e.message : String(e)}`);
     }
 
     this.logger.debug(`Connected to ${name} MCP server`);


### PR DESCRIPTION
## Description

<img width="844" alt="Screenshot 2025-04-16 at 09 58 16" src="https://github.com/user-attachments/assets/2fc0051d-09f3-44ec-b783-1904e46cf137" />


If there a connection error on any MCP tool, we log the name of which tool had the issue. But the error that we then throw doesn't include that metadata. That makes it harder for the consumer to know which of those tools is the one that failed.

This PR includes the name of the tool that failed in the error message.

## Type of Change
- [X] Code refactoring

## Checklist

- [X] I have performed a self-review of my own code
- [x] I have generated a changeset for this PR
