### PR TITLE
fix: playground ui shows duration with sig digits

### DIFF
--- a/.changeset/curvy-pens-clean.md
+++ b/.changeset/curvy-pens-clean.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+fix showing sig digits in trace / span duration

--- a/packages/playground-ui/src/domains/traces/trace-span-details.tsx
+++ b/packages/playground-ui/src/domains/traces/trace-span-details.tsx
@@ -15,6 +15,7 @@ import { getSpanVariant } from './utils/getSpanVariant';
 import { spanIconMap, spanVariantClasses } from '@/ds/components/TraceTree/Span';
 import type { Span } from './types';
 import React from 'react';
+import { toSigFigs } from '@/lib/number';
 
 export function SpanDetail() {
   const { span, setSpan, trace, setIsOpen } = useContext(TraceContext);
@@ -80,11 +81,11 @@ export function SpanDetail() {
         <div className="flex flex-row gap-2 items-center">
           {span.status.code === 0 ? (
             <Badge icon={<LatencyIcon />} variant="success">
-              {Math.round(span.duration / 1000)}ms
+              {toSigFigs(span.duration / 1000, 3)}ms
             </Badge>
           ) : (
             <Badge variant="error" icon={<X />}>
-              Failed in {Math.round(span.duration / 1000)}ms
+              Failed in {toSigFigs(span.duration / 1000, 3)}ms
             </Badge>
           )}
         </div>

--- a/packages/playground-ui/src/domains/traces/traces-table.tsx
+++ b/packages/playground-ui/src/domains/traces/traces-table.tsx
@@ -10,6 +10,7 @@ import { Txt } from '@/ds/components/Txt';
 import { useContext } from 'react';
 import { TraceContext } from './context/trace-context';
 import { Check, X } from 'lucide-react';
+import { toSigFigs } from '@/lib/number';
 
 const TracesTableSkeleton = ({ colsCount }: { colsCount: number }) => {
   return (
@@ -58,11 +59,12 @@ export interface TracesTableProps {
 const TraceRow = ({ trace, index, isActive }: { trace: RefinedTrace; index: number; isActive: boolean }) => {
   const { openTrace } = useOpenTrace();
   const hasFailure = trace.trace.some(span => span.status.code !== 0);
+
   return (
     <Row className={isActive ? 'bg-surface4' : ''} onClick={() => openTrace(trace.trace, index)}>
       <DateTimeCell dateTime={new Date(trace.started / 1000)} />
       <TxtCell title={trace.traceId}>{trace.traceId.substring(0, 7)}...</TxtCell>
-      <UnitCell unit="ms">{Math.round(trace.duration / 1000)}</UnitCell>
+      <UnitCell unit="ms">{toSigFigs(trace.duration / 1000, 3)}</UnitCell>
       <Cell>
         <button onClick={() => openTrace(trace.trace, index)}>
           <Badge icon={<TraceIcon />}>{trace.trace.length}</Badge>

--- a/packages/playground-ui/src/ds/components/TraceTree/Time.tsx
+++ b/packages/playground-ui/src/ds/components/TraceTree/Time.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import { Txt } from '../Txt';
+import { toSigFigs } from '@/lib/number';
 
 export interface TimeProps {
   durationMs: number;
@@ -16,15 +16,16 @@ const variantClasses = {
 
 export const Time = ({ durationMs, tokenCount, variant, progressPercent }: TimeProps) => {
   const variantClass = variant ? variantClasses[variant] : 'bg-accent3';
+  const percent = Math.max(100, progressPercent);
 
   return (
     <div className="w-[80px] xl:w-[166px] shrink-0">
       <div className="bg-surface4 relative h-[6px] w-full rounded-full p-px overflow-hidden">
-        <div className={clsx('absolute h-1 rounded-full', variantClass)} style={{ width: `${progressPercent}%` }} />
+        <div className={clsx('absolute h-1 rounded-full', variantClass)} style={{ width: `${percent}%` }} />
       </div>
       <div className="flex items-center gap-4 pt-0.5">
         <Txt variant="ui-sm" className="text-icon2 font-medium">
-          {Math.round(durationMs)}ms
+          {toSigFigs(durationMs, 3)}ms
         </Txt>
         {tokenCount && (
           <Txt variant="ui-sm" className="text-icon2 font-medium">

--- a/packages/playground-ui/src/ds/components/TraceTree/Time.tsx
+++ b/packages/playground-ui/src/ds/components/TraceTree/Time.tsx
@@ -16,7 +16,7 @@ const variantClasses = {
 
 export const Time = ({ durationMs, tokenCount, variant, progressPercent }: TimeProps) => {
   const variantClass = variant ? variantClasses[variant] : 'bg-accent3';
-  const percent = Math.max(100, progressPercent);
+  const percent = Math.min(100, progressPercent);
 
   return (
     <div className="w-[80px] xl:w-[166px] shrink-0">

--- a/packages/playground-ui/src/lib/number.ts
+++ b/packages/playground-ui/src/lib/number.ts
@@ -1,0 +1,5 @@
+export const toSigFigs = (num: number, sigFigs: number) => {
+  // toPrecision  returns significant digits formatted with potentially exponential notation
+  // Number() converts the exponential notation to a regular number
+  return Number(num.toPrecision(sigFigs));
+};


### PR DESCRIPTION
## Description

Use 3 sig digits in the playground UI for span duration / traces duration

![CleanShot 2025-05-02 at 09 35 18@2x](https://github.com/user-attachments/assets/b93daa83-bf6c-4075-b963-b4e96a51f68b)


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have generated a changeset for this PR
