### PR TITLE
Type CopilotKit runtimeContext

### DIFF
--- a/.changeset/friendly-dragons-march.md
+++ b/.changeset/friendly-dragons-march.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Type CopilotKit runtimeContext

--- a/docs/src/content/en/docs/frameworks/copilotkit.mdx
+++ b/docs/src/content/en/docs/frameworks/copilotkit.mdx
@@ -217,6 +217,59 @@ export const POST = async (req: NextRequest) => {
 };
 ```
 
+### Using Typed Runtime Context
+
+For better type safety, you can specify the type of your runtime context:
+
+```typescript copy
+import { Mastra } from "@mastra/core/mastra";
+import { PinoLogger } from "@mastra/loggers";
+import { LibSQLStore } from "@mastra/libsql";
+import { registerCopilotKit } from "@mastra/agui";
+import { weatherAgent } from "./agents";
+
+// Define your runtime context type
+type WeatherRuntimeContext = {
+  "user-id": string;
+  "temperature-scale": "celsius" | "fahrenheit";
+  "api-key": string;
+};
+
+export const mastra = new Mastra({
+  agents: { weatherAgent },
+  storage: new LibSQLStore({
+    url: ":memory:",
+  }),
+  logger: new PinoLogger({
+    name: "Mastra",
+    level: "info",
+  }),
+  server: {
+    cors: {
+      origin: "*",
+      allowMethods: ["*"],
+      allowHeaders: ["*"],
+    },
+    apiRoutes: [
+      registerCopilotKit<WeatherRuntimeContext>({
+        path: "/copilotkit",
+        resourceId: "weatherAgent",
+        setContext: (c, runtimeContext) => {
+          // TypeScript will enforce the correct types here
+          runtimeContext.set("user-id", c.req.header("X-User-ID") || "anonymous");
+          runtimeContext.set("temperature-scale", "celsius"); // Only "celsius" | "fahrenheit" allowed
+          runtimeContext.set("api-key", process.env.WEATHER_API_KEY || "");
+
+          // This would cause a TypeScript error:
+          // runtimeContext.set("invalid-key", "value"); // ❌ Error: invalid key
+          // runtimeContext.set("temperature-scale", "kelvin"); // ❌ Error: invalid value
+        }
+      }),
+    ],
+  },
+});
+```
+
 ## Further Reading
 
 - [CopilotKit Documentation](https://docs.copilotkit.ai)

--- a/packages/agui/src/index.ts
+++ b/packages/agui/src/index.ts
@@ -315,7 +315,7 @@ export function getAGUINetwork({
   }) as AbstractAgent;
 }
 
-export function registerCopilotKit({
+export function registerCopilotKit<T extends Record<string, any> | unknown = unknown>({
   path,
   resourceId,
   serviceAdapter = new ExperimentalEmptyAdapter(),
@@ -332,7 +332,7 @@ export function registerCopilotKit({
         mastra: Mastra;
       };
     }>,
-    runtimeContext: RuntimeContext,
+    runtimeContext: RuntimeContext<T>,
   ) => void | Promise<void>;
 }) {
   return registerApiRoute(path, {
@@ -340,7 +340,7 @@ export function registerCopilotKit({
     handler: async c => {
       const mastra = c.get('mastra');
 
-      const runtimeContext = new RuntimeContext();
+      const runtimeContext = new RuntimeContext<T>();
 
       if (setContext) {
         await setContext(c, runtimeContext);


### PR DESCRIPTION
When adding support to set the runtimeContext with CopilotKit I didn't include an option to be able to type it.
