### PR TITLE
fix(docs): make RAG breadcrumb link not clickable

### DIFF
--- a/docs/src/content/en/examples/rag/_meta.ts
+++ b/docs/src/content/en/examples/rag/_meta.ts
@@ -1,4 +1,10 @@
-const meta = {
+import type { MetaRecord } from "nextra";
+
+const meta: MetaRecord = {
+  "###": {
+    type: "separator",
+    title: "RAG",
+  },
   chunking: {
     title: "Chunking",
   },


### PR DESCRIPTION
## Description

When a breadcrumb is nested on multiple levels we have to make sure that that the second level of nesting explicitly dictates that it's not a link. Otherwise it defaults to a route that is the first nav option in that list. Ie if we're nesting `Examples > RAG > Upsert > Upsert Embeddings`. It will automatically make `RAG` a link and default to the first navigation option in `RAG` so `RAG becomes a clickable link that navigates to `https://mastra.ai/en/examples/rag/chunking` which is not a real link.

We have to explicitly set `RAG` to a separator.

Before:
<img width="388" alt="image" src="https://github.com/user-attachments/assets/cb2b9b60-0e05-491f-bb5b-d11ba253dfc1" />


After:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/2533c55b-0d3a-48ae-898c-fbbdd4607001" />

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
