### PR TITLE
docs: update cli references and getting started

### DIFF
--- a/docs/src/content/en/docs/getting-started/installation.mdx
+++ b/docs/src/content/en/docs/getting-started/installation.mdx
@@ -53,18 +53,18 @@ To create a project, run:
 <Tabs items={["npx", "npm", "yarn", "pnpm", "bun"]}>
 
   <Tabs.Tab>
-  ```bash copy 
-npx create-mastra@latest 
+  ```bash copy
+npx create-mastra@latest
   ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-npm create mastra@latest 
+npm create mastra@latest
    ```
    </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-yarn create mastra@latest 
+yarn create mastra@latest
    ```
    </Tabs.Tab>
   <Tabs.Tab>
@@ -79,24 +79,6 @@ bun create mastra@latest
   </Tabs.Tab>
 </Tabs>
 
-On installation, you'll be guided through the following prompts:
-
-```bash
-What do you want to name your project? my-mastra-app
-Choose components to install:
-  ◯ Agents (recommended)
-  ◯ Tools
-  ◯ Workflows
-Select default provider:
-  ◯ OpenAI (recommended)
-  ◯ Anthropic
-  ◯ Groq
-Would you like to include example code? No / Yes
-Turn your IDE into a Mastra expert? (Installs MCP server)
-  ◯ Skip for now
-  ◯ Cursor
-  ◯ Windsurf
-```
 
 After the prompts, `create-mastra` will:
 
@@ -109,40 +91,14 @@ After the prompts, `create-mastra` will:
 
 #### Non-Interactive
 
-You can run the Mastra CLI in fully non-interactive mode by passing all required flags. Start with:
+You can run the Mastra CLI in fully non-interactive mode by passing all required flags, for example:
 
-```bash copy
-npx create-mastra@latest
-```
-
-**Required Flags**
-
-| Short | Long            | Description                                                             |
-| ----- | --------------- | ----------------------------------------------------------------------- |
-| `-d`  | `--dir`         | Directory for Mastra files (defaults to `src/mastra`)                   |
-| `-c`  | `--components`  | Comma-separated list of components (`agents`, `tools`, `workflows`)     |
-| `-l`  | `--llm`         | Model provider (`openai`, `anthropic`, `groq`, `google`, or `cerebras`) |
-| `-k`  | `--llm-api-key` | API key for the selected LLM provider (added to `.env` file)            |
-| `-e`  | `--example`     | Include example code                                                    |
-| `-ne` | `--no-example`  | Skip example code                                                       |
-
-**Optional Flags**
-
-| Short | Long             | Description                                           |
-| ----- | ---------------- | ----------------------------------------------------- |
-| `-m`  | `--mcp`          | IDE (`windsurf`, `cursor`, `cursor-global`, `vscode`) |
-| `-p`  | `--project-name` | Project name                                          |
-| `-d`  | `--dir`          | Target directory for generated code (default: `src/`) |
-| `-t`  | `--timeout`      | Set timeout in milliseconds for installation steps    |
-| `-h`  | `--help`         | Display available flags                               |
-
-**Example One-Liner**
 
 ```bash copy
 npx create-mastra@latest --project-name hello-mastra --example --components tools,agents,workflows --llm openai
 ```
 
-> Providing all required flags lets the CLI run without any prompts.
+> See the [mastra init](/reference/cli/init) documentation for a full list of available CLI options.
 
 ### Set Up your API Key
 

--- a/docs/src/content/en/reference/cli/_meta.ts
+++ b/docs/src/content/en/reference/cli/_meta.ts
@@ -1,4 +1,5 @@
 const meta = {
+  "create-mastra": "create-mastra",
   init: "mastra init",
   dev: "mastra dev",
   build: "mastra build",

--- a/docs/src/content/en/reference/cli/build.mdx
+++ b/docs/src/content/en/reference/cli/build.mdx
@@ -21,19 +21,19 @@ mastra build [options]
       name: "--dir",
       type: "string",
       description: "Path to your Mastra Folder",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--root",
       type: "string",
       description: "Path to your root folder",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--tools",
       type: "string",
       description: "Comma-separated list of paths to tool files to include",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--help",
@@ -43,7 +43,6 @@ mastra build [options]
     },
   ]}
 />
-
 
 ## Advanced usage
 

--- a/docs/src/content/en/reference/cli/build.mdx
+++ b/docs/src/content/en/reference/cli/build.mdx
@@ -1,9 +1,11 @@
 ---
-title: "mastra build"
+title: "mastra build | Production Bundle | Mastra CLI"
 description: "Build your Mastra project for production deployment"
 ---
 
