### PR TITLE
chore: add discord link to readme shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@mastra%2Fcore.svg)](https://www.npmjs.com/package/@mastra/core)
 ![GitHub Repo stars](https://img.shields.io/github/stars/mastra-ai/mastra)
-![Discord](https://img.shields.io/discord/1309558646228779139?logo=discord&label=Discord&labelColor=white&color=7289DA)
+[![Discord](https://img.shields.io/discord/1309558646228779139?logo=discord&label=Discord&labelColor=white&color=7289DA)](https://discord.gg/BTYqqHKUrf)
 [![Twitter Follow](https://img.shields.io/twitter/follow/mastra_ai?style=social)](https://x.com/mastra_ai)
 [![NPM Downloads](https://img.shields.io/npm/dm/%40mastra%252Fcore)](https://www.npmjs.com/package/@mastra/core)
 ![Static Badge](https://img.shields.io/badge/Y%20Combinator-W25-orange)


### PR DESCRIPTION
## Description

Wanted to join discord, was surprised that the shield did not link to it. Fixed it.