### PR TITLE
Create separate sqllite store

### DIFF
--- a/.changeset/wet-candles-reply.md
+++ b/.changeset/wet-candles-reply.md
@@ -1,0 +1,8 @@
+---
+'create-mastra': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'mastra': patch
+---
+
+Add new @msstra/libsql package and use it in create-mastra

--- a/.github/workflows/test-combined-stores.yml
+++ b/.github/workflows/test-combined-stores.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
     paths:
       - 'stores/**'
-      - 'stores/*/package.json'
       - 'packages/core/**'
+      - 'stores/*/package.json'
       - '.github/workflows/test-combined-stores.yml'
 
 permissions:

--- a/.github/workflows/test-combined-stores.yml
+++ b/.github/workflows/test-combined-stores.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-stores
         run: |
-          STORES=$(ls -d stores/*/ | cut -f2 -d'/' | jq -R -s -c 'split("\n")[:-1]')
+          STORES=$(ls -d stores/*/ | grep -v '_test-utils' | cut -f2 -d'/' | jq -R -s -c 'split("\n")[:-1]')
           echo "stores=$STORES" >> $GITHUB_OUTPUT
   test:
     needs: setup

--- a/client-sdks/client-js/package.json
+++ b/client-sdks/client-js/package.json
@@ -33,6 +33,9 @@
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },
+  "peerDependencies": {
+    "zod": "^3.24.2"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -88,19 +88,17 @@ const memory = new Memory({
 ### Storage Configuration
 
 Conversation history relies on a [storage adapter](/reference/memory/Memory#parameters) to store messages.
+By default it uses the same storage provided to the [main Mastra instance](https://mastra.ai/reference/core/mastra-class#initialization)
 
 ```ts {7-12}
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
-import { LibSQLStore } from "@mastra/core/storage/libsql";
+import { LibSQLStore } from "@mastra/libsql";
 
 const agent = new Agent({
   memory: new Memory({
-    // this is the default storage db if omitted
     storage: new LibSQLStore({
-      config: {
-        url: "file:local.db",
-      },
+      url: "file:./local.db",
     }),
   }),
 });

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -63,20 +63,17 @@ Semantic recall relies on a [storage and vector db](/reference/memory/Memory#par
 ```ts {8-17}
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
-import { LibSQLStore } from "@mastra/core/storage/libsql";
-import { LibSQLVector } from "@mastra/core/vector/libsql";
+import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 
 const agent = new Agent({
   memory: new Memory({
     // this is the default storage db if omitted
     storage: new LibSQLStore({
-      config: {
-        url: "file:local.db",
-      },
+      url: "file:./local.db",
     }),
     // this is the default vector db if omitted
     vector: new LibSQLVector({
-      connectionUrl: "file:local.db",
+      connectionUrl: "file:./local.db",
     }),
   }),
 });

--- a/docs/src/content/en/docs/storage/overview.mdx
+++ b/docs/src/content/en/docs/storage/overview.mdx
@@ -32,13 +32,11 @@ Mastra can be configured with a default storage option:
 
 ```typescript copy
 import { Mastra } from "@mastra/core/mastra";
-import { DefaultStorage } from "@mastra/core/storage/libsql";
+import { LibSQLStore } from "@mastra/libsql";
 
 const mastra = new Mastra({
-  storage: new DefaultStorage({
-    config: {
-      url: "file:.mastra/mastra.db",
-    },
+  storage: new LibSQLStore({
+    url: "file:./mastra.db",
   }),
 });
 ```

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -281,16 +281,14 @@ By default, Mastra uses LibSQL as its storage engine:
 
 ```typescript
 import { Mastra } from "@mastra/core/mastra";
-import { DefaultStorage } from "@mastra/core/storage/libsql";
+import { LibSQLStore } from "@mastra/libsql";
 
 const mastra = new Mastra({
-  storage: new DefaultStorage({
-    config: {
-      url: "file:storage.db", // Local file-based database for development
-      // For production, use a persistent URL:
-      // url: process.env.DATABASE_URL,
-      // authToken: process.env.DATABASE_AUTH_TOKEN, // Optional for authenticated connections
-    },
+  storage: new LibSQLStore({
+    url: "file:./storage.db", // Local file-based database for development
+    // For production, use a persistent URL:
+    // url: process.env.DATABASE_URL,
+    // authToken: process.env.DATABASE_AUTH_TOKEN, // Optional for authenticated connections
   }),
 });
 ```

--- a/docs/src/content/en/reference/memory/Memory.mdx
+++ b/docs/src/content/en/reference/memory/Memory.mdx
@@ -18,19 +18,18 @@ const agent = new Agent({
 
 ```typescript copy showLineNumbers
 import { Memory } from "@mastra/memory";
-import { LibSQLStore } from "@mastra/core/storage/libsql";
-import { LibSQLVector } from "@mastra/core/vector/libsql";
+import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 import { Agent } from "@mastra/core/agent";
 
 const memory = new Memory({
   // Optional storage configuration - libsql will be used by default
   storage: new LibSQLStore({
-    url: "file:memory.db",
+    url: "file:./memory.db",
   }),
 
   // Optional vector database for semantic search - libsql will be used by default
   vector: new LibSQLVector({
-    url: "file:vector.db",
+    url: "file:./vector.db",
   }),
 
   // Memory configuration options
@@ -209,4 +208,3 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
 - [query](/reference/memory/query.mdx)
 - [getThreadById](/reference/memory/getThreadById.mdx)
 - [getThreadsByResourceId](/reference/memory/getThreadsByResourceId.mdx)
-

--- a/docs/src/content/en/reference/storage/libsql.mdx
+++ b/docs/src/content/en/reference/storage/libsql.mdx
@@ -16,20 +16,16 @@ npm install @mastra/storage-libsql
 ## Usage
 
 ```typescript copy showLineNumbers
-import { LibSQLStore } from "@mastra/core/storage/libsql";
+import { LibSQLStore } from "@mastra/libsql";
 
 // File database (development)
 const storage = new LibSQLStore({
-    config: {
-        url: 'file:storage.db',
-    }
+  url: "file:./storage.db",
 });
 
 // Persistent database (production)
 const storage = new LibSQLStore({
-    config: {
-        url: process.env.DATABASE_URL,
-    }
+  url: process.env.DATABASE_URL,
 });
 ```
 

--- a/e2e-tests/create-mastra/setup.js
+++ b/e2e-tests/create-mastra/setup.js
@@ -84,7 +84,7 @@ export async function setupRegistry(storageDirectory, port) {
     });
 
     execSync(
-      `pnpm --filter="create-mastra^..." --filter="create-mastra" publish --registry=http://localhost:${port}/ --no-git-checks --tag=create-mastra-e2e-test`,
+      `pnpm --filter="create-mastra^..." --filter="create-mastra" --filter="@mastra/libsql" publish --registry=http://localhost:${port}/ --no-git-checks --tag=create-mastra-e2e-test`,
       {
         cwd: rootDir,
         stdio: ['ignore', 'ignore', 'ignore'],

--- a/e2e-tests/pkg-outputs/bundle.test.ts
+++ b/e2e-tests/pkg-outputs/bundle.test.ts
@@ -17,6 +17,7 @@ let allPackages = await globby(
     '!./e2e-tests/**',
     '!**/mcp-docs-server/**',
     '!**/mcp-registry-registry/**',
+    '!**/stores/_test-utils/**',
   ],
   {
     cwd: resolve(__dirname, '..', '..'),

--- a/examples/dane/package.json
+++ b/examples/dane/package.json
@@ -33,6 +33,7 @@
     "@libsql/client": "^0.14.0",
     "@mastra/core": "workspace:*",
     "@mastra/github": "workspace:*",
+    "@mastra/libsql": "workspace:*",
     "@mastra/mcp": "workspace:*",
     "@mastra/memory": "workspace:*",
     "@mastra/rag": "workspace:*",

--- a/examples/dane/src/mastra/index.ts
+++ b/examples/dane/src/mastra/index.ts
@@ -1,5 +1,5 @@
 import { Mastra } from '@mastra/core';
-import { LibSQLStore } from '@mastra/core/storage/libsql';
+import { LibSQLStore } from '@mastra/libsql';
 
 import { dane, daneChangeLog, daneCommitMessage, daneIssueLabeler, daneLinkChecker } from './agents/index.js';
 import { daneNewContributor } from './agents/new-contributor.js';
@@ -22,9 +22,7 @@ export const mastra = new Mastra({
     daneNewContributor,
   },
   storage: new LibSQLStore({
-    config: {
-      url: ':memory:',
-    },
+    url: ':memory:',
   }),
   workflows: {
     message: messageWorkflow,

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -147,6 +147,9 @@ export const createMastraProject = async ({
   s.start('Installing @mastra/core');
   await installMastraDependency(pm, '@mastra/core', versionTag, false, timeout);
   s.stop('@mastra/core installed');
+  s.start('Installing @mastra/libsql');
+  await installMastraDependency(pm, '@mastra/libsql', versionTag, false, timeout);
+  s.stop('@mastra/libsql installed');
 
   s.start('Adding .gitignore');
   await exec(`echo output.txt >> .gitignore`);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -12,6 +12,7 @@ import {
   createMastraDir,
   getAISDKPackage,
   getAPIKey,
+  installCoreDeps,
   writeAPIKey,
   writeCodeSample,
   writeIndexFile,
@@ -66,6 +67,12 @@ export const init = async ({
           writeCodeSample(dirPath, component as Components, llmProvider, components as Components[]),
         ),
       ]);
+
+      const depService = new DepsService();
+      const depCheck = await depService.checkDependencies(['@mastra/libsql']);
+      if (depCheck !== 'ok') {
+        await depService.installPackages(['@mastra/libsql']);
+      }
     }
 
     const key = await getAPIKey(llmProvider || 'openai');

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -12,7 +12,6 @@ import {
   createMastraDir,
   getAISDKPackage,
   getAPIKey,
-  installCoreDeps,
   writeAPIKey,
   writeCodeSample,
   writeIndexFile,

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -365,6 +365,7 @@ ${addAgent ? `import { weatherAgent } from './agents';` : ''}
 export const mastra = new Mastra({
   ${filteredExports.join('\n  ')}
   storage: new LibSQLStore({
+    // stores telemetry, evals, ... into memory storage, if it needs to persist, change to file:../mastra.db
     url: ":memory:",
   }),
   logger: createLogger({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,7 +97,7 @@ program
       args,
       execution: async () => {
         await checkPkgJson();
-        await checkAndInstallCoreDeps();
+        await checkAndInstallCoreDeps(args?.example || args?.default);
 
         if (!Object.keys(args).length) {
           const result = await interactivePrompt();

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -3,8 +3,8 @@
 node_modules/
 dist/
 .env
-memory:
 *.d.ts
-vector/
-telemetry/
-storage/
+./memory
+./vector/
+./telemetry/
+./storage/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,16 @@
         "default": "./dist/storage/libsql/index.cjs"
       }
     },
+    "./storage/test-utils": {
+      "import": {
+        "types": "./dist/storage/test-utils/storage.d.ts",
+        "default": "./dist/storage/test-utils/storage.js"
+      },
+      "require": {
+        "types": "./dist/storage/test-utils/storage.d.cts",
+        "default": "./dist/storage/test-utils/storage.cjs"
+      }
+    },
     "./vector/libsql": {
       "import": {
         "types": "./dist/vector/libsql/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,16 +50,6 @@
         "default": "./dist/storage/libsql/index.cjs"
       }
     },
-    "./storage/test-utils": {
-      "import": {
-        "types": "./dist/storage/test-utils/storage.d.ts",
-        "default": "./dist/storage/test-utils/storage.js"
-      },
-      "require": {
-        "types": "./dist/storage/test-utils/storage.d.cts",
-        "default": "./dist/storage/test-utils/storage.cjs"
-      }
-    },
     "./vector/libsql": {
       "import": {
         "types": "./dist/vector/libsql/index.d.ts",

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -386,6 +386,17 @@ This is a warning for now, but will throw an error in the future
   }
 
   public setStorage(storage: MastraStorage) {
+    if (storage instanceof DefaultProxyStorage) {
+      this.#logger.warn(`Importing "DefaultStorage" from '@mastra/core/storage/libsql' is deprecated.
+
+Instead of:
+  import { DefaultStorage } from '@mastra/core/storage/libsql';
+
+Do:
+  import { LibSQLStore } from '@mastra/libsql';
+`);
+    }
+
     this.#storage = augmentWithInit(storage);
   }
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -82,7 +82,7 @@ export abstract class MastraMemory extends MastraBase {
     this.storage = augmentWithInit(this.storage);
 
     const semanticRecallIsEnabled = this.threadConfig.semanticRecall !== false; // default is to have it enabled, so any value except false means it's on
-
+    console.log(config);
     if (config.vector && semanticRecallIsEnabled) {
       this.vector = config.vector;
     } else if (
@@ -93,6 +93,7 @@ export abstract class MastraMemory extends MastraBase {
       semanticRecallIsEnabled
       // add the default vector store
     ) {
+      console.log(' are you seeying this papa?');
       // for backwards compat reasons, check if there's a memory-vector.db in cwd or in cwd/.mastra
       // if it's there we need to use it, otherwise use the same file:memory.db
       // We used to need two separate DBs because we would get schema errors
@@ -106,6 +107,20 @@ export abstract class MastraMemory extends MastraBase {
           `Found deprecated Memory vector db file ${oldDb} this db is now merged with the default ${newDb} file. Delete the old one to use the new one. You will need to migrate any data if that's important to you. For now the deprecated path will be used but in a future breaking change we will only use the new db file path.`,
         );
       }
+
+      setTimeout(() => {
+        this.logger?.warn(`
+
+The default vector storage is deprecated in Mastra Memory.
+
+import { LibSQLVector } from '@mastra/libsql';
+
+export const agent = new Agent({
+  new Memory({ vector: new LibSQLVector({ connectionUrl: 'file:../memory.db' }) })
+})
+  
+`);
+      }, 1000);
 
       this.vector = new DefaultVectorDB({
         connectionUrl: hasOldDb ? `file:${oldDb}` : `file:${newDb}`,
@@ -132,6 +147,17 @@ export abstract class MastraMemory extends MastraBase {
   }
 
   public setStorage(storage: MastraStorage) {
+    if (storage instanceof DefaultProxyStorage) {
+      this.logger?.warn(`Importing "DefaultStorage" from '@mastra/core/storage/libsql' is deprecated.
+
+Instead of:
+  import { DefaultStorage } from '@mastra/core/storage/libsql';
+
+Do:
+  import { LibSQLStore } from '@mastra/libsql';
+`);
+    }
+
     this.storage = storage;
   }
 

--- a/packages/core/src/storage/test-utils/storage.ts
+++ b/packages/core/src/storage/test-utils/storage.ts
@@ -6,7 +6,7 @@ import type { MastraStorage } from '../base';
 import { TABLE_WORKFLOW_SNAPSHOT, TABLE_EVALS, TABLE_MESSAGES, TABLE_THREADS } from '../constants';
 
 export function createTestSuite(storage: MastraStorage) {
-  describe('DefaultStorage', () => {
+  describe(storage.constructor.name, () => {
     // Sample test data factory functions to ensure unique records
     const createSampleThread = () => ({
       id: `thread-${randomUUID()}`,

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
     'src/*/index.ts',
     'src/workflows/vNext/index.ts',
     'src/storage/libsql/index.ts',
+    'src/storage/test-utils/storage.ts',
     'src/vector/libsql/index.ts',
     'src/vector/filter/index.ts',
     'src/telemetry/otel-vendor.ts',

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -46,7 +46,6 @@ export default defineConfig({
     'src/*/index.ts',
     'src/workflows/vNext/index.ts',
     'src/storage/libsql/index.ts',
-    'src/storage/test-utils/storage.ts',
     'src/vector/libsql/index.ts',
     'src/vector/filter/index.ts',
     'src/telemetry/otel-vendor.ts',

--- a/packages/create-mastra/turbo.json
+++ b/packages/create-mastra/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build", "@mastra/libsql#build", "@mastra/core#build"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4073,6 +4073,15 @@ importers:
         specifier: ^5.7.3
         version: 5.8.2
 
+  stores/_test-utils:
+    dependencies:
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      vitest:
+        specifier: '*'
+        version: 3.0.9(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.17.30)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+
   stores/astra:
     dependencies:
       '@datastax/astra-db-ts':
@@ -4258,6 +4267,9 @@ importers:
       '@internal/lint':
         specifier: workspace:*
         version: link:../../packages/_config
+      '@internal/storage-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
       '@microsoft/api-extractor':
         specifier: ^7.52.1
         version: 7.52.2(@types/node@20.17.30)
@@ -30533,7 +30545,7 @@ snapshots:
       eslint: 8.57.1
       eslint-config-prettier: 8.10.0(eslint@8.57.1)
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.10(@swc/helpers@0.5.15))(@types/node@20.17.30)(typescript@5.8.2)))(typescript@5.8.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8)
@@ -31226,7 +31238,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -31236,7 +31248,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@8.57.1)(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -31247,7 +31259,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.23.0(jiti@2.4.2)))(eslint@9.23.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -31303,7 +31315,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -31314,7 +31326,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -31343,7 +31355,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@8.57.1)(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -31372,7 +31384,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.23.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import-x@4.8.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-plugin-import@2.31.0)(eslint@9.23.0(jiti@2.4.2)))(eslint@9.23.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.23.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1385,6 +1385,9 @@ importers:
       '@mastra/github':
         specifier: workspace:*
         version: link:../../integrations/github
+      '@mastra/libsql':
+        specifier: workspace:*
+        version: link:../../stores/libsql
       '@mastra/mcp':
         specifier: workspace:*
         version: link:../../packages/mcp

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4243,6 +4243,37 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.17.30)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
+  stores/libsql:
+    dependencies:
+      '@libsql/client':
+        specifier: ^0.15.4
+        version: 0.15.4(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+      '@mastra/core':
+        specifier: workspace:^
+        version: link:../../packages/core
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@microsoft/api-extractor':
+        specifier: ^7.52.1
+        version: 7.52.2(@types/node@20.17.30)
+      '@types/node':
+        specifier: ^20.17.27
+        version: 20.17.30
+      eslint:
+        specifier: ^9.23.0
+        version: 9.23.0(jiti@2.4.2)
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(@microsoft/api-extractor@7.52.2(@types/node@20.17.30))(@swc/core@1.11.10(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.2
+      vitest:
+        specifier: ^3.0.9
+        version: 3.0.9(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.17.30)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+
   stores/pg:
     dependencies:
       '@mastra/core':
@@ -7869,16 +7900,32 @@ packages:
   '@libsql/client@0.14.0':
     resolution: {integrity: sha512-/9HEKfn6fwXB5aTEEoMeFh4CtG0ZzbncBb1e++OCdVpgKZ/xyMsIVYXm0w7Pv4RUel803vE6LwniB3PqD72R0Q==}
 
+  '@libsql/client@0.15.4':
+    resolution: {integrity: sha512-m8a7giWlhLdfKVIZFd3UlBptWTS+H0toSOL09BxbqzBeFHwuVC+5ewyi4LMBxoy2TLNQGE4lO8cwpsTWmu695w==}
+
   '@libsql/core@0.14.0':
     resolution: {integrity: sha512-nhbuXf7GP3PSZgdCY2Ecj8vz187ptHlZQ0VRc751oB2C1W8jQUXKKklvt7t1LJiUTQBVJuadF628eUk+3cRi4Q==}
+
+  '@libsql/core@0.15.4':
+    resolution: {integrity: sha512-NMvh6xnn3vrcd7DNehj0HiJcRWB2a8hHhJUTkOBej3Pf3KB21HOmdOUjXxJ5pGbjWXh4ezQBmHtF5ozFhocXaA==}
 
   '@libsql/darwin-arm64@0.4.7':
     resolution: {integrity: sha512-yOL742IfWUlUevnI5PdnIT4fryY3LYTdLm56bnY0wXBw7dhFcnjuA7jrH3oSVz2mjZTHujxoITgAE7V6Z+eAbg==}
     cpu: [arm64]
     os: [darwin]
 
+  '@libsql/darwin-arm64@0.5.6':
+    resolution: {integrity: sha512-N0lt/I6xCTW6zE3J1I0/YH+TFnoMeZyeSorfLWg1wQi6QrB2PQ3je4R/bGViaU1uMEXaCc5OyI3GrrXJIDOLWg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@libsql/darwin-x64@0.4.7':
     resolution: {integrity: sha512-ezc7V75+eoyyH07BO9tIyJdqXXcRfZMbKcLCeF8+qWK5nP8wWuMcfOVywecsXGRbT99zc5eNra4NEx6z5PkSsA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.6':
+    resolution: {integrity: sha512-v8YYImGB3klHvLViWAqsmgYuG32iO+Mt52VSfuqM5m8KzI2XQ2CRxKdBGYnLI9D3Q1T7upYGuHVTSoK3GpKoXQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -7897,8 +7944,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@libsql/linux-arm64-gnu@0.5.6':
+    resolution: {integrity: sha512-2SdnSd/Tg+l5qN4yuc7Fh9Uvy/TakL8RiBJMSZEQkFta4FBk9H/Cp49SF9YRx9g2jItTlzOGJ+PAfnkU5HbabA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@libsql/linux-arm64-musl@0.4.7':
     resolution: {integrity: sha512-6kK9xAArVRlTCpWeqnNMCoXW1pe7WITI378n4NpvU5EJ0Ok3aNTIC2nRPRjhro90QcnmLL1jPcrVwO4WD1U0xw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.6':
+    resolution: {integrity: sha512-DhfDtTWksAGXe70fA4cyhJHGYBB2BpLnF9EB1Rli2ACHrQbgWFHCiSrSg91tk4UVCVRDZ91KkXqU5bWL16Kwcg==}
     cpu: [arm64]
     os: [linux]
 
@@ -7907,13 +7964,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@libsql/linux-x64-gnu@0.5.6':
+    resolution: {integrity: sha512-lB6zcJw0u+Y3d2rN4ruxJtqxq9UjtzsoA+naJFmYEiDcls1p6OZQ+0OphO5qzTuet/MwbmiHrda/Kk15brBQBw==}
+    cpu: [x64]
+    os: [linux]
+
   '@libsql/linux-x64-musl@0.4.7':
     resolution: {integrity: sha512-nI6tpS1t6WzGAt1Kx1n1HsvtBbZ+jHn0m7ogNNT6pQHZQj7AFFTIMeDQw/i/Nt5H38np1GVRNsFe99eSIMs9XA==}
     cpu: [x64]
     os: [linux]
 
+  '@libsql/linux-x64-musl@0.5.6':
+    resolution: {integrity: sha512-gNbiJg0GGhKZSCTiRpbd9cD2/xT1Nj8bnXra+5ZvPYxiIaphE9xy3ELPIZjGIzBLX9dnn5E920K2tIOrBMRVBw==}
+    cpu: [x64]
+    os: [linux]
+
   '@libsql/win32-x64-msvc@0.4.7':
     resolution: {integrity: sha512-7pJzOWzPm6oJUxml+PCDRzYQ4A1hTMHAciTAHfFK4fkbDZX33nWPVG7Y3vqdKtslcwAzwmrNDc6sXy2nwWnbiw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@libsql/win32-x64-msvc@0.5.6':
+    resolution: {integrity: sha512-8PtI2LrcacvFvzGOkm1CFCGWR5Y5eJDliAlZUEv7BTSAWf07FIVi21mEAyB9VG5y3VpWtY0f+6JYblrwqgqD3A==}
     cpu: [x64]
     os: [win32]
 
@@ -15751,6 +15823,10 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    os: [darwin, linux, win32]
+
+  libsql@0.5.6:
+    resolution: {integrity: sha512-k0qHpyU47iWBplT4IJKEcMgUbms8jl9cNGE6aqsdOYmSJjtZIaYkn8f4ku5DzxRHpk1+o4FK7ZwGVCExYboZqQ==}
     os: [darwin, linux, win32]
 
   light-my-request@5.14.0:
@@ -24025,14 +24101,35 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@libsql/client@0.15.4(bufferutil@4.0.9)(utf-8-validate@6.0.5)':
+    dependencies:
+      '@libsql/core': 0.15.4
+      '@libsql/hrana-client': 0.7.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+      js-base64: 3.7.7
+      libsql: 0.5.6
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@libsql/core@0.14.0':
+    dependencies:
+      js-base64: 3.7.7
+
+  '@libsql/core@0.15.4':
     dependencies:
       js-base64: 3.7.7
 
   '@libsql/darwin-arm64@0.4.7':
     optional: true
 
+  '@libsql/darwin-arm64@0.5.6':
+    optional: true
+
   '@libsql/darwin-x64@0.4.7':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.6':
     optional: true
 
   '@libsql/hrana-client@0.7.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)':
@@ -24058,16 +24155,31 @@ snapshots:
   '@libsql/linux-arm64-gnu@0.4.7':
     optional: true
 
+  '@libsql/linux-arm64-gnu@0.5.6':
+    optional: true
+
   '@libsql/linux-arm64-musl@0.4.7':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.6':
     optional: true
 
   '@libsql/linux-x64-gnu@0.4.7':
     optional: true
 
+  '@libsql/linux-x64-gnu@0.5.6':
+    optional: true
+
   '@libsql/linux-x64-musl@0.4.7':
     optional: true
 
+  '@libsql/linux-x64-musl@0.5.6':
+    optional: true
+
   '@libsql/win32-x64-msvc@0.4.7':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.6':
     optional: true
 
   '@llamaindex/cloud@4.0.3(@llamaindex/core@0.6.2(@huggingface/transformers@3.4.0)(gpt-tokenizer@2.9.0))(@llamaindex/env@0.1.29(@huggingface/transformers@3.4.0)(gpt-tokenizer@2.9.0))':
@@ -27683,7 +27795,7 @@ snapshots:
       '@types/node': 20.17.30
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
@@ -27691,7 +27803,7 @@ snapshots:
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       debug: 4.4.0(supports-color@8.1.1)
-      eslint: 9.23.0(jiti@2.4.2)
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
@@ -30401,7 +30513,7 @@ snapshots:
       '@rollup/plugin-replace': 5.0.7(rollup@3.29.5)
       '@rollup/plugin-terser': 0.4.4(rollup@3.29.5)
       '@types/jest': 29.5.14
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       ansi-escapes: 4.3.2
       asyncro: 3.0.0
@@ -31280,7 +31392,7 @@ snapshots:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
       jest: 29.7.0(@types/node@20.17.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.10(@swc/helpers@0.5.15))(@types/node@20.17.30)(typescript@5.8.2))
     transitivePeerDependencies:
       - supports-color
@@ -34152,6 +34264,19 @@ snapshots:
       '@libsql/linux-x64-gnu': 0.4.7
       '@libsql/linux-x64-musl': 0.4.7
       '@libsql/win32-x64-msvc': 0.4.7
+
+  libsql@0.5.6:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.6
+      '@libsql/darwin-x64': 0.5.6
+      '@libsql/linux-arm64-gnu': 0.5.6
+      '@libsql/linux-arm64-musl': 0.5.6
+      '@libsql/linux-x64-gnu': 0.5.6
+      '@libsql/linux-x64-musl': 0.5.6
+      '@libsql/win32-x64-msvc': 0.5.6
 
   light-my-request@5.14.0:
     dependencies:

--- a/stores/_test-utils/CHANGELOG.md
+++ b/stores/_test-utils/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @internal/lint

--- a/stores/_test-utils/LICENSE.md
+++ b/stores/_test-utils/LICENSE.md
@@ -1,0 +1,46 @@
+# Elastic License 2.0 (ELv2)
+
+Copyright (c) 2025 Mastra AI, Inc.
+
+**Acceptance**
+By using the software, you agree to all of the terms and conditions below.
+
+**Copyright License**
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license to use, copy, distribute, make available, and prepare derivative works of the software, in each case subject to the limitations and conditions below
+
+**Limitations**
+You may not provide the software to third parties as a hosted or managed service, where the service provides users with access to any substantial set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality in the software, and you may not remove or obscure any functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
+
+**Patents**
+The licensor grants you a license, under any patent claims the licensor can license, or becomes able to license, to make, have made, use, sell, offer for sale, import and have imported the software, in each case subject to the limitations and conditions in this license. This license does not cover any patent claims that you cause to be infringed by modifications or additions to the software. If you or your company make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+**Notices**
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the software prominent notices stating that you have modified the software.
+
+**No Other Rights**
+These terms do not imply any licenses other than those expressly granted in these terms.
+
+**Termination**
+If you use the software in violation of these terms, such use is not licensed, and your licenses will automatically terminate. If the licensor provides you with a notice of your violation, and you cease all violation of this license no later than 30 days after you receive that notice, your licenses will be reinstated retroactively. However, if you violate these terms after such reinstatement, any additional violation of these terms will cause your licenses to terminate automatically and permanently.
+
+**No Liability**
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.
+
+**Definitions**
+The _licensor_ is the entity offering these terms, and the _software_ is the software the licensor makes available under these terms, including any portion of it.
+
+_you_ refers to the individual or entity agreeing to these terms.
+
+_your company_ is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization. _control_ means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+_your licenses_ are all the licenses granted to you for the software under these terms.
+
+_use_ means anything you do with the software requiring one of your licenses.
+
+_trademark_ means trademarks, service marks, and similar rights.

--- a/stores/_test-utils/package.json
+++ b/stores/_test-utils/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@internal/storage-test-utils",
+  "version": "0.0.0",
+  "description": "",
+  "type": "module",
+  "main": "src/default-tests.ts",
+  "private": true,
+  "exports": {
+    ".": "./src/default-tests.ts"
+  },
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "Elastic-2.0",
+  "dependencies": {
+    "@mastra/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "vitest": "*"
+  }
+}

--- a/stores/_test-utils/src/default-tests.ts
+++ b/stores/_test-utils/src/default-tests.ts
@@ -1,0 +1,683 @@
+import { randomUUID } from 'crypto';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import type { MetricResult } from '@mastra/core/eval';
+import type { WorkflowRunState } from '@mastra/core/workflows';
+import type { MastraStorage } from '../base';
+import { TABLE_WORKFLOW_SNAPSHOT, TABLE_EVALS, TABLE_MESSAGES, TABLE_THREADS } from '@mastra/core/storage';
+
+export function createTestSuite(storage: MastraStorage) {
+  describe(storage.constructor.name, () => {
+    // Sample test data factory functions to ensure unique records
+    const createSampleThread = () => ({
+      id: `thread-${randomUUID()}`,
+      resourceId: `resource-${randomUUID()}`,
+      title: 'Test Thread',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      metadata: { key: 'value' },
+    });
+
+    const createSampleThreadWithParams = (threadId: string, resourceId: string, createdAt: Date, updatedAt: Date) => ({
+      id: threadId,
+      resourceId,
+      title: 'Test Thread with given ThreadId and ResourceId',
+      createdAt,
+      updatedAt,
+      metadata: { key: 'value' },
+    });
+
+    const createSampleMessage = (threadId: string) =>
+      ({
+        id: `msg-${randomUUID()}`,
+        role: 'user',
+        type: 'text',
+        threadId,
+        content: [{ type: 'text', text: 'Hello' }],
+        createdAt: new Date(),
+      }) as any;
+
+    const createSampleWorkflowSnapshot = (status: string, createdAt?: Date) => {
+      const runId = `run-${randomUUID()}`;
+      const stepId = `step-${randomUUID()}`;
+      const timestamp = createdAt || new Date();
+      const snapshot = {
+        result: { success: true },
+        value: {},
+        context: {
+          steps: {
+            [stepId]: {
+              status,
+              payload: {},
+              error: undefined,
+            },
+          },
+          triggerData: {},
+          attempts: {},
+        },
+        activePaths: [],
+        runId,
+        timestamp: timestamp.getTime(),
+      } as WorkflowRunState;
+      return { snapshot, runId, stepId };
+    };
+
+    beforeAll(async () => {
+      await storage.init();
+    });
+
+    beforeEach(async () => {
+      // Clear tables before each test
+      await storage.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
+      await storage.clearTable({ tableName: TABLE_EVALS });
+      await storage.clearTable({ tableName: TABLE_MESSAGES });
+      await storage.clearTable({ tableName: TABLE_THREADS });
+    });
+
+    afterAll(async () => {
+      // Clear tables after tests
+      await storage.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
+      await storage.clearTable({ tableName: TABLE_EVALS });
+      await storage.clearTable({ tableName: TABLE_MESSAGES });
+      await storage.clearTable({ tableName: TABLE_THREADS });
+    });
+
+    describe('Thread Operations', () => {
+      it('should create and retrieve a thread', async () => {
+        const thread = createSampleThread();
+
+        // Save thread
+        const savedThread = await storage.saveThread({ thread });
+        expect(savedThread).toEqual(thread);
+
+        // Retrieve thread
+        const retrievedThread = await storage.getThreadById({ threadId: thread.id });
+        expect(retrievedThread?.title).toEqual(thread.title);
+      });
+
+      it('should create and retrieve a thread with the same given threadId and resourceId', async () => {
+        const exampleThreadId = '1346362547862769664';
+        const exampleResourceId = '532374164040974346';
+        const createdAt = new Date();
+        const updatedAt = new Date();
+        const thread = createSampleThreadWithParams(exampleThreadId, exampleResourceId, createdAt, updatedAt);
+
+        // Save thread
+        const savedThread = await storage.saveThread({ thread });
+        expect(savedThread).toEqual(thread);
+
+        // Retrieve thread
+        const retrievedThread = await storage.getThreadById({ threadId: thread.id });
+        expect(retrievedThread?.id).toEqual(exampleThreadId);
+        expect(retrievedThread?.resourceId).toEqual(exampleResourceId);
+        expect(retrievedThread?.title).toEqual(thread.title);
+        expect(retrievedThread?.createdAt).toEqual(createdAt.toISOString());
+        expect(retrievedThread?.updatedAt).toEqual(updatedAt.toISOString());
+      });
+
+      it('should return null for non-existent thread', async () => {
+        const result = await storage.getThreadById({ threadId: 'non-existent' });
+        expect(result).toBeNull();
+      });
+
+      it('should get threads by resource ID', async () => {
+        const thread1 = createSampleThread();
+        const thread2 = { ...createSampleThread(), resourceId: thread1.resourceId };
+
+        await storage.saveThread({ thread: thread1 });
+        await storage.saveThread({ thread: thread2 });
+
+        const threads = await storage.getThreadsByResourceId({ resourceId: thread1.resourceId });
+        expect(threads).toHaveLength(2);
+        expect(threads.map(t => t.id)).toEqual(expect.arrayContaining([thread1.id, thread2.id]));
+      });
+
+      it('should update thread title and metadata', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const newMetadata = { newKey: 'newValue' };
+        const updatedThread = await storage.updateThread({
+          id: thread.id,
+          title: 'Updated Title',
+          metadata: newMetadata,
+        });
+
+        expect(updatedThread.title).toBe('Updated Title');
+        expect(updatedThread.metadata).toEqual({
+          ...thread.metadata,
+          ...newMetadata,
+        });
+
+        // Verify persistence
+        const retrievedThread = await storage.getThreadById({ threadId: thread.id });
+        expect(retrievedThread).toEqual(updatedThread);
+      });
+
+      it('should delete thread', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        await storage.deleteThread({ threadId: thread.id });
+
+        const retrievedThread = await storage.getThreadById({ threadId: thread.id });
+        expect(retrievedThread).toBeNull();
+      });
+    });
+
+    describe('Message Operations', () => {
+      it('should save and retrieve messages', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const messages = [createSampleMessage(thread.id), createSampleMessage(thread.id)];
+
+        // Save messages
+        const savedMessages = await storage.saveMessages({ messages });
+
+        expect(savedMessages).toEqual(messages);
+
+        // Retrieve messages
+        const retrievedMessages = await storage.getMessages({ threadId: thread.id });
+
+        expect(retrievedMessages).toHaveLength(2);
+
+        expect(retrievedMessages).toEqual(expect.arrayContaining(messages));
+      });
+
+      it('should handle empty message array', async () => {
+        const result = await storage.saveMessages({ messages: [] });
+        expect(result).toEqual([]);
+      });
+
+      it('should maintain message order', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const messages = [
+          { ...createSampleMessage(thread.id), content: [{ type: 'text', text: 'First' }] },
+          { ...createSampleMessage(thread.id), content: [{ type: 'text', text: 'Second' }] },
+          { ...createSampleMessage(thread.id), content: [{ type: 'text', text: 'Third' }] },
+        ];
+
+        await storage.saveMessages({ messages });
+
+        const retrievedMessages = await storage.getMessages({ threadId: thread.id });
+
+        expect(retrievedMessages).toHaveLength(3);
+
+        // Verify order is maintained
+        retrievedMessages.forEach((msg, idx) => {
+          // @ts-expect-error
+          expect(msg.content[0].text).toBe(messages[idx].content[0].text);
+        });
+      });
+
+      it('should rollback on error during message save', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const messages = [
+          createSampleMessage(thread.id),
+          { ...createSampleMessage(thread.id), id: null }, // This will cause an error
+        ];
+
+        await expect(storage.saveMessages({ messages })).rejects.toThrow();
+
+        // Verify no messages were saved
+        const savedMessages = await storage.getMessages({ threadId: thread.id });
+        expect(savedMessages).toHaveLength(0);
+      });
+    });
+
+    describe('Edge Cases and Error Handling', () => {
+      it('should handle large metadata objects', async () => {
+        const thread = createSampleThread();
+        const largeMetadata = {
+          ...thread.metadata,
+          largeArray: Array.from({ length: 1000 }, (_, i) => ({ index: i, data: 'test'.repeat(100) })),
+        };
+
+        const threadWithLargeMetadata = {
+          ...thread,
+          metadata: largeMetadata,
+        };
+
+        await storage.saveThread({ thread: threadWithLargeMetadata });
+        const retrieved = await storage.getThreadById({ threadId: thread.id });
+
+        expect(retrieved?.metadata).toEqual(largeMetadata);
+      });
+
+      it('should handle special characters in thread titles', async () => {
+        const thread = {
+          ...createSampleThread(),
+          title: 'Special \'quotes\' and "double quotes" and emoji 🎉',
+        };
+
+        await storage.saveThread({ thread });
+        const retrieved = await storage.getThreadById({ threadId: thread.id });
+
+        expect(retrieved?.title).toBe(thread.title);
+      });
+
+      it('should handle concurrent thread updates', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        // Perform multiple updates concurrently
+        const updates = Array.from({ length: 5 }, (_, i) =>
+          storage.updateThread({
+            id: thread.id,
+            title: `Update ${i}`,
+            metadata: { update: i },
+          }),
+        );
+
+        await expect(Promise.all(updates)).resolves.toBeDefined();
+
+        // Verify final state
+        const finalThread = await storage.getThreadById({ threadId: thread.id });
+        expect(finalThread).toBeDefined();
+      });
+    });
+
+    describe('Workflow Snapshots', () => {
+      beforeAll(async () => {
+        // Create workflow_snapshot table
+        await storage.createTable({
+          tableName: TABLE_WORKFLOW_SNAPSHOT,
+          schema: {
+            workflow_name: { type: 'text', nullable: false },
+            run_id: { type: 'text', nullable: false },
+            snapshot: { type: 'text', nullable: false },
+            created_at: { type: 'timestamp', nullable: false },
+            updated_at: { type: 'timestamp', nullable: false },
+          },
+        });
+      });
+
+      it('should persist and load workflow snapshots', async () => {
+        const workflowName = 'test-workflow';
+        const runId = `run-${randomUUID()}`;
+        const snapshot = {
+          status: 'running',
+          context: {
+            stepResults: {},
+            attempts: {},
+            triggerData: { type: 'manual' },
+          },
+        } as any;
+
+        await storage.persistWorkflowSnapshot({
+          workflowName,
+          runId,
+          snapshot,
+        });
+
+        const loadedSnapshot = await storage.loadWorkflowSnapshot({
+          workflowName,
+          runId,
+        });
+
+        expect(loadedSnapshot).toEqual(snapshot);
+      });
+
+      it('should return null for non-existent workflow snapshot', async () => {
+        const result = await storage.loadWorkflowSnapshot({
+          workflowName: 'non-existent',
+          runId: 'non-existent',
+        });
+
+        expect(result).toBeNull();
+      });
+
+      it('should update existing workflow snapshot', async () => {
+        const workflowName = 'test-workflow';
+        const runId = `run-${randomUUID()}`;
+        const initialSnapshot = {
+          status: 'running',
+          context: {
+            stepResults: {},
+            attempts: {},
+            triggerData: { type: 'manual' },
+          },
+        };
+
+        await storage.persistWorkflowSnapshot({
+          workflowName,
+          runId,
+          snapshot: initialSnapshot as any,
+        });
+
+        const updatedSnapshot = {
+          status: 'completed',
+          context: {
+            stepResults: {
+              'step-1': { status: 'success', result: { data: 'test' } },
+            },
+            attempts: { 'step-1': 1 },
+            triggerData: { type: 'manual' },
+          },
+        } as any;
+
+        await storage.persistWorkflowSnapshot({
+          workflowName,
+          runId,
+          snapshot: updatedSnapshot,
+        });
+
+        const loadedSnapshot = await storage.loadWorkflowSnapshot({
+          workflowName,
+          runId,
+        });
+
+        expect(loadedSnapshot).toEqual(updatedSnapshot);
+      });
+
+      it('should handle complex workflow state', async () => {
+        const workflowName = 'complex-workflow';
+        const runId = `run-${randomUUID()}`;
+        const complexSnapshot = {
+          value: { currentState: 'running' },
+          context: {
+            stepResults: {
+              'step-1': {
+                status: 'success',
+                result: {
+                  nestedData: {
+                    array: [1, 2, 3],
+                    object: { key: 'value' },
+                    date: new Date().toISOString(),
+                  },
+                },
+              },
+              'step-2': {
+                status: 'waiting',
+                dependencies: ['step-3', 'step-4'],
+              },
+            },
+            attempts: { 'step-1': 1, 'step-2': 0 },
+            triggerData: {
+              type: 'scheduled',
+              metadata: {
+                schedule: '0 0 * * *',
+                timezone: 'UTC',
+              },
+            },
+          },
+          activePaths: [
+            {
+              stepPath: ['step-1'],
+              stepId: 'step-1',
+              status: 'success',
+            },
+            {
+              stepPath: ['step-2'],
+              stepId: 'step-2',
+              status: 'waiting',
+            },
+          ],
+          runId: runId,
+          timestamp: Date.now(),
+        };
+
+        await storage.persistWorkflowSnapshot({
+          workflowName,
+          runId,
+          snapshot: complexSnapshot as unknown as WorkflowRunState,
+        });
+
+        const loadedSnapshot = await storage.loadWorkflowSnapshot({
+          workflowName,
+          runId,
+        });
+
+        expect(loadedSnapshot).toEqual(complexSnapshot);
+      });
+    });
+    describe('getWorkflowRuns', () => {
+      beforeEach(async () => {
+        await storage.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
+      });
+      it('returns empty array when no workflows exist', async () => {
+        const { runs, total } = await storage.getWorkflowRuns();
+        expect(runs).toEqual([]);
+        expect(total).toBe(0);
+      });
+
+      it('returns all workflows by default', async () => {
+        const workflowName1 = 'default_test_1';
+        const workflowName2 = 'default_test_2';
+
+        const { snapshot: workflow1, runId: runId1, stepId: stepId1 } = createSampleWorkflowSnapshot('completed');
+        const { snapshot: workflow2, runId: runId2, stepId: stepId2 } = createSampleWorkflowSnapshot('running');
+
+        await storage.persistWorkflowSnapshot({ workflowName: workflowName1, runId: runId1, snapshot: workflow1 });
+        await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
+        await storage.persistWorkflowSnapshot({ workflowName: workflowName2, runId: runId2, snapshot: workflow2 });
+
+        const { runs, total } = await storage.getWorkflowRuns();
+        expect(runs).toHaveLength(2);
+        expect(total).toBe(2);
+        expect(runs[0]!.workflowName).toBe(workflowName2); // Most recent first
+        expect(runs[1]!.workflowName).toBe(workflowName1);
+        const firstSnapshot = runs[0]!.snapshot as WorkflowRunState;
+        const secondSnapshot = runs[1]!.snapshot as WorkflowRunState;
+        expect(firstSnapshot.context?.steps[stepId2]?.status).toBe('running');
+        expect(secondSnapshot.context?.steps[stepId1]?.status).toBe('completed');
+      });
+
+      it('filters by workflow name', async () => {
+        const workflowName1 = 'filter_test_1';
+        const workflowName2 = 'filter_test_2';
+
+        const { snapshot: workflow1, runId: runId1, stepId: stepId1 } = createSampleWorkflowSnapshot('completed');
+        const { snapshot: workflow2, runId: runId2 } = createSampleWorkflowSnapshot('failed');
+
+        await storage.persistWorkflowSnapshot({ workflowName: workflowName1, runId: runId1, snapshot: workflow1 });
+        await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
+        await storage.persistWorkflowSnapshot({ workflowName: workflowName2, runId: runId2, snapshot: workflow2 });
+
+        const { runs, total } = await storage.getWorkflowRuns({ workflowName: workflowName1 });
+        expect(runs).toHaveLength(1);
+        expect(total).toBe(1);
+        expect(runs[0]!.workflowName).toBe(workflowName1);
+        const snapshot = runs[0]!.snapshot as WorkflowRunState;
+        expect(snapshot.context?.steps[stepId1]?.status).toBe('completed');
+      });
+
+      it('filters by date range', async () => {
+        const now = new Date();
+        const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+        const workflowName1 = 'date_test_1';
+        const workflowName2 = 'date_test_2';
+        const workflowName3 = 'date_test_3';
+
+        const { snapshot: workflow1, runId: runId1 } = createSampleWorkflowSnapshot('completed');
+        const { snapshot: workflow2, runId: runId2, stepId: stepId2 } = createSampleWorkflowSnapshot('running');
+        const { snapshot: workflow3, runId: runId3, stepId: stepId3 } = createSampleWorkflowSnapshot('waiting');
+
+        await storage.insert({
+          tableName: TABLE_WORKFLOW_SNAPSHOT,
+          record: {
+            workflow_name: workflowName1,
+            run_id: runId1,
+            snapshot: workflow1,
+            createdAt: twoDaysAgo,
+            updatedAt: twoDaysAgo,
+          },
+        });
+        await storage.insert({
+          tableName: TABLE_WORKFLOW_SNAPSHOT,
+          record: {
+            workflow_name: workflowName2,
+            run_id: runId2,
+            snapshot: workflow2,
+            createdAt: yesterday,
+            updatedAt: yesterday,
+          },
+        });
+        await storage.insert({
+          tableName: TABLE_WORKFLOW_SNAPSHOT,
+          record: {
+            workflow_name: workflowName3,
+            run_id: runId3,
+            snapshot: workflow3,
+            createdAt: now,
+            updatedAt: now,
+          },
+        });
+
+        const { runs } = await storage.getWorkflowRuns({
+          fromDate: yesterday,
+          toDate: now,
+        });
+
+        expect(runs).toHaveLength(2);
+        expect(runs[0]!.workflowName).toBe(workflowName3);
+        expect(runs[1]!.workflowName).toBe(workflowName2);
+        const firstSnapshot = runs[0]!.snapshot as WorkflowRunState;
+        const secondSnapshot = runs[1]!.snapshot as WorkflowRunState;
+        expect(firstSnapshot.context?.steps[stepId3]?.status).toBe('waiting');
+        expect(secondSnapshot.context?.steps[stepId2]?.status).toBe('running');
+      });
+
+      it('handles pagination', async () => {
+        const workflowName1 = 'page_test_1';
+        const workflowName2 = 'page_test_2';
+        const workflowName3 = 'page_test_3';
+
+        const { snapshot: workflow1, runId: runId1, stepId: stepId1 } = createSampleWorkflowSnapshot('completed');
+        const { snapshot: workflow2, runId: runId2, stepId: stepId2 } = createSampleWorkflowSnapshot('running');
+        const { snapshot: workflow3, runId: runId3, stepId: stepId3 } = createSampleWorkflowSnapshot('waiting');
+
+        await storage.persistWorkflowSnapshot({ workflowName: workflowName1, runId: runId1, snapshot: workflow1 });
+        await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
+        await storage.persistWorkflowSnapshot({ workflowName: workflowName2, runId: runId2, snapshot: workflow2 });
+        await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
+        await storage.persistWorkflowSnapshot({ workflowName: workflowName3, runId: runId3, snapshot: workflow3 });
+
+        // Get first page
+        const page1 = await storage.getWorkflowRuns({ limit: 2, offset: 0 });
+        expect(page1.runs).toHaveLength(2);
+        expect(page1.total).toBe(3); // Total count of all records
+        expect(page1.runs[0]!.workflowName).toBe(workflowName3);
+        expect(page1.runs[1]!.workflowName).toBe(workflowName2);
+        const firstSnapshot = page1.runs[0]!.snapshot as WorkflowRunState;
+        const secondSnapshot = page1.runs[1]!.snapshot as WorkflowRunState;
+        expect(firstSnapshot.context?.steps[stepId3]?.status).toBe('waiting');
+        expect(secondSnapshot.context?.steps[stepId2]?.status).toBe('running');
+
+        // Get second page
+        const page2 = await storage.getWorkflowRuns({ limit: 2, offset: 2 });
+        expect(page2.runs).toHaveLength(1);
+        expect(page2.total).toBe(3);
+        expect(page2.runs[0]!.workflowName).toBe(workflowName1);
+        const snapshot = page2.runs[0]!.snapshot as WorkflowRunState;
+        expect(snapshot.context?.steps[stepId1]?.status).toBe('completed');
+      });
+    });
+  });
+
+  describe('Eval Operations', () => {
+    const createSampleEval = (agentName: string, isTest = false) => {
+      const testInfo = isTest ? { testPath: 'test/path.ts', testName: 'Test Name' } : undefined;
+
+      return {
+        id: randomUUID(),
+        agentName,
+        input: 'Sample input',
+        output: 'Sample output',
+        result: { score: 0.8 } as MetricResult,
+        metricName: 'sample-metric',
+        instructions: 'Sample instructions',
+        testInfo,
+        globalRunId: `global-${randomUUID()}`,
+        runId: `run-${randomUUID()}`,
+        createdAt: new Date().toISOString(),
+      };
+    };
+
+    it('should retrieve evals by agent name', async () => {
+      const agentName = `test-agent-${randomUUID()}`;
+
+      // Create sample evals
+      const liveEval = createSampleEval(agentName, false);
+      const testEval = createSampleEval(agentName, true);
+      const otherAgentEval = createSampleEval(`other-agent-${randomUUID()}`, false);
+
+      // Insert evals
+      await storage.insert({
+        tableName: TABLE_EVALS,
+        record: {
+          agent_name: liveEval.agentName,
+          input: liveEval.input,
+          output: liveEval.output,
+          result: liveEval.result,
+          metric_name: liveEval.metricName,
+          instructions: liveEval.instructions,
+          test_info: null,
+          global_run_id: liveEval.globalRunId,
+          run_id: liveEval.runId,
+          created_at: liveEval.createdAt,
+          createdAt: new Date(liveEval.createdAt),
+        },
+      });
+
+      await storage.insert({
+        tableName: TABLE_EVALS,
+        record: {
+          agent_name: testEval.agentName,
+          input: testEval.input,
+          output: testEval.output,
+          result: testEval.result,
+          metric_name: testEval.metricName,
+          instructions: testEval.instructions,
+          test_info: JSON.stringify(testEval.testInfo),
+          global_run_id: testEval.globalRunId,
+          run_id: testEval.runId,
+          created_at: testEval.createdAt,
+          createdAt: new Date(testEval.createdAt),
+        },
+      });
+
+      await storage.insert({
+        tableName: TABLE_EVALS,
+        record: {
+          agent_name: otherAgentEval.agentName,
+          input: otherAgentEval.input,
+          output: otherAgentEval.output,
+          result: otherAgentEval.result,
+          metric_name: otherAgentEval.metricName,
+          instructions: otherAgentEval.instructions,
+          test_info: null,
+          global_run_id: otherAgentEval.globalRunId,
+          run_id: otherAgentEval.runId,
+          created_at: otherAgentEval.createdAt,
+          createdAt: new Date(otherAgentEval.createdAt),
+        },
+      });
+
+      // Test getting all evals for the agent
+      const allEvals = await storage.getEvalsByAgentName(agentName);
+      expect(allEvals).toHaveLength(2);
+      expect(allEvals.map(e => e.runId)).toEqual(expect.arrayContaining([liveEval.runId, testEval.runId]));
+
+      // Test getting only live evals
+      const liveEvals = await storage.getEvalsByAgentName(agentName, 'live');
+      expect(liveEvals).toHaveLength(1);
+      expect(liveEvals?.[0]?.runId).toBe(liveEval.runId);
+
+      // Test getting only test evals
+      const testEvals = await storage.getEvalsByAgentName(agentName, 'test');
+      expect(testEvals).toHaveLength(1);
+      expect(testEvals?.[0]?.runId).toBe(testEval.runId);
+      expect(testEvals?.[0]?.testInfo).toEqual(testEval.testInfo);
+
+      // Test getting evals for non-existent agent
+      const nonExistentEvals = await storage.getEvalsByAgentName('non-existent-agent');
+      expect(nonExistentEvals).toHaveLength(0);
+    });
+  });
+}

--- a/stores/libsql/.gitignore
+++ b/stores/libsql/.gitignore
@@ -1,0 +1,3 @@
+.env
+dist/
+node_modules/

--- a/stores/libsql/LICENSE.md
+++ b/stores/libsql/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2025 Mastra AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/stores/libsql/README.md
+++ b/stores/libsql/README.md
@@ -1,0 +1,144 @@
+# @mastra/pg
+
+SQLite implementation for Mastra, providing both vector similarity search and general storage capabilities with connection pooling and transaction support.
+
+## Installation
+
+```bash
+npm install @mastra/libsql
+```
+
+## Usage
+
+### Vector Store
+
+```typescript
+import { LibSQLVector } from '@mastra/libsql';
+
+const vectorStore = new LibSQLVector({
+  url: 'file:./my-db.db'
+});
+
+// Create a new table with vector support
+await vectorStore.createIndex({
+  indexName: 'my_vectors',
+  dimension: 1536,
+  metric: 'cosine',
+});
+
+// Add vectors
+const ids = await vectorStore.upsert({
+  indexName: 'my_vectors',
+  vectors: [[0.1, 0.2, ...], [0.3, 0.4, ...]],
+  metadata: [{ text: 'doc1' }, { text: 'doc2' }],
+});
+
+// Query vectors
+const results = await vectorStore.query({
+  indexName: 'my_vectors',
+  queryVector: [0.1, 0.2, ...],
+  topK: 10, // topK
+  filter: { text: 'doc1' }, // filter
+  includeVector: false, // includeVector
+  minScore: 0.5, // minScore
+});
+```
+
+### Storage
+
+```typescript
+import { LibSQLStore } from '@mastra/pg';
+
+const store = new LibSQLStore({
+  url: 'file:./my-db.db',
+});
+
+// Create a thread
+await store.saveThread({
+  id: 'thread-123',
+  resourceId: 'resource-456',
+  title: 'My Thread',
+  metadata: { key: 'value' },
+});
+
+// Add messages to thread
+await store.saveMessages([
+  {
+    id: 'msg-789',
+    threadId: 'thread-123',
+    role: 'user',
+    type: 'text',
+    content: [{ type: 'text', text: 'Hello' }],
+  },
+]);
+
+// Query threads and messages
+const savedThread = await store.getThread('thread-123');
+const messages = await store.getMessages('thread-123');
+```
+
+## Configuration
+
+The LibSQLStore store can be initialized with:
+
+- Configuration object with url and auth. Auth is only necessary when using a provider like [Turso](https://turso.tech/)
+
+## Features
+
+### Vector Store Features
+
+- Vector similarity search with cosine, euclidean, and dot product metrics
+- Advanced metadata filtering with MongoDB-like query syntax
+- Minimum score threshold for queries
+- Automatic UUID generation for vectors
+- Table management (create, list, describe, delete, truncate)
+
+### Storage Features
+
+- Thread and message storage with JSON support
+- Atomic transactions for data consistency
+- Efficient batch operations
+- Rich metadata support
+- Timestamp tracking
+- Cascading deletes
+
+## Supported Filter Operators
+
+The following filter operators are supported for metadata queries:
+
+- Comparison: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`
+- Logical: `$and`, `$or`
+- Array: `$in`, `$nin`
+- Text: `$regex`, `$like`
+
+Example filter:
+
+```typescript
+{
+  $and: [{ age: { $gt: 25 } }, { tags: { $in: ['tag1', 'tag2'] } }];
+}
+```
+
+## Vector Store Methods
+
+- `createIndex({indexName, dimension, metric?, indexConfig?, defineIndex?})`: Create a new table with vector support
+- `upsert({indexName, vectors, metadata?, ids?})`: Add or update vectors
+- `query({indexName, queryVector, topK?, filter?, includeVector?, minScore?})`: Search for similar vectors
+- `defineIndex({indexName, metric?, indexConfig?})`: Define an index
+- `listIndexes()`: List all vector-enabled tables
+- `describeIndex(indexName)`: Get table statistics
+- `deleteIndex(indexName)`: Delete a table
+- `truncateIndex(indexName)`: Remove all data from a table
+
+## Storage Methods
+
+- `saveThread(thread)`: Create or update a thread
+- `getThread(threadId)`: Get a thread by ID
+- `deleteThread(threadId)`: Delete a thread and its messages
+- `saveMessages(messages)`: Save multiple messages in a transaction
+- `getMessages(threadId)`: Get all messages for a thread
+- `deleteMessages(messageIds)`: Delete specific messages
+
+## Related Links
+
+- [LibSQL Documentation](https://docs.turso.tech/sdk/introductionh)

--- a/stores/libsql/eslint.config.js
+++ b/stores/libsql/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config.map(conf => ({ ...conf, ignores: [...(conf.ignores || []), '**/vitest.perf.config.ts'] }))];

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
+    "@internal/storage-test-utils": "workspace:*",
     "@microsoft/api-extractor": "^7.52.1",
     "@types/node": "^20.17.27",
     "eslint": "^9.23.0",

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@mastra/libsql",
+  "version": "0.0.1-alpha.0",
+  "description": "Libsql provider for Mastra - includes both vector and db storage capabilities",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --experimental-dts --clean --treeshake=smallest --splitting",
+    "build:watch": "pnpm build --watch",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@mastra/core": "workspace:^",
+    "@libsql/client": "^0.15.4"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@microsoft/api-extractor": "^7.52.1",
+    "@types/node": "^20.17.27",
+    "eslint": "^9.23.0",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.9"
+  }
+}

--- a/stores/libsql/src/index.ts
+++ b/stores/libsql/src/index.ts
@@ -1,0 +1,2 @@
+export * from './vector';
+export * from './storage';

--- a/stores/libsql/src/storage/index.test.ts
+++ b/stores/libsql/src/storage/index.test.ts
@@ -1,5 +1,5 @@
+import { createTestSuite } from '@internal/storage-test-utils';
 import { Mastra } from '@mastra/core/mastra';
-import { createTestSuite } from '@mastra/core/storage/test-utils';
 
 import { LibSQLStore } from './index';
 

--- a/stores/libsql/src/storage/index.test.ts
+++ b/stores/libsql/src/storage/index.test.ts
@@ -1,0 +1,15 @@
+import { Mastra } from '@mastra/core/mastra';
+import { createTestSuite } from '@mastra/core/storage/test-utils';
+
+import { LibSQLStore } from './index';
+
+// Test database configuration
+const TEST_DB_URL = 'file::memory:?cache=shared'; // Use in-memory SQLite for tests
+
+const mastra = new Mastra({
+  storage: new LibSQLStore({
+    url: TEST_DB_URL,
+  }),
+});
+
+createTestSuite(mastra.getStorage()!);

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1,0 +1,624 @@
+import { createClient } from '@libsql/client';
+import type { Client, InValue } from '@libsql/client';
+import type { MetricResult, TestInfo } from '@mastra/core/eval';
+import type { MessageType, StorageThreadType } from '@mastra/core/memory';
+import {
+  MastraStorage,
+  TABLE_MESSAGES,
+  TABLE_THREADS,
+  TABLE_TRACES,
+  TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_EVALS,
+} from '@mastra/core/storage';
+import type { EvalRow, StorageColumn, StorageGetMessagesArg, TABLE_NAMES } from '@mastra/core/storage';
+import type { WorkflowRunState } from '@mastra/core/workflows';
+
+function safelyParseJSON(jsonString: string): any {
+  try {
+    return JSON.parse(jsonString);
+  } catch {
+    return {};
+  }
+}
+
+export interface LibSQLConfig {
+  url: string;
+  authToken?: string;
+}
+
+export class LibSQLStore extends MastraStorage {
+  private client: Client;
+
+  constructor(config: LibSQLConfig) {
+    super({ name: `LibSQLStore` });
+
+    // need to re-init every time for in memory dbs or the tables might not exist
+    if (config.url.endsWith(':memory:')) {
+      this.shouldCacheInit = false;
+    }
+
+    this.client = createClient(config);
+  }
+
+  private getCreateTableSQL(tableName: TABLE_NAMES, schema: Record<string, StorageColumn>): string {
+    const columns = Object.entries(schema).map(([name, col]) => {
+      let type = col.type.toUpperCase();
+      if (type === 'TEXT') type = 'TEXT';
+      if (type === 'TIMESTAMP') type = 'TEXT'; // Store timestamps as ISO strings
+      // if (type === 'BIGINT') type = 'INTEGER';
+
+      const nullable = col.nullable ? '' : 'NOT NULL';
+      const primaryKey = col.primaryKey ? 'PRIMARY KEY' : '';
+
+      return `${name} ${type} ${nullable} ${primaryKey}`.trim();
+    });
+
+    // For workflow_snapshot table, create a composite primary key
+    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      const stmnt = `CREATE TABLE IF NOT EXISTS ${tableName} (
+                ${columns.join(',\n')},
+                PRIMARY KEY (workflow_name, run_id)
+            )`;
+      return stmnt;
+    }
+
+    return `CREATE TABLE IF NOT EXISTS ${tableName} (${columns.join(', ')})`;
+  }
+
+  async createTable({
+    tableName,
+    schema,
+  }: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+  }): Promise<void> {
+    try {
+      this.logger.debug(`Creating database table`, { tableName, operation: 'schema init' });
+      const sql = this.getCreateTableSQL(tableName, schema);
+      await this.client.execute(sql);
+    } catch (error) {
+      this.logger.error(`Error creating table ${tableName}: ${error}`);
+      throw error;
+    }
+  }
+
+  async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
+    try {
+      await this.client.execute(`DELETE FROM ${tableName}`);
+    } catch (e) {
+      if (e instanceof Error) {
+        this.logger.error(e.message);
+      }
+    }
+  }
+
+  private prepareStatement({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): {
+    sql: string;
+    args: InValue[];
+  } {
+    const columns = Object.keys(record);
+    const values = Object.values(record).map(v => {
+      if (typeof v === `undefined`) {
+        // returning an undefined value will cause libsql to throw
+        return null;
+      }
+      if (v instanceof Date) {
+        return v.toISOString();
+      }
+      return typeof v === 'object' ? JSON.stringify(v) : v;
+    });
+    const placeholders = values.map(() => '?').join(', ');
+
+    return {
+      sql: `INSERT OR REPLACE INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`,
+      args: values,
+    };
+  }
+
+  async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+    try {
+      await this.client.execute(
+        this.prepareStatement({
+          tableName,
+          record,
+        }),
+      );
+    } catch (error) {
+      this.logger.error(`Error upserting into table ${tableName}: ${error}`);
+      throw error;
+    }
+  }
+
+  async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+    if (records.length === 0) return;
+
+    try {
+      const batchStatements = records.map(r => this.prepareStatement({ tableName, record: r }));
+      await this.client.batch(batchStatements, 'write');
+    } catch (error) {
+      this.logger.error(`Error upserting into table ${tableName}: ${error}`);
+      throw error;
+    }
+  }
+
+  async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
+    const conditions = Object.entries(keys)
+      .map(([key]) => `${key} = ?`)
+      .join(' AND ');
+    const values = Object.values(keys);
+
+    const result = await this.client.execute({
+      sql: `SELECT * FROM ${tableName} WHERE ${conditions} ORDER BY createdAt DESC LIMIT 1`,
+      args: values,
+    });
+
+    if (!result.rows || result.rows.length === 0) {
+      return null;
+    }
+
+    const row = result.rows[0];
+    // Checks whether the string looks like a JSON object ({}) or array ([])
+    // If the string starts with { or [, it assumes it's JSON and parses it
+    // Otherwise, it just returns, preventing unintended number conversions
+    const parsed = Object.fromEntries(
+      Object.entries(row || {}).map(([k, v]) => {
+        try {
+          return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
+        } catch {
+          return [k, v];
+        }
+      }),
+    );
+
+    return parsed as R;
+  }
+
+  async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
+    const result = await this.load<StorageThreadType>({
+      tableName: TABLE_THREADS,
+      keys: { id: threadId },
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      ...result,
+      metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
+    };
+  }
+
+  async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
+    const result = await this.client.execute({
+      sql: `SELECT * FROM ${TABLE_THREADS} WHERE resourceId = ?`,
+      args: [resourceId],
+    });
+
+    if (!result.rows) {
+      return [];
+    }
+
+    return result.rows.map(thread => ({
+      id: thread.id,
+      resourceId: thread.resourceId,
+      title: thread.title,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      metadata: typeof thread.metadata === 'string' ? JSON.parse(thread.metadata) : thread.metadata,
+    })) as any as StorageThreadType[];
+  }
+
+  async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
+    await this.insert({
+      tableName: TABLE_THREADS,
+      record: {
+        ...thread,
+        metadata: JSON.stringify(thread.metadata),
+      },
+    });
+
+    return thread;
+  }
+
+  async updateThread({
+    id,
+    title,
+    metadata,
+  }: {
+    id: string;
+    title: string;
+    metadata: Record<string, unknown>;
+  }): Promise<StorageThreadType> {
+    const thread = await this.getThreadById({ threadId: id });
+    if (!thread) {
+      throw new Error(`Thread ${id} not found`);
+    }
+
+    const updatedThread = {
+      ...thread,
+      title,
+      metadata: {
+        ...thread.metadata,
+        ...metadata,
+      },
+    };
+
+    await this.client.execute({
+      sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = ? WHERE id = ?`,
+      args: [title, JSON.stringify(updatedThread.metadata), id],
+    });
+
+    return updatedThread;
+  }
+
+  async deleteThread({ threadId }: { threadId: string }): Promise<void> {
+    await this.client.execute({
+      sql: `DELETE FROM ${TABLE_THREADS} WHERE id = ?`,
+      args: [threadId],
+    });
+    // Messages will be automatically deleted due to CASCADE constraint
+  }
+
+  private parseRow(row: any): MessageType {
+    let content = row.content;
+    try {
+      content = JSON.parse(row.content);
+    } catch {
+      // use content as is if it's not JSON
+    }
+    return {
+      id: row.id,
+      content,
+      role: row.role,
+      type: row.type,
+      createdAt: new Date(row.createdAt as string),
+      threadId: row.thread_id,
+    } as MessageType;
+  }
+
+  async getMessages<T extends MessageType[]>({ threadId, selectBy }: StorageGetMessagesArg): Promise<T> {
+    try {
+      const messages: MessageType[] = [];
+      const limit = typeof selectBy?.last === `number` ? selectBy.last : 40;
+
+      // If we have specific messages to select
+      if (selectBy?.include?.length) {
+        const includeIds = selectBy.include.map(i => i.id);
+        const maxPrev = Math.max(...selectBy.include.map(i => i.withPreviousMessages || 0));
+        const maxNext = Math.max(...selectBy.include.map(i => i.withNextMessages || 0));
+
+        // Get messages around all specified IDs in one query using row numbers
+        const includeResult = await this.client.execute({
+          sql: `
+            WITH numbered_messages AS (
+              SELECT 
+                id,
+                content,
+                role,
+                type,
+                "createdAt",
+                thread_id,
+                ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) as row_num
+              FROM "${TABLE_MESSAGES}"
+              WHERE thread_id = ?
+            ),
+            target_positions AS (
+              SELECT row_num as target_pos
+              FROM numbered_messages
+              WHERE id IN (${includeIds.map(() => '?').join(', ')})
+            )
+            SELECT DISTINCT m.*
+            FROM numbered_messages m
+            CROSS JOIN target_positions t
+            WHERE m.row_num BETWEEN (t.target_pos - ?) AND (t.target_pos + ?)
+            ORDER BY m."createdAt" ASC
+          `,
+          args: [threadId, ...includeIds, maxPrev, maxNext],
+        });
+
+        if (includeResult.rows) {
+          messages.push(...includeResult.rows.map((row: any) => this.parseRow(row)));
+        }
+      }
+
+      // Get remaining messages, excluding already fetched IDs
+      const excludeIds = messages.map(m => m.id);
+      const remainingSql = `
+        SELECT 
+          id, 
+          content, 
+          role, 
+          type,
+          "createdAt", 
+          thread_id
+        FROM "${TABLE_MESSAGES}"
+        WHERE thread_id = ?
+        ${excludeIds.length ? `AND id NOT IN (${excludeIds.map(() => '?').join(', ')})` : ''}
+        ORDER BY "createdAt" DESC
+        LIMIT ?
+      `;
+      const remainingArgs = [threadId, ...(excludeIds.length ? excludeIds : []), limit];
+
+      const remainingResult = await this.client.execute({
+        sql: remainingSql,
+        args: remainingArgs,
+      });
+
+      if (remainingResult.rows) {
+        messages.push(...remainingResult.rows.map((row: any) => this.parseRow(row)));
+      }
+
+      // Sort all messages by creation date
+      messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+      return messages as T;
+    } catch (error) {
+      this.logger.error('Error getting messages:', error as Error);
+      throw error;
+    }
+  }
+
+  async saveMessages({ messages }: { messages: MessageType[] }): Promise<MessageType[]> {
+    if (messages.length === 0) return messages;
+
+    try {
+      const threadId = messages[0]?.threadId;
+      if (!threadId) {
+        throw new Error('Thread ID is required');
+      }
+
+      // Prepare batch statements for all messages
+      const batchStatements = messages.map(message => {
+        const time = message.createdAt || new Date();
+        return {
+          sql: `INSERT INTO ${TABLE_MESSAGES} (id, thread_id, content, role, type, createdAt) 
+                VALUES (?, ?, ?, ?, ?, ?)`,
+          args: [
+            message.id,
+            threadId,
+            typeof message.content === 'object' ? JSON.stringify(message.content) : message.content,
+            message.role,
+            message.type,
+            time instanceof Date ? time.toISOString() : time,
+          ],
+        };
+      });
+
+      // Execute all inserts in a single batch
+      await this.client.batch(batchStatements, 'write');
+
+      return messages;
+    } catch (error) {
+      this.logger.error('Failed to save messages in database: ' + (error as { message: string })?.message);
+      throw error;
+    }
+  }
+
+  private transformEvalRow(row: Record<string, any>): EvalRow {
+    const resultValue = JSON.parse(row.result as string);
+    const testInfoValue = row.test_info ? JSON.parse(row.test_info as string) : undefined;
+
+    if (!resultValue || typeof resultValue !== 'object' || !('score' in resultValue)) {
+      throw new Error(`Invalid MetricResult format: ${JSON.stringify(resultValue)}`);
+    }
+
+    return {
+      input: row.input as string,
+      output: row.output as string,
+      result: resultValue as MetricResult,
+      agentName: row.agent_name as string,
+      metricName: row.metric_name as string,
+      instructions: row.instructions as string,
+      testInfo: testInfoValue as TestInfo,
+      globalRunId: row.global_run_id as string,
+      runId: row.run_id as string,
+      createdAt: row.created_at as string,
+    };
+  }
+
+  async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
+    try {
+      const baseQuery = `SELECT * FROM ${TABLE_EVALS} WHERE agent_name = ?`;
+      const typeCondition =
+        type === 'test'
+          ? " AND test_info IS NOT NULL AND test_info->>'testPath' IS NOT NULL"
+          : type === 'live'
+            ? " AND (test_info IS NULL OR test_info->>'testPath' IS NULL)"
+            : '';
+
+      const result = await this.client.execute({
+        sql: `${baseQuery}${typeCondition} ORDER BY created_at DESC`,
+        args: [agentName],
+      });
+
+      return result.rows?.map(row => this.transformEvalRow(row)) ?? [];
+    } catch (error) {
+      // Handle case where table doesn't exist yet
+      if (error instanceof Error && error.message.includes('no such table')) {
+        return [];
+      }
+      this.logger.error('Failed to get evals for the specified agent: ' + (error as any)?.message);
+      throw error;
+    }
+  }
+
+  // TODO: add types
+  async getTraces(
+    {
+      name,
+      scope,
+      page,
+      perPage,
+      attributes,
+      filters,
+    }: {
+      name?: string;
+      scope?: string;
+      page: number;
+      perPage: number;
+      attributes?: Record<string, string>;
+      filters?: Record<string, any>;
+    } = {
+      page: 0,
+      perPage: 100,
+    },
+  ): Promise<any[]> {
+    const limit = perPage;
+    const offset = page * perPage;
+
+    const args: (string | number)[] = [];
+
+    const conditions: string[] = [];
+    if (name) {
+      conditions.push("name LIKE CONCAT(?, '%')");
+    }
+    if (scope) {
+      conditions.push('scope = ?');
+    }
+    if (attributes) {
+      Object.keys(attributes).forEach(key => {
+        conditions.push(`attributes->>'$.${key}' = ?`);
+      });
+    }
+
+    if (filters) {
+      Object.entries(filters).forEach(([key, _value]) => {
+        conditions.push(`${key} = ?`);
+      });
+    }
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    if (name) {
+      args.push(name);
+    }
+
+    if (scope) {
+      args.push(scope);
+    }
+
+    if (attributes) {
+      for (const [, value] of Object.entries(attributes)) {
+        args.push(value);
+      }
+    }
+
+    if (filters) {
+      for (const [, value] of Object.entries(filters)) {
+        args.push(value);
+      }
+    }
+
+    args.push(limit, offset);
+
+    const result = await this.client.execute({
+      sql: `SELECT * FROM ${TABLE_TRACES} ${whereClause} ORDER BY "startTime" DESC LIMIT ? OFFSET ?`,
+      args,
+    });
+
+    if (!result.rows) {
+      return [];
+    }
+
+    return result.rows.map(row => ({
+      id: row.id,
+      parentSpanId: row.parentSpanId,
+      traceId: row.traceId,
+      name: row.name,
+      scope: row.scope,
+      kind: row.kind,
+      status: safelyParseJSON(row.status as string),
+      events: safelyParseJSON(row.events as string),
+      links: safelyParseJSON(row.links as string),
+      attributes: safelyParseJSON(row.attributes as string),
+      startTime: row.startTime,
+      endTime: row.endTime,
+      other: safelyParseJSON(row.other as string),
+      createdAt: row.createdAt,
+    })) as any;
+  }
+
+  async getWorkflowRuns({
+    workflowName,
+    fromDate,
+    toDate,
+    limit,
+    offset,
+  }: {
+    workflowName?: string;
+    fromDate?: Date;
+    toDate?: Date;
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<{
+    runs: Array<{
+      workflowName: string;
+      runId: string;
+      snapshot: WorkflowRunState | string;
+      createdAt: Date;
+      updatedAt: Date;
+    }>;
+    total: number;
+  }> {
+    const conditions: string[] = [];
+    const args: InValue[] = [];
+
+    if (workflowName) {
+      conditions.push('workflow_name = ?');
+      args.push(workflowName);
+    }
+
+    if (fromDate) {
+      conditions.push('createdAt >= ?');
+      args.push(fromDate.toISOString());
+    }
+
+    if (toDate) {
+      conditions.push('createdAt <= ?');
+      args.push(toDate.toISOString());
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    let total = 0;
+    // Only get total count when using pagination
+    if (limit !== undefined && offset !== undefined) {
+      const countResult = await this.client.execute({
+        sql: `SELECT COUNT(*) as count FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause}`,
+        args,
+      });
+      total = Number(countResult.rows?.[0]?.count ?? 0);
+    }
+
+    // Get results
+    const result = await this.client.execute({
+      sql: `SELECT * FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause} ORDER BY createdAt DESC${limit !== undefined && offset !== undefined ? ` LIMIT ? OFFSET ?` : ''}`,
+      args: limit !== undefined && offset !== undefined ? [...args, limit, offset] : args,
+    });
+
+    const runs = (result.rows || []).map(row => {
+      let parsedSnapshot: WorkflowRunState | string = row.snapshot as string;
+      if (typeof parsedSnapshot === 'string') {
+        try {
+          parsedSnapshot = JSON.parse(row.snapshot as string) as WorkflowRunState;
+        } catch (e) {
+          // If parsing fails, return the raw snapshot string
+          console.warn(`Failed to parse snapshot for workflow ${row.workflow_name}: ${e}`);
+        }
+      }
+
+      return {
+        workflowName: row.workflow_name as string,
+        runId: row.run_id as string,
+        snapshot: parsedSnapshot,
+        createdAt: new Date(row.createdAt as string),
+        updatedAt: new Date(row.updatedAt as string),
+      };
+    });
+
+    // Use runs.length as total when not paginating
+    return { runs, total: total || runs.length };
+  }
+}
+
+export { LibSQLStore as DefaultStorage };

--- a/stores/libsql/src/vector/filter.test.ts
+++ b/stores/libsql/src/vector/filter.test.ts
@@ -1,0 +1,968 @@
+import { describe, expect, it } from 'vitest';
+
+import { LibSQLFilterTranslator } from './filter';
+
+describe('LibSQLFilterTranslator', () => {
+  const translator = new LibSQLFilterTranslator();
+
+  // Basic Filter Translation
+  describe('Basic Filter Translation', () => {
+    it('handles empty filter', () => {
+      expect(translator.translate({})).toEqual({});
+    });
+
+    it('translates primitive to $eq', () => {
+      expect(translator.translate({ field: 'value' })).toEqual({
+        field: { $eq: 'value' },
+      });
+    });
+
+    it('translates array to $in', () => {
+      expect(translator.translate({ field: ['a', 'b'] })).toEqual({
+        field: { $in: ['a', 'b'] },
+      });
+    });
+
+    it('preserves comparison operators', () => {
+      const filter = {
+        field1: { $eq: 'value' },
+        field2: { $ne: 'value' },
+        field3: { $gt: 5 },
+        field4: { $gte: 5 },
+        field5: { $lt: 5 },
+        field6: { $lte: 5 },
+      };
+      expect(translator.translate(filter)).toEqual(filter);
+    });
+
+    it('preserves multiple comparison operators', () => {
+      expect(translator.translate({ field: { $gt: 5, $lt: 10 } })).toEqual({ field: { $gt: 5, $lt: 10 } });
+    });
+
+    it('handles nested paths', () => {
+      expect(
+        translator.translate({
+          'nested.field': { $eq: 'value' },
+        }),
+      ).toEqual({
+        'nested.field': { $eq: 'value' },
+      });
+    });
+
+    it('handles nested objects', () => {
+      expect(
+        translator.translate({
+          nested: {
+            field: 'value',
+          },
+        }),
+      ).toEqual({
+        'nested.field': { $eq: 'value' },
+      });
+    });
+  });
+
+  // Array Operations
+  describe('array operations', () => {
+    it('translates array to $in', () => {
+      expect(translator.translate({ field: ['a', 'b'] })).toEqual({
+        field: { $in: ['a', 'b'] },
+      });
+    });
+
+    it('translates arrays to JSON for basic operators', () => {
+      expect(translator.translate({ field: { $eq: ['a', 'b'] } })).toEqual({
+        field: { $eq: JSON.stringify(['a', 'b']) },
+      });
+      expect(translator.translate({ field: { $ne: ['a', 'b'] } })).toEqual({
+        field: { $ne: JSON.stringify(['a', 'b']) },
+      });
+    });
+
+    it('handles empty arrays', () => {
+      expect(
+        translator.translate({
+          field: [],
+        }),
+      ).toEqual({
+        field: { $in: [] },
+      });
+    });
+
+    it('validates $elemMatch translation', () => {
+      expect(
+        translator.translate({
+          field: {
+            $elemMatch: {
+              $eq: 'value',
+            },
+          },
+        }),
+      ).toEqual({
+        field: {
+          $elemMatch: {
+            $eq: 'value',
+          },
+        },
+      });
+
+      // Test multiple conditions
+      expect(
+        translator.translate({
+          field: {
+            $elemMatch: {
+              $gt: 5,
+              $lt: 10,
+            },
+          },
+        }),
+      ).toEqual({
+        field: {
+          $elemMatch: {
+            $gt: 5,
+            $lt: 10,
+          },
+        },
+      });
+    });
+  });
+
+  // Array Operator Normalization
+  describe('array operator normalization', () => {
+    it('normalizes single values for $all', () => {
+      expect(
+        translator.translate({
+          field: { $all: 'value' },
+        }),
+      ).toEqual({
+        field: { $all: ['value'] },
+      });
+    });
+
+    it('normalizes single values for $in', () => {
+      expect(
+        translator.translate({
+          field: { $in: 'value' },
+        }),
+      ).toEqual({
+        field: { $in: ['value'] },
+      });
+    });
+
+    it('normalizes single values for $nin', () => {
+      expect(
+        translator.translate({
+          field: { $nin: 'value' },
+        }),
+      ).toEqual({
+        field: { $nin: ['value'] },
+      });
+    });
+
+    it('preserves arrays for array operators', () => {
+      expect(
+        translator.translate({
+          field: { $all: ['value1', 'value2'] },
+        }),
+      ).toEqual({
+        field: { $all: ['value1', 'value2'] },
+      });
+    });
+  });
+
+  // Logical Operators
+  describe('Logical Operators', () => {
+    it('handles logical operators', () => {
+      const filter = {
+        $and: [{ field1: { $eq: 'value1' } }, { field2: { $eq: 'value2' } }],
+        $or: [{ field3: { $eq: 'value3' } }, { field4: { $eq: 'value4' } }],
+      };
+      expect(translator.translate(filter)).toEqual(filter);
+    });
+
+    it('handles empty logical operators', () => {
+      expect(
+        translator.translate({
+          $and: [],
+          $or: [],
+        }),
+      ).toEqual({
+        $and: [],
+        $or: [],
+      });
+    });
+
+    it('handles multiple logical operators at root level', () => {
+      expect(
+        translator.translate({
+          $and: [{ category: 'electronics' }],
+          $or: [{ price: { $lt: 100 } }, { price: { $gt: 20 } }],
+        }),
+      ).toEqual({
+        $and: [{ category: { $eq: 'electronics' } }],
+        $or: [{ price: { $lt: 100 } }, { price: { $gt: 20 } }],
+      });
+    });
+
+    it('handles empty conditions in logical operators', () => {
+      expect(
+        translator.translate({
+          $and: [],
+          category: 'electronics',
+        }),
+      ).toEqual({
+        $and: [],
+        category: { $eq: 'electronics' },
+      });
+    });
+
+    it('handles $nor operator', () => {
+      expect(
+        translator.translate({
+          $nor: [{ field1: 'value1' }, { field2: { $gt: 100 } }],
+        }),
+      ).toEqual({
+        $nor: [{ field1: { $eq: 'value1' } }, { field2: { $gt: 100 } }],
+      });
+    });
+
+    it('handles $not operator with comparison', () => {
+      expect(
+        translator.translate({
+          field: { $not: { $eq: 'value' } },
+        }),
+      ).toEqual({
+        field: { $not: { $eq: 'value' } },
+      });
+    });
+
+    it('handles $not operator with regex', () => {
+      expect(
+        translator.translate({
+          field: { $not: { $regex: 'pattern' } },
+        }),
+      ).toEqual({
+        field: { $not: { $regex: 'pattern' } },
+      });
+    });
+
+    it('handles nested logical operators', () => {
+      expect(
+        translator.translate({
+          $and: [
+            {
+              $or: [{ field1: 'value1' }, { field2: 'value2' }],
+            },
+            {
+              $nor: [{ field3: 'value3' }, { field4: 'value4' }],
+            },
+          ],
+        }),
+      ).toEqual({
+        $and: [
+          {
+            $or: [{ field1: { $eq: 'value1' } }, { field2: { $eq: 'value2' } }],
+          },
+          {
+            $nor: [{ field3: { $eq: 'value3' } }, { field4: { $eq: 'value4' } }],
+          },
+        ],
+      });
+    });
+
+    it('handles logical operators with empty arrays and primitives', () => {
+      expect(
+        translator.translate({
+          $and: [],
+          $or: [{ field1: 'value1' }],
+          field2: true,
+          $nor: [],
+        }),
+      ).toEqual({
+        $and: [],
+        $or: [{ field1: { $eq: 'value1' } }],
+        field2: { $eq: true },
+        $nor: [],
+      });
+    });
+
+    it('handles $not operator with comparison', () => {
+      expect(
+        translator.translate({
+          field: { $not: { $eq: 'value' } },
+        }),
+      ).toEqual({
+        field: { $not: { $eq: 'value' } },
+      });
+    });
+
+    it('handles $not operator with array operators', () => {
+      expect(
+        translator.translate({
+          field: { $not: { $in: ['value1', 'value2'] } },
+        }),
+      ).toEqual({
+        field: { $not: { $in: ['value1', 'value2'] } },
+      });
+    });
+
+    it('handles multiple $not conditions', () => {
+      expect(
+        translator.translate({
+          $and: [{ field1: { $not: { $eq: 'value1' } } }, { field2: { $not: { $in: ['value2', 'value3'] } } }],
+        }),
+      ).toEqual({
+        $and: [{ field1: { $not: { $eq: 'value1' } } }, { field2: { $not: { $in: ['value2', 'value3'] } } }],
+      });
+    });
+
+    it('handles combination of all logical operators', () => {
+      expect(
+        translator.translate({
+          $and: [
+            {
+              $or: [{ field1: 'value1' }, { field2: { $gt: 100 } }],
+            },
+            {
+              $nor: [{ field3: { $lt: 50 } }, { field4: { $eq: 'value4' } }],
+            },
+            {
+              field5: { $not: { $in: ['value5', 'value6'] } },
+            },
+          ],
+        }),
+      ).toEqual({
+        $and: [
+          {
+            $or: [{ field1: { $eq: 'value1' } }, { field2: { $gt: 100 } }],
+          },
+          {
+            $nor: [{ field3: { $lt: 50 } }, { field4: { $eq: 'value4' } }],
+          },
+          {
+            field5: { $not: { $in: ['value5', 'value6'] } },
+          },
+        ],
+      });
+    });
+  });
+
+  // Complex Filter Structures
+  describe('complex filter structures', () => {
+    it('handles nested logical operators with mixed conditions', () => {
+      expect(
+        translator.translate({
+          $or: [
+            {
+              $and: [{ category: 'value1' }, { price: { $gt: 90 } }, { active: true }],
+            },
+            {
+              $and: [{ category: 'value2' }, { tags: { $exists: true } }, { price: { $lt: 30 } }],
+            },
+          ],
+        }),
+      ).toEqual({
+        $or: [
+          {
+            $and: [{ category: { $eq: 'value1' } }, { price: { $gt: 90 } }, { active: { $eq: true } }],
+          },
+          {
+            $and: [{ category: { $eq: 'value2' } }, { tags: { $exists: true } }, { price: { $lt: 30 } }],
+          },
+        ],
+      });
+    });
+
+    it('handles deeply nested metadata paths', () => {
+      expect(
+        translator.translate({
+          'level1.level2.level3': 'deep value',
+        }),
+      ).toEqual({
+        'level1.level2.level3': { $eq: 'deep value' },
+      });
+    });
+
+    it('handles non-existent nested paths', () => {
+      expect(
+        translator.translate({
+          'nonexistent.path': 'value',
+        }),
+      ).toEqual({
+        'nonexistent.path': { $eq: 'value' },
+      });
+    });
+
+    it('handles logical operators with empty arrays and primitives', () => {
+      expect(
+        translator.translate({
+          $and: [],
+          $or: [{ field1: 'value1' }],
+          field2: true,
+          $nor: [],
+        }),
+      ).toEqual({
+        $and: [],
+        $or: [{ field1: { $eq: 'value1' } }],
+        field2: { $eq: true },
+        $nor: [],
+      });
+    });
+  });
+
+  // Edge Cases and Special Values
+  describe('Edge Cases and Special Values', () => {
+    it('handles null values', () => {
+      expect(
+        translator.translate({
+          field: null,
+        }),
+      ).toEqual({
+        field: { $eq: null },
+      });
+    });
+
+    it('handles boolean values', () => {
+      expect(
+        translator.translate({
+          field1: true,
+          field2: false,
+        }),
+      ).toEqual({
+        field1: { $eq: true },
+        field2: { $eq: false },
+      });
+    });
+
+    it('handles numeric values', () => {
+      expect(
+        translator.translate({
+          int: 42,
+          float: 42.42,
+          negative: -42,
+        }),
+      ).toEqual({
+        int: { $eq: 42 },
+        float: { $eq: 42.42 },
+        negative: { $eq: -42 },
+      });
+    });
+
+    it('handles empty strings', () => {
+      expect(
+        translator.translate({
+          field: '',
+        }),
+      ).toEqual({
+        field: { $eq: '' },
+      });
+    });
+
+    it('handles empty arrays', () => {
+      expect(
+        translator.translate({
+          field: [],
+        }),
+      ).toEqual({
+        field: { $in: [] },
+      });
+    });
+  });
+
+  // Complex Filter Structures
+  describe('Complex Filter Structures', () => {
+    it('handles nested logical operators with mixed conditions', () => {
+      expect(
+        translator.translate({
+          $or: [
+            {
+              $and: [{ category: 'value1' }, { price: { $gt: 90 } }, { active: true }],
+            },
+            {
+              $and: [{ category: 'value2' }, { tags: { $exists: true } }, { price: { $lt: 30 } }],
+            },
+          ],
+        }),
+      ).toEqual({
+        $or: [
+          {
+            $and: [{ category: { $eq: 'value1' } }, { price: { $gt: 90 } }, { active: { $eq: true } }],
+          },
+          {
+            $and: [{ category: { $eq: 'value2' } }, { tags: { $exists: true } }, { price: { $lt: 30 } }],
+          },
+        ],
+      });
+    });
+
+    it('handles multiple logical operators at root level', () => {
+      expect(
+        translator.translate({
+          $and: [{ category: 'electronics' }],
+          $or: [{ price: { $lt: 100 } }, { price: { $gt: 20 } }],
+        }),
+      ).toEqual({
+        $and: [{ category: { $eq: 'electronics' } }],
+        $or: [{ price: { $lt: 100 } }, { price: { $gt: 20 } }],
+      });
+    });
+
+    it('handles empty conditions in logical operators', () => {
+      expect(
+        translator.translate({
+          $and: [],
+          category: 'electronics',
+        }),
+      ).toEqual({
+        $and: [],
+        category: { $eq: 'electronics' },
+      });
+    });
+
+    it('handles deeply nested metadata paths', () => {
+      expect(
+        translator.translate({
+          'level1.level2.level3': 'deep value',
+        }),
+      ).toEqual({
+        'level1.level2.level3': { $eq: 'deep value' },
+      });
+    });
+
+    it('handles non-existent nested paths', () => {
+      expect(
+        translator.translate({
+          'nonexistent.path': 'value',
+        }),
+      ).toEqual({
+        'nonexistent.path': { $eq: 'value' },
+      });
+    });
+  });
+
+  // Array Operator Normalization
+  describe('Array Operator Normalization', () => {
+    it('normalizes single values for $all', () => {
+      expect(
+        translator.translate({
+          field: { $all: 'value' },
+        }),
+      ).toEqual({
+        field: { $all: ['value'] },
+      });
+    });
+
+    it('normalizes single values for $in', () => {
+      expect(
+        translator.translate({
+          field: { $in: 'value' },
+        }),
+      ).toEqual({
+        field: { $in: ['value'] },
+      });
+    });
+
+    it('normalizes single values for $nin', () => {
+      expect(
+        translator.translate({
+          field: { $nin: 'value' },
+        }),
+      ).toEqual({
+        field: { $nin: ['value'] },
+      });
+    });
+
+    it('preserves arrays for array operators', () => {
+      expect(
+        translator.translate({
+          field: { $all: ['value1', 'value2'] },
+        }),
+      ).toEqual({
+        field: { $all: ['value1', 'value2'] },
+      });
+    });
+  });
+
+  // Operator Support Validation
+  describe('Operator Support Validation', () => {
+    it('ensure all operator filters are supported', () => {
+      const supportedFilters = [
+        // Basic comparison operators
+        { field: { $eq: 'value' } },
+        { field: { $ne: 'value' } },
+        { field: { $gt: 'value' } },
+        { field: { $gte: 'value' } },
+        { field: { $lt: 'value' } },
+        { field: { $lte: 'value' } },
+
+        // Array operators
+        { field: { $in: ['value'] } },
+        { field: { $nin: ['value'] } },
+        { field: { $all: ['value'] } },
+        { field: { $elemMatch: { $gt: 5 } } },
+
+        // Pattern matching
+        // { field: { $regex: 'value' } },
+        { field: { $contains: 'value' } },
+
+        // Existence
+        { field: { $exists: true } },
+
+        { $and: [{ field1: 'value1' }, { field2: 'value2' }] },
+        { $or: [{ field1: 'value1' }, { field2: 'value2' }] },
+        { $nor: [{ field1: 'value1' }, { field2: 'value2' }] },
+
+        { $and: { field: 'value' } },
+        { $or: { field: 'value' } },
+        { $nor: { field: 'value' } },
+        { $not: { field: 'value' } },
+
+        { $or: [{ $and: { field1: 'value1' } }, { $not: { field2: 'value2' } }] },
+
+        { field: { $not: { $eq: 'value' } } },
+        { field: { $not: { $in: ['value1', 'value2'] } } },
+        { field: { $not: { $gt: 100 } } },
+        { field: { $not: { $lt: 50 } } },
+
+        { field: { $size: 1 } },
+      ];
+
+      supportedFilters.forEach(filter => {
+        expect(() => translator.translate(filter)).not.toThrow();
+      });
+    });
+
+    it('throws error for $not if not an object', () => {
+      expect(() => translator.translate({ $not: 'value' })).toThrow();
+      expect(() => translator.translate({ $not: [{ field: 'value' }] })).toThrow();
+    });
+    it('throws error for $not if empty', () => {
+      expect(() => translator.translate({ $not: {} })).toThrow();
+    });
+
+    // Add tests for logical operator placement restrictions
+    it('throws error when logical operators are used in field-level conditions', () => {
+      // $and cannot be used in field conditions
+      expect(() =>
+        translator.translate({
+          field: { $and: [{ $eq: 'value1' }, { $eq: 'value2' }] },
+        }),
+      ).toThrow();
+
+      // $or cannot be used in field conditions
+      expect(() =>
+        translator.translate({
+          field: { $or: [{ $eq: 'value1' }, { $eq: 'value2' }] },
+        }),
+      ).toThrow();
+
+      // $nor cannot be used in field conditions
+      expect(() =>
+        translator.translate({
+          field: { $nor: [{ $eq: 'value1' }, { $eq: 'value2' }] },
+        }),
+      ).toThrow();
+    });
+
+    it('allows logical operators at root level', () => {
+      // Valid root level usage
+      expect(() =>
+        translator.translate({
+          $and: [{ field1: 'value1' }, { field2: 'value2' }],
+          $or: [{ field3: 'value3' }, { field4: 'value4' }],
+          $nor: [{ field5: 'value5' }, { field6: 'value6' }],
+        }),
+      ).not.toThrow();
+    });
+
+    it('allows logical operators nested within other logical operators', () => {
+      // Valid nested usage
+      expect(() =>
+        translator.translate({
+          $and: [
+            {
+              $or: [{ field1: 'value1' }, { field2: 'value2' }],
+            },
+            {
+              $nor: [{ field3: 'value3' }, { field4: 'value4' }],
+            },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it('allows $not in field-level conditions', () => {
+      // $not is allowed in field conditions
+      expect(() =>
+        translator.translate({
+          field1: { $not: { $eq: 'value1' } },
+          field2: { $not: { $in: ['value2', 'value3'] } },
+          field3: { $not: { $regex: 'pattern' } },
+        }),
+      ).not.toThrow();
+    });
+
+    it('throws error for deeply nested logical operators in non-logical contexts', () => {
+      // Invalid deep nesting in comparison operators
+      expect(() =>
+        translator.translate({
+          field: {
+            $gt: {
+              $or: [{ subfield: 'value1' }, { subfield: 'value2' }],
+            },
+          },
+        }),
+      ).toThrow();
+
+      // Invalid deep nesting in array operators
+      expect(() =>
+        translator.translate({
+          field: {
+            $in: [
+              {
+                $and: [{ subfield: 'value1' }, { subfield: 'value2' }],
+              },
+            ],
+          },
+        }),
+      ).toThrow();
+    });
+
+    it('validates $not operator structure', () => {
+      // $not must be an object
+      expect(() => translator.translate({ field: { $not: 'value' } })).toThrow();
+      expect(() => translator.translate({ field: { $not: ['value'] } })).toThrow();
+      expect(() => translator.translate({ $not: 'value' })).toThrow();
+      expect(() => translator.translate({ $not: ['value'] })).toThrow();
+    });
+
+    it('validates $not operator nesting', () => {
+      // $not can be nested
+      expect(() =>
+        translator.translate({
+          field: { $not: { $not: { $eq: 'value' } } },
+        }),
+      ).not.toThrow();
+
+      // $not can be deeply nested
+      expect(() =>
+        translator.translate({
+          field: { $not: { $not: { $not: { $eq: 'value' } } } },
+        }),
+      ).not.toThrow();
+
+      // Cannot use $not with logical operators
+      expect(() =>
+        translator.translate({
+          field: { $not: { $and: [{ $eq: 'value1' }, { $eq: 'value2' }] } },
+        }),
+      ).not.toThrow();
+
+      expect(() =>
+        translator.translate({
+          field: { $not: { $or: [{ $eq: 'value1' }, { $eq: 'value2' }] } },
+        }),
+      ).not.toThrow();
+
+      // $not can be used with comparison operators at any nesting level
+      expect(() =>
+        translator.translate({
+          field: { $not: { $not: { $gt: 100 } } },
+          field2: { $not: { $not: { $lt: 50 } } },
+        }),
+      ).not.toThrow();
+    });
+
+    it('allows $not with comparison operators', () => {
+      expect(() =>
+        translator.translate({
+          field: { $not: { $eq: 'value' } },
+          field2: { $not: { $gt: 100 } },
+          field3: { $not: { $lt: 50 } },
+          field4: { $not: { $in: ['value1', 'value2'] } },
+        }),
+      ).not.toThrow();
+    });
+
+    it('validates empty $not conditions', () => {
+      expect(() => translator.translate({ field: { $not: {} } })).toThrow();
+      expect(() => translator.translate({ $not: {} })).toThrow();
+    });
+
+    it('throws error for non-logical operators at top level', () => {
+      const invalidFilters = [{ $gt: 100 }, { $in: ['value1', 'value2'] }, { $eq: true }];
+
+      invalidFilters.forEach(filter => {
+        expect(() => translator.translate(filter)).toThrow(/Invalid top-level operator/);
+      });
+    });
+    it('allows logical operators at top level', () => {
+      const validFilters = [{ $and: [{ field: 'value' }] }, { $or: [{ field: 'value' }] }];
+
+      validFilters.forEach(filter => {
+        expect(() => translator.translate(filter)).not.toThrow();
+      });
+    });
+
+    it('should throw error for direct regex patterns', () => {
+      const filter = {
+        field: /pattern/,
+      };
+      expect(() => translator.translate(filter)).toThrow();
+    });
+
+    it('validates $elemMatch requires an object with conditions', () => {
+      // Should throw for non-object values
+      expect(() =>
+        translator.translate({
+          field: { $elemMatch: 'value' },
+        }),
+      ).toThrow('$elemMatch requires an object with conditions');
+
+      expect(() =>
+        translator.translate({
+          field: { $elemMatch: ['value'] },
+        }),
+      ).toThrow('$elemMatch requires an object with conditions');
+    });
+  });
+
+  // Regex Support (Currently Commented)
+  // describe('regex translation', () => {
+  // it('translates string pattern', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: 'pattern' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: 'pattern' },
+  //   });
+  // });
+  // it('translates regex with options', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: 'pattern', $options: 'i' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: 'pattern', $options: 'i' },
+  //   });
+  // });
+  // it('translates regex literal', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: /pattern/i,
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: 'pattern', $options: 'i' },
+  //   });
+  // });
+  // it('translates starts with pattern', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: '^start' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: '^start' },
+  //   });
+  // });
+  // it('translates ends with pattern', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: 'end$' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: 'end$' },
+  //   });
+  // });
+  // it('translates exact match pattern', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: '^exact$' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: '^exact$' },
+  //   });
+  // });
+  // it('translates contains pattern', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: 'contains' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: 'contains' },
+  //   });
+  // });
+  // it('supports complex patterns', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: 'pat.*ern' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: 'pat.*ern' },
+  //   });
+  // });
+  // it('combines multiple regex flags', () => {
+  //   expect(
+  //     translator.translate({
+  //       field: { $regex: 'pattern', $options: 'imsx' },
+  //     }),
+  //   ).toEqual({
+  //     field: { $regex: 'pattern', $options: 'imsx' },
+  //   });
+  // });
+  // it('throws on $options without $regex', () => {
+  //   expect(() =>
+  //     translator.translate({
+  //       field: { $options: 'i' },
+  //     }),
+  //   ).toThrow();
+  // });
+  // it('handles nested regex patterns', () => {
+  //   expect(
+  //     translator.translate({
+  //       nested: {
+  //         field: { $regex: 'pattern', $options: 'i' },
+  //       },
+  //     }),
+  //   ).toEqual({
+  //     'nested.field': { $regex: 'pattern', $options: 'i' },
+  //   });
+  // });
+  // it('handles multiple regex patterns', () => {
+  //   expect(
+  //     translator.translate({
+  //       field1: { $regex: 'pattern1' },
+  //       field2: { $regex: 'pattern2', $options: 'i' },
+  //     }),
+  //   ).toEqual({
+  //     field1: { $regex: 'pattern1' },
+  //     field2: { $regex: 'pattern2', $options: 'i' },
+  //   });
+  // });
+  // it('handles regex in logical operators', () => {
+  //   expect(
+  //     translator.translate({
+  //       $or: [{ field: { $regex: 'pattern1' } }, { field: { $regex: 'pattern2', $options: 'i' } }],
+  //     }),
+  //   ).toEqual({
+  //     $or: [{ field: { $regex: 'pattern1' } }, { field: { $regex: 'pattern2', $options: 'i' } }],
+  //   });
+  // });
+  // it('handles deeply nested paths with regex', () => {
+  //   expect(
+  //     translator.translate({
+  //       'level1.level2.level3': { $regex: 'pattern', $options: 'i' },
+  //     }),
+  //   ).toEqual({
+  //     'level1.level2.level3': { $regex: 'pattern', $options: 'i' },
+  //   });
+  // });
+  // });
+
+  // Unsupported Operations
+  describe('unsupported operators', () => {
+    it('throws on unsupported operators', () => {
+      expect(() => translator.translate({ field: { $regex: 'value' } })).toThrow();
+    });
+  });
+});

--- a/stores/libsql/src/vector/filter.ts
+++ b/stores/libsql/src/vector/filter.ts
@@ -1,0 +1,117 @@
+import { BaseFilterTranslator } from '@mastra/core/vector/filter';
+import type { FieldCondition, VectorFilter, OperatorSupport } from '@mastra/core/vector/filter';
+
+/**
+ * Translates MongoDB-style filters to LibSQL compatible filters.
+ *
+ * Key differences from MongoDB:
+ *
+ * Logical Operators ($and, $or, $nor):
+ * - Can be used at the top level or nested within fields
+ * - Can take either a single condition or an array of conditions
+ *
+ */
+export class LibSQLFilterTranslator extends BaseFilterTranslator {
+  protected override getSupportedOperators(): OperatorSupport {
+    return {
+      ...BaseFilterTranslator.DEFAULT_OPERATORS,
+      regex: [],
+      custom: ['$contains', '$size'],
+    };
+  }
+
+  translate(filter?: VectorFilter): VectorFilter {
+    if (this.isEmpty(filter)) {
+      return filter;
+    }
+    this.validateFilter(filter);
+    return this.translateNode(filter);
+  }
+
+  private translateNode(node: VectorFilter | FieldCondition, currentPath: string = ''): any {
+    if (this.isRegex(node)) {
+      throw new Error('Direct regex pattern format is not supported in LibSQL');
+    }
+    // Helper to wrap result with path if needed
+    const withPath = (result: any) => (currentPath ? { [currentPath]: result } : result);
+
+    // Handle primitives
+    if (this.isPrimitive(node)) {
+      return withPath({ $eq: this.normalizeComparisonValue(node) });
+    }
+
+    // Handle arrays
+    if (Array.isArray(node)) {
+      return withPath({ $in: this.normalizeArrayValues(node) });
+    }
+
+    // Handle regex
+    // TODO: Look more into regex support for LibSQL
+    // if (node instanceof RegExp) {
+    //   return withPath(this.translateRegexPattern(node.source, node.flags));
+    // }
+
+    const entries = Object.entries(node as Record<string, any>);
+    const result: Record<string, any> = {};
+
+    // if ('$options' in node && !('$regex' in node)) {
+    //   throw new Error('$options is not valid without $regex');
+    // }
+
+    // TODO: Look more into regex support for LibSQL
+    // // Handle special regex object format
+    // if ('$regex' in node) {
+    //   const options = (node as any).$options || '';
+    //   return withPath(this.translateRegexPattern(node.$regex, options));
+    // }
+
+    // Process remaining entries
+    for (const [key, value] of entries) {
+      // // Skip options as they're handled with $regex
+      // if (key === '$options') continue;
+
+      const newPath = currentPath ? `${currentPath}.${key}` : key;
+
+      if (this.isLogicalOperator(key)) {
+        result[key] = Array.isArray(value)
+          ? value.map((filter: VectorFilter) => this.translateNode(filter))
+          : this.translateNode(value);
+      } else if (this.isOperator(key)) {
+        if (this.isArrayOperator(key) && !Array.isArray(value) && key !== '$elemMatch') {
+          result[key] = [value];
+        } else if (this.isBasicOperator(key) && Array.isArray(value)) {
+          result[key] = JSON.stringify(value);
+        } else {
+          result[key] = value;
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        // Handle nested objects
+        const hasOperators = Object.keys(value).some(k => this.isOperator(k));
+        if (hasOperators) {
+          result[newPath] = this.translateNode(value);
+        } else {
+          Object.assign(result, this.translateNode(value, newPath));
+        }
+      } else {
+        result[newPath] = this.translateNode(value);
+      }
+    }
+
+    return result;
+  }
+
+  // TODO: Look more into regex support for LibSQL
+  // private translateRegexPattern(pattern: string, options: string = ''): any {
+  //   if (!options) return { $regex: pattern };
+
+  //   const flags = options
+  //     .split('')
+  //     .filter(f => 'imsux'.includes(f))
+  //     .join('');
+
+  //   return {
+  //     $regex: pattern,
+  //     $options: flags,
+  //   };
+  // }
+}

--- a/stores/libsql/src/vector/index.test.ts
+++ b/stores/libsql/src/vector/index.test.ts
@@ -1,0 +1,1702 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+
+import { LibSQLVector } from './index.js';
+
+describe('LibSQLVector', () => {
+  let vectorDB: LibSQLVector;
+  const testIndexName = 'test_vectors';
+  // const testIndexName2 = 'test_vectors1';
+
+  beforeAll(async () => {
+    vectorDB = new LibSQLVector({
+      connectionUrl: 'file::memory:?cache=shared',
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up test tables
+    await vectorDB.deleteIndex(testIndexName);
+  });
+
+  // Index Management Tests
+  describe('Index Management', () => {
+    describe('createIndex', () => {
+      it('should create a new vector table with specified dimensions', async () => {
+        await vectorDB.createIndex({ indexName: testIndexName, dimension: 3 });
+
+        const stats = await vectorDB.describeIndex(testIndexName);
+        expect(stats?.dimension).toBe(3);
+        expect(stats?.count).toBe(0);
+      });
+
+      // it('should create index with specified metric', async () => {
+      //   await vectorDB.createIndex(testIndexName2, 3, 'euclidean');
+      //
+      //   const stats = await vectorDB.describeIndex(testIndexName2);
+      //
+      //   expect(stats.metric).toBe('euclidean');
+      // });
+
+      it('should throw error if dimension is invalid', async () => {
+        await expect(vectorDB.createIndex({ indexName: `testIndexNameFail`, dimension: 0 })).rejects.toThrow();
+      });
+    });
+
+    describe('listIndexes', () => {
+      const indexName = 'test_query_3';
+      beforeAll(async () => {
+        await vectorDB.createIndex({ indexName, dimension: 3 });
+      });
+
+      afterAll(async () => {
+        await vectorDB.deleteIndex(indexName);
+      });
+
+      it('should list all vector tables', async () => {
+        const indexes = await vectorDB.listIndexes();
+        expect(indexes).toContain(indexName);
+      });
+
+      it('should not return created index in list if it is deleted', async () => {
+        await vectorDB.deleteIndex(indexName);
+        const indexes = await vectorDB.listIndexes();
+        expect(indexes).not.toContain(indexName);
+      });
+    });
+
+    describe('describeIndex', () => {
+      const indexName = 'test_query_4';
+      beforeAll(async () => {
+        await vectorDB.createIndex({ indexName, dimension: 3 });
+      });
+
+      afterAll(async () => {
+        await vectorDB.deleteIndex(indexName);
+      });
+
+      it('should return correct index stats', async () => {
+        await vectorDB.createIndex({ indexName, dimension: 3, metric: 'cosine' });
+        const vectors = [
+          [1, 2, 3],
+          [4, 5, 6],
+        ];
+        await vectorDB.upsert({ indexName, vectors });
+
+        const stats = await vectorDB.describeIndex(indexName);
+        expect(stats).toEqual({
+          dimension: 3,
+          count: 2,
+          metric: 'cosine',
+        });
+      });
+
+      it('should throw error for non-existent index', async () => {
+        await expect(vectorDB.describeIndex('non_existent')).rejects.toThrow();
+      });
+    });
+  });
+
+  // Vector Operations Tests
+  describe('Vector Operations', () => {
+    describe('upsert', () => {
+      beforeEach(async () => {
+        await vectorDB.createIndex({ indexName: testIndexName, dimension: 3 });
+      });
+
+      afterEach(async () => {
+        await vectorDB.deleteIndex(testIndexName);
+      });
+
+      it('should insert new vectors', async () => {
+        const vectors = [
+          [1, 2, 3],
+          [4, 5, 6],
+        ];
+        const ids = await vectorDB.upsert({ indexName: testIndexName, vectors });
+
+        expect(ids).toHaveLength(2);
+        const stats = await vectorDB.describeIndex(testIndexName);
+        expect(stats.count).toBe(2);
+      });
+
+      it('should update existing vectors', async () => {
+        const vectors = [[1, 2, 3]];
+        const metadata = [{ test: 'initial' }];
+        const [id] = await vectorDB.upsert({ indexName: testIndexName, vectors, metadata });
+
+        const updatedVectors = [[4, 5, 6]];
+        const updatedMetadata = [{ test: 'updated' }];
+        await vectorDB.upsert({
+          indexName: testIndexName,
+          vectors: updatedVectors,
+          metadata: updatedMetadata,
+          ids: [id!],
+        });
+
+        const results = await vectorDB.query({ indexName: testIndexName, queryVector: [4, 5, 6], topK: 1 });
+        expect(results[0]?.id).toBe(id);
+        expect(results[0]?.metadata).toEqual({ test: 'updated' });
+      });
+
+      it('should handle metadata correctly', async () => {
+        const vectors = [[1, 2, 3]];
+        const metadata = [{ test: 'value', num: 123 }];
+
+        await vectorDB.upsert({ indexName: testIndexName, vectors, metadata });
+        const results = await vectorDB.query({ indexName: testIndexName, queryVector: [1, 2, 3], topK: 1 });
+
+        expect(results[0]?.metadata).toEqual(metadata[0]);
+      });
+
+      it('should throw error if vector dimensions dont match', async () => {
+        const vectors = [[1, 2, 3, 4]]; // 4D vector for 3D index
+        await expect(vectorDB.upsert({ indexName: testIndexName, vectors })).rejects.toThrow(
+          `Vector dimension mismatch: Index "${testIndexName}" expects 3 dimensions but got 4 dimensions. ` +
+            `Either use a matching embedding model or delete and recreate the index with the new dimension.`,
+        );
+      });
+
+      it('should delete the vector by id', async () => {
+        const vectors = [
+          [1, 2, 3],
+          [4, 5, 6],
+        ];
+        const ids = await vectorDB.upsert({ indexName: testIndexName, vectors });
+        expect(ids).toHaveLength(2);
+        const id = ids[1];
+
+        await vectorDB.deleteIndexById(testIndexName, ids[0]);
+
+        const results = await vectorDB.query({ indexName: testIndexName, queryVector: [1, 2, 3] });
+        expect(results).toHaveLength(1);
+        expect(results[0]?.id).toBe(id);
+      });
+
+      it('should update the vector by id', async () => {
+        const vectors = [[1, 2, 3]];
+        const metadata = [{ test: 'initial' }];
+        const [id] = await vectorDB.upsert({ indexName: testIndexName, vectors, metadata });
+
+        const update = {
+          vector: [4, 5, 6],
+          metadata: { test: 'updated' },
+        };
+        await vectorDB.updateIndexById(testIndexName, id, update);
+
+        const results = await vectorDB.query({
+          indexName: testIndexName,
+          queryVector: [4, 5, 6],
+          topK: 1,
+          includeVector: true,
+        });
+        expect(results[0]?.id).toBe(id);
+        expect(results[0]?.metadata).toEqual({ test: 'updated' });
+        expect(results[0]?.vector).toEqual([4, 5, 6]);
+      });
+
+      it('should update only metadata by id', async () => {
+        const vectors = [[1, 2, 3]];
+        const metadata = [{ test: 'initial' }];
+        const [id] = await vectorDB.upsert({ indexName: testIndexName, vectors, metadata });
+
+        const update = {
+          metadata: { test: 'updated' },
+        };
+        await vectorDB.updateIndexById(testIndexName, id, update);
+
+        const results = await vectorDB.query({ indexName: testIndexName, queryVector: [1, 2, 3], topK: 1 });
+        expect(results[0]?.id).toBe(id);
+        expect(results[0]?.metadata).toEqual({ test: 'updated' });
+        expect(results[0]?.vector).toBeUndefined();
+      });
+
+      it('should update only vector by id', async () => {
+        const vectors = [[1, 2, 3]];
+        const metadata = [{ test: 'initial' }];
+        const [id] = await vectorDB.upsert({ indexName: testIndexName, vectors, metadata });
+
+        const update = {
+          vector: [4, 5, 6],
+        };
+        await vectorDB.updateIndexById(testIndexName, id, update);
+
+        const results = await vectorDB.query({
+          indexName: testIndexName,
+          queryVector: [4, 5, 6],
+          topK: 1,
+          includeVector: true,
+        });
+        expect(results[0]?.id).toBe(id);
+        expect(results[0]?.metadata).toEqual({ test: 'initial' });
+        expect(results[0]?.vector).toEqual([4, 5, 6]);
+      });
+
+      it('should throw error if no updates are provided', async () => {
+        const vectors = [[1, 2, 3]];
+        const metadata = [{ test: 'initial' }];
+        const [id] = await vectorDB.upsert({ indexName: testIndexName, vectors, metadata });
+
+        await expect(vectorDB.updateIndexById(testIndexName, id, {})).rejects.toThrow('No updates provided');
+      });
+    });
+
+    describe('Basic Query Operations', () => {
+      const indexName = 'test_query_2';
+      beforeEach(async () => {
+        await vectorDB.createIndex({ indexName, dimension: 3 });
+        const vectors = [
+          [1, 0, 0],
+          [0.8, 0.2, 0],
+          [0, 1, 0],
+        ];
+        const metadata = [
+          { type: 'a', value: 1 },
+          { type: 'b', value: 2 },
+          { type: 'a', value: 3 },
+        ];
+        await vectorDB.upsert({ indexName, vectors, metadata });
+      });
+
+      afterEach(async () => {
+        await vectorDB.deleteIndex(indexName);
+      });
+
+      it('should return closest vectors', async () => {
+        const results = await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 1 });
+        expect(results).toHaveLength(1);
+        expect(results[0]?.vector).toBe(undefined);
+        expect(results[0]?.score).toBeCloseTo(1, 5);
+      });
+
+      it('should return vector with result', async () => {
+        const results = await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 1, includeVector: true });
+        expect(results).toHaveLength(1);
+        expect(results[0]?.vector).toStrictEqual([1, 0, 0]);
+      });
+
+      it('should respect topK parameter', async () => {
+        const results = await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 2 });
+        expect(results).toHaveLength(2);
+      });
+
+      it('should handle filters correctly', async () => {
+        const results = await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 10, filter: { type: 'a' } });
+
+        expect(results).toHaveLength(1);
+        results.forEach(result => {
+          expect(result?.metadata?.type).toBe('a');
+        });
+      });
+    });
+  });
+
+  // Advanced Query and Filter Tests
+  describe('Advanced Query and Filter Operations', () => {
+    const indexName = 'test_query_filters';
+
+    beforeEach(async () => {
+      await vectorDB.createIndex({ indexName, dimension: 3 });
+      const vectors = [
+        [1, 0.1, 0],
+        [0.9, 0.2, 0],
+        [0.95, 0.1, 0],
+        [0.85, 0.2, 0],
+        [0.9, 0.1, 0],
+      ];
+
+      const metadata = [
+        {
+          category: 'electronics',
+          price: 100,
+          tags: ['new', 'premium'],
+          active: true,
+          ratings: [4.5, 4.8, 4.2], // Array of numbers
+          stock: [
+            { location: 'A', count: 25 },
+            { location: 'B', count: 15 },
+          ], // Array of objects
+          reviews: [
+            { user: 'alice', score: 5, verified: true },
+            { user: 'bob', score: 4, verified: true },
+            { user: 'charlie', score: 3, verified: false },
+          ], // Complex array objects
+        },
+        {
+          category: 'books',
+          price: 50,
+          tags: ['used'],
+          active: true,
+          ratings: [3.8, 4.0, 4.1],
+          stock: [
+            { location: 'A', count: 10 },
+            { location: 'C', count: 30 },
+          ],
+          reviews: [
+            { user: 'dave', score: 4, verified: true },
+            { user: 'eve', score: 5, verified: false },
+          ],
+        },
+        { category: 'electronics', price: 75, tags: ['refurbished'], active: false },
+        { category: 'books', price: 25, tags: ['used', 'sale'], active: true },
+        { category: 'clothing', price: 60, tags: ['new'], active: true },
+      ];
+
+      await vectorDB.upsert({ indexName, vectors, metadata });
+    });
+
+    afterEach(async () => {
+      await vectorDB.deleteIndex(indexName);
+    });
+
+    // Numeric Comparison Tests
+    describe('Comparison Operators', () => {
+      it('should handle numeric string comparisons', async () => {
+        // Insert a record with numeric string
+        await vectorDB.upsert({ indexName, vectors: [[1, 0.1, 0]], metadata: [{ numericString: '123' }] });
+
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { numericString: { $gt: '100' } }, // Compare strings numerically
+        });
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0]?.metadata?.numericString).toBe('123');
+      });
+
+      it('should filter with $gt operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $gt: 75 } },
+        });
+        expect(results).toHaveLength(1);
+        expect(results[0]?.metadata?.price).toBe(100);
+      });
+
+      it('should filter with $lte operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $lte: 50 } },
+        });
+        expect(results).toHaveLength(2);
+        results.forEach(result => {
+          expect(result.metadata?.price).toBeLessThanOrEqual(50);
+        });
+      });
+
+      it('should filter with lt operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $lt: 60 } },
+        });
+        expect(results).toHaveLength(2);
+        results.forEach(result => {
+          expect(result.metadata?.price).toBeLessThan(60);
+        });
+      });
+
+      it('should filter with gte operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $gte: 75 } },
+        });
+        expect(results).toHaveLength(2);
+        results.forEach(result => {
+          expect(result.metadata?.price).toBeGreaterThanOrEqual(75);
+        });
+      });
+
+      it('should filter with ne operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $ne: 'electronics' } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).not.toBe('electronics');
+        });
+      });
+
+      it('should filter with $gt and $lte operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $gt: 70, $lte: 100 } },
+        });
+        expect(results).toHaveLength(2);
+        results.forEach(result => {
+          expect(result.metadata?.price).toBeGreaterThan(70);
+          expect(result.metadata?.price).toBeLessThanOrEqual(100);
+        });
+      });
+    });
+
+    // Array Operator Tests
+    describe('Array Operators', () => {
+      it('should filter with $in operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $in: ['electronics', 'clothing'] } },
+        });
+        expect(results).toHaveLength(3);
+        results.forEach(result => {
+          expect(['electronics', 'clothing']).toContain(result.metadata?.category);
+        });
+      });
+
+      it('should filter with $nin operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $nin: ['electronics', 'books'] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(['electronics', 'books']).not.toContain(result.metadata?.category);
+        });
+      });
+
+      it('should handle empty arrays in in/nin operators', async () => {
+        // Should return no results for empty IN
+        const resultsIn = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $in: [] } },
+        });
+        expect(resultsIn).toHaveLength(0);
+
+        // Should return all results for empty NIN
+        const resultsNin = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $nin: [] } },
+        });
+        expect(resultsNin.length).toBeGreaterThan(0);
+      });
+
+      it('should filter with array $contains operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0.1, 0],
+          filter: { tags: { $contains: ['new'] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.tags).toContain('new');
+        });
+      });
+
+      it('should filter with $elemMatch operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            tags: {
+              $elemMatch: {
+                $in: ['new', 'premium'],
+              },
+            },
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.tags.some(tag => ['new', 'premium'].includes(tag))).toBe(true);
+        });
+      });
+
+      it('should filter with $elemMatch using equality', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            tags: {
+              $elemMatch: {
+                $eq: 'sale',
+              },
+            },
+          },
+        });
+        expect(results).toHaveLength(1);
+        expect(results[0]?.metadata?.tags).toContain('sale');
+      });
+
+      it('should filter with $elemMatch using multiple conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            ratings: {
+              $elemMatch: {
+                $gt: 4,
+                $lt: 4.5,
+              },
+            },
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(Array.isArray(result.metadata?.ratings)).toBe(true);
+          expect(result.metadata?.ratings.some(rating => rating > 4 && rating < 4.5)).toBe(true);
+        });
+      });
+
+      it('should handle complex $elemMatch conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            stock: {
+              $elemMatch: {
+                location: 'A',
+                count: { $gt: 20 },
+              },
+            },
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          const matchingStock = result.metadata?.stock.find(s => s.location === 'A' && s.count > 20);
+          expect(matchingStock).toBeDefined();
+        });
+      });
+
+      it('should filter with $elemMatch on nested numeric fields', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            reviews: {
+              $elemMatch: {
+                score: { $gt: 4 },
+              },
+            },
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.reviews.some(r => r.score > 4)).toBe(true);
+        });
+      });
+
+      it('should filter with $elemMatch on multiple nested fields', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            reviews: {
+              $elemMatch: {
+                score: { $gte: 4 },
+                verified: true,
+              },
+            },
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.reviews.some(r => r.score >= 4 && r.verified)).toBe(true);
+        });
+      });
+
+      it('should filter with $elemMatch on exact string match', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            reviews: {
+              $elemMatch: {
+                user: 'alice',
+              },
+            },
+          },
+        });
+        expect(results).toHaveLength(1);
+        expect(results[0].metadata?.reviews.some(r => r.user === 'alice')).toBe(true);
+      });
+
+      it('should handle $elemMatch with no matches', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            reviews: {
+              $elemMatch: {
+                score: 10, // No review has score 10
+              },
+            },
+          },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      it('should filter with $all operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $all: ['used', 'sale'] } },
+        });
+        expect(results).toHaveLength(1);
+        results.forEach(result => {
+          expect(result.metadata?.tags).toContain('used');
+          expect(result.metadata?.tags).toContain('sale');
+        });
+      });
+
+      it('should filter with $all using single value', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $all: ['new'] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.tags).toContain('new');
+        });
+      });
+
+      it('should handle empty array for $all', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $all: [] } },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      it('should handle non-array field $all', async () => {
+        // First insert a record with non-array field
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [{ tags: 'not-an-array' }],
+        });
+
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $all: ['value'] } },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      // Contains Operator Tests
+      it('should filter with contains operator for exact field match', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0.1, 0],
+          filter: { category: { $contains: 'electronics' } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).toBe('electronics');
+        });
+      });
+
+      it('should filter with $contains operator for nested objects', async () => {
+        // First insert a record with nested object
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [
+            {
+              details: { color: 'red', size: 'large' },
+              category: 'clothing',
+            },
+          ],
+        });
+
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0.1, 0],
+          filter: { details: { $contains: { color: 'red' } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.details.color).toBe('red');
+        });
+      });
+
+      // String Pattern Tests
+      it('should handle exact string matches', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: 'electronics' },
+        });
+        expect(results).toHaveLength(2);
+      });
+
+      it('should handle case-sensitive string matches', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: 'ELECTRONICS' },
+        });
+        expect(results).toHaveLength(0);
+      });
+      it('should filter arrays by size', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { ratings: { $size: 3 } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.ratings).toHaveLength(3);
+        });
+
+        const noResults = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { ratings: { $size: 10 } },
+        });
+        expect(noResults).toHaveLength(0);
+      });
+
+      it('should handle $size with nested arrays', async () => {
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [{ nested: { array: [1, 2, 3, 4] } }],
+        });
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { 'nested.array': { $size: 4 } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.nested.array).toHaveLength(4);
+        });
+      });
+    });
+
+    // Logical Operator Tests
+    describe('Logical Operators', () => {
+      it('should handle AND filter conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $and: [{ category: { $eq: 'electronics' } }, { price: { $gt: 75 } }] },
+        });
+        expect(results).toHaveLength(1);
+        expect(results[0]?.metadata?.category).toBe('electronics');
+        expect(results[0]?.metadata?.price).toBeGreaterThan(75);
+      });
+
+      it('should handle OR filter conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $or: [{ category: { $eq: 'electronics' } }, { category: { $eq: 'books' } }] },
+        });
+        expect(results.length).toBeGreaterThan(1);
+        results.forEach(result => {
+          expect(['electronics', 'books']).toContain(result?.metadata?.category);
+        });
+      });
+
+      it('should handle $not operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $not: { category: 'electronics' } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).not.toBe('electronics');
+        });
+      });
+
+      it('should handle $nor operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $nor: [{ category: 'electronics' }, { category: 'books' }] },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(['electronics', 'books']).not.toContain(result.metadata?.category);
+        });
+      });
+
+      it('should handle nested $not with $or', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $not: { $or: [{ category: 'electronics' }, { category: 'books' }] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(['electronics', 'books']).not.toContain(result.metadata?.category);
+        });
+      });
+
+      it('should handle $not with comparison operators', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $not: { $gt: 100 } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(Number(result.metadata?.price)).toBeLessThanOrEqual(100);
+        });
+      });
+
+      it('should handle $not with $in operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $not: { $in: ['electronics', 'books'] } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(['electronics', 'books']).not.toContain(result.metadata?.category);
+        });
+      });
+
+      it('should handle $not with multiple nested conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $not: { $and: [{ category: 'electronics' }, { price: { $gt: 50 } }] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category !== 'electronics' || result.metadata?.price <= 50).toBe(true);
+        });
+      });
+
+      it('should handle $not with $exists operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $not: { $exists: true } } },
+        });
+        expect(results.length).toBe(0); // All test data has tags
+      });
+
+      it('should handle $not with array operators', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $not: { $all: ['new', 'premium'] } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(!result.metadata?.tags.includes('new') || !result.metadata?.tags.includes('premium')).toBe(true);
+        });
+      });
+
+      it('should handle $not with complex nested conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            $not: {
+              $or: [
+                { $and: [{ category: 'electronics' }, { price: { $gt: 90 } }] },
+                { $and: [{ category: 'books' }, { price: { $lt: 30 } }] },
+              ],
+            },
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          const notExpensiveElectronics = !(result.metadata?.category === 'electronics' && result.metadata?.price > 90);
+          const notCheapBooks = !(result.metadata?.category === 'books' && result.metadata?.price < 30);
+          expect(notExpensiveElectronics && notCheapBooks).toBe(true);
+        });
+      });
+
+      it('should handle $not with empty arrays', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $not: { $in: [] } } },
+        });
+        expect(results.length).toBeGreaterThan(0); // Should match all records
+      });
+
+      it('should handle $not with null values', async () => {
+        // First insert a record with null value
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [{ category: null, price: 0 }],
+        });
+
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $not: { $eq: null } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).not.toBeNull();
+        });
+      });
+
+      it('should handle $not with boolean values', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { active: { $not: { $eq: true } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.active).not.toBe(true);
+        });
+      });
+
+      it('should handle $not with multiple conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $not: { category: 'electronics', price: { $gt: 50 } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+      });
+
+      it('should handle $not with $not operator', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $not: { $not: { category: 'electronics' } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+      });
+
+      it('should handle $not in nested fields', async () => {
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [{ user: { profile: { price: 10 } } }],
+        });
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { 'user.profile.price': { $not: { $gt: 25 } } },
+        });
+        expect(results.length).toBe(1);
+      });
+
+      it('should handle $not with multiple operators', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $not: { $gte: 30, $lte: 70 } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          const price = Number(result.metadata?.price);
+          expect(price < 30 || price > 70).toBe(true);
+        });
+      });
+
+      it('should handle $not with comparison operators', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $not: { $gt: 100 } } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(Number(result.metadata?.price)).toBeLessThanOrEqual(100);
+        });
+      });
+
+      it('should handle $not with $and', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $not: { $and: [{ category: 'electronics' }, { price: { $gt: 50 } }] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category !== 'electronics' || result.metadata?.price <= 50).toBe(true);
+        });
+      });
+
+      it('should handle $nor with $or', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $nor: [{ $or: [{ category: 'electronics' }, { category: 'books' }] }, { price: { $gt: 75 } }] },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(['electronics', 'books']).not.toContain(result.metadata?.category);
+          expect(result.metadata?.price).toBeLessThanOrEqual(75);
+        });
+      });
+
+      it('should handle $nor with nested $and conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            $nor: [
+              { $and: [{ category: 'electronics' }, { active: true }] },
+              { $and: [{ category: 'books' }, { price: { $lt: 30 } }] },
+            ],
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          const notElectronicsActive = !(
+            result.metadata?.category === 'electronics' && result.metadata?.active === true
+          );
+          const notBooksLowPrice = !(result.metadata?.category === 'books' && result.metadata?.price < 30);
+          expect(notElectronicsActive && notBooksLowPrice).toBe(true);
+        });
+      });
+
+      it('should handle nested $and with $or and $not', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            $and: [{ $or: [{ category: 'electronics' }, { category: 'books' }] }, { $not: { price: { $lt: 50 } } }],
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(['electronics', 'books']).toContain(result.metadata?.category);
+          expect(result.metadata?.price).toBeGreaterThanOrEqual(50);
+        });
+      });
+
+      it('should handle $or with multiple $not conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $or: [{ $not: { category: 'electronics' } }, { $not: { price: { $gt: 50 } } }] },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category !== 'electronics' || result.metadata?.price <= 50).toBe(true);
+        });
+      });
+    });
+
+    // Edge Cases and Special Values
+    describe('Edge Cases and Special Values', () => {
+      it('should handle empty result sets with valid filters', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $gt: 1000 } },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      it('should throw error for invalid operator', async () => {
+        await expect(
+          vectorDB.query({
+            indexName,
+            queryVector: [1, 0, 0],
+            filter: { price: { $invalid: 100 } },
+          }),
+        ).rejects.toThrow('Unsupported operator: $invalid');
+      });
+
+      it('should handle empty filter object', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {},
+        });
+        expect(results.length).toBeGreaterThan(0);
+      });
+
+      it('should handle numeric string comparisons', async () => {
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [{ numericString: '123' }],
+        });
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { numericString: { $gt: '100' } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0]?.metadata?.numericString).toBe('123');
+      });
+    });
+
+    // Score Threshold Tests
+    describe('Score Threshold', () => {
+      it('should respect minimum score threshold', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: 'electronics' },
+          includeVector: false,
+          minScore: 0.9,
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.score).toBeGreaterThan(0.9);
+        });
+      });
+    });
+
+    describe('Edge Cases and Special Values', () => {
+      // Additional Edge Cases
+      it('should handle empty result sets with valid filters', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $gt: 1000 } },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      it('should handle empty filter object', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {},
+        });
+        expect(results.length).toBeGreaterThan(0);
+      });
+
+      it('should handle non-existent field', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { nonexistent: { $elemMatch: { $eq: 'value' } } },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      it('should handle non-existent values', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $elemMatch: { $eq: 'nonexistent-tag' } } },
+        });
+        expect(results).toHaveLength(0);
+      });
+      // Empty Conditions Tests
+      it('should handle empty conditions in logical operators', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $and: [], category: 'electronics' },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).toBe('electronics');
+        });
+      });
+
+      it('should handle empty $and conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $and: [], category: 'electronics' },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).toBe('electronics');
+        });
+      });
+
+      it('should handle empty $or conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $or: [], category: 'electronics' },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      it('should handle empty $nor conditions', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $nor: [], category: 'electronics' },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).toBe('electronics');
+        });
+      });
+
+      it('should handle empty $not conditions', async () => {
+        await expect(
+          vectorDB.query({
+            indexName,
+            queryVector: [1, 0, 0],
+            filter: { $not: {}, category: 'electronics' },
+          }),
+        ).rejects.toThrow('$not operator cannot be empty');
+      });
+
+      it('should handle multiple empty logical operators', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { $and: [], $or: [], $nor: [], category: 'electronics' },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      // Nested Field Tests
+      it('should handle deeply nested metadata paths', async () => {
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [
+            {
+              level1: {
+                level2: {
+                  level3: 'deep value',
+                },
+              },
+            },
+          ],
+        });
+
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { 'level1.level2.level3': 'deep value' },
+        });
+        expect(results).toHaveLength(1);
+        expect(results[0]?.metadata?.level1?.level2?.level3).toBe('deep value');
+      });
+
+      it('should handle non-existent nested paths', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { 'nonexistent.path': 'value' },
+        });
+        expect(results).toHaveLength(0);
+      });
+
+      // Score Threshold Tests
+      it('should respect minimum score threshold', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: 'electronics' },
+          includeVector: false,
+          minScore: 0.9,
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.score).toBeGreaterThan(0.9);
+        });
+      });
+
+      // Complex Nested Operators Test
+      it('should handle deeply nested logical operators', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            $and: [
+              { $or: [{ category: 'electronics' }, { $and: [{ category: 'books' }, { price: { $lt: 30 } }] }] },
+              { $not: { $or: [{ active: false }, { price: { $gt: 100 } }] } },
+            ],
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          // First condition: electronics OR (books AND price < 30)
+          const firstCondition =
+            result.metadata?.category === 'electronics' ||
+            (result.metadata?.category === 'books' && result.metadata?.price < 30);
+
+          // Second condition: NOT (active = false OR price > 100)
+          const secondCondition = result.metadata?.active !== false && result.metadata?.price <= 100;
+
+          expect(firstCondition && secondCondition).toBe(true);
+        });
+      });
+
+      it('should throw error for invalid operator', async () => {
+        await expect(
+          vectorDB.query({
+            indexName,
+            queryVector: [1, 0, 0],
+            filter: { price: { $invalid: 100 } },
+          }),
+        ).rejects.toThrow('Unsupported operator: $invalid');
+      });
+
+      it('should handle multiple logical operators at root level', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {
+            $and: [{ category: 'electronics' }],
+            $or: [{ price: { $lt: 100 } }, { price: { $gt: 20 } }],
+            $nor: [],
+          },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).toBe('electronics');
+          expect(result.metadata?.price < 100 || result.metadata?.price > 20).toBe(true);
+        });
+      });
+
+      it('should handle non-array field with $elemMatch', async () => {
+        // First insert a record with non-array field
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [{ tags: 'not-an-array' }],
+        });
+
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $elemMatch: { $eq: 'value' } } },
+        });
+        expect(results).toHaveLength(0); // Should return no results for non-array field
+      });
+      it('should handle undefined filter', async () => {
+        const results1 = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: undefined,
+        });
+        const results2 = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+        });
+        expect(results1).toEqual(results2);
+        expect(results1.length).toBeGreaterThan(0);
+      });
+
+      it('should handle empty object filter', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: {},
+        });
+        const results2 = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+        });
+        expect(results).toEqual(results2);
+        expect(results.length).toBeGreaterThan(0);
+      });
+
+      it('should handle null filter', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: null,
+        });
+        const results2 = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+        });
+        expect(results).toEqual(results2);
+        expect(results.length).toBeGreaterThan(0);
+      });
+    });
+
+    // Regex Operator Tests
+    // describe('Regex Operators', () => {
+    //   //   // it('should handle $not with regex', async () => {
+    //   //   //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     category: { $not: { $regex: '^elect' } },
+    //   //   //   });
+    //   //   //   expect(results.length).toBeGreaterThan(0);
+    //   //   //   results.forEach(result => {
+    //   //   //     expect(result.metadata?.category).not.toMatch(/^elect/);
+    //   //   //   });
+    //   //   // });
+    //   // Regex operator tests
+    //   // it('should handle basic regex patterns', async () => {
+    //   //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //     category: { $regex: 'elect.*' },
+    //   //   });
+    //   //   expect(results).toHaveLength(2);
+    //   // });
+    //   // it('should handle case sensitivity', async () => {
+    //   //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //     category: { $regex: 'ELECTRONICS' },
+    //   //   });
+    //   //   expect(results).toHaveLength(0); // Case sensitive by default
+    //   //   const iResults = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //     category: { $regex: 'ELECTRONICS', $options: 'i' },
+    //   //   });
+    //   //   expect(iResults).toHaveLength(2); // Case insensitive
+    //   // });
+    //   // it('should handle start/end anchors', async () => {
+    //   //   const startResults = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //     category: { $regex: '^elect' },
+    //   //   });
+    //   //   expect(startResults).toHaveLength(2);
+    //   //   const endResults = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //     category: { $regex: 'nics$' },
+    //   //   });
+    //   //   expect(endResults).toHaveLength(2);
+    //   // });
+    //   // it('should handle multiline flag', async () => {
+    //   //   // First insert a record with multiline text
+    //   //   await vectorDB.upsert(
+    //   //   //     indexName,
+    //   //   //     [[1, 0.1, 0]],
+    //   //   //     [
+    //   //   //       {
+    //   //   //         description: 'First line\nSecond line\nThird line',
+    //   //   //       },
+    //   //   //     ],
+    //   //   //   );
+    //   //   //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     description: { $regex: '^Second', $options: 'm' },
+    //   //   //   });
+    //   //   //   expect(results).toHaveLength(1);
+    //   //   // });
+    //   // it('should handle multiline regex patterns', async () => {
+    //   //   await vectorDB.upsert(
+    //   //   //     indexName,
+    //   //   //     [[1, 0.1, 0]],
+    //   //   //     [
+    //   //   //       {
+    //   //   //         description: 'First line\nSecond line\nThird line',
+    //   //   //       },
+    //   //   //     ],
+    //   //   //   );
+    //   //   //   // Test without multiline flag
+    //   //   //   const withoutM = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     description: { $regex: '^Second' },
+    //   //   //   });
+    //   //   //   expect(withoutM).toHaveLength(0); // Won't match "Second" at start of line
+    //   //   // Test with multiline flag
+    //   //   //   const withM = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     description: { $regex: '^Second', $options: 'm' },
+    //   //   //   });
+    //   //   //   expect(withM).toHaveLength(1); // Will match "Second" at start of any line
+    //   //   // });
+    //   // });
+    //   // it('should handle dotall flag', async () => {
+    //   //   await vectorDB.upsert(
+    //   //     indexName,
+    //   //     [[1, 0.1, 0]],
+    //   //     [
+    //   //       {
+    //   //         description: 'First\nSecond\nThird',
+    //   //       },
+    //   //     ],
+    //   //   );
+    //   //   // Test with a more complex pattern that demonstrates s flag behavior
+    //   //   const withoutS = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     description: { $regex: 'First[^\\n]*Third' },
+    //   //   //   });
+    //   //   //   expect(withoutS).toHaveLength(0); // Won't match across lines without s flag
+    //   //   //   const withS = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     description: { $regex: 'First.*Third', $options: 's' },
+    //   //   //   });
+    //   //   //   expect(withS).toHaveLength(1); // Matches across lines with s flag
+    //   //   // });
+    //   // });
+    //   // it('should handle extended flag', async () => {
+    //   //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //     category: { $regex: 'elect # start\nronics # end', $options: 'x' },
+    //   //   });
+    //   //   expect(results).toHaveLength(2); // x flag allows comments and whitespace
+    //   // });
+    //   // it('should handle flag combinations', async () => {
+    //   //   await vectorDB.upsert(
+    //   //     indexName,
+    //   //     [[1, 0.1, 0]],
+    //   //     [
+    //   //       {
+    //   //         description: 'FIRST line\nSECOND line',
+    //   //       },
+    //   //     ],
+    //   //   );
+    //   //   // Test case-insensitive and multiline flags together
+    //   //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     description: {
+    //   //   //       $regex: '^first',
+    //   //   //       $options: 'im', // Case-insensitive and multiline
+    //   //   //     },
+    //   //   //   });
+    //   //   //   expect(results).toHaveLength(1);
+    //   //   // Test with second line
+    //   //   const secondResults = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //   //   //     description: {
+    //   //   //       $regex: '^second',
+    //   //   //       $options: 'im',
+    //   //   //     },
+    //   //   //   });
+    //   //   //   expect(secondResults).toHaveLength(1);
+    //   //   // });
+    // it('should handle case insensitive flag (i)', async () => {
+    //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //     category: { $regex: 'ELECTRONICS', $options: 'i' },
+    //   });
+    //   expect(results.length).toBeGreaterThan(0);
+    // });
+
+    // it('should handle multiline flag (m)', async () => {
+    //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //     description: { $regex: '^start', $options: 'm' },
+    //   });
+    //   expect(results.length).toBeGreaterThan(0);
+    // });
+
+    // it('should handle extended flag (x)', async () => {
+    //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //     category: {
+    //       $regex: 'elect # match electronics\nronics',
+    //       $options: 'x',
+    //     },
+    //   });
+    //   expect(results.length).toBeGreaterThan(0);
+    // });
+
+    // it('should handle multiple flags', async () => {
+    //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //     category: {
+    //       $regex: 'ELECTRONICS\nITEM',
+    //       $options: 'im',
+    //     },
+    //   });
+    //   expect(results.length).toBeGreaterThan(0);
+    // });
+    // it('should handle special regex characters as literals', async () => {
+    //   await vectorDB.upsert(
+    //     indexName,
+    //     [[1, 0.1, 0]],
+    //     [
+    //       {
+    //         special: 'text.with*special(chars)',
+    //       },
+    //     ],
+    //   );
+
+    //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //     special: 'text.with*special(chars)',
+    //   });
+    //   expect(results).toHaveLength(1); // Exact match, not regex
+    // });
+    // it('should handle $not with $regex operator', async () => {
+    //   const results = await vectorDB.query(indexName, [1, 0, 0], 10, {
+    //     category: { $not: { $regex: '^elect' } },
+    //   });
+    //   expect(results.length).toBeGreaterThan(0);
+    //   results.forEach(result => {
+    //     expect(result.metadata?.category).not.toMatch(/^elect/);
+    //   });
+    // });
+
+    // });
+  });
+
+  describe('Deprecation Warnings', () => {
+    const indexName = 'testdeprecationwarnings';
+
+    const indexName2 = 'testdeprecationwarnings2';
+
+    let warnSpy;
+
+    beforeAll(async () => {
+      await vectorDB.createIndex({ indexName: indexName, dimension: 3 });
+    });
+
+    afterAll(async () => {
+      await vectorDB.deleteIndex(indexName);
+      await vectorDB.deleteIndex(indexName2);
+    });
+
+    beforeEach(async () => {
+      warnSpy = vi.spyOn(vectorDB['logger'], 'warn');
+    });
+
+    afterEach(async () => {
+      warnSpy.mockRestore();
+      await vectorDB.deleteIndex(indexName2);
+    });
+
+    it('should show deprecation warning when using individual args for createIndex', async () => {
+      await vectorDB.createIndex(indexName2, 3, 'cosine');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Deprecation Warning: Passing individual arguments to createIndex() is deprecated'),
+      );
+    });
+
+    it('should show deprecation warning when using individual args for upsert', async () => {
+      await vectorDB.upsert(indexName, [[1, 2, 3]], [{ test: 'data' }]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Deprecation Warning: Passing individual arguments to upsert() is deprecated'),
+      );
+    });
+
+    it('should show deprecation warning when using individual args for query', async () => {
+      await vectorDB.query(indexName, [1, 2, 3], 5);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Deprecation Warning: Passing individual arguments to query() is deprecated'),
+      );
+    });
+
+    it('should not show deprecation warning when using object param for query', async () => {
+      await vectorDB.query({
+        indexName,
+        queryVector: [1, 2, 3],
+        topK: 5,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not show deprecation warning when using object param for createIndex', async () => {
+      await vectorDB.createIndex({
+        indexName: indexName2,
+        dimension: 3,
+        metric: 'cosine',
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not show deprecation warning when using object param for upsert', async () => {
+      await vectorDB.upsert({
+        indexName,
+        vectors: [[1, 2, 3]],
+        metadata: [{ test: 'data' }],
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should maintain backward compatibility with individual args', async () => {
+      // Query
+      const queryResults = await vectorDB.query(indexName, [1, 2, 3], 5);
+      expect(Array.isArray(queryResults)).toBe(true);
+
+      // CreateIndex
+      await expect(vectorDB.createIndex(indexName2, 3, 'cosine')).resolves.not.toThrow();
+
+      // Upsert
+      const upsertResults = await vectorDB.upsert({
+        indexName,
+        vectors: [[1, 2, 3]],
+        metadata: [{ test: 'data' }],
+      });
+      expect(Array.isArray(upsertResults)).toBe(true);
+      expect(upsertResults).toHaveLength(1);
+    });
+  });
+});

--- a/stores/libsql/src/vector/index.ts
+++ b/stores/libsql/src/vector/index.ts
@@ -1,0 +1,344 @@
+import { createClient } from '@libsql/client';
+import type { Client as TursoClient, InValue } from '@libsql/client';
+import { MastraVector } from '@mastra/core/vector';
+import type {
+  IndexStats,
+  QueryResult,
+  QueryVectorParams,
+  CreateIndexParams,
+  UpsertVectorParams,
+  ParamsToArgs,
+  QueryVectorArgs,
+} from '@mastra/core/vector';
+import type { VectorFilter } from '@mastra/core/vector/filter';
+import { LibSQLFilterTranslator } from './filter';
+import { buildFilterQuery } from './sql-builder';
+
+interface LibSQLQueryParams extends QueryVectorParams {
+  minScore?: number;
+}
+
+type LibSQLQueryArgs = [...QueryVectorArgs, number?];
+
+export class LibSQLVector extends MastraVector {
+  private turso: TursoClient;
+
+  constructor({
+    connectionUrl,
+    authToken,
+    syncUrl,
+    syncInterval,
+  }: {
+    connectionUrl: string;
+    authToken?: string;
+    syncUrl?: string;
+    syncInterval?: number;
+  }) {
+    super();
+
+    this.turso = createClient({
+      url: connectionUrl,
+      syncUrl: syncUrl,
+      authToken,
+      syncInterval,
+    });
+
+    if (connectionUrl.includes(`file:`) || connectionUrl.includes(`:memory:`)) {
+      void this.turso.execute({
+        sql: 'PRAGMA journal_mode=WAL;',
+        args: {},
+      });
+    }
+  }
+
+  transformFilter(filter?: VectorFilter) {
+    const translator = new LibSQLFilterTranslator();
+    return translator.translate(filter);
+  }
+
+  async query(...args: ParamsToArgs<LibSQLQueryParams> | LibSQLQueryArgs): Promise<QueryResult[]> {
+    const params = this.normalizeArgs<LibSQLQueryParams, LibSQLQueryArgs>('query', args, ['minScore']);
+
+    try {
+      const { indexName, queryVector, topK = 10, filter, includeVector = false, minScore = 0 } = params;
+
+      const vectorStr = `[${queryVector.join(',')}]`;
+
+      const translatedFilter = this.transformFilter(filter);
+      const { sql: filterQuery, values: filterValues } = buildFilterQuery(translatedFilter);
+      filterValues.push(minScore);
+
+      const query = `
+        WITH vector_scores AS (
+          SELECT
+            vector_id as id,
+            (1-vector_distance_cos(embedding, '${vectorStr}')) as score,
+            metadata
+            ${includeVector ? ', vector_extract(embedding) as embedding' : ''}
+          FROM ${indexName}
+          ${filterQuery}
+        )
+        SELECT *
+        FROM vector_scores
+        WHERE score > ?
+        ORDER BY score DESC
+        LIMIT ${topK}`;
+
+      const result = await this.turso.execute({
+        sql: query,
+        args: filterValues,
+      });
+
+      return result.rows.map(({ id, score, metadata, embedding }) => ({
+        id: id as string,
+        score: score as number,
+        metadata: JSON.parse((metadata as string) ?? '{}'),
+        ...(includeVector && embedding && { vector: JSON.parse(embedding as string) }),
+      }));
+    } finally {
+      // client.release()
+    }
+  }
+
+  async upsert(...args: ParamsToArgs<UpsertVectorParams>): Promise<string[]> {
+    const params = this.normalizeArgs<UpsertVectorParams>('upsert', args);
+
+    const { indexName, vectors, metadata, ids } = params;
+    const tx = await this.turso.transaction('write');
+
+    try {
+      const vectorIds = ids || vectors.map(() => crypto.randomUUID());
+
+      for (let i = 0; i < vectors.length; i++) {
+        const query = `
+          INSERT INTO ${indexName} (vector_id, embedding, metadata)
+          VALUES (?, vector32(?), ?)
+          ON CONFLICT(vector_id) DO UPDATE SET
+            embedding = vector32(?),
+            metadata = ?
+        `;
+
+        // console.log('INSERTQ', query, [
+        //   vectorIds[i] as InValue,
+        //   JSON.stringify(vectors[i]),
+        //   JSON.stringify(metadata?.[i] || {}),
+        //   JSON.stringify(vectors[i]),
+        //   JSON.stringify(metadata?.[i] || {}),
+        // ]);
+        await tx.execute({
+          sql: query,
+          // @ts-ignore
+          args: [
+            vectorIds[i] as InValue,
+            JSON.stringify(vectors[i]),
+            JSON.stringify(metadata?.[i] || {}),
+            JSON.stringify(vectors[i]),
+            JSON.stringify(metadata?.[i] || {}),
+          ],
+        });
+      }
+
+      await tx.commit();
+      return vectorIds;
+    } catch (error) {
+      await tx.rollback();
+      if (error instanceof Error && error.message?.includes('dimensions are different')) {
+        const match = error.message.match(/dimensions are different: (\d+) != (\d+)/);
+        if (match) {
+          const [, actual, expected] = match;
+          throw new Error(
+            `Vector dimension mismatch: Index "${indexName}" expects ${expected} dimensions but got ${actual} dimensions. ` +
+              `Either use a matching embedding model or delete and recreate the index with the new dimension.`,
+          );
+        }
+      }
+      throw error;
+    }
+  }
+
+  async createIndex(...args: ParamsToArgs<CreateIndexParams>): Promise<void> {
+    const params = this.normalizeArgs<CreateIndexParams>('createIndex', args);
+
+    const { indexName, dimension } = params;
+    try {
+      // Validate inputs
+      if (!indexName.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
+        throw new Error('Invalid index name format');
+      }
+      if (!Number.isInteger(dimension) || dimension <= 0) {
+        throw new Error('Dimension must be a positive integer');
+      }
+
+      // Create the table with explicit schema
+      await this.turso.execute({
+        sql: `
+        CREATE TABLE IF NOT EXISTS ${indexName} (
+          id SERIAL PRIMARY KEY,
+          vector_id TEXT UNIQUE NOT NULL,
+          embedding F32_BLOB(${dimension}),
+          metadata TEXT DEFAULT '{}'
+        );
+      `,
+        args: [],
+      });
+
+      await this.turso.execute({
+        sql: `
+        CREATE INDEX IF NOT EXISTS ${indexName}_vector_idx
+        ON ${indexName} (libsql_vector_idx(embedding))
+      `,
+        args: [],
+      });
+    } catch (error: any) {
+      console.error('Failed to create vector table:', error);
+      throw error;
+    } finally {
+      // client.release()
+    }
+  }
+
+  async deleteIndex(indexName: string): Promise<void> {
+    try {
+      // Drop the table
+      await this.turso.execute({
+        sql: `DROP TABLE IF EXISTS ${indexName}`,
+        args: [],
+      });
+    } catch (error: any) {
+      console.error('Failed to delete vector table:', error);
+      throw new Error(`Failed to delete vector table: ${error.message}`);
+    } finally {
+      // client.release()
+    }
+  }
+
+  async listIndexes(): Promise<string[]> {
+    try {
+      const vectorTablesQuery = `
+        SELECT name FROM sqlite_master 
+        WHERE type='table' 
+        AND sql LIKE '%F32_BLOB%';
+      `;
+      const result = await this.turso.execute({
+        sql: vectorTablesQuery,
+        args: [],
+      });
+      return result.rows.map(row => row.name as string);
+    } catch (error: any) {
+      throw new Error(`Failed to list vector tables: ${error.message}`);
+    }
+  }
+
+  async describeIndex(indexName: string): Promise<IndexStats> {
+    try {
+      // Get table info including column info
+      const tableInfoQuery = `
+        SELECT sql 
+        FROM sqlite_master 
+        WHERE type='table' 
+        AND name = ?;
+      `;
+      const tableInfo = await this.turso.execute({
+        sql: tableInfoQuery,
+        args: [indexName],
+      });
+
+      if (!tableInfo.rows[0]?.sql) {
+        throw new Error(`Table ${indexName} not found`);
+      }
+
+      // Extract dimension from F32_BLOB definition
+      const dimension = parseInt((tableInfo.rows[0].sql as string).match(/F32_BLOB\((\d+)\)/)?.[1] || '0');
+
+      // Get row count
+      const countQuery = `
+        SELECT COUNT(*) as count
+        FROM ${indexName};
+      `;
+      const countResult = await this.turso.execute({
+        sql: countQuery,
+        args: [],
+      });
+
+      // LibSQL only supports cosine similarity currently
+      const metric: 'cosine' | 'euclidean' | 'dotproduct' = 'cosine';
+
+      return {
+        dimension,
+        count: (countResult?.rows?.[0]?.count as number) ?? 0,
+        metric,
+      };
+    } catch (e: any) {
+      throw new Error(`Failed to describe vector table: ${e.message}`);
+    }
+  }
+
+  /**
+   * Updates an index entry by its ID with the provided vector and/or metadata.
+   *
+   * @param indexName - The name of the index to update.
+   * @param id - The ID of the index entry to update.
+   * @param update - An object containing the vector and/or metadata to update.
+   * @param update.vector - An optional array of numbers representing the new vector.
+   * @param update.metadata - An optional record containing the new metadata.
+   * @returns A promise that resolves when the update is complete.
+   * @throws Will throw an error if no updates are provided or if the update operation fails.
+   */
+  async updateIndexById(
+    indexName: string,
+    id: string,
+    update: { vector?: number[]; metadata?: Record<string, any> },
+  ): Promise<void> {
+    try {
+      const updates = [];
+      const args: InValue[] = [];
+
+      if (update.vector) {
+        updates.push('embedding = vector32(?)');
+        args.push(JSON.stringify(update.vector));
+      }
+
+      if (update.metadata) {
+        updates.push('metadata = ?');
+        args.push(JSON.stringify(update.metadata));
+      }
+
+      if (updates.length === 0) {
+        throw new Error('No updates provided');
+      }
+
+      args.push(id);
+
+      const query = `
+        UPDATE ${indexName}
+        SET ${updates.join(', ')}
+        WHERE vector_id = ?;
+      `;
+
+      await this.turso.execute({
+        sql: query,
+        args,
+      });
+    } catch (error: any) {
+      throw new Error(`Failed to update index by id: ${id} for index: ${indexName}: ${error.message}`);
+    }
+  }
+
+  async deleteIndexById(indexName: string, id: string): Promise<void> {
+    try {
+      await this.turso.execute({
+        sql: `DELETE FROM ${indexName} WHERE vector_id = ?`,
+        args: [id],
+      });
+    } catch (error: any) {
+      throw new Error(`Failed to delete index by id: ${id} for index: ${indexName}: ${error.message}`);
+    }
+  }
+
+  async truncateIndex(indexName: string) {
+    await this.turso.execute({
+      sql: `DELETE FROM ${indexName}`,
+      args: [],
+    });
+  }
+}

--- a/stores/libsql/src/vector/sql-builder.ts
+++ b/stores/libsql/src/vector/sql-builder.ts
@@ -1,0 +1,462 @@
+import type { InValue } from '@libsql/client';
+import type {
+  VectorFilter,
+  BasicOperator,
+  NumericOperator,
+  ArrayOperator,
+  ElementOperator,
+  LogicalOperator,
+  RegexOperator,
+} from '@mastra/core/vector/filter';
+
+export type OperatorType =
+  | BasicOperator
+  | NumericOperator
+  | ArrayOperator
+  | ElementOperator
+  | LogicalOperator
+  | '$contains'
+  | Exclude<RegexOperator, '$options'>;
+
+type FilterOperator = {
+  sql: string;
+  needsValue: boolean;
+  transformValue?: (value: any) => any;
+};
+
+type OperatorFn = (key: string, value?: any) => FilterOperator;
+
+// Helper functions to create operators
+const createBasicOperator = (symbol: string) => {
+  return (key: string): FilterOperator => ({
+    sql: `CASE 
+      WHEN ? IS NULL THEN json_extract(metadata, '$."${handleKey(key)}"') IS ${symbol === '=' ? '' : 'NOT'} NULL
+      ELSE json_extract(metadata, '$."${handleKey(key)}"') ${symbol} ?
+    END`,
+    needsValue: true,
+    transformValue: (value: any) => {
+      // Return the values directly, not in an object
+      return [value, value];
+    },
+  });
+};
+const createNumericOperator = (symbol: string) => {
+  return (key: string): FilterOperator => ({
+    sql: `CAST(json_extract(metadata, '$."${handleKey(key)}"') AS NUMERIC) ${symbol} ?`,
+    needsValue: true,
+  });
+};
+
+const validateJsonArray = (key: string) =>
+  `json_valid(json_extract(metadata, '$."${handleKey(key)}"'))
+   AND json_type(json_extract(metadata, '$."${handleKey(key)}"')) = 'array'`;
+
+// Define all filter operators
+export const FILTER_OPERATORS: Record<string, OperatorFn> = {
+  $eq: createBasicOperator('='),
+  $ne: createBasicOperator('!='),
+  $gt: createNumericOperator('>'),
+  $gte: createNumericOperator('>='),
+  $lt: createNumericOperator('<'),
+  $lte: createNumericOperator('<='),
+
+  // Array Operators
+  $in: (key: string, value: any) => ({
+    sql: `json_extract(metadata, '$."${handleKey(key)}"') IN (${value.map(() => '?').join(',')})`,
+    needsValue: true,
+  }),
+
+  $nin: (key: string, value: any) => ({
+    sql: `json_extract(metadata, '$."${handleKey(key)}"') NOT IN (${value.map(() => '?').join(',')})`,
+    needsValue: true,
+  }),
+  $all: (key: string) => ({
+    sql: `json_extract(metadata, '$."${handleKey(key)}"') = ?`,
+    needsValue: true,
+    transformValue: (value: any) => {
+      const arrayValue = Array.isArray(value) ? value : [value];
+      if (arrayValue.length === 0) {
+        return {
+          sql: '1 = 0',
+          values: [],
+        };
+      }
+
+      return {
+        sql: `(
+          CASE
+            WHEN ${validateJsonArray(key)} THEN
+                NOT EXISTS (
+                    SELECT value 
+                    FROM json_each(?) 
+                    WHERE value NOT IN (
+                    SELECT value 
+                    FROM json_each(json_extract(metadata, '$."${handleKey(key)}"'))
+                )
+            )
+            ELSE FALSE
+          END
+        )`,
+        values: [JSON.stringify(arrayValue)],
+      };
+    },
+  }),
+  $elemMatch: (key: string) => ({
+    sql: `json_extract(metadata, '$."${handleKey(key)}"') = ?`,
+    needsValue: true,
+    transformValue: (value: any) => {
+      if (typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error('$elemMatch requires an object with conditions');
+      }
+
+      // For nested object conditions
+      const conditions = Object.entries(value).map(([field, fieldValue]) => {
+        if (field.startsWith('$')) {
+          // Direct operators on array elements ($in, $gt, etc)
+          const { sql, values } = buildCondition('elem.value', { [field]: fieldValue }, '');
+          // Replace the metadata path with elem.value
+          const pattern = /json_extract\(metadata, '\$\."[^"]*"(\."[^"]*")*'\)/g;
+          const elemSql = sql.replace(pattern, 'elem.value');
+          return { sql: elemSql, values };
+        } else if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
+          // Nested field with operators (count: { $gt: 20 })
+          const { sql, values } = buildCondition(field, fieldValue, '');
+          // Replace the field path with elem.value path
+          const pattern = /json_extract\(metadata, '\$\."[^"]*"(\."[^"]*")*'\)/g;
+          const elemSql = sql.replace(pattern, `json_extract(elem.value, '$."${field}"')`);
+          return { sql: elemSql, values };
+        } else {
+          // Simple field equality (warehouse: 'A')
+          return {
+            sql: `json_extract(elem.value, '$."${field}"') = ?`,
+            values: [fieldValue],
+          };
+        }
+      });
+
+      return {
+        sql: `(
+          CASE
+            WHEN ${validateJsonArray(key)} THEN
+              EXISTS (
+                SELECT 1 
+                FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as elem
+                WHERE ${conditions.map(c => c.sql).join(' AND ')}
+              )
+            ELSE FALSE
+          END
+        )`,
+        values: conditions.flatMap(c => c.values),
+      };
+    },
+  }),
+
+  // Element Operators
+  $exists: (key: string) => ({
+    sql: `json_extract(metadata, '$."${handleKey(key)}"') IS NOT NULL`,
+    needsValue: false,
+  }),
+
+  // Logical Operators
+  $and: (key: string) => ({
+    sql: `(${key})`,
+    needsValue: false,
+  }),
+  $or: (key: string) => ({
+    sql: `(${key})`,
+    needsValue: false,
+  }),
+  $not: key => ({ sql: `NOT (${key})`, needsValue: false }),
+  $nor: (key: string) => ({
+    sql: `NOT (${key})`,
+    needsValue: false,
+  }),
+  $size: (key: string, paramIndex: number) => ({
+    sql: `(
+    CASE
+      WHEN json_type(json_extract(metadata, '$."${handleKey(key)}"')) = 'array' THEN 
+        json_array_length(json_extract(metadata, '$."${handleKey(key)}"')) = $${paramIndex}
+      ELSE FALSE
+    END
+  )`,
+    needsValue: true,
+  }),
+  //   /**
+  //    * Regex Operators
+  //    * Supports case insensitive and multiline
+  //    */
+  //   $regex: (key: string): FilterOperator => ({
+  //     sql: `json_extract(metadata, '$."${handleKey(key)}"') = ?`,
+  //     needsValue: true,
+  //     transformValue: (value: any) => {
+  //       const pattern = typeof value === 'object' ? value.$regex : value;
+  //       const options = typeof value === 'object' ? value.$options || '' : '';
+  //       let sql = `json_extract(metadata, '$."${handleKey(key)}"')`;
+
+  //       // Handle multiline
+  //       //   if (options.includes('m')) {
+  //       //     sql = `REPLACE(${sql}, CHAR(10), '\n')`;
+  //       //   }
+
+  //       //       let finalPattern = pattern;
+  //       // if (options) {
+  //       //   finalPattern = `(\\?${options})${pattern}`;
+  //       // }
+
+  //       //   // Handle case insensitivity
+  //       //   if (options.includes('i')) {
+  //       //     sql = `LOWER(${sql}) REGEXP LOWER(?)`;
+  //       //   } else {
+  //       //     sql = `${sql} REGEXP ?`;
+  //       //   }
+
+  //       if (options.includes('m')) {
+  //         sql = `EXISTS (
+  //         SELECT 1
+  //         FROM json_each(
+  //           json_array(
+  //             ${sql},
+  //             REPLACE(${sql}, CHAR(10), CHAR(13))
+  //           )
+  //         ) as lines
+  //         WHERE lines.value REGEXP ?
+  //       )`;
+  //       } else {
+  //         sql = `${sql} REGEXP ?`;
+  //       }
+
+  //       // Handle case insensitivity
+  //       if (options.includes('i')) {
+  //         sql = sql.replace('REGEXP ?', 'REGEXP LOWER(?)');
+  //         sql = sql.replace('value REGEXP', 'LOWER(value) REGEXP');
+  //       }
+
+  //       // Handle extended - allows whitespace and comments in pattern
+  //       if (options.includes('x')) {
+  //         // Remove whitespace and comments from pattern
+  //         const cleanPattern = pattern.replace(/\s+|#.*$/gm, '');
+  //         return {
+  //           sql,
+  //           values: [cleanPattern],
+  //         };
+  //       }
+
+  //       return {
+  //         sql,
+  //         values: [pattern],
+  //       };
+  //     },
+  //   }),
+  $contains: (key: string) => ({
+    sql: `json_extract(metadata, '$."${handleKey(key)}"') = ?`,
+    needsValue: true,
+    transformValue: (value: any) => {
+      // Array containment
+      if (Array.isArray(value)) {
+        return {
+          sql: `(
+            SELECT ${validateJsonArray(key)}
+            AND EXISTS (
+              SELECT 1 
+              FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as m
+              WHERE m.value IN (SELECT value FROM json_each(?))
+            )
+          )`,
+          values: [JSON.stringify(value)],
+        };
+      }
+
+      // Nested object traversal
+      if (value && typeof value === 'object') {
+        const paths: string[] = [];
+        const values: any[] = [];
+
+        function traverse(obj: any, path: string[] = []) {
+          for (const [k, v] of Object.entries(obj)) {
+            const currentPath = [...path, k];
+            if (v && typeof v === 'object' && !Array.isArray(v)) {
+              traverse(v, currentPath);
+            } else {
+              paths.push(currentPath.join('.'));
+              values.push(v);
+            }
+          }
+        }
+
+        traverse(value);
+        return {
+          sql: `(${paths.map(path => `json_extract(metadata, '$."${handleKey(key)}"."${path}"') = ?`).join(' AND ')})`,
+          values,
+        };
+      }
+
+      return value;
+    },
+  }),
+};
+
+export interface FilterResult {
+  sql: string;
+  values: InValue[];
+}
+
+export const handleKey = (key: string) => {
+  return key.replace(/\./g, '"."');
+};
+
+export function buildFilterQuery(filter: VectorFilter): FilterResult {
+  if (!filter) {
+    return { sql: '', values: [] };
+  }
+
+  const values: InValue[] = [];
+  const conditions = Object.entries(filter)
+    .map(([key, value]) => {
+      const condition = buildCondition(key, value, '');
+      values.push(...condition.values);
+      return condition.sql;
+    })
+    .join(' AND ');
+
+  return {
+    sql: conditions ? `WHERE ${conditions}` : '',
+    values,
+  };
+}
+
+function buildCondition(key: string, value: any, parentPath: string): FilterResult {
+  // Handle logical operators ($and/$or)
+  if (['$and', '$or', '$not', '$nor'].includes(key)) {
+    return handleLogicalOperator(key as '$and' | '$or' | '$not' | '$nor', value, parentPath);
+  }
+
+  // If condition is not a FilterCondition object, assume it's an equality check
+  if (!value || typeof value !== 'object') {
+    return {
+      sql: `json_extract(metadata, '$."${key.replace(/\./g, '"."')}"') = ?`,
+      values: [value],
+    };
+  }
+
+  //TODO: Add regex support
+  //   if ('$regex' in value) {
+  //     return handleRegexOperator(key, value);
+  //   }
+
+  // Handle operator conditions
+  return handleOperator(key, value);
+}
+
+// function handleRegexOperator(key: string, value: any): FilterResult {
+//   const operatorFn = FILTER_OPERATORS['$regex']!;
+//   const operatorResult = operatorFn(key, value);
+//   const transformed = operatorResult.transformValue ? operatorResult.transformValue(value) : value;
+
+//   return {
+//     sql: transformed.sql,
+//     values: transformed.values,
+//   };
+// }
+
+function handleLogicalOperator(
+  key: '$and' | '$or' | '$not' | '$nor',
+  value: VectorFilter[] | VectorFilter,
+  parentPath: string,
+): FilterResult {
+  // Handle empty conditions
+  if (!value || value.length === 0) {
+    switch (key) {
+      case '$and':
+      case '$nor':
+        return { sql: 'true', values: [] };
+      case '$or':
+        return { sql: 'false', values: [] };
+      case '$not':
+        throw new Error('$not operator cannot be empty');
+      default:
+        return { sql: 'true', values: [] };
+    }
+  }
+
+  if (key === '$not') {
+    // For top-level $not
+    const entries = Object.entries(value);
+    const conditions = entries.map(([fieldKey, fieldValue]) => buildCondition(fieldKey, fieldValue, key));
+    return {
+      sql: `NOT (${conditions.map(c => c.sql).join(' AND ')})`,
+      values: conditions.flatMap(c => c.values),
+    };
+  }
+
+  const values: InValue[] = [];
+  const joinOperator = key === '$or' || key === '$nor' ? 'OR' : 'AND';
+  const conditions = Array.isArray(value)
+    ? value.map(f => {
+        const entries = Object.entries(f);
+        return entries.map(([k, v]) => buildCondition(k, v, key));
+      })
+    : [buildCondition(key, value, parentPath)];
+
+  const joined = conditions
+    .flat()
+    .map(c => {
+      values.push(...c.values);
+      return c.sql;
+    })
+    .join(` ${joinOperator} `);
+
+  return {
+    sql: key === '$nor' ? `NOT (${joined})` : `(${joined})`,
+    values,
+  };
+}
+
+function handleOperator(key: string, value: any): FilterResult {
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const entries = Object.entries(value);
+    const results = entries.map(([operator, operatorValue]) =>
+      operator === '$not'
+        ? {
+            sql: `NOT (${Object.entries(operatorValue as Record<string, any>)
+              .map(([op, val]) => processOperator(key, op, val).sql)
+              .join(' AND ')})`,
+            values: Object.entries(operatorValue as Record<string, any>).flatMap(
+              ([op, val]) => processOperator(key, op, val).values,
+            ),
+          }
+        : processOperator(key, operator, operatorValue),
+    );
+
+    return {
+      sql: `(${results.map(r => r.sql).join(' AND ')})`,
+      values: results.flatMap(r => r.values),
+    };
+  }
+
+  // Handle single operator
+  const [[operator, operatorValue] = []] = Object.entries(value);
+  return processOperator(key, operator as string, operatorValue);
+}
+
+const processOperator = (key: string, operator: string, operatorValue: any): FilterResult => {
+  if (!operator.startsWith('$') || !FILTER_OPERATORS[operator]) {
+    throw new Error(`Invalid operator: ${operator}`);
+  }
+  const operatorFn = FILTER_OPERATORS[operator]!;
+  const operatorResult = operatorFn(key, operatorValue);
+
+  if (!operatorResult.needsValue) {
+    return { sql: operatorResult.sql, values: [] };
+  }
+
+  const transformed = operatorResult.transformValue ? operatorResult.transformValue(operatorValue) : operatorValue;
+
+  if (transformed && typeof transformed === 'object' && 'sql' in transformed) {
+    return transformed;
+  }
+
+  return {
+    sql: operatorResult.sql,
+    values: Array.isArray(transformed) ? transformed : [transformed],
+  };
+};

--- a/stores/libsql/tsconfig.json
+++ b/stores/libsql/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/stores/libsql/vitest.config.ts
+++ b/stores/libsql/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION

## Description

Decouples sqlite from @mastra/core by introducing a @mastra/sqlite storage.

- adds it to create-mastra/init template explicitly instead of magic import

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
