### PR TITLE
fix(core): tool compat assumed only zod schemas

### DIFF
--- a/.changeset/wild-moles-divide.md
+++ b/.changeset/wild-moles-divide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixes and issue when a tool provides no inputSchema and when a tool uses a non-zod schema.

--- a/packages/core/src/tools/tool-compatibility/builder.ts
+++ b/packages/core/src/tools/tool-compatibility/builder.ts
@@ -217,7 +217,7 @@ export class CoreToolBuilder extends MastraBase {
 
     return {
       ...definition,
-      parameters: hasParameters ? convertZodSchemaToAISDKSchema(this.getParameters()) : undefined,
+      parameters: convertZodSchemaToAISDKSchema(this.getParameters()),
     };
   }
 }

--- a/packages/core/src/tools/tool-compatibility/builder.ts
+++ b/packages/core/src/tools/tool-compatibility/builder.ts
@@ -2,7 +2,7 @@ import type { ToolExecutionOptions } from 'ai';
 import { jsonSchema } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 import jsonSchemaToZod from 'json-schema-to-zod';
-import type { ZodSchema } from 'zod';
+import type { ZodSchema, ZodType } from 'zod';
 import { z } from 'zod';
 import type { Targets } from 'zod-to-json-schema';
 import { zodToJsonSchema } from 'zod-to-json-schema';
@@ -188,9 +188,19 @@ export class CoreToolBuilder extends MastraBase {
         : undefined,
     };
 
+    const parametersObject: { parameters?: ZodType; inputSchema?: ZodType } = {};
+
+    if (isVercelTool(this.originalTool)) {
+      parametersObject.parameters = this.getParameters();
+    } else {
+      parametersObject.inputSchema = this.getParameters();
+    }
+
     const model = this.options.model;
 
-    if (model) {
+    const hasParameters = parametersObject.parameters || parametersObject.inputSchema;
+
+    if (model && hasParameters) {
       for (const compat of [
         new OpenAIReasoningToolCompat(model),
         new OpenAIToolCompat(model),
@@ -200,11 +210,14 @@ export class CoreToolBuilder extends MastraBase {
         new MetaToolCompat(model),
       ]) {
         if (compat.shouldApply()) {
-          return { ...definition, ...compat.process(this.originalTool) };
+          return { ...definition, ...compat.process({ ...this.originalTool, ...parametersObject }) };
         }
       }
     }
 
-    return { ...definition, parameters: convertZodSchemaToAISDKSchema(this.getParameters()) };
+    return {
+      ...definition,
+      parameters: hasParameters ? convertZodSchemaToAISDKSchema(this.getParameters()) : undefined,
+    };
   }
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -12,7 +12,7 @@ export type VercelTool = Tool;
 export type CoreTool = {
   id?: string;
   description?: string;
-  parameters?: ZodSchema | JSONSchema7Type | Schema;
+  parameters: ZodSchema | JSONSchema7Type | Schema;
   execute?: (params: any, options: ToolExecutionOptions) => Promise<any>;
 } & (
   | {

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -12,7 +12,7 @@ export type VercelTool = Tool;
 export type CoreTool = {
   id?: string;
   description?: string;
-  parameters: ZodSchema | JSONSchema7Type | Schema;
+  parameters?: ZodSchema | JSONSchema7Type | Schema;
   execute?: (params: any, options: ToolExecutionOptions) => Promise<any>;
 } & (
   | {


### PR DESCRIPTION
## Description

There were two issues with the compatibility function.
1. it assumed that the original tool's schema was always zod (ie but can also receive a json schema)
2. it assumed that the original schema always existed (it's possible to not have any parameters)
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
