### PR TITLE
feat(cli): add option for cursor global install for mastra mcp docs server

### DIFF
--- a/e2e-tests/commonjs/commonjs.test.ts
+++ b/e2e-tests/commonjs/commonjs.test.ts
@@ -49,7 +49,7 @@ describe('commonjs', () => {
 
             Your primary function is to help users get weather details for specific locations. When responding:
             - Always ask for a location if none is provided
-            - If the location name isn’t in English, please translate it
+            - If the location name isn't in English, please translate it
             - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
             - Include relevant details like humidity, wind conditions, and precipitation
             - Keep responses concise but informative

--- a/e2e-tests/commonjs/commonjs.test.ts
+++ b/e2e-tests/commonjs/commonjs.test.ts
@@ -49,7 +49,7 @@ describe('commonjs', () => {
 
             Your primary function is to help users get weather details for specific locations. When responding:
             - Always ask for a location if none is provided
-            - If the location name isn't in English, please translate it
+            - If the location name isn’t in English, please translate it
             - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
             - Include relevant details like humidity, wind conditions, and precipitation
             - Keep responses concise but informative

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -87,8 +87,6 @@ export const init = async ({
     const installCommand = getPackageManagerInstallCommand(pm);
     await exec(`${pm} ${installCommand} ${aiSdkPackage}`);
 
-    console.log(`configureEditorWithDocsMCP: ${configureEditorWithDocsMCP}`);
-
     if (configureEditorWithDocsMCP) {
       await installMastraDocsMCPServer({
         editor: configureEditorWithDocsMCP,

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -35,7 +35,7 @@ export const init = async ({
   llmProvider: LLMProvider;
   addExample: boolean;
   llmApiKey?: string;
-  configureEditorWithDocsMCP?: undefined | 'windsurf' | 'cursor';
+  configureEditorWithDocsMCP?: undefined | 'windsurf' | 'cursor' | 'cursor-global';
 }) => {
   s.start('Initializing Mastra');
 
@@ -86,6 +86,8 @@ export const init = async ({
     const pm = depsService.packageManager;
     const installCommand = getPackageManagerInstallCommand(pm);
     await exec(`${pm} ${installCommand} ${aiSdkPackage}`);
+
+    console.log(`configureEditorWithDocsMCP: ${configureEditorWithDocsMCP}`);
 
     if (configureEditorWithDocsMCP) {
       await installMastraDocsMCPServer({

--- a/packages/cli/src/commands/init/mcp-docs-server-install.ts
+++ b/packages/cli/src/commands/init/mcp-docs-server-install.ts
@@ -41,25 +41,6 @@ async function writeMergedConfig(configPath: string) {
 export const windsurfGlobalMCPConfigPath = path.join(os.homedir(), '.codeium', 'windsurf', 'mcp_config.json');
 export const cursorGlobalMCPConfigPath = path.join(os.homedir(), '.cursor', 'mcp.json');
 
-export async function globalCursorMCPIsAlreadyInstalled(directory?: string) {
-  // If directory is provided, check project .cursor/mcp.json, else check global ~/.cursor/mcp.json
-  const configPath = directory ? path.join(directory, '.cursor', 'mcp.json') : cursorGlobalMCPConfigPath;
-  if (!existsSync(configPath)) {
-    return false;
-  }
-  try {
-    const configContents = await readJSON(configPath);
-    if (!configContents?.mcpServers) return false;
-    const hasMastraMCP = Object.values(configContents.mcpServers).some((server?: any) =>
-      server?.args?.find((arg?: string) => arg?.includes(`@mastra/mcp-docs-server`)),
-    );
-    return hasMastraMCP;
-  } catch (e) {
-    console.error(e);
-    return false;
-  }
-}
-
 export async function installMastraDocsMCPServer({
   editor,
   directory,
@@ -71,7 +52,7 @@ export async function installMastraDocsMCPServer({
     await writeMergedConfig(path.join(directory, '.cursor', 'mcp.json'));
   }
   if (editor === `cursor-global`) {
-    const alreadyInstalled = await globalMCPIsAlreadyInstalled(`cursor`);
+    const alreadyInstalled = await globalMCPIsAlreadyInstalled(editor);
     if (alreadyInstalled) {
       return;
     }
@@ -79,7 +60,7 @@ export async function installMastraDocsMCPServer({
   }
 
   if (editor === `windsurf`) {
-    const alreadyInstalled = await globalMCPIsAlreadyInstalled(`windsurf`);
+    const alreadyInstalled = await globalMCPIsAlreadyInstalled(editor);
     if (alreadyInstalled) {
       return;
     }
@@ -87,16 +68,16 @@ export async function installMastraDocsMCPServer({
   }
 }
 
-export async function globalMCPIsAlreadyInstalled(editor: 'windsurf' | 'cursor') {
+export async function globalMCPIsAlreadyInstalled(editor: undefined | 'cursor' | 'cursor-global' | 'windsurf') {
   let configPath: string = ``;
 
   if (editor === 'windsurf') {
     configPath = windsurfGlobalMCPConfigPath;
-  } else if (editor === 'cursor') {
+  } else if (editor === 'cursor-global') {
     configPath = cursorGlobalMCPConfigPath;
   }
 
-  if (!existsSync(configPath)) {
+  if (!configPath || !existsSync(configPath)) {
     return false;
   }
 

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -70,7 +70,7 @@ export async function writeAgentSample(llmProvider: LLMProvider, destPath: strin
 
       Your primary function is to help users get weather details for specific locations. When responding:
       - Always ask for a location if none is provided
-      - If the location name isn't in English, please translate it
+      - If the location name isn’t in English, please translate it
       - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
       - Include relevant details like humidity, wind conditions, and precipitation
       - Keep responses concise but informative

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -11,7 +11,11 @@ import yoctoSpinner from 'yocto-spinner';
 import { DepsService } from '../../services/service.deps';
 import { FileService } from '../../services/service.file';
 import { logger } from '../../utils/logger';
-import { globalWindsurfMCPIsAlreadyInstalled, windsurfGlobalMCPConfigPath } from './mcp-docs-server-install';
+import {
+  cursorGlobalMCPConfigPath,
+  globalMCPIsAlreadyInstalled,
+  windsurfGlobalMCPConfigPath,
+} from './mcp-docs-server-install';
 
 const exec = util.promisify(child_process.exec);
 
@@ -66,7 +70,7 @@ export async function writeAgentSample(llmProvider: LLMProvider, destPath: strin
 
       Your primary function is to help users get weather details for specific locations. When responding:
       - Always ask for a location if none is provided
-      - If the location name isn’t in English, please translate it
+      - If the location name isn't in English, please translate it
       - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
       - Include relevant details like humidity, wind conditions, and precipitation
       - Keep responses concise but informative
@@ -568,13 +572,23 @@ export const interactivePrompt = async () => {
           initialValue: false,
         }),
       configureEditorWithDocsMCP: async () => {
-        const windsurfIsAlreadyInstalled = await globalWindsurfMCPIsAlreadyInstalled();
+        const windsurfIsAlreadyInstalled = await globalMCPIsAlreadyInstalled(`windsurf`);
+        const cursorIsAlreadyInstalled = await globalMCPIsAlreadyInstalled(`cursor`);
 
         const editor = await p.select({
           message: `Make your AI IDE into a Mastra expert? (installs Mastra docs MCP server)`,
           options: [
             { value: 'skip', label: 'Skip for now', hint: 'default' },
-            { value: 'cursor', label: 'Cursor' },
+            {
+              value: 'cursor',
+              label: 'Cursor (project only)',
+              hint: cursorIsAlreadyInstalled ? `Already installed globally` : undefined,
+            },
+            {
+              value: 'cursor-global',
+              label: 'Cursor (global, all projects)',
+              hint: cursorIsAlreadyInstalled ? `Already installed` : undefined,
+            },
             {
               value: 'windsurf',
               label: 'Windsurf',
@@ -593,6 +607,19 @@ export const interactivePrompt = async () => {
           p.log.message(
             `\nNote: you will need to go into Cursor Settings -> MCP Settings and manually enable the installed Mastra MCP server.\n`,
           );
+        }
+
+        if (editor === `cursor-global`) {
+          const confirm = await p.select({
+            message: `Global install will add/update ${cursorGlobalMCPConfigPath} and make the Mastra docs MCP server available in all your Cursor projects. Continue?`,
+            options: [
+              { value: 'yes', label: 'Yes, I understand' },
+              { value: 'skip', label: 'No, skip for now' },
+            ],
+          });
+          if (confirm !== `yes`) {
+            return undefined;
+          }
         }
 
         if (editor === `windsurf`) {


### PR DESCRIPTION
## Description

Adds ability to add a global configuration for cursor for the Mastra docs MCP server during creation of a Mastra project. Allowing all cursor projects to have access to the MCP server.

New option in the CLI:
<img width="531" alt="Screenshot 2025-04-28 at 3 15 38 PM" src="https://github.com/user-attachments/assets/45ee71cf-cd3e-48b3-a792-f94c48a5c7df" />

Prompt making sure you want to add the MCP server globally:
<img width="1074" alt="Screenshot 2025-04-28 at 3 14 50 PM" src="https://github.com/user-attachments/assets/edaa8a35-72c7-4bbd-83fd-abd02c66fa86" />

Hint telling the user that they already have it installed globally:
<img width="524" alt="Screenshot 2025-04-28 at 3 24 39 PM" src="https://github.com/user-attachments/assets/e92535b2-4038-4b1b-a83e-fc68b167f107" />


<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
