### PR TITLE
[MASTRA-3439] Working Memory tool call fix

### DIFF
--- a/.changeset/cool-pillows-flow.md
+++ b/.changeset/cool-pillows-flow.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Updated saveMessages to filter out workingmemory content from messages, rather than skip message completely
+[MASTRA-3439] Working Memory tool call fix: Updated saveMessages to filter out workingmemory content from messages, rather than skip message completely

--- a/.changeset/cool-pillows-flow.md
+++ b/.changeset/cool-pillows-flow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Updated saveMessages to filter out workingmemory content from messages, rather than skip message completely

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -570,6 +570,7 @@ describe('Working Memory Tests', () => {
     const threadId = thread.id;
     const messages = [
       createTestMessage(threadId, 'User says something'),
+      // Pure tool-call message (should be removed)
       {
         id: randomUUID(),
         threadId,
@@ -584,19 +585,38 @@ describe('Working Memory Tests', () => {
         ],
         toolNames: ['updateWorkingMemory'],
       },
+      // Mixed content: tool-call + text (tool-call part should be filtered, text kept)
       {
         id: randomUUID(),
         threadId,
         role: 'assistant',
         type: 'text',
-        content: 'Normal message',
+        content: [
+          {
+            type: 'tool-call',
+            toolName: 'updateWorkingMemory',
+            args: { memory: 'should not persist' },
+          },
+          {
+            type: 'text',
+            text: 'Normal message',
+          },
+        ],
+      },
+      // Pure text message (should be kept)
+      {
+        id: randomUUID(),
+        threadId,
+        role: 'assistant',
+        type: 'text',
+        content: 'Another normal message',
       },
     ];
 
     // Save messages
     const saved = await memory.saveMessages({ messages: messages as MessageType[] });
 
-    // Should not include the updateWorkingMemory tool-call message
+    // Should not include any updateWorkingMemory tool-call messages (pure or mixed)
     expect(
       saved.some(
         m =>
@@ -606,8 +626,23 @@ describe('Working Memory Tests', () => {
       ),
     ).toBe(false);
 
-    // Should still include the user and normal text message
-    expect(saved.some(m => m.content === 'Normal message')).toBe(true);
+    // Mixed content message: should only keep the text part
+    const assistantMessages = saved.filter(m => m.role === 'assistant');
+    expect(
+      assistantMessages.some(m => {
+        if (typeof m.content === 'string') {
+          return m.content.includes('Normal message');
+        }
+        if (Array.isArray(m.content)) {
+          return m.content.some(c => c.type === 'text' && c.text === 'Normal message');
+        }
+        return false;
+      }),
+    ).toBe(true);
+
+    // Pure text message should be present
+    expect(saved.some(m => m.content === 'Another normal message')).toBe(true);
+    // User message should be present
     expect(saved.some(m => typeof m.content === 'string' && m.content.includes('User says something'))).toBe(true);
   });
 });

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -584,6 +584,8 @@ describe('Working Memory Tests', () => {
           },
         ],
         toolNames: ['updateWorkingMemory'],
+        createdAt: new Date(),
+        resourceId,
       },
       // Mixed content: tool-call + text (tool-call part should be filtered, text kept)
       {
@@ -602,6 +604,8 @@ describe('Working Memory Tests', () => {
             text: 'Normal message',
           },
         ],
+        createdAt: new Date(),
+        resourceId,
       },
       // Pure text message (should be kept)
       {
@@ -610,6 +614,8 @@ describe('Working Memory Tests', () => {
         role: 'assistant',
         type: 'text',
         content: 'Another normal message',
+        createdAt: new Date(),
+        resourceId,
       },
     ];
 
@@ -639,6 +645,15 @@ describe('Working Memory Tests', () => {
         return false;
       }),
     ).toBe(true);
+    // working memory should not be present
+    expect(
+      saved.some(
+        m =>
+          (m.type === 'tool-call' || m.type === 'tool-result') &&
+          Array.isArray(m.content) &&
+          m.content.some(c => (c as ToolCallPart).toolName === 'updateWorkingMemory'),
+      ),
+    ).toBe(false);
 
     // Pure text message should be present
     expect(saved.some(m => m.content === 'Another normal message')).toBe(true);

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -394,15 +394,19 @@ export class Memory extends MastraMemory {
           content: message.content.replace(workingMemoryRegex, ``).trim(),
         });
       } else if (Array.isArray(message?.content)) {
-        const contentIsWorkingMemory = message.content.some(
+        // Filter out updateWorkingMemory tool-call/result content items
+        const filteredContent = message.content.filter(
           content =>
-            (content.type === `tool-call` || content.type === `tool-result`) &&
-            content.toolName === `updateWorkingMemory`,
+            !(
+              (content.type === 'tool-call' || content.type === 'tool-result') &&
+              content.toolName === 'updateWorkingMemory'
+            ),
         );
-        if (contentIsWorkingMemory) {
+        if (filteredContent.length === 0) {
+          // If nothing left, skip this message
           continue;
         }
-        const newContent = message.content.map(content => {
+        const newContent = filteredContent.map(content => {
           if (content.type === 'text') {
             return {
               ...content,


### PR DESCRIPTION
…t content

## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes an issue where if the agent sent a message before updating working memory, that message would not be saved in the db. 

We were skipping messages completely that had workingmemory in the message content, but instead we are now filtering the message content to remove references to workingmemory.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#4221 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
