### PR TITLE
fix(@mastra/core, mastra): use correct log level in mastra dev

### DIFF
--- a/.changeset/neat-aliens-join.md
+++ b/.changeset/neat-aliens-join.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastra': patch
+---
+
+Fixed an issue where "mastra dev" wouldn't always print out localhost:4111 logs due to new NODE_ENV fixes

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -31,6 +31,7 @@ const startServer = async (dotMastraPath: string, port: number, env: Map<string,
       env: {
         NODE_ENV: 'production',
         ...Object.fromEntries(env),
+        MASTRA_DEV: 'true',
         PORT: port.toString() || process.env.PORT || '4111',
         MASTRA_DEFAULT_STORAGE_URL: `file:${join(dotMastraPath, '..', 'mastra.db')}`,
       },

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -116,7 +116,8 @@ export class Mastra<
       if (config?.logger) {
         logger = config.logger;
       } else {
-        const levleOnEnv = process.env.NODE_ENV === 'production' ? LogLevel.WARN : LogLevel.INFO;
+        const levleOnEnv =
+          process.env.NODE_ENV === 'production' && process.env.MASTRA_DEV !== 'true' ? LogLevel.WARN : LogLevel.INFO;
         logger = createLogger({ name: 'Mastra', level: levleOnEnv }) as unknown as TLogger;
       }
     }

--- a/packages/memory/integration-tests/package.json
+++ b/packages/memory/integration-tests/package.json
@@ -23,7 +23,8 @@
     "pretest:libsql:perf": "docker compose up -d postgres && (for i in $(seq 1 30); do docker compose exec -T postgres pg_isready -U postgres && break || (sleep 1; [ $i -eq 30 ] && exit 1); done)",
     "test:libsql:perf": "vitest run ./src/performance-testing/with-libsql-storage.test.ts",
     "posttest:libsql:perf": "docker compose down --volumes",
-    "test:perf": "pnpm test:pg:perf && pnpm test:upstash:perf && pnpm test:libsql:perf"
+    "test:perf": "pnpm test:pg:perf && pnpm test:upstash:perf && pnpm test:libsql:perf",
+    "dev": "mastra dev"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.0",


### PR DESCRIPTION
In https://github.com/mastra-ai/mastra/issues/3610#issuecomment-2801496249 the env is now `production` instead of undefined, which changed the log level from `INFO` to `WARN` in `mastra dev`. This was only noticeable if you didn't have a `logger: createLogger(x)` in your Mastra project, which `create-mastra` adds 