### PR TITLE
fix: add location: name to forecast return values

### DIFF
--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -242,6 +242,7 @@ const fetchWeather = createStep({
         (acc, curr) => Math.max(acc, curr),
         0
       ),
+      location: name
     }
 
     return forecast;
@@ -275,7 +276,7 @@ const planActivities = createStep({
     ]);
 
     let activitiesText = '';
-    
+
     for await (const chunk of response.textStream) {
       process.stdout.write(chunk);
       activitiesText += chunk;


### PR DESCRIPTION
## Description

If you run `npx create-mastra@latest` and select "workflows". 

The template file is missing `location` from the `forecast` return values. This causes a TypeScript warning on `const fetchWeather = createStep({...` on #L43 of the generated file: `weather-workflow.ts`

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
