### PR TITLE
fix: setTraceContextTraces is not a function

### DIFF
--- a/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
+++ b/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
@@ -19,14 +19,16 @@ function AgentTracesContent() {
   }
 
   return (
-    <TraceProvider initialTraces={traces || []}>
-      <AgentTraces traces={traces || []} isLoading={firstCallLoading} error={error} className="h-[calc(100vh-40px)]" />
-    </TraceProvider>
+    <AgentTraces traces={traces || []} isLoading={firstCallLoading} error={error} className="h-[calc(100vh-40px)]" />
   );
 }
 
 function AgentTracesPage() {
-  return <AgentTracesContent />;
+  return (
+    <TraceProvider>
+      <AgentTracesContent />
+    </TraceProvider>
+  );
 }
 
 export default AgentTracesPage;


### PR DESCRIPTION
## Description
The incorrect position of TraceProvider leads to an error in setTraceContextTraces.
<!-- Provide a brief description of the changes in this PR -->
<img width="436" alt="image" src="https://github.com/user-attachments/assets/773c5c9e-7ec6-4f00-abbf-945cccab33c6" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
