### PR TITLE
fix: filter out setting loggers and telemetry for LLM component

### DIFF
--- a/.changeset/full-bobcats-doubt.md
+++ b/.changeset/full-bobcats-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+fix: filter out excessive logs when getting LLM for agents

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -20,7 +20,10 @@ export class MastraBase {
    */
   __setLogger(logger: Logger) {
     this.logger = logger;
-    this.logger.debug(`Logger updated [component=${this.component}] [name=${this.name}]`);
+
+    if (this.component !== RegisteredLogger.LLM) {
+      this.logger.debug(`Logger updated [component=${this.component}] [name=${this.name}]`);
+    }
   }
 
   /**
@@ -29,7 +32,10 @@ export class MastraBase {
    */
   __setTelemetry(telemetry: Telemetry) {
     this.telemetry = telemetry;
-    this.logger.debug(`Telemetry updated [component=${this.component}] [tracer=${this.telemetry.tracer}]`);
+
+    if (this.component !== RegisteredLogger.LLM) {
+      this.logger.debug(`Telemetry updated [component=${this.component}] [tracer=${this.telemetry.tracer}]`);
+    }
   }
 
   /**

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -34,9 +34,7 @@ export class MastraBase {
     this.telemetry = telemetry;
 
     if (this.component !== RegisteredLogger.LLM) {
-      this.logger.debug(
-        `Telemetry updated [component=${this.component}] [tracer=${JSON.stringify(this.telemetry.tracer)}]`,
-      );
+      this.logger.debug(`Telemetry updated [component=${this.component}] [name=${this.telemetry.name}]`);
     }
   }
 

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -34,7 +34,9 @@ export class MastraBase {
     this.telemetry = telemetry;
 
     if (this.component !== RegisteredLogger.LLM) {
-      this.logger.debug(`Telemetry updated [component=${this.component}] [tracer=${this.telemetry.tracer}]`);
+      this.logger.debug(
+        `Telemetry updated [component=${this.component}] [tracer=${JSON.stringify(this.telemetry.tracer)}]`,
+      );
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Now that we can dynamically get the LLM for agents, we need to register the LLM for logging and tracing. When this happens, the following is logged:

```
Logger updated [component=LLM] [name=aisdk]
Telemetry updated [component=LLM] [tracer=[object Object]]
```

In cloud, we ping the api/agents endpoint, and with every ping to this endpoint, these logs are generated, creating an abundance of logs.

This PR will make it so we do not log when getting the LLM for an agent

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
