### PR TITLE
Check if listen capabilities are enabled

### DIFF
--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -70,6 +70,14 @@ export class AgentVoice extends BaseResource {
   getSpeakers(): Promise<Array<{ voiceId: string; [key: string]: any }>> {
     return this.request(`/api/agents/${this.agentId}/voice/speakers`);
   }
+
+  /**
+   * Get the listener configuration for the agent's voice provider
+   * @returns Promise containing a check if the agent has listening capabilities
+   */
+  getListener(): Promise<{ enabled: boolean }> {
+    return this.request(`/api/agents/${this.agentId}/voice/listener`);
+  }
 }
 
 export class Agent extends BaseResource {

--- a/packages/core/src/voice/composite-voice.ts
+++ b/packages/core/src/voice/composite-voice.ts
@@ -71,6 +71,16 @@ export class CompositeVoice extends MastraVoice<unknown, unknown, unknown, Tools
     throw new Error('No speak provider or realtime provider configured');
   }
 
+  async getListener() {
+    if (this.realtimeProvider) {
+      return this.realtimeProvider.getListener();
+    } else if (this.listenProvider) {
+      return this.listenProvider.getListener();
+    }
+
+    throw new Error('No listener provider or realtime provider configured');
+  }
+
   updateConfig(options: Record<string, unknown>): void {
     if (!this.realtimeProvider) {
       return;

--- a/packages/core/src/voice/default-voice.ts
+++ b/packages/core/src/voice/default-voice.ts
@@ -16,4 +16,8 @@ export class DefaultVoice extends MastraVoice {
   async getSpeakers(): Promise<{ voiceId: string }[]> {
     throw new Error('No voice provider configured');
   }
+
+  async getListener(): Promise<{ enabled: boolean }> {
+    throw new Error('No voice provider configured');
+  }
 }

--- a/packages/core/src/voice/voice.ts
+++ b/packages/core/src/voice/voice.ts
@@ -205,4 +205,14 @@ export abstract class MastraVoice<
     this.logger.warn('getSpeakers not implemented by this voice provider');
     return Promise.resolve([]);
   }
+
+  /**
+   * Get available speakers/voices
+   * @returns Array of available voice IDs and their metadata
+   */
+  getListener(): Promise<{ enabled: boolean }> {
+    // Default implementation - voice providers can override if they support this feature
+    this.logger.warn('getListener not implemented by this voice provider');
+    return Promise.resolve({ enabled: false });
+  }
 }

--- a/packages/deployer/src/server/handlers/voice.ts
+++ b/packages/deployer/src/server/handlers/voice.ts
@@ -2,6 +2,7 @@ import type { Mastra } from '@mastra/core';
 import {
   getSpeakersHandler as getOriginalSpeakersHandler,
   generateSpeechHandler as getOriginalSpeakHandler,
+  getListenerHandler as getOriginalListenerHandler,
   transcribeSpeechHandler as getOriginalListenHandler,
 } from '@mastra/server/handlers/voice';
 import type { Context } from 'hono';
@@ -49,6 +50,25 @@ export async function speakHandler(c: Context) {
     return c.body(audioStream as any);
   } catch (error) {
     return handleError(error, 'Error generating speech');
+  }
+}
+
+/**
+ * Get available speakers for an agent
+ */
+export async function getListenerHandler(c: Context) {
+  try {
+    const mastra: Mastra = c.get('mastra');
+    const agentId = c.req.param('agentId');
+
+    const listeners = await getOriginalListenerHandler({
+      mastra,
+      agentId,
+    });
+
+    return c.json(listeners);
+  } catch (error) {
+    return handleError(error, 'Error getting listener');
   }
 }
 

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -1129,7 +1129,7 @@ export async function createHonoServer(mastra: Mastra, options: ServerBundleOpti
                 type: 'object',
                 description: 'Listener information depending on the voice provider',
                 properties: {
-                  listenerId: { type: 'string' },
+                  enabled: { type: 'boolean' },
                 },
                 additionalProperties: true,
               },

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -69,7 +69,7 @@ import { rootHandler } from './handlers/root';
 import { getTelemetryHandler, storeTelemetryHandler } from './handlers/telemetry';
 import { executeAgentToolHandler, executeToolHandler, getToolByIdHandler, getToolsHandler } from './handlers/tools';
 import { createIndex, deleteIndex, describeIndex, listIndexes, queryVectors, upsertVectors } from './handlers/vector';
