### PR TITLE
doc: Corrected description of default values for api in useObject

### DIFF
--- a/docs/src/content/en/docs/frameworks/ai-sdk.mdx
+++ b/docs/src/content/en/docs/frameworks/ai-sdk.mdx
@@ -148,7 +148,6 @@ export function CompletionComponent() {
 For consuming text streams that represent JSON objects and parsing them into a complete object based on a schema.
 
 - Works with agent text streams i.e. `.toTextStreamResponse()`
-- The useObject `api` defaults to `/api/completion`
 - Works with the Mastra REST API agent stream endpoint `{MASTRA_BASE_URL}/agents/:agentId/stream` for text streams,
   i.e. structured output is defined.
 

--- a/docs/src/content/ja/docs/frameworks/ai-sdk.mdx
+++ b/docs/src/content/ja/docs/frameworks/ai-sdk.mdx
@@ -146,7 +146,6 @@ export function CompletionComponent() {
 JSONオブジェクトを表すテキストストリームを消費し、スキーマに基づいて完全なオブジェクトに解析するために使用します。
 
 - エージェントテキストストリーム（`.toTextStreamResponse()`）と連携します
-- useObjectの`api`はデフォルトで`/api/completion`に設定されています
 - Mastra REST APIのエージェントストリームエンドポイント`{MASTRA_BASE_URL}/agents/:agentId/stream`とテキストストリーム用に連携します（構造化された出力が定義されている場合）
 
 ```typescript filename="app/api/use-object/route.ts" copy


### PR DESCRIPTION
## Description

useObject does not set the api property by default, but the documentation states that /api/completion is set by default.
So, remove the description of defaults.

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/3731

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
