### PR TITLE
added deprecation warnings for pg and individual args

### DIFF
--- a/.changeset/solid-toes-bake.md
+++ b/.changeset/solid-toes-bake.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/pg': patch
+---
+
+added deprecation warnings for pg and individual args

--- a/packages/core/src/vector/vector.ts
+++ b/packages/core/src/vector/vector.ts
@@ -32,7 +32,7 @@ export abstract class MastraVector extends MastraBase {
     }
 
     this.logger.warn(
-      `DEPRECATION WARNING: Passing individual arguments to ${method}() is deprecated.
+      `Deprecation Warning: Passing individual arguments to ${method}() is deprecated.
       Please use an object parameter instead.
       Individual arguments will be removed on May 20th.`,
     );

--- a/packages/core/src/vector/vector.ts
+++ b/packages/core/src/vector/vector.ts
@@ -32,8 +32,9 @@ export abstract class MastraVector extends MastraBase {
     }
 
     this.logger.warn(
-      `Deprecation Warning: Passing individual arguments to ${method}() is deprecated. ` +
-        'Please use an object parameter instead.',
+      `DEPRECATION WARNING: Passing individual arguments to ${method}() is deprecated.
+      Please use an object parameter instead.
+      Individual arguments will be removed on May 20th.`,
     );
 
     const baseKeys = this.baseKeys[method as keyof typeof this.baseKeys] || [];

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -70,6 +70,10 @@ export class PgVector extends MastraVector {
   private vectorExtensionInstalled: boolean | undefined = undefined;
   private schemaSetupComplete: boolean | undefined = undefined;
 
+  /**
+   * @deprecated Passing connectionString as a string is deprecated.
+   * Use the object parameter instead. This signature will be removed on May 20th.
+   */
   constructor(connectionString: string);
   constructor(config: {
     connectionString: string;
@@ -90,6 +94,15 @@ export class PgVector extends MastraVector {
     let schemaName: string | undefined;
 
     if (typeof config === 'string') {
+      // DEPRECATION WARNING
+      console.warn(
+        `DEPRECATION WARNING: Passing connectionString as a string to PgVector constructor is deprecated.
+
+        Please use an object parameter instead:
+        new PgVector({ connectionString })
+
+        The string signature will be removed on May 20th.`,
+      );
       connectionString = config;
       schemaName = undefined;
       pgPoolOptions = undefined;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR adds deprecation warnings for PGVector constructor and individual args for vectors.
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