-import { getSpeakersHandler, listenHandler, speakHandler } from './handlers/voice';
+import { getSpeakersHandler, getListenerHandler, listenHandler, speakHandler } from './handlers/voice';
 import {
   createWorkflowRunHandler,
   getWorkflowByIdHandler,
@@ -1105,6 +1105,46 @@ export async function createHonoServer(mastra: Mastra, options: ServerBundleOpti
       },
     }),
     speakHandler,
+  );
+
+  app.get(
+    '/api/agents/:agentId/voice/listener',
+    describeRoute({
+      description: 'Get available listener for an agent',
+      tags: ['agents'],
+      parameters: [
+        {
+          name: 'agentId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {
+        200: {
+          description: 'Checks if listener is available for the agent',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                description: 'Listener information depending on the voice provider',
+                properties: {
+                  listenerId: { type: 'string' },
+                },
+                additionalProperties: true,
+              },
+            },
+          },
+        },
+        400: {
+          description: 'Agent does not have voice capabilities',
+        },
+        404: {
+          description: 'Agent not found',
+        },
+      },
+    }),
+    getListenerHandler,
   );
 
   app.post(

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -122,3 +122,29 @@ export async function transcribeSpeechHandler({
     return handleError(error, 'Error transcribing speech');
   }
 }
+
+/**
+ * Get available listeners for an agent
+ */
+export async function getListenerHandler({ mastra, agentId }: VoiceContext) {
+  try {
+    if (!agentId) {
+      throw new HTTPException(400, { message: 'Agent ID is required' });
+    }
+
+    const agent = mastra.getAgent(agentId);
+
+    if (!agent) {
+      throw new HTTPException(404, { message: 'Agent not found' });
+    }
+
+    if (!agent.voice) {
+      throw new HTTPException(400, { message: 'Agent does not have voice capabilities' });
+    }
+
+    const listeners = await agent.voice.getListener();
+    return listeners;
+  } catch (error) {
+    return handleError(error, 'Error getting listeners');
+  }
+}

--- a/voice/azure/src/index.ts
+++ b/voice/azure/src/index.ts
@@ -172,6 +172,15 @@ export class AzureVoice extends MastraVoice {
   }
 
   /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: true };
