### PR TITLE
[docs] remove mention of evaluating tools in evals

### DIFF
--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -17,8 +17,7 @@ There are different kinds of evals, each serving a specific purpose. Here are so
 
 1. **Textual Evals**: Evaluate accuracy, reliability, and context understanding of agent responses
 2. **Classification Evals**: Measure accuracy in categorizing data based on predefined categories
-3. **Tool Usage Evals**: Assess how effectively an agent uses external tools or APIs
-4. **Prompt Engineering Evals**: Explore impact of different instructions and input formats
+3. **Prompt Engineering Evals**: Explore impact of different instructions and input formats
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

I don't see an example of how to get reference to tool calls in a Metric or MastraAgentJudge or EvaluationResult.
And in [this](https://discord.com/channels/1309558646228779139/1362166435799105626/1362166435799105626) discord message it seems verified this is not supported.
So I think it's best to remove the mention of "Assess how effectively an agent uses external tools or APIs" in the Eval docs (for the time-being at least)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
