### PR TITLE
[MASTRA-3234] added limit for client-js getMessages

### DIFF
--- a/client-sdks/client-js/src/index.test.ts
+++ b/client-sdks/client-js/src/index.test.ts
@@ -552,6 +552,35 @@ describe('MastraClient Resources', () => {
         }),
       );
     });
+
+    it('should get thread messages with limit', async () => {
+      const mockResponse = {
+        messages: [
+          {
+            id: '1',
+            content: 'test',
+            threadId,
+            role: 'user',
+            type: 'text',
+            resourceId: 'test-resource',
+            createdAt: new Date(),
+          },
+        ],
+        uiMessages: [],
+      };
+      mockFetchResponse(mockResponse);
+
+      const limit = 5;
+      const result = await memoryThread.getMessages({ limit });
+
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/memory/threads/${threadId}/messages?agentId=${agentId}&limit=${limit}`,
+        expect.objectContaining({
+          headers: expect.objectContaining(clientOptions.headers),
+        }),
+      );
+    });
   });
 
   describe('Tool Resource', () => {

--- a/client-sdks/client-js/src/resources/memory-thread.ts
+++ b/client-sdks/client-js/src/resources/memory-thread.ts
@@ -1,6 +1,11 @@
 import type { StorageThreadType } from '@mastra/core';
 
-import type { GetMemoryThreadMessagesResponse, ClientOptions, UpdateMemoryThreadParams } from '../types';
+import type {
+  GetMemoryThreadMessagesResponse,
+  ClientOptions,
+  UpdateMemoryThreadParams,
+  GetMemoryThreadMessagesParams,
+} from '../types';
 
 import { BaseResource } from './base';
 
@@ -45,9 +50,14 @@ export class MemoryThread extends BaseResource {
 
   /**
    * Retrieves messages associated with the thread
+   * @param params - Optional parameters including limit for number of messages to retrieve
    * @returns Promise containing thread messages and UI messages
    */
-  getMessages(): Promise<GetMemoryThreadMessagesResponse> {
-    return this.request(`/api/memory/threads/${this.threadId}/messages?agentId=${this.agentId}`);
+  getMessages(params?: GetMemoryThreadMessagesParams): Promise<GetMemoryThreadMessagesResponse> {
+    const query = new URLSearchParams({
+      agentId: this.agentId,
+      ...(params?.limit ? { limit: params.limit.toString() } : {}),
+    });
+    return this.request(`/api/memory/threads/${this.threadId}/messages?${query.toString()}`);
   }
 }

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -174,6 +174,10 @@ export interface UpdateMemoryThreadParams {
   resourceId: string;
 }
 
+export interface GetMemoryThreadMessagesParams {
+  limit?: number;
+}
+
 export interface GetMemoryThreadMessagesResponse {
   messages: CoreMessage[];
   uiMessages: AiMessageType[];

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -175,6 +175,9 @@ export interface UpdateMemoryThreadParams {
 }
 
 export interface GetMemoryThreadMessagesParams {
+  /**
+   * Limit the number of messages to retrieve (default: 40)
+   */
   limit?: number;
 }
 

--- a/packages/deployer/src/server/handlers/memory.ts
+++ b/packages/deployer/src/server/handlers/memory.ts
@@ -145,7 +145,7 @@ export async function getMessagesHandler(c: Context) {
     const mastra: Mastra = c.get('mastra');
     const agentId = c.req.query('agentId');
     const threadId = c.req.param('threadId');
-    const rawLimit = c.req.param('limit');
+    const rawLimit = c.req.query('limit');
     let limit: number | undefined = undefined;
 
     if (rawLimit !== undefined) {

--- a/packages/deployer/src/server/handlers/memory.ts
+++ b/packages/deployer/src/server/handlers/memory.ts
@@ -145,11 +145,21 @@ export async function getMessagesHandler(c: Context) {
     const mastra: Mastra = c.get('mastra');
     const agentId = c.req.query('agentId');
     const threadId = c.req.param('threadId');
+    const rawLimit = c.req.param('limit');
+    let limit: number | undefined = undefined;
+
+    if (rawLimit !== undefined) {
+      const n = Number(rawLimit);
+      if (Number.isFinite(n) && Number.isInteger(n) && n > 0) {
+        limit = n;
+      }
+    }
 
     const result = await getOriginalGetMessagesHandler({
       mastra,
       agentId,
       threadId,
+      limit,
     });
 
     return c.json(result);

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -1473,7 +1473,8 @@ export async function createHonoServer(mastra: Mastra, options: ServerBundleOpti
           name: 'limit',
           in: 'query',
           required: false,
-          schema: { type: 'string' },
+          schema: { type: 'number' },
+          description: 'Limit the number of messages to retrieve (default: 40)',
         },
       ],
       responses: {

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -1469,6 +1469,12 @@ export async function createHonoServer(mastra: Mastra, options: ServerBundleOpti
           required: true,
           schema: { type: 'string' },
         },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          schema: { type: 'string' },
+        },
       ],
       responses: {
         200: {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -228,6 +228,9 @@ export async function getMessagesHandler({
 }: Pick<MemoryContext, 'mastra' | 'agentId' | 'threadId'> & {
   limit?: number;
 }) {
+  if (limit !== undefined && (!Number.isInteger(limit) || limit <= 0)) {
+    throw new HTTPException(400, { message: 'Invalid limit: must be a positive integer' });
+  }
   try {
     validateBody({ threadId });
 

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -224,7 +224,10 @@ export async function getMessagesHandler({
   mastra,
   agentId,
   threadId,
-}: Pick<MemoryContext, 'mastra' | 'agentId' | 'threadId'>) {
+  limit,
+}: Pick<MemoryContext, 'mastra' | 'agentId' | 'threadId'> & {
+  limit?: number;
+}) {
   try {
     validateBody({ threadId });
 
@@ -239,7 +242,10 @@ export async function getMessagesHandler({
       throw new HTTPException(404, { message: 'Thread not found' });
     }
 
-    const result = await memory.query({ threadId: threadId! });
+    const result = await memory.query({
+      threadId: threadId!,
+      ...(limit && { selectBy: { last: limit } }),
+    });
     return result;
   } catch (error) {
     return handleError(error, 'Error getting messages');


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Adds a limit query option to increase limit of messages retrieved by getMessages.
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
