### PR TITLE
fix(cloudflare): paginate listing kv namespaces

### DIFF
--- a/.changeset/early-bats-search.md
+++ b/.changeset/early-bats-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloudflare': patch
+---
+
+Add pagination to cloudflare kv listing namespaces.

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -107,7 +107,34 @@ export class CloudflareStore extends MastraStorage {
         })),
       };
     }
-    return await this.client!.kv.namespaces.list({ account_id: this.accountId! });
+
+    let allNamespaces: Array<Cloudflare.KV.Namespace> = [];
+    let currentPage = 1;
+    const perPage = 50; // Using 50, max is 100 for namespaces.list
+    let morePagesExist = true;
+
+    while (morePagesExist) {
+      const response = await this.client!.kv.namespaces.list({
+        account_id: this.accountId!,
+        page: currentPage,
+        per_page: perPage,
+      });
+
+      if (response.result) {
+        allNamespaces = allNamespaces.concat(response.result);
+      }
+
+      if (response.result_info && (response.result_info as any).total_count !== undefined) {
+        morePagesExist = allNamespaces.length < (response.result_info as any).total_count;
+      } else {
+        morePagesExist = response.result ? response.result.length === perPage : false;
+      }
+
+      if (morePagesExist) {
+        currentPage++;
+      }
+    }
+    return { result: allNamespaces };
   }
 
   private async getNamespaceValue(tableName: TABLE_NAMES, key: string) {

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -124,6 +124,7 @@ export class CloudflareStore extends MastraStorage {
         allNamespaces = allNamespaces.concat(response.result);
       }
 
+      // total_count seems to be optionally returned by the API, so it's preferred but it might not be there.
       if (response.result_info && (response.result_info as any).total_count !== undefined) {
         morePagesExist = allNamespaces.length < (response.result_info as any).total_count;
       } else {

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -124,12 +124,7 @@ export class CloudflareStore extends MastraStorage {
         allNamespaces = allNamespaces.concat(response.result);
       }
 
-      // total_count seems to be optionally returned by the API, so it's preferred but it might not be there.
-      if (response.result_info && (response.result_info as any).total_count !== undefined) {
-        morePagesExist = allNamespaces.length < (response.result_info as any).total_count;
-      } else {
-        morePagesExist = response.result ? response.result.length === perPage : false;
-      }
+      morePagesExist = response.result ? response.result.length === perPage : false;
 
       if (morePagesExist) {
         currentPage++;

--- a/stores/cloudflare/src/storage/rest-api.test.ts
+++ b/stores/cloudflare/src/storage/rest-api.test.ts
@@ -46,7 +46,16 @@ describe.skip('CloudflareStore REST API', () => {
 
   // Helper to clean up KV namespaces
   const cleanupNamespaces = async () => {
-    const tables = [TABLE_THREADS, TABLE_MESSAGES, TABLE_WORKFLOW_SNAPSHOT, TABLE_EVALS, TABLE_TRACES] as TABLE_NAMES[];
+    const dummyTables = Array.from({ length: 100 }, (_, i) => `test${i + 1}`);
+
+    const tables = [
+      ...dummyTables,
+      TABLE_THREADS,
+      TABLE_MESSAGES,
+      TABLE_WORKFLOW_SNAPSHOT,
+      TABLE_EVALS,
+      TABLE_TRACES,
+    ] as TABLE_NAMES[];
 
     for (const table of tables) {
       try {
@@ -180,8 +189,7 @@ describe.skip('CloudflareStore REST API', () => {
     });
   });
 
-  // eslint-disable-next-line vitest/no-focused-tests
-  describe.only('Trace Operations', () => {
+  describe('Trace Operations', () => {
     beforeEach(async () => {
       await store.clearTable({ tableName: TABLE_TRACES });
     });


### PR DESCRIPTION
## Description

If a user had more than 20 kv namespaces, it's possible that the namespace that was needed wouldn't be in the first list as the API is paginated.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