-The `mastra build` command bundles your Mastra project into a production-ready Hono server. Hono is a lightweight web framework that provides type-safe routing and middleware support, making it ideal for deploying Mastra agents as HTTP endpoints.
+# mastra build
+
+The `mastra build` command bundles your Mastra project into a production-ready Hono server. Hono is a lightweight, type-safe web framework that makes it easy to deploy Mastra agents as HTTP endpoints with middleware support.
 
 ## Usage
 
@@ -13,7 +15,35 @@ mastra build [options]
 
 ## Options
 
-- `--dir <path>`: Directory containing your Mastra project (default: current directory)
+<PropertiesTable
+  content={[
+    {
+      name: "--dir",
+      type: "string",
+      description: "Path to your Mastra Folder",
+      isOptional: false,
+    },
+    {
+      name: "--root",
+      type: "string",
+      description: "Path to your root folder",
+      isOptional: false,
+    },
+    {
+      name: "--tools",
+      type: "string",
+      description: "Comma-separated list of paths to tool files to include",
+      isOptional: false,
+    },
+    {
+      name: "--help",
+      type: "boolean",
+      description: "display help for command",
+      isOptional: true,
+    },
+  ]}
+/>
+
 
 ## Advanced usage
 
@@ -22,7 +52,7 @@ mastra build [options]
 For CI or when running in resource constrained environments you can cap
 how many expensive tasks run at once by setting `MASTRA_CONCURRENCY`.
 
-```bash
+```bash copy
 MASTRA_CONCURRENCY=2 mastra build
 ```
 
@@ -32,7 +62,7 @@ Unset it to allow the CLI to base concurrency on the host capabilities.
 
 To opt out of anonymous build analytics set:
 
-```bash
+```bash copy
 MASTRA_TELEMETRY_DISABLED=1 mastra build
 ```
 
@@ -53,7 +83,7 @@ any workflows or tools that call the providers.
 
 ## Example
 
-```bash
+```bash copy
 # Build from current directory
 mastra build
 

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -13,6 +13,12 @@ The `create-mastra` command **creates** a new standalone Mastra project. Use thi
 create-mastra [options]
 ```
 
+## Example
+
+```bash copy
+npx create-mastra@latest --project-name hello-mastra --example --components tools,agents,workflows --llm openai
+```
+
 ## Options
 
 Accepts the same options as [mastra init](/reference/cli/init/).

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -13,12 +13,82 @@ The `create-mastra` command **creates** a new standalone Mastra project. Use thi
 create-mastra [options]
 ```
 
-## Example
-
-```bash copy
-npx create-mastra@latest --project-name hello-mastra --example --components tools,agents,workflows --llm openai
-```
-
 ## Options
 
-Accepts the same options as [mastra init](/reference/cli/init/).
+<PropertiesTable
+  content={[
+    {
+      name: "--version",
+      type: "boolean",
+      description: "Output the version number",
+      isOptional: true,
+    },
+    {
+      name: "--project-name",
+      type: "string",
+      description: "Project name that will be used in package.json and as the project directory name",
+      isOptional: true,
+    },
+    {
+      name: "--default",
+      type: "boolean",
+      description: "Quick start with defaults(src, OpenAI, no examples)",
+      isOptional: true,
+    },
+    {
+      name: "--components",
+      type: "string",
+      description: "Comma-separated list of components (agents, tools, workflows)",
+      isOptional: true,
+    },
+    {
+      name: "--llm",
+      type: "string",
+      description: "Default model provider (openai, anthropic, groq, google, or cerebras)",
+      isOptional: true,
+    },
+    {
+      name: "--llm-api-key",
+      type: "string",
+      description: "API key for the model provider",
+      isOptional: true,
+    },
+    {
+      name: "--example",
+      type: "boolean",
+      description: "Include example code",
+      isOptional: true,
+    },
+    {
+      name: "--no-example",
+      type: "boolean",
+      description: "Do not include example code",
+      isOptional: true,
+    },
+    {
+      name: "--timeout",
+      type: "number",
+      description: "Configurable timeout for package installation, defaults to 60000 ms",
+      isOptional: true,
+    },
+    {
+      name: "--dir",
+      type: "string",
+      description: "Target directory for Mastra source code (default: src/)",
+      isOptional: true,
+    },
+    {
+      name: "--mcp",
+      type: "string",
+      description: "MCP Server for code editor (cursor, cursor-global, windsurf, vscode)",
+      isOptional: true,
+    },
+    {
+      name: "--help",
+      type: "boolean",
+      description: "Display help for command",
+      isOptional: true,
+    },
+  ]}
+/>
+

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -1,0 +1,18 @@
+---
+title: "create-mastra | Create Project | Mastra CLI"
+description: Documentation for the create-mastra command, which creates a new Mastra project with interactive setup options.
+---
+
+# create-mastra
+
+The `create-mastra` command **creates** a new standalone Mastra project. Use this command to scaffold a complete Mastra setup in a dedicated directory.
+
+## Usage
+
+```bash
+create-mastra [options]
+```
+
+## Options
+
+Accepts the same options as [mastra init](/reference/cli/init/).

