### PR TITLE
docs: add MCPServer reference

### DIFF
--- a/docs/src/content/en/examples/agents/_meta.ts
+++ b/docs/src/content/en/examples/agents/_meta.ts
@@ -6,6 +6,7 @@ const meta = {
   "multi-agent-workflow": "Multi-Agent Workflow",
   "bird-checker": "Bird Checker",
   "adding-voice-capabilities": "Give your Agent a voice",
+  "deploying-mcp-server": "Deploying an MCPServer",
 };
 
 export default meta;

--- a/docs/src/content/en/examples/agents/deploying-mcp-server.mdx
+++ b/docs/src/content/en/examples/agents/deploying-mcp-server.mdx
@@ -1,0 +1,111 @@
+---
+title: "Example: Deploying an MCPServer | Agents | Mastra Docs"
+description: Example of setting up, building, and deploying a Mastra MCPServer using the stdio transport and publishing it to NPM.
+---
+
+# Example: Deploying an MCPServer
+
+This example guides you through setting up a basic Mastra MCPServer using the stdio transport, building it, and preparing it for deployment, such as publishing to NPM.
+
+## Install Dependencies
+
+Install the necessary packages:
+
+```bash
+pnpm add @mastra/mcp @mastra/core tsup
+```
+
+## Set up MCP Server
+
+1.  Create a file for your stdio server, for example, `/src/mastra/stdio.ts`.
+
+2.  Add the following code to the file. Remember to import your actual Mastra tools and name the server appropriately.
+
+    ```typescript filename="src/mastra/stdio.ts" copy
+    #!/usr/bin/env node
+    import { MCPServer } from "@mastra/mcp";
+    import { weatherTool } from "./tools";
+
+    const server = new MCPServer({
+      name: "my-mcp-server",
+      version: "1.0.0",
+      tools: { weatherTool },
+    });
+
+    server.startStdio().catch((error) => {
+      console.error("Error running MCP server:", error);
+      process.exit(1);
+    });
+    ```
+
+3.  Update your `package.json` to include the `bin` entry pointing to your built server file and a script to build the server.
+
+    ```json filename="package.json" copy
+    {
+      // ... other package.json fields
+      "bin": "dist/stdio.js",
+      "scripts": {
+        // ... other scripts
+        "build:mcp": "tsup src/mastra/stdio.ts --format esm --no-splitting --dts && chmod +x dist/stdio.js"
+      }
+      // ... other package.json fields
+    }
+    ```
+
+4.  Run the build command:
+
+    ```bash
+    pnpm run build:mcp
+    ```
+
+    This will compile your server code and make the output file executable.
+
+## Deploying to NPM
+
+To make your MCP server available for others (or yourself) to use via `npx` or as a dependency, you can publish it to NPM.
+
+1.  Ensure you have an NPM account and are logged in (`npm login`).
+2.  Make sure your package name in `package.json` is unique and available.
+3.  Run the publish command from your project root after building:
+
+    ```bash
+    npm publish --access public
+    ```
+
+    For more details on publishing packages, refer to the [NPM documentation](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages).
+
+## Use the Deployed MCP Server
+
+Once published, your MCP server can be used by an `MastraMCPClient` or `MCPConfiguration` by specifying the command to run your package. You can also use any other MCP client like Claude desktop, Cursor, or Windsurf.
+
+```typescript
+import { MCPConfiguration } from "@mastra/mcp";
+
+const mcp = new MCPConfiguration({
+  servers: {
+    // Give this MCP server instance a name
+    yourServerName: {
+      command: "npx",
+      args: ["-y", "@your-org-name/your-package-name@latest"], // Replace with your package name
+    },
+  },
+});
+
+// You can then get tools or toolsets from this configuration to use in your agent
+const tools = await mcp.getTools();
+const toolsets = await mcp.getToolsets();
+```
+
+Note: If you published without an organization scope, the `args` might just be `["-y", "your-package-name@latest"]`.
+
+<br />
+<br />
+<hr className="dark:border-[#404040] border-gray-300" />
+<br />
+<br />
+
+<GithubLink
+  link={
+    "https://github.com/mastra-ai/mastra/blob/main/examples/agents/deploying-mcp-server"
+  }
+/>

