### PR TITLE
Add streaming support to workflows

### DIFF
--- a/.changeset/rare-beds-wash.md
+++ b/.changeset/rare-beds-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Move emitter to symbol to make private

--- a/.changeset/rare-beds-wash.md
+++ b/.changeset/rare-beds-wash.md
@@ -1,5 +1,9 @@
 ---
 '@mastra/inngest': patch
+'@mastra/core': patch
+'@mastra/deployer': patch
+'@mastra/server': patch
+'@mastra/client-js': patch
 ---
 
 Move emitter to symbol to make private

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -225,7 +225,7 @@ export class Workflow extends BaseResource {
     runId?: string;
     inputData: Record<string, any>;
     runtimeContext?: RuntimeContext;
-  }): Promise<AsyncGenerator<VNextWorkflowWatchResult, void, unknown>> {
+  }): Promise<AsyncGenerator<WorkflowWatchResult, void, unknown>> {
     const searchParams = new URLSearchParams();
 
     if (!!params?.runId) {

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -221,11 +221,7 @@ export class Workflow extends BaseResource {
    * @param params - Object containing the optional runId, inputData and runtimeContext
    * @returns Promise containing the vNext workflow execution results
    */
-  async stream(params: {
-    runId?: string;
-    inputData: Record<string, any>;
-    runtimeContext?: RuntimeContext;
-  }): Promise<AsyncGenerator<WorkflowWatchResult, void, unknown>> {
+  async stream(params: { runId?: string; inputData: Record<string, any>; runtimeContext?: RuntimeContext }) {
     const searchParams = new URLSearchParams();
 
     if (!!params?.runId) {
@@ -250,7 +246,36 @@ export class Workflow extends BaseResource {
       throw new Error('Response body is null');
     }
 
-    return this.streamProcessor(response.body);
+    // Create a transform stream that processes the response body
+    const transformStream = new TransformStream<ArrayBuffer, WorkflowWatchResult>({
+      start() {},
+      async transform(chunk, controller) {
+        try {
+          // Decode binary data to text
+          const decoded = new TextDecoder().decode(chunk);
+
+          // Split by record separator
+          const chunks = decoded.split(RECORD_SEPARATOR);
+
+          // Process each chunk
+          for (const chunk of chunks) {
+            if (chunk) {
+              try {
+                const parsedChunk = JSON.parse(chunk);
+                controller.enqueue(parsedChunk);
+              } catch {
+                // Silently ignore parsing errors
+              }
+            }
+          }
+        } catch {
+          // Silently ignore processing errors
+        }
+      },
+    });
+
+    // Pipe the response body through the transform stream
+    return response.body.pipeThrough(transformStream);
   }
 
   /**
@@ -296,5 +321,29 @@ export class Workflow extends BaseResource {
     for await (const record of this.streamProcessor(response.body)) {
       onRecord(record);
     }
+  }
+
+  /**
+   * Creates a new ReadableStream from an iterable or async iterable of objects,
+   * serializing each as JSON and separating them with the record separator (\x1E).
+   *
+   * @param records - An iterable or async iterable of objects to stream
+   * @returns A ReadableStream emitting the records as JSON strings separated by the record separator
+   */
+  static createRecordStream(records: Iterable<any> | AsyncIterable<any>): ReadableStream {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const record of records as AsyncIterable<any>) {
+            const json = JSON.stringify(record) + RECORD_SEPARATOR;
+            controller.enqueue(encoder.encode(json));
+          }
+          controller.close();
+        } catch (err) {
+          controller.error(err);
+        }
+      },
+    });
   }
 }

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -298,6 +298,162 @@ export type WorkflowResult<...> =
 
 5. **error**: Optional error object present when `status` is `'failed'`
 
