### PR TITLE
docs: add provider string to model capabilities table

### DIFF
--- a/docs/src/components/provider-table.tsx
+++ b/docs/src/components/provider-table.tsx
@@ -491,7 +491,7 @@ export function ProviderTable() {
                 {model.provider}
               </Link>
             </TableCell>
-            <TableCell className="font-medium">
+            <TableCell className="font-mono">
               {model.providerUrl.split("/").pop()!.split("-")[0]}
             </TableCell>
             <TableCell className="font-medium">

--- a/docs/src/components/provider-table.tsx
+++ b/docs/src/components/provider-table.tsx
@@ -458,6 +458,9 @@ export function ProviderTable() {
       <TableHeader>
         <TableRow className="dark:border-neutral-700 border-[var(--light-border-muted)]">
           <TableHead className="w-[200px] font-bold pb-2">Provider</TableHead>
+          <TableHead className="w-[200px] font-bold pb-2">
+            Provider String
+          </TableHead>
           <TableHead className="w-[200px] font-bold pb-2">API Key</TableHead>
           <TableHead className="w-[250px] font-bold pb-2">Model</TableHead>
           <TableHead className="pb-2 font-bold text-center">
@@ -487,6 +490,9 @@ export function ProviderTable() {
               >
                 {model.provider}
               </Link>
+            </TableCell>
+            <TableCell className="font-medium">
+              {model.providerUrl.split("/").pop()!.split("-")[0]}
             </TableCell>
             <TableCell className="font-medium">
               <Badge


### PR DESCRIPTION
## Description

Add Provider String to Model Capabilities Table.

I was going to add a new key to the `modelData` array, but upon close inspection, the string is always the URL, but without the dashes: E.g

- https://sdk.vercel.ai/providers/ai-sdk-providers/xai | `xai`
- https://sdk.vercel.ai/providers/ai-sdk-providers/google-generative-ai | `google`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
