### PR TITLE
[MASTRA-1582] Chunk API

### DIFF
--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -103,44 +103,6 @@ const chunksWithMetadata = await doc.chunk({
   ]}
 />
 
-## Strategy-Specific Options
-
-Strategy-specific options are passed as top-level parameters alongside the strategy parameter. For example:
-
-```typescript showLineNumbers copy
-// HTML strategy example
-const chunks = await doc.chunk({
-  strategy: "html",
-  headers: [
-    ["h1", "title"],
-    ["h2", "subtitle"],
-  ], // HTML-specific option
-  sections: [["div.content", "main"]], // HTML-specific option
-  size: 500, // general option
-});
-
-// Markdown strategy example
-const chunks = await doc.chunk({
-  strategy: "markdown",
-  headers: [
-    ["#", "title"],
-    ["##", "section"],
-  ], // Markdown-specific option
-  stripHeaders: true, // Markdown-specific option
-  overlap: 50, // general option
-});
-
-// Token strategy example
-const chunks = await doc.chunk({
-  strategy: "token",
-  encodingName: "gpt2", // Token-specific option
-  modelName: "gpt-3.5-turbo", // Token-specific option
-  size: 1000, // general option
-});
-```
-
-The options documented below are passed directly at the top level of the configuration object, not nested within a separate options object.
-
 ### Common Chunking Options
 
 These options are available to all chunking strategies:
@@ -201,6 +163,82 @@ These options are available to all chunking strategies:
     }
   ]}
 />
+
+> **Note:** Both the common chunking options and strategy-specific options may be provided directly at the top level (not nested) when letting the system infer the strategy. However, for clarity and maintainability, it is recommended to explicitly set a `strategy` and use the matching options field.
+
+<br/>
+
+## Strategy-Specific Options
+
+Strategy-specific options are passed as top-level parameters or nested within the strategy-specific options object. For example:
+
+```typescript showLineNumbers copy
+// HTML strategy example (top-level)
+const chunks = await doc.chunk({
+  strategy: "html",
+  headers: [
+    ["h1", "title"],
+    ["h2", "subtitle"],
+  ], // HTML-specific option
+  sections: [["div.content", "main"]], // HTML-specific option
+  size: 500, // general option
+});
+
+// HTML strategy example (nested)
+const chunks = await doc.chunk({
+  strategy: "html",
+  htmlOptions: {
+    headers: [
+      ["h1", "title"],
+      ["h2", "subtitle"],
+    ], // HTML-specific option
+    sections: [["div.content", "main"]], // HTML-specific option
+    size: 500, // general option
+  },
+});
+
+// Markdown strategy example (top-level)
+const chunks = await doc.chunk({
+  strategy: "markdown",
+  headers: [
+    ["#", "title"],
+    ["##", "section"],
+  ], // Markdown-specific option
+  stripHeaders: true, // Markdown-specific option
+  overlap: 50, // general option
+});
+
+// Markdown strategy example (nested)
+const chunks = await doc.chunk({
+  strategy: "markdown",
+  markdownOptions: {
+    headers: [
+      ["#", "title"],
+      ["##", "section"],
+    ], // Markdown-specific option
+    stripHeaders: true, // Markdown-specific option
+    overlap: 50, // general option
+  },
+});
+
+// Token strategy example (top-level)
+const chunks = await doc.chunk({
+  strategy: "token",
+  encodingName: "gpt2", // Token-specific option
+  modelName: "gpt-3.5-turbo", // Token-specific option
+  size: 1000, // general option
+});
+
+// Token strategy example (nested)
+const chunks = await doc.chunk({
+  strategy: "token",
+  tokenOptions: {
+    encodingName: "gpt2", // Token-specific option
+    modelName: "gpt-3.5-turbo", // Token-specific option
+    size: 1000, // general option
+  },
+});
+```
 
 > **Note:** Other than `html`, all strategies use the [Common Chunking Options](#common-chunking-options), as well as the strategy-specific options documented below.
 

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -200,6 +200,18 @@ The options documented below are passed directly at the top level of the configu
       isOptional: true,
       description: "Name of the model for tokenization",
     },
