### PR TITLE
[MASTRA-3078] added sources to return for vector query tool

### DIFF
--- a/.changeset/hungry-pans-pull.md
+++ b/.changeset/hungry-pans-pull.md
@@ -1,0 +1,5 @@
+---
+"@mastra/rag": patch
+---
+
+[MASTRA-3078] added sources to return for vector query tool

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -49,6 +49,20 @@ const graphTool = createGraphRAGTool({
       isOptional: false,
     },
     {
+      name: "enableFilter",
+      type: "boolean",
+      description: "Enable filtering of results based on metadata",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
+      name: "includeSources",
+      type: "boolean",
+      description: "Include the full retrieval objects in the results",
+      isOptional: true,
+      defaultValue: "true",
+    },
+    {
       name: "graphOptions",
       type: "GraphOptions",
       description: "Configuration for the graph-based retrieval",
@@ -113,8 +127,25 @@ The tool returns an object with:
       description:
         "Combined text from the most relevant document chunks, retrieved using graph-based ranking",
     },
+    {
+      name: "sources",
+      type: "QueryResult[]",
+      description: "Array of full retrieval result objects. Each object contains all information needed to reference the original document, chunk, and similarity score.",
+    },
   ]}
 />
+
+### QueryResult object structure
+
+```typescript
+{
+  id: string;         // Unique chunk/document identifier
+  metadata: any;      // All metadata fields (document ID, etc.)
+  vector: number[];   // Embedding vector (if available)
+  score: number;      // Similarity score for this retrieval
+  document: string;   // Full chunk/document text (if available)
+}
+```
 
 ## Default Tool Description
 

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -44,6 +44,27 @@ const queryTool = createVectorQueryTool({
       isOptional: false,
     },
     {
+      name: "enableFilter",
+      type: "boolean",
+      description: "Enable filtering of results based on metadata",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
+      name: "includeVectors",
+      type: "boolean",
+      description: "Include the embedding vectors in the results",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
+      name: "includeSources",
+      type: "boolean",
+      description: "Include the full retrieval objects in the results",
+      isOptional: true,
+      defaultValue: "true",
+    },
+    {
       name: "reranker",
       type: "RerankConfig",
       description: "Options for reranking results",
@@ -117,8 +138,25 @@ The tool returns an object with:
       type: "string",
       description: "Combined text from the most relevant document chunks",
     },
+    {
+      name: "sources",
+      type: "QueryResult[]",
+      description: "Array of full retrieval result objects. Each object contains all information needed to reference the original document, chunk, and similarity score.",
+    },
   ]}
 />
+
+### QueryResult object structure
+
+```typescript
+{
+  id: string;         // Unique chunk/document identifier
+  metadata: any;      // All metadata fields (document ID, etc.)
+  vector: number[];   // Embedding vector (if available)
+  score: number;      // Similarity score for this retrieval
+  document: string;   // Full chunk/document text (if available)
+}
+```
 
 ## Default Tool Description
 

--- a/packages/rag/src/graph-rag/index.ts
+++ b/packages/rag/src/graph-rag/index.ts
@@ -16,7 +16,7 @@ export interface GraphNode {
   metadata?: Record<string, any>;
 }
 
