### PR TITLE
Add Prettify utility for clearer types

### DIFF
--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -11,6 +11,7 @@ import type {
   VNextWorkflowRuns,
   WorkflowRuns,
 } from '@mastra/core';
+import type { Prettify } from '@mastra/core';
 
 import type { AgentGenerateOptions, AgentStreamOptions } from '@mastra/core/agent';
 import type { RuntimeContext } from '@mastra/core/runtime-context';
@@ -60,19 +61,29 @@ export interface GetAgentResponse {
   modelId: string;
 }
 
-export type GenerateParams<T extends JSONSchema7 | ZodSchema | undefined = undefined> = {
-  messages: string | string[] | CoreMessage[] | AiMessageType[];
-  output?: T;
-  experimental_output?: T;
-  runtimeContext?: RuntimeContext;
-} & WithoutMethods<Omit<AgentGenerateOptions<T>, 'output' | 'experimental_output' | 'runtimeContext'>>;
+export type GenerateParams<T extends JSONSchema7 | ZodSchema | undefined = undefined> = Prettify<
+  {
+    messages: string | string[] | CoreMessage[] | AiMessageType[];
+    output?: T;
+    experimental_output?: T;
+    runtimeContext?: RuntimeContext;
+  } & WithoutMethods<Omit<
+    AgentGenerateOptions<T>,
+    'output' | 'experimental_output' | 'runtimeContext'
+  >>
+>;
 
-export type StreamParams<T extends JSONSchema7 | ZodSchema | undefined = undefined> = {
-  messages: string | string[] | CoreMessage[] | AiMessageType[];
-  output?: T;
-  experimental_output?: T;
-  runtimeContext?: RuntimeContext;
-} & WithoutMethods<Omit<AgentStreamOptions<T>, 'output' | 'experimental_output' | 'runtimeContext'>>;
+export type StreamParams<T extends JSONSchema7 | ZodSchema | undefined = undefined> = Prettify<
+  {
+    messages: string | string[] | CoreMessage[] | AiMessageType[];
+    output?: T;
+    experimental_output?: T;
+    runtimeContext?: RuntimeContext;
+  } & WithoutMethods<Omit<
+    AgentStreamOptions<T>,
+    'output' | 'experimental_output' | 'runtimeContext'
+  >>
+>;
 
 export interface GetEvalsByAgentIdResponse extends GetAgentResponse {
   evals: any[];
@@ -133,7 +144,7 @@ export interface GetVNextWorkflowResponse {
   outputSchema: string;
 }
 
-export type VNextWorkflowWatchResult = WatchEvent & { runId: string };
+export type VNextWorkflowWatchResult = Prettify<WatchEvent & { runId: string }>;
 
 export type VNextWorkflowRunResult = VNextWorkflowResult<any, any>;
 export interface UpsertVectorParams {

--- a/packages/core/src/a2a/types.ts
+++ b/packages/core/src/a2a/types.ts
@@ -280,17 +280,23 @@ export interface FileContentBase {
   uri?: string | null;
 }
 
-export type FileContentBytes = FileContentBase & {
-  /* File content encoded as a Base64 string. Use this OR `uri`. */
-  bytes: string;
-  uri?: never;
-};
+import type { Prettify } from '../utils';
 
-export type FileContentUri = FileContentBase & {
-  /** URI pointing to the file content. */
-  uri: string;
-  bytes?: never;
-};
+export type FileContentBytes = Prettify<
+  FileContentBase & {
+    /* File content encoded as a Base64 string. Use this OR `uri`. */
+    bytes: string;
+    uri?: never;
+  }
+>;
+
+export type FileContentUri = Prettify<
+  FileContentBase & {
+    /** URI pointing to the file content. */
+    uri: string;
+    bytes?: never;
+  }
+>;
 
 /**
  * Represents the content of a file, either as base64 encoded bytes or a URI.

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -23,6 +23,7 @@ import type { MastraLanguageModel } from '../agent/types';
 import type { Run } from '../run/types';
 import type { RuntimeContext } from '../runtime-context';
 import type { CoreTool } from '../tools/types';
+import type { Prettify } from '../utils';
 
 export { createMockModel } from './model/mock';
 
@@ -111,29 +112,40 @@ type MastraCustomLLMOptions<Z extends ZodSchema | JSONSchema7 | undefined = unde
   runtimeContext: RuntimeContext;
 } & Run;
 
-export type LLMTextOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {
-  messages: CoreMessage[];
-} & MastraCustomLLMOptions<Z> &
-  DefaultLLMTextOptions;
+export type LLMTextOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> =
+  Prettify<
+    {
+      messages: CoreMessage[];
+    } & MastraCustomLLMOptions<Z> &
+      DefaultLLMTextOptions
+  >;
 
-export type LLMTextObjectOptions<T extends ZodSchema | JSONSchema7 | undefined = undefined> = LLMTextOptions<T> &
-  DefaultLLMTextObjectOptions & {
+export type LLMTextObjectOptions<T extends ZodSchema | JSONSchema7 | undefined = undefined> = Prettify<
+  LLMTextOptions<T> &
+    DefaultLLMTextObjectOptions & {
+      structuredOutput: JSONSchema7 | z.ZodType<T> | StructuredOutput;
+    }
+>;
+
+export type LLMStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Prettify<
+  {
+    output?: OutputType | Z;
+    onFinish?: (result: string) => Promise<void> | void;
+  } & MastraCustomLLMOptions<Z> &
+    DefaultLLMStreamOptions
+>;
+
+export type LLMInnerStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Prettify<
+  {
+    messages: CoreMessage[];
+    onFinish?: (result: string) => Promise<void> | void;
+  } & MastraCustomLLMOptions<Z> &
+    DefaultLLMStreamOptions
+>;
+
+export type LLMStreamObjectOptions<T extends ZodSchema | JSONSchema7 | undefined = undefined> = Prettify<
+  {
     structuredOutput: JSONSchema7 | z.ZodType<T> | StructuredOutput;
-  };
-
-export type LLMStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {
-  output?: OutputType | Z;
-  onFinish?: (result: string) => Promise<void> | void;
-} & MastraCustomLLMOptions<Z> &
-  DefaultLLMStreamOptions;
-
-export type LLMInnerStreamOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {
-  messages: CoreMessage[];
-  onFinish?: (result: string) => Promise<void> | void;
-} & MastraCustomLLMOptions<Z> &
-  DefaultLLMStreamOptions;
-
-export type LLMStreamObjectOptions<T extends ZodSchema | JSONSchema7 | undefined = undefined> = {
-  structuredOutput: JSONSchema7 | z.ZodType<T> | StructuredOutput;
-} & LLMInnerStreamOptions<T> &
-  DefaultLLMStreamObjectOptions;
+  } & LLMInnerStreamOptions<T> &
+    DefaultLLMStreamObjectOptions
+>;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -14,6 +14,10 @@ import { Tool } from './tools';
 import type { CoreTool, ToolAction, VercelTool } from './tools';
 import { CoreToolBuilder } from './tools/tool-compatibility/builder';
 
+export type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
 export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 /**


### PR DESCRIPTION
## Summary
- introduce `Prettify` type helper under `core/utils`
- apply `Prettify` across core and client types for easier consumption
- avoid using `Prettify` inside workflow types to prevent recursion issues

## Testing
- `pnpm test` *(fails to fetch pnpm)*
- `npx vitest run` *(fails to fetch vitest)*