--- a/docs/src/content/en/reference/cli/dev.mdx
+++ b/docs/src/content/en/reference/cli/dev.mdx
@@ -21,19 +21,19 @@ mastra dev [options]
       name: "--dir",
       type: "string",
       description: "Path to your mastra folder",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--root",
       type: "string",
       description: "Path to your root folder",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--tools",
       type: "string",
       description: "Comma-separated list of paths to tool files to include",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--port",
@@ -49,6 +49,7 @@ mastra dev [options]
     },
   ]}
 />
+
 
 ## Routes
 
@@ -190,7 +191,7 @@ requests through proxies or internal gateways by setting a base URL. For
 OpenAI:
 
 ```bash copy
-OPENAI_API_KEY=sk-this_key \
+OPENAI_API_KEY=<your-api-key> \
 OPENAI_BASE_URL=https://openrouter.example/v1 \
 mastra dev
 ```
@@ -198,7 +199,7 @@ mastra dev
 and for Anthropic:
 
 ```bash copy
-ANTHROPIC_API_KEY=sk-anthropic42 \
+OPENAI_API_KEY=<your-api-key> \
 ANTHROPIC_BASE_URL=https://anthropic.internal \
 mastra dev
 ```

--- a/docs/src/content/en/reference/cli/dev.mdx
+++ b/docs/src/content/en/reference/cli/dev.mdx
@@ -1,28 +1,50 @@
 ---
-title: "`mastra dev` Reference | Local Development | Mastra CLI"
+title: "mastra dev | Development Server | Mastra CLI"
 description: Documentation for the mastra dev command, which starts a development server for agents, tools, and workflows.
 ---
 
-# `mastra dev` Reference
+# mastra dev
 
-The `mastra dev` command starts a development server that exposes REST routes for your agents, tools, and workflows,
+The `mastra dev` command starts a development server that exposes REST endpoints for your agents, tools, and workflows.
 
-## Parameters
+## Usage
+
+```bash
+mastra dev [options]
+```
+
+## Options
 
 <PropertiesTable
   content={[
     {
       name: "--dir",
       type: "string",
-      description:
-        "Specifies the path to your Mastra folder (containing agents, tools, and workflows). Defaults to the current working directory.",
-      isOptional: true,
+      description: "Path to your mastra folder",
+      isOptional: false,
+    },
+    {
+      name: "--root",
+      type: "string",
+      description: "Path to your root folder",
+      isOptional: false,
     },
     {
       name: "--tools",
       type: "string",
-      description:
-        "Comma-separated paths to additional tool directories that should be registered. For example: 'src/tools/dbTools,src/tools/scraperTools'.",
+      description: "Comma-separated list of paths to tool files to include",
+      isOptional: false,
+    },
+    {
+      name: "--port",
+      type: "number",
+      description: "deprecated: Port number for the development server (defaults to 4111)",
+      isOptional: true,
+    },
+    {
+      name: "--help",
+      type: "boolean",
+      description: "display help for command",
       isOptional: true,
     },
   ]}
@@ -123,7 +145,7 @@ Make sure the `index.ts` file in your Mastra folder exports the Mastra instance 
 
 To test an agent after running `mastra dev`:
 
-```bash
+```bash copy
 curl -X POST http://localhost:4111/api/agents/myAgent/generate \
   -H "Content-Type: application/json" \
   -d '{
@@ -143,7 +165,7 @@ be handy during development:
 Set `MASTRA_DEV_NO_CACHE=1` to force a full rebuild rather than using
 the cached assets under `.mastra/`:
 
-```bash
+```bash copy
 MASTRA_DEV_NO_CACHE=1 mastra dev
 ```
 
@@ -155,7 +177,7 @@ output.
 `MASTRA_CONCURRENCY` caps how many expensive operations run in parallel
 (primarily build and evaluation steps). For example:
 
-```bash
+```bash copy
 MASTRA_CONCURRENCY=4 mastra dev
 ```
 
