### PR TITLE
Fix: fix branching doc with correct input data

### DIFF
--- a/docs/src/content/en/docs/workflows/flow-control.mdx
+++ b/docs/src/content/en/docs/workflows/flow-control.mdx
@@ -58,7 +58,7 @@ myWorkflow
     [async ({ inputData }) => inputData.value > 50, highValueStep],
     // If value is between 11 and 50, run lowValueStep
     [
-      async ({ inputData }) => inputData.value > 10 && inputData.value <= 50,
+      async ({ inputData }) => inputData.value > 4 && inputData.value <= 50,
       lowValueStep,
     ],
     // If value <= 10, run extremelyLowValueStep

--- a/docs/src/content/en/docs/workflows/flow-control.mdx
+++ b/docs/src/content/en/docs/workflows/flow-control.mdx
@@ -56,7 +56,7 @@ myWorkflow
   .branch([
     // If value > 50, run highValueStep
     [async ({ inputData }) => inputData.value > 50, highValueStep],
-    // If value is between 11 and 50, run lowValueStep
+    // If value is between 4 and 50, run lowValueStep
     [
       async ({ inputData }) => inputData.value > 4 && inputData.value <= 50,
       lowValueStep,


### PR DESCRIPTION
## Description

Fix the input data value because if the second branch condition need to > than 10, only `extremelyLowValueStep` will be ran. Based on what the doc's purpose, we want an example that both conditions met