### PR TITLE
fix: add visible underline and text offset

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -157,11 +157,7 @@ article span.m-tag {
 }
 
 article a {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
+  text-underline-offset: 1px;
 }
 
 article strong > a {


### PR DESCRIPTION
## Description

Links are given an underline and a `1px` offset from the text.

Image indicating change:
![CleanShot 2025-04-23 at 18 48 43@2x](https://github.com/user-attachments/assets/982d7823-6928-47e0-a66f-e727058b4d3d)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code