### PR TITLE
Fixx enableFilters parameter to enableFilter for both en/ja

### DIFF
--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -134,7 +134,7 @@ const queryTool = createVectorQueryTool({
   vectorStoreName: "pinecone",
   indexName: "docs",
   model: openai.embedding('text-embedding-3-small'),
-  enableFilters: true,
+  enableFilter: true,
 });
 ```
 

--- a/docs/src/content/ja/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/ja/reference/tools/vector-query-tool.mdx
@@ -134,7 +134,7 @@ const queryTool = createVectorQueryTool({
   vectorStoreName: "pinecone",
   indexName: "docs",
   model: openai.embedding('text-embedding-3-small'),
-  enableFilters: true,
+  enableFilter: true,
 });
 ```
 


### PR DESCRIPTION
## Description

Fixes a typo in the documentation where the `enableFilter` parameter was incorrectly referred to as `enableFilters` in the `createVectorQueryTool()` usage example. Updated the example to correctly use `enableFilter`.

## Related Issue(s)

Fixes #3815 [DOCS] fix enableFilters parameter name

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
