### PR TITLE
fix: [MASTRA-3160] install external deps from telemetry config

### DIFF
--- a/.changeset/bumpy-news-post.md
+++ b/.changeset/bumpy-news-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+fix: When using a third party exporter such as Langfuse we were not installing external deps imported from the telemetry config

--- a/packages/deployer/src/build/telemetry.ts
+++ b/packages/deployer/src/build/telemetry.ts
@@ -5,13 +5,13 @@ import commonjs from '@rollup/plugin-commonjs';
 import { removeAllOptionsExceptTelemetry } from './babel/remove-all-options-telemetry';
 import { recursiveRemoveNonReferencedNodes } from './plugins/remove-unused-references';
 
-export async function getTelemetryBundler(
+export function getTelemetryBundler(
   entryFile: string,
   result: {
     hasCustomConfig: false;
   },
 ) {
-  return await rollup({
+  return rollup({
     logLevel: 'silent',
     input: {
       'telemetry-config': entryFile,

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -187,10 +187,15 @@ export abstract class Bundler extends MastraBundler {
       this.logger,
     );
 
-    await writeTelemetryConfig(mastraEntryFile, join(outputDirectory, this.outputDir));
+    const { externalDependencies } = await writeTelemetryConfig(mastraEntryFile, join(outputDirectory, this.outputDir));
+
+    const dependenciesToInstall = new Map<string, string>();
+    // Add extenal dependencies from telemetry file
+    for (const external of externalDependencies) {
+      dependenciesToInstall.set(external, 'latest');
+    }
 
     const workspaceMap = await createWorkspacePackageMap();
-    const dependenciesToInstall = new Map<string, string>();
     const workspaceDependencies = new Set<string>();
     for (const dep of analyzedBundleInfo.externalDependencies) {
       try {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

When using a third party exporter such as Langfuse we were not installing external deps which caused the runner to fail

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