@@ -167,7 +189,7 @@ When using providers supported by the Vercel AI SDK you can redirect
 requests through proxies or internal gateways by setting a base URL. For
 OpenAI:
 
-```bash
+```bash copy
 OPENAI_API_KEY=sk-this_key \
 OPENAI_BASE_URL=https://openrouter.example/v1 \
 mastra dev
@@ -175,7 +197,7 @@ mastra dev
 
 and for Anthropic:
 
-```bash
+```bash copy
 ANTHROPIC_API_KEY=sk-anthropic42 \
 ANTHROPIC_BASE_URL=https://anthropic.internal \
 mastra dev
@@ -190,6 +212,6 @@ To opt out of anonymous CLI analytics set
 `MASTRA_TELEMETRY_DISABLED=1`. This also prevents tracking within the
 local playground.
 
-```bash
+```bash copy
 MASTRA_TELEMETRY_DISABLED=1 mastra dev
 ```

--- a/docs/src/content/en/reference/cli/init.mdx
+++ b/docs/src/content/en/reference/cli/init.mdx
@@ -13,12 +13,6 @@ The `mastra init` command **initializes** Mastra in an existing project. Use thi
 mastra init [options]
 ```
 
-## Example
-
-```bash copy
-npx mastra init --example --components tools,agents,workflows --llm openai
-```
-
 ## Options
 
 <PropertiesTable

--- a/docs/src/content/en/reference/cli/init.mdx
+++ b/docs/src/content/en/reference/cli/init.mdx
@@ -13,6 +13,11 @@ The `mastra init` command **initializes** Mastra in an existing project. Use thi
 mastra init [options]
 ```
 
+## Example
+
+```bash copy
+npx mastra init --example --components tools,agents,workflows --llm openai
+```
 
 ## Options
 
@@ -27,8 +32,8 @@ mastra init [options]
     {
       name: "--dir",
       type: "string",
-      description: "Directory for Mastra files to (defaults to src/)",
-      isOptional: true,
+      description: "Directory for Mastra files (defaults to src/)",
+      isOptional: false,
     },
     {
       name: "--components",
@@ -52,24 +57,24 @@ mastra init [options]
       name: "--example",
       type: "boolean",
       description: "Include example code",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--no-example",
       type: "boolean",
       description: "Do not include example code",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--mcp",
       type: "string",
       description: "MCP Server for code editor (cursor, cursor-global, windsurf, vscode)",
-      isOptional: true,
+      isOptional: false,
     },
     {
       name: "--help",
       type: "boolean",
-      description: "display help for command",
+      description: "Display help for command",
       isOptional: true,
     },
   ]}

--- a/docs/src/content/en/reference/cli/init.mdx
+++ b/docs/src/content/en/reference/cli/init.mdx
@@ -1,46 +1,79 @@
 ---
-title: "`mastra init` reference | Project Creation | Mastra CLI"
+title: "mastra init | Initialize Project | Mastra CLI"
 description: Documentation for the mastra init command, which creates a new Mastra project with interactive setup options.
 ---
 
-# `mastra init` Reference
+# mastra init
 
-## `mastra init`
+The `mastra init` command **initializes** Mastra in an existing project. Use this command to scaffold the necessary folders and configuration without generating a new project.
 
-This creates a new Mastra project. You can run it in three different ways:
+## Usage
 
-1. **Interactive Mode (Recommended)**
-   Run without flags to use the interactive prompt, which will guide you through:
+```bash
+mastra init [options]
+```
 
-   - Choosing a directory for Mastra files
-   - Selecting components to install (Agents, Tools, Workflows)
-   - Choosing a default LLM provider (OpenAI, Anthropic, or Groq)
-   - Deciding whether to include example code
 
-2. **Quick Start with Defaults**
+## Options
 
-   ```bash
-   mastra init --default
-   ```
-
-   This sets up a project with:
-
-   - Source directory: `src/`
-   - All components: agents, tools, workflows
-   - OpenAI as the default provider
-   - No example code
-
-3. **Custom Setup**
-   ```bash
-   mastra init --dir src/mastra --components agents,tools --llm openai --example
-   ```
-   Options:
-   - `-d, --dir`: Directory for Mastra files (defaults to src/mastra)
-   - `-c, --components`: Comma-separated list of components (agents, tools, workflows)
-   - `-l, --llm`: Default model provider (openai, anthropic, groq, google or cerebras)
-   - `-k, --llm-api-key`: API key for the selected LLM provider (will be added to .env file)
-   - `-e, --example`: Include example code
-   - `-ne, --no-example`: Skip example code
+<PropertiesTable
+  content={[
+    {
+      name: "--default",
+      type: "boolean",
+      description: "Quick start with defaults (src, OpenAI, no examples)",
+      isOptional: true,
+    },
+    {
+      name: "--dir",
+      type: "string",
+      description: "Directory for Mastra files to (defaults to src/)",
+      isOptional: true,
+    },
+    {
+      name: "--components",
+      type: "string",
+      description: "Comma-separated list of components (agents, tools, workflows)",
+      isOptional: false,
+    },
+    {
+      name: "--llm",
+      type: "string",
+      description: "Default model provider (openai, anthropic, groq, google or cerebras)",
+      isOptional: false,
+    },
+    {
+      name: "--llm-api-key",
+      type: "string",
+      description: "API key for the model provider",
+      isOptional: false,
+    },
+    {
+      name: "--example",
+      type: "boolean",
+      description: "Include example code",
+      isOptional: false,
+    },
+    {
+      name: "--no-example",
+      type: "boolean",
+      description: "Do not include example code",
+      isOptional: false,
+    },
+    {
+      name: "--mcp",
+      type: "string",
+      description: "MCP Server for code editor (cursor, cursor-global, windsurf, vscode)",
+      isOptional: true,
+    },
+    {
+      name: "--help",
+      type: "boolean",
+      description: "display help for command",
+      isOptional: true,
+    },
+  ]}
+/>
 
 ## Advanced usage
 
@@ -50,13 +83,13 @@ If you prefer not to send anonymous usage data then set the
 `MASTRA_TELEMETRY_DISABLED=1` environment variable when running the
 command:
 
-```bash
+```bash copy
 MASTRA_TELEMETRY_DISABLED=1 mastra init
 ```
 
 ### Custom provider endpoints
 
