### PR TITLE
[MASTRA-3100] changed markdown chunking to correctly strip headers

### DIFF
--- a/.changeset/sixty-aliens-greet.md
+++ b/.changeset/sixty-aliens-greet.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Changed stripHeaders for markdown chunking to strip headers correctly from output when true

--- a/packages/rag/src/document/transformers/markdown.ts
+++ b/packages/rag/src/document/transformers/markdown.ts
@@ -61,6 +61,8 @@ export class MarkdownHeaderTransformer {
     const aggregatedChunks: LineType[] = [];
 
     for (const line of lines) {
+      const lastLine = aggregatedChunks[aggregatedChunks.length - 1]?.content?.split('\n')?.slice(-1)[0]?.trim();
+      const isHeaderLine = lastLine ? this.headersToSplitOn.some(([sep]) => lastLine.startsWith(sep)) : false;
       if (
         aggregatedChunks.length > 0 &&
         JSON.stringify(aggregatedChunks?.[aggregatedChunks.length - 1]!.metadata) === JSON.stringify(line.metadata)
@@ -72,8 +74,7 @@ export class MarkdownHeaderTransformer {
         JSON.stringify(aggregatedChunks?.[aggregatedChunks.length - 1]!.metadata) !== JSON.stringify(line.metadata) &&
         Object.keys(aggregatedChunks?.[aggregatedChunks.length - 1]!.metadata).length <
           Object.keys(line.metadata).length &&
-        aggregatedChunks?.[aggregatedChunks.length - 1]?.content?.split('\n')?.slice(-1)[0]![0] === '#' &&
-        !this.stripHeaders
+        isHeaderLine
       ) {
         if (aggregatedChunks && aggregatedChunks?.[aggregatedChunks.length - 1]) {
           const aggChunk = aggregatedChunks[aggregatedChunks.length - 1];
@@ -166,12 +167,13 @@ export class MarkdownHeaderTransformer {
             initialMetadata[name] = header.data;
           }
 
-          // Always create a separate chunk for the header
-          linesWithMetadata.push({
-            content: line,
-            metadata: { ...currentMetadata, ...initialMetadata },
-          });
-
+          // Only add header to linesWithMetadata if stripHeaders is false
+          if (!this.stripHeaders) {
+            linesWithMetadata.push({
+              content: line,
+              metadata: { ...currentMetadata, ...initialMetadata },
+            });
+          }
           break;
         }
       }

--- a/packages/rag/src/document/transformers/markdown.ts
+++ b/packages/rag/src/document/transformers/markdown.ts
@@ -62,7 +62,7 @@ export class MarkdownHeaderTransformer {
 
     for (const line of lines) {
       const lastLine = aggregatedChunks[aggregatedChunks.length - 1]?.content?.split('\n')?.slice(-1)[0]?.trim();
-      const isHeaderLine = lastLine ? this.headersToSplitOn.some(([sep]) => lastLine.startsWith(sep)) : false;
+      const lastChunkIsHeader = lastLine ? this.headersToSplitOn.some(([sep]) => lastLine.startsWith(sep)) : false;
       if (
         aggregatedChunks.length > 0 &&
         JSON.stringify(aggregatedChunks?.[aggregatedChunks.length - 1]!.metadata) === JSON.stringify(line.metadata)
@@ -74,7 +74,7 @@ export class MarkdownHeaderTransformer {
         JSON.stringify(aggregatedChunks?.[aggregatedChunks.length - 1]!.metadata) !== JSON.stringify(line.metadata) &&
         Object.keys(aggregatedChunks?.[aggregatedChunks.length - 1]!.metadata).length <
           Object.keys(line.metadata).length &&
-        isHeaderLine
+        lastChunkIsHeader
       ) {
         if (aggregatedChunks && aggregatedChunks?.[aggregatedChunks.length - 1]) {
           const aggChunk = aggregatedChunks[aggregatedChunks.length - 1];
@@ -199,6 +199,7 @@ export class MarkdownHeaderTransformer {
         }
       }
 
+      // Reset metadata for next line
       currentMetadata = { ...initialMetadata };
     }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes the stripHeaders field for markdown chunking to correctly strip headers from the output.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
