### PR TITLE
[MASTRA-3130] Metadata Filter Update for PG and Libsql

### DIFF
--- a/.changeset/friendly-berries-share.md
+++ b/.changeset/friendly-berries-share.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+"@mastra/pg": patch
+---
+
+[MASTRA-3130] Metadata Filter Update for PG and Libsql

--- a/packages/core/src/vector/libsql/sql-builder.ts
+++ b/packages/core/src/vector/libsql/sql-builder.ts
@@ -22,23 +22,20 @@ export type OperatorType =
 type FilterOperator = {
   sql: string;
   needsValue: boolean;
-  transformValue?: (value: any) => any;
+  transformValue?: () => any;
 };
 
 type OperatorFn = (key: string, value?: any) => FilterOperator;
 
 // Helper functions to create operators
 const createBasicOperator = (symbol: string) => {
-  return (key: string): FilterOperator => ({
+  return (key: string, value: any): FilterOperator => ({
     sql: `CASE 
       WHEN ? IS NULL THEN json_extract(metadata, '$."${handleKey(key)}"') IS ${symbol === '=' ? '' : 'NOT'} NULL
       ELSE json_extract(metadata, '$."${handleKey(key)}"') ${symbol} ?
     END`,
     needsValue: true,
-    transformValue: (value: any) => {
-      // Return the values directly, not in an object
-      return [value, value];
-    },
+    transformValue: () => [value, value],
   });
 };
 const createNumericOperator = (symbol: string) => {
@@ -47,6 +44,34 @@ const createNumericOperator = (symbol: string) => {
     needsValue: true,
   });
 };
+
+function buildElemMatchConditions(value: any) {
+  const conditions = Object.entries(value).map(([field, fieldValue]) => {
+    if (field.startsWith('$')) {
+      // Direct operators on array elements ($in, $gt, etc)
+      const { sql, values } = buildCondition('elem.value', { [field]: fieldValue }, '');
+      // Replace the metadata path with elem.value
+      const pattern = /json_extract\(metadata, '\$\."[^"]*"(\."[^"]*")*'\)/g;
+      const elemSql = sql.replace(pattern, 'elem.value');
+      return { sql: elemSql, values };
+    } else if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
+      // Nested field with operators (count: { $gt: 20 })
+      const { sql, values } = buildCondition(field, fieldValue, '');
+      // Replace the field path with elem.value path
+      const pattern = /json_extract\(metadata, '\$\."[^"]*"(\."[^"]*")*'\)/g;
+      const elemSql = sql.replace(pattern, `json_extract(elem.value, '$."${field}"')`);
+      return { sql: elemSql, values };
+    } else {
+      // Simple field equality (warehouse: 'A')
+      return {
+        sql: `json_extract(elem.value, '$."${field}"') = ?`,
+        values: [fieldValue],
+      };
+    }
+  });
+
+  return conditions;
+}
 
 const validateJsonArray = (key: string) =>
   `json_valid(json_extract(metadata, '$."${handleKey(key)}"'))
@@ -61,96 +86,118 @@ export const FILTER_OPERATORS: Record<string, OperatorFn> = {
   $lt: createNumericOperator('<'),
   $lte: createNumericOperator('<='),
 
+  // $in: (key: string, value: any) => ({
+  //   sql: `json_extract(metadata, '$."${handleKey(key)}"') IN (${value.map(() => '?').join(',')})`,
+  //   needsValue: true,
+  // }),
+
+  // $nin: (key: string, value: any) => ({
+  //   sql: `json_extract(metadata, '$."${handleKey(key)}"') NOT IN (${value.map(() => '?').join(',')})`,
+  //   needsValue: true,
+  // }),
   // Array Operators
-  $in: (key: string, value: any) => ({
-    sql: `json_extract(metadata, '$."${handleKey(key)}"') IN (${value.map(() => '?').join(',')})`,
-    needsValue: true,
-  }),
+  $in: (key: string, value: any) => {
+    const arr = Array.isArray(value) ? value : [value];
+    if (arr.length === 0) {
+      return { sql: '1 = 0', needsValue: true, transformValue: () => [] };
+    }
+    const paramPlaceholders = arr.map(() => '?').join(',');
+    return {
+      sql: `(
+      CASE
+        WHEN ${validateJsonArray(key)} THEN
+          EXISTS (
+            SELECT 1 FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as elem
+            WHERE elem.value IN (SELECT value FROM json_each(?))
+          )
+        ELSE json_extract(metadata, '$."${handleKey(key)}"') IN (${paramPlaceholders})
+      END
+    )`,
+      needsValue: true,
+      transformValue: () => [JSON.stringify(arr), ...arr],
+    };
+  },
 
-  $nin: (key: string, value: any) => ({
-    sql: `json_extract(metadata, '$."${handleKey(key)}"') NOT IN (${value.map(() => '?').join(',')})`,
-    needsValue: true,
-  }),
-  $all: (key: string) => ({
-    sql: `json_extract(metadata, '$."${handleKey(key)}"') = ?`,
-    needsValue: true,
-    transformValue: (value: any) => {
-      const arrayValue = Array.isArray(value) ? value : [value];
-      if (arrayValue.length === 0) {
-        return {
-          sql: '1 = 0',
-          values: [],
-        };
-      }
+  $nin: (key: string, value: any) => {
+    const arr = Array.isArray(value) ? value : [value];
+    if (arr.length === 0) {
+      return { sql: '1 = 1', needsValue: true, transformValue: () => [] };
+    }
+    const paramPlaceholders = arr.map(() => '?').join(',');
+    return {
+      sql: `(
+      CASE
+        WHEN ${validateJsonArray(key)} THEN
+          NOT EXISTS (
+            SELECT 1 FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as elem
+            WHERE elem.value IN (SELECT value FROM json_each(?))
+          )
+        ELSE json_extract(metadata, '$."${handleKey(key)}"') NOT IN (${paramPlaceholders})
+      END
+    )`,
+      needsValue: true,
+      transformValue: () => [JSON.stringify(arr), ...arr],
+    };
+  },
+  $all: (key: string, value: any) => {
+    let sql: string;
+    const arrayValue = Array.isArray(value) ? value : [value];
 
-      return {
-        sql: `(
-          CASE
-            WHEN ${validateJsonArray(key)} THEN
-                NOT EXISTS (
-                    SELECT value 
-                    FROM json_each(?) 
-                    WHERE value NOT IN (
-                    SELECT value 
-                    FROM json_each(json_extract(metadata, '$."${handleKey(key)}"'))
-                )
+    if (arrayValue.length === 0) {
+      // If the array is empty, always return false (no matches)
+      sql = '1 = 0';
+    } else {
+      sql = `(
+      CASE
+        WHEN ${validateJsonArray(key)} THEN
+          NOT EXISTS (
+            SELECT value
+            FROM json_each(?)
+            WHERE value NOT IN (
+              SELECT value
+              FROM json_each(json_extract(metadata, '$."${handleKey(key)}"'))
             )
-            ELSE FALSE
-          END
-        )`,
-        values: [JSON.stringify(arrayValue)],
-      };
-    },
-  }),
-  $elemMatch: (key: string) => ({
-    sql: `json_extract(metadata, '$."${handleKey(key)}"') = ?`,
-    needsValue: true,
-    transformValue: (value: any) => {
-      if (typeof value !== 'object' || Array.isArray(value)) {
-        throw new Error('$elemMatch requires an object with conditions');
-      }
+          )
+        ELSE FALSE
+      END
+    )`;
+    }
 
-      // For nested object conditions
-      const conditions = Object.entries(value).map(([field, fieldValue]) => {
-        if (field.startsWith('$')) {
-          // Direct operators on array elements ($in, $gt, etc)
-          const { sql, values } = buildCondition('elem.value', { [field]: fieldValue }, '');
-          // Replace the metadata path with elem.value
-          const pattern = /json_extract\(metadata, '\$\."[^"]*"(\."[^"]*")*'\)/g;
-          const elemSql = sql.replace(pattern, 'elem.value');
-          return { sql: elemSql, values };
-        } else if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
-          // Nested field with operators (count: { $gt: 20 })
-          const { sql, values } = buildCondition(field, fieldValue, '');
-          // Replace the field path with elem.value path
-          const pattern = /json_extract\(metadata, '\$\."[^"]*"(\."[^"]*")*'\)/g;
-          const elemSql = sql.replace(pattern, `json_extract(elem.value, '$."${field}"')`);
-          return { sql: elemSql, values };
-        } else {
-          // Simple field equality (warehouse: 'A')
-          return {
-            sql: `json_extract(elem.value, '$."${field}"') = ?`,
-            values: [fieldValue],
-          };
+    return {
+      sql,
+      needsValue: true,
+      transformValue: () => {
+        if (arrayValue.length === 0) {
+          return [];
         }
-      });
+        return [JSON.stringify(arrayValue)];
+      },
+    };
+  },
+  $elemMatch: (key: string, value: any) => {
+    if (typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('$elemMatch requires an object with conditions');
+    }
 
-      return {
-        sql: `(
-          CASE
-            WHEN ${validateJsonArray(key)} THEN
-              EXISTS (
-                SELECT 1 
-                FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as elem
-                WHERE ${conditions.map(c => c.sql).join(' AND ')}
-              )
-            ELSE FALSE
-          END
-        )`,
-        values: conditions.flatMap(c => c.values),
-      };
-    },
-  }),
+    // For nested object conditions
+    const conditions = buildElemMatchConditions(value);
+
+    return {
+      sql: `(
+        CASE
+          WHEN ${validateJsonArray(key)} THEN
+            EXISTS (
+              SELECT 1
+              FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as elem
+              WHERE ${conditions.map(c => c.sql).join(' AND ')}
+            )
+          ELSE FALSE
+        END
+      )`,
+      needsValue: true,
+      transformValue: () => conditions.flatMap(c => c.values),
+    };
+  },
 
   // Element Operators
   $exists: (key: string) => ({
@@ -248,52 +295,49 @@ export const FILTER_OPERATORS: Record<string, OperatorFn> = {
   //       };
   //     },
   //   }),
-  $contains: (key: string) => ({
-    sql: `json_extract(metadata, '$."${handleKey(key)}"') = ?`,
-    needsValue: true,
-    transformValue: (value: any) => {
-      // Array containment
-      if (Array.isArray(value)) {
-        return {
-          sql: `(
-            SELECT ${validateJsonArray(key)}
-            AND EXISTS (
-              SELECT 1 
-              FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as m
-              WHERE m.value IN (SELECT value FROM json_each(?))
-            )
-          )`,
-          values: [JSON.stringify(value)],
-        };
-      }
-
-      // Nested object traversal
-      if (value && typeof value === 'object') {
-        const paths: string[] = [];
-        const values: any[] = [];
-
-        function traverse(obj: any, path: string[] = []) {
-          for (const [k, v] of Object.entries(obj)) {
-            const currentPath = [...path, k];
-            if (v && typeof v === 'object' && !Array.isArray(v)) {
-              traverse(v, currentPath);
-            } else {
-              paths.push(currentPath.join('.'));
-              values.push(v);
-            }
-          }
+  $contains: (key: string, value: any) => {
+    let sql;
+    if (Array.isArray(value)) {
+      sql = `(
+        SELECT ${validateJsonArray(key)}
+        AND EXISTS (
+          SELECT 1
+          FROM json_each(json_extract(metadata, '$."${handleKey(key)}"')) as m
+          WHERE m.value IN (SELECT value FROM json_each(?))
+        )
+      )`;
+    } else if (typeof value === 'string') {
+      sql = `lower(json_extract(metadata, '$."${handleKey(key)}"')) LIKE '%' || lower(?) || '%'`;
+    } else {
+      sql = `json_extract(metadata, '$."${handleKey(key)}"') = ?`;
+    }
+    return {
+      sql,
+      needsValue: true,
+      transformValue: () => {
+        if (Array.isArray(value)) {
+          return [JSON.stringify(value)];
         }
-
-        traverse(value);
-        return {
-          sql: `(${paths.map(path => `json_extract(metadata, '$."${handleKey(key)}"."${path}"') = ?`).join(' AND ')})`,
-          values,
-        };
-      }
-
-      return value;
-    },
-  }),
+        if (typeof value === 'object' && value !== null) {
+          return [JSON.stringify(value)];
+        }
+        return [value];
+      },
+    };
+  },
+  /**
+   * $objectContains: True JSON containment for advanced use (deep sub-object match).
+   * Usage: { field: { $objectContains: { ...subobject } } }
+   */
+  // $objectContains: (key: string) => ({
+  //   sql: '', // Will be overridden by transformValue
+  //   needsValue: true,
+  //   transformValue: (value: any) => ({
+  //     sql: `json_type(json_extract(metadata, '$."${handleKey(key)}"')) = 'object'
+  //         AND json_patch(json_extract(metadata, '$."${handleKey(key)}"'), ?) = json_extract(metadata, '$."${handleKey(key)}"')`,
+  //     values: [JSON.stringify(value)],
+  //   }),
+  // }),
 };
 
 export interface FilterResult {
@@ -450,11 +494,7 @@ const processOperator = (key: string, operator: string, operatorValue: any): Fil
     return { sql: operatorResult.sql, values: [] };
   }
 