--- a/docs/src/content/en/reference/tools/_meta.ts
+++ b/docs/src/content/en/reference/tools/_meta.ts
@@ -4,6 +4,7 @@ const meta = {
   "vector-query-tool": "createVectorQueryTool()",
   client: "MastraMCPClient",
   "mcp-configuration": "MCPConfiguration",
+  "mcp-server": "MCPServer",
 };
 
 export default meta;

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1,0 +1,174 @@
+---
+title: "Reference: MCPServer | Exposing Mastra Tools via MCP | Mastra Docs"
+description: API Reference for MCPServer - A class for exposing Mastra tools and capabilities as a Model Context Protocol server.
+---
+
+# MCPServer
+
+The `MCPServer` class provides the functionality to expose your existing Mastra tools as a Model Context Protocol (MCP) server. This allows any MCP client (like Cursor, Windsurf, or Claude Desktop) to connect to the tools and make them available to an agent.
+Note that if you only need to use your tools in your Mastra agents you don't need to create an MCP server. This API allows you to expose your Mastra tools to external MCP clients. In Mastra you can use your tools directly without MCP.
+
+It supports both [stdio (subprocess) and SSE (HTTP) MCP transports](https://modelcontextprotocol.io/docs/concepts/transports).
+
+## Properties
+
+To create a new MCPServer, you need to provide some basic information about your server and the tools it will offer.
+
+<PropertiesTable
+  content={[
+    {
+      name: "name",
+      type: "string",
+      description: "A name for your server (like 'My Weather Server').",
+    },
+    {
+      name: "version",
+      type: "string",
+      description: "The version of your server (like '1.0.0').",
+    },
+    {
+      name: "tools",
+      type: "ToolsInput",
+      description:
+        "An object containing the tools you want to make available. This can include tools created with Mastra or the Vercel AI SDK.",
+    },
+  ]}
+/>
+
+For example, here's how you might create a new `MCPServer` instance:
+
+```typescript
+import { MCPServer } from "@mastra/mcp";
+import { weatherTool } from "./tools"; // Assuming you have a weather tool defined in this file
+
+const server = new MCPServer({
+  name: "My Weather Server",
+  version: "1.0.0",
+  tools: { weatherTool },
+});
+```
+
+## Methods
+
+These are the functions you can call on an `MCPServer` instance to control its behavior and get information.
+
+### startStdio()
+
+Use this method to start the server so it communicates using standard input and output (stdio). This is typical when running the server as a command-line program.
+
+```typescript
+async startStdio(): Promise<void>
+```
+
+Here's how you would start the server using stdio:
+
+```typescript
+const server = new MCPServer({
+  // example configuration above
+});
+await server.startStdio();
+```
+
+### startSSE()
+
+This method helps you integrate the MCP server with an existing web server to use Server-Sent Events (SSE) for communication. You'll call this from your web server's code when it receives a request for the SSE or message paths.
+
+```typescript
+async startSSE({
+  url,
+  ssePath,
+  messagePath,
+  req,
+  res,
+}: {
+  url: URL;
+  ssePath: string;
+  messagePath: string;
+  req: any;
+  res: any;
+}): Promise<void>
+```
+
+Here's an example of how you might use `startSSE` within an HTTP server request handler. In this example an MCP client could connect to your MCP server at `http://localhost:1234/sse`:
+
+```typescript
+import http from "http";
+
+const httpServer = http.createServer(async (req, res) => {
+  await server.startSSE({
+    url: new URL(req.url || "", `http://localhost:1234`),
+    ssePath: "/sse",
+    messagePath: "/message",
+    req,
+    res,
+  });
+});
+
+httpServer.listen(PORT, () => {
+  console.log(`HTTP server listening on port ${PORT}`);
+});
+```
+
+Here are the details for the values needed by the `startSSE` method:
+
+<PropertiesTable
+  content={[
+    {
+      name: "url",
+      type: "URL",
+      description: "The web address the user is requesting.",
+    },
+    {
+      name: "ssePath",
+      type: "string",
+      description: "The specific part of the URL where clients will connect for SSE (e.g., '/sse').",
+    },
+    {
+      name: "messagePath",
+      type: "string",
+      description: "The specific part of the URL where clients will send messages (e.g., '/message').",
+    },
+    {
+      name: "req",
+      type: "any",
+      description: "The incoming request object from your web server.",
+    },\n    {
+      name: "res",
+      type: "any",
+      description: "The response object from your web server, used to send data back.",
+    },
+  ]}
+/>
+
+### getStdioTransport()
+
+If you started the server with `startStdio()`, you can use this to get the object that manages the stdio communication. This is mostly for checking things internally or for testing.
+
+```typescript
+getStdioTransport(): StdioServerTransport | undefined
+```
+
+### getSseTransport()
+
+If you started the server with `startSSE()`, you can use this to get the object that manages the SSE communication. Like `getStdioTransport`, this is mainly for internal checks or testing.
+
+```typescript
+getSseTransport(): SSEServerTransport | undefined
+```
+
+### tools()
+
+This method gives you a look at the tools that were set up when you created the server. It's a read-only list, useful for debugging purposes.
+
+```typescript
+tools(): Readonly<Record<string, ConvertedTool>>
+```
+
+## Examples
+
+For practical examples of setting up and deploying an MCPServer, see the [Deploying an MCPServer Example](/examples/agents/deploying-mcp-server).
+
+## Related Information
+
+- For connecting to MCP servers in Mastra, see the [MCPConfiguration documentation](./mcp-configuration).
+- For more about the Model Context Protocol, see the [@modelcontextprotocol/sdk documentation](https://github.com/modelcontextprotocol/typescript-sdk).


### PR DESCRIPTION
This PR adds documentation for https://github.com/mastra-ai/mastra/pull/3714

I added a reference page and I also added an example. We don't have a proper tools or MCP sidebar section yet - once we do I'll move the example page into that section