### PR TITLE
[MASTRA-3091] added runtime context to vector-query and graph-rag tools

### DIFF
--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -225,7 +225,7 @@ runtimeContext.set("indexName", "my-index");
 runtimeContext.set("topK", 5);
 runtimeContext.set("filter", { "category": "docs" });
 
-const response = await agent.generate("What's the weather like today?", {
+const response = await agent.generate("Find documentation from the knowledge base.", {
   runtimeContext,
 });
 ```

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -33,7 +33,7 @@ const graphTool = createGraphRAGTool({
 <Callout>
 **Parameter Requirements:**  
 This tool uses a discriminated union for configuration:
-- If `useRuntimeContext: true`, only `id`, `description`, `useRuntimeContext`, `graphOptions`, and `model` are accepted at creation. All other fields must be provided at runtime via the runtime context.
+- If `useRuntimeContext: true`, only `id`, `description`, `graphOptions`, and `model` are accepted at creation. All other fields can be provided at runtime via the runtime context.
 - If `useRuntimeContext` is `false` or omitted, all required fields must be provided at creation time as described in the table below.
 </Callout>
 
@@ -42,35 +42,33 @@ This tool uses a discriminated union for configuration:
     {
       name: "id",
       type: "string",
-      description: "Custom ID for the tool.",
+      description: "Custom ID for the tool. (Default: 'GraphRAG Tool')",
       isOptional: true,
-      defaultValue: "GraphRAG Tool",
     },
     {
       name: "description",
       type: "string",
-      description: "Custom description for the tool.",
+      description: "Custom description for the tool. (Default: 'Access and analyze relationships between information in the knowledge base to answer complex questions about connections and patterns.')",
       isOptional: true,
-      defaultValue: `Access and analyze relationships between information in the knowledge base to answer complex questions about connections and patterns.`,
     },
     {
       name: "useRuntimeContext",
       type: "boolean",
-      description: "Whether to use runtime context for configuration.",
+      description: "Whether to use runtime context to provide runtime configuration variables.",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "vectorStoreName",
       type: "string",
-      description: "Name of the vector store to query (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
-      isOptional: true,
+      description: "Name of the vector store to query (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      isOptional: false,
     },
     {
       name: "indexName",
       type: "string",
-      description: "Name of the index within the vector store (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
-      isOptional: true,
+      description: "Name of the index within the vector store (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      isOptional: false,
     },
     {
       name: "model",
@@ -81,21 +79,21 @@ This tool uses a discriminated union for configuration:
     {
       name: "enableFilter",
       type: "boolean",
-      description: "Enable filtering of results based on metadata (can be provided at runtime if `useRuntimeContext` is true).",
+      description: "Enable filtering of results based on metadata.",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeSources",
       type: "boolean",
-      description: "Include the full retrieval objects in the results (can be provided at runtime if `useRuntimeContext` is true).",
+      description: "Include the full retrieval objects in the results.",
       isOptional: true,
       defaultValue: "true",
     },
     {
       name: "graphOptions",
       type: "GraphOptions",
-      description: "Configuration for the graph-based retrieval (can be provided at runtime if `useRuntimeContext` is true).",
+      description: "Configuration for the graph-based retrieval",
       isOptional: true,
       defaultValue: "Default graph options",
     }

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -32,9 +32,8 @@ const graphTool = createGraphRAGTool({
 
 <Callout>
 **Parameter Requirements:**  
-This tool uses a discriminated union for configuration:
-- If `useRuntimeContext: true`, only `id`, `description`, `graphOptions`, and `model` are accepted at creation. All other fields can be provided at runtime via the runtime context.
-- If `useRuntimeContext` is `false` or omitted, all required fields must be provided at creation time as described in the table below.
+All fields can be set at creation as defaults. At runtime, any field may be overridden by providing a value in the runtime context or input.  
+If a required field (such as `vectorStoreName`, `indexName`, or `model`) is missing from both creation and runtime, an error will be thrown.
 </Callout>
 
 <PropertiesTable
@@ -42,51 +41,44 @@ This tool uses a discriminated union for configuration:
     {
       name: "id",
       type: "string",
-      description: "Custom ID for the tool. (Default: 'GraphRAG Tool')",
+      description: "Custom ID for the tool. By default: 'GraphRAG {vectorStoreName} {indexName} Tool'. (Set at creation only.)",
       isOptional: true,
     },
     {
       name: "description",
       type: "string",
-      description: "Custom description for the tool. (Default: 'Access and analyze relationships between information in the knowledge base to answer complex questions about connections and patterns.')",
+      description: "Custom description for the tool. By default: 'Access and analyze relationships between information in the knowledge base to answer complex questions about connections and patterns.' (Set at creation only.)",
       isOptional: true,
-    },
-    {
-      name: "useRuntimeContext",
-      type: "boolean",
-      description: "Whether to use runtime context to provide runtime configuration variables.",
-      isOptional: true,
-      defaultValue: "false",
     },
     {
       name: "vectorStoreName",
       type: "string",
-      description: "Name of the vector store to query (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      description: "Name of the vector store to query. (Can be set at creation or overridden at runtime.)",
       isOptional: false,
     },
     {
       name: "indexName",
       type: "string",
-      description: "Name of the index within the vector store (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      description: "Name of the index within the vector store. (Can be set at creation or overridden at runtime.)",
       isOptional: false,
     },
     {
       name: "model",
       type: "EmbeddingModel",
-      description: "Embedding model to use for vector search",
+      description: "Embedding model to use for vector search. (Set at creation only.)",
       isOptional: false,
     },
     {
       name: "enableFilter",
       type: "boolean",
-      description: "Enable filtering of results based on metadata.",
+      description: "Enable filtering of results based on metadata. (Set at creation only, but will be automatically enabled if a filter is provided in the runtime context.)",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeSources",
       type: "boolean",
-      description: "Include the full retrieval objects in the results.",
+      description: "Include the full retrieval objects in the results. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
       defaultValue: "true",
     },
@@ -122,14 +114,14 @@ This tool uses a discriminated union for configuration:
     {
       name: "randomWalkSteps",
       type: "number",
-      description: "Number of steps in random walk for graph traversal",
+      description: "Number of steps in random walk for graph traversal. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
       defaultValue: "100",
     },
     {
       name: "restartProb",
       type: "number",
-      description: "Probability of restarting random walk from query node",
+      description: "Probability of restarting random walk from query node. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
       defaultValue: "0.15",
     },
@@ -207,16 +199,17 @@ const graphTool = createGraphRAGTool({
 This example shows how to customize the tool description for a specific use case while maintaining its core purpose of relationship analysis.
 
 
-## Example: Using `useRuntimeContext`
+## Example: Using Runtime Context
 
 ```typescript
 const graphTool = createGraphRAGTool({
-  useRuntimeContext: true,
+  vectorStoreName: "pinecone",
+  indexName: "docs",
   model: openai.embedding("text-embedding-3-small"),
 });
 ```
 
-When using useRuntimeContext: true, provide required parameters at execution time via the runtime context:
+When using runtime context, provide required parameters at execution time via the runtime context:
 
 ```typescript
 const runtimeContext = new RuntimeContext<{ vectorStoreName: string; indexName: string; topK: number; filter: any }>();
@@ -234,12 +227,6 @@ For more information on runtime context, please see:
 
 - [Runtime Variables](../../docs/agents/runtime-variables)
 - [Dynamic Context](../../docs/tools-mcp/dynamic-context)
-
-## Notes
-
-- If you set `useRuntimeContext: true` but do not provide required runtime parameters (e.g., `vectorStoreName`, `indexName`), the tool will throw an error at execution time.
-- Default values for optional fields are only used if not provided at creation or runtime.
-- When using runtime context, ensure your agent or invocation environment supports passing runtime parameters.
 
 ## Related
 

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -3,6 +3,8 @@ title: "Reference: createGraphRAGTool() | RAG | Mastra Tools Docs"
 description: Documentation for the Graph RAG Tool in Mastra, which enhances RAG by building a graph of semantic relationships between documents.
 ---
 
+import { Callout } from "nextra/components";
+
 # createGraphRAGTool()
 
 The `createGraphRAGTool()` creates a tool that enhances RAG by building a graph of semantic relationships between documents. It uses the `GraphRAG` system under the hood to provide graph-based retrieval, finding relevant content through both direct similarity and connected relationships.
@@ -28,19 +30,47 @@ const graphTool = createGraphRAGTool({
 
 ## Parameters
 
+<Callout>
+**Parameter Requirements:**  
+This tool uses a discriminated union for configuration:
+- If `useRuntimeContext: true`, only `id`, `description`, `useRuntimeContext`, `graphOptions`, and `model` are accepted at creation. All other fields must be provided at runtime via the runtime context.
+- If `useRuntimeContext` is `false` or omitted, all required fields must be provided at creation time as described in the table below.
+</Callout>
+
 <PropertiesTable
   content={[
     {
+      name: "id",
+      type: "string",
+      description: "Custom ID for the tool.",
+      isOptional: true,
+      defaultValue: "GraphRAG Tool",
+    },
+    {
+      name: "description",
+      type: "string",
+      description: "Custom description for the tool.",
+      isOptional: true,
+      defaultValue: `Access and analyze relationships between information in the knowledge base to answer complex questions about connections and patterns.`,
+    },
+    {
+      name: "useRuntimeContext",
+      type: "boolean",
+      description: "Whether to use runtime context for configuration.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
       name: "vectorStoreName",
       type: "string",
-      description: "Name of the vector store to query",
-      isOptional: false,
+      description: "Name of the vector store to query (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
+      isOptional: true,
     },
     {
       name: "indexName",
       type: "string",
-      description: "Name of the index within the vector store",
-      isOptional: false,
+      description: "Name of the index within the vector store (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
+      isOptional: true,
     },
     {
       name: "model",
@@ -51,31 +81,24 @@ const graphTool = createGraphRAGTool({
     {
       name: "enableFilter",
       type: "boolean",
-      description: "Enable filtering of results based on metadata",
+      description: "Enable filtering of results based on metadata (can be provided at runtime if `useRuntimeContext` is true).",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeSources",
       type: "boolean",
-      description: "Include the full retrieval objects in the results",
+      description: "Include the full retrieval objects in the results (can be provided at runtime if `useRuntimeContext` is true).",
       isOptional: true,
       defaultValue: "true",
     },
     {
       name: "graphOptions",
       type: "GraphOptions",
-      description: "Configuration for the graph-based retrieval",
+      description: "Configuration for the graph-based retrieval (can be provided at runtime if `useRuntimeContext` is true).",
       isOptional: true,
       defaultValue: "Default graph options",
-    },
-    {
-      name: "description",
-      type: "string",
-      description:
-        "Custom description for the tool. By default: 'Access and analyze relationships between information in the knowledge base to answer complex questions about connections and patterns'",
-      isOptional: true,
-    },
+    }
   ]}
 />
 
@@ -184,6 +207,41 @@ const graphTool = createGraphRAGTool({
 ```
 
 This example shows how to customize the tool description for a specific use case while maintaining its core purpose of relationship analysis.
+
+
+## Example: Using `useRuntimeContext`
+
+```typescript
+const graphTool = createGraphRAGTool({
+  useRuntimeContext: true,
+  model: openai.embedding("text-embedding-3-small"),
+});
+```
+
+When using useRuntimeContext: true, provide required parameters at execution time via the runtime context:
+
+```typescript
+const runtimeContext = new RuntimeContext<{ vectorStoreName: string; indexName: string; topK: number; filter: any }>();
+runtimeContext.set("vectorStoreName", "my-store");
+runtimeContext.set("indexName", "my-index");
+runtimeContext.set("topK", 5);
+runtimeContext.set("filter", { "category": "docs" });
+
+const response = await agent.generate("What's the weather like today?", {
+  runtimeContext,
+});
+```
+
+For more information on runtime context, please see:
+
+- [Runtime Variables](../../docs/agents/runtime-variables)
+- [Dynamic Context](../../docs/tools-mcp/dynamic-context)
+
+## Notes
+
+- If you set `useRuntimeContext: true` but do not provide required runtime parameters (e.g., `vectorStoreName`, `indexName`), the tool will throw an error at execution time.
+- Default values for optional fields are only used if not provided at creation or runtime.
+- When using runtime context, ensure your agent or invocation environment supports passing runtime parameters.
 
 ## Related
 

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -32,8 +32,8 @@ const graphTool = createGraphRAGTool({
 
 <Callout>
 **Parameter Requirements:**  
-All fields can be set at creation as defaults. At runtime, any field may be overridden by providing a value in the runtime context or input.  
-If a required field (such as `vectorStoreName`, `indexName`, or `model`) is missing from both creation and runtime, an error will be thrown.
+Most fields can be set at creation as defaults. Some fields can be overridden at runtime via the runtime context or input.  
+If a required field is missing from both creation and runtime, an error will be thrown. Note that `model`, `id`, and `description` can only be set at creation time.
 </Callout>
 
 <PropertiesTable
@@ -217,6 +217,8 @@ runtimeContext.set("vectorStoreName", "my-store");
 runtimeContext.set("indexName", "my-index");
 runtimeContext.set("topK", 5);
 runtimeContext.set("filter", { "category": "docs" });
+runtimeContext.set("randomWalkSteps", 100);
+runtimeContext.set("restartProb", 0.15);
 
 const response = await agent.generate("Find documentation from the knowledge base.", {
   runtimeContext,

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -27,7 +27,7 @@ const queryTool = createVectorQueryTool({
 <Callout>
 **Parameter Requirements:**  
 This tool uses a discriminated union for configuration:
-- If `useRuntimeContext: true`, only `id`, `description`, `useRuntimeContext`, and `model` are accepted at creation. All other fields must be provided at runtime via the runtime context.
+- If `useRuntimeContext: true`, only `id`, `description`, and `model` are accepted at creation. All other fields can be provided at runtime via the runtime context.
 - If `useRuntimeContext` is `false` or omitted, all required fields must be provided at creation time as described in the table below.
 </Callout>
 
@@ -36,21 +36,19 @@ This tool uses a discriminated union for configuration:
     {
       name: "id",
       type: "string",
-      description: "Custom ID for the tool.",
+      description: "Custom ID for the tool. (Default: 'VectorQuery Tool')",
       isOptional: true,
-      defaultValue: "VectorQuery Tool",
     },
     {
       name: "description",
       type: "string",
-      description: "Custom description for the tool.",
+      description: "Custom description for the tool. (Default: 'Access the knowledge base to find information needed to answer user questions')",
       isOptional: true,
-      defaultValue: `Access the knowledge base to find information needed to answer user questions`,
     },
     {
       name: "useRuntimeContext",
       type: "boolean",
-      description: "Whether to use runtime context for configuration.",
+      description: "Whether to use runtime context to provide runtime configuration variables.",
       isOptional: true,
       defaultValue: "false",
     },
@@ -63,40 +61,40 @@ This tool uses a discriminated union for configuration:
     {
       name: "vectorStoreName",
       type: "string",
-      description: "Name of the vector store to query (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
-      isOptional: true,
+      description: "Name of the vector store to query (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      isOptional: false,
     },
     {
       name: "indexName",
       type: "string",
-      description: "Name of the index within the vector store (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
-      isOptional: true,
+      description: "Name of the index within the vector store (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      isOptional: false,
     },
     {
       name: "enableFilter",
       type: "boolean",
-      description: "Enable filtering of results based on metadata (can be provided at runtime if `useRuntimeContext` is true).",
+      description: "Enable filtering of results based on metadata.",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeVectors",
       type: "boolean",
-      description: "Include the embedding vectors in the results (can be provided at runtime if `useRuntimeContext` is true).",
+      description: "Include the embedding vectors in the results.",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeSources",
       type: "boolean",
-      description: "Include the full retrieval objects in the results (can be provided at runtime if `useRuntimeContext` is true).",
+      description: "Include the full retrieval objects in the results.",
       isOptional: true,
       defaultValue: "true",
     },
     {
       name: "reranker",
       type: "RerankConfig",
-      description: "Options for reranking results (can be provided at runtime if `useRuntimeContext` is true).",
+      description: "Options for reranking results.",
       isOptional: true,
     },
   ]}

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -275,7 +275,7 @@ runtimeContext.set("indexName", "my-index");
 runtimeContext.set("topK", 5);
 runtimeContext.set("filter", { "category": "docs" });
 
-const response = await agent.generate("What's the weather like today?", {
+const response = await agent.generate("Find documentation from the knowledge base.", {
   runtimeContext,
 });
 ```

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -26,9 +26,8 @@ const queryTool = createVectorQueryTool({
 
 <Callout>
 **Parameter Requirements:**  
-This tool uses a discriminated union for configuration:
-- If `useRuntimeContext: true`, only `id`, `description`, and `model` are accepted at creation. All other fields can be provided at runtime via the runtime context.
-- If `useRuntimeContext` is `false` or omitted, all required fields must be provided at creation time as described in the table below.
+All fields can be set at creation as defaults. At runtime, any field may be overridden by providing a value in the runtime context or input.  
+If a required field (such as `vectorStoreName`, `indexName`, or `model`) is missing from both creation and runtime, an error will be thrown.
 </Callout>
 
 <PropertiesTable
@@ -36,65 +35,58 @@ This tool uses a discriminated union for configuration:
     {
       name: "id",
       type: "string",
-      description: "Custom ID for the tool. (Default: 'VectorQuery Tool')",
+      description: "Custom ID for the tool. By default: 'VectorQuery {vectorStoreName} {indexName} Tool'. (Set at creation only.)",
       isOptional: true,
     },
     {
       name: "description",
       type: "string",
-      description: "Custom description for the tool. (Default: 'Access the knowledge base to find information needed to answer user questions')",
+      description: "Custom description for the tool. By default: 'Access the knowledge base to find information needed to answer user questions' (Set at creation only.)",
       isOptional: true,
-    },
-    {
-      name: "useRuntimeContext",
-      type: "boolean",
-      description: "Whether to use runtime context to provide runtime configuration variables.",
-      isOptional: true,
-      defaultValue: "false",
     },
     {
       name: "model",
       type: "EmbeddingModel",
-      description: "Embedding model to use for vector search",
+      description: "Embedding model to use for vector search. (Set at creation only.)",
       isOptional: false,
     },
     {
       name: "vectorStoreName",
       type: "string",
-      description: "Name of the vector store to query (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      description: "Name of the vector store to query. (Can be set at creation or overridden at runtime.)",
       isOptional: false,
     },
     {
       name: "indexName",
       type: "string",
-      description: "Name of the index within the vector store (Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.)",
+      description: "Name of the index within the vector store. (Can be set at creation or overridden at runtime.)",
       isOptional: false,
     },
     {
       name: "enableFilter",
       type: "boolean",
-      description: "Enable filtering of results based on metadata.",
+      description: "Enable filtering of results based on metadata. (Set at creation only, but will be automatically enabled if a filter is provided in the runtime context.)",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeVectors",
       type: "boolean",
-      description: "Include the embedding vectors in the results.",
+      description: "Include the embedding vectors in the results. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeSources",
       type: "boolean",
-      description: "Include the full retrieval objects in the results.",
+      description: "Include the full retrieval objects in the results. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
       defaultValue: "true",
     },
     {
       name: "reranker",
       type: "RerankConfig",
-      description: "Options for reranking results.",
+      description: "Options for reranking results. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
     },
   ]}
@@ -257,16 +249,17 @@ const queryTool = createVectorQueryTool({
 
 This example shows how to customize the tool description for a specific use case while maintaining its core purpose of information retrieval.
 
-## Example: Using `useRuntimeContext`
+## Example: Using Runtime Context
 
 ```typescript
 const queryTool = createVectorQueryTool({
-  useRuntimeContext: true,
+  vectorStoreName: "pinecone",
+  indexName: "docs",
   model: openai.embedding("text-embedding-3-small"),
 });
 ```
 
-When using useRuntimeContext: true, provide required parameters at execution time via the runtime context:
+When using runtime context, provide required parameters at execution time via the runtime context:
 
 ```typescript
 const runtimeContext = new RuntimeContext<{ vectorStoreName: string; indexName: string; topK: number; filter: any }>();
@@ -292,12 +285,6 @@ The tool is created with:
 - **ID**: `VectorQuery {vectorStoreName} {indexName} Tool`
 - **Input Schema**: Requires queryText and filter objects
 - **Output Schema**: Returns relevantContext string
-
-## Notes
-
-- If you set `useRuntimeContext: true` but do not provide required runtime parameters (e.g., `vectorStoreName`, `indexName`), the tool will throw an error at execution time.
-- Default values for optional fields are only used if not provided at creation or runtime.
-- When using runtime context, ensure your agent or invocation environment supports passing runtime parameters.
 
 ## Related
 

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -26,8 +26,8 @@ const queryTool = createVectorQueryTool({
 
 <Callout>
 **Parameter Requirements:**  
-All fields can be set at creation as defaults. At runtime, any field may be overridden by providing a value in the runtime context or input.  
-If a required field (such as `vectorStoreName`, `indexName`, or `model`) is missing from both creation and runtime, an error will be thrown.
+Most fields can be set at creation as defaults. Some fields can be overridden at runtime via the runtime context or input.  
+If a required field is missing from both creation and runtime, an error will be thrown. Note that `model`, `id`, and `description` can only be set at creation time.
 </Callout>
 
 <PropertiesTable

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -3,6 +3,8 @@ title: "Reference: createVectorQueryTool() | RAG | Mastra Tools Docs"
 description: Documentation for the Vector Query Tool in Mastra, which facilitates semantic search over vector stores with filtering and reranking capabilities.
 ---
 
+import { Callout } from "nextra/components";
+
 # createVectorQueryTool()
 
 The `createVectorQueryTool()` function creates a tool for semantic search over vector stores. It supports filtering, reranking, and integrates with various vector store backends.
@@ -22,20 +24,35 @@ const queryTool = createVectorQueryTool({
 
 ## Parameters
 
+<Callout>
+**Parameter Requirements:**  
+This tool uses a discriminated union for configuration:
+- If `useRuntimeContext: true`, only `id`, `description`, `useRuntimeContext`, and `model` are accepted at creation. All other fields must be provided at runtime via the runtime context.
+- If `useRuntimeContext` is `false` or omitted, all required fields must be provided at creation time as described in the table below.
+</Callout>
+
 <PropertiesTable
   content={[
     {
-      name: "vectorStoreName",
+      name: "id",
       type: "string",
-      description:
-        "Name of the vector store to query (must be configured in Mastra)",
-      isOptional: false,
+      description: "Custom ID for the tool.",
+      isOptional: true,
+      defaultValue: "VectorQuery Tool",
     },
     {
-      name: "indexName",
+      name: "description",
       type: "string",
-      description: "Name of the index within the vector store",
-      isOptional: false,
+      description: "Custom description for the tool.",
+      isOptional: true,
+      defaultValue: `Access the knowledge base to find information needed to answer user questions`,
+    },
+    {
+      name: "useRuntimeContext",
+      type: "boolean",
+      description: "Whether to use runtime context for configuration.",
+      isOptional: true,
+      defaultValue: "false",
     },
     {
       name: "model",
@@ -44,49 +61,46 @@ const queryTool = createVectorQueryTool({
       isOptional: false,
     },
     {
+      name: "vectorStoreName",
+      type: "string",
+      description: "Name of the vector store to query (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
+      isOptional: true,
+    },
+    {
+      name: "indexName",
+      type: "string",
+      description: "Name of the index within the vector store (**Required at creation if `useRuntimeContext` is false; must be provided at runtime if true.**)",
+      isOptional: true,
+    },
+    {
       name: "enableFilter",
       type: "boolean",
-      description: "Enable filtering of results based on metadata",
+      description: "Enable filtering of results based on metadata (can be provided at runtime if `useRuntimeContext` is true).",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeVectors",
       type: "boolean",
-      description: "Include the embedding vectors in the results",
+      description: "Include the embedding vectors in the results (can be provided at runtime if `useRuntimeContext` is true).",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "includeSources",
       type: "boolean",
-      description: "Include the full retrieval objects in the results",
+      description: "Include the full retrieval objects in the results (can be provided at runtime if `useRuntimeContext` is true).",
       isOptional: true,
       defaultValue: "true",
     },
     {
       name: "reranker",
       type: "RerankConfig",
-      description: "Options for reranking results",
-      isOptional: true,
-    },
-    {
-      name: "id",
-      type: "string",
-      description:
-        "Custom ID for the tool (defaults to 'VectorQuery {vectorStoreName} {indexName} Tool')",
-      isOptional: true,
-    },
-    {
-      name: "description",
-      type: "string",
-      description:
-        "Custom description for the tool. By default: 'Access the knowledge base to find information needed to answer user questions'",
+      description: "Options for reranking results (can be provided at runtime if `useRuntimeContext` is true).",
       isOptional: true,
     },
   ]}
 />
-
 ### RerankConfig
 
 <PropertiesTable
@@ -245,6 +259,34 @@ const queryTool = createVectorQueryTool({
 
 This example shows how to customize the tool description for a specific use case while maintaining its core purpose of information retrieval.
 
+## Example: Using `useRuntimeContext`
+
+```typescript
+const queryTool = createVectorQueryTool({
+  useRuntimeContext: true,
+  model: openai.embedding("text-embedding-3-small"),
+});
+```
+
+When using useRuntimeContext: true, provide required parameters at execution time via the runtime context:
+
+```typescript
+const runtimeContext = new RuntimeContext<{ vectorStoreName: string; indexName: string; topK: number; filter: any }>();
+runtimeContext.set("vectorStoreName", "my-store");
+runtimeContext.set("indexName", "my-index");
+runtimeContext.set("topK", 5);
+runtimeContext.set("filter", { "category": "docs" });
+
+const response = await agent.generate("What's the weather like today?", {
+  runtimeContext,
+});
+```
+
+For more information on runtime context, please see:
+
+- [Runtime Variables](../../docs/agents/runtime-variables)
+- [Dynamic Context](../../docs/tools-mcp/dynamic-context)
+
 ## Tool Details
 
 The tool is created with:
@@ -252,6 +294,12 @@ The tool is created with:
 - **ID**: `VectorQuery {vectorStoreName} {indexName} Tool`
 - **Input Schema**: Requires queryText and filter objects
 - **Output Schema**: Returns relevantContext string
+
+## Notes
+
+- If you set `useRuntimeContext: true` but do not provide required runtime parameters (e.g., `vectorStoreName`, `indexName`), the tool will throw an error at execution time.
+- Default values for optional fields are only used if not provided at creation or runtime.
+- When using runtime context, ensure your agent or invocation environment supports passing runtime parameters.
 
 ## Related
 

--- a/packages/rag/src/tools/graph-rag.test.ts
+++ b/packages/rag/src/tools/graph-rag.test.ts
@@ -36,8 +36,8 @@ vi.mock('../graph-rag', async importOriginal => {
 
 const mockModel = { name: 'test-model' } as any;
 const mockMastra = {
-  getVector: vi.fn(() => ({
-    testStore: {},
+  getVector: vi.fn(storeName => ({
+    [storeName]: {},
   })),
   getLogger: vi.fn(() => ({
     debug: vi.fn(),
@@ -72,9 +72,9 @@ describe('createGraphRAGTool', () => {
         vectorStoreName: 'testStore',
       });
       const runtimeContext = new RuntimeContext();
-      runtimeContext.set('indexName', 'testIndex');
-      runtimeContext.set('vectorStoreName', 'testStore');
-      runtimeContext.set('topK', 2);
+      runtimeContext.set('indexName', 'anotherIndex');
+      runtimeContext.set('vectorStoreName', 'anotherStore');
+      runtimeContext.set('topK', 5);
       runtimeContext.set('filter', { foo: 'bar' });
       runtimeContext.set('randomWalkSteps', 99);
       runtimeContext.set('restartProb', 0.42);
@@ -87,12 +87,14 @@ describe('createGraphRAGTool', () => {
       expect(result.sources.length).toBe(2);
       expect(vectorQuerySearch).toHaveBeenCalledWith(
         expect.objectContaining({
-          indexName: 'testIndex',
-          vectorStore: expect.anything(),
+          indexName: 'anotherIndex',
+          vectorStore: {
+            anotherStore: {},
+          },
           queryText: 'foo',
           model: mockModel,
           queryFilter: { foo: 'bar' },
-          topK: 2,
+          topK: 5,
           includeVectors: true,
         }),
       );
@@ -103,7 +105,7 @@ describe('createGraphRAGTool', () => {
       expect(instance.query).toHaveBeenCalledWith(
         expect.objectContaining({
           query: [1, 2, 3],
-          topK: 2,
+          topK: 5,
           randomWalkSteps: 99,
           restartProb: 0.42,
         }),

--- a/packages/rag/src/tools/graph-rag.test.ts
+++ b/packages/rag/src/tools/graph-rag.test.ts
@@ -64,31 +64,13 @@ describe('createGraphRAGTool', () => {
   });
 
   describe('runtimeContext', () => {
-    it('throws if indexName or vectorStoreName missing', async () => {
-      const runtimeContext = new RuntimeContext();
-      runtimeContext.set('vectorStoreName', 'testStore');
-
-      const tool = createGraphRAGTool({ id: 'test', model: mockModel, useRuntimeContext: true });
-      await expect(
-        tool.execute({
-          context: { queryText: 'foo' },
-          mastra: mockMastra as any,
-          runtimeContext,
-        }),
-      ).rejects.toThrow('indexName is required');
-      const runtimeContext2 = new RuntimeContext();
-      runtimeContext2.set('indexName', 'testIndex');
-      await expect(
-        tool.execute({
-          context: { queryText: 'foo' },
-          mastra: mockMastra as any,
-          runtimeContext: runtimeContext2,
-        }),
-      ).rejects.toThrow('vectorStoreName is required');
-    });
-
     it('calls vectorQuerySearch and GraphRAG with runtimeContext params', async () => {
-      const tool = createGraphRAGTool({ id: 'test', model: mockModel, useRuntimeContext: true });
+      const tool = createGraphRAGTool({
+        id: 'test',
+        model: mockModel,
+        indexName: 'testIndex',
+        vectorStoreName: 'testStore',
+      });
       const runtimeContext = new RuntimeContext();
       runtimeContext.set('indexName', 'testIndex');
       runtimeContext.set('vectorStoreName', 'testStore');
@@ -97,7 +79,7 @@ describe('createGraphRAGTool', () => {
       runtimeContext.set('randomWalkSteps', 99);
       runtimeContext.set('restartProb', 0.42);
       const result = await tool.execute({
-        context: { queryText: 'foo' },
+        context: { queryText: 'foo', topK: 2 },
         mastra: mockMastra as any,
         runtimeContext,
       });

--- a/packages/rag/src/tools/graph-rag.test.ts
+++ b/packages/rag/src/tools/graph-rag.test.ts
@@ -1,0 +1,131 @@
+import { RuntimeContext } from '@mastra/core/runtime-context';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphRAG } from '../graph-rag';
+import { vectorQuerySearch } from '../utils';
+import { createGraphRAGTool } from './graph-rag';
+
+vi.mock('../utils', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    vectorQuerySearch: vi.fn().mockResolvedValue({
+      results: [
+        { metadata: { text: 'foo' }, vector: [1, 2, 3] },
+        { metadata: { text: 'bar' }, vector: [4, 5, 6] },
+      ],
+      queryEmbedding: [1, 2, 3],
+    }),
+  };
+});
+
+vi.mock('../graph-rag', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    GraphRAG: vi.fn().mockImplementation(() => {
+      return {
+        createGraph: vi.fn(),
+        query: vi.fn(() => [
+          { content: 'foo', metadata: { text: 'foo' } },
+          { content: 'bar', metadata: { text: 'bar' } },
+        ]),
+      };
+    }),
+  };
+});
+
+const mockModel = { name: 'test-model' } as any;
+const mockMastra = {
+  getVector: vi.fn(() => ({
+    testStore: {},
+  })),
+  getLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  })),
+};
+
+describe('createGraphRAGTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('validates input schema', () => {
+    const tool = createGraphRAGTool({
+      id: 'test',
+      model: mockModel,
+      vectorStoreName: 'testStore',
+      indexName: 'testIndex',
+    });
+    expect(() => tool.inputSchema?.parse({ queryText: 'foo', topK: 10 })).not.toThrow();
+    expect(() => tool.inputSchema?.parse({})).toThrow();
+  });
+
+  describe('runtimeContext', () => {
+    it('throws if indexName or vectorStoreName missing', async () => {
+      const runtimeContext = new RuntimeContext();
+      runtimeContext.set('vectorStoreName', 'testStore');
+
+      const tool = createGraphRAGTool({ id: 'test', model: mockModel, useRuntimeContext: true });
+      await expect(
+        tool.execute({
+          context: { queryText: 'foo' },
+          mastra: mockMastra as any,
+          runtimeContext,
+        }),
+      ).rejects.toThrow('indexName is required');
+      const runtimeContext2 = new RuntimeContext();
+      runtimeContext2.set('indexName', 'testIndex');
+      await expect(
+        tool.execute({
+          context: { queryText: 'foo' },
+          mastra: mockMastra as any,
+          runtimeContext: runtimeContext2,
+        }),
+      ).rejects.toThrow('vectorStoreName is required');
+    });
+
+    it('calls vectorQuerySearch and GraphRAG with runtimeContext params', async () => {
+      const tool = createGraphRAGTool({ id: 'test', model: mockModel, useRuntimeContext: true });
+      const runtimeContext = new RuntimeContext();
+      runtimeContext.set('indexName', 'testIndex');
+      runtimeContext.set('vectorStoreName', 'testStore');
+      runtimeContext.set('topK', 2);
+      runtimeContext.set('filter', { foo: 'bar' });
+      runtimeContext.set('randomWalkSteps', 99);
+      runtimeContext.set('restartProb', 0.42);
+      const result = await tool.execute({
+        context: { queryText: 'foo' },
+        mastra: mockMastra as any,
+        runtimeContext,
+      });
+      expect(result.relevantContext).toEqual(['foo', 'bar']);
+      expect(result.sources.length).toBe(2);
+      expect(vectorQuerySearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexName: 'testIndex',
+          vectorStore: expect.anything(),
+          queryText: 'foo',
+          model: mockModel,
+          queryFilter: { foo: 'bar' },
+          topK: 2,
+          includeVectors: true,
+        }),
+      );
+      // GraphRAG createGraph and query should be called
+      expect(GraphRAG).toHaveBeenCalled();
+      const instance = (GraphRAG as any).mock.results[0].value;
+      expect(instance.createGraph).toHaveBeenCalled();
+      expect(instance.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: [1, 2, 3],
+          topK: 2,
+          randomWalkSteps: 99,
+          restartProb: 0.42,
+        }),
+      );
+    });
+  });
+});

--- a/packages/rag/src/tools/graph-rag.ts
+++ b/packages/rag/src/tools/graph-rag.ts
@@ -14,23 +14,17 @@ import {
 import type { RagTool } from '../utils';
 import { convertToSources } from '../utils/convert-sources';
 import type { GraphRagToolOptions } from './types';
+import { defaultGraphOptions } from './types';
 
 export const createGraphRAGTool = (options: GraphRagToolOptions) => {
-  const {
-    model,
-    graphOptions = {
-      dimension: 1536,
-      randomWalkSteps: 100,
-      restartProb: 0.15,
-      threshold: 0.7,
-    },
-    id,
-    description,
-    useRuntimeContext,
-  } = options;
+  const { model, id, description, useRuntimeContext } = options;
 
   const toolId = id || `GraphRAG Tool`;
   const toolDescription = description || defaultGraphRagDescription();
+  const graphOptions = {
+    ...defaultGraphOptions,
+    ...(options.graphOptions || {}),
+  };
   // Initialize GraphRAG
   const graphRag = new GraphRAG(graphOptions.dimension, graphOptions.threshold);
   let isInitialized = false;
@@ -59,7 +53,7 @@ export const createGraphRAGTool = (options: GraphRagToolOptions) => {
         indexName,
         vectorStoreName,
         enableFilter,
-      } = getToolParams({ runtimeContext, context, options });
+      } = getToolParams({ runtimeContext, context, options: { ...options, graphOptions } });
       if (!indexName) {
         throw new Error('indexName is required');
       }

--- a/packages/rag/src/tools/graph-rag.ts
+++ b/packages/rag/src/tools/graph-rag.ts
@@ -54,12 +54,8 @@ export const createGraphRAGTool = (options: GraphRagToolOptions) => {
         vectorStoreName,
         enableFilter,
       } = getToolParams({ runtimeContext, context, options: { ...options, graphOptions } });
-      if (!indexName) {
-        throw new Error('indexName is required');
-      }
-      if (!vectorStoreName) {
-        throw new Error('vectorStoreName is required');
-      }
+      if (!indexName) throw new Error(`indexName is required, got: ${indexName}`);
+      if (!vectorStoreName) throw new Error(`vectorStoreName is required, got: ${vectorStoreName}`);
       const logger = mastra?.getLogger();
       if (!logger) {
         console.warn(
@@ -214,7 +210,7 @@ function getToolParams({
       includeSources,
       randomWalkSteps,
       restartProb,
-      enableFilter: !!filter,
+      enableFilter: Object.keys(filter || {}).length > 0,
     };
   }
 }

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -11,7 +11,7 @@ export type VectorQueryToolOptions =
   | {
       id?: string;
       description?: string;
-      useRuntimeContext?: false; // default is false if not provided
+      useRuntimeContext?: false;
       indexName: string;
       vectorStoreName: string;
       model: EmbeddingModel<string>;
@@ -37,7 +37,7 @@ export type GraphRagToolOptions =
   | {
       id?: string;
       description?: string;
-      useRuntimeContext?: false; // default is false if not provided
+      useRuntimeContext?: false;
       indexName: string;
       vectorStoreName: string;
       model: EmbeddingModel<string>;

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -1,55 +1,33 @@
 import type { EmbeddingModel } from 'ai';
 import type { RerankConfig } from '../rerank';
 
-export type VectorQueryToolOptions =
-  | {
-      id?: string;
-      description?: string;
-      useRuntimeContext: true;
-      model: EmbeddingModel<string>;
-    }
-  | {
-      id?: string;
-      description?: string;
-      useRuntimeContext?: false;
-      indexName: string;
-      vectorStoreName: string;
-      model: EmbeddingModel<string>;
-      enableFilter?: boolean;
-      includeVectors?: boolean;
-      includeSources?: boolean;
-      reranker?: RerankConfig;
-    };
+export type VectorQueryToolOptions = {
+  id?: string;
+  description?: string;
+  indexName: string;
+  vectorStoreName: string;
+  model: EmbeddingModel<string>;
+  enableFilter?: boolean;
+  includeVectors?: boolean;
+  includeSources?: boolean;
+  reranker?: RerankConfig;
+};
 
-export type GraphRagToolOptions =
-  | {
-      id?: string;
-      description?: string;
-      useRuntimeContext: true;
-      model: EmbeddingModel<string>;
-      graphOptions?: {
-        dimension?: number;
-        randomWalkSteps?: number;
-        restartProb?: number;
-        threshold?: number;
-      };
-    }
-  | {
-      id?: string;
-      description?: string;
-      useRuntimeContext?: false;
-      indexName: string;
-      vectorStoreName: string;
-      model: EmbeddingModel<string>;
-      enableFilter?: boolean;
-      includeSources?: boolean;
-      graphOptions?: {
-        dimension?: number;
-        randomWalkSteps?: number;
-        restartProb?: number;
-        threshold?: number;
-      };
-    };
+export type GraphRagToolOptions = {
+  id?: string;
+  description?: string;
+  indexName: string;
+  vectorStoreName: string;
+  model: EmbeddingModel<string>;
+  enableFilter?: boolean;
+  includeSources?: boolean;
+  graphOptions?: {
+    dimension?: number;
+    randomWalkSteps?: number;
+    restartProb?: number;
+    threshold?: number;
+  };
+};
 
 export const defaultGraphOptions = {
   dimension: 1536,

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -29,6 +29,18 @@ export type GraphRagToolOptions = {
   };
 };
 
+/**
+ * Default options for GraphRAG
+ * @default
+ * ```json
+ * {
+ *   "dimension": 1536,
+ *   "randomWalkSteps": 100,
+ *   "restartProb": 0.15,
+ *   "threshold": 0.7
+ * }
+ * ```
+ */
 export const defaultGraphOptions = {
   dimension: 1536,
   randomWalkSteps: 100,

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -3,30 +3,30 @@ import type { RerankConfig } from '../rerank';
 
 export type VectorQueryToolOptions =
   | {
-      useRuntimeContext: true;
-      model: EmbeddingModel<string>;
       id?: string;
       description?: string;
+      useRuntimeContext: true;
+      model: EmbeddingModel<string>;
     }
   | {
+      id?: string;
+      description?: string;
       useRuntimeContext?: false; // default is false if not provided
+      indexName: string;
+      vectorStoreName: string;
       model: EmbeddingModel<string>;
       enableFilter?: boolean;
       includeVectors?: boolean;
       includeSources?: boolean;
       reranker?: RerankConfig;
-      id?: string;
-      description?: string;
-      vectorStoreName: string;
-      indexName: string;
     };
 
 export type GraphRagToolOptions =
   | {
-      useRuntimeContext: true;
-      model: EmbeddingModel<string>;
       id?: string;
       description?: string;
+      useRuntimeContext: true;
+      model: EmbeddingModel<string>;
       graphOptions?: {
         dimension?: number;
         randomWalkSteps?: number;
@@ -35,9 +35,11 @@ export type GraphRagToolOptions =
       };
     }
   | {
+      id?: string;
+      description?: string;
       useRuntimeContext?: false; // default is false if not provided
-      vectorStoreName: string;
       indexName: string;
+      vectorStoreName: string;
       model: EmbeddingModel<string>;
       enableFilter?: boolean;
       includeSources?: boolean;
@@ -47,6 +49,11 @@ export type GraphRagToolOptions =
         restartProb?: number;
         threshold?: number;
       };
-      id?: string;
-      description?: string;
     };
+
+export const defaultGraphOptions = {
+  dimension: 1536,
+  randomWalkSteps: 100,
+  restartProb: 0.15,
+  threshold: 0.7,
+};

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -1,0 +1,52 @@
+import type { EmbeddingModel } from 'ai';
+import type { RerankConfig } from '../rerank';
+
+export type VectorQueryToolOptions =
+  | {
+      useRuntimeContext: true;
+      model: EmbeddingModel<string>;
+      id?: string;
+      description?: string;
+    }
+  | {
+      useRuntimeContext?: false; // default is false if not provided
+      model: EmbeddingModel<string>;
+      enableFilter?: boolean;
+      includeVectors?: boolean;
+      includeSources?: boolean;
+      reranker?: RerankConfig;
+      id?: string;
+      description?: string;
+      vectorStoreName: string;
+      indexName: string;
+    };
+
+export type GraphRagToolOptions =
+  | {
+      useRuntimeContext: true;
+      model: EmbeddingModel<string>;
+      id?: string;
+      description?: string;
+      graphOptions?: {
+        dimension?: number;
+        randomWalkSteps?: number;
+        restartProb?: number;
+        threshold?: number;
+      };
+    }
+  | {
+      useRuntimeContext?: false; // default is false if not provided
+      vectorStoreName: string;
+      indexName: string;
+      model: EmbeddingModel<string>;
+      enableFilter?: boolean;
+      includeSources?: boolean;
+      graphOptions?: {
+        dimension?: number;
+        randomWalkSteps?: number;
+        restartProb?: number;
+        threshold?: number;
+      };
+      id?: string;
+      description?: string;
+    };

--- a/packages/rag/src/tools/vector-query.test.ts
+++ b/packages/rag/src/tools/vector-query.test.ts
@@ -168,6 +168,8 @@ describe('createVectorQueryTool', () => {
 
   describe('execute function', () => {
     it('should not process filter when enableFilter is false', async () => {
+      const runtimeContext = new RuntimeContext();
+
       // Create tool with enableFilter set to false
       const tool = createVectorQueryTool({
         vectorStoreName: 'testStore',
@@ -183,7 +185,7 @@ describe('createVectorQueryTool', () => {
           topK: 5,
         },
         mastra: mockMastra as any,
-        runtimeContext: {} as any,
+        runtimeContext,
       });
 
       // Check that vectorQuerySearch was called with undefined queryFilter
@@ -195,6 +197,7 @@ describe('createVectorQueryTool', () => {
     });
 
     it('should process filter when enableFilter is true and filter is provided', async () => {
+      const runtimeContext = new RuntimeContext();
       // Create tool with enableFilter set to true
       const tool = createVectorQueryTool({
         vectorStoreName: 'testStore',
@@ -213,7 +216,7 @@ describe('createVectorQueryTool', () => {
           filter: filterJson,
         },
         mastra: mockMastra as any,
-        runtimeContext: {} as any,
+        runtimeContext,
       });
 
       // Check that vectorQuerySearch was called with the parsed filter
@@ -225,6 +228,7 @@ describe('createVectorQueryTool', () => {
     });
 
     it('should handle string filters correctly', async () => {
+      const runtimeContext = new RuntimeContext();
       // Create tool with enableFilter set to true
       const tool = createVectorQueryTool({
         vectorStoreName: 'testStore',
@@ -243,7 +247,7 @@ describe('createVectorQueryTool', () => {
           filter: stringFilter,
         },
         mastra: mockMastra as any,
-        runtimeContext: {} as any,
+        runtimeContext,
       });
 
       // Since this is not a valid filter, it should be ignored
@@ -256,30 +260,13 @@ describe('createVectorQueryTool', () => {
   });
 
   describe('runtimeContext', () => {
-    it('throws if indexName or vectorStoreName missing', async () => {
-      const tool = createVectorQueryTool({ id: 'test', model: mockModel, useRuntimeContext: true });
-      const runtimeContext = new RuntimeContext();
-      runtimeContext.set('vectorStoreName', 'testStore');
-      await expect(
-        tool.execute({
-          context: { queryText: 'foo' },
-          mastra: mockMastra as any,
-          runtimeContext,
-        }),
-      ).rejects.toThrow('indexName is required');
-      const runtimeContext2 = new RuntimeContext();
-      runtimeContext2.set('indexName', 'testIndex');
-      await expect(
-        tool.execute({
-          context: { queryText: 'foo' },
-          mastra: mockMastra as any,
-          runtimeContext: runtimeContext2,
-        }),
-      ).rejects.toThrow('vectorStoreName is required');
-    });
-
     it('calls vectorQuerySearch with runtimeContext params', async () => {
-      const tool = createVectorQueryTool({ id: 'test', model: mockModel, useRuntimeContext: true });
+      const tool = createVectorQueryTool({
+        id: 'test',
+        model: mockModel,
+        indexName: 'testIndex',
+        vectorStoreName: 'testStore',
+      });
       const runtimeContext = new RuntimeContext();
       runtimeContext.set('indexName', 'testIndex');
       runtimeContext.set('vectorStoreName', 'testStore');
@@ -288,7 +275,7 @@ describe('createVectorQueryTool', () => {
       runtimeContext.set('includeVectors', true);
       runtimeContext.set('includeSources', false);
       const result = await tool.execute({
-        context: { queryText: 'foo' },
+        context: { queryText: 'foo', topK: 3 },
         mastra: mockMastra as any,
         runtimeContext,
       });
@@ -308,7 +295,12 @@ describe('createVectorQueryTool', () => {
     });
 
     it('handles reranker from runtimeContext', async () => {
-      const tool = createVectorQueryTool({ id: 'test', model: mockModel, useRuntimeContext: true });
+      const tool = createVectorQueryTool({
+        id: 'test',
+        model: mockModel,
+        indexName: 'testIndex',
+        vectorStoreName: 'testStore',
+      });
       const runtimeContext = new RuntimeContext();
       runtimeContext.set('indexName', 'testIndex');
       runtimeContext.set('vectorStoreName', 'testStore');
@@ -322,7 +314,7 @@ describe('createVectorQueryTool', () => {
         },
       ]);
       const result = await tool.execute({
-        context: { queryText: 'foo' },
+        context: { queryText: 'foo', topK: 1 },
         mastra: mockMastra as any,
         runtimeContext,
       });

--- a/packages/rag/src/tools/vector-query.test.ts
+++ b/packages/rag/src/tools/vector-query.test.ts
@@ -31,9 +31,12 @@ describe('createVectorQueryTool', () => {
       testStore: {
         // Mock vector store methods
       },
+      anotherStore: {
+        // Mock vector store methods
+      },
     },
-    getVector: vi.fn(() => ({
-      testStore: {
+    getVector: vi.fn(storeName => ({
+      [storeName]: {
         // Mock vector store methods
       },
     })),
@@ -268,14 +271,14 @@ describe('createVectorQueryTool', () => {
         vectorStoreName: 'testStore',
       });
       const runtimeContext = new RuntimeContext();
-      runtimeContext.set('indexName', 'testIndex');
-      runtimeContext.set('vectorStoreName', 'testStore');
+      runtimeContext.set('indexName', 'anotherIndex');
+      runtimeContext.set('vectorStoreName', 'anotherStore');
       runtimeContext.set('topK', 3);
       runtimeContext.set('filter', { foo: 'bar' });
       runtimeContext.set('includeVectors', true);
       runtimeContext.set('includeSources', false);
       const result = await tool.execute({
-        context: { queryText: 'foo', topK: 3 },
+        context: { queryText: 'foo', topK: 6 },
         mastra: mockMastra as any,
         runtimeContext,
       });
@@ -283,8 +286,10 @@ describe('createVectorQueryTool', () => {
       expect(result.sources).toEqual([]); // includeSources false
       expect(vectorQuerySearch).toHaveBeenCalledWith(
         expect.objectContaining({
-          indexName: 'testIndex',
-          vectorStore: expect.anything(),
+          indexName: 'anotherIndex',
+          vectorStore: {
+            anotherStore: {},
+          },
           queryText: 'foo',
           model: mockModel,
           queryFilter: { foo: 'bar' },

--- a/packages/rag/src/tools/vector-query.ts
+++ b/packages/rag/src/tools/vector-query.ts
@@ -50,8 +50,8 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
         context,
         options,
       });
-      if (!indexName) throw new Error('indexName is required');
-      if (!vectorStoreName) throw new Error('vectorStoreName is required');
+      if (!indexName) throw new Error(`indexName is required, got: ${indexName}`);
+      if (!vectorStoreName) throw new Error(`vectorStoreName is required, got: ${vectorStoreName}`);
 
       const logger = mastra?.getLogger();
       if (!logger) {
@@ -195,7 +195,7 @@ function getToolParams({
       includeVectors,
       includeSources,
       reranker,
-      enableFilter: !!filter,
+      enableFilter: Object.keys(filter || {}).length > 0,
     };
   }
 }

--- a/packages/rag/src/tools/vector-query.ts
+++ b/packages/rag/src/tools/vector-query.ts
@@ -1,43 +1,58 @@
+import type { RuntimeContext } from '@mastra/core/runtime-context';
 import { createTool } from '@mastra/core/tools';
-import type { EmbeddingModel } from 'ai';
 import { z } from 'zod';
 
 import { rerank } from '../rerank';
 import type { RerankConfig } from '../rerank';
-import { vectorQuerySearch, defaultVectorQueryDescription, filterSchema, outputSchema, baseSchema } from '../utils';
+import {
+  vectorQuerySearch,
+  defaultVectorQueryDescription,
+  filterSchema,
+  outputSchema,
+  baseSchema,
+  queryTextDescription,
+} from '../utils';
 import type { RagTool } from '../utils';
 import { convertToSources } from '../utils/convert-sources';
+import type { VectorQueryToolOptions } from './types';
 
-export const createVectorQueryTool = ({
-  vectorStoreName,
-  indexName,
-  model,
-  enableFilter = false,
-  includeVectors = false,
-  includeSources = true,
-  reranker,
-  id,
-  description,
-}: {
-  vectorStoreName: string;
-  indexName: string;
-  model: EmbeddingModel<string>;
-  enableFilter?: boolean;
-  includeVectors?: boolean;
-  includeSources?: boolean;
-  reranker?: RerankConfig;
-  id?: string;
-  description?: string;
-}) => {
-  const toolId = id || `VectorQuery ${vectorStoreName} ${indexName} Tool`;
+export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
+  const { model, id, description, useRuntimeContext } = options;
+  const toolId = id || `VectorQuery Tool`;
   const toolDescription = description || defaultVectorQueryDescription();
-  const inputSchema = enableFilter ? filterSchema : z.object(baseSchema).passthrough();
+  let inputSchema;
+  if (!useRuntimeContext) {
+    inputSchema = options.enableFilter ? filterSchema : z.object(baseSchema).passthrough();
+  } else {
+    inputSchema = z.object({
+      queryText: z.string().describe(queryTextDescription),
+    });
+  }
+
   return createTool({
     id: toolId,
+    description: toolDescription,
     inputSchema,
     outputSchema,
-    description: toolDescription,
-    execute: async ({ context: { queryText, topK, filter }, mastra }) => {
+    execute: async ({ context, mastra, runtimeContext }) => {
+      const {
+        indexName,
+        vectorStoreName,
+        queryText,
+        topK,
+        filter,
+        includeVectors,
+        includeSources,
+        reranker,
+        enableFilter,
+      } = getToolParams({
+        runtimeContext,
+        context,
+        options,
+      });
+      if (!indexName) throw new Error('indexName is required');
+      if (!vectorStoreName) throw new Error('vectorStoreName is required');
+
       const logger = mastra?.getLogger();
       if (!logger) {
         console.warn(
@@ -137,3 +152,50 @@ export const createVectorQueryTool = ({
     // Use any for output schema as the structure of the output causes type inference issues
   }) as RagTool<typeof inputSchema, any>;
 };
+
+function getToolParams({
+  runtimeContext,
+  context,
+  options,
+}: {
+  runtimeContext: RuntimeContext;
+  context: any;
+  options: VectorQueryToolOptions;
+}) {
+  if (!options.useRuntimeContext) {
+    const { queryText, topK, filter } = context;
+    // Use static config for store/index, etc.
+    return {
+      indexName: options.indexName,
+      vectorStoreName: options.vectorStoreName,
+      queryText,
+      topK,
+      filter,
+      includeVectors: options.includeVectors,
+      includeSources: options.includeSources,
+      reranker: options.reranker,
+      enableFilter: options.enableFilter,
+    };
+  } else {
+    // Get params from runtimeContext
+    const { queryText } = context;
+    const indexName: string = runtimeContext.get('indexName');
+    const vectorStoreName: string = runtimeContext.get('vectorStoreName');
+    const topK: number = runtimeContext.get('topK') ?? 10;
+    const filter: Record<string, any> = runtimeContext.get('filter') ?? {};
+    const includeVectors: boolean = runtimeContext.get('includeVectors') ?? false;
+    const includeSources: boolean = runtimeContext.get('includeSources') ?? true;
+    const reranker: RerankConfig = runtimeContext.get('reranker');
+    return {
+      indexName,
+      vectorStoreName,
+      queryText,
+      topK,
+      filter,
+      includeVectors,
+      includeSources,
+      reranker,
+      enableFilter: !!filter,
+    };
+  }
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR adds an optional field to all for the use of runtime context for the vector-query tool and graph-rag tool. When used, users can inject the indexName, vectorStoreName, topK, filter and other parameters into the tool when using the agent. This allows users to specify their own values for these fields without needing to create different tools or modify their prompts.
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
