### PR TITLE
fix: zodSchema shape is safely preventing runtime errors

### DIFF
--- a/.changeset/upset-otters-design.md
+++ b/.changeset/upset-otters-design.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': major
+---
+
+Fix tool compatibility schema handling by ensuring zodSchema.shape is safely accessed, preventing potential runtime errors.

--- a/.changeset/upset-otters-design.md
+++ b/.changeset/upset-otters-design.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/core': major
+'@mastra/core': patch
 ---
 
 Fix tool compatibility schema handling by ensuring zodSchema.shape is safely accessed, preventing potential runtime errors.

--- a/packages/core/src/tools/tool-compatibility/index.ts
+++ b/packages/core/src/tools/tool-compatibility/index.ts
@@ -83,7 +83,7 @@ export abstract class ToolCompatibility extends MastraBase {
     schema: z.AnyZodObject;
   } {
     const newSchema = z.object(
-      Object.entries<z.ZodTypeAny>(zodSchema.shape).reduce(
+      Object.entries<z.ZodTypeAny>(zodSchema.shape || {}).reduce(
         (acc, [key, value]) => ({
           ...acc,
           [key]: this.processZodType<any>(value),


### PR DESCRIPTION
## Description

Fix issues when loading toolsets from SSE MCPs from this code

```
const mcp = new MCPClient({
  id: agentId,
  servers,
});

const toolsets = await mcp.getToolsets();
```

Getting the following error:
```
Failed to process stream: TypeError: Cannot read properties of undefined (reading 'shape')
    at OpenAIToolCompat.zodToAISDKSchema (../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-ZQ7FXUGY.js:50:33)
    at OpenAIToolCompat.process (../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-ZQ7FXUGY.js:292:29)
    at CoreToolBuilder.build (../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-ZQ7FXUGY.js:659:45)
    at makeCoreTool (../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-ZQ7FXUGY.js:798:66)
    at ../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-XYP6MY7U.js:565:20
    at Array.map (<anonymous>)
    at Agent.convertTools (../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-XYP6MY7U.js:549:76)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async before (../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-XYP6MY7U.js:776:26)
    at async Agent.stream (../node_modules/.pnpm/@mastra+core@0.9.3_@hono+zod-validator@0.5.0_hono@4.7.9_zod@3.24.4__openapi-types@12.1.3_react@19.1.0_zod@3.24.4/node_modules/@mastra/core/dist/chunk-XYP6MY7U.js:1124:9)
```

## Related Issue(s)

https://discord.com/channels/1309558646228779139/1371409479056490506

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have generated a changeset for this PR
