### PR TITLE
[MASTRA-3612] updated logging for non-existent paths

### DIFF
--- a/.changeset/social-teeth-ring.md
+++ b/.changeset/social-teeth-ring.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-docs-server': patch
+---
+
+Change logging for non existent paths when using mcp-docs-server

--- a/packages/mcp-docs-server/src/tools/__tests__/blog.test.ts
+++ b/packages/mcp-docs-server/src/tools/__tests__/blog.test.ts
@@ -26,7 +26,7 @@ describe('blog tool', () => {
 
   test('handles fetch errors gracefully', async () => {
     const result = await callTool(tools.mastra_mastraBlog, { url: '/blog/non-existent-post' });
-    expect(result).toBe('Error: Failed to fetch blog post');
+    expect(result).toContain('The requested blog post could not be found or fetched');
   });
 
   test('returns specific blog post content when URL is provided', async () => {

--- a/packages/mcp-docs-server/src/tools/__tests__/changes.test.ts
+++ b/packages/mcp-docs-server/src/tools/__tests__/changes.test.ts
@@ -133,7 +133,7 @@ describe('changesTool', () => {
 
       try {
         const result = await callTool(tools.mastra_mastraChanges, { package: '@mastra/test-empty' });
-        expect(result).toContain('Error: Changelog for "@mastra/test-empty" not found');
+        expect(result).toContain('Changelog for "@mastra/test-empty" not found');
       } finally {
         // Restore original function
         tools.mastra_mastraChanges.getChangelog = originalGetChangelog;
@@ -147,7 +147,7 @@ describe('changesTool', () => {
 
       try {
         const result = await callTool(tools.mastra_mastraChanges, { package: '@mastra/test-header-only' });
-        expect(result).toContain('Error: Changelog for "@mastra/test-header-only" not found');
+        expect(result).toContain('Changelog for "@mastra/test-header-only" not found');
       } finally {
         // Restore original function
         tools.mastra_mastraChanges.getChangelog = originalGetChangelog;

--- a/packages/mcp-docs-server/src/tools/blog.ts
+++ b/packages/mcp-docs-server/src/tools/blog.ts
@@ -44,7 +44,21 @@ async function fetchBlogPost(url: string): Promise<string> {
     if (response.status === 429) {
       throw new Error('Rate limit exceeded');
     }
-    throw new Error('Failed to fetch blog post');
+    let blogList: string;
+    try {
+      const blogPosts = await fetchBlogPosts();
+      void logger.warning(
+        `Blog post not found or failed to fetch: ${url}. Returning a list of available blog posts as fallback.`,
+      );
+      blogList = `Here are available blog posts:\n\n${blogPosts}`;
+    } catch (e) {
+      void logger.error(
+        `Blog post not found or failed to fetch: ${url}, and failed to fetch blog post listing as fallback.`,
+        e,
+      );
+      blogList = 'Additionally, the list of available blog posts could not be fetched at this time.';
+    }
+    return `The requested blog post could not be found or fetched: ${url}\n\n${blogList}`;
   }
   const html = await response.text();
 

--- a/packages/mcp-docs-server/src/tools/blog.ts
+++ b/packages/mcp-docs-server/src/tools/blog.ts
@@ -47,9 +47,6 @@ async function fetchBlogPost(url: string): Promise<string> {
     let blogList: string;
     try {
       const blogPosts = await fetchBlogPosts();
-      void logger.warning(
-        `Blog post not found or failed to fetch: ${url}. Returning a list of available blog posts as fallback.`,
-      );
       blogList = `Here are available blog posts:\n\n${blogPosts}`;
     } catch (e) {
       void logger.error(

--- a/packages/mcp-docs-server/src/tools/changes.ts
+++ b/packages/mcp-docs-server/src/tools/changes.ts
@@ -44,7 +44,6 @@ async function readPackageChangelog(filename: string): Promise<string> {
   } catch {
     const packages = await listPackageChangelogs();
     const availablePackages = packages.map(pkg => `- ${pkg.name}`).join('\n');
-    void logger.warning(`Changelog not found: ${filename}`);
     return `Changelog for "${filename.replace('.md', '')}" not found.\n\nAvailable packages:\n${availablePackages}`;
   }
 }

--- a/packages/mcp-docs-server/src/tools/changes.ts
+++ b/packages/mcp-docs-server/src/tools/changes.ts
@@ -44,9 +44,8 @@ async function readPackageChangelog(filename: string): Promise<string> {
   } catch {
     const packages = await listPackageChangelogs();
     const availablePackages = packages.map(pkg => `- ${pkg.name}`).join('\n');
-    throw new Error(
-      `Changelog for "${filename.replace('.md', '')}" not found.\n\nAvailable packages:\n${availablePackages}`,
-    );
+    void logger.warning(`Changelog not found: ${filename}`);
+    return `Changelog for "${filename.replace('.md', '')}" not found.\n\nAvailable packages:\n${availablePackages}`;
   }
 }
 

--- a/packages/mcp-docs-server/src/tools/examples.ts
+++ b/packages/mcp-docs-server/src/tools/examples.ts
@@ -33,7 +33,8 @@ async function readCodeExample(filename: string): Promise<string> {
   } catch {
     const examples = await listCodeExamples();
     const availableExamples = examples.map(ex => `- ${ex.name}`).join('\n');
-    throw new Error(`Example "${filename}" not found.\n\nAvailable examples:\n${availableExamples}`);
+    void logger.warning(`Example not found: ${filename}`);
+    return `Example "${filename}" not found.\n\nAvailable examples:\n${availableExamples}`;
   }
 }
 

--- a/packages/mcp-docs-server/src/tools/examples.ts
+++ b/packages/mcp-docs-server/src/tools/examples.ts
@@ -23,18 +23,21 @@ async function listCodeExamples(): Promise<Array<{ name: string; path: string }>
   }
 }
 
+type CodeExampleResult = { found: boolean; content: string };
+
 // Helper function to read a code example
-async function readCodeExample(filename: string): Promise<string> {
+async function readCodeExample(filename: string): Promise<CodeExampleResult> {
   const filePath = path.join(examplesDir, filename);
   void logger.debug(`Reading example: ${filename}`);
 
   try {
-    return await fs.readFile(filePath, 'utf-8');
+    const content = await fs.readFile(filePath, 'utf-8');
+    return { found: true, content };
   } catch {
     const examples = await listCodeExamples();
     const availableExamples = examples.map(ex => `- ${ex.name}`).join('\n');
     void logger.warning(`Example not found: ${filename}`);
-    return `Example "${filename}" not found.\n\nAvailable examples:\n${availableExamples}`;
+    return { found: false, content: `Example "${filename}" not found.\n\nAvailable examples:\n${availableExamples}` };
   }
 }
 
@@ -77,15 +80,15 @@ export const examplesTool = {
       }
 
       const filename = args.example.endsWith('.md') ? args.example : `${args.example}.md`;
-      const content = await readCodeExample(filename);
+      const result = await readCodeExample(filename);
       return {
         content: [
           {
             type: 'text',
-            text: content,
+            text: result.content,
           },
         ],
-        isError: false,
+        isError: !result.found,
       };
     } catch (error) {
       void logger.error('Failed to execute mastraExamples tool', error);

--- a/packages/mcp-docs-server/src/tools/examples.ts
+++ b/packages/mcp-docs-server/src/tools/examples.ts
@@ -36,7 +36,6 @@ async function readCodeExample(filename: string): Promise<CodeExampleResult> {
   } catch {
     const examples = await listCodeExamples();
     const availableExamples = examples.map(ex => `- ${ex.name}`).join('\n');
-    void logger.warning(`Example not found: ${filename}`);
     return { found: false, content: `Example "${filename}" not found.\n\nAvailable examples:\n${availableExamples}` };
   }
 }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR changes the logging for the mcp-docs-server, adding more logs when paths are not found, rather than throwing errors.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
