### PR TITLE
fix(@mastra/core): extra safety for message ordering

### DIFF
--- a/.changeset/clever-lions-strive.md
+++ b/.changeset/clever-lions-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added an extra safety for Memory message ordering

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -309,15 +309,16 @@ export class Agent<
     response,
     threadId,
     resourceId,
+    now,
   }: {
     response: any; // why??
     threadId: string;
     resourceId: string;
+    now: number;
   }) {
     if (!response.messages) return [];
     const messagesArray = Array.isArray(response.messages) ? response.messages : [response.messages];
 
-    const now = Date.now();
     return this.sanitizeResponseMessages(messagesArray).map((message: CoreMessage | CoreAssistantMessage, index) => {
       const messageId = randomUUID();
       let toolCallIds: string[] | undefined;
@@ -820,6 +821,7 @@ export class Agent<
                 };
               },
             );
+            const dateResponseMessagesFrom = (threadMessages.at(-1)?.createdAt?.getTime?.() || Date.now()) + 1;
 
             // renaming the thread doesn't need to block finishing the req
             void (async () => {
@@ -843,7 +845,12 @@ export class Agent<
             await memory.saveMessages({
               messages: [
                 ...threadMessages,
-                ...this.getResponseMessages({ threadId, resourceId, response: result.response }),
+                ...this.getResponseMessages({
+                  threadId,
+                  resourceId,
+                  response: result.response,
+                  now: dateResponseMessagesFrom,
+                }),
               ],
               memoryConfig,
             });


### PR DESCRIPTION
Yesterday I merged https://github.com/mastra-ai/mastra/pull/3654 and today it occurred to me we can do this in an even safer way. This doesn't fix any reported bug but it should make it even more likely there isn't one lurking