-  const transformed = operatorResult.transformValue ? operatorResult.transformValue(operatorValue) : operatorValue;
-
-  if (transformed && typeof transformed === 'object' && 'sql' in transformed) {
-    return transformed;
-  }
+  const transformed = operatorResult.transformValue ? operatorResult.transformValue() : operatorValue;
 
   return {
     sql: operatorResult.sql,

--- a/packages/core/src/vector/libsql/sql-builder.ts
+++ b/packages/core/src/vector/libsql/sql-builder.ts
@@ -86,15 +86,6 @@ export const FILTER_OPERATORS: Record<string, OperatorFn> = {
   $lt: createNumericOperator('<'),
   $lte: createNumericOperator('<='),
 
-  // $in: (key: string, value: any) => ({
-  //   sql: `json_extract(metadata, '$."${handleKey(key)}"') IN (${value.map(() => '?').join(',')})`,
-  //   needsValue: true,
-  // }),
-
-  // $nin: (key: string, value: any) => ({
-  //   sql: `json_extract(metadata, '$."${handleKey(key)}"') NOT IN (${value.map(() => '?').join(',')})`,
-  //   needsValue: true,
-  // }),
   // Array Operators
   $in: (key: string, value: any) => {
     const arr = Array.isArray(value) ? value : [value];

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -435,12 +435,7 @@ describe('PgVector', () => {
         });
 
         it('should handle filters correctly', async () => {
-          const results = await vectorDB.query({
-            indexName,
-            queryVector: [1, 0, 0],
-            topK: 10,
-            filter: { type: 'a' },
-          });
+          const results = await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 10, filter: { type: 'a' } });
 
           expect(results).toHaveLength(1);
           results.forEach(result => {
@@ -606,7 +601,7 @@ describe('PgVector', () => {
 
     // Array Operator Tests
     describe('Array Operators', () => {
-      it('should filter with $in operator', async () => {
+      it('should filter with $in operator for scalar field', async () => {
         const results = await vectorDB.query({
           indexName,
           queryVector: [1, 0, 0],
@@ -618,7 +613,25 @@ describe('PgVector', () => {
         });
       });
 
-      it('should filter with $nin operator', async () => {
+      it('should filter with $in operator for array field', async () => {
+        // Insert a record with tags as array
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[2, 0.2, 0]],
+          metadata: [{ tags: ['featured', 'sale', 'new'] }],
+        });
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $in: ['sale', 'clearance'] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.tags.some((tag: string) => ['sale', 'clearance'].includes(tag))).toBe(true);
+        });
+      });
+
+      it('should filter with $nin operator for scalar field', async () => {
         const results = await vectorDB.query({
           indexName,
           queryVector: [1, 0, 0],
@@ -627,6 +640,24 @@ describe('PgVector', () => {
         expect(results.length).toBeGreaterThan(0);
         results.forEach(result => {
           expect(['electronics', 'books']).not.toContain(result.metadata?.category);
+        });
+      });
+
+      it('should filter with $nin operator for array field', async () => {
+        // Insert a record with tags as array
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[2, 0.3, 0]],
+          metadata: [{ tags: ['clearance', 'used'] }],
+        });
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { tags: { $nin: ['new', 'sale'] } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.tags.every((tag: string) => !['new', 'sale'].includes(tag))).toBe(true);
         });
       });
 
@@ -657,6 +688,52 @@ describe('PgVector', () => {
         expect(results.length).toBeGreaterThan(0);
         results.forEach(result => {
           expect(result.metadata?.tags).toContain('new');
+        });
+      });
+
+      it('should filter with $contains operator for string substring', async () => {
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { category: { $contains: 'lectro' } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.category).toContain('lectro');
+        });
+      });
+
+      it('should not match deep object containment with $contains', async () => {
+        // Insert a record with a nested object
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.1, 0]],
+          metadata: [{ details: { color: 'red', size: 'large' }, category: 'clothing' }],
+        });
+        // $contains does NOT support deep object containment in Postgres
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0.1, 0],
+          filter: { details: { $contains: { color: 'red' } } },
+        });
+        expect(results.length).toBe(0);
+      });
+
+      it('should fallback to direct equality for non-array, non-string', async () => {
+        // Insert a record with a numeric field
+        await vectorDB.upsert({
+          indexName,
+          vectors: [[1, 0.2, 0]],
+          metadata: [{ price: 123 }],
+        });
+        const results = await vectorDB.query({
+          indexName,
+          queryVector: [1, 0, 0],
+          filter: { price: { $contains: 123 } },
+        });
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(result => {
+          expect(result.metadata?.price).toBe(123);
         });
       });
 
