### PR TITLE
fix(@mastra/core, @mastra/memory, storage): Add backwards compat logic for public storage APIs

### DIFF
--- a/.changeset/moody-snakes-walk.md
+++ b/.changeset/moody-snakes-walk.md
@@ -1,0 +1,16 @@
+---
+'@mastra/client-js': patch
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/memory': patch
+'@mastra/server': patch
+'@mastra/dynamodb': patch
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Add backwards compat code for new MessageList in storage

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1,5 +1,5 @@
 import type {
-  MessageType,
+  MastraMessageV1,
   AiMessageType,
   CoreMessage,
   QueryResult,
@@ -172,11 +172,11 @@ export interface GetVectorIndexResponse {
 }
 
 export interface SaveMessageToMemoryParams {
-  messages: MessageType[];
+  messages: MastraMessageV1[];
   agentId: string;
 }
 
-export type SaveMessageToMemoryResponse = MessageType[];
+export type SaveMessageToMemoryResponse = MastraMessageV1[];
 
 export interface CreateMemoryThreadParams {
   title?: string;

--- a/packages/cli/src/playground/src/hooks/use-memory.ts
+++ b/packages/cli/src/playground/src/hooks/use-memory.ts
@@ -1,4 +1,4 @@
-import type { AiMessageType, MessageType, StorageThreadType as ThreadType } from '@mastra/core/memory';
+import type { AiMessageType, MastraMessageV1, StorageThreadType as ThreadType } from '@mastra/core/memory';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
 import useSWR, { useSWRConfig } from 'swr';
@@ -69,7 +69,7 @@ export const useThreads = ({
 };
 
 export const useMessages = ({ threadId, memory, agentId }: { threadId: string; memory: boolean; agentId: string }) => {
-  const { data, isLoading, mutate } = useSWR<{ uiMessages: Array<AiMessageType>; messages: Array<MessageType> }>(
+  const { data, isLoading, mutate } = useSWR<{ uiMessages: Array<AiMessageType>; messages: Array<MastraMessageV1> }>(
     `/api/memory/threads/${threadId}/messages?agentId=${agentId}`,
     url => fetcher(url, true),
     {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -485,7 +485,7 @@ export class Agent<
                   config: memoryConfig,
                   vectorMessageSearch: lastUserMessageContent,
                 })
-                .then(r => r.messages),
+                .then(r => r.messagesV2),
               memory.getSystemMessage({ threadId, memoryConfig }),
             ])
           : [[], null];

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1019,7 +1019,7 @@ export class Agent<
           .addSystem(memorySystemMessage)
           .add(context || [], 'user')
           .add(processedMemoryMessages, 'memory')
-          .add(messageList.get.input.mastra(), 'user')
+          .add(messageList.get.input.v2(), 'user')
           .get.all.prompt();
 
         return {

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -43,8 +43,8 @@ export class MessageList {
 
   // used to filter this.messages by how it was added: input/response/memory
   private memoryMessages = new Set<MastraMessageV2>();
-  private newMessages = new Set<MastraMessageV2>();
-  private responseMessages = new Set<MastraMessageV2>();
+  private newUserMessages = new Set<MastraMessageV2>();
+  private newResponseMessages = new Set<MastraMessageV2>();
 
   private generateMessageId?: IDGenerator;
 
@@ -103,18 +103,18 @@ export class MessageList {
     core: () => this.convertToCoreMessages(this.remembered.ui()),
   };
   private input = {
-    v2: () => this.messages.filter(m => this.newMessages.has(m)),
+    v2: () => this.messages.filter(m => this.newUserMessages.has(m)),
     v1: () => convertToV1Messages(this.input.v2()),
     ui: () => this.input.v2().map(MessageList.toUIMessage),
     core: () => this.convertToCoreMessages(this.input.ui()),
   };
   private response = {
-    v2: () => this.messages.filter(m => this.responseMessages.has(m)),
+    v2: () => this.messages.filter(m => this.newResponseMessages.has(m)),
   };
   public drainUnsavedMessages(): MastraMessageV2[] {
-    const messages = this.messages.filter(m => this.newMessages.has(m) || this.responseMessages.has(m));
-    this.newMessages.clear();
-    this.responseMessages.clear();
+    const messages = this.messages.filter(m => this.newUserMessages.has(m) || this.newResponseMessages.has(m));
+    this.newUserMessages.clear();
+    this.newResponseMessages.clear();
     return messages;
   }
   public getSystemMessages(tag?: string): CoreMessage[] {
@@ -383,9 +383,9 @@ ${JSON.stringify(message, null, 2)}`,
       if (messageSource === `memory`) {
         this.memoryMessages.add(messageV2);
       } else if (messageSource === `response`) {
-        this.responseMessages.add(messageV2);
+        this.newResponseMessages.add(messageV2);
       } else if (messageSource === `user`) {
-        this.newMessages.add(messageV2);
+        this.newUserMessages.add(messageV2);
       } else {
         throw new Error(`Missing message source for message ${messageV2}`);
       }

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -88,7 +88,7 @@ export class MessageList {
     };
   }
   private all = {
-    mastra: () => this.messages,
+    v2: () => this.messages,
     v1: () => convertToV1Messages(this.messages),
     ui: () => this.messages.map(MessageList.toUIMessage),
     core: () => this.convertToCoreMessages(this.all.ui()),
@@ -97,19 +97,19 @@ export class MessageList {
     },
   };
   private remembered = {
-    mastra: () => this.messages.filter(m => this.memoryMessages.has(m)),
-    v1: () => convertToV1Messages(this.remembered.mastra()),
-    ui: () => this.remembered.mastra().map(MessageList.toUIMessage),
+    v2: () => this.messages.filter(m => this.memoryMessages.has(m)),
+    v1: () => convertToV1Messages(this.remembered.v2()),
+    ui: () => this.remembered.v2().map(MessageList.toUIMessage),
     core: () => this.convertToCoreMessages(this.remembered.ui()),
   };
   private input = {
-    mastra: () => this.messages.filter(m => this.newMessages.has(m)),
-    v1: () => convertToV1Messages(this.input.mastra()),
-    ui: () => this.input.mastra().map(MessageList.toUIMessage),
+    v2: () => this.messages.filter(m => this.newMessages.has(m)),
+    v1: () => convertToV1Messages(this.input.v2()),
+    ui: () => this.input.v2().map(MessageList.toUIMessage),
     core: () => this.convertToCoreMessages(this.input.ui()),
   };
   private response = {
-    mastra: () => this.messages.filter(m => this.responseMessages.has(m)),
+    v2: () => this.messages.filter(m => this.responseMessages.has(m)),
   };
   public drainUnsavedMessages(): MastraMessageV2[] {
     const messages = this.messages.filter(m => this.newMessages.has(m) || this.responseMessages.has(m));

--- a/packages/core/src/agent/message-list/message-list.test.ts
+++ b/packages/core/src/agent/message-list/message-list.test.ts
@@ -26,7 +26,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(input, 'user');
 
-      const messages = list.get.all.mastra();
+      const messages = list.get.all.v2();
       expect(messages.length).toBe(1);
 
       expect(messages[0]).toEqual({
@@ -54,7 +54,7 @@ describe('MessageList', () => {
         resourceId,
       }).add(input, 'user');
 
-      const messages = list.get.all.mastra();
+      const messages = list.get.all.v2();
       expect(messages.length).toBe(1);
 
       expect(messages[0]).toEqual({
@@ -148,7 +148,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputV1Message, 'response');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: inputV1Message.id,
           role: inputV1Message.role,
@@ -188,7 +188,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputV1Message, 'user');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: inputV1Message.id,
           role: inputV1Message.role,
@@ -220,7 +220,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputCoreMessage, 'user');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'assistant',
@@ -345,7 +345,7 @@ describe('MessageList', () => {
           resourceId,
         },
       ];
-      expect(new MessageList({ threadId, resourceId }).add(messageSequence, 'user').get.all.mastra()).toEqual(
+      expect(new MessageList({ threadId, resourceId }).add(messageSequence, 'user').get.all.v2()).toEqual(
         expected.map(m => ({ ...m, createdAt: expect.any(Date) })),
       );
 
@@ -400,7 +400,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputCoreMessage, 'user');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'assistant',
@@ -435,7 +435,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputCoreMessage, 'user');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'user',
@@ -470,7 +470,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputV1Message, 'response');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: inputV1Message.id,
           role: inputV1Message.role,
@@ -510,7 +510,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputV1Message, 'user');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: inputV1Message.id,
           role: inputV1Message.role,
@@ -560,7 +560,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(messageSequence, 'memory');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'assistant',
@@ -676,9 +676,9 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(messageSequence, 'memory');
 
-      console.log(JSON.stringify(list.get.all.mastra(), null, 2));
+      console.log(JSON.stringify(list.get.all.v2(), null, 2));
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'user',
@@ -772,7 +772,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputV1Message, 'memory');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: inputV1Message.id,
           role: inputV1Message.role,
@@ -810,7 +810,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputCoreMessage, 'user');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'user',
@@ -850,7 +850,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(input, 'user');
 
-      const messages = list.get.all.mastra();
+      const messages = list.get.all.v2();
       expect(messages.length).toBe(1);
 
       expect(messages[0]).toEqual({
@@ -891,7 +891,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(input, 'user');
 
-      const messages = list.get.all.mastra();
+      const messages = list.get.all.v2();
       expect(messages.length).toBe(1);
 
       expect(messages[0]).toEqual({
@@ -963,7 +963,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(messageSequence, 'memory');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: userMsgV1.id,
           role: 'user',
@@ -1062,7 +1062,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(messageSequence, 'memory');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'user',
@@ -1138,7 +1138,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputCoreMessage, 'user');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'user',
@@ -1169,7 +1169,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputCoreMessage, 'memory');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'assistant',
@@ -1247,7 +1247,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(messageSequence, 'memory');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'user',
@@ -1342,7 +1342,7 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(inputCoreMessage, 'memory');
 
-      expect(list.get.all.mastra()).toEqual([
+      expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),
           role: 'assistant',
@@ -1753,7 +1753,7 @@ describe('MessageList', () => {
         expect(systemMessages[0]?.role).toBe('system');
         expect(systemMessages[0]?.content).toBe(systemMsgContent);
 
-        expect(list.get.all.mastra().length).toBe(0); // Should not be in MastraMessageV2 list
+        expect(list.get.all.v2().length).toBe(0); // Should not be in MastraMessageV2 list
         expect(list.get.all.ui().length).toBe(0); // Should not be in UI messages
       });
 
@@ -1793,7 +1793,7 @@ describe('MessageList', () => {
         expect(systemMessages.find(m => m.content === 'System setup complete.')).toBeDefined();
         expect(systemMessages.find(m => m.content === 'Another system note.')).toBeDefined();
 
-        expect(list.get.all.mastra().length).toBe(2); // user and assistant
+        expect(list.get.all.v2().length).toBe(2); // user and assistant
         expect(list.get.all.ui().length).toBe(2); // user and assistant
       });
     });

--- a/packages/core/src/agent/message-list/message-list.test.ts
+++ b/packages/core/src/agent/message-list/message-list.test.ts
@@ -676,8 +676,6 @@ describe('MessageList', () => {
 
       const list = new MessageList({ threadId, resourceId }).add(messageSequence, 'memory');
 
-      console.log(JSON.stringify(list.get.all.v2(), null, 2));
-
       expect(list.get.all.v2()).toEqual([
         {
           id: expect.any(String),

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -247,13 +247,21 @@ export abstract class MastraMemory extends MastraBase {
    * @param messages - Array of messages to save
    * @returns Promise resolving to the saved messages
    */
-  abstract saveMessages({
-    messages,
-    memoryConfig,
-  }: {
-    messages: (MastraMessageV1 | MastraMessageV2)[];
-    memoryConfig: MemoryConfig | undefined;
+  abstract saveMessages(args: {
+    messages: (MastraMessageV1 | MastraMessageV2)[] | MastraMessageV1[] | MastraMessageV2[];
+    memoryConfig?: MemoryConfig | undefined;
+    format?: 'v1';
+  }): Promise<MastraMessageV1[]>;
+  abstract saveMessages(args: {
+    messages: (MastraMessageV1 | MastraMessageV2)[] | MastraMessageV1[] | MastraMessageV2[];
+    memoryConfig?: MemoryConfig | undefined;
+    format: 'v2';
   }): Promise<MastraMessageV2[]>;
+  abstract saveMessages(args: {
+    messages: (MastraMessageV1 | MastraMessageV2)[] | MastraMessageV1[] | MastraMessageV2[];
+    memoryConfig?: MemoryConfig | undefined;
+    format?: 'v1' | 'v2';
+  }): Promise<MastraMessageV2[] | MastraMessageV1[]>;
 
   /**
    * Retrieves all messages for a specific thread
@@ -264,7 +272,7 @@ export abstract class MastraMemory extends MastraBase {
     threadId,
     resourceId,
     selectBy,
-  }: StorageGetMessagesArg): Promise<{ messages: MastraMessageV1[]; uiMessages: UIMessage[] }>;
+  }: StorageGetMessagesArg): Promise<{ messages: CoreMessage[]; uiMessages: UIMessage[] }>;
 
   /**
    * Helper method to create a new thread

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1,6 +1,6 @@
 import type { AssistantContent, CoreMessage, EmbeddingModel, ToolContent, UserContent } from 'ai';
 
-import type { MastraMessageV2 } from '../agent';
+export type { MastraMessageV2 } from '../agent';
 import type { MastraStorage } from '../storage';
 import type { MastraVector } from '../vector';
 import type { MemoryProcessor } from '.';
@@ -13,15 +13,18 @@ export type MastraMessageV1 = {
   content: string | UserContent | AssistantContent | ToolContent;
   role: 'system' | 'user' | 'assistant' | 'tool';
   createdAt: Date;
-  threadId: string;
-  resourceId: string;
+  threadId?: string;
+  resourceId?: string;
   toolCallIds?: string[];
   toolCallArgs?: Record<string, unknown>[];
   toolNames?: string[];
   type: 'text' | 'tool-call' | 'tool-result';
 };
 
-export type MessageType = MastraMessageV2 & { threadId: string };
+/**
+ * @deprecated use MastraMessageV1 or MastraMessageV2
+ */
+export type MessageType = MastraMessageV1;
 
 export type StorageThreadType = {
   id: string;

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -74,9 +74,20 @@ export abstract class MastraStorage extends MastraBase {
 
   abstract deleteThread({ threadId }: { threadId: string }): Promise<void>;
 
-  abstract getMessages({ threadId, selectBy, threadConfig }: StorageGetMessagesArg): Promise<MastraMessageV2[]>;
+  abstract getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  abstract getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  abstract getMessages({
+    threadId,
+    resourceId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]>;
 
-  abstract saveMessages({ messages }: { messages: (MastraMessageV1 | MastraMessageV2)[] }): Promise<MastraMessageV2[]>;
+  abstract saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  abstract saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  abstract saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]>;
 
   abstract getTraces({
     name,

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -1,5 +1,6 @@
+import { MessageList } from '../agent';
 import type { MastraMessageV2 } from '../agent';
-import type { StorageThreadType } from '../memory/types';
+import type { MastraMessageV1, StorageThreadType } from '../memory/types';
 import { MastraStorage } from './base';
 import type { TABLE_NAMES } from './constants';
 import type { EvalRow, StorageColumn, StorageGetMessagesArg, WorkflowRun, WorkflowRuns } from './types';
@@ -112,13 +113,21 @@ export class MockStore extends MastraStorage {
     return messages as T;
   }
 
-  async saveMessages({ messages }: { messages: MastraMessageV2[] }): Promise<MastraMessageV2[]> {
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+    const { messages, format = 'v1' } = args;
     this.logger.debug(`MockStore: saveMessages called with ${messages.length} messages`);
     for (const message of messages) {
       const key = message.id;
       this.data.mastra_messages[key] = message;
     }
-    return messages;
+
+    const list = new MessageList().add(messages, 'memory');
+    if (format === `v2`) return list.get.all.mastra();
+    return list.get.all.v1();
   }
 
   async getTraces({

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -126,7 +126,7 @@ export class MockStore extends MastraStorage {
     }
 
     const list = new MessageList().add(messages, 'memory');
-    if (format === `v2`) return list.get.all.mastra();
+    if (format === `v2`) return list.get.all.v2();
     return list.get.all.v1();
   }
 

--- a/packages/memory/integration-tests/src/processors.test.ts
+++ b/packages/memory/integration-tests/src/processors.test.ts
@@ -117,9 +117,7 @@ describe('Memory with Processors', () => {
       processors: [new TokenLimiter(3000)], // High limit that should exceed total tokens
     });
 
-    const listed = new MessageList({ threadId: thread.id, resourceId })
-      .add(allMessagesResult, 'memory')
-      .get.all.mastra();
+    const listed = new MessageList({ threadId: thread.id, resourceId }).add(allMessagesResult, 'memory').get.all.v2();
 
     // We should get all 20 messages
     expect(listed.length).toBe(20);
@@ -154,7 +152,7 @@ describe('Memory with Processors', () => {
       messages: v2ToCoreMessages(queryResult.uiMessages),
       processors: [new ToolCallFilter({ exclude: ['weather'] })],
     });
-    expect(new MessageList().add(result, 'memory').get.all.mastra().length).toBeLessThan(messagesV2.length);
+    expect(new MessageList().add(result, 'memory').get.all.v2().length).toBeLessThan(messagesV2.length);
     expect(filterToolCallsByName(result, 'weather')).toHaveLength(0);
     expect(filterToolResultsByName(result, 'weather')).toHaveLength(0);
     expect(filterToolCallsByName(result, 'calculator')).toHaveLength(1);
@@ -166,7 +164,7 @@ describe('Memory with Processors', () => {
       selectBy: { last: 20 },
     });
     const result2 = memory.processMessages({ messages: v2ToCoreMessages(queryResult2.uiMessages), processors: [] });
-    expect(new MessageList().add(result2, 'memory').get.all.mastra()).toHaveLength(messagesV2.length);
+    expect(new MessageList().add(result2, 'memory').get.all.v2()).toHaveLength(messagesV2.length);
     expect(filterToolCallsByName(result2, 'weather')).toHaveLength(1);
     expect(filterToolResultsByName(result2, 'weather')).toHaveLength(1);
     expect(filterToolCallsByName(result2, 'calculator')).toHaveLength(1);

--- a/packages/memory/integration-tests/src/processors.test.ts
+++ b/packages/memory/integration-tests/src/processors.test.ts
@@ -66,14 +66,14 @@ describe('Memory with Processors', () => {
     });
 
     // Generate conversation with 10 turn pairs (20 messages total)
-    const { messages } = generateConversationHistory({
+    const { messagesV2 } = generateConversationHistory({
       threadId: thread.id,
       messageCount: 10,
       toolFrequency: 3,
     });
 
     // Save messages
-    await memory.saveMessages({ messages });
+    await memory.saveMessages({ messages: messagesV2, format: 'v2' });
 
     // Get messages with a token limit of 250 (should get ~2.5 messages)
     const queryResult = await memory.query({
@@ -135,7 +135,7 @@ describe('Memory with Processors', () => {
     });
 
     // Generate conversation with tool calls
-    const { messages } = generateConversationHistory({
+    const { messagesV2 } = generateConversationHistory({
       threadId: thread.id,
       messageCount: 5,
       toolFrequency: 2, // Every other assistant response is a tool call
@@ -143,7 +143,7 @@ describe('Memory with Processors', () => {
     });
 
     // Save messages
-    await memory.saveMessages({ messages });
+    await memory.saveMessages({ messages: messagesV2, format: 'v2' });
 
     // filter weather tool calls
     const queryResult = await memory.query({
@@ -154,7 +154,7 @@ describe('Memory with Processors', () => {
       messages: v2ToCoreMessages(queryResult.uiMessages),
       processors: [new ToolCallFilter({ exclude: ['weather'] })],
     });
-    expect(new MessageList().add(result, 'memory').get.all.mastra().length).toBeLessThan(messages.length);
+    expect(new MessageList().add(result, 'memory').get.all.mastra().length).toBeLessThan(messagesV2.length);
     expect(filterToolCallsByName(result, 'weather')).toHaveLength(0);
     expect(filterToolResultsByName(result, 'weather')).toHaveLength(0);
     expect(filterToolCallsByName(result, 'calculator')).toHaveLength(1);
@@ -166,7 +166,7 @@ describe('Memory with Processors', () => {
       selectBy: { last: 20 },
     });
     const result2 = memory.processMessages({ messages: v2ToCoreMessages(queryResult2.uiMessages), processors: [] });
-    expect(new MessageList().add(result2, 'memory').get.all.mastra()).toHaveLength(messages.length);
+    expect(new MessageList().add(result2, 'memory').get.all.mastra()).toHaveLength(messagesV2.length);
     expect(filterToolCallsByName(result2, 'weather')).toHaveLength(1);
     expect(filterToolResultsByName(result2, 'weather')).toHaveLength(1);
     expect(filterToolCallsByName(result2, 'calculator')).toHaveLength(1);
@@ -181,7 +181,7 @@ describe('Memory with Processors', () => {
       messages: v2ToCoreMessages(queryResult3.uiMessages),
       processors: [new ToolCallFilter({ exclude: ['weather', 'calculator'] })],
     });
-    expect(result3.length).toBeLessThan(messages.length);
+    expect(result3.length).toBeLessThan(messagesV2.length);
     expect(filterToolCallsByName(result3, 'weather')).toHaveLength(0);
     expect(filterToolResultsByName(result3, 'weather')).toHaveLength(0);
     expect(filterToolCallsByName(result3, 'calculator')).toHaveLength(0);
@@ -196,7 +196,7 @@ describe('Memory with Processors', () => {
       messages: v2ToCoreMessages(queryResult4.uiMessages),
       processors: [new ToolCallFilter()],
     });
-    expect(result4.length).toBeLessThan(messages.length);
+    expect(result4.length).toBeLessThan(messagesV2.length);
     expect(filterToolCallsByName(result4, 'weather')).toHaveLength(0);
     expect(filterToolResultsByName(result4, 'weather')).toHaveLength(0);
     expect(filterToolCallsByName(result4, 'calculator')).toHaveLength(0);

--- a/packages/memory/integration-tests/src/test-utils.ts
+++ b/packages/memory/integration-tests/src/test-utils.ts
@@ -123,7 +123,7 @@ export function generateConversationHistory({
   return {
     fakeCore: list.get.all.v1() as CoreMessage[],
     messages: list.get.all.v1(),
-    messagesV2: list.get.all.mastra(),
+    messagesV2: list.get.all.v2(),
     counts,
   };
 }

--- a/packages/memory/integration-tests/src/test-utils.ts
+++ b/packages/memory/integration-tests/src/test-utils.ts
@@ -1,4 +1,5 @@
-import type { CoreMessage } from '@mastra/core';
+import type { CoreMessage, MastraMessageV1 } from '@mastra/core';
+import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV2 } from '@mastra/core/agent';
 
 const toolArgs = {
@@ -30,7 +31,12 @@ export function generateConversationHistory({
   messageCount?: number;
   toolFrequency?: number;
   toolNames?: (keyof typeof toolArgs)[];
-}): { messages: MastraMessageV2[]; counts: { messages: number; toolCalls: number; toolResults: number } } {
+}): {
+  messages: MastraMessageV1[];
+  messagesV2: MastraMessageV2[];
+  fakeCore: CoreMessage[];
+  counts: { messages: number; toolCalls: number; toolResults: number };
+} {
   const counts = { messages: 0, toolCalls: 0, toolResults: 0 };
   // Create some words that will each be about one token
   const words = ['apple', 'banana', 'orange', 'grape'];
@@ -113,7 +119,13 @@ export function generateConversationHistory({
     counts.messages++;
   }
 
-  return { messages, counts };
+  const list = new MessageList().add(messages, 'memory');
+  return {
+    fakeCore: list.get.all.v1() as CoreMessage[],
+    messages: list.get.all.v1(),
+    messagesV2: list.get.all.mastra(),
+    counts,
+  };
 }
 
 export function filterToolCallsByName(messages: CoreMessage[], name: string) {

--- a/packages/memory/integration-tests/src/worker/generic-memory-worker.ts
+++ b/packages/memory/integration-tests/src/worker/generic-memory-worker.ts
@@ -1,5 +1,5 @@
 import { parentPort, workerData } from 'worker_threads';
-import type { MessageType, SharedMemoryConfig } from '@mastra/core';
+import type { MastraMessageV2, SharedMemoryConfig } from '@mastra/core';
 import type { LibSQLConfig } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
 import type { PostgresConfig } from '@mastra/pg';
@@ -23,7 +23,7 @@ interface WorkerTestConfig {
 }
 
 interface MessageToProcess {
-  originalMessage: MessageType;
+  originalMessage: MastraMessageV2;
 }
 
 interface WorkerData {

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -150,7 +150,7 @@ describe('Working Memory Tests', () => {
       ),
     ];
 
-    await memory.saveMessages({ messages });
+    await memory.saveMessages({ messages, format: 'v2' });
 
     const remembered = await memory.rememberMessages({
       threadId: thread.id,
@@ -211,7 +211,7 @@ describe('Working Memory Tests', () => {
       ),
     ];
 
-    await disabledMemory.saveMessages({ messages });
+    await disabledMemory.saveMessages({ messages, format: 'v2' });
 
     // Working memory should be null when disabled
     const workingMemory = await disabledMemory.getWorkingMemory({ threadId: thread.id });
@@ -389,7 +389,7 @@ describe('Working Memory Tests', () => {
     ];
 
     // Save messages
-    const saved = await memory.saveMessages({ messages: messages as MastraMessageV1[] });
+    const saved = await memory.saveMessages({ messages: messages as MastraMessageV1[], format: 'v2' });
 
     // Should not include any updateWorkingMemory tool-call messages (pure or mixed)
     expect(
@@ -425,8 +425,10 @@ describe('Working Memory Tests', () => {
     // It actually should return V1 for now (CoreMessage compatible)
 
     // Pure text message should be present
-    expect(saved.some(m => m.content === 'Another normal message')).toBe(true);
+    expect(saved.some(m => m.content.content === 'Another normal message')).toBe(true);
     // User message should be present
-    expect(saved.some(m => typeof m.content === 'string' && m.content.includes('User says something'))).toBe(true);
+    expect(
+      saved.some(m => typeof m.content.content === 'string' && m.content.content.includes('User says something')),
+    ).toBe(true);
   });
 });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -6,7 +6,7 @@ import { MastraMemory } from '@mastra/core/memory';
 import type { MemoryConfig, SharedMemoryConfig, StorageThreadType } from '@mastra/core/memory';
 import type { StorageGetMessagesArg } from '@mastra/core/storage';
 import { embedMany } from 'ai';
-import type { TextPart, UIMessage } from 'ai';
+import type { CoreMessage, TextPart, UIMessage } from 'ai';
 
 import xxhash from 'xxhash-wasm';
 import { updateWorkingMemoryTool } from './tools/working-memory';
@@ -56,7 +56,7 @@ export class Memory extends MastraMemory {
     threadConfig,
   }: StorageGetMessagesArg & {
     threadConfig?: MemoryConfig;
-  }): Promise<{ messages: MastraMessageV1[]; uiMessages: UIMessage[] }> {
+  }): Promise<{ messages: CoreMessage[]; uiMessages: UIMessage[]; messagesV2: MastraMessageV2[] }> {
     if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId);
 
     const vectorResults: {
@@ -117,6 +117,7 @@ export class Memory extends MastraMemory {
     // Get raw messages from storage
     const rawMessages = await this.storage.getMessages({
       threadId,
+      format: 'v2',
       selectBy: {
         ...selectBy,
         ...(vectorResults?.length
@@ -138,9 +139,8 @@ export class Memory extends MastraMemory {
       threadConfig: config,
     });
 
-    const orderedByDate = rawMessages.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-
-    const list = new MessageList({ threadId, resourceId }).add(orderedByDate, 'memory');
+    // const orderedByDate = rawMessages.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    const list = new MessageList({ threadId, resourceId }).add(rawMessages, 'memory');
     return {
       get messages() {
         // returning v1 messages for backwards compat! v1 messages were CoreMessages stored in the db.
@@ -152,12 +152,17 @@ export class Memory extends MastraMemory {
         if (selectBy?.last && v1Messages.length > selectBy.last) {
           // ex: 23 (v1 messages) minus 20 (selectBy.last messages)
           // means we will start from index 3 and keep all the later newer messages from index 3 til the end of the array
-          return v1Messages.slice(v1Messages.length - selectBy.last);
+          return v1Messages.slice(v1Messages.length - selectBy.last) as CoreMessage[];
         }
-        return v1Messages;
+        // TODO: this is absolutely wrong but became apparent that this is what we were doing before adding MessageList. Our public types said CoreMessage but we were returning MessageType which is equivalent to MastraMessageV1
+        // In a breaking change we should make this the type it actually is.
+        return v1Messages as CoreMessage[];
       },
       get uiMessages() {
         return list.get.all.ui();
+      },
+      get messagesV2() {
+        return list.get.all.mastra();
       },
     };
   }
@@ -190,9 +195,10 @@ export class Memory extends MastraMemory {
         vectorSearchString: threadConfig.semanticRecall && vectorMessageSearch ? vectorMessageSearch : undefined,
       },
       threadConfig: config,
+      format: 'v2',
     });
     // Using MessageList here just to convert mixed input messages to single type output messages
-    const list = new MessageList({ threadId, resourceId }).add(messagesResult.messages, 'memory');
+    const list = new MessageList({ threadId, resourceId }).add(messagesResult.messagesV2, 'memory');
 
     this.logger.debug(`Remembered message history includes ${messagesResult.messages.length} messages.`);
     return { messages: list.get.all.v1(), messagesV2: list.get.all.mastra() };
@@ -326,13 +332,25 @@ export class Memory extends MastraMemory {
     return result;
   }
 
+  async saveMessages(args: {
+    messages: (MastraMessageV1 | MastraMessageV2)[] | MastraMessageV1[] | MastraMessageV2[];
+    memoryConfig?: MemoryConfig | undefined;
+    format?: 'v1';
+  }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: {
+    messages: (MastraMessageV1 | MastraMessageV2)[] | MastraMessageV1[] | MastraMessageV2[];
+    memoryConfig?: MemoryConfig | undefined;
+    format: 'v2';
+  }): Promise<MastraMessageV2[]>;
   async saveMessages({
     messages,
     memoryConfig,
+    format = `v1`,
   }: {
     messages: (MastraMessageV1 | MastraMessageV2)[];
-    memoryConfig?: MemoryConfig;
-  }): Promise<MastraMessageV2[]> {
+    memoryConfig?: MemoryConfig | undefined;
+    format?: 'v1' | 'v2';
+  }): Promise<MastraMessageV2[] | MastraMessageV1[]> {
     // Then strip working memory tags from all messages
     const updatedMessages = messages
       .map(m => {
@@ -347,7 +365,10 @@ export class Memory extends MastraMemory {
 
     const config = this.getMergedThreadConfig(memoryConfig);
 
-    const result = this.storage.saveMessages({ messages: updatedMessages });
+    const result = this.storage.saveMessages({
+      messages: new MessageList().add(updatedMessages, 'memory').get.all.mastra(),
+      format: 'v2',
+    });
 
     if (this.vector && config.semanticRecall) {
       let indexName: Promise<string>;
@@ -412,6 +433,7 @@ export class Memory extends MastraMemory {
       );
     }
 
+    if (format === `v1`) return new MessageList().add(await result, 'memory').get.all.v1(); // for backwards compat convert to v1 message format
     return result;
   }
   protected updateMessageToHideWorkingMemory(message: MastraMessageV1): MastraMessageV1 | null {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -162,7 +162,7 @@ export class Memory extends MastraMemory {
         return list.get.all.ui();
       },
       get messagesV2() {
-        return list.get.all.mastra();
+        return list.get.all.v2();
       },
     };
   }
@@ -201,7 +201,7 @@ export class Memory extends MastraMemory {
     const list = new MessageList({ threadId, resourceId }).add(messagesResult.messagesV2, 'memory');
 
     this.logger.debug(`Remembered message history includes ${messagesResult.messages.length} messages.`);
-    return { messages: list.get.all.v1(), messagesV2: list.get.all.mastra() };
+    return { messages: list.get.all.v1(), messagesV2: list.get.all.v2() };
   }
 
   async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
@@ -366,7 +366,7 @@ export class Memory extends MastraMemory {
     const config = this.getMergedThreadConfig(memoryConfig);
 
     const result = this.storage.saveMessages({
-      messages: new MessageList().add(updatedMessages, 'memory').get.all.mastra(),
+      messages: new MessageList().add(updatedMessages, 'memory').get.all.v2(),
       format: 'v2',
     });
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -139,7 +139,6 @@ export class Memory extends MastraMemory {
       threadConfig: config,
     });
 
-    // const orderedByDate = rawMessages.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
     const list = new MessageList({ threadId, resourceId }).add(rawMessages, 'memory');
     return {
       get messages() {

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1,7 +1,7 @@
 import { Agent } from '@mastra/core/agent';
 import type { CoreMessage } from '@mastra/core/llm';
 import { Mastra } from '@mastra/core/mastra';
-import type { MessageType } from '@mastra/core/memory';
+import type { MastraMessageV1, MastraMessageV2 } from '@mastra/core/memory';
 import { MastraMemory } from '@mastra/core/memory';
 import { MockStore } from '@mastra/core/storage';
 import type { Mock } from 'vitest';
@@ -241,7 +241,7 @@ describe('Memory Handlers', () => {
         saveMessagesHandler({
           mastra,
           agentId: 'test-agent',
-          body: {} as { messages: MessageType[] },
+          body: {} as { messages: MastraMessageV2[] },
         }),
       ).rejects.toThrow(new HTTPException(400, { message: 'Messages are required' }));
     });
@@ -257,13 +257,13 @@ describe('Memory Handlers', () => {
         saveMessagesHandler({
           mastra,
           agentId: 'test-agent',
-          body: { messages: 'not-an-array' as unknown as MessageType[] },
+          body: { messages: 'not-an-array' as unknown as MastraMessageV2[] },
         }),
       ).rejects.toThrow(new HTTPException(400, { message: 'Messages should be an array' }));
     });
 
     it('should save messages successfully', async () => {
-      const mockMessages: MessageType[] = [
+      const mockMessages: MastraMessageV1[] = [
         {
           id: 'test-id',
           content: 'Test message',

--- a/stores/_test-utils/src/default-tests.ts
+++ b/stores/_test-utils/src/default-tests.ts
@@ -4,6 +4,7 @@ import type { MetricResult } from '@mastra/core/eval';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import type { MastraStorage } from '@mastra/core/storage';
 import { TABLE_WORKFLOW_SNAPSHOT, TABLE_EVALS, TABLE_MESSAGES, TABLE_THREADS } from '@mastra/core/storage';
+import { MastraMessageV1 } from '@mastra/core';
 
 export function createTestSuite(storage: MastraStorage) {
   describe(storage.constructor.name, () => {
@@ -34,7 +35,7 @@ export function createTestSuite(storage: MastraStorage) {
         threadId,
         content: [{ type: 'text', text: 'Hello' }],
         createdAt: new Date(),
-      }) as any;
+      }) satisfies MastraMessageV1;
 
     const createSampleWorkflowSnapshot = (status: string, createdAt?: Date) => {
       const runId = `run-${randomUUID()}`;
@@ -204,7 +205,7 @@ export function createTestSuite(storage: MastraStorage) {
           { ...createSampleMessage(thread.id), content: [{ type: 'text', text: 'First' }] },
           { ...createSampleMessage(thread.id), content: [{ type: 'text', text: 'Second' }] },
           { ...createSampleMessage(thread.id), content: [{ type: 'text', text: 'Third' }] },
-        ];
+        ] satisfies MastraMessageV1[];
 
         await storage.saveMessages({ messages });
 
@@ -225,8 +226,9 @@ export function createTestSuite(storage: MastraStorage) {
 
         const messages = [
           createSampleMessage(thread.id),
+          // @ts-ignore
           { ...createSampleMessage(thread.id), id: null }, // This will cause an error
-        ];
+        ] as MastraMessageV1[];
 
         await expect(storage.saveMessages({ messages })).rejects.toThrow();
 

--- a/stores/_test-utils/src/default-tests.ts
+++ b/stores/_test-utils/src/default-tests.ts
@@ -27,10 +27,16 @@ export function createTestSuite(storage: MastraStorage) {
       metadata: { key: 'value' },
     });
 
+    let role: 'assistant' | 'user' = 'assistant';
+    const getRole = () => {
+      if (role === 'user') role = 'assistant';
+      else role = 'user';
+      return role;
+    };
     const createSampleMessage = (threadId: string) =>
       ({
         id: `msg-${randomUUID()}`,
-        role: 'user',
+        role: getRole(),
         type: 'text',
         threadId,
         content: [{ type: 'text', text: 'Hello' }],

--- a/stores/clickhouse/src/storage/index.test.ts
+++ b/stores/clickhouse/src/storage/index.test.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { WorkflowRunState } from '@mastra/core';
-import type { MessageType } from '@mastra/core/memory';
+import type { MastraMessageV1, WorkflowRunState } from '@mastra/core';
 import { TABLE_THREADS, TABLE_MESSAGES, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi, afterEach } from 'vitest';
 
@@ -28,20 +27,27 @@ const TEST_CONFIG: ClickhouseConfig = {
 // Sample test data factory functions
 const createSampleThread = () => ({
   id: `thread-${randomUUID()}`,
-  resourceId: `resource-${randomUUID()}`,
+  resourceId: `clickhouse-test`,
   title: 'Test Thread',
   createdAt: new Date(),
   updatedAt: new Date(),
   metadata: { key: 'value' },
 });
 
-const createSampleMessage = (threadId: string, createdAt: Date = new Date()): MessageType => ({
+let role = `user`;
+const getRole = () => {
+  if (role === `user`) role = `assistant`;
+  else role = `user`;
+  return role as 'user' | 'assistant';
+};
+
+const createSampleMessage = (threadId: string, createdAt: Date = new Date()): MastraMessageV1 => ({
   id: `msg-${randomUUID()}`,
-  resourceId: `resource-${randomUUID()}`,
-  role: 'user',
+  resourceId: `clickhouse-test`,
+  role: getRole(),
   type: 'text',
   threadId,
-  content: [{ type: 'text', text: 'Hello' }] as MessageType['content'],
+  content: 'Hello',
   createdAt,
 });
 
@@ -207,28 +213,31 @@ describe('ClickhouseStore', () => {
       expect(result).toEqual([]);
     }, 10e3);
 
-    it('should maintain message order', async () => {
+    it.only('should maintain message order', async () => {
       const thread = createSampleThread();
       await store.saveThread({ thread });
 
-      const messages: MessageType[] = [
+      const messages: MastraMessageV1[] = [
         {
           ...createSampleMessage(thread.id, new Date(Date.now() - 1000 * 3)),
           content: [{ type: 'text', text: 'First' }],
+          role: 'user',
         },
         {
           ...createSampleMessage(thread.id, new Date(Date.now() - 1000 * 2)),
           content: [{ type: 'text', text: 'Second' }],
+          role: 'assistant',
         },
         {
           ...createSampleMessage(thread.id, new Date(Date.now() - 1000 * 1)),
           content: [{ type: 'text', text: 'Third' }],
+          role: 'user',
         },
       ];
 
       await store.saveMessages({ messages });
 
-      const retrievedMessages = await store.getMessages<MessageType>({ threadId: thread.id });
+      const retrievedMessages = await store.getMessages({ threadId: thread.id });
       expect(retrievedMessages).toHaveLength(3);
 
       // Verify order is maintained

--- a/stores/clickhouse/src/storage/index.test.ts
+++ b/stores/clickhouse/src/storage/index.test.ts
@@ -213,7 +213,7 @@ describe('ClickhouseStore', () => {
       expect(result).toEqual([]);
     }, 10e3);
 
-    it.only('should maintain message order', async () => {
+    it('should maintain message order', async () => {
       const thread = createSampleThread();
       await store.saveThread({ thread });
 

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -1,8 +1,9 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
+import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV2 } from '@mastra/core/agent';
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
-import type { StorageThreadType } from '@mastra/core/memory';
+import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
 import {
   MastraStorage,
   TABLE_EVALS,
@@ -647,7 +648,14 @@ export class ClickhouseStore extends MastraStorage {
     }
   }
 
-  async getMessages<T = unknown>({ threadId, selectBy }: StorageGetMessagesArg): Promise<T[]> {
+  public async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  public async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  public async getMessages({
+    threadId,
+    resourceId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
     try {
       const messages: any[] = [];
       const limit = typeof selectBy?.last === `number` ? selectBy.last : 40;
@@ -752,21 +760,28 @@ export class ClickhouseStore extends MastraStorage {
             // If parsing fails, leave as string
           }
         }
-        if (message.type === `v2`) delete message.type;
       });
 
-      return messages as T[];
+      const list = new MessageList({ threadId, resourceId }).add(messages, 'memory');
+      if (format === `v2`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       console.error('Error getting messages:', error);
       throw error;
     }
   }
 
-  async saveMessages({ messages }: { messages: MastraMessageV2[] }): Promise<MastraMessageV2[]> {
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+    const { messages, format = 'v1' } = args;
     if (messages.length === 0) return messages;
 
     try {
       const threadId = messages[0]?.threadId;
+      const resourceId = messages[0]?.resourceId;
       if (!threadId) {
         throw new Error('Thread ID is required');
       }
@@ -796,7 +811,9 @@ export class ClickhouseStore extends MastraStorage {
         },
       });
 
-      return messages;
+      const list = new MessageList({ threadId, resourceId }).add(messages, 'memory');
+      if (format === `v2`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       console.error('Error saving messages:', error);
       throw error;

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -763,7 +763,7 @@ export class ClickhouseStore extends MastraStorage {
       });
 
       const list = new MessageList({ threadId, resourceId }).add(messages, 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       console.error('Error getting messages:', error);
@@ -812,7 +812,7 @@ export class ClickhouseStore extends MastraStorage {
       });
 
       const list = new MessageList({ threadId, resourceId }).add(messages, 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       console.error('Error saving messages:', error);

--- a/stores/cloudflare-d1/src/storage/binding-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/binding-api.test.ts
@@ -374,7 +374,7 @@ describe('D1Store', () => {
       expect(threads).toHaveLength(0);
 
       // Verify messages were also deleted
-      const retrievedMessages = await store.getMessages({ threadId: thread.id });
+      const retrievedMessages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(retrievedMessages).toHaveLength(0);
     });
   });
@@ -395,7 +395,7 @@ describe('D1Store', () => {
       expect(savedMessages).toEqual(messages);
 
       // Retrieve messages
-      const retrievedMessages = await store.getMessages({ threadId: thread.id });
+      const retrievedMessages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       const checkMessages = messages.map(m => {
         const { resourceId, ...rest } = m;
         return {
@@ -423,7 +423,7 @@ describe('D1Store', () => {
 
       await store.saveMessages({ messages, format: 'v2' });
 
-      const retrievedMessages = await store.getMessages({ threadId: thread.id });
+      const retrievedMessages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(retrievedMessages).toHaveLength(3);
 
       // Verify order is maintained
@@ -444,7 +444,7 @@ describe('D1Store', () => {
       await expect(store.saveMessages({ messages, format: 'v2' })).rejects.toThrow();
 
       // Verify no messages were saved
-      const savedMessages = await store.getMessages({ threadId: thread.id });
+      const savedMessages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(savedMessages).toHaveLength(0);
     });
   });
@@ -575,7 +575,7 @@ describe('D1Store', () => {
       await store.saveMessages({ messages, format: 'v2' });
 
       // Verify order is maintained based on insertion order
-      const order = await store.getMessages({ threadId: thread.id });
+      const order = await store.getMessages({ threadId: thread.id, format: 'v2' });
       const orderIds = order.map(m => m.id);
       const messageIds = messages.map(m => m.id);
 
@@ -599,7 +599,7 @@ describe('D1Store', () => {
       await Promise.all(reversedMessages.map(msg => store.saveMessages({ messages: [msg], format: 'v2' })));
 
       // Verify messages are saved and maintain write order (not timestamp order)
-      const order = await store.getMessages({ threadId: thread.id });
+      const order = await store.getMessages({ threadId: thread.id, format: 'v2' });
       const orderIds = order.map(m => m.id);
       const messageIds = messages.map(m => m.id);
 
@@ -633,7 +633,7 @@ describe('D1Store', () => {
       await new Promise(resolve => setTimeout(resolve, 5000));
 
       // Get messages and verify order
-      const order = await store.getMessages({ threadId: thread.id });
+      const order = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(order.length).toBe(3);
     });
   });
@@ -1078,7 +1078,7 @@ describe('D1Store', () => {
       await store.saveMessages({ messages: [message], format: 'v2' });
 
       // Should retrieve correctly
-      const messages = await store.getMessages({ threadId: thread.id });
+      const messages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(messages).toHaveLength(1);
       expect(messages[0].content).toEqual(message.content);
     });
@@ -1100,7 +1100,7 @@ describe('D1Store', () => {
       await Promise.all(messages.map(msg => store.saveMessages({ messages: [msg], format: 'v2' })));
 
       // Order should reflect write order, not timestamp order
-      const order = await store.getMessages({ threadId: thread.id });
+      const order = await store.getMessages({ threadId: thread.id, format: 'v2' });
 
       // Verify messages exist in write order
       const orderIds = order.map(m => m.id);
@@ -1122,7 +1122,7 @@ describe('D1Store', () => {
       await store.saveMessages({ messages, format: 'v2' });
 
       // Verify messages exist
-      const initialOrder = await store.getMessages({ threadId: thread.id });
+      const initialOrder = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(initialOrder).toHaveLength(messages.length);
 
       // Delete thread
@@ -1131,7 +1131,7 @@ describe('D1Store', () => {
       await new Promise(resolve => setTimeout(resolve, 5000));
 
       // Verify messages are cleaned up
-      const finalOrder = await store.getMessages({ threadId: thread.id });
+      const finalOrder = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(finalOrder).toHaveLength(0);
 
       // Verify thread is gone
@@ -1218,7 +1218,7 @@ describe('D1Store', () => {
       await store.saveMessages({ messages: [malformedMessage], format: 'v2' });
 
       // Should still be able to retrieve and handle the message
-      const messages = await store.getMessages({ threadId: thread.id });
+      const messages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(messages).toHaveLength(1);
       expect(messages[0].id).toBe(malformedMessage.id);
     });

--- a/stores/cloudflare-d1/src/storage/binding-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/binding-api.test.ts
@@ -398,10 +398,7 @@ describe('D1Store', () => {
       const retrievedMessages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       const checkMessages = messages.map(m => {
         const { resourceId, ...rest } = m;
-        return {
-          ...rest,
-          createdAt: m.createdAt.toISOString(),
-        };
+        return rest;
       });
       expect(retrievedMessages).toEqual(expect.arrayContaining(checkMessages));
     });

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -642,7 +642,7 @@ export class D1Store extends MastraStorage {
 
       this.logger.debug(`Saved ${messages.length} messages`);
       const list = new MessageList().add(messages, 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       this.logger.error('Error saving messages:', { message: error instanceof Error ? error.message : String(error) });
@@ -747,7 +747,7 @@ export class D1Store extends MastraStorage {
       });
       this.logger.debug(`Retrieved ${messages.length} messages for thread ${threadId}`);
       const list = new MessageList().add(processedMessages as MastraMessageV1[] | MastraMessageV2[], 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       this.logger.error('Error retrieving messages for thread', {

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -104,42 +104,6 @@ export class D1Store extends MastraStorage {
     return params.map(p => (p === undefined || p === null ? null : p) as string);
   }
 
-  // Helper method to create SQL indexes for better query performance
-  private async createIndexIfNotExists(
-    tableName: TABLE_NAMES,
-    columnName: string,
-    indexType: string = '',
-  ): Promise<void> {
-    const fullTableName = this.getTableName(tableName);
-    const indexName = `idx_${tableName}_${columnName}`;
-
-    try {
-      // Check if index exists
-      const checkQuery = createSqlBuilder().checkIndexExists(indexName, fullTableName);
-      const { sql: checkSql, params: checkParams } = checkQuery.build();
-
-      const indexExists = await this.executeQuery({
-        sql: checkSql,
-        params: checkParams,
-        first: true,
-      });
-
-      if (!indexExists) {
-        // Create the index if it doesn't exist
-        const createQuery = createSqlBuilder().createIndex(indexName, fullTableName, columnName, indexType);
-        const { sql: createSql, params: createParams } = createQuery.build();
-
-        await this.executeQuery({ sql: createSql, params: createParams });
-        this.logger.debug(`Created index ${indexName} on ${fullTableName}(${columnName})`);
-      }
-    } catch (error) {
-      this.logger.error(`Error creating index on ${fullTableName}(${columnName}):`, {
-        message: error instanceof Error ? error.message : String(error),
-      });
-      // Non-fatal error, continue execution
-    }
-  }
-
   private async executeWorkersBindingQuery({
     sql,
     params = [],

--- a/stores/cloudflare-d1/src/storage/rest-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/rest-api.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { MessageType, StorageThreadType } from '@mastra/core/memory';
+import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '@mastra/core/memory';
 import type { TABLE_NAMES } from '@mastra/core/storage';
 import {
   TABLE_MESSAGES,
@@ -437,15 +437,15 @@ describe.skip('D1Store REST API', () => {
       const messages = [
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'First' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'First' }] as MastraMessageV2['content'],
         },
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Second' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'Second' }] as MastraMessageV2['content'],
         },
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Third' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'Third' }] as MastraMessageV2['content'],
         },
       ];
 
@@ -1152,7 +1152,7 @@ describe.skip('D1Store REST API', () => {
           content: [{ type: 'text', text: 'Third' }],
           createdAt: new Date(baseTime + 2000),
         },
-      ] as MessageType[];
+      ] as MastraMessageV1[];
 
       await store.saveMessages({ messages });
 
@@ -1189,11 +1189,12 @@ describe.skip('D1Store REST API', () => {
       const thread = createSampleThread();
       const message = {
         ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }] as MessageType['content'],
+        content: [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }] as MastraMessageV1['content'],
+        threadId: thread.id,
       };
 
       await store.saveThread({ thread });
-      await store.saveMessages({ messages: [message] });
+      await store.saveMessages({ messages: [message], format: 'v2' });
 
       // Should retrieve correctly
       const messages = await retryUntil(
@@ -1342,7 +1343,7 @@ describe.skip('D1Store REST API', () => {
       // Test with various malformed data
       const malformedMessage = {
         ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') }] as MessageType['content'], // Very large content
+        content: [{ type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') }] as MastraMessageV2['content'], // Very large content
       };
 
       await store.saveMessages({ messages: [malformedMessage] });

--- a/stores/cloudflare-d1/src/storage/test-utils.ts
+++ b/stores/cloudflare-d1/src/storage/test-utils.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { MessageType, WorkflowRunState } from '@mastra/core';
+import type { MastraMessageV2, WorkflowRunState } from '@mastra/core';
 import { expect } from 'vitest';
 
 export const createSampleTrace = (name: string, scope?: string, attributes?: Record<string, string>) => ({
@@ -29,15 +29,15 @@ export const createSampleThread = () => ({
   metadata: { key: 'value' },
 });
 
-export const createSampleMessage = (threadId: string): MessageType =>
+export const createSampleMessage = (threadId: string, parts?: MastraMessageV2['content']['parts']): MastraMessageV2 =>
   ({
     id: `msg-${randomUUID()}`,
     role: 'user',
     threadId,
-    content: { format: 2, parts: [{ type: 'text' as const, text: 'Hello' }] },
+    content: { format: 2, parts: parts || [{ type: 'text' as const, text: 'Hello' }] },
     createdAt: new Date(),
     resourceId: `resource-${randomUUID()}`,
-  }) satisfies MessageType;
+  }) satisfies MastraMessageV2;
 
 export const createSampleWorkflowSnapshot = (threadId: string, status: string, createdAt?: Date) => {
   const runId = `run-${randomUUID()}`;

--- a/stores/cloudflare/src/storage/binding-api.test.ts
+++ b/stores/cloudflare/src/storage/binding-api.test.ts
@@ -364,7 +364,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Add some messages
       const messages = [createSampleMessage(thread.id), createSampleMessage(thread.id)];
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
       await store.deleteThread({ threadId: thread.id });
 
@@ -376,7 +376,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Verify messages were also deleted with retry
       const retrievedMessages = await retryUntil(
-        async () => await store.getMessages({ threadId: thread.id }),
+        async () => await store.getMessages({ threadId: thread.id, format: 'v2' }),
         messages => messages.length === 0,
       );
       expect(retrievedMessages).toHaveLength(0);
@@ -395,13 +395,13 @@ describe('CloudflareStore Workers Binding', () => {
       const messages = [createSampleMessage(thread.id), createSampleMessage(thread.id)];
 
       // Save messages
-      const savedMessages = await store.saveMessages({ messages });
+      const savedMessages = await store.saveMessages({ messages, format: 'v2' });
       expect(savedMessages).toEqual(messages);
 
       // Retrieve messages with retry
       const retrievedMessages = await retryUntil(
         async () => {
-          const msgs = await store.getMessages({ threadId: thread.id });
+          const msgs = await store.getMessages({ threadId: thread.id, format: 'v2' });
           return msgs;
         },
         msgs => msgs.length === 2,
@@ -421,23 +421,20 @@ describe('CloudflareStore Workers Binding', () => {
 
       const messages = [
         {
-          ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'First' }] as MastraMessageV1['content'],
+          ...createSampleMessage(thread.id, [{ type: 'text' as const, text: 'First' }]),
         },
         {
-          ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Second' }] as MastraMessageV1['content'],
+          ...createSampleMessage(thread.id, [{ type: 'text' as const, text: 'Second' }]),
         },
         {
-          ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Third' }] as MastraMessageV1['content'],
+          ...createSampleMessage(thread.id, [{ type: 'text' as const, text: 'Third' }]),
         },
       ];
 
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
       const retrievedMessages = await retryUntil(
-        async () => await store.getMessages({ threadId: thread.id }),
+        async () => await store.getMessages({ threadId: thread.id, format: 'v2' }),
         messages => messages.length > 0,
       );
       expect(retrievedMessages).toHaveLength(3);
@@ -581,7 +578,7 @@ describe('CloudflareStore Workers Binding', () => {
         createdAt: timestamp,
       }));
 
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
       // Verify order is maintained based on insertion order
       const orderKey = store['getThreadMessagesKey'](thread.id);
@@ -607,7 +604,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Save messages in reverse order to verify write order is preserved
       const reversedMessages = [...messages].reverse(); // newest -> oldest
-      await Promise.all(reversedMessages.map(msg => store.saveMessages({ messages: [msg] })));
+      await Promise.all(reversedMessages.map(msg => store.saveMessages({ messages: [msg], format: 'v2' })));
 
       // Verify messages are saved and maintain write order (not timestamp order)
       const orderKey = store['getThreadMessagesKey'](thread.id);
@@ -632,7 +629,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Create initial messages
       const messages = Array.from({ length: 3 }, () => createSampleMessage(thread.id));
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
       // Update scores to reverse order
       const orderKey = store['getThreadMessagesKey'](thread.id);
@@ -1250,16 +1247,15 @@ describe('CloudflareStore Workers Binding', () => {
     it('should sanitize and handle special characters', async () => {
       const thread = createSampleThread();
       const message = {
-        ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }] as MastraMessageV1['content'],
+        ...createSampleMessage(thread.id, [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }]),
       };
 
       await store.saveThread({ thread });
-      await store.saveMessages({ messages: [message] });
+      await store.saveMessages({ messages: [message], format: 'v2' });
 
       // Should retrieve correctly
       const messages = await retryUntil(
-        async () => await store.getMessages({ threadId: thread.id }),
+        async () => await store.getMessages({ threadId: thread.id, format: 'v2' }),
         messages => messages.length > 0,
       );
       expect(messages).toHaveLength(1);
@@ -1319,7 +1315,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Save thread and message
       await store.saveThread({ thread });
-      await store.saveMessages({ messages: [message] });
+      await store.saveMessages({ messages: [message], format: 'v2' });
 
       // Verify message key format
       const msgKey = store['getKey'](TABLE_MESSAGES, { threadId: thread.id, id: message.id });
@@ -1358,7 +1354,7 @@ describe('CloudflareStore Workers Binding', () => {
       }));
 
       // Save messages in parallel - write order should be preserved
-      await Promise.all(messages.map(msg => store.saveMessages({ messages: [msg] })));
+      await Promise.all(messages.map(msg => store.saveMessages({ messages: [msg], format: 'v2' })));
 
       // Order should reflect write order, not timestamp order
       const orderKey = store['getThreadMessagesKey'](thread.id);
@@ -1379,7 +1375,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Create initial messages
       const messages = Array.from({ length: 3 }, () => createSampleMessage(thread.id));
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
       const orderKey = store['getThreadMessagesKey'](thread.id);
 
@@ -1413,7 +1409,7 @@ describe('CloudflareStore Workers Binding', () => {
       const messages = Array.from({ length: 3 }, () => createSampleMessage(thread.id));
 
       await store.saveThread({ thread });
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
       // Verify messages exist
       const orderKey = store['getThreadMessagesKey'](thread.id);
@@ -1450,11 +1446,11 @@ describe('CloudflareStore Workers Binding', () => {
         ...createSampleMessage(thread.id),
         createdAt: new Date(Date.now() + i * 1000),
       }));
-      await store.saveMessages({ messages: testMessages });
+      await store.saveMessages({ messages: testMessages, format: 'v2' });
 
       // Verify messages are saved
       const initialMessages = await retryUntil(
-        async () => await store.getMessages({ threadId: thread.id }),
+        async () => await store.getMessages({ threadId: thread.id, format: 'v2' }),
         messages => messages.length === testMessages.length,
       );
       expect(initialMessages).toHaveLength(testMessages.length);
@@ -1476,7 +1472,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Verify all data is cleaned up
       const remainingMessages = await retryUntil(
-        async () => await store.getMessages({ threadId: thread.id }),
+        async () => await store.getMessages({ threadId: thread.id, format: 'v2' }),
         messages => messages.length === 0,
       );
       expect(remainingMessages).toHaveLength(0);
@@ -1562,7 +1558,7 @@ describe('CloudflareStore Workers Binding', () => {
       }));
 
       // Save messages in parallel to create race condition
-      await Promise.all(messages.map(msg => store.saveMessages({ messages: [msg] })));
+      await Promise.all(messages.map(msg => store.saveMessages({ messages: [msg], format: 'v2' })));
 
       // Verify both presence and order consistency
       const orderKey = store['getThreadMessagesKey'](thread.id);
@@ -1612,6 +1608,7 @@ describe('CloudflareStore Workers Binding', () => {
       await expect(
         store.saveMessages({
           messages: [message],
+          format: 'v2',
         }),
       ).rejects.toThrow();
     });
@@ -1621,16 +1618,15 @@ describe('CloudflareStore Workers Binding', () => {
       await store.saveThread({ thread });
 
       // Test with various malformed data
-      const malformedMessage = {
-        ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') }] as MastraMessageV1['content'], // Very large content
-      };
+      const malformedMessage = createSampleMessage(thread.id, [
+        { type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') },
+      ]);
 
-      await store.saveMessages({ messages: [malformedMessage] });
+      await store.saveMessages({ messages: [malformedMessage], format: 'v2' });
 
       // Should still be able to retrieve and handle the message
       const messages = await retryUntil(
-        async () => await store.getMessages({ threadId: thread.id }),
+        async () => await store.getMessages({ threadId: thread.id, format: 'v2' }),
         messages => messages.length === 1,
       );
       expect(messages).toHaveLength(1);
@@ -1643,7 +1639,7 @@ describe('CloudflareStore Workers Binding', () => {
 
       // Create initial messages
       const messages = Array.from({ length: 3 }, () => createSampleMessage(thread.id));
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
       // Perform multiple concurrent updates
       const orderKey = store['getThreadMessagesKey'](thread.id);

--- a/stores/cloudflare/src/storage/binding-api.test.ts
+++ b/stores/cloudflare/src/storage/binding-api.test.ts
@@ -1,5 +1,5 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
-import type { MessageType, StorageThreadType } from '@mastra/core/memory';
+import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
 import type { TABLE_NAMES } from '@mastra/core/storage';
 import {
   TABLE_MESSAGES,
@@ -264,10 +264,10 @@ describe('CloudflareStore Workers Binding', () => {
           threadId: 'thread-1',
           content: [{ type: 'text', text: 'test-data-2' }],
           role: 'user',
-        } as MessageType,
+        } as MastraMessageV1,
       });
 
-      const result = await store.load<MessageType>({
+      const result = await store.load<MastraMessageV1>({
         tableName: testTableName2,
         keys: { id: 'test2', threadId: 'thread-1' },
       });
@@ -422,15 +422,15 @@ describe('CloudflareStore Workers Binding', () => {
       const messages = [
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'First' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'First' }] as MastraMessageV1['content'],
         },
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Second' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'Second' }] as MastraMessageV1['content'],
         },
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Third' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'Third' }] as MastraMessageV1['content'],
         },
       ];
 
@@ -674,7 +674,7 @@ describe('CloudflareStore Workers Binding', () => {
           content: [{ type: 'text', text: 'Third' }],
           createdAt: new Date(baseTime + 2000),
         },
-      ] as MessageType[];
+      ] as MastraMessageV1[];
 
       await store.saveMessages({ messages });
 
@@ -1251,7 +1251,7 @@ describe('CloudflareStore Workers Binding', () => {
       const thread = createSampleThread();
       const message = {
         ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }] as MessageType['content'],
+        content: [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }] as MastraMessageV1['content'],
       };
 
       await store.saveThread({ thread });
@@ -1623,7 +1623,7 @@ describe('CloudflareStore Workers Binding', () => {
       // Test with various malformed data
       const malformedMessage = {
         ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') }] as MessageType['content'], // Very large content
+        content: [{ type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') }] as MastraMessageV1['content'], // Very large content
       };
 
       await store.saveMessages({ messages: [malformedMessage] });

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -1081,7 +1081,7 @@ export class CloudflareStore extends MastraStorage {
           ({ ...message, type: message.type !== 'v2' ? message.type : undefined }) as MastraMessageV1,
       );
       const list = new MessageList().add(prepared, 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -1153,7 +1153,7 @@ export class CloudflareStore extends MastraStorage {
       }));
       const list = new MessageList({ threadId, resourceId }).add(prepared as MastraMessageV1[], 'memory');
 
-      if (format === `v1`) return list.get.all.mastra();
+      if (format === `v1`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -1,5 +1,7 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
-import type { StorageThreadType, MessageType } from '@mastra/core/memory';
+import { MessageList } from '@mastra/core/agent';
+import type { MastraMessageV2 } from '@mastra/core/agent';
+import type { StorageThreadType, MastraMessageV1 } from '@mastra/core/memory';
 import {
   MastraStorage,
   TABLE_MESSAGES,
@@ -441,7 +443,7 @@ export class CloudflareStore extends MastraStorage {
     }
   }
 
-  private async updateSorting(threadMessages: (MessageType & { _index?: number })[]) {
+  private async updateSorting(threadMessages: (MastraMessageV1 & { _index?: number })[]) {
     // Sort messages by index or timestamp
     return threadMessages
       .map(msg => ({
@@ -502,7 +504,7 @@ export class CloudflareStore extends MastraStorage {
   private async fetchAndParseMessages(
     threadId: string,
     messageIds: string[],
-  ): Promise<(MessageType & { _index?: number })[]> {
+  ): Promise<(MastraMessageV1 & { _index?: number })[]> {
     const messages = await Promise.all(
       messageIds.map(async id => {
         try {
@@ -517,7 +519,7 @@ export class CloudflareStore extends MastraStorage {
         }
       }),
     );
-    return messages.filter((msg): msg is MessageType & { _index?: number } => msg !== null);
+    return messages.filter((msg): msg is MastraMessageV1 & { _index?: number } => msg !== null);
   }
 
   /**
@@ -996,7 +998,12 @@ export class CloudflareStore extends MastraStorage {
     }
   }
 
-  async saveMessages({ messages }: { messages: MessageType[] }): Promise<MessageType[]> {
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+    const { messages, format = 'v1' } = args;
     if (!Array.isArray(messages) || messages.length === 0) return [];
 
     try {
@@ -1023,12 +1030,14 @@ export class CloudflareStore extends MastraStorage {
 
       // Group messages by thread for batch processing
       const messagesByThread = validatedMessages.reduce((acc, message) => {
-        if (!acc.has(message.threadId)) {
+        if (message.threadId && !acc.has(message.threadId)) {
           acc.set(message.threadId, []);
         }
-        acc.get(message.threadId)!.push(message as MessageType & { _index?: number });
+        if (message.threadId) {
+          acc.get(message.threadId)!.push(message as MastraMessageV1 & { _index?: number });
+        }
         return acc;
-      }, new Map<string, (MessageType & { _index?: number })[]>());
+      }, new Map<string, (MastraMessageV1 & { _index?: number })[]>());
 
       // Process each thread's messages
       await Promise.all(
@@ -1043,7 +1052,7 @@ export class CloudflareStore extends MastraStorage {
             // Save messages with serialized dates
             await Promise.all(
               threadMessages.map(async message => {
-                const key = await this.getMessageKey(threadId, message.id);
+                const key = this.getMessageKey(threadId, message.id);
                 // Strip _index and serialize dates before saving
                 const { _index, ...cleanMessage } = message;
                 const serializedMessage = {
@@ -1067,10 +1076,13 @@ export class CloudflareStore extends MastraStorage {
       );
 
       // Remove _index from returned messages
-      return validatedMessages.map(
+      const prepared = validatedMessages.map(
         ({ _index, ...message }) =>
-          ({ ...message, type: message.type !== 'v2' ? message.type : undefined }) as MessageType,
+          ({ ...message, type: message.type !== 'v2' ? message.type : undefined }) as MastraMessageV1,
       );
+      const list = new MessageList().add(prepared, 'memory');
+      if (format === `v2`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Error saving messages: ${errorMessage}`);
@@ -1078,7 +1090,14 @@ export class CloudflareStore extends MastraStorage {
     }
   }
 
-  async getMessages<T extends MessageType = MessageType>({ threadId, selectBy }: StorageGetMessagesArg): Promise<T[]> {
+  public async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  public async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  public async getMessages({
+    threadId,
+    resourceId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
     if (!threadId) throw new Error('threadId is required');
 
     // Handle selectBy.last type safely - it can be number or false
@@ -1127,11 +1146,15 @@ export class CloudflareStore extends MastraStorage {
       }
 
       // Remove _index and ensure dates before returning, just like Upstash
-      return messages.map(({ _index, ...message }) => ({
+      const prepared = messages.map(({ _index, ...message }) => ({
         ...message,
-        type: message.type === `v2` ? undefined : message.type,
+        type: message.type === (`v2` as `text`) ? undefined : message.type,
         createdAt: this.ensureDate(message.createdAt)!,
-      })) as T[];
+      }));
+      const list = new MessageList({ threadId, resourceId }).add(prepared as MastraMessageV1[], 'memory');
+
+      if (format === `v1`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Error retrieving messages for thread ${threadId}: ${errorMessage}`);

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -1153,8 +1153,8 @@ export class CloudflareStore extends MastraStorage {
       }));
       const list = new MessageList({ threadId, resourceId }).add(prepared as MastraMessageV1[], 'memory');
 
-      if (format === `v1`) return list.get.all.v2();
-      return list.get.all.v1();
+      if (format === `v1`) return list.get.all.v1();
+      return list.get.all.v2();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Error retrieving messages for thread ${threadId}: ${errorMessage}`);

--- a/stores/cloudflare/src/storage/rest-api.test.ts
+++ b/stores/cloudflare/src/storage/rest-api.test.ts
@@ -1,4 +1,4 @@
-import type { MessageType, StorageThreadType } from '@mastra/core/memory';
+import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
 import type { TABLE_NAMES } from '@mastra/core/storage';
 import {
   TABLE_MESSAGES,
@@ -173,10 +173,10 @@ describe.skip('CloudflareStore REST API', () => {
           threadId: 'thread-1',
           content: [{ type: 'text', text: 'test-data-2' }],
           role: 'user',
-        } as MessageType,
+        } as MastraMessageV1,
       });
 
-      const result = await store.load<MessageType>({
+      const result = await store.load<MastraMessageV1>({
         tableName: testTableName2,
         keys: { id: 'test2', threadId: 'thread-1' },
       });
@@ -422,15 +422,15 @@ describe.skip('CloudflareStore REST API', () => {
       const messages = [
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'First' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'First' }] as MastraMessageV1['content'],
         },
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Second' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'Second' }] as MastraMessageV1['content'],
         },
         {
           ...createSampleMessage(thread.id),
-          content: [{ type: 'text' as const, text: 'Third' }] as MessageType['content'],
+          content: [{ type: 'text' as const, text: 'Third' }] as MastraMessageV1['content'],
         },
       ];
 
@@ -676,7 +676,7 @@ describe.skip('CloudflareStore REST API', () => {
           content: [{ type: 'text', text: 'Third' }],
           createdAt: new Date(baseTime + 2000),
         },
-      ] as MessageType[];
+      ] as MastraMessageV1[];
 
       await store.saveMessages({ messages });
 
@@ -1256,7 +1256,7 @@ describe.skip('CloudflareStore REST API', () => {
       const thread = createSampleThread();
       const message = {
         ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }] as MessageType['content'],
+        content: [{ type: 'text' as const, text: '特殊字符 !@#$%^&*()' }] as MastraMessageV1['content'],
       };
 
       await store.saveThread({ thread });
@@ -1628,7 +1628,7 @@ describe.skip('CloudflareStore REST API', () => {
       // Test with various malformed data
       const malformedMessage = {
         ...createSampleMessage(thread.id),
-        content: [{ type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') }] as MessageType['content'], // Very large content
+        content: [{ type: 'text' as const, text: ''.padStart(1024 * 1024, 'x') }] as MastraMessageV1['content'], // Very large content
       };
 
       await store.saveMessages({ messages: [malformedMessage] });

--- a/stores/cloudflare/src/storage/test-utils.ts
+++ b/stores/cloudflare/src/storage/test-utils.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { MessageType, WorkflowRunState } from '@mastra/core';
+import type { MastraMessageV2, WorkflowRunState } from '@mastra/core';
 import { expect } from 'vitest';
 
 export const createSampleTrace = (name: string, scope?: string, attributes?: Record<string, string>) => ({
@@ -29,7 +29,7 @@ export const createSampleThread = () => ({
   metadata: { key: 'value' },
 });
 
-export const createSampleMessage = (threadId: string): MessageType =>
+export const createSampleMessage = (threadId: string): MastraMessageV2 =>
   ({
     id: `msg-${randomUUID()}`,
     role: 'user',
@@ -37,7 +37,7 @@ export const createSampleMessage = (threadId: string): MessageType =>
     content: { format: 2, parts: [{ type: 'text' as const, text: 'Hello' }] },
     createdAt: new Date(),
     resourceId: `resource-${randomUUID()}`,
-  }) satisfies MessageType;
+  }) satisfies MastraMessageV2;
 
 export const createSampleWorkflowSnapshot = (threadId: string, status: string, createdAt?: Date) => {
   const runId = `run-${randomUUID()}`;

--- a/stores/cloudflare/src/storage/test-utils.ts
+++ b/stores/cloudflare/src/storage/test-utils.ts
@@ -29,10 +29,16 @@ export const createSampleThread = () => ({
   metadata: { key: 'value' },
 });
 
+let role: 'assistant' | 'user' = 'assistant';
+const getRole = () => {
+  if (role === 'user') role = 'assistant';
+  else role = 'user';
+  return role;
+};
 export const createSampleMessage = (threadId: string, parts?: MastraMessageV2['content']['parts']): MastraMessageV2 =>
   ({
     id: `msg-${randomUUID()}`,
-    role: 'user',
+    role: getRole(),
     threadId,
     content: { format: 2, parts: parts || [{ type: 'text' as const, text: 'Hello' }] },
     createdAt: new Date(),

--- a/stores/cloudflare/src/storage/test-utils.ts
+++ b/stores/cloudflare/src/storage/test-utils.ts
@@ -29,12 +29,12 @@ export const createSampleThread = () => ({
   metadata: { key: 'value' },
 });
 
-export const createSampleMessage = (threadId: string): MastraMessageV2 =>
+export const createSampleMessage = (threadId: string, parts?: MastraMessageV2['content']['parts']): MastraMessageV2 =>
   ({
     id: `msg-${randomUUID()}`,
     role: 'user',
     threadId,
-    content: { format: 2, parts: [{ type: 'text' as const, text: 'Hello' }] },
+    content: { format: 2, parts: parts || [{ type: 'text' as const, text: 'Hello' }] },
     createdAt: new Date(),
     resourceId: `resource-${randomUUID()}`,
   }) satisfies MastraMessageV2;

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -1,5 +1,5 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
-import type { StorageThreadType, MessageType } from '@mastra/core/memory';
+import type { StorageThreadType, MastraMessageV2 } from '@mastra/core/memory';
 import type {
   TABLE_MESSAGES,
   TABLE_THREADS,
@@ -67,7 +67,7 @@ export function isWorkersConfig(config: CloudflareStoreConfig): config is Cloudf
 
 export type RecordTypes = {
   [TABLE_THREADS]: StorageThreadType;
-  [TABLE_MESSAGES]: MessageType;
+  [TABLE_MESSAGES]: MastraMessageV2;
   [TABLE_WORKFLOW_SNAPSHOT]: WorkflowRunState;
   [TABLE_EVALS]: EvalRow;
   [TABLE_TRACES]: any;

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -541,7 +541,7 @@ export class DynamoDBStore extends MastraStorage {
           results.data.map((data: any) => this.parseMessageData(data)),
           'memory',
         );
-        if (format === `v2`) return list.get.all.mastra();
+        if (format === `v2`) return list.get.all.v2();
         return list.get.all.v1();
       }
 
@@ -552,7 +552,7 @@ export class DynamoDBStore extends MastraStorage {
         results.data.map((data: any) => this.parseMessageData(data)),
         'memory',
       );
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       this.logger.error('Failed to get messages', { threadId, error });
@@ -617,7 +617,7 @@ export class DynamoDBStore extends MastraStorage {
 
       const list = new MessageList().add(messages, 'memory');
       if (format === `v1`) return list.get.all.v1();
-      return list.get.all.mastra();
+      return list.get.all.v2();
     } catch (error) {
       this.logger.error('Failed to save messages', { error });
       throw error;

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -1,7 +1,6 @@
 import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import type { StorageThreadType, WorkflowRunState, MastraMessageV1 } from '@mastra/core';
-import type { MastraMessageV2 } from '@mastra/core/agent';
+import type { StorageThreadType, WorkflowRunState, MastraMessageV1, MastraMessageV2 } from '@mastra/core';
 import { MessageList } from '@mastra/core/agent';
 import {
   MastraStorage,

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -445,7 +445,7 @@ export class LibSQLStore extends MastraStorage {
       messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
       const list = new MessageList().add(messages, 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       this.logger.error('Error getting messages:', error as Error);
@@ -490,7 +490,7 @@ export class LibSQLStore extends MastraStorage {
       await this.client.batch(batchStatements, 'write');
 
       const list = new MessageList().add(messages, 'memory');
-      if (format === `v1`) return list.get.all.mastra();
+      if (format === `v1`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       this.logger.error('Failed to save messages in database: ' + (error as { message: string })?.message);

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -490,7 +490,7 @@ export class LibSQLStore extends MastraStorage {
       await this.client.batch(batchStatements, 'write');
 
       const list = new MessageList().add(messages, 'memory');
-      if (format === `v1`) return list.get.all.v2();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       this.logger.error('Failed to save messages in database: ' + (error as { message: string })?.message);

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1,8 +1,9 @@
 import { createClient } from '@libsql/client';
 import type { Client, InValue } from '@libsql/client';
+import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV2 } from '@mastra/core/agent';
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
-import type { StorageThreadType } from '@mastra/core/memory';
+import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
 import {
   MastraStorage,
   TABLE_MESSAGES,
@@ -362,7 +363,13 @@ export class LibSQLStore extends MastraStorage {
     return result;
   }
 
-  async getMessages<T extends MastraMessageV2[]>({ threadId, selectBy }: StorageGetMessagesArg): Promise<T> {
+  public async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  public async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  public async getMessages({
+    threadId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
     try {
       const messages: MastraMessageV2[] = [];
       const limit = typeof selectBy?.last === `number` ? selectBy.last : 40;
@@ -437,14 +444,23 @@ export class LibSQLStore extends MastraStorage {
       // Sort all messages by creation date
       messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-      return messages as T;
+      const list = new MessageList().add(messages, 'memory');
+      if (format === `v2`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       this.logger.error('Error getting messages:', error as Error);
       throw error;
     }
   }
 
-  async saveMessages({ messages }: { messages: MastraMessageV2[] }): Promise<MastraMessageV2[]> {
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages({
+    messages,
+    format,
+  }:
+    | { messages: MastraMessageV1[]; format?: undefined | 'v1' }
+    | { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[] | MastraMessageV1[]> {
     if (messages.length === 0) return messages;
 
     try {
@@ -473,7 +489,9 @@ export class LibSQLStore extends MastraStorage {
       // Execute all inserts in a single batch
       await this.client.batch(batchStatements, 'write');
 
-      return messages;
+      const list = new MessageList().add(messages, 'memory');
+      if (format === `v1`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       this.logger.error('Failed to save messages in database: ' + (error as { message: string })?.message);
       throw error;

--- a/stores/mongodb/src/storage/index.test.ts
+++ b/stores/mongodb/src/storage/index.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { MessageType, MetricResult, WorkflowRunState } from '@mastra/core';
+import type { MastraMessageV1, MetricResult, WorkflowRunState } from '@mastra/core';
 import { TABLE_EVALS, TABLE_MESSAGES, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MongoDBConfig } from './index';
@@ -40,7 +40,7 @@ class Test {
     };
   }
 
-  generateSampleMessage(threadId: string): MessageType {
+  generateSampleMessage(threadId: string): MastraMessageV1 {
     return {
       id: `msg-${randomUUID()}`,
       role: 'user',
@@ -274,15 +274,15 @@ describe('MongoDBStore', () => {
       const messages = [
         {
           ...test.generateSampleMessage(thread.id),
-          content: [{ type: 'text', text: 'First' }] as MessageType['content'],
+          content: [{ type: 'text', text: 'First' }] as MastraMessageV1['content'],
         },
         {
           ...test.generateSampleMessage(thread.id),
-          content: [{ type: 'text', text: 'Second' }] as MessageType['content'],
+          content: [{ type: 'text', text: 'Second' }] as MastraMessageV1['content'],
         },
         {
           ...test.generateSampleMessage(thread.id),
-          content: [{ type: 'text', text: 'Third' }] as MessageType['content'],
+          content: [{ type: 'text', text: 'Third' }] as MastraMessageV1['content'],
         },
       ];
 

--- a/stores/mongodb/src/storage/index.test.ts
+++ b/stores/mongodb/src/storage/index.test.ts
@@ -244,7 +244,10 @@ describe('MongoDBStore', () => {
       const thread = test.generateSampleThread();
       await store.saveThread({ thread });
 
-      const messages = [test.generateSampleMessage(thread.id), test.generateSampleMessage(thread.id)];
+      const messages = [
+        test.generateSampleMessage(thread.id),
+        { ...test.generateSampleMessage(thread.id), role: 'assistant' as const },
+      ];
 
       // Save messages
       const savedMessages = await store.saveMessages({ messages });

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -1,5 +1,6 @@
+import { MessageList } from '@mastra/core/agent';
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
-import type { MessageType, StorageThreadType } from '@mastra/core/memory';
+import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '@mastra/core/memory';
 import type { EvalRow, StorageGetMessagesArg, TABLE_NAMES, WorkflowRun } from '@mastra/core/storage';
 import {
   MastraStorage,
@@ -235,8 +236,8 @@ export class MongoDBStore extends MastraStorage {
     try {
       const limit = typeof selectBy?.last === 'number' ? selectBy.last : 40;
       const include = selectBy?.include || [];
-      let messages: MessageType[] = [];
-      let allMessages: MessageType[] = [];
+      let messages: MastraMessageV2[] = [];
+      let allMessages: MastraMessageV2[] = [];
       const collection = await this.getCollection(TABLE_MESSAGES);
       // Get all messages from the thread ordered by creation date descending
       allMessages = (await collection.find({ thread_id: threadId }).sort({ createdAt: -1 }).toArray()).map((row: any) =>
@@ -270,7 +271,7 @@ export class MongoDBStore extends MastraStorage {
         messages.push(
           ...Array.from(selectedIndexes)
             .map(i => allMessages[i])
-            .filter((m): m is MessageType => !!m),
+            .filter((m): m is MastraMessageV2 => !!m),
         );
       }
 
@@ -293,7 +294,14 @@ export class MongoDBStore extends MastraStorage {
     }
   }
 
-  async saveMessages({ messages }: { messages: MessageType[] }): Promise<MessageType[]> {
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages({
+    messages,
+    format,
+  }:
+    | { messages: MastraMessageV1[]; format?: undefined | 'v1' }
+    | { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[] | MastraMessageV1[]> {
     if (!messages.length) {
       return messages;
     }
@@ -321,7 +329,9 @@ export class MongoDBStore extends MastraStorage {
       // Execute all inserts in a single batch
       const collection = await this.getCollection(TABLE_MESSAGES);
       await collection.insertMany(messagesToInsert);
-      return messages;
+      const list = new MessageList().add(messages, 'memory');
+      if (format === `v2`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       this.logger.error('Failed to save messages in database: ' + (error as { message: string })?.message);
       throw error;
@@ -628,7 +638,7 @@ export class MongoDBStore extends MastraStorage {
     };
   }
 
-  private parseRow(row: any): MessageType {
+  private parseRow(row: any): MastraMessageV2 {
     let content = row.content;
     try {
       content = JSON.parse(row.content);
@@ -642,7 +652,7 @@ export class MongoDBStore extends MastraStorage {
       type: row.type,
       createdAt: new Date(row.createdAt as string),
       threadId: row.thread_id,
-    } as MessageType;
+    } as MastraMessageV2;
   }
 
   private transformEvalRow(row: Record<string, any>): EvalRow {

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -330,7 +330,7 @@ export class MongoDBStore extends MastraStorage {
       const collection = await this.getCollection(TABLE_MESSAGES);
       await collection.insertMany(messagesToInsert);
       const list = new MessageList().add(messages, 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       this.logger.error('Failed to save messages in database: ' + (error as { message: string })?.message);

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -31,10 +31,16 @@ const createSampleThread = () => ({
   metadata: { key: 'value' },
 });
 
+let role: 'user' | 'assistant' = 'assistant';
+const getRole = () => {
+  if (role === `user`) role = `assistant`;
+  else role = `user`;
+  return role;
+};
 const createSampleMessage = (threadId: string): MastraMessageV1 => ({
   id: `msg-${randomUUID()}`,
   resourceId: `resource-${randomUUID()}`,
-  role: 'user',
+  role: getRole(),
   type: 'text',
   threadId,
   content: [{ type: 'text', text: 'Hello' }],

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,6 +1,6 @@
-import type { MastraMessageV2 } from '@mastra/core/agent';
+import { MessageList, type MastraMessageV2 } from '@mastra/core/agent';
 import type { MetricResult } from '@mastra/core/eval';
-import type { StorageThreadType } from '@mastra/core/memory';
+import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
 import {
   MastraStorage,
   TABLE_MESSAGES,
@@ -677,7 +677,14 @@ export class PostgresStore extends MastraStorage {
     }
   }
 
-  async saveMessages({ messages }: { messages: MastraMessageV2[] }): Promise<MastraMessageV2[]> {
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages({
+    messages,
+    format,
+  }:
+    | { messages: MastraMessageV1[]; format?: undefined | 'v1' }
+    | { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[] | MastraMessageV1[]> {
     if (messages.length === 0) return messages;
 
     try {
@@ -709,7 +716,9 @@ export class PostgresStore extends MastraStorage {
         }
       });
 
-      return messages;
+      const list = new MessageList().add(messages, 'memory');
+      if (format === `v2`) return list.get.all.mastra();
+      return list.get.all.v1();
     } catch (error) {
       console.error('Error saving messages:', error);
       throw error;

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,4 +1,5 @@
-import { MessageList, type MastraMessageV2 } from '@mastra/core/agent';
+import { MessageList } from '@mastra/core/agent';
+import type { MastraMessageV2 } from '@mastra/core/agent';
 import type { MetricResult } from '@mastra/core/eval';
 import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
 import {
@@ -717,7 +718,7 @@ export class PostgresStore extends MastraStorage {
       });
 
       const list = new MessageList().add(messages, 'memory');
-      if (format === `v2`) return list.get.all.mastra();
+      if (format === `v2`) return list.get.all.v2();
       return list.get.all.v1();
     } catch (error) {
       console.error('Error saving messages:', error);

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -546,7 +546,7 @@ export class UpstashStore extends MastraStorage {
     }
 
     const list = new MessageList().add(messages, 'memory');
-    if (format === `v2`) return list.get.all.mastra();
+    if (format === `v2`) return list.get.all.v2();
     return list.get.all.v1();
   }
 
@@ -612,7 +612,7 @@ export class UpstashStore extends MastraStorage {
     const prepared = messages.map(({ _index, ...message }) => message as unknown as MastraMessageV1);
 
     const list = new MessageList().add(prepared, 'memory');
-    if (format === `v2`) return list.get.all.mastra();
+    if (format === `v2`) return list.get.all.v2();
     return list.get.all.v1();
   }
 

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
-import type { StorageThreadType, MessageType } from '@mastra/core/memory';
+import type { StorageThreadType, MastraMessageV1, MastraMessageV2 } from '@mastra/core/memory';
 import {
   MastraStorage,
   TABLE_MESSAGES,
@@ -18,6 +18,7 @@ import type {
 } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import { Redis } from '@upstash/redis';
+import { MessageList } from '../../../../packages/core/dist/agent/index.cjs';
 
 export interface UpstashConfig {
   url: string;
@@ -509,7 +510,12 @@ export class UpstashStore extends MastraStorage {
     await this.redis.del(key);
   }
 
-  async saveMessages({ messages }: { messages: MessageType[] }): Promise<MessageType[]> {
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+    const { messages, format = 'v1' } = args;
     if (messages.length === 0) return [];
 
     // Add an index to each message to maintain order
@@ -523,14 +529,14 @@ export class UpstashStore extends MastraStorage {
       const batch = messagesWithIndex.slice(i, i + batchSize);
       const pipeline = this.redis.pipeline();
       for (const message of batch) {
-        const key = this.getMessageKey(message.threadId, message.id);
+        const key = this.getMessageKey(message.threadId!, message.id);
         const score = message._index !== undefined ? message._index : new Date(message.createdAt).getTime();
 
         // Store the message data
         pipeline.set(key, message);
 
         // Add to sorted set for this thread
-        pipeline.zadd(this.getThreadMessagesKey(message.threadId), {
+        pipeline.zadd(this.getThreadMessagesKey(message.threadId!), {
           score,
           member: message.id,
         });
@@ -539,10 +545,18 @@ export class UpstashStore extends MastraStorage {
       await pipeline.exec();
     }
 
-    return messages;
+    const list = new MessageList().add(messages, 'memory');
+    if (format === `v2`) return list.get.all.mastra();
+    return list.get.all.v1();
   }
 
-  async getMessages<T = unknown>({ threadId, selectBy }: StorageGetMessagesArg): Promise<T[]> {
+  public async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  public async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  public async getMessages({
+    threadId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
     const limit = typeof selectBy?.last === `number` ? selectBy.last : 40;
     const messageIds = new Set<string>();
     const threadMessagesKey = this.getThreadMessagesKey(threadId);
@@ -585,17 +599,21 @@ export class UpstashStore extends MastraStorage {
     const messages = (
       await Promise.all(
         Array.from(messageIds).map(async id =>
-          this.redis.get<MessageType & { _index?: number }>(this.getMessageKey(threadId, id)),
+          this.redis.get<MastraMessageV2 & { _index?: number }>(this.getMessageKey(threadId, id)),
         ),
       )
-    ).filter(msg => msg !== null) as (MessageType & { _index?: number })[];
+    ).filter(msg => msg !== null) as (MastraMessageV2 & { _index?: number })[];
 
     // Sort messages by their position in the sorted set
     const messageOrder = await this.redis.zrange(threadMessagesKey, 0, -1);
     messages.sort((a, b) => messageOrder.indexOf(a!.id) - messageOrder.indexOf(b!.id));
 
     // Remove _index before returning
-    return messages.map(({ _index, ...message }) => message as unknown as T);
+    const prepared = messages.map(({ _index, ...message }) => message as unknown as MastraMessageV1);
+
+    const list = new MessageList().add(prepared, 'memory');
+    if (format === `v2`) return list.get.all.mastra();
+    return list.get.all.v1();
   }
 
   async persistWorkflowSnapshot(params: {

--- a/stores/upstash/src/storage/upstash.test.ts
+++ b/stores/upstash/src/storage/upstash.test.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { MastraMessageV2 } from '@mastra/core/agent';
-import type { MessageType } from '@mastra/core/memory';
+import type { MastraMessageV2 } from '@mastra/core';
 import type { TABLE_NAMES } from '@mastra/core/storage';
 import {
   TABLE_MESSAGES,
@@ -26,7 +25,7 @@ const createSampleThread = (date?: Date) => ({
   metadata: { key: 'value' },
 });
 
-const createSampleMessage = (threadId: string, content: string = 'Hello'): MessageType => ({
+const createSampleMessage = (threadId: string, content: string = 'Hello'): MastraMessageV2 => ({
   id: `msg-${randomUUID()}`,
   role: 'user',
   threadId,
@@ -319,15 +318,15 @@ describe('UpstashStore', () => {
     });
 
     it('should save and retrieve messages in order', async () => {
-      const messages: MessageType[] = [
+      const messages: MastraMessageV2[] = [
         createSampleMessage(threadId, 'First'),
         createSampleMessage(threadId, 'Second'),
         createSampleMessage(threadId, 'Third'),
       ];
 
-      await store.saveMessages({ messages: messages });
+      await store.saveMessages({ messages: messages, format: 'v2' });
 
-      const retrievedMessages = await store.getMessages<MastraMessageV2[]>({ threadId });
+      const retrievedMessages = await store.getMessages({ threadId, format: 'v2' });
       expect(retrievedMessages).toHaveLength(3);
       expect(retrievedMessages.map((m: any) => m.content.parts[0].text)).toEqual(['First', 'Second', 'Third']);
     });
@@ -353,11 +352,11 @@ describe('UpstashStore', () => {
           },
           createdAt: new Date(),
         },
-      ] as MessageType[];
+      ] as MastraMessageV2[];
 
-      await store.saveMessages({ messages });
+      await store.saveMessages({ messages, format: 'v2' });
 
-      const retrievedMessages = await store.getMessages<MastraMessageV2>({ threadId });
+      const retrievedMessages = await store.getMessages({ threadId });
       expect(retrievedMessages[0].content).toEqual(messages[0].content);
     });
   });

--- a/stores/upstash/src/storage/upstash.test.ts
+++ b/stores/upstash/src/storage/upstash.test.ts
@@ -356,7 +356,7 @@ describe('UpstashStore', () => {
 
       await store.saveMessages({ messages, format: 'v2' });
 
-      const retrievedMessages = await store.getMessages({ threadId });
+      const retrievedMessages = await store.getMessages({ threadId, format: 'v2' });
       expect(retrievedMessages[0].content).toEqual(messages[0].content);
     });
   });


### PR DESCRIPTION
In https://github.com/mastra-ai/mastra/pull/4436 I added code to save UIMessages in memory/storage.
Today @TheIsrael1 showed me that the typecheck for dynamodb was actually failing after these changes (fixed in https://github.com/mastra-ai/mastra/pull/4527). This made me realize I needed to add this extra code for all storage adapters until our next big breaking change