### PR TITLE
Use detected package manager in post-create instructions

### DIFF
--- a/.changeset/evil-oranges-cut.md
+++ b/.changeset/evil-oranges-cut.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Use detected package manager in post-create instructions

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -4,6 +4,7 @@ import color from 'picocolors';
 import { init } from '../init/init';
 import { interactivePrompt } from '../init/utils';
 import type { LLMProvider } from '../init/utils';
+import { getPackageManager } from '../utils.js';
 
 import { createMastraProject } from './utils';
 
@@ -52,10 +53,11 @@ export const create = async (args: {
 };
 
 const postCreate = ({ projectName }: { projectName: string }) => {
+  const packageManager = getPackageManager();
   p.outro(`
    ${color.green('To start your project:')}
 
     ${color.cyan('cd')} ${projectName}
-    ${color.cyan('npm run dev')}
+    ${color.cyan(`${packageManager} run dev`)}
   `);
 };


### PR DESCRIPTION
## Description

- The post-create message in the `create` command now uses the detected package manager from `getPackageManager()` instead of hardcoding `npm`.
- This ensures users see the correct command (`npm`, `yarn`, `pnpm`, etc.) based on their environment.
- Improves user experience and consistency for different package manager setups.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