-Initialised projects respect the `OPENAI_BASE_URL` and
+Initialized projects respect the `OPENAI_BASE_URL` and
 `ANTHROPIC_BASE_URL` variables if present. This lets you route provider
 traffic through proxies or private gateways when starting the dev server
 later on.

--- a/docs/src/content/en/reference/cli/lint.mdx
+++ b/docs/src/content/en/reference/cli/lint.mdx
@@ -1,9 +1,11 @@
 ---
-title: "mastra lint"
+title: "mastra lint | Validate Project | Mastra CLI"
 description: "Lint your Mastra project"
 ---
 
-The `mastra lint` command validates your Mastra project structure and code.
+# mastra lint
+
+The `mastra lint` command validates the structure and code of your Mastra project to ensure it follows best practices and is error-free.
 
 ## Usage
 
@@ -13,11 +15,34 @@ mastra lint [options]
 
 ## Options
 
-| Option                    | Description                                            |
-| ------------------------- | ------------------------------------------------------ |
-| `-d, --dir <path>`        | Path to your Mastra folder                             |
-| `-r, --root <path>`       | Path to your root folder                               |
-| `-t, --tools <toolsDirs>` | Comma-separated list of paths to tool files to include |
+<PropertiesTable
+  content={[
+    {
+      name: "--dir",
+      type: "string",
+      description: "Path to your Mastra folder",
+      isOptional: false,
+    },
+    {
+      name: "--root",
+      type: "string",
+      description: "Path to your root folder",
+      isOptional: false,
+    },
+    {
+      name: "--tools",
+      type: "string",
+      description: "Comma-separated list of paths to tool files to include",
+      isOptional: false,
+    },
+    {
+      name: "--help",
+      type: "boolean",
+      description: "display help for command",
+      isOptional: true,
+    },
+  ]}
+/>
 
 ## Advanced usage
 
@@ -26,6 +51,6 @@ mastra lint [options]
 To disable CLI analytics while running linting (and other commands) set
 `MASTRA_TELEMETRY_DISABLED=1`:
 
-```bash
+```bash copy
 MASTRA_TELEMETRY_DISABLED=1 mastra lint
 ```

--- a/docs/src/content/en/reference/cli/lint.mdx
+++ b/docs/src/content/en/reference/cli/lint.mdx
@@ -21,19 +21,19 @@ mastra lint [options]
       name: "--dir",
       type: "string",
       description: "Path to your Mastra folder",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--root",
       type: "string",
       description: "Path to your root folder",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--tools",
       type: "string",
       description: "Comma-separated list of paths to tool files to include",
-      isOptional: false,
+      isOptional: true,
     },
     {
       name: "--help",


### PR DESCRIPTION
## Description

- Move CLI options from getting started guide to CLI mastra init page.
- Format all CLI options the same, using the same order and descriptions as the `--help` for each. 

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
