### PR TITLE
Add clear instructions on setting up cloudflare d1

### DIFF
--- a/docs/src/content/en/reference/storage/cloudflare-d1.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare-d1.mdx
@@ -40,13 +40,10 @@ const storageRest = new D1Store({
 
 And add the following to your `wrangler.toml` or `wrangler.jsonc` file:
 ```
-"d1_databases": [
-  {
-    "binding": "D1Database",
-    "database_name": "db-name",
-    "database_id": "db-id"
-  }
-]
+[[d1_databases]]
+binding = "D1Database"
+database_name = "db-name"
+database_id = "db-id"
 ```
 
 ## Parameters

--- a/docs/src/content/en/reference/storage/cloudflare-d1.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare-d1.mdx
@@ -18,6 +18,11 @@ npm install @mastra/cloudflare-d1@latest
 ```typescript copy showLineNumbers
 import { D1Store } from "@mastra/cloudflare-d1";
 
+type Env = {
+	// Add your bindings here, e.g. Workers KV, D1, Workers AI, etc.
+	D1Database: D1Database;
+};
+
 // --- Example 1: Using Workers Binding ---
 const storageWorkers = new D1Store({
   binding: D1Database, // D1Database binding provided by the Workers runtime
@@ -31,6 +36,17 @@ const storageRest = new D1Store({
   apiToken: process.env.CLOUDFLARE_API_TOKEN!, // Cloudflare API Token
   tablePrefix: "dev_", // Optional: isolate tables per environment
 });
+```
+
+And add the following to your `wrangler.toml` or `wrangler.jsonc` file:
+```
+"d1_databases": [
+  {
+    "binding": "D1Database",
+    "database_name": "db-name",
+    "database_id": "db-id"
+  }
+]
 ```
 
 ## Parameters


### PR DESCRIPTION
## Description

Cloudflare D1 storage doc lacked clarity on adding the D1 storage, which might cause user issues. This PR adds more setup steps needed to set it up correctly.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
