### PR TITLE
fix(@mastra/memory): improve token estimation from 96% to 99%

### DIFF
--- a/.changeset/curvy-worms-study.md
+++ b/.changeset/curvy-worms-study.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improved token estimation in TokenLimiter from 96% accuracy back to 99%

--- a/packages/memory/src/processors/index.test.ts
+++ b/packages/memory/src/processors/index.test.ts
@@ -72,7 +72,7 @@ describe('TokenLimiter', () => {
       estimatedTokens += testLimiter.countTokens(message as CoreMessage);
     }
 
-    return estimatedTokens;
+    return Number(estimatedTokens.toFixed(2));
   }
 
   function percentDifference(a: number, b: number) {
@@ -90,7 +90,7 @@ describe('TokenLimiter', () => {
     console.log(`Estimated ${estimate} tokens, used ${used} tokens.\n`, counts);
 
     // Check if within 2% margin
-    expect(percentDifference(estimate, used)).toBeLessThanOrEqual(4);
+    expect(percentDifference(estimate, used)).toBeLessThanOrEqual(2);
   }
 
   const calculatorTool = createTool({

--- a/packages/memory/src/processors/index.test.ts
+++ b/packages/memory/src/processors/index.test.ts
@@ -111,7 +111,7 @@ describe('TokenLimiter', () => {
     tools: { calculatorTool },
   });
 
-  describe.concurrent(`96% accuracy`, () => {
+  describe.concurrent(`98% accuracy`, () => {
     it(`20 messages, no tools`, async () => {
       await expectTokenEstimate(
         {

--- a/packages/memory/src/processors/index.test.ts
+++ b/packages/memory/src/processors/index.test.ts
@@ -134,10 +134,10 @@ describe('TokenLimiter', () => {
       );
     });
 
-    it(`4 messages, 0 tools`, async () => {
+    it(`20 messages, 0 tools`, async () => {
       await expectTokenEstimate(
         {
-          messageCount: 2,
+          messageCount: 10,
           toolFrequency: 0,
           threadId: '3',
         },

--- a/packages/memory/src/processors/token-limiter.ts
+++ b/packages/memory/src/processors/token-limiter.ts
@@ -25,8 +25,8 @@ export class TokenLimiter extends MemoryProcessor {
   // Token overheads per OpenAI's documentation
   // See: https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken#6-counting-tokens-for-chat-completions-api-calls
   // Every message follows <|start|>{role/name}\n{content}<|end|>
-  public TOKENS_PER_MESSAGE = 3; // tokens added for each message (start & end tokens)
-  public TOKENS_PER_TOOL = 2; // empirical adjustment for tool calls
+  public TOKENS_PER_MESSAGE = 3.8; // tokens added for each message (start & end tokens)
+  public TOKENS_PER_TOOL = 2.2; // empirical adjustment for tool calls
   public TOKENS_PER_CONVERSATION = 25; // fixed overhead for the conversation
 
   /**


### PR DESCRIPTION
Follow up on https://github.com/mastra-ai/mastra/pull/3768

I ran the tests a few times and tweaked our base token amount we add to messages and tools until the estimate was very close to actuals. The difference is actually around 0.01-0.5% but I left it as 98% in tests to make sure we wont have any flakiness