### PR TITLE
feat(memory): add customizable title generation instructions for threads

### DIFF
--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1,5 +1,6 @@
-import type { AssistantContent, CoreMessage, EmbeddingModel, ToolContent, UserContent } from 'ai';
+import type { AssistantContent, CoreMessage, CoreUserMessage, EmbeddingModel, ToolContent, UserContent } from 'ai';
 
+import type { RuntimeContext } from '../runtime-context';
 import type { MastraStorage } from '../storage';
 import type { MastraVector } from '../vector';
 import type { MemoryProcessor } from '.';
@@ -56,6 +57,12 @@ export type MemoryConfig = {
       };
   threads?: {
     generateTitle?: boolean;
+    generateTitleInstructions?:
+      | string
+      | ((
+          userMessage: CoreUserMessage | undefined,
+          { runtimeContext }: { runtimeContext: RuntimeContext },
+        ) => Promise<string>);
   };
 };
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR adds support for customizable title generation instructions in threads, addressing the current limitation of hardcoded title generation. Users can now provide custom instructions through `memoryOptions`, either as a static string or a dynamic function that receives `runtimeContext`. This enables use cases like localization and instruction tuning for thread titles.

_[WIP] Draft implementation for team review. Tests and docs will be added after approach approval._

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#4032

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
