### PR TITLE
fix(@mastra/mcp, @mastra/core): don't coerce all input fields to required

### DIFF
--- a/.changeset/deep-wolves-sink.md
+++ b/.changeset/deep-wolves-sink.md
@@ -1,5 +1,6 @@
 ---
 '@mastra/mcp': patch
+'@mastra/core': patch
 ---
 
-Fixed a bug where MCP tool input schema properties that were optional became required
+Fixed a bug where tool input schema properties that were optional became required

--- a/.changeset/deep-wolves-sink.md
+++ b/.changeset/deep-wolves-sink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed a bug where MCP tool input schema properties that were optional became required

--- a/packages/core/src/tools/tool-compatibility/builder.ts
+++ b/packages/core/src/tools/tool-compatibility/builder.ts
@@ -3,7 +3,7 @@ import { jsonSchema } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema, ZodType } from 'zod';
 import { z } from 'zod';
-import { jsonSchemaObjectToZodRawShape } from 'zod-from-json-schema';
+import { convertJsonSchemaToZod } from 'zod-from-json-schema';
 import type { JSONSchema as ZodFromJSONSchema_JSONSchema } from 'zod-from-json-schema';
 import type { Targets } from 'zod-to-json-schema';
 import { zodToJsonSchema } from 'zod-to-json-schema';
@@ -56,8 +56,7 @@ export function convertVercelToolParameters(tool: VercelTool): z.ZodType {
   } else {
     const jsonSchemaToConvert = ('jsonSchema' in schema ? schema.jsonSchema : schema) as ZodFromJSONSchema_JSONSchema;
     try {
-      const rawShape = jsonSchemaObjectToZodRawShape(jsonSchemaToConvert);
-      return z.object(rawShape);
+      return convertJsonSchemaToZod(jsonSchemaToConvert);
     } catch (e: unknown) {
       const errorMessage = `[CoreToolBuilder] Failed to convert Vercel tool JSON schema parameters to Zod. Original schema: ${JSON.stringify(jsonSchemaToConvert)}`;
       console.error(errorMessage, e);
@@ -72,8 +71,7 @@ function convertInputSchema(tool: ToolAction<any, any, any>): z.ZodType {
     return schema;
   } else {
     try {
-      const rawShape = jsonSchemaObjectToZodRawShape(schema as ZodFromJSONSchema_JSONSchema);
-      return z.object(rawShape);
+      return convertJsonSchemaToZod(schema as ZodFromJSONSchema_JSONSchema);
     } catch (e: unknown) {
       const errorMessage = `[CoreToolBuilder] Failed to convert tool input JSON schema to Zod. Original schema: ${JSON.stringify(schema)}`;
       console.error(errorMessage, e);

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,4 +1,5 @@
 import { MastraBase } from '@mastra/core/base';
+
 import type { RuntimeContext } from '@mastra/core/di';
 import { createTool } from '@mastra/core/tools';
 import { isZodType } from '@mastra/core/utils';
@@ -13,10 +14,9 @@ import type { Protocol } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { ClientCapabilities, LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
 import { CallToolResultSchema, ListResourcesResultSchema } from '@modelcontextprotocol/sdk/types.js';
-
 import { asyncExitHook, gracefulExit } from 'exit-hook';
 import { z } from 'zod';
-import { jsonSchemaObjectToZodRawShape } from 'zod-from-json-schema';
+import { convertJsonSchemaToZod } from 'zod-from-json-schema';
 import type { JSONSchema } from 'zod-from-json-schema';
 
 // Re-export MCP SDK LoggingLevel for convenience
@@ -334,9 +334,7 @@ export class InternalMastraMCPClient extends MastraBase {
     }
 
     try {
-      // Assuming inputSchema is a JSONSchema object type for tool inputs
-      const rawShape = jsonSchemaObjectToZodRawShape(inputSchema as JSONSchema);
-      return z.object(rawShape); // Wrap the raw shape to return a ZodType (object)
+      return convertJsonSchemaToZod(inputSchema as JSONSchema);
     } catch (error: unknown) {
       let errorDetails: string | undefined;
       if (error instanceof Error) {


### PR DESCRIPTION
Using `jsonSchemaToObjectToRawZodShape` causes all optional input args to become required, breaking many MCP servers