### PR TITLE
Fix bug where we were not traversing dirs when creating vercel.json to add al files to the includedFiles array

### DIFF
--- a/.changeset/kind-days-stand.md
+++ b/.changeset/kind-days-stand.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-vercel': patch
+---
+
+Fix bug where we were not traversing dirs when creating vercel.json to add al files to the includedFiles array

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -196,8 +196,15 @@ export const POST = handle(app);
     const result = await this._bundle(this.getEntry(), entryFile, outputDirectory, toolsPaths);
 
     // read dist files one level deep in the output directory
-    const files = readdirSync(join(outputDirectory, this.outputDir));
-    this.writeVercelJSON(outputDirectory, files);
+    const files = readdirSync(join(outputDirectory, this.outputDir), {
+      recursive: true,
+    });
+
+    const filesWithoutNodeModules = files.filter(
+      file => typeof file === 'string' && !file.startsWith('node_modules'),
+    ) as string[];
+
+    this.writeVercelJSON(outputDirectory, filesWithoutNodeModules);
 
     return result;
   }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fix bug where we were not traversing dirs when creating vercel.json to add al files to the includedFiles array

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes #4096

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