@@ -810,29 +887,29 @@ describe('PgVector', () => {
         });
       });
 
-      it('should filter with $contains operator for nested objects', async () => {
-        // First insert a record with nested object
-        await vectorDB.upsert({
-          indexName,
-          vectors: [[1, 0.1, 0]],
-          metadata: [
-            {
-              details: { color: 'red', size: 'large' },
-              category: 'clothing',
-            },
-          ],
-        });
+      // it('should filter with $objectContains operator for nested objects', async () => {
+      //   // First insert a record with nested object
+      //   await vectorDB.upsert({
+      //     indexName,
+      //     vectors: [[1, 0.1, 0]],
+      //     metadata: [
+      //       {
+      //         details: { color: 'red', size: 'large' },
+      //         category: 'clothing',
+      //       },
+      //     ],
+      //   });
 
-        const results = await vectorDB.query({
-          indexName,
-          queryVector: [1, 0.1, 0],
-          filter: { details: { $contains: { color: 'red' } } },
-        });
-        expect(results.length).toBeGreaterThan(0);
-        results.forEach(result => {
-          expect(result.metadata?.details.color).toBe('red');
-        });
-      });
+      //   const results = await vectorDB.query({
+      //     indexName,
+      //     queryVector: [1, 0.1, 0],
+      //     filter: { details: { $objectContains: { color: 'red' } } },
+      //   });
+      //   expect(results.length).toBeGreaterThan(0);
+      //   results.forEach(result => {
+      //     expect(result.metadata?.details.color).toBe('red');
+      //   });
+      // });
 
       // String Pattern Tests
       it('should handle exact string matches', async () => {
@@ -1252,6 +1329,7 @@ describe('PgVector', () => {
           indexName,
           queryVector: [1, 0, 0],
           filter: { category: 'electronics' },
+          includeVector: false,
           minScore: 0.9,
         });
         expect(results.length).toBeGreaterThan(0);
@@ -1403,7 +1481,8 @@ describe('PgVector', () => {
           indexName,
           queryVector: [1, 0, 0],
           filter: { category: 'electronics' },
-          minScore: 0.9, // minScore
+          includeVector: false,
+          minScore: 0.9,
         });
         expect(results.length).toBeGreaterThan(0);
         results.forEach(result => {
@@ -1457,7 +1536,11 @@ describe('PgVector', () => {
         const results = await vectorDB.query({
           indexName,
           queryVector: [1, 0, 0],
-          filter: { $and: [{ category: 'electronics' }], $or: [{ price: { $lt: 100 } }, { price: { $gt: 20 } }] },
+          filter: {
+            $and: [{ category: 'electronics' }],
+            $or: [{ price: { $lt: 100 } }, { price: { $gt: 20 } }],
+            $nor: [],
+          },
         });
         expect(results.length).toBeGreaterThan(0);
         results.forEach(result => {
@@ -1477,13 +1560,7 @@ describe('PgVector', () => {
         const results = await vectorDB.query({
           indexName,
           queryVector: [1, 0, 0],
-          filter: {
-            tags: {
-              $elemMatch: {
-                $eq: 'value',
-              },
-            },
-          },
+          filter: { tags: { $elemMatch: { $eq: 'value' } } },
         });
         expect(results).toHaveLength(0); // Should return no results for non-array field
       });


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
The $in, $nin and $contains operators did not have correct functionality for PG and LibSQL.

$in/$nin - only handled scalar fields, and did not work with arrays
$contains - did not work for substring matches

This PR fixes these operators to match Mongo and Upstash functionality.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