+## Streaming Workflow Execution
+
+You can also stream workflow execution:
+
+```typescript
+const run = myWorkflow.createRun();
+
+// Start the workflow
+const result = run.stream({ inputData: {...} });
+
+for (const chunk of result.stream) {
+  // do something
+}
+```
+
+The `event` object has the following schema:
+
+<PropertiesTable
+  content={[
+    {
+      name: "start",
+      type: "object",
+      description: "The workflow starts",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'start', payload: { runId: '1' } }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "step-start",
+      type: "object", 
+      description: "The start of a step",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'step-start', payload: { id: 'fetch-weather' } }",
+              description: "Example message structure", 
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "tool-call-streaming-start",
+      type: "object",
+      description: "A tool call/agent has started",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'tool-call-streaming-start', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "tool-call-delta",
+      type: "object",
+      description: "The delta of the tool output",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'tool-call-delta', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:\\n' + '            [\\n' + '  {\\n' + '    \"date\": \"2025-05-16\",\\n' + '    \"maxTemp\": 22.2,\\n' + '    \"minTemp\": 16,\\n' + '    \"precipitationChance\": 5,\\n' + '    \"condition\": \"Dense drizzle\",\\n' + '    \"location\": \"New York\"\\n' + '  },\\n' + '            ' }, argsTextDelta: '📅' }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+  {
+    name: "step-result",
+    type: "object",
+    description: "The result of a step",
+    isOptional: false,
+    properties: [
+      {
+        type: "object",
+        parameters: [
+          {
+            name: "example",
+            type: "{ type: 'step-result', payload: { id: 'Weather Agent', status: 'success', output: [Object] } }",
+            description: "Example message structure",
+            isOptional: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "step-finish",
+    type: "object",
+    description: "The end of a step",
+    isOptional: false,
+    properties: [
+      {
+        type: "object",
+        parameters: [
+          {
+            name: "example",
+            type: "{ type: 'step-finish', payload: { id: 'Weather Agent', metadata: {} } }",
+            description: "Example message structure",
+            isOptional: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "finish",
+    type: "object",
+    description: "The end of the workflow",
+    isOptional: false,
+    properties: [
+      {
+        type: "object",
+        parameters: [
+          {
+            name: "example",
+            type: "{ type: 'finish', payload: { runId: '1' } }",
+            description: "Example message structure",
+            isOptional: false,
+          },
+        ],
+      },
+    ],
+  },
+  ]}
+/>
+
+
 ## Watching Workflow Execution
 
 You can also watch workflow execution:

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -355,6 +355,25 @@ The `event` object has the following schema:
         },
       ],
     },
+     {
+      name: "tool-call",
+      type: "object",
+      description: "A tool call has started",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'tool-call', toolCallId: 'weatherAgent', toolName: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
     {
       name: "tool-call-streaming-start",
       type: "object",
@@ -366,7 +385,7 @@ The `event` object has the following schema:
           parameters: [
             {
               name: "example",
-              type: "{ type: 'tool-call-streaming-start', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
+              type: "{ type: 'tool-call-streaming-start', toolCallId: 'weatherAgent', toolName: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
               description: "Example message structure",
               isOptional: false,
             },
@@ -385,7 +404,7 @@ The `event` object has the following schema:
           parameters: [
             {
               name: "example",
-              type: "{ type: 'tool-call-delta', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:\\n' + '            [\\n' + '  {\\n' + '    \"date\": \"2025-05-16\",\\n' + '    \"maxTemp\": 22.2,\\n' + '    \"minTemp\": 16,\\n' + '    \"precipitationChance\": 5,\\n' + '    \"condition\": \"Dense drizzle\",\\n' + '    \"location\": \"New York\"\\n' + '  },\\n' + '            ' }, argsTextDelta: '📅' }",
+              type: "{ type: 'tool-call-delta', toolCallId: 'weatherAgent', toolName: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:\\n' + '            [\\n' + '  {\\n' + '    \"date\": \"2025-05-16\",\\n' + '    \"maxTemp\": 22.2,\\n' + '    \"minTemp\": 16,\\n' + '    \"precipitationChance\": 5,\\n' + '    \"condition\": \"Dense drizzle\",\\n' + '    \"location\": \"New York\"\\n' + '  },\\n' + '            ' }, argsTextDelta: '📅' }",
               description: "Example message structure",
               isOptional: false,
             },

--- a/docs/src/content/en/reference/workflows/_meta.ts
+++ b/docs/src/content/en/reference/workflows/_meta.ts
@@ -12,6 +12,7 @@ const meta = {
   "create-run": "createRun()",
   snapshots: "Snapshots",
   watch: "watch()",
+  stream: "stream()",
   execute: "execute()",
   resume: "resume()",
   start: "start()",

--- a/docs/src/content/en/reference/workflows/stream.mdx
+++ b/docs/src/content/en/reference/workflows/stream.mdx
@@ -63,6 +63,25 @@ for (const chunk of stream) {
         },
       ],
     },
+     {
+      name: "tool-call",
+      type: "object",
+      description: "A tool call has started",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'tool-call', toolCallId: 'weatherAgent', toolName: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
     {
       name: "tool-call-streaming-start",
       type: "object",
@@ -74,7 +93,7 @@ for (const chunk of stream) {
           parameters: [
             {
               name: "example",
-              type: "{ type: 'tool-call-streaming-start', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
+              type: "{ type: 'tool-call-streaming-start', toolCallId: 'weatherAgent', toolName: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
               description: "Example message structure",
               isOptional: false,
             },
@@ -93,7 +112,7 @@ for (const chunk of stream) {
           parameters: [
             {
               name: "example",
-              type: "{ type: 'tool-call-delta', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:\\n' + '            [\\n' + '  {\\n' + '    \"date\": \"2025-05-16\",\\n' + '    \"maxTemp\": 22.2,\\n' + '    \"minTemp\": 16,\\n' + '    \"precipitationChance\": 5,\\n' + '    \"condition\": \"Dense drizzle\",\\n' + '    \"location\": \"New York\"\\n' + '  },\\n' + '            ' }, argsTextDelta: '📅' }",
+              type: "{ type: 'tool-call-delta', toolCallId: 'weatherAgent', toolName: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:\\n' + '            [\\n' + '  {\\n' + '    \"date\": \"2025-05-16\",\\n' + '    \"maxTemp\": 22.2,\\n' + '    \"minTemp\": 16,\\n' + '    \"precipitationChance\": 5,\\n' + '    \"condition\": \"Dense drizzle\",\\n' + '    \"location\": \"New York\"\\n' + '  },\\n' + '            ' }, argsTextDelta: '📅' }",
               description: "Example message structure",
               isOptional: false,
             },

--- a/docs/src/content/en/reference/workflows/stream.mdx
+++ b/docs/src/content/en/reference/workflows/stream.mdx
@@ -1,0 +1,210 @@
+---
+title: "Reference: Workflow.stream() | Building Workflows | Mastra Docs"
+description: Documentation for the `.stream()` method in workflows, which allows you to monitor the execution of a workflow run as a stream.
+---
+
+# Run.stream()
+
+The `.stream()` method allows you to monitor the execution of a workflow run, providing real-time updates on the status of steps.
+
+## Usage
+
+```typescript
+const run = myWorkflow.createRun();
+
+// Add a stream to monitor execution
+const result = run.stream({ inputData: {...} });
+
+
+for (const chunk of stream) {
+  // do something with the chunk
+}
+```
+
+## Messages
+
+<PropertiesTable
+  content={[
+    {
+      name: "start",
+      type: "object",
+      description: "The workflow starts",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'start', payload: { runId: '1' } }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "step-start",
+      type: "object", 
+      description: "The start of a step",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'step-start', payload: { id: 'fetch-weather' } }",
+              description: "Example message structure", 
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "tool-call-streaming-start",
+      type: "object",
+      description: "A tool call/agent has started",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'tool-call-streaming-start', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:...' } }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "tool-call-delta",
+      type: "object",
+      description: "The delta of the tool output",
+      isOptional: false,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "example",
+              type: "{ type: 'tool-call-delta', name: 'Weather Agent', args: { prompt: 'Based on the following weather forecast for New York, suggest appropriate activities:\\n' + '            [\\n' + '  {\\n' + '    \"date\": \"2025-05-16\",\\n' + '    \"maxTemp\": 22.2,\\n' + '    \"minTemp\": 16,\\n' + '    \"precipitationChance\": 5,\\n' + '    \"condition\": \"Dense drizzle\",\\n' + '    \"location\": \"New York\"\\n' + '  },\\n' + '            ' }, argsTextDelta: '📅' }",
+              description: "Example message structure",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+  {
+    name: "step-result",
+    type: "object",
+    description: "The result of a step",
+    isOptional: false,
+    properties: [
+      {
+        type: "object",
+        parameters: [
+          {
+            name: "example",
+            type: "{ type: 'step-result', payload: { id: 'Weather Agent', status: 'success', output: [Object] } }",
+            description: "Example message structure",
+            isOptional: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "step-finish",
+    type: "object",
+    description: "The end of a step",
+    isOptional: false,
+    properties: [
+      {
+        type: "object",
+        parameters: [
+          {
+            name: "example",
+            type: "{ type: 'step-finish', payload: { id: 'Weather Agent', metadata: {} } }",
+            description: "Example message structure",
+            isOptional: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "finish",
+    type: "object",
+    description: "The end of the workflow",
+    isOptional: false,
+    properties: [
+      {
+        type: "object",
+        parameters: [
+          {
+            name: "example",
+            type: "{ type: 'finish', payload: { runId: '1' } }",
+            description: "Example message structure",
+            isOptional: false,
+          },
+        ],
+      },
+    ],
+  },
+  ]}
+/>
+
+
+
+## Parameters
+<PropertiesTable
+  content={[
+    {
+      name: "params",
+      type: "object",
+      description: "Configuration object for starting the workflow run",
+      isOptional: false,
+      properties: [
+        {
+          name: "inputData",
+          type: "z.infer<TInput>",
+          parameters: [{
+            name: "z.infer<TInput>",
+            type: "inputData",
+            description: "Runtime context data to use when starting the workflow",
+            isOptional: true
+          }]
+        },
+        { 
+          name: "runtimeContext",
+          type: "RuntimeContext",
+          parameters: [{
+            name: "runtimeContext",
+            type: "RuntimeContext",
+            description: "Runtime context data to use when starting the workflow",
+            isOptional: true
+          }]
+        },
+      ],
+    },
+  ]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: "result",
+      type: "Promise<WorkflowResult<TOutput, TSteps>>",
+      description: "A stream that pipes each step to the stream",
+    },
+  ]}
+/>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,12 @@
         "default": "./dist/workflows/legacy/index.cjs"
       }
     },
+    "./workflows/_constants": {
+      "import": {
+        "types": "./dist/workflows/constants.d.ts",
+        "default": "./dist/workflows/constants.js"
+      }
+    },
     "./vector/filter": {
       "import": {
         "types": "./dist/vector/filter/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,10 @@
       "import": {
         "types": "./dist/workflows/constants.d.ts",
         "default": "./dist/workflows/constants.js"
+      },
+      "require": {
+        "types": "./dist/workflows/constants.d.cts",
+        "default": "./dist/workflows/constants.cjs"
       }
     },
     "./vector/filter": {

--- a/packages/core/src/workflows/constants.ts
+++ b/packages/core/src/workflows/constants.ts
@@ -1,0 +1,2 @@
+// symbol is used to not leak emitter to the user
+export const EMITTER_SYMBOL = Symbol('emitter');

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -246,6 +246,12 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       },
       eventTimestamp: Date.now(),
     });
+    await emitter.emit('watch-v2', {
+      type: 'step-start',
+      payload: {
+        id: step.id,
+      },
+    });
 
     const _runStep = (step: Step<any, any, any, any>, spanName: string, attributes?: Record<string, string>) => {
       return async (data: any) => {
@@ -347,6 +353,33 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       },
       eventTimestamp: Date.now(),
     });
+
+    if (execResults.status === 'suspended') {
+      await emitter.emit('watch-v2', {
+        type: 'step-suspended',
+        payload: {
+          id: step.id,
+          output: execResults.output,
+        },
+      });
+    } else {
+      await emitter.emit('watch-v2', {
+        type: 'step-result',
+        payload: {
+          id: step.id,
+          status: execResults.status,
+          output: execResults.output,
+        },
+      });
+
+      await emitter.emit('watch-v2', {
+        type: 'step-finish',
+        payload: {
+          id: step.id,
+          metadata: {},
+        },
+      });
+    }
 
     return execResults;
   }

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -1,6 +1,6 @@
 import { context as otlpContext, trace } from '@opentelemetry/api';
 import type { Span } from '@opentelemetry/api';
-import type { RuntimeContext } from '../../di';
+import type { RuntimeContext } from '../di';
 import { EMITTER_SYMBOL } from './constants';
 import type { ExecutionGraph } from './execution-engine';
 import { ExecutionEngine } from './execution-engine';

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -510,7 +510,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
 
               // TODO: this function shouldn't have suspend probably?
               suspend: async (_suspendPayload: any) => {},
-              emitter,
+              [EMITTER_SYMBOL]: emitter,
             });
             return result ? index : null;
           } catch (e: unknown) {
@@ -634,7 +634,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
           return result?.status === 'success' ? result.output : null;
         },
         suspend: async (_suspendPayload: any) => {},
-        emitter,
+        [EMITTER_SYMBOL]: emitter,
       });
     } while (entry.loopType === 'dowhile' ? isTrue : !isTrue);
 

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -1,6 +1,7 @@
 import { context as otlpContext, trace } from '@opentelemetry/api';
 import type { Span } from '@opentelemetry/api';
-import type { RuntimeContext } from '../di';
+import type { RuntimeContext } from '../../di';
+import { EMITTER_SYMBOL } from './constants';
 import type { ExecutionGraph } from './execution-engine';
 import { ExecutionEngine } from './execution-engine';
 import type { ExecuteFunction, Step } from './step';
@@ -311,7 +312,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
             // @ts-ignore
             runId: stepResults[step.id]?.payload?.__workflow_meta?.runId,
           },
-          emitter,
+          [EMITTER_SYMBOL]: emitter,
         });
 
         if (suspended) {

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 import type { Mastra } from '..';
 import type { RuntimeContext } from '../di';
+import type { EMITTER_SYMBOL } from './constants';
 import type { Workflow } from './workflow';
 
 // Define a type for the execute function
@@ -22,7 +23,7 @@ export type ExecuteFunction<TStepInput, TStepOutput, TResumeSchema, TSuspendSche
     steps: string[];
     resumePayload: any;
   };
-  emitter: { emit: (event: string, data: any) => Promise<void> };
+  [EMITTER_SYMBOL]: { emit: (event: string, data: any) => Promise<void> };
 }) => Promise<TStepOutput>;
 
 // Define a Step interface

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -364,7 +364,12 @@ describe('Workflow', () => {
         },
       });
 
-      expect(await Array.fromAsync(stream.values())).toMatchInlineSnapshot(`
+      const values: WatchEvent[] = [];
+      for await (const value of stream.values()) {
+        values.push(value);
+      }
+
+      expect(values).toMatchInlineSnapshot(`
         [
           {
             "payload": {
@@ -2950,7 +2955,12 @@ describe('Workflow', () => {
 
       const { stream, getWorkflowState } = await workflow.createRun().stream({ inputData: {} });
 
-      expect(await Array.fromAsync(stream.values())).toMatchInlineSnapshot(`
+      const values: WatchEvent[] = [];
+      for await (const value of stream.values()) {
+        values.push(value);
+      }
+
+      expect(values).toMatchInlineSnapshot(`
         [
           {
             "payload": {

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import { openai } from '@ai-sdk/openai';
 import { simulateReadableStream } from 'ai';
 import { MockLanguageModelV1 } from 'ai/test';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { simulateReadableStream } from 'ai';
@@ -218,17 +219,9 @@ describe('Workflow', () => {
         .then(evaluateImproved)
         .commit();
 
-      // Create a new storage instance for initial run
-      const initialStorage = new DefaultStorage({
-        config: {
-          url: 'file::memory:',
-        },
-      });
-      await initialStorage.init();
-
       new Mastra({
-        storage: initialStorage,
-        vnext_workflows: { 'test-workflow': promptEvalWorkflow },
+        storage: testStorage,
+        workflows: { 'test-workflow': promptEvalWorkflow },
       });
 
       const run = promptEvalWorkflow.createRun();
@@ -336,7 +329,7 @@ describe('Workflow', () => {
       });
 
       new Mastra({
-        vnext_workflows: { 'test-workflow': workflow },
+        workflows: { 'test-workflow': workflow },
         agents: { 'test-agent-1': agent, 'test-agent-2': agent2 },
       });
 
@@ -405,13 +398,13 @@ describe('Workflow', () => {
           },
           {
             "payload": {
-              "id": "mapping_mock-uuid-2",
+              "id": "mapping_mock-uuid-1",
             },
             "type": "step-start",
           },
           {
             "payload": {
-              "id": "mapping_mock-uuid-2",
+              "id": "mapping_mock-uuid-1",
               "output": {
                 "prompt": "Capital of France, just the name",
               },
@@ -421,7 +414,7 @@ describe('Workflow', () => {
           },
           {
             "payload": {
-              "id": "mapping_mock-uuid-2",
+              "id": "mapping_mock-uuid-1",
               "metadata": {},
             },
             "type": "step-finish",
@@ -431,6 +424,21 @@ describe('Workflow', () => {
               "id": "test-agent-1",
             },
             "type": "step-start",
+          },
+          {
+            "args": {
+              "prompt": "Capital of France, just the name",
+            },
+            "name": "test-agent-1",
+            "type": "tool-call-streaming-start",
+          },
+          {
+            "args": {
+              "prompt": "Capital of France, just the name",
+            },
+            "argsTextDelta": "Paris",
+            "name": "test-agent-1",
+            "type": "tool-call-delta",
           },
           {
             "payload": {
@@ -451,13 +459,13 @@ describe('Workflow', () => {
           },
           {
             "payload": {
-              "id": "mapping_mock-uuid-3",
+              "id": "mapping_mock-uuid-2",
             },
             "type": "step-start",
           },
           {
             "payload": {
-              "id": "mapping_mock-uuid-3",
+              "id": "mapping_mock-uuid-2",
               "output": {
                 "prompt": "Capital of UK, just the name",
               },
@@ -467,7 +475,7 @@ describe('Workflow', () => {
           },
           {
             "payload": {
-              "id": "mapping_mock-uuid-3",
+              "id": "mapping_mock-uuid-2",
               "metadata": {},
             },
             "type": "step-finish",
@@ -477,6 +485,21 @@ describe('Workflow', () => {
               "id": "test-agent-2",
             },
             "type": "step-start",
+          },
+          {
+            "args": {
+              "prompt": "Capital of UK, just the name",
+            },
+            "name": "test-agent-2",
+            "type": "tool-call-streaming-start",
+          },
+          {
+            "args": {
+              "prompt": "Capital of UK, just the name",
+            },
+            "argsTextDelta": "London",
+            "name": "test-agent-2",
+            "type": "tool-call-delta",
           },
           {
             "payload": {
@@ -2931,7 +2954,7 @@ describe('Workflow', () => {
         [
           {
             "payload": {
-              "runId": "mock-uuid-3",
+              "runId": "mock-uuid-1",
             },
             "type": "start",
           },
@@ -2983,7 +3006,7 @@ describe('Workflow', () => {
           },
           {
             "payload": {
-              "runId": "mock-uuid-3",
+              "runId": "mock-uuid-1",
             },
             "type": "finish",
           },

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -382,9 +382,6 @@ export class Workflow<
     delay?: number;
   };
 
-  #closeStreamAction?: () => Promise<void>;
-  #executionResults?: Promise<WorkflowResult<TOutput, TSteps>>;
-
   #mastra?: Mastra;
 
   #runs: Map<string, Run<TSteps, TInput, TOutput>> = new Map();
@@ -957,6 +954,9 @@ export class Run<
    * The storage for this run
    */
   #mastra?: Mastra;
+
+  #closeStreamAction?: () => Promise<void>;
+  #executionResults?: Promise<WorkflowResult<TOutput, TSteps>>;
 
   protected cleanup?: () => void;
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -244,7 +244,7 @@ export function createStep<
       id: params.id,
       inputSchema: params.inputSchema,
       outputSchema: params.outputSchema,
-      execute: async ({ inputData, mastra, [EMITTER_SYMBOL]: emitter }) => {
+      execute: async ({ inputData, mastra }) => {
         return params.execute({
           context: inputData,
           mastra,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -245,10 +245,26 @@ export function createStep<
       inputSchema: params.inputSchema,
       outputSchema: params.outputSchema,
       execute: async ({ inputData, mastra, [EMITTER_SYMBOL]: emitter }) => {
-        return params.execute({
+        await emitter.emit('watch-v2', {
+          type: 'tool-call',
+          toolCallId: params.id,
+          toolName: params.id,
+          args: inputData,
+        });
+
+        const result = await params.execute({
           context: inputData,
           mastra,
         });
+
+        await emitter.emit('watch-v2', {
+          type: 'tool-call-result',
+          toolCallId: params.id,
+          toolName: params.id,
+          result,
+        });
+
+        return result;
       },
     };
   }

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -195,7 +195,6 @@ export function createStep<
           // resourceId: inputData.resourceId,
           // threadId: inputData.threadId,
           onFinish: result => {
-            console.log('on finish', result.text);
             streamPromise.resolve(result.text);
           },
         });
@@ -1044,15 +1043,11 @@ export class Run<
       unwatch();
 
       try {
-        try {
-          await writer.close();
-        } catch {
-          // Stream might already be closed
-        } finally {
-          writer.releaseLock();
-        }
+        await writer.close();
       } catch (err) {
         console.error('Error closing stream:', err);
+      } finally {
+        writer.releaseLock();
       }
     };
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -245,26 +245,10 @@ export function createStep<
       inputSchema: params.inputSchema,
       outputSchema: params.outputSchema,
       execute: async ({ inputData, mastra, [EMITTER_SYMBOL]: emitter }) => {
-        await emitter.emit('watch-v2', {
-          type: 'tool-call',
-          toolCallId: params.id,
-          toolName: params.id,
-          args: inputData,
-        });
-
-        const result = await params.execute({
+        return params.execute({
           context: inputData,
           mastra,
         });
-
-        await emitter.emit('watch-v2', {
-          type: 'tool-call-result',
-          toolCallId: params.id,
-          toolName: params.id,
-          result,
-        });
-
-        return result;
       },
     };
   }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     '!src/action/index.ts',
     'src/*/index.ts',
     'src/workflows/legacy/index.ts',
+    'src/workflows/constants.ts',
     'src/storage/libsql/index.ts',
     'src/vector/libsql/index.ts',
     'src/vector/filter/index.ts',

--- a/packages/deployer/src/server/handlers/workflows.ts
+++ b/packages/deployer/src/server/handlers/workflows.ts
@@ -144,7 +144,7 @@ export function watchWorkflowHandler(c: Context) {
             await stream.write(JSON.stringify(chunkResult.value) + '\x1E');
           }
         } catch (err) {
-          console.log(err);
+          mastra.getLogger().error('Error in watch stream: ' + ((err as Error)?.message ?? 'Unknown error'));
         }
       },
       async err => {
@@ -193,11 +193,11 @@ export async function streamWorkflowHandler(c: Context) {
         }
       },
       async err => {
-        logger.error('Error in watch stream: ' + err?.message);
+        logger.error('Error in workflow stream: ' + err?.message);
       },
     );
   } catch (error) {
-    return handleError(error, 'Error watching workflow');
+    return handleError(error, 'Error streaming workflow');
   }
 }
 

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -289,6 +289,45 @@ export async function watchWorkflowHandler({
   }
 }
 
+export function streamWorkflowHandler({
+  mastra,
+  runtimeContext,
+  workflowId,
+  runId,
+  inputData,
+  runtimeContextFromRequest,
+}: Pick<WorkflowContext, 'mastra' | 'workflowId' | 'runId'> & {
+  inputData?: unknown;
+  runtimeContext?: RuntimeContext;
+  runtimeContextFromRequest?: Record<string, unknown>;
+}) {
+  try {
+    if (!workflowId) {
+      throw new HTTPException(400, { message: 'Workflow ID is required' });
+    }
+
+    const workflow = mastra.vnext_getWorkflow(workflowId);
+
+    if (!workflow) {
+      throw new HTTPException(404, { message: 'Workflow not found' });
+    }
+
+    const finalRuntimeContext = new RuntimeContext<Record<string, unknown>>([
+      ...Array.from(runtimeContext?.entries() ?? []),
+      ...Array.from(Object.entries(runtimeContextFromRequest ?? {})),
+    ]);
+
+    const run = workflow.createRun({ runId });
+    const result = run.stream({
+      inputData,
+      runtimeContext: finalRuntimeContext,
+    });
+    return result;
+  } catch (error) {
+    throw new HTTPException(500, { message: (error as Error)?.message || 'Error executing workflow' });
+  }
+}
+
 export async function resumeAsyncWorkflowHandler({
   mastra,
   workflowId,

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -306,7 +306,7 @@ export function streamWorkflowHandler({
       throw new HTTPException(400, { message: 'Workflow ID is required' });
     }
 
-    const workflow = mastra.vnext_getWorkflow(workflowId);
+    const workflow = mastra.getWorkflow(workflowId);
 
     if (!workflow) {
       throw new HTTPException(404, { message: 'Workflow not found' });

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -306,6 +306,10 @@ export function streamWorkflowHandler({
       throw new HTTPException(400, { message: 'Workflow ID is required' });
     }
 
+    if (!runId) {
+      throw new HTTPException(400, { message: 'runId required to resume workflow' });
+    }
+
     const workflow = mastra.getWorkflow(workflowId);
 
     if (!workflow) {
@@ -324,7 +328,7 @@ export function streamWorkflowHandler({
     });
     return result;
   } catch (error) {
-    throw new HTTPException(500, { message: (error as Error)?.message || 'Error executing workflow' });
+    return handleError(error, 'Error executing workflow');
   }
 }
 

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -14,6 +14,7 @@ import type {
   StepResult,
   WorkflowResult,
 } from '@mastra/core/workflows';
+import { EMITTER_SYMBOL } from '@mastra/core/workflows/_constants';
 import type { Span } from '@opentelemetry/api';
 import type { Inngest, BaseContext } from 'inngest';
 import { serve as inngestServe } from 'inngest/hono';

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -895,7 +895,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
 
                 // TODO: this function shouldn't have suspend probably?
                 suspend: async (_suspendPayload: any) => {},
-                emitter,
+                [EMITTER_SYMBOL]: emitter,
               });
               return result ? index : null;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Add "stream" support to vNext workflows.

Introduce new function `stream` which gives you a readablestream that you can read from. Similar to the client-js watch sdk.

```
     const { stream } = run.stream({inputData: {}))
     for await (const data of stream) {
        if (data.type === 'step-suspended') {
          // make it async to show that execution is not blocked
          setImmediate(() => {
            const resumeData = { stepId: 'promptAgent', context: { userInput: 'test input for resumption' } };
            run.resume({ resumeData: resumeData as any, step: promptAgent });
          });
        }
      }
```

```
const { stream } = run.stream({inputData: {}))
const reader = stream.getReader();
let result;
while(!(result = await reader.read()).done) {
  console.log(result.value)
}
```

TOOD:
- Get agent streaming as a step to work
- Convert watch to use watch-v2 (cleanup)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have generated a changeset for this PR