-interface RankedNode extends GraphNode {
+export interface RankedNode extends GraphNode {
   score: number;
 }
 

--- a/packages/rag/src/tools/graph-rag.ts
+++ b/packages/rag/src/tools/graph-rag.ts
@@ -172,7 +172,7 @@ export const createGraphRAGTool = ({
           logger.debug('Returning relevant context chunks', { count: relevantChunks.length });
         }
         // `sources` exposes the full retrieval objects
-        const sources = includeSources ? convertToSources(results) : [];
+        const sources = includeSources ? convertToSources(rerankedResults) : [];
         return {
           relevantContext: relevantChunks,
           sources,

--- a/packages/rag/src/tools/graph-rag.ts
+++ b/packages/rag/src/tools/graph-rag.ts
@@ -10,12 +10,14 @@ import {
   topKDescription,
   queryTextDescription,
 } from '../utils';
+import { convertToSources } from '../utils/convert-sources';
 
 export const createGraphRAGTool = ({
   vectorStoreName,
   indexName,
   model,
   enableFilter = false,
+  includeSources = true,
   graphOptions = {
     dimension: 1536,
     randomWalkSteps: 100,
@@ -29,6 +31,7 @@ export const createGraphRAGTool = ({
   indexName: string;
   model: EmbeddingModel<string>;
   enableFilter?: boolean;
+  includeSources?: boolean;
   graphOptions?: {
     dimension?: number;
     randomWalkSteps?: number;
@@ -59,8 +62,22 @@ export const createGraphRAGTool = ({
   return createTool({
     id: toolId,
     inputSchema,
+    // Output schema includes `sources`, which exposes the full set of retrieved chunks (QueryResult objects)
+    // Each source contains all information needed to reference
+    // the original document, chunk, and similarity score.
     outputSchema: z.object({
+      // Array of metadata or content for compatibility with prior usage
       relevantContext: z.any(),
+      // Array of full retrieval result objects
+      sources: z.array(
+        z.object({
+          id: z.string(), // Unique chunk/document identifier
+          metadata: z.any(), // All metadata fields (document ID, etc.)
+          vector: z.array(z.number()), // Embedding vector (if available)
+          score: z.number(), // Similarity score for this retrieval
+          document: z.string(), // Full chunk/document text (if available)
+        }),
+      ),
     }),
     description: toolDescription,
     execute: async ({ context: { queryText, topK, filter }, mastra }) => {
@@ -86,7 +103,7 @@ export const createGraphRAGTool = ({
           if (logger) {
             logger.error('Vector store not found', { vectorStoreName });
           }
-          return { relevantContext: [] };
+          return { relevantContext: [], sources: [] };
         }
 
         let queryFilter = {};
@@ -154,8 +171,11 @@ export const createGraphRAGTool = ({
         if (logger) {
           logger.debug('Returning relevant context chunks', { count: relevantChunks.length });
         }
+        // `sources` exposes the full retrieval objects
+        const sources = includeSources ? convertToSources(results) : [];
         return {
           relevantContext: relevantChunks,
+          sources,
         };
       } catch (err) {
         if (logger) {
@@ -165,7 +185,7 @@ export const createGraphRAGTool = ({
             errorStack: err instanceof Error ? err.stack : undefined,
           });
         }
-        return { relevantContext: [] };
+        return { relevantContext: [], sources: [] };
       }
     },
   });

--- a/packages/rag/src/tools/vector-query.ts
+++ b/packages/rag/src/tools/vector-query.ts
@@ -11,12 +11,15 @@ import {
   topKDescription,
   queryTextDescription,
 } from '../utils';
+import { convertToSources } from '../utils/convert-sources';
 
 export const createVectorQueryTool = ({
   vectorStoreName,
   indexName,
   model,
   enableFilter = false,
+  includeVectors = false,
+  includeSources = true,
   reranker,
   id,
   description,
@@ -25,6 +28,8 @@ export const createVectorQueryTool = ({
   indexName: string;
   model: EmbeddingModel<string>;
   enableFilter?: boolean;
+  includeVectors?: boolean;
+  includeSources?: boolean;
   reranker?: RerankConfig;
   id?: string;
   description?: string;
@@ -47,8 +52,22 @@ export const createVectorQueryTool = ({
   return createTool({
     id: toolId,
     inputSchema,
+    // Output schema includes `sources`, which exposes the full set of retrieved chunks (QueryResult objects)
+    // Each source contains all information needed to reference
+    // the original document, chunk, and similarity score.
     outputSchema: z.object({
+      // Array of metadata or content for compatibility with prior usage
       relevantContext: z.any(),
+      // Array of full retrieval result objects
+      sources: z.array(
+        z.object({
+          id: z.string(), // Unique chunk/document identifier
+          metadata: z.any(), // All metadata fields (document ID, etc.)
+          vector: z.array(z.number()), // Embedding vector (if available)
+          score: z.number(), // Similarity score for this retrieval
+          document: z.string(), // Full chunk/document text (if available)
+        }),
+      ),
     }),
     description: toolDescription,
     execute: async ({ context: { queryText, topK, filter }, mastra }) => {
@@ -75,7 +94,7 @@ export const createVectorQueryTool = ({
           if (logger) {
             logger.error('Vector store not found', { vectorStoreName });
           }
-          return { relevantContext: [] };
+          return { relevantContext: [], sources: [] };
         }
         // Get relevant chunks from the vector database
         let queryFilter = {};
@@ -103,6 +122,7 @@ export const createVectorQueryTool = ({
           model,
           queryFilter: Object.keys(queryFilter || {}).length > 0 ? queryFilter : undefined,
           topK: topKValue,
+          includeVectors,
         });
         if (logger) {
           logger.debug('vectorQuerySearch returned results', { count: results.length });
@@ -122,15 +142,19 @@ export const createVectorQueryTool = ({
           if (logger) {
             logger.debug('Returning reranked relevant context chunks', { count: relevantChunks.length });
           }
-          return { relevantContext: relevantChunks };
+          const sources = includeSources ? convertToSources(results) : [];
+          return { relevantContext: relevantChunks, sources };
         }
 
         const relevantChunks = results.map(result => result?.metadata);
         if (logger) {
           logger.debug('Returning relevant context chunks', { count: relevantChunks.length });
         }
+        // `sources` exposes the full retrieval objects
+        const sources = includeSources ? convertToSources(results) : [];
         return {
           relevantContext: relevantChunks,
+          sources,
         };
       } catch (err) {
         if (logger) {
@@ -140,7 +164,7 @@ export const createVectorQueryTool = ({
             errorStack: err instanceof Error ? err.stack : undefined,
           });
         }
-        return { relevantContext: [] };
+        return { relevantContext: [], sources: [] };
       }
     },
   });

--- a/packages/rag/src/tools/vector-query.ts
+++ b/packages/rag/src/tools/vector-query.ts
@@ -142,7 +142,7 @@ export const createVectorQueryTool = ({
           if (logger) {
             logger.debug('Returning reranked relevant context chunks', { count: relevantChunks.length });
           }
-          const sources = includeSources ? convertToSources(results) : [];
+          const sources = includeSources ? convertToSources(rerankedResults) : [];
           return { relevantContext: relevantChunks, sources };
         }
 

--- a/packages/rag/src/utils/convert-sources.ts
+++ b/packages/rag/src/utils/convert-sources.ts
@@ -1,8 +1,37 @@
 import type { QueryResult } from '@mastra/core';
+import type { RankedNode } from '../graph-rag';
+import type { RerankResult } from '../rerank';
 
-// Utility to normalize raw vector search results into the standard QueryResult structure for sources
-export const convertToSources = (results: QueryResult[]) => {
+type SourceInput = QueryResult | RankedNode | RerankResult;
+
+/**
+ * Convert an array of source inputs (QueryResult, RankedNode, or RerankResult) to an array of sources.
+ * @param results Array of source inputs to convert.
+ * @returns Array of sources.
+ */
+export const convertToSources = (results: SourceInput[]) => {
   return results.map(result => {
+    // RankedNode
+    if ('content' in result) {
+      return {
+        id: result?.id,
+        vector: result?.embedding || [],
+        score: result?.score,
+        metadata: result?.metadata,
+        document: result?.content || '',
+      };
+    }
+    // RerankResult
+    if ('result' in result) {
+      return {
+        id: result?.result?.id,
+        vector: result?.result?.vector || [],
+        score: result?.score || result?.result?.score,
+        metadata: result?.result?.metadata,
+        document: result?.result?.document || '',
+      };
+    }
+    // QueryResult
     return {
       id: result?.id,
       vector: result?.vector || [],

--- a/packages/rag/src/utils/convert-sources.ts
+++ b/packages/rag/src/utils/convert-sources.ts
@@ -1,0 +1,14 @@
+import type { QueryResult } from '@mastra/core';
+
+// Utility to normalize raw vector search results into the standard QueryResult structure for sources
+export const convertToSources = (results: QueryResult[]) => {
+  return results.map(result => {
+    return {
+      id: result?.id,
+      vector: result?.vector || [],
+      score: result?.score,
+      metadata: result?.metadata,
+      document: result?.document || '',
+    };
+  });
+};

--- a/packages/rag/src/utils/convert-sources.ts
+++ b/packages/rag/src/utils/convert-sources.ts
@@ -14,30 +14,30 @@ export const convertToSources = (results: SourceInput[]) => {
     // RankedNode
     if ('content' in result) {
       return {
-        id: result?.id,
-        vector: result?.embedding || [],
-        score: result?.score,
-        metadata: result?.metadata,
-        document: result?.content || '',
+        id: result.id,
+        vector: result.embedding || [],
+        score: result.score,
+        metadata: result.metadata,
+        document: result.content || '',
       };
     }
     // RerankResult
     if ('result' in result) {
       return {
-        id: result?.result?.id,
-        vector: result?.result?.vector || [],
-        score: result?.score || result?.result?.score,
-        metadata: result?.result?.metadata,
-        document: result?.result?.document || '',
+        id: result.result.id,
+        vector: result.result.vector || [],
+        score: result.score,
+        metadata: result.result.metadata,
+        document: result.result.document || '',
       };
     }
     // QueryResult
     return {
-      id: result?.id,
-      vector: result?.vector || [],
-      score: result?.score,
-      metadata: result?.metadata,
-      document: result?.document || '',
+      id: result.id,
+      vector: result.vector || [],
+      score: result.score,
+      metadata: result.metadata,
+      document: result.document || '',
     };
   });
 };


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR adds a sources array field in the outputschema for the vector query tool and graph rag tool. This lets users retrieve all the results related to a query (id, score, vector, metadata).

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
