### PR TITLE
fix(@mastra/mcp-docs-server): allow up to 1k lines in an example

### DIFF
--- a/.changeset/old-laws-sleep.md
+++ b/.changeset/old-laws-sleep.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-docs-server': patch
+---
+
+Increased the allowed size of loc in the docs MCPs examples tool so that the agents.md example still fits in

--- a/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
+++ b/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
@@ -57,8 +57,8 @@ export async function prepareCodeExamples() {
 
       const totalLines = output.split('\n').length;
 
-      // Skip if total lines would exceed 500
-      if (totalLines > 500) {
+      // Skip if total lines would exceed 1000
+      if (totalLines > 1000) {
         log(`Skipping ${dir.name}: ${totalLines} lines exceeds limit of 500`);
         continue;
       }

--- a/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
+++ b/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
@@ -58,8 +58,9 @@ export async function prepareCodeExamples() {
       const totalLines = output.split('\n').length;
 
       // Skip if total lines would exceed 1000
-      if (totalLines > 1000) {
-        log(`Skipping ${dir.name}: ${totalLines} lines exceeds limit of 500`);
+      const limit = 1000;
+      if (totalLines > limit) {
+        log(`Skipping ${dir.name}: ${totalLines} lines exceeds limit of ${limit}`);
         continue;
       }
 


### PR DESCRIPTION
The `agent` code example is now 550 lines. The line limit here (500 lines) was really to omit anything excessive like the yc example which is too long at 5k loc. Bumped this up to 1k so tests pass _and_ so that the agent example is still included in the docs MCP