### PR TITLE
fix: allow overflow in agent traces

### DIFF
--- a/.changeset/lucky-friends-wash.md
+++ b/.changeset/lucky-friends-wash.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/core': patch
+'create-mastra': patch
+---
+
+fixing overflow on agent traces

--- a/.changeset/lucky-friends-wash.md
+++ b/.changeset/lucky-friends-wash.md
@@ -1,6 +1,6 @@
 ---
 '@mastra/playground-ui': patch
-'@mastra/core': patch
+'mastra': patch
 'create-mastra': patch
 ---
 

--- a/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
+++ b/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
@@ -17,7 +17,7 @@ function AgentTracesPage() {
     );
   }
 
-  return <AgentTraces agentName={agent?.name!} baseUrl="" />;
+  return <AgentTraces agentName={agent?.name!} baseUrl="" className="h-[calc(100vh-40px)]" />;
 }
 
 export default AgentTracesPage;

--- a/packages/playground-ui/src/domains/agents/agent/agent-traces.tsx
+++ b/packages/playground-ui/src/domains/agents/agent/agent-traces.tsx
@@ -10,28 +10,29 @@ import clsx from 'clsx';
 export interface AgentTracesProps {
   agentName: string;
   baseUrl: string;
+  className?: string;
 }
 
-export function AgentTraces({ agentName, baseUrl }: AgentTracesProps) {
+export function AgentTraces({ agentName, baseUrl, className }: AgentTracesProps) {
   return (
     <TraceProvider>
-      <AgentTracesInner agentName={agentName} baseUrl={baseUrl} />
+      <AgentTracesInner agentName={agentName} baseUrl={baseUrl} className={className} />
     </TraceProvider>
   );
 }
 
-function AgentTracesInner({ agentName, baseUrl }: AgentTracesProps) {
+function AgentTracesInner({ agentName, baseUrl, className }: AgentTracesProps) {
   const [sidebarWidth, setSidebarWidth] = useState(100);
   const { traces, firstCallLoading, error } = useTraces(agentName, baseUrl);
   const { isOpen: open } = useContext(TraceContext);
 
   return (
-    <main className="h-full relative overflow-hidden flex">
-      <div className={clsx('h-full', open ? 'w-auto' : 'w-full')}>
+    <div className={clsx('h-full relative overflow-hidden flex', className)}>
+      <div className={clsx('h-full overflow-y-scroll', open ? 'w-auto' : 'w-full')}>
         <TracesTable traces={traces} isLoading={firstCallLoading} error={error} />
       </div>
 
       {open && <TracesSidebar width={sidebarWidth} onResize={setSidebarWidth} />}
-    </main>
+    </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/TraceTree/Span.tsx
+++ b/packages/playground-ui/src/ds/components/TraceTree/Span.tsx
@@ -62,8 +62,8 @@ export const Span = ({ children, durationMs, variant, tokenCount, spans, isRoot,
   return (
     <TraceDurationProvider durationMs={durationMs}>
       <li>
-        <div className={clsx('grid grid-cols-2 items-center gap-2 rounded-md pl-2', isActive && 'bg-surface4')}>
-          <div className="flex h-8 items-center gap-1">
+        <div className={clsx('flex justify-between items-center gap-2 rounded-md pl-2', isActive && 'bg-surface4')}>
+          <div className="flex h-8 items-center gap-1 min-w-0">
             {spans ? (
               <button
                 type="button"

--- a/packages/playground-ui/src/ds/components/TraceTree/Time.tsx
+++ b/packages/playground-ui/src/ds/components/TraceTree/Time.tsx
@@ -18,7 +18,7 @@ export const Time = ({ durationMs, tokenCount, variant, progressPercent }: TimeP
   const variantClass = variant ? variantClasses[variant] : 'bg-accent3';
 
   return (
-    <div>
+    <div className="w-[166px] shrink-0">
       <div className="bg-surface4 relative h-[6px] w-full rounded-full p-px overflow-hidden">
         <div className={clsx('absolute h-1 rounded-full', variantClass)} style={{ width: `${progressPercent}%` }} />
       </div>


### PR DESCRIPTION
## Description

Add overflow scroll to the traces table and allow to pass down className to override some behaviour (like default height)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
