### PR TITLE
fix: traces are not showing for agents

### DIFF
--- a/.changeset/sweet-lies-reply.md
+++ b/.changeset/sweet-lies-reply.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+fix traces not showing and reduce API surface from playground ui

--- a/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
+++ b/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
@@ -1,4 +1,4 @@
-import { AgentTraces, TraceProvider, useTraces } from '@mastra/playground-ui';
+import { AgentTraces, useTraces } from '@mastra/playground-ui';
 import { useParams } from 'react-router';
 
 import { Skeleton } from '@/components/ui/skeleton';
@@ -10,7 +10,7 @@ function AgentTracesContent() {
   const { agent, isLoading: isAgentLoading } = useAgent(agentId!);
   const { traces, firstCallLoading, error } = useTraces(agent?.name || '', '');
 
-  if (isAgentLoading) {
+  if (isAgentLoading || firstCallLoading) {
     return (
       <div className="p-4">
         <Skeleton className="h-10" />
@@ -18,11 +18,7 @@ function AgentTracesContent() {
     );
   }
 
-  return (
-    <TraceProvider initialTraces={traces || []}>
-      <AgentTraces traces={traces || []} isLoading={firstCallLoading} error={error} className="h-[calc(100vh-40px)]" />
-    </TraceProvider>
-  );
+  return <AgentTraces traces={traces || []} error={error} className="h-[calc(100vh-40px)]" />;
 }
 
 function AgentTracesPage() {

--- a/packages/cli/src/playground/src/pages/workflows/workflow/legacy/traces.tsx
+++ b/packages/cli/src/playground/src/pages/workflows/workflow/legacy/traces.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router';
-import { TraceProvider, useTraces, WorkflowTraces } from '@mastra/playground-ui';
+import { useTraces, WorkflowTraces } from '@mastra/playground-ui';
 
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -9,11 +9,9 @@ import { useLegacyWorkflow } from '@/hooks/use-workflows';
 function WorkflowTracesContent() {
   const { workflowId } = useParams();
   const { legacyWorkflow, isLoading: isWorkflowLoading } = useLegacyWorkflow(workflowId!);
-
-  // This hook will now be called within a TraceProvider context
   const { traces, error, firstCallLoading } = useTraces(legacyWorkflow?.name || '', '', true);
 
-  if (isWorkflowLoading) {
+  if (isWorkflowLoading || firstCallLoading) {
     return (
       <main className="flex-1 relative grid grid-cols-[1fr_325px] divide-x h-full">
         <div className="p-4">
@@ -26,15 +24,11 @@ function WorkflowTracesContent() {
     );
   }
 
-  return <WorkflowTraces traces={traces} isLoading={firstCallLoading} error={error} />;
+  return <WorkflowTraces traces={traces} error={error} />;
 }
 
 function WorkflowTracesPage() {
-  return (
-    <TraceProvider>
-      <WorkflowTracesContent />
-    </TraceProvider>
-  );
+  return <WorkflowTracesContent />;
 }
 
 export default WorkflowTracesPage;

--- a/packages/cli/src/playground/src/pages/workflows/workflow/traces.tsx
+++ b/packages/cli/src/playground/src/pages/workflows/workflow/traces.tsx
@@ -1,5 +1,5 @@
 import { useParams, useSearchParams } from 'react-router';
-import { TraceProvider, useTraces, WorkflowTraces } from '@mastra/playground-ui';
+import { useTraces, WorkflowTraces } from '@mastra/playground-ui';
 
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -13,10 +13,9 @@ function WorkflowTracesContent() {
   const stepName = searchParams.get('stepName');
   const { workflow, isLoading: isWorkflowLoading } = useWorkflow(workflowId!);
 
-  // This hook will now be called within a TraceProvider context
   const { traces, error, firstCallLoading } = useTraces(workflow?.name || '', '', true);
 
-  if (isWorkflowLoading) {
+  if (isWorkflowLoading || firstCallLoading) {
     return (
       <main className="flex-1 relative grid grid-cols-[1fr_325px] divide-x h-full">
         <div className="p-4">
@@ -29,23 +28,11 @@ function WorkflowTracesContent() {
     );
   }
 
-  return (
-    <WorkflowTraces
-      traces={traces}
-      isLoading={firstCallLoading}
-      error={error}
-      runId={runId || undefined}
-      stepName={stepName || undefined}
-    />
-  );
+  return <WorkflowTraces traces={traces} error={error} runId={runId || undefined} stepName={stepName || undefined} />;
 }
 
 function WorkflowTracesPage() {
-  return (
-    <TraceProvider>
-      <WorkflowTracesContent />
-    </TraceProvider>
-  );
+  return <WorkflowTracesContent />;
 }
 
 export default WorkflowTracesPage;

--- a/packages/playground-ui/src/domains/agents/agent/agent-traces.tsx
+++ b/packages/playground-ui/src/domains/agents/agent/agent-traces.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from 'react';
 
-import { TraceContext } from '@/domains/traces/context/trace-context';
+import { TraceContext, TraceProvider } from '@/domains/traces/context/trace-context';
 
 import { TracesTable } from '../../traces/traces-table';
 import { TracesSidebar } from '@/domains/traces/traces-sidebar';
@@ -10,22 +10,25 @@ import { RefinedTrace } from '@/domains/traces/types';
 export interface AgentTracesProps {
   className?: string;
   traces: RefinedTrace[];
-  isLoading: boolean;
   error: { message: string } | null;
 }
 
-export function AgentTraces({ className, traces, isLoading, error }: AgentTracesProps) {
-  return <AgentTracesInner className={className} traces={traces} isLoading={isLoading} error={error} />;
+export function AgentTraces({ className, traces, error }: AgentTracesProps) {
+  return (
+    <TraceProvider initialTraces={traces || []}>
+      <AgentTracesInner className={className} traces={traces} error={error} />
+    </TraceProvider>
+  );
 }
 
-function AgentTracesInner({ className, traces, isLoading, error }: AgentTracesProps) {
+function AgentTracesInner({ className, traces, error }: AgentTracesProps) {
   const [sidebarWidth, setSidebarWidth] = useState(100);
   const { isOpen: open } = useContext(TraceContext);
 
   return (
     <div className={clsx('h-full relative overflow-hidden flex', className)}>
       <div className="h-full overflow-y-scroll w-full">
-        <TracesTable traces={traces} isLoading={isLoading} error={error} />
+        <TracesTable traces={traces} error={error} />
       </div>
 
       {open && <TracesSidebar width={sidebarWidth} onResize={setSidebarWidth} />}

--- a/packages/playground-ui/src/domains/traces/context/trace-context.tsx
+++ b/packages/playground-ui/src/domains/traces/context/trace-context.tsx
@@ -8,7 +8,6 @@ export type TraceContextType = {
   trace: Span[] | null;
   setTrace: React.Dispatch<React.SetStateAction<Span[] | null>>;
   traces: RefinedTrace[];
-  setTraces: React.Dispatch<React.SetStateAction<RefinedTrace[]>>;
   currentTraceIndex: number;
   setCurrentTraceIndex: React.Dispatch<React.SetStateAction<number>>;
   nextTrace: () => void;
@@ -22,14 +21,13 @@ export const TraceContext = createContext<TraceContextType>({} as TraceContextTy
 
 export function TraceProvider({
   children,
-  initialTraces,
+  initialTraces: traces = [],
 }: {
   children: React.ReactNode;
   initialTraces?: RefinedTrace[];
 }) {
   const [open, setOpen] = useState(false);
   const [trace, setTrace] = useState<Span[] | null>(null);
-  const [traces, setTraces] = useState<RefinedTrace[]>(initialTraces || []);
   const [currentTraceIndex, setCurrentTraceIndex] = useState(0);
   const [span, setSpan] = useState<Span | null>(null);
 
@@ -69,7 +67,6 @@ export function TraceProvider({
         trace,
         setTrace,
         traces,
-        setTraces,
         currentTraceIndex,
         setCurrentTraceIndex,
         nextTrace,

--- a/packages/playground-ui/src/domains/traces/traces-table.tsx
+++ b/packages/playground-ui/src/domains/traces/traces-table.tsx
@@ -11,20 +11,6 @@ import { TraceContext } from './context/trace-context';
 import { Check, X } from 'lucide-react';
 import { toSigFigs } from '@/lib/number';
 
-const TracesTableSkeleton = ({ colsCount }: { colsCount: number }) => {
-  return (
-    <Tbody>
-      <Row>
-        {Array.from({ length: colsCount }).map((_, index) => (
-          <Cell key={index}>
-            <Skeleton className="w-1/2" />
-          </Cell>
-        ))}
-      </Row>
-    </Tbody>
-  );
-};
-
 const TracesTableEmpty = ({ colsCount }: { colsCount: number }) => {
   return (
     <Tbody>
@@ -51,7 +37,6 @@ const TracesTableError = ({ error, colsCount }: { error: { message: string }; co
 
 export interface TracesTableProps {
   traces: RefinedTrace[];
-  isLoading: boolean;
   error: { message: string } | null;
 }
 
@@ -84,7 +69,7 @@ const TraceRow = ({ trace, index, isActive }: { trace: RefinedTrace; index: numb
   );
 };
 
-export const TracesTable = ({ traces, isLoading, error }: TracesTableProps) => {
+export const TracesTable = ({ traces, error }: TracesTableProps) => {
   const hasNoTraces = !traces || traces.length === 0;
   const { currentTraceIndex } = useContext(TraceContext);
   const colsCount = 4;
@@ -98,9 +83,7 @@ export const TracesTable = ({ traces, isLoading, error }: TracesTableProps) => {
         <Th width={120}>Spans</Th>
         <Th width={120}>Status</Th>
       </Thead>
-      {isLoading ? (
-        <TracesTableSkeleton colsCount={colsCount} />
-      ) : error ? (
+      {error ? (
         <TracesTableError error={error} colsCount={colsCount} />
       ) : hasNoTraces ? (
         <TracesTableEmpty colsCount={colsCount} />

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-traces.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-traces.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef, useState } from 'react';
 
-import { TraceContext } from '@/domains/traces/context/trace-context';
+import { TraceContext, TraceProvider } from '@/domains/traces/context/trace-context';
 
 import { TracesTable } from '@/domains/traces/traces-table';
 import { TracesSidebar } from '@/domains/traces/traces-sidebar';
@@ -8,17 +8,20 @@ import { RefinedTrace } from '@/domains/traces/types';
 
 export interface WorkflowTracesProps {
   traces: RefinedTrace[];
-  isLoading: boolean;
   error: { message: string } | null;
   runId?: string;
   stepName?: string;
 }
 
-export function WorkflowTraces({ traces, isLoading, error, runId, stepName }: WorkflowTracesProps) {
-  return <WorkflowTracesInner traces={traces} isLoading={isLoading} error={error} runId={runId} stepName={stepName} />;
+export function WorkflowTraces({ traces, error, runId, stepName }: WorkflowTracesProps) {
+  return (
+    <TraceProvider initialTraces={traces || []}>
+      <WorkflowTracesInner traces={traces} error={error} runId={runId} stepName={stepName} />
+    </TraceProvider>
+  );
 }
 
-function WorkflowTracesInner({ traces, isLoading, error, runId, stepName }: WorkflowTracesProps) {
+function WorkflowTracesInner({ traces, error, runId, stepName }: WorkflowTracesProps) {
   // This is a hack. To fix, The provider should not resolve the data like this.
   // We should resolve the data first and pass them to the provider instead of having the proving setState on the result.
   const hasRunRef = useRef(false);
@@ -44,7 +47,7 @@ function WorkflowTracesInner({ traces, isLoading, error, runId, stepName }: Work
   return (
     <main className="h-full relative overflow-hidden flex">
       <div className="h-full overflow-y-scroll w-full">
-        <TracesTable traces={traces} isLoading={isLoading} error={error} />
+        <TracesTable traces={traces} error={error} />
       </div>
 
       {open && <TracesSidebar width={sidebarWidth} onResize={setSidebarWidth} />}

--- a/packages/playground-ui/src/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/hooks/use-traces.tsx
@@ -1,17 +1,14 @@
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import usePolling from '@/lib/polls';
 
 import type { RefinedTrace } from '@/domains/traces/types';
 import { refineTraces } from '@/domains/traces/utils';
-import { TraceContext } from '@/domains/traces/context/trace-context';
 import { createMastraClient } from '@/lib/mastra-client';
 
 export const useTraces = (componentName: string, baseUrl: string, isWorkflow: boolean = false) => {
   const [traces, setTraces] = useState<RefinedTrace[]>([]);
-
-  const { setTraces: setTraceContextTraces } = useContext(TraceContext);
 
   const client = useMemo(() => createMastraClient(baseUrl), [baseUrl]);
 
@@ -33,15 +30,11 @@ export const useTraces = (componentName: string, baseUrl: string, isWorkflow: bo
     }
   }, [client, componentName, isWorkflow]);
 
-  const onSuccess = useCallback(
-    (newTraces: RefinedTrace[]) => {
-      if (newTraces.length > 0) {
-        setTraces(() => newTraces);
-        setTraceContextTraces(() => newTraces);
-      }
-    },
-    [setTraceContextTraces],
-  );
+  const onSuccess = useCallback((newTraces: RefinedTrace[]) => {
+    if (newTraces.length > 0) {
+      setTraces(() => newTraces);
+    }
+  }, []);
 
   const onError = useCallback((error: { message: string }) => {
     console.log(`error, onError`, error);

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -22,7 +22,6 @@ export * from './lib/polls';
 export * from './hooks/use-speech-recognition';
 export { useTraces } from './hooks/index';
 
-export { TraceContext, TraceProvider } from './domains/traces/context/trace-context';
 export type { TraceContextType } from './domains/traces/context/trace-context';
 export { refineTraces } from './domains/traces/utils';
 


### PR DESCRIPTION
## Description

Fix an issue about the `TraceProvider` not wrapping the `useTraces`. This PR does:

- remove the need from having the TraceProvider used in `cli` by removing the reference to it in `useTraces`. `useTraces` is now only responsible for fetching the data, that's it.
- pass down the traces to the `WorkflowTraces` and `AgentTraces` ONLY when the fetch request is finished. This allows to only create the `TraceProvider` here and also allows to only use it in playground UI and not in `cli` anymore.
- By the previous points, it reduces the surface area of the playground-ui API with more straighforward component and scopes the usage of the `TraceContext` in `playground-ui`

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