+    {
+      name: "allowedSpecial",
+      type: "Set<string> | 'all'",
+      isOptional: true,
+      description: "Set of allowed special tokens",
+    },
+    {
+      name: "disallowedSpecial",
+      type: "Set<string> | 'all'",
+      isOptional: true,
+      description: "Set of disallowed special tokens",
+    },
   ]}
 />
 

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -81,11 +81,11 @@ const chunksWithMetadata = await doc.chunk({
       description: "Whether the separator is a regex pattern",
     },
     {
-      name: "keepSeparator",
+      name: "separatorPosition",
       type: "'start' | 'end'",
       isOptional: true,
       description:
-        "Whether to keep the separator at the start or end of chunks",
+        "Whether to keep the separator at the start or end of chunks. Defaults to 'none' if not specified.",
     },
     {
       name: "extract",

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -52,48 +52,54 @@ const chunksWithMetadata = await doc.chunk({
         "The chunking strategy to use. If not specified, defaults based on document type. Depending on the chunking strategy, there are additional optionals. Defaults: .md files → 'markdown', .html/.htm → 'html', .json → 'json', .tex → 'latex', others → 'recursive'",
     },
     {
-      name: "size",
-      type: "number",
-      isOptional: true,
-      defaultValue: "512",
-      description: "Maximum size of each chunk",
-    },
-    {
-      name: "overlap",
-      type: "number",
-      isOptional: true,
-      defaultValue: "50",
-      description: "Number of characters/tokens that overlap between chunks.",
-    },
-    {
-      name: "separator",
-      type: "string",
-      isOptional: true,
-      defaultValue: "\\n\\n",
-      description:
-        "Character(s) to split on. Defaults to double newline for text content.",
-    },
-    {
-      name: "isSeparatorRegex",
-      type: "boolean",
-      isOptional: true,
-      defaultValue: "false",
-      description: "Whether the separator is a regex pattern",
-    },
-    {
-      name: "separatorPosition",
-      type: "'start' | 'end'",
-      isOptional: true,
-      description:
-        "Whether to keep the separator at the start or end of chunks. Defaults to 'none' if not specified.",
-    },
-    {
       name: "extract",
       type: "ExtractParams",
       isOptional: true,
       description:
         "Metadata extraction configuration. See [ExtractParams reference](./extract-params) for details.",
     },
+    {
+      name: "characterOptions",
+      type: "CharacterChunkOptions",
+      isOptional: true,
+      description: "Options specific to the 'character' strategy. See below."
+    },
+    {
+      name: "tokenOptions",
+      type: "TokenChunkOptions",
+      isOptional: true,
+      description: "Options specific to the 'token' strategy. See below."
+    },
+    {
+      name: "markdownOptions",
+      type: "MarkdownChunkOptions",
+      isOptional: true,
+      description: "Options specific to the 'markdown' strategy. See below."
+    },
+    {
+      name: "htmlOptions",
+      type: "HtmlChunkOptions",
+      isOptional: true,
+      description: "Options specific to the 'html' strategy. See below."
+    },
+    {
+      name: "recursiveOptions",
+      type: "RecursiveChunkOptions",
+      isOptional: true,
+      description: "Options specific to the 'recursive' strategy. See below."
+    },
+    {
+      name: "jsonOptions",
+      type: "JsonChunkOptions",
+      isOptional: true,
+      description: "Options specific to the 'json' strategy. See below."
+    },
+    {
+      name: "latexOptions",
+      type: "LatexChunkOptions",
+      isOptional: true,
+      description: "Options specific to the 'latex' strategy. See below."
+    }
   ]}
 />
 
@@ -135,7 +141,122 @@ const chunks = await doc.chunk({
 
 The options documented below are passed directly at the top level of the configuration object, not nested within a separate options object.
 
+### Common Chunking Options
+
+These options are available to all chunking strategies:
+
+<PropertiesTable
+  content={[
+    {
+      name: "size",
+      type: "number",
+      isOptional: true,
+      defaultValue: "512",
+      description: "Maximum size of each chunk."
+    },
+    {
+      name: "overlap",
+      type: "number",
+      isOptional: true,
+      defaultValue: "50",
+      description: "Number of characters/tokens that overlap between chunks."
+    },
+    {
+      name: "separator",
+      type: "string",
+      isOptional: true,
+      defaultValue: "\\n\\n",
+      description: "Character(s) to split on. Defaults to double newline for text content."
+    },
+    {
+      name: "isSeparatorRegex",
+      type: "boolean",
+      isOptional: true,
+      defaultValue: "false",
+      description: "Whether the separator is a regex pattern."
+    },
+    {
+      name: "separatorPosition",
+      type: "'start' | 'end'",
+      isOptional: true,
+      description: "Whether to keep the separator at the start or end of chunks."
+    },
+    {
+      name: "addStartIndex",
+      type: "boolean",
+      isOptional: true,
+      description: "Whether to add the start index of each chunk to the metadata."
+    },
+    {
+      name: "stripWhitespace",
+      type: "boolean",
+      isOptional: true,
+      description: "Whether to strip whitespace from the start/end of each chunk."
+    },
+    {
+      name: "keepSeparator",
+      type: "boolean | 'start' | 'end'",
+      isOptional: true,
+      description: "Deprecated. Use `separatorPosition` instead."
+    }
+  ]}
+/>
+
+> **Note:** Other than `html`, all strategies use the [Common Chunking Options](#common-chunking-options), as well as the strategy-specific options documented below.
+
+### Recursive
+
+<br/>
+
+<PropertiesTable
+  content={[
+    {
+      name: "separators",
+      type: "string[]",
+      isOptional: true,
+      description: "The separators to use when splitting the text."
+    },
+    {
+      name: "isSeparatorRegex",
+      type: "boolean",
+      isOptional: true,
+      description: "Whether the separators are regular expressions."
+    },
+    {
+      name: "language",
+      type: "Language",
+      isOptional: true,
+      description: "The language to use when splitting the text."
+    }
+  ]}
+/>
+
+### Character
+
+<br/>
+
+<PropertiesTable
+  content={[
+    {
+      name: "separator",
+      type: "string",
+      isOptional: true,
+      defaultValue: "\\n\\n",
+      description: "Character(s) to split on. Defaults to double newline for text content."
+    },
+    {
+      name: "isSeparatorRegex",
+      type: "boolean",
+      isOptional: true,
+      defaultValue: "false",
+      description: "Whether the separator is a regex pattern."
+    }
+  ]}
+/>
+
 ### HTML
+
+<br/>
 
 <PropertiesTable
   content={[
@@ -162,6 +283,8 @@ The options documented below are passed directly at the top level of the configu
 
 ### Markdown
 
+<br/>
+
 <PropertiesTable
   content={[
     {
@@ -185,6 +308,8 @@ The options documented below are passed directly at the top level of the configu
 />
 
 ### Token
+
+<br/>
 
 <PropertiesTable
   content={[
@@ -217,6 +342,8 @@ The options documented below are passed directly at the top level of the configu
 
 ### JSON
 
+<br/>
+
 <PropertiesTable
   content={[
     {
@@ -244,6 +371,10 @@ The options documented below are passed directly at the top level of the configu
     },
   ]}
 />
+
+### Latex
+
+The Latex strategy only uses the [Common Chunking Options](#common-chunking-options).
 
 ## Return Value
 

--- a/packages/rag/src/document/document.test.ts
+++ b/packages/rag/src/document/document.test.ts
@@ -114,7 +114,7 @@ describe('MDocument', () => {
         isSeparatorRegex: false,
         size: 50,
         overlap: 5,
-        keepSeparator: 'end',
+        separatorPosition: 'end',
       });
       const chunks = doc.getText();
 
@@ -134,7 +134,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           size: 50,
           overlap: 5,
-          keepSeparator: 'end',
+          separatorPosition: 'end',
         });
 
         const chunks = doc.getText();
@@ -155,7 +155,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           size: 50,
           overlap: 5,
-          keepSeparator: 'start',
+          separatorPosition: 'start',
         });
 
         const chunks = doc.getText();
@@ -177,7 +177,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           size: 50,
           overlap: 5,
-          keepSeparator: 'end',
+          separatorPosition: 'end',
         });
 
         const chunks = doc.getText();
@@ -197,7 +197,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           size: 50,
           overlap: 5,
-          keepSeparator: 'end',
+          separatorPosition: 'end',
         });
 
         const chunks = doc.getText();
@@ -217,7 +217,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           size: 50,
           overlap: 5,
-          keepSeparator: 'start',
+          separatorPosition: 'start',
         });
 
         const chunks = doc.getText();

--- a/packages/rag/src/document/document.ts
+++ b/packages/rag/src/document/document.ts
@@ -163,15 +163,6 @@ export class MDocument {
 
     const restObj = rest as Record<string, unknown>;
 
-    const legacyFields = Object.keys(restObj).filter(
-      key => !['strategy', 'extract'].includes(key) && restObj[key] !== undefined,
-    );
-    if (legacyFields.length > 0) {
-      console.warn(
-        '[DEPRECATION] Passing chunking options directly to ChunkParams is deprecated. Use the dedicated strategy-specific options fields instead. Support will be removed after May 20th, 2025.',
-        { deprecatedFields: legacyFields },
-      );
-    }
     switch (strategy) {
       case 'recursive':
         await this.chunkRecursive({ ...restObj, ...recursiveOptions });

--- a/packages/rag/src/document/transformers/character.ts
+++ b/packages/rag/src/document/transformers/character.ts
@@ -1,5 +1,5 @@
 import { Language } from '../types';
-import type { ChunkOptions } from '../types';
+import type { CharacterChunkOptions, RecursiveChunkOptions } from '../types';
 
 import { TextTransformer } from './text';
 
@@ -52,24 +52,8 @@ export class CharacterTransformer extends TextTransformer {
   protected separator: string;
   protected isSeparatorRegex: boolean;
 
-  constructor({
-    separator = '\n\n',
-    isSeparatorRegex = false,
-    options = {},
-  }: {
-    separator?: string;
-    isSeparatorRegex?: boolean;
-    options?: {
-      size?: number;
-      overlap?: number;
-      lengthFunction?: (text: string) => number;
-      keepSeparator?: boolean | 'start' | 'end';
-      separatorPosition?: 'start' | 'end';
-      addStartIndex?: boolean;
-      stripWhitespace?: boolean;
-    };
-  }) {
-    super(options);
+  constructor({ separator = '\n\n', isSeparatorRegex = false, ...rest }: CharacterChunkOptions = {}) {
+    super(rest);
     this.separator = separator;
     this.isSeparatorRegex = isSeparatorRegex;
   }
@@ -126,16 +110,8 @@ export class RecursiveCharacterTransformer extends TextTransformer {
   protected separators: string[];
   protected isSeparatorRegex: boolean;
 
-  constructor({
-    separators,
-    isSeparatorRegex = false,
-    options = {},
-  }: {
-    separators?: string[];
-    isSeparatorRegex?: boolean;
-    options?: ChunkOptions;
-  }) {
-    super(options);
+  constructor({ separators, isSeparatorRegex = false, ...rest }: RecursiveChunkOptions = {}) {
+    super(rest);
     this.separators = separators || ['\n\n', '\n', ' ', ''];
     this.isSeparatorRegex = isSeparatorRegex;
   }
@@ -199,20 +175,10 @@ export class RecursiveCharacterTransformer extends TextTransformer {
     return this._splitText(text, this.separators);
   }
 
-  static fromLanguage(
-    language: Language,
-    options: {
-      size?: number;
-      chunkOverlap?: number;
-      lengthFunction?: (text: string) => number;
-      keepSeparator?: boolean | 'start' | 'end';
-      separatorPosition?: 'start' | 'end';
-      addStartIndex?: boolean;
-      stripWhitespace?: boolean;
-    } = {},
-  ): RecursiveCharacterTransformer {
-    const separators = RecursiveCharacterTransformer.getSeparatorsForLanguage(language);
-    return new RecursiveCharacterTransformer({ separators, isSeparatorRegex: true, options });
+  static fromLanguage(options: RecursiveChunkOptions = {}): RecursiveCharacterTransformer {
+    const { language } = options;
+    const separators = RecursiveCharacterTransformer.getSeparatorsForLanguage(language!);
+    return new RecursiveCharacterTransformer({ ...options, separators, isSeparatorRegex: true });
   }
 
   static getSeparatorsForLanguage(language: Language): string[] {

--- a/packages/rag/src/document/transformers/character.ts
+++ b/packages/rag/src/document/transformers/character.ts
@@ -3,12 +3,12 @@ import type { ChunkOptions } from '../types';
 
 import { TextTransformer } from './text';
 
-function splitTextWithRegex(text: string, separator: string, keepSeparator: boolean | 'start' | 'end'): string[] {
+function splitTextWithRegex(text: string, separator: string, separatorPosition?: 'start' | 'end'): string[] {
   if (!separator) {
     return text.split('');
   }
 
-  if (!keepSeparator) {
+  if (!separatorPosition) {
     return text.split(new RegExp(separator)).filter(s => s !== '');
   }
 
@@ -20,7 +20,7 @@ function splitTextWithRegex(text: string, separator: string, keepSeparator: bool
   const splits = text.split(new RegExp(`(${separator})`));
   const result: string[] = [];
 
-  if (keepSeparator === 'end') {
+  if (separatorPosition === 'end') {
     // Process all complete pairs
     for (let i = 0; i < splits.length - 1; i += 2) {
       if (i + 1 < splits.length) {
@@ -64,6 +64,7 @@ export class CharacterTransformer extends TextTransformer {
       overlap?: number;
       lengthFunction?: (text: string) => number;
       keepSeparator?: boolean | 'start' | 'end';
+      separatorPosition?: 'start' | 'end';
       addStartIndex?: boolean;
       stripWhitespace?: boolean;
     };
@@ -77,7 +78,7 @@ export class CharacterTransformer extends TextTransformer {
     // First, split the text into initial chunks
     const separator = this.isSeparatorRegex ? this.separator : this.separator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-    const initialSplits = splitTextWithRegex(text, separator, this.keepSeparator);
+    const initialSplits = splitTextWithRegex(text, separator, this.separatorPosition);
 
     // If length of any split is greater than chunk size, perform additional splitting
     const chunks: string[] = [];
@@ -163,10 +164,10 @@ export class RecursiveCharacterTransformer extends TextTransformer {
 
     const _separator = this.isSeparatorRegex ? separator : separator?.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-    const splits = splitTextWithRegex(text, _separator, this.keepSeparator);
+    const splits = splitTextWithRegex(text, _separator, this.separatorPosition);
 
     const goodSplits: string[] = [];
-    const mergeSeparator = this.keepSeparator ? '' : separator;
+    const mergeSeparator = this.separatorPosition ? '' : separator;
 
     for (const s of splits) {
       if (this.lengthFunction(s) < this.size) {
@@ -205,6 +206,7 @@ export class RecursiveCharacterTransformer extends TextTransformer {
       chunkOverlap?: number;
       lengthFunction?: (text: string) => number;
       keepSeparator?: boolean | 'start' | 'end';
+      separatorPosition?: 'start' | 'end';
       addStartIndex?: boolean;
       stripWhitespace?: boolean;
     } = {},

--- a/packages/rag/src/document/transformers/html.ts
+++ b/packages/rag/src/document/transformers/html.ts
@@ -1,6 +1,7 @@
 import { parse } from 'node-html-better-parser';
 import { Document } from '../schema';
 
+import type { HtmlChunkOptions } from '../types';
 import { RecursiveCharacterTransformer } from './character';
 
 interface ElementType {
@@ -14,9 +15,9 @@ export class HTMLHeaderTransformer {
   private headersToSplitOn: [string, string][];
   private returnEachElement: boolean;
 
-  constructor(headersToSplitOn: [string, string][], returnEachElement: boolean = false) {
-    this.returnEachElement = returnEachElement;
-    this.headersToSplitOn = [...headersToSplitOn].sort();
+  constructor({ headers = [], returnEachLine = false }: HtmlChunkOptions = {}) {
+    this.returnEachElement = returnEachLine;
+    this.headersToSplitOn = [...headers].sort();
   }
 
   splitText({ text }: { text: string }): Document[] {
@@ -197,9 +198,12 @@ export class HTMLSectionTransformer {
   private headersToSplitOn: Record<string, string>;
   private options: Record<string, any>;
 
-  constructor(headersToSplitOn: [string, string][], options: Record<string, any> = {}) {
-    this.headersToSplitOn = Object.fromEntries(headersToSplitOn.map(([tag, name]) => [tag.toLowerCase(), name]));
-    this.options = options;
+  constructor({
+    sections = [],
+    additionalOptions = {},
+  }: HtmlChunkOptions & { additionalOptions?: Record<string, any> } = {}) {
+    this.headersToSplitOn = Object.fromEntries(sections.map(([tag, name]) => [tag.toLowerCase(), name]));
+    this.options = additionalOptions;
   }
 
   splitText(text: string): Document[] {
@@ -296,7 +300,7 @@ export class HTMLSectionTransformer {
       metadatas.push(doc.metadata);
     }
     const results = await this.createDocuments(texts, metadatas);
-    const textSplitter = new RecursiveCharacterTransformer({ options: this.options });
+    const textSplitter = new RecursiveCharacterTransformer(this.options);
 
     return textSplitter.splitDocuments(results);
   }

--- a/packages/rag/src/document/transformers/json.ts
+++ b/packages/rag/src/document/transformers/json.ts
@@ -1,10 +1,11 @@
 import { Document } from '../schema';
+import type { JsonChunkOptions } from '../types';
 
 export class RecursiveJsonTransformer {
   private maxSize: number;
   private minSize: number;
 
-  constructor({ maxSize = 2000, minSize }: { maxSize: number; minSize?: number }) {
+  constructor({ maxSize = 2000, minSize }: JsonChunkOptions = {}) {
     this.maxSize = maxSize;
     this.minSize = minSize ?? Math.max(maxSize - 200, 50);
   }

--- a/packages/rag/src/document/transformers/latex.ts
+++ b/packages/rag/src/document/transformers/latex.ts
@@ -9,6 +9,7 @@ export class LatexTransformer extends RecursiveCharacterTransformer {
       overlap?: number;
       lengthFunction?: (text: string) => number;
       keepSeparator?: boolean | 'start' | 'end';
+      separatorPosition?: 'start' | 'end';
       addStartIndex?: boolean;
       stripWhitespace?: boolean;
     } = {},

--- a/packages/rag/src/document/transformers/latex.ts
+++ b/packages/rag/src/document/transformers/latex.ts
@@ -1,20 +1,11 @@
 import { Language } from '../types';
 
+import type { LatexChunkOptions } from '../types';
 import { RecursiveCharacterTransformer } from './character';
 
 export class LatexTransformer extends RecursiveCharacterTransformer {
-  constructor(
-    options: {
-      size?: number;
-      overlap?: number;
-      lengthFunction?: (text: string) => number;
-      keepSeparator?: boolean | 'start' | 'end';
-      separatorPosition?: 'start' | 'end';
-      addStartIndex?: boolean;
-      stripWhitespace?: boolean;
-    } = {},
-  ) {
+  constructor(options: LatexChunkOptions = {}) {
     const separators = RecursiveCharacterTransformer.getSeparatorsForLanguage(Language.LATEX);
-    super({ separators, isSeparatorRegex: true, options });
+    super({ ...options, separators, isSeparatorRegex: true });
   }
 }

--- a/packages/rag/src/document/transformers/markdown.ts
+++ b/packages/rag/src/document/transformers/markdown.ts
@@ -22,6 +22,7 @@ export class MarkdownTransformer extends RecursiveCharacterTransformer {
       chunkOverlap?: number;
       lengthFunction?: (text: string) => number;
       keepSeparator?: boolean | 'start' | 'end';
+      separatorPosition?: 'start' | 'end';
       addStartIndex?: boolean;
       stripWhitespace?: boolean;
     } = {},

--- a/packages/rag/src/document/transformers/markdown.ts
+++ b/packages/rag/src/document/transformers/markdown.ts
@@ -1,6 +1,7 @@
 import { Document } from '../schema';
 
 import { Language } from '../types';
+import type { MarkdownChunkOptions } from '../types';
 
 import { RecursiveCharacterTransformer } from './character';
 
@@ -16,19 +17,9 @@ interface HeaderType {
 }
 
 export class MarkdownTransformer extends RecursiveCharacterTransformer {
-  constructor(
-    options: {
-      chunkSize?: number;
-      chunkOverlap?: number;
-      lengthFunction?: (text: string) => number;
-      keepSeparator?: boolean | 'start' | 'end';
-      separatorPosition?: 'start' | 'end';
-      addStartIndex?: boolean;
-      stripWhitespace?: boolean;
-    } = {},
-  ) {
+  constructor(options: MarkdownChunkOptions = {}) {
     const separators = RecursiveCharacterTransformer.getSeparatorsForLanguage(Language.MARKDOWN);
-    super({ separators, isSeparatorRegex: true, options });
+    super({ ...options, separators, isSeparatorRegex: true });
   }
 }
 
@@ -37,8 +28,8 @@ export class MarkdownHeaderTransformer {
   private returnEachLine: boolean;
   private stripHeaders: boolean;
 
-  constructor(headersToSplitOn: [string, string][], returnEachLine: boolean = false, stripHeaders: boolean = true) {
-    this.headersToSplitOn = [...headersToSplitOn].sort((a, b) => b[0].length - a[0].length);
+  constructor({ headers = [], returnEachLine = false, stripHeaders = true }: MarkdownChunkOptions = {}) {
+    this.headersToSplitOn = [...headers].sort((a, b) => b[0].length - a[0].length);
     this.returnEachLine = returnEachLine;
     this.stripHeaders = stripHeaders;
   }

--- a/packages/rag/src/document/transformers/text.ts
+++ b/packages/rag/src/document/transformers/text.ts
@@ -1,6 +1,6 @@
 import { Document } from '../schema';
 
-import type { ChunkOptions } from '../types';
+import type { BaseChunkOptions } from '../types';
 
 import type { Transformer } from './transformer';
 
@@ -21,11 +21,11 @@ export abstract class TextTransformer implements Transformer {
     separatorPosition,
     addStartIndex = false,
     stripWhitespace = true,
-  }: ChunkOptions) {
+  }: BaseChunkOptions) {
     if (overlap > size) {
       throw new Error(`Got a larger chunk overlap (${overlap}) than chunk size ` + `(${size}), should be smaller.`);
     }
-    if (keepSeparator !== undefined) {
+    if (keepSeparator !== undefined && keepSeparator !== false) {
       // Runtime warning for deprecated usage
       console.warn(
         '[DEPRECATION] `keepSeparator` is deprecated and will be removed after May 20th, 2025. Use `separatorPosition` instead.',

--- a/packages/rag/src/document/transformers/text.ts
+++ b/packages/rag/src/document/transformers/text.ts
@@ -9,6 +9,7 @@ export abstract class TextTransformer implements Transformer {
   protected overlap: number;
   protected lengthFunction: (text: string) => number;
   protected keepSeparator: boolean | 'start' | 'end';
+  protected separatorPosition?: 'start' | 'end';
   protected addStartIndex: boolean;
   protected stripWhitespace: boolean;
 
@@ -17,16 +18,27 @@ export abstract class TextTransformer implements Transformer {
     overlap = 200,
     lengthFunction = (text: string) => text.length,
     keepSeparator = false,
+    separatorPosition,
     addStartIndex = false,
     stripWhitespace = true,
   }: ChunkOptions) {
     if (overlap > size) {
       throw new Error(`Got a larger chunk overlap (${overlap}) than chunk size ` + `(${size}), should be smaller.`);
     }
+    if (keepSeparator !== undefined) {
+      // Runtime warning for deprecated usage
+      console.warn(
+        '[DEPRECATION] `keepSeparator` is deprecated and will be removed after May 20th, 2025. Use `separatorPosition` instead.',
+      );
+      if (keepSeparator === 'end') separatorPosition = 'end';
+      else if (keepSeparator === 'start') separatorPosition = 'start';
+      else if (keepSeparator === true) separatorPosition = 'start';
+    }
     this.size = size;
     this.overlap = overlap;
     this.lengthFunction = lengthFunction;
     this.keepSeparator = keepSeparator;
+    this.separatorPosition = separatorPosition;
     this.addStartIndex = addStartIndex;
     this.stripWhitespace = stripWhitespace;
   }

--- a/packages/rag/src/document/transformers/token.ts
+++ b/packages/rag/src/document/transformers/token.ts
@@ -51,6 +51,7 @@ export class TokenTransformer extends TextTransformer {
       overlap?: number;
       lengthFunction?: (text: string) => number;
       keepSeparator?: boolean | 'start' | 'end';
+      separatorPosition?: 'start' | 'end';
       addStartIndex?: boolean;
       stripWhitespace?: boolean;
     };

--- a/packages/rag/src/document/types.ts
+++ b/packages/rag/src/document/types.ts
@@ -43,8 +43,10 @@ export type ExtractParams = {
 };
 
 /**
- * @deprecated Use dedicated strategy-specific options fields on {@link ChunkParams} instead.
- * This type will be removed after May 20th, 2025.
+ * Legacy chunking options for backward compatibility and ergonomic defaults.
+ *
+ * This type is still supported, especially when the chunking strategy is inferred from document type.
+ * For new code, prefer using the dedicated strategy-specific options fields on {@link ChunkParams}.
  */
 export type ChunkOptions = {
   headers?: [string, string][];

--- a/packages/rag/src/document/types.ts
+++ b/packages/rag/src/document/types.ts
@@ -54,7 +54,19 @@ export type ChunkOptions = {
   minSize?: number;
   overlap?: number;
   lengthFunction?: (text: string) => number;
+  /**
+   * @deprecated Use `separatorPosition` instead. This option will be removed after May 20th, 2025.
+   * If provided, a runtime warning should be emitted.
+   */
   keepSeparator?: boolean | 'start' | 'end';
+
+  /**
+   * Controls where the separator appears in the chunk. Replaces `keepSeparator`.
+   * - 'start': separator appears at the start of the chunk
+   * - 'end': separator appears at the end of the chunk
+   * If not provided, the separator is omitted.
+   */
+  separatorPosition?: 'start' | 'end';
   addStartIndex?: boolean;
   stripWhitespace?: boolean;
   language?: Language;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR changes the chunk API to add strategy specific options fields to the chunk method, as well as deprecates keepSeparator in favor of separatorPosition.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
