### PR TITLE
fix(mcp): deprecation warning on wrong class

### DIFF
--- a/.changeset/huge-trains-film.md
+++ b/.changeset/huge-trains-film.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Deprecation warning was on the subclass, rather than the deprecated class. So the deprecation warning would show even if you used the new class.

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -103,7 +103,6 @@ export class InternalMastraMCPClient extends MastraBase {
   private readonly timeout: number;
   private logHandler?: LogHandler;
   private enableServerLogs?: boolean;
-  private static hasWarned = false;
   private serverConfig: MastraMCPServerDefinition;
   private transport?: Transport;
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -89,6 +89,14 @@ function convertLogLevelToLoggerMethod(level: LoggingLevel): 'debug' | 'info' | 
   }
 }
 
+export type InternalMastraMCPClientOptions = {
+  name: string;
+  server: MastraMCPServerDefinition;
+  capabilities?: ClientCapabilities;
+  version?: string;
+  timeout?: number;
+};
+
 export class InternalMastraMCPClient extends MastraBase {
   name: string;
   private client: Client;
@@ -105,21 +113,8 @@ export class InternalMastraMCPClient extends MastraBase {
     server,
     capabilities = {},
     timeout = DEFAULT_REQUEST_TIMEOUT_MSEC,
-  }: {
-    name: string;
-    server: MastraMCPServerDefinition;
-    capabilities?: ClientCapabilities;
-    version?: string;
-    timeout?: number;
-  }) {
+  }: InternalMastraMCPClientOptions) {
     super({ name: 'MastraMCPClient' });
-    if (!InternalMastraMCPClient.hasWarned) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[DEPRECATION] MastraMCPClient is deprecated and will be removed in a future release. Please use MCPClient instead.',
-      );
-      InternalMastraMCPClient.hasWarned = true;
-    }
     this.name = name;
     this.timeout = timeout;
     this.logHandler = server.logger;
@@ -374,4 +369,12 @@ export class InternalMastraMCPClient extends MastraBase {
 /**
  * @deprecated MastraMCPClient is deprecated and will be removed in a future release. Please use MCPClient instead.
  */
-export const MastraMCPClient = InternalMastraMCPClient;
+
+export class MastraMCPClient extends InternalMastraMCPClient {
+  constructor(args: InternalMastraMCPClientOptions) {
+    super(args);
+    this.logger.warn(
+      '[DEPRECATION] MastraMCPClient is deprecated and will be removed in a future release. Please use MCPClient instead.',
+    );
+  }
+}


### PR DESCRIPTION
## Description

Deprecation warning was on the subclass, rather than the deprecated class. So the deprecation warning would show even if you used the new class.
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