+  }
+
+  /**
    * Transcribes audio (STT) from a Node.js stream using Azure.
    *
    * @param {NodeJS.ReadableStream} audioStream - The audio to be transcribed, must be in .wav format.

--- a/voice/azure/src/index.ts
+++ b/voice/azure/src/index.ts
@@ -174,7 +174,7 @@ export class AzureVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: true };

--- a/voice/cloudflare/src/index.ts
+++ b/voice/cloudflare/src/index.ts
@@ -56,6 +56,15 @@ export class CloudflareVoice extends MastraVoice {
     }
   }
 
+  /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: true };
+  }
+
   async listen(audioStream: NodeJS.ReadableStream, options?: CloudflareListenOptions): Promise<string> {
     return this.traced(async () => {
       // Collect audio data into buffer

--- a/voice/cloudflare/src/index.ts
+++ b/voice/cloudflare/src/index.ts
@@ -59,7 +59,7 @@ export class CloudflareVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: true };

--- a/voice/deepgram/src/index.ts
+++ b/voice/deepgram/src/index.ts
@@ -152,6 +152,15 @@ export class DeepgramVoice extends MastraVoice {
     }, 'voice.deepgram.speak')();
   }
 
+  /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: true };
+  }
+
   async listen(
     audioStream: NodeJS.ReadableStream,
     options?: {

--- a/voice/deepgram/src/index.ts
+++ b/voice/deepgram/src/index.ts
@@ -155,7 +155,7 @@ export class DeepgramVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: true };

--- a/voice/elevenlabs/src/index.ts
+++ b/voice/elevenlabs/src/index.ts
@@ -143,6 +143,15 @@ export class ElevenLabsVoice extends MastraVoice {
   }
 
   /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: true };
+  }
+
+  /**
    * Converts audio input to text using ElevenLabs Speech-to-Text API.
    *
    * @param input - A readable stream containing the audio data to transcribe

--- a/voice/elevenlabs/src/index.ts
+++ b/voice/elevenlabs/src/index.ts
@@ -145,7 +145,7 @@ export class ElevenLabsVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: true };

--- a/voice/google/src/index.ts
+++ b/voice/google/src/index.ts
@@ -148,6 +148,15 @@ export class GoogleVoice extends MastraVoice {
   }
 
   /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: true };
+  }
+
+  /**
    * Converts speech to text
    * @param {NodeJS.ReadableStream} audioStream - Audio stream to transcribe. Default encoding is LINEAR16.
    * @param {Object} [options] - Recognition options

--- a/voice/google/src/index.ts
+++ b/voice/google/src/index.ts
@@ -150,7 +150,7 @@ export class GoogleVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: true };

--- a/voice/murf/src/index.ts
+++ b/voice/murf/src/index.ts
@@ -145,7 +145,7 @@ export class MurfVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: false };

--- a/voice/murf/src/index.ts
+++ b/voice/murf/src/index.ts
@@ -142,6 +142,15 @@ export class MurfVoice extends MastraVoice {
     }, 'voice.murf.speak')();
   }
 
+  /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: false };
+  }
+
   async listen(
     _input: NodeJS.ReadableStream,
     _options?: Record<string, unknown>,

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -289,7 +289,7 @@ export class OpenAIRealtimeVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: true };

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -287,6 +287,15 @@ export class OpenAIRealtimeVoice extends MastraVoice {
   }
 
   /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: true };
+  }
+
+  /**
    * Processes audio input for speech recognition.
    * Takes a readable stream of audio data and emits a writing event.
    * The output of the writing event is int16 audio data.

--- a/voice/openai/src/index.ts
+++ b/voice/openai/src/index.ts
@@ -166,6 +166,18 @@ export class OpenAIVoice extends MastraVoice {
   }
 
   /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    if (!this.listeningClient) {
+      return { enabled: false };
+    }
+    return { enabled: true };
+  }
+
+  /**
    * Transcribes audio from a given stream using the configured listening model.
    *
    * @param {NodeJS.ReadableStream} audioStream - The audio stream to be transcribed.

--- a/voice/openai/src/index.ts
+++ b/voice/openai/src/index.ts
@@ -168,7 +168,7 @@ export class OpenAIVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     if (!this.listeningClient) {

--- a/voice/playai/src/index.ts
+++ b/voice/playai/src/index.ts
@@ -233,6 +233,15 @@ export class PlayAIVoice extends MastraVoice {
     }, 'voice.playai.speak')();
   }
 
+  /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: false };
+  }
+
   async listen(
     _input: NodeJS.ReadableStream,
     _options?: Record<string, unknown>,

--- a/voice/playai/src/index.ts
+++ b/voice/playai/src/index.ts
@@ -236,7 +236,7 @@ export class PlayAIVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: false };

--- a/voice/sarvam/src/index.ts
+++ b/voice/sarvam/src/index.ts
@@ -153,6 +153,15 @@ export class SarvamVoice extends MastraVoice {
     }, 'voice.deepgram.getSpeakers')();
   }
 
+  /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: true };
+  }
+
   async listen(input: NodeJS.ReadableStream, options?: SarvamListenOptions): Promise<string> {
     return this.traced(async () => {
       // Collect audio data into buffer

--- a/voice/sarvam/src/index.ts
+++ b/voice/sarvam/src/index.ts
@@ -156,7 +156,7 @@ export class SarvamVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: true };

--- a/voice/speechify/src/index.ts
+++ b/voice/speechify/src/index.ts
@@ -97,6 +97,15 @@ export class SpeechifyVoice extends MastraVoice {
     }, 'voice.speechify.speak')();
   }
 
+  /**
+   * Checks if listening capabilities are enabled.
+   *
+   * @returns {Promise<string>} The default voice ID
+   */
+  async getListener() {
+    return { enabled: false };
+  }
+
   async listen(
     _input: NodeJS.ReadableStream,
     _options?: Record<string, unknown>,

--- a/voice/speechify/src/index.ts
+++ b/voice/speechify/src/index.ts
@@ -100,7 +100,7 @@ export class SpeechifyVoice extends MastraVoice {
   /**
    * Checks if listening capabilities are enabled.
    *
-   * @returns {Promise<string>} The default voice ID
+   * @returns {Promise<{ enabled: boolean }>}
    */
   async getListener() {
     return { enabled: false };


### PR DESCRIPTION
Adds a helper method to voice to check if listening is enabled.

Exposes the helper method in a new server endpoint `/api/agents/${this.agentId}/voice/listener`

Added new method `getListener` to the AgentVoice client sdk method