### PR TITLE
feat(@mastra/core): add a Memory default storage breaking change warning

### DIFF
--- a/.changeset/few-mails-begin.md
+++ b/.changeset/few-mails-begin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add Memory default storage breaking change warning

--- a/.changeset/ninety-webs-win.md
+++ b/.changeset/ninety-webs-win.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastra': patch
+---
+
+Added explicit storage to memory in create-mastra so new projects don't see breaking change warnings

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -81,6 +81,7 @@ export async function writeAgentSample(llmProvider: LLMProvider, destPath: strin
 ${providerImport}
 import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
+import { LibSQLStore } from '@mastra/libsql';
 ${addExampleTool ? `import { weatherTool } from '../tools';` : ''}
 
 export const weatherAgent = new Agent({
@@ -89,6 +90,9 @@ export const weatherAgent = new Agent({
   model: ${modelItem},
   ${addExampleTool ? 'tools: { weatherTool },' : ''}
   memory: new Memory({
+    storage: new LibSQLStore({
+      url: "file:../mastra.db", // path is relative to the .mastra/output directory
+    }),
     options: {
       lastMessages: 10,
       semanticRecall: false,

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -121,6 +121,25 @@ export abstract class MastraMemory extends MastraBase {
       this.threadConfig = this.getMergedThreadConfig(config.options);
     }
 
+    // user is running mastra outside mastra dev in their own code, and is using default memory storage
+    const hasRootMemoryDbFile = existsSync(join(process.cwd(), `memory.db`));
+    // user is running mastra server and has default memory storage
+    const hasParentMemoryDbFile = existsSync(join(process.cwd(), `..`, `..`, `memory.db`));
+    // May 20th we wont worry about this anymore
+    const suggestDbPath =
+      hasRootMemoryDbFile || hasParentMemoryDbFile
+        ? `file:${hasParentMemoryDbFile ? `../../` : ``}memory.db`
+        : `file:../mastra.db`;
+
+    // TODO: MAY 20th BREAKING CHANGE: Memory will inherit storage from Mastra instance by default
+    // if (config.storage) {
+    //   this.storage = config.storage;
+    // } else if (this.mastra?.storage) { // Assuming Mastra instance is available as this.mastra
+    //   this.storage = this.mastra.storage;
+    // } else {
+    //   throw new Error(`Memory requires a storage provider to function. Add a storage configuration to Memory or add one to your Mastra instance`)
+    // }
+    // TODO: remove in may 20th breaking change, replace with above code.
     if (config.storage) {
       this.storage = config.storage;
     } else {
@@ -129,6 +148,56 @@ export abstract class MastraMemory extends MastraBase {
           url: 'file:memory.db',
         },
       });
+
+      // TODO: remove in may 20th breaking change
+      this.deprecationWarnings.push(`
+Default storage is deprecated in Mastra Memory.
+You're using it as an implicit default by not setting a storage adapter.
+
+In the May 20th breaking change the default store will be removed.
+
+Instead of this:
+export const agent = new Agent({
+  memory: new Memory({
+    // your config
+  })
+})
+
+Do this:
+import { LibSQLStore } from '@mastra/libsql';
+
+export const agent = new Agent({
+  memory: new Memory({
+    // your config
+    storage: new LibSQLStore({
+      url: '${suggestDbPath}' // relative path from bundled .mastra/output dir
+    })
+  })
+})
+
+Additionally, in the breaking release, Memory will inherit storage from the Mastra instance.
+If you plan on using that feature you can prepare by setting the same storage instance on Mastra and Memory.
+
+Ex:
+// mastra/storage.ts
+export const storage = new LibSQLStore({
+  url: '${suggestDbPath}'
+})
+
+// mastra/index.ts
+import { storage } from "./storage"
+export const mastra = new Mastra({
+  // your config
+  storage
+})
+
+// mastra/agents/index.ts
+import { storage } from "../storage"
+export const yourAgent = new Agent({
+  // your config
+  storage
+})
+`);
     }
 
     this.storage = augmentWithInit(this.storage);
@@ -144,6 +213,7 @@ export abstract class MastraMemory extends MastraBase {
       semanticRecallIsEnabled
       // add the default vector store
     ) {
+      // TODO: remove in may 20th breaking change
       // for backwards compat reasons, check if there's a memory-vector.db in cwd or in cwd/.mastra
       // if it's there we need to use it, otherwise use the same file:memory.db
       // We used to need two separate DBs because we would get schema errors
@@ -153,14 +223,18 @@ export abstract class MastraMemory extends MastraBase {
       const newDb = 'memory.db';
 
       if (hasOldDb) {
+        // TODO: remove in may 20th breaking change
         this.deprecationWarnings.push(
-          `Found deprecated Memory vector db file ${oldDb} this db is now merged with the default ${newDb} file. Delete the old one to use the new one. You will need to migrate any data if that's important to you. For now the deprecated path will be used but in a future breaking change we will only use the new db file path.`,
+          `Found deprecated Memory vector db file ${oldDb}. In the May 20th breaking change, this will no longer be used by default. This db is now merged with the default storage file (${newDb}). You will need to manually migrate any data from ${oldDb} to ${newDb} if it's important to you. For now the deprecated path will be used, but in the May 20th breaking change we will only use the new db file path.`,
         );
       }
 
+      // TODO: remove in may 20th breaking change
       this.deprecationWarnings.push(`
 Default vector storage is deprecated in Mastra Memory.
 You're using it as an implicit default by not setting a vector store.
+
+In the May 20th breaking change the default vector store will be removed.
 
 Instead of this:
 export const agent = new Agent({
@@ -176,13 +250,14 @@ export const agent = new Agent({
   memory: new Memory({
     options: { semanticRecall: true },
     vector: new LibSQLVector({
-      connectionUrl: 'file:../memory.db'
+      connectionUrl: '${suggestDbPath}' // relative path from bundled .mastra/output dir
     })
   })
 })
 `);
 
       this.vector = new DefaultVectorDB({
+        // TODO: MAY 20th BREAKING CHANGE: remove this default and throw an error if semantic recall is enabled but there's no vector db
         connectionUrl: hasOldDb ? `file:${oldDb}` : `file:${newDb}`,
       });
     }

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -72,6 +72,7 @@ export const memoryDefaultOptions = {
   },
 } satisfies MemoryConfig;
 
+// TODO: May 20th breaking change, make these the default options. Also in packages/cli/src/commands/init/utils.ts remove the hardcoded options to use the new defaults instead
 const newMemoryDefaultOptions = {
   lastMessages: 10,
   semanticRecall: false,

--- a/packages/memory/integration-tests/.env.test
+++ b/packages/memory/integration-tests/.env.test
@@ -1,9 +1,5 @@
 # PostgreSQL connection
 DB_URL=postgres://postgres:password@localhost:5434/mastra
 
-# Redis connection (for Upstash KV tests)
-KV_REST_API_URL=http://localhost:8079
-KV_REST_API_TOKEN=test_token
-
 # OpenAI (for vector embeddings)
 # OPENAI_API_KEY=your_openai_api_key

--- a/packages/memory/integration-tests/src/with-upstash-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-upstash-storage.test.ts
@@ -1,22 +1,14 @@
 import { Memory } from '@mastra/memory';
 import { UpstashStore } from '@mastra/upstash';
-import dotenv from 'dotenv';
 import { describe } from 'vitest';
 
 import { getResuableTests } from './reusable-tests';
 
-dotenv.config({ path: '.env.test' });
-
-// Ensure environment variables are set
-if (!process.env.KV_REST_API_URL || !process.env.KV_REST_API_TOKEN) {
-  throw new Error('Required Vercel KV environment variables are not set');
-}
-
 describe('Memory with UpstashStore Integration', () => {
   const memory = new Memory({
     storage: new UpstashStore({
-      url: process.env.KV_REST_API_URL!,
-      token: process.env.KV_REST_API_TOKEN!,
+      url: 'http://localhost:8079',
+      token: 'test_token',
     }),
     options: {
       lastMessages: 10,


### PR DESCRIPTION
In the May 20th breaking change release Memory wont have default storage unless it's inherited from the Mastra instance.
This PR adds a warning ahead of that breaking change

<img width="702" alt="Screenshot 2025-05-05 at 9 55 56 AM" src="https://github.com/user-attachments/assets/f5f60ccc-7ecb-42ed-93e0-a8ec1f38c632" />

<img width="689" alt="Screenshot 2025-05-05 at 9 56 08 AM" src="https://github.com/user-attachments/assets/e33eafa0-f5fc-4cf0-802a-154cb2727628" />
