### PR TITLE
feat: compute agent name initials on empty thread

### DIFF
--- a/packages/playground-ui/src/components/assistant-ui/thread.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/thread.tsx
@@ -18,9 +18,10 @@ import { useAutoscroll } from '@/hooks/use-autoscroll';
 
 export interface ThreadProps {
   ToolFallback?: ToolCallContentPartComponent;
+  agentName?: string;
 }
 
-export const Thread = ({ ToolFallback }: ThreadProps) => {
+export const Thread = ({ ToolFallback, agentName }: ThreadProps) => {
   const areaRef = useRef<HTMLDivElement>(null);
   useAutoscroll(areaRef, { enabled: true });
 
@@ -32,7 +33,7 @@ export const Thread = ({ ToolFallback }: ThreadProps) => {
     <ThreadPrimitive.Root className="max-w-[568px] w-full mx-auto h-[calc(100%-100px)] px-4">
       <ThreadPrimitive.Viewport className="py-10 overflow-y-auto scroll-smooth h-full" ref={areaRef} autoScroll={false}>
         <div>
-          <ThreadWelcome />
+          <ThreadWelcome agentName={agentName} />
           <ThreadPrimitive.Messages
             components={{
               UserMessage: UserMessage,
@@ -52,12 +53,29 @@ export const Thread = ({ ToolFallback }: ThreadProps) => {
   );
 };
 
-const ThreadWelcome = () => {
+export interface ThreadWelcomeProps {
+  agentName?: string;
+}
+
+const ThreadWelcome = ({ agentName }: ThreadWelcomeProps) => {
+  const safeAgentName = agentName ?? '';
+  const words = safeAgentName.split(' ') ?? [];
+
+  let initials = 'A';
+
+  if (words.length === 2) {
+    initials = `${words[0][0]}${words[1][0]}`;
+  } else if (safeAgentName.length > 0) {
+    initials = `${safeAgentName[0]}`;
+  } else {
+    initials = 'A';
+  }
+
   return (
     <ThreadPrimitive.Empty>
       <div className="flex w-full flex-grow flex-col items-center justify-center">
         <Avatar>
-          <AvatarFallback>C</AvatarFallback>
+          <AvatarFallback>{initials}</AvatarFallback>
         </Avatar>
         <p className="mt-4 font-medium">How can I help you today?</p>
       </div>

--- a/packages/playground-ui/src/domains/agents/agent/agent-chat.tsx
+++ b/packages/playground-ui/src/domains/agents/agent/agent-chat.tsx
@@ -28,7 +28,7 @@ export const AgentChat = ({
       chatWithGenerate={chatWithGenerate}
     >
       <div className="h-full pb-4">
-        <Thread />
+        <Thread agentName={agentName ?? ''} />
       </div>
     </MastraRuntimeProvider>
   );


### PR DESCRIPTION
## Description

Showing "WA" for "Weather Agent" instead of "C"

![CleanShot 2025-04-30 at 17 01 37@2x](https://github.com/user-attachments/assets/b06cd11c-8680-439e-b0c1-1191d2420274)


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
