### PR TITLE
fix: exclude new agent getters from telemetry

### DIFF
--- a/.changeset/brave-ghosts-shake.md
+++ b/.changeset/brave-ghosts-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+fix: removes new agent getter methods from telemetry

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -56,7 +56,21 @@ function resoolveMaybePromise<T, R = void>(value: T | Promise<T>, cb: (value: T)
 
 @InstrumentClass({
   prefix: 'agent',
-  excludeMethods: ['hasOwnMemory', 'getMemory', '__primitive', '__setTools', '__setLogger', '__setTelemetry', 'log'],
+  excludeMethods: [
+    'hasOwnMemory',
+    'getMemory',
+    '__primitive',
+    '__registerMastra',
+    '__registerPrimitives',
+    '__setTools',
+    '__setLogger',
+    '__setTelemetry',
+    'log',
+    'getModel',
+    'getInstructions',
+    'getTools',
+    'getLLM',
+  ],
 })
 export class Agent<
   TAgentId extends string = string,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

removes new agent getter methods from telemetry:
BEFORE:
![image](https://github.com/user-attachments/assets/79aed952-b9c1-4638-809f-7bd554148501)


AFTER
<img width="1442" alt="image" src="https://github.com/user-attachments/assets/57d1ba8e-212b-400b-91ec-42fabaca7d91" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
