### PR TITLE
getInitData<typeof workflow>() proposal

### DIFF
--- a/packages/core/src/workflows/vNext/default.ts
+++ b/packages/core/src/workflows/vNext/default.ts
@@ -190,6 +190,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
           mastra: this.mastra!,
           inputData: prevOutput,
           resumeData: resume?.steps[0]!.id === step.id ? resume?.resumePayload : undefined,
+          getInitData: () => stepResults?.input as any,
           getStepResult: (step: any) => {
             const result = stepResults[step.id];
             if (result?.status === 'success') {
@@ -326,6 +327,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
             const result = await cond({
               mastra: this.mastra!,
               inputData: prevOutput,
+              getInitData: () => stepResults?.input as any,
               getStepResult: (step: any) => {
                 if (!step?.id) {
                   return null;
@@ -442,6 +444,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       isTrue = await condition({
         mastra: this.mastra!,
         inputData: result.output,
+        getInitData: () => stepResults?.input as any,
         getStepResult: (step: any) => {
           if (!step?.id) {
             return null;

--- a/packages/core/src/workflows/vNext/step.ts
+++ b/packages/core/src/workflows/vNext/step.ts
@@ -8,7 +8,9 @@ export type ExecuteFunction<TStepInput, TStepOutput, TResumeSchema, TSuspendSche
   mastra: Mastra;
   inputData: TStepInput;
   resumeData?: TResumeSchema;
-  getInitData<T extends NewWorkflow<any, any, any, any, any>>(): z.infer<NonNullable<T['inputSchema']>>;
+  getInitData<T extends NewWorkflow<any, any, any, any, any>>(): T extends undefined
+    ? unknown
+    : z.infer<NonNullable<T['inputSchema']>>;
   getStepResult<T extends NewStep<any, any, any>>(
     stepId: T,
   ): T['outputSchema'] extends undefined ? unknown : z.infer<NonNullable<T['outputSchema']>>;

--- a/packages/core/src/workflows/vNext/step.ts
+++ b/packages/core/src/workflows/vNext/step.ts
@@ -1,12 +1,14 @@
 import type EventEmitter from 'events';
 import type { z } from 'zod';
 import type { Mastra } from '../..';
+import type { NewWorkflow } from './workflow';
 
 // Define a type for the execute function
 export type ExecuteFunction<TStepInput, TStepOutput, TResumeSchema, TSuspendSchema> = (params: {
   mastra: Mastra;
   inputData: TStepInput;
   resumeData?: TResumeSchema;
+  getInitData<T extends NewWorkflow<any, any, any, any, any>>(): z.infer<NonNullable<T['inputSchema']>>;
   getStepResult<T extends NewStep<any, any, any>>(
     stepId: T,
   ): T['outputSchema'] extends undefined ? unknown : z.infer<NonNullable<T['outputSchema']>>;

--- a/packages/core/src/workflows/vNext/workflow-next.test.ts
+++ b/packages/core/src/workflows/vNext/workflow-next.test.ts
@@ -248,6 +248,49 @@ describe('Workflow', () => {
         );
       });
 
+      it('should resolve trigger data from getInitData', async () => {
+        const execute = vi.fn<any>().mockResolvedValue({ result: 'success' });
+        const triggerSchema = z.object({
+          cool: z.string(),
+        });
+
+        const step1 = createStep({
+          id: 'step1',
+          execute,
+          inputSchema: triggerSchema,
+          outputSchema: z.object({ result: z.string() }),
+        });
+
+        const step2 = createStep({
+          id: 'step2',
+          execute: async ({ getInitData }) => {
+            const initData = getInitData<typeof workflow>();
+            return { result: initData };
+          },
+          inputSchema: z.object({ result: z.string() }),
+          outputSchema: z.object({ result: z.object({ cool: z.string() }) }),
+        });
+
+        const workflow = createWorkflow({
+          id: 'test-workflow',
+          inputSchema: triggerSchema,
+          outputSchema: z.object({ result: z.string() }),
+        });
+
+        workflow.then(step1).then(step2).commit();
+
+        const run = workflow.createRun();
+        const result = await run.start({ inputData: { cool: 'test-input' } });
+
+        expect(execute).toHaveBeenCalledWith(
+          expect.objectContaining({
+            inputData: { cool: 'test-input' },
+          }),
+        );
+
+        expect(result.steps.step2).toEqual({ status: 'success', output: { result: { cool: 'test-input' } } });
+      });
+
       it('should resolve variables from previous steps', async () => {
         const step1Action = vi.fn<any>().mockResolvedValue({
           nested: { value: 'step1-data' },


### PR DESCRIPTION
```ts
execute: async ({ getInitData }) => {
  const initData = getInitData<typeof workflow>();
  return { result: initData };
},
```

The challenge doing this without explicit arguments is that steps are not directly associated with workflows so there are no static type inference possibilities. 