### PR TITLE
feat(rag): db specific configuration for runtime or static for createVectorQueryTool

### DIFF
--- a/.changeset/fast-hands-lay.md
+++ b/.changeset/fast-hands-lay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Adds runtime and initialization DB specific configuration to createVectorQueryTool to account for different configuration between db providers.

--- a/docs/src/content/en/docs/rag/retrieval.mdx
+++ b/docs/src/content/en/docs/rag/retrieval.mdx
@@ -166,6 +166,82 @@ This is particularly useful when:
 - The retrieval process requires complex decision-making
 - You want the agent to combine multiple retrieval strategies based on context
 
+#### Database-Specific Configurations
+
+The Vector Query Tool supports database-specific configurations that enable you to leverage unique features and optimizations of different vector stores:
+
+```ts showLineNumbers copy
+// Pinecone with namespace
+const pineconeQueryTool = createVectorQueryTool({
+  vectorStoreName: "pinecone",
+  indexName: "docs",
+  model: openai.embedding("text-embedding-3-small"),
+  databaseConfig: {
+    pinecone: {
+      namespace: "production"  // Isolate data by environment
+    }
+  }
+});
+
+// pgVector with performance tuning
+const pgVectorQueryTool = createVectorQueryTool({
+  vectorStoreName: "postgres",
+  indexName: "embeddings", 
+  model: openai.embedding("text-embedding-3-small"),
+  databaseConfig: {
+    pgvector: {
+      minScore: 0.7,    // Filter low-quality results
+      ef: 200,          // HNSW search parameter
+      probes: 10        // IVFFlat probe parameter
+    }
+  }
+});
+
+// Chroma with advanced filtering
+const chromaQueryTool = createVectorQueryTool({
+  vectorStoreName: "chroma",
+  indexName: "documents",
+  model: openai.embedding("text-embedding-3-small"),
+  databaseConfig: {
+    chroma: {
+      where: { "category": "technical" },
+      whereDocument: { "$contains": "API" }
+    }
+  }
+});
+```
+
+**Key Benefits:**
+- **Pinecone namespaces**: Organize vectors by tenant, environment, or data type
+- **pgVector optimization**: Control search accuracy and speed with ef/probes parameters
+- **Quality filtering**: Set minimum similarity thresholds to improve result relevance
+- **Runtime flexibility**: Override configurations dynamically based on context
+
+**Common Use Cases:**
+- Multi-tenant applications using Pinecone namespaces
+- Performance optimization in high-load scenarios
+- Environment-specific configurations (dev/staging/prod)
+- Quality-gated search results
+
+You can also override these configurations at runtime using the runtime context:
+
+```ts showLineNumbers copy
+import { RuntimeContext } from '@mastra/core/runtime-context';
+
+const runtimeContext = new RuntimeContext();
+runtimeContext.set('databaseConfig', {
+  pinecone: {
+    namespace: 'runtime-namespace'
+  }
+});
+
+await vectorTool.execute({
+  context: { queryText: 'search query' },
+  mastra,
+  runtimeContext
+});
+```
+
 For detailed configuration options and advanced usage, see the [Vector Query Tool Reference](/reference/tools/vector-query-tool).
 
 ### Vector Store Prompts

--- a/docs/src/content/en/docs/rag/retrieval.mdx
+++ b/docs/src/content/en/docs/rag/retrieval.mdx
@@ -235,7 +235,7 @@ runtimeContext.set('databaseConfig', {
   }
 });
 
-await vectorTool.execute({
+await pineconeQueryTool.execute({
   context: { queryText: 'search query' },
   mastra,
   runtimeContext

--- a/docs/src/content/en/examples/rag/usage/database-specific-config.mdx
+++ b/docs/src/content/en/examples/rag/usage/database-specific-config.mdx
@@ -1,0 +1,454 @@
+---
+title: "Database-Specific Configurations | RAG | Mastra Examples"
+description: Learn how to use database-specific configurations to optimize vector search performance and leverage unique features of different vector stores.
+---
+
+import { Tabs } from "nextra/components";
+
+# Database-Specific Configurations
+
+This example demonstrates how to use database-specific configurations with vector query tools to optimize performance and leverage unique features of different vector stores.
+
+## Multi-Environment Setup
+
+Use different configurations for different environments:
+
+<Tabs items={['TypeScript', 'JavaScript']}>
+  <Tabs.Tab>
+    ```typescript
+    import { openai } from "@ai-sdk/openai";
+    import { createVectorQueryTool } from "@mastra/rag";
+    import { RuntimeContext } from "@mastra/core/runtime-context";
+
+    // Base configuration
+    const createSearchTool = (environment: 'dev' | 'staging' | 'prod') => {
+      return createVectorQueryTool({
+        vectorStoreName: "pinecone",
+        indexName: "documents",
+        model: openai.embedding("text-embedding-3-small"),
+        databaseConfig: {
+          pinecone: {
+            namespace: environment
+          }
+        }
+      });
+    };
+
+    // Create environment-specific tools
+    const devSearchTool = createSearchTool('dev');
+    const prodSearchTool = createSearchTool('prod');
+
+    // Or use runtime override
+    const dynamicSearchTool = createVectorQueryTool({
+      vectorStoreName: "pinecone", 
+      indexName: "documents",
+      model: openai.embedding("text-embedding-3-small")
+    });
+
+    // Switch environment at runtime
+    const switchEnvironment = async (environment: string, query: string) => {
+      const runtimeContext = new RuntimeContext();
+      runtimeContext.set('databaseConfig', {
+        pinecone: {
+          namespace: environment
+        }
+      });
+
+      return await dynamicSearchTool.execute({
+        context: { queryText: query },
+        mastra,
+        runtimeContext
+      });
+    };
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```javascript
+    import { openai } from "@ai-sdk/openai";
+    import { createVectorQueryTool } from "@mastra/rag";
+    import { RuntimeContext } from "@mastra/core/runtime-context";
+
+    // Base configuration
+    const createSearchTool = (environment) => {
+      return createVectorQueryTool({
+        vectorStoreName: "pinecone",
+        indexName: "documents", 
+        model: openai.embedding("text-embedding-3-small"),
+        databaseConfig: {
+          pinecone: {
+            namespace: environment
+          }
+        }
+      });
+    };
+
+    // Create environment-specific tools
+    const devSearchTool = createSearchTool('dev');
+    const prodSearchTool = createSearchTool('prod');
+
+    // Or use runtime override
+    const dynamicSearchTool = createVectorQueryTool({
+      vectorStoreName: "pinecone",
+      indexName: "documents",
+      model: openai.embedding("text-embedding-3-small")
+    });
+
+    // Switch environment at runtime
+    const switchEnvironment = async (environment, query) => {
+      const runtimeContext = new RuntimeContext();
+      runtimeContext.set('databaseConfig', {
+        pinecone: {
+          namespace: environment
+        }
+      });
+
+      return await dynamicSearchTool.execute({
+        context: { queryText: query },
+        mastra,
+        runtimeContext
+      });
+    };
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Performance Optimization with pgVector
+
+Optimize search performance for different use cases:
+
+<Tabs items={['High Accuracy', 'High Speed', 'Balanced']}>
+  <Tabs.Tab>
+    ```typescript
+    // High accuracy configuration - slower but more precise
+    const highAccuracyTool = createVectorQueryTool({
+      vectorStoreName: "postgres",
+      indexName: "embeddings",
+      model: openai.embedding("text-embedding-3-small"),
+      databaseConfig: {
+        pgvector: {
+          ef: 400,          // High accuracy for HNSW
+          probes: 20,       // High recall for IVFFlat
+          minScore: 0.85    // High quality threshold
+        }
+      }
+    });
+
+    // Use for critical searches where accuracy is paramount
+    const criticalSearch = async (query: string) => {
+      return await highAccuracyTool.execute({
+        context: { 
+          queryText: query,
+          topK: 5  // Fewer, higher quality results
+        },
+        mastra
+      });
+    };
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```typescript
+    // High speed configuration - faster but less precise
+    const highSpeedTool = createVectorQueryTool({
+      vectorStoreName: "postgres", 
+      indexName: "embeddings",
+      model: openai.embedding("text-embedding-3-small"),
+      databaseConfig: {
+        pgvector: {
+          ef: 50,           // Lower accuracy for speed
+          probes: 3,        // Lower recall for speed
+          minScore: 0.6     // Lower quality threshold
+        }
+      }
+    });
+
+    // Use for real-time applications
+    const realtimeSearch = async (query: string) => {
+      return await highSpeedTool.execute({
+        context: { 
+          queryText: query,
+          topK: 10  // More results to compensate for lower precision
+        },
+        mastra
+      });
+    };
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```typescript
+    // Balanced configuration - good compromise
+    const balancedTool = createVectorQueryTool({
+      vectorStoreName: "postgres",
+      indexName: "embeddings", 
+      model: openai.embedding("text-embedding-3-small"),
+      databaseConfig: {
+        pgvector: {
+          ef: 150,          // Moderate accuracy
+          probes: 8,        // Moderate recall
+          minScore: 0.7     // Moderate quality threshold
+        }
+      }
+    });
+
+    // Adjust parameters based on load
+    const adaptiveSearch = async (query: string, isHighLoad: boolean) => {
+      const runtimeContext = new RuntimeContext();
+      
+      if (isHighLoad) {
+        // Reduce quality for speed during high load
+        runtimeContext.set('databaseConfig', {
+          pgvector: {
+            ef: 75,
+            probes: 5,
+            minScore: 0.65
+          }
+        });
+      }
+
+      return await balancedTool.execute({
+        context: { queryText: query },
+        mastra,
+        runtimeContext
+      });
+    };
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Multi-Tenant Application with Pinecone
+
+Implement tenant isolation using Pinecone namespaces:
+
+```typescript
+interface Tenant {
+  id: string;
+  name: string;
+  namespace: string;
+}
+
+class MultiTenantSearchService {
+  private searchTool: any;
+
+  constructor() {
+    this.searchTool = createVectorQueryTool({
+      vectorStoreName: "pinecone",
+      indexName: "shared-documents",
+      model: openai.embedding("text-embedding-3-small")
+    });
+  }
+
+  async searchForTenant(tenant: Tenant, query: string) {
+    const runtimeContext = new RuntimeContext();
+    
+    // Isolate search to tenant's namespace
+    runtimeContext.set('databaseConfig', {
+      pinecone: {
+        namespace: tenant.namespace
+      }
+    });
+
+    const results = await this.searchTool.execute({
+      context: { 
+        queryText: query,
+        topK: 10
+      },
+      mastra,
+      runtimeContext
+    });
+
+    // Add tenant context to results
+    return {
+      tenant: tenant.name,
+      query,
+      results: results.relevantContext,
+      sources: results.sources
+    };
+  }
+
+  async bulkSearchForTenants(tenants: Tenant[], query: string) {
+    const promises = tenants.map(tenant => 
+      this.searchForTenant(tenant, query)
+    );
+    
+    return await Promise.all(promises);
+  }
+}
+
+// Usage
+const searchService = new MultiTenantSearchService();
+
+const tenants = [
+  { id: '1', name: 'Company A', namespace: 'company-a' },
+  { id: '2', name: 'Company B', namespace: 'company-b' }
+];
+
+const results = await searchService.searchForTenant(
+  tenants[0], 
+  "product documentation"
+);
+```
+
+## Hybrid Search with Pinecone
+
+Combine semantic and keyword search:
+
+```typescript
+const hybridSearchTool = createVectorQueryTool({
+  vectorStoreName: "pinecone",
+  indexName: "documents",
+  model: openai.embedding("text-embedding-3-small"),
+  databaseConfig: {
+    pinecone: {
+      namespace: "production",
+      sparseVector: {
+        // Example sparse vector for keyword "API"
+        indices: [1, 5, 10, 15],
+        values: [0.8, 0.6, 0.4, 0.2]
+      }
+    }
+  }
+});
+
+// Helper function to generate sparse vectors for keywords
+const generateSparseVector = (keywords: string[]) => {
+  // This is a simplified example - in practice, you'd use
+  // a proper sparse encoding method like BM25
+  const indices: number[] = [];
+  const values: number[] = [];
+  
+  keywords.forEach((keyword, i) => {
+    const hash = keyword.split('').reduce((a, b) => {
+      a = ((a << 5) - a) + b.charCodeAt(0);
+      return a & a;
+    }, 0);
+    
+    indices.push(Math.abs(hash) % 1000);
+    values.push(1.0 / (i + 1)); // Decrease weight for later keywords
+  });
+  
+  return { indices, values };
+};
+
+const hybridSearch = async (query: string, keywords: string[]) => {
+  const runtimeContext = new RuntimeContext();
+  
+  if (keywords.length > 0) {
+    const sparseVector = generateSparseVector(keywords);
+    runtimeContext.set('databaseConfig', {
+      pinecone: {
+        namespace: "production",
+        sparseVector
+      }
+    });
+  }
+
+  return await hybridSearchTool.execute({
+    context: { queryText: query },
+    mastra,
+    runtimeContext
+  });
+};
+
+// Usage
+const results = await hybridSearch(
+  "How to use the REST API",
+  ["API", "REST", "documentation"]
+);
+```
+
+## Quality-Gated Search
+
+Implement progressive search quality:
+
+```typescript
+const createQualityGatedSearch = () => {
+  const baseConfig = {
+    vectorStoreName: "postgres",
+    indexName: "embeddings",
+    model: openai.embedding("text-embedding-3-small")
+  };
+
+  return {
+    // High quality search first
+    highQuality: createVectorQueryTool({
+      ...baseConfig,
+      databaseConfig: {
+        pgvector: {
+          minScore: 0.85,
+          ef: 200,
+          probes: 15
+        }
+      }
+    }),
+    
+    // Medium quality fallback
+    mediumQuality: createVectorQueryTool({
+      ...baseConfig,
+      databaseConfig: {
+        pgvector: {
+          minScore: 0.7,
+          ef: 150,
+          probes: 10
+        }
+      }
+    }),
+    
+    // Low quality last resort
+    lowQuality: createVectorQueryTool({
+      ...baseConfig,
+      databaseConfig: {
+        pgvector: {
+          minScore: 0.5,
+          ef: 100,
+          probes: 5
+        }
+      }
+    })
+  };
+};
+
+const progressiveSearch = async (query: string, minResults: number = 3) => {
+  const tools = createQualityGatedSearch();
+  
+  // Try high quality first
+  let results = await tools.highQuality.execute({
+    context: { queryText: query },
+    mastra
+  });
+  
+  if (results.sources.length >= minResults) {
+    return { quality: 'high', ...results };
+  }
+  
+  // Fallback to medium quality
+  results = await tools.mediumQuality.execute({
+    context: { queryText: query },
+    mastra
+  });
+  
+  if (results.sources.length >= minResults) {
+    return { quality: 'medium', ...results };
+  }
+  
+  // Last resort: low quality
+  results = await tools.lowQuality.execute({
+    context: { queryText: query },
+    mastra
+  });
+  
+  return { quality: 'low', ...results };
+};
+
+// Usage
+const results = await progressiveSearch("complex technical query", 5);
+console.log(`Found ${results.sources.length} results with ${results.quality} quality`);
+```
+
+## Key Takeaways
+
+1. **Environment Isolation**: Use namespaces to separate data by environment or tenant
+2. **Performance Tuning**: Adjust ef/probes parameters based on your accuracy vs speed requirements
+3. **Quality Control**: Use minScore to filter out low-quality matches
+4. **Runtime Flexibility**: Override configurations dynamically based on context
+5. **Progressive Quality**: Implement fallback strategies for different quality levels
+
+This approach allows you to optimize vector search for your specific use case while maintaining flexibility and performance. 

--- a/docs/src/content/en/examples/rag/usage/database-specific-config.mdx
+++ b/docs/src/content/en/examples/rag/usage/database-specific-config.mdx
@@ -226,7 +226,7 @@ interface Tenant {
 }
 
 class MultiTenantSearchService {
-  private searchTool: any;
+  private searchTool: RagTool
 
   constructor() {
     this.searchTool = createVectorQueryTool({

--- a/docs/src/content/en/reference/rag/_meta.ts
+++ b/docs/src/content/en/reference/rag/_meta.ts
@@ -5,6 +5,7 @@ export default {
   rerank: "rerank()",
   document: "MDocument",
   "metadata-filters": "Metadata Filters",
+  "database-config": "DatabaseConfig",
   "graph-rag": "GraphRAG",
   astra: "AstraVector",
   chroma: "ChromaVector",

--- a/docs/src/content/en/reference/rag/database-config.mdx
+++ b/docs/src/content/en/reference/rag/database-config.mdx
@@ -38,7 +38,7 @@ Configuration options specific to Pinecone vector store.
     {
       name: "sparseVector",
       type: "{ indices: number[]; values: number[]; }",
-      description: "Sparse vector for hybrid search combining dense and sparse embeddings. Enables better search quality for keyword-based queries.",
+      description: "Sparse vector for hybrid search combining dense and sparse embeddings. Enables better search quality for keyword-based queries.  The indices and values arrays must be the same length.",
       isOptional: true,
       properties: [
         {

--- a/docs/src/content/en/reference/rag/database-config.mdx
+++ b/docs/src/content/en/reference/rag/database-config.mdx
@@ -1,0 +1,334 @@
+---
+title: "Reference: DatabaseConfig | RAG | Mastra Docs"
+description: API reference for database-specific configuration types used with vector query tools in Mastra RAG systems.
+---
+
+import { Callout } from "nextra/components";
+import { Tabs } from "nextra/components";
+
+# DatabaseConfig
+
+The `DatabaseConfig` type allows you to specify database-specific configurations when using vector query tools. These configurations enable you to leverage unique features and optimizations offered by different vector stores.
+
+## Type Definition
+
+```typescript
+export type DatabaseConfig = {
+  pinecone?: PineconeConfig;
+  pgvector?: PgVectorConfig;
+  chroma?: ChromaConfig;
+  [key: string]: any; // Extensible for future databases
+};
+```
+
+## Database-Specific Types
+
+### PineconeConfig
+
+Configuration options specific to Pinecone vector store.
+
+<PropertiesTable
+  content={[
+    {
+      name: "namespace",
+      type: "string",
+      description: "Pinecone namespace for organizing and isolating vectors within the same index. Useful for multi-tenancy or environment separation.",
+      isOptional: true,
+    },
+    {
+      name: "sparseVector",
+      type: "{ indices: number[]; values: number[]; }",
+      description: "Sparse vector for hybrid search combining dense and sparse embeddings. Enables better search quality for keyword-based queries.",
+      isOptional: true,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "indices",
+              description: "Array of indices for sparse vector components",
+              isOptional: false,
+              type: "number[]",
+            },
+            {
+              name: "values",
+              description: "Array of values corresponding to the indices",
+              isOptional: false,
+              type: "number[]",
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+
+**Use Cases:**
+- Multi-tenant applications (separate namespaces per tenant)
+- Environment isolation (dev/staging/prod namespaces)
+- Hybrid search combining semantic and keyword matching
+
+### PgVectorConfig
+
+Configuration options specific to PostgreSQL with pgvector extension.
+
+<PropertiesTable
+  content={[
+    {
+      name: "minScore",
+      type: "number",
+      description: "Minimum similarity score threshold for results. Only vectors with similarity scores above this value will be returned.",
+      isOptional: true,
+    },
+    {
+      name: "ef",
+      type: "number",
+      description: "HNSW search parameter that controls the size of the dynamic candidate list during search. Higher values improve accuracy at the cost of speed. Typically set between topK and 200.",
+      isOptional: true,
+    },
+    {
+      name: "probes",
+      type: "number",
+      description: "IVFFlat probe parameter that specifies the number of index cells to visit during search. Higher values improve recall at the cost of speed.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+**Performance Guidelines:**
+- **ef**: Start with 2-4x your topK value, increase for better accuracy
+- **probes**: Start with 1-10, increase for better recall
+- **minScore**: Use values between 0.5-0.9 depending on your quality requirements
+
+**Use Cases:**
+- Performance optimization for high-load scenarios
+- Quality filtering to remove irrelevant results
+- Fine-tuning search accuracy vs speed tradeoffs
+
+### ChromaConfig
+
+Configuration options specific to Chroma vector store.
+
+<PropertiesTable
+  content={[
+    {
+      name: "where",
+      type: "Record<string, any>",
+      description: "Metadata filtering conditions using MongoDB-style query syntax. Filters results based on metadata fields.",
+      isOptional: true,
+    },
+    {
+      name: "whereDocument",
+      type: "Record<string, any>",
+      description: "Document content filtering conditions. Allows filtering based on the actual document text content.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+**Filter Syntax Examples:**
+```typescript
+// Simple equality
+where: { "category": "technical" }
+
+// Operators
+where: { "price": { "$gt": 100 } }
+
+// Multiple conditions
+where: { 
+  "category": "electronics",
+  "inStock": true 
+}
+
+// Document content filtering
+whereDocument: { "$contains": "API documentation" }
+```
+
+**Use Cases:**
+- Advanced metadata filtering
+- Content-based document filtering
+- Complex query combinations
+
+## Usage Examples
+
+<Tabs items={['Basic Usage', 'Runtime Override', 'Multi-Database', 'Performance Tuning']}>
+  <Tabs.Tab>
+    ### Basic Database Configuration
+
+    ```typescript
+    import { createVectorQueryTool } from '@mastra/rag';
+    
+    const vectorTool = createVectorQueryTool({
+      vectorStoreName: 'pinecone',
+      indexName: 'documents',
+      model: embedModel,
+      databaseConfig: {
+        pinecone: {
+          namespace: 'production'
+        }
+      }
+    });
+    ```
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+    ### Runtime Configuration Override
+
+    ```typescript
+    import { RuntimeContext } from '@mastra/core/runtime-context';
+    
+    // Initial configuration
+    const vectorTool = createVectorQueryTool({
+      vectorStoreName: 'pinecone',
+      indexName: 'documents', 
+      model: embedModel,
+      databaseConfig: {
+        pinecone: {
+          namespace: 'development'
+        }
+      }
+    });
+    
+    // Override at runtime
+    const runtimeContext = new RuntimeContext();
+    runtimeContext.set('databaseConfig', {
+      pinecone: {
+        namespace: 'production'
+      }
+    });
+    
+    await vectorTool.execute({
+      context: { queryText: 'search query' },
+      mastra,
+      runtimeContext
+    });
+    ```
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+    ### Multi-Database Configuration
+
+    ```typescript
+    const vectorTool = createVectorQueryTool({
+      vectorStoreName: 'dynamic', // Will be determined at runtime
+      indexName: 'documents',
+      model: embedModel,
+      databaseConfig: {
+        pinecone: {
+          namespace: 'default'
+        },
+        pgvector: {
+          minScore: 0.8,
+          ef: 150
+        },
+        chroma: {
+          where: { 'type': 'documentation' }
+        }
+      }
+    });
+    ```
+
+    <Callout>
+      **Multi-Database Support**: When you configure multiple databases, only the configuration matching the actual vector store being used will be applied.
+    </Callout>
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+    ### Performance Tuning
+
+    ```typescript
+    // High accuracy configuration
+    const highAccuracyTool = createVectorQueryTool({
+      vectorStoreName: 'postgres',
+      indexName: 'embeddings',
+      model: embedModel,
+      databaseConfig: {
+        pgvector: {
+          ef: 400,        // High accuracy
+          probes: 20,     // High recall
+          minScore: 0.85  // High quality threshold
+        }
+      }
+    });
+    
+    // High speed configuration  
+    const highSpeedTool = createVectorQueryTool({
+      vectorStoreName: 'postgres',
+      indexName: 'embeddings',
+      model: embedModel,
+      databaseConfig: {
+        pgvector: {
+          ef: 50,         // Lower accuracy, faster
+          probes: 3,      // Lower recall, faster
+          minScore: 0.6   // Lower quality threshold
+        }
+      }
+    });
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Extensibility
+
+The `DatabaseConfig` type is designed to be extensible. To add support for a new vector database:
+
+```typescript
+// 1. Define the configuration interface
+export interface NewDatabaseConfig {
+  customParam1?: string;
+  customParam2?: number;
+}
+
+// 2. Extend DatabaseConfig type
+export type DatabaseConfig = {
+  pinecone?: PineconeConfig;
+  pgvector?: PgVectorConfig;
+  chroma?: ChromaConfig;
+  newdatabase?: NewDatabaseConfig;
+  [key: string]: any;
+};
+
+// 3. Use in vector query tool
+const vectorTool = createVectorQueryTool({
+  vectorStoreName: 'newdatabase',
+  indexName: 'documents',
+  model: embedModel,
+  databaseConfig: {
+    newdatabase: {
+      customParam1: 'value',
+      customParam2: 42
+    }
+  }
+});
+```
+
+## Best Practices
+
+1. **Environment Configuration**: Use different namespaces or configurations for different environments
+2. **Performance Tuning**: Start with default values and adjust based on your specific needs
+3. **Quality Filtering**: Use minScore to filter out low-quality results
+4. **Runtime Flexibility**: Override configurations at runtime for dynamic scenarios
+5. **Documentation**: Document your specific configuration choices for team members
+
+## Migration Guide
+
+Existing vector query tools continue to work without changes. To add database configurations:
+
+```diff
+const vectorTool = createVectorQueryTool({
+  vectorStoreName: 'pinecone',
+  indexName: 'documents',
+  model: embedModel,
++ databaseConfig: {
++   pinecone: {
++     namespace: 'production'
++   }
++ }
+});
+```
+
+## Related
+
+- [createVectorQueryTool()](/reference/tools/vector-query-tool)
+- [Vector Query Search](/reference/rag/vector-search)
+- [Metadata Filters](/reference/rag/metadata-filters) 

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -4,10 +4,11 @@ description: Documentation for the Vector Query Tool in Mastra, which facilitate
 ---
 
 import { Callout } from "nextra/components";
+import { Tabs } from "nextra/components";
 
 # createVectorQueryTool()
 
-The `createVectorQueryTool()` function creates a tool for semantic search over vector stores. It supports filtering, reranking, and integrates with various vector store backends.
+The `createVectorQueryTool()` function creates a tool for semantic search over vector stores. It supports filtering, reranking, database-specific configurations, and integrates with various vector store backends.
 
 ## Basic Usage
 
@@ -100,8 +101,106 @@ const queryTool = createVectorQueryTool({
         "Options for reranking results. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
     },
+    {
+      name: "databaseConfig",
+      type: "DatabaseConfig",
+      description:
+        "Database-specific configuration options for optimizing queries. (Can be set at creation or overridden at runtime.)",
+      isOptional: true,
+    },
   ]}
 />
+
+### DatabaseConfig
+
+The `DatabaseConfig` type allows you to specify database-specific configurations that are automatically applied to query operations. This enables you to take advantage of unique features and optimizations offered by different vector stores.
+
+<PropertiesTable
+  content={[
+    {
+      name: "pinecone",
+      type: "PineconeConfig",
+      description: "Configuration specific to Pinecone vector store",
+      isOptional: true,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "namespace",
+              description: "Pinecone namespace for organizing vectors",
+              isOptional: true,
+              type: "string",
+            },
+            {
+              name: "sparseVector",
+              description: "Sparse vector for hybrid search",
+              isOptional: true,
+              type: "{ indices: number[]; values: number[]; }",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "pgvector",
+      type: "PgVectorConfig",
+      description: "Configuration specific to PostgreSQL with pgvector extension",
+      isOptional: true,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "minScore",
+              description: "Minimum similarity score threshold for results",
+              isOptional: true,
+              type: "number",
+            },
+            {
+              name: "ef",
+              description: "HNSW search parameter - controls accuracy vs speed tradeoff",
+              isOptional: true,
+              type: "number",
+            },
+            {
+              name: "probes",
+              description: "IVFFlat probe parameter - number of cells to visit during search",
+              isOptional: true,
+              type: "number",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "chroma",
+      type: "ChromaConfig",
+      description: "Configuration specific to Chroma vector store",
+      isOptional: true,
+      properties: [
+        {
+          type: "object",
+          parameters: [
+            {
+              name: "where",
+              description: "Metadata filtering conditions",
+              isOptional: true,
+              type: "Record<string, any>",
+            },
+            {
+              name: "whereDocument",
+              description: "Document content filtering conditions",
+              isOptional: true,
+              type: "Record<string, any>",
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+
 ### RerankConfig
 
 <PropertiesTable
@@ -261,6 +360,158 @@ const queryTool = createVectorQueryTool({
 
 This example shows how to customize the tool description for a specific use case while maintaining its core purpose of information retrieval.
 
+## Database-Specific Configuration Examples
+
+The `databaseConfig` parameter allows you to leverage unique features and optimizations specific to each vector database. These configurations are automatically applied during query execution.
+
+<Tabs items={['Pinecone', 'pgVector', 'Chroma', 'Multiple Configs']}>
+  <Tabs.Tab>
+    ### Pinecone Configuration
+
+    ```typescript
+    const pineconeQueryTool = createVectorQueryTool({
+      vectorStoreName: "pinecone",
+      indexName: "docs",
+      model: openai.embedding("text-embedding-3-small"),
+      databaseConfig: {
+        pinecone: {
+          namespace: "production",  // Organize vectors by environment
+          sparseVector: {          // Enable hybrid search
+            indices: [0, 1, 2, 3],
+            values: [0.1, 0.2, 0.15, 0.05]
+          }
+        }
+      }
+    });
+    ```
+
+    **Pinecone Features:**
+    - **Namespace**: Isolate different data sets within the same index
+    - **Sparse Vector**: Combine dense and sparse embeddings for improved search quality
+    - **Use Cases**: Multi-tenant applications, hybrid semantic search
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+    ### pgVector Configuration
+
+    ```typescript
+    const pgVectorQueryTool = createVectorQueryTool({
+      vectorStoreName: "postgres",
+      indexName: "embeddings",
+      model: openai.embedding("text-embedding-3-small"),
+      databaseConfig: {
+        pgvector: {
+          minScore: 0.7,    // Only return results above 70% similarity
+          ef: 200,          // Higher value = better accuracy, slower search
+          probes: 10        // For IVFFlat: more probes = better recall
+        }
+      }
+    });
+    ```
+
+    **pgVector Features:**
+    - **minScore**: Filter out low-quality matches
+    - **ef (HNSW)**: Control accuracy vs speed for HNSW indexes
+    - **probes (IVFFlat)**: Control recall vs speed for IVFFlat indexes
+    - **Use Cases**: Performance tuning, quality filtering
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+    ### Chroma Configuration
+
+    ```typescript
+    const chromaQueryTool = createVectorQueryTool({
+      vectorStoreName: "chroma",
+      indexName: "documents",
+      model: openai.embedding("text-embedding-3-small"),
+      databaseConfig: {
+        chroma: {
+          where: {                    // Metadata filtering
+            "category": "technical",
+            "status": "published"
+          },
+          whereDocument: {            // Document content filtering
+            "$contains": "API"
+          }
+        }
+      }
+    });
+    ```
+
+    **Chroma Features:**
+    - **where**: Filter by metadata fields
+    - **whereDocument**: Filter by document content
+    - **Use Cases**: Advanced filtering, content-based search
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+    ### Multiple Database Configurations
+
+    ```typescript
+    // Configure for multiple databases (useful for dynamic stores)
+    const multiDbQueryTool = createVectorQueryTool({
+      vectorStoreName: "dynamic-store", // Will be set at runtime
+      indexName: "docs",
+      model: openai.embedding("text-embedding-3-small"),
+      databaseConfig: {
+        pinecone: {
+          namespace: "default"
+        },
+        pgvector: {
+          minScore: 0.8,
+          ef: 150
+        },
+        chroma: {
+          where: { "type": "documentation" }
+        }
+      }
+    });
+    ```
+
+    **Multi-Config Benefits:**
+    - Support multiple vector stores with one tool
+    - Database-specific optimizations are automatically applied
+    - Flexible deployment scenarios
+  </Tabs.Tab>
+</Tabs>
+
+### Runtime Configuration Override
+
+You can override database configurations at runtime to adapt to different scenarios:
+
+```typescript
+import { RuntimeContext } from '@mastra/core/runtime-context';
+
+const queryTool = createVectorQueryTool({
+  vectorStoreName: "pinecone",
+  indexName: "docs",
+  model: openai.embedding("text-embedding-3-small"),
+  databaseConfig: {
+    pinecone: {
+      namespace: "development"
+    }
+  }
+});
+
+// Override at runtime
+const runtimeContext = new RuntimeContext();
+runtimeContext.set('databaseConfig', {
+  pinecone: {
+    namespace: 'production'  // Switch to production namespace
+  }
+});
+
+const response = await agent.generate(
+  "Find information about deployment",
+  { runtimeContext }
+);
+```
+
+This approach allows you to:
+- Switch between environments (dev/staging/prod)
+- Adjust performance parameters based on load
+- Apply different filtering strategies per request
+
 ## Example: Using Runtime Context
 
 ```typescript
@@ -279,11 +530,15 @@ const runtimeContext = new RuntimeContext<{
   indexName: string;
   topK: number;
   filter: any;
+  databaseConfig: any;
 }>();
 runtimeContext.set("vectorStoreName", "my-store");
 runtimeContext.set("indexName", "my-index");
 runtimeContext.set("topK", 5);
 runtimeContext.set("filter", { category: "docs" });
+runtimeContext.set("databaseConfig", {
+  pinecone: { namespace: "runtime-namespace" }
+});
 
 const response = await agent.generate(
   "Find documentation from the knowledge base.",

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -529,8 +529,8 @@ const runtimeContext = new RuntimeContext<{
   vectorStoreName: string;
   indexName: string;
   topK: number;
-  filter: any;
-  databaseConfig: any;
+  filter: VectorFilter;
+  databaseConfig: DatabaseConfig;
 }>();
 runtimeContext.set("vectorStoreName", "my-store");
 runtimeContext.set("indexName", "my-index");

--- a/packages/rag/src/tools/README.md
+++ b/packages/rag/src/tools/README.md
@@ -1,0 +1,153 @@
+# Vector Query Tool with Database-Specific Configurations
+
+The `createVectorQueryTool` function now supports database-specific configurations to handle unique properties and optimizations for different vector databases.
+
+## Database Configuration Types
+
+### Pinecone Configuration
+
+```typescript
+import { createVectorQueryTool } from '@mastra/rag/tools';
+
+const pineconeVectorTool = createVectorQueryTool({
+  id: 'pinecone-search',
+  indexName: 'my-index',
+  vectorStoreName: 'pinecone',
+  model: embedModel,
+  databaseConfig: {
+    pinecone: {
+      namespace: 'my-namespace', // Pinecone namespace
+      sparseVector: {
+        // For hybrid search
+        indices: [0, 1, 2],
+        values: [0.1, 0.2, 0.3],
+      },
+    },
+  },
+});
+```
+
+### pgVector Configuration
+
+```typescript
+const pgVectorTool = createVectorQueryTool({
+  id: 'pgvector-search',
+  indexName: 'my-index',
+  vectorStoreName: 'postgres',
+  model: embedModel,
+  databaseConfig: {
+    pgvector: {
+      minScore: 0.7, // Minimum similarity score
+      ef: 200, // HNSW search parameter
+      probes: 10, // IVFFlat probe parameter
+    },
+  },
+});
+```
+
+### Chroma Configuration
+
+```typescript
+const chromaTool = createVectorQueryTool({
+  id: 'chroma-search',
+  indexName: 'my-index',
+  vectorStoreName: 'chroma',
+  model: embedModel,
+  databaseConfig: {
+    chroma: {
+      where: {
+        // Metadata filtering
+        category: 'documents',
+      },
+      whereDocument: {
+        // Document content filtering
+        $contains: 'important',
+      },
+    },
+  },
+});
+```
+
+## Runtime Configuration Override
+
+You can also override database configurations at runtime using the runtime context:
+
+```typescript
+import { RuntimeContext } from '@mastra/core/runtime-context';
+
+const runtimeContext = new RuntimeContext();
+
+// Override Pinecone namespace at runtime
+runtimeContext.set('databaseConfig', {
+  pinecone: {
+    namespace: 'runtime-namespace',
+  },
+});
+
+await vectorTool.execute({
+  context: { queryText: 'search query' },
+  mastra,
+  runtimeContext,
+});
+```
+
+## Extensibility for New Databases
+
+The system is designed to be extensible. For new vector databases, you can:
+
+1. Add configuration types:
+
+```typescript
+export interface NewDatabaseConfig {
+  customParam1?: string;
+  customParam2?: number;
+}
+
+export type DatabaseConfig = {
+  pinecone?: PineconeConfig;
+  pgvector?: PgVectorConfig;
+  chroma?: ChromaConfig;
+  newdatabase?: NewDatabaseConfig; // Add your config here
+  [key: string]: any;
+};
+```
+
+2. The configuration will be automatically passed through to the vector store's query method.
+
+## Type Safety
+
+All database configurations are fully typed, providing IntelliSense and compile-time checking:
+
+```typescript
+const config: DatabaseConfig = {
+  pinecone: {
+    namespace: 'valid-namespace',
+    sparseVector: {
+      indices: [1, 2, 3],
+      values: [0.1, 0.2, 0.3],
+    },
+  },
+  pgvector: {
+    minScore: 0.8,
+    ef: 100,
+    probes: 5,
+  },
+};
+```
+
+## Migration Guide
+
+Existing code will continue to work without changes. To add database-specific configurations:
+
+```diff
+const vectorTool = createVectorQueryTool({
+  indexName: 'my-index',
+  vectorStoreName: 'pinecone',
+  model: embedModel,
++ databaseConfig: {
++   pinecone: {
++     namespace: 'my-namespace'
++   }
++ }
+});
+```

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -1,6 +1,35 @@
 import type { EmbeddingModel } from 'ai';
 import type { RerankConfig } from '../rerank';
 
+export interface PineconeConfig {
+  namespace?: string;
+  sparseVector?: {
+    indices: number[];
+    values: number[];
+  };
+}
+
+export interface PgVectorConfig {
+  minScore?: number;
+  ef?: number; // HNSW search parameter
+  probes?: number; // IVFFlat probe parameter
+}
+
+export interface ChromaConfig {
+  // Add Chroma-specific configs here if needed
+  where?: Record<string, any>;
+  whereDocument?: Record<string, any>;
+}
+
+// Union type for all database-specific configs
+export type DatabaseConfig = {
+  pinecone?: PineconeConfig;
+  pgvector?: PgVectorConfig;
+  chroma?: ChromaConfig;
+  // Add other database configs as needed
+  [key: string]: any; // Allow for future database extensions
+};
+
 export type VectorQueryToolOptions = {
   id?: string;
   description?: string;
@@ -11,6 +40,8 @@ export type VectorQueryToolOptions = {
   includeVectors?: boolean;
   includeSources?: boolean;
   reranker?: RerankConfig;
+  /** Database-specific configuration options */
+  databaseConfig?: DatabaseConfig;
 };
 
 export type GraphRagToolOptions = {

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -15,10 +15,32 @@ export interface PgVectorConfig {
   probes?: number; // IVFFlat probe parameter
 }
 
+// Chroma types
+type LiteralValue = string | number | boolean;
+type ListLiteralValue = LiteralValue[];
+type LiteralNumber = number;
+type LogicalOperator = "$and" | "$or";
+type InclusionOperator = "$in" | "$nin";
+type WhereOperator = "$gt" | "$gte" | "$lt" | "$lte" | "$ne" | "$eq";
+type OperatorExpression = {
+    [key in WhereOperator | InclusionOperator | LogicalOperator]?: LiteralValue | ListLiteralValue;
+};
+type BaseWhere = {
+    [key: string]: LiteralValue | OperatorExpression;
+};
+type LogicalWhere = {
+    [key in LogicalOperator]?: Where[];
+};
+type Where = BaseWhere | LogicalWhere;
+type WhereDocumentOperator = "$contains" | "$not_contains" | LogicalOperator;
+type WhereDocument = {
+    [key in WhereDocumentOperator]?: LiteralValue | LiteralNumber | WhereDocument[];
+};
+
 export interface ChromaConfig {
   // Add Chroma-specific configs here if needed
-  where?: Record<string, any>;
-  whereDocument?: Record<string, any>;
+  where?: Where;
+  whereDocument?: WhereDocument
 }
 
 // Union type for all database-specific configs

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -19,28 +19,28 @@ export interface PgVectorConfig {
 type LiteralValue = string | number | boolean;
 type ListLiteralValue = LiteralValue[];
 type LiteralNumber = number;
-type LogicalOperator = "$and" | "$or";
-type InclusionOperator = "$in" | "$nin";
-type WhereOperator = "$gt" | "$gte" | "$lt" | "$lte" | "$ne" | "$eq";
+type LogicalOperator = '$and' | '$or';
+type InclusionOperator = '$in' | '$nin';
+type WhereOperator = '$gt' | '$gte' | '$lt' | '$lte' | '$ne' | '$eq';
 type OperatorExpression = {
-    [key in WhereOperator | InclusionOperator | LogicalOperator]?: LiteralValue | ListLiteralValue;
+  [key in WhereOperator | InclusionOperator | LogicalOperator]?: LiteralValue | ListLiteralValue;
 };
 type BaseWhere = {
-    [key: string]: LiteralValue | OperatorExpression;
+  [key: string]: LiteralValue | OperatorExpression;
 };
 type LogicalWhere = {
-    [key in LogicalOperator]?: Where[];
+  [key in LogicalOperator]?: Where[];
 };
 type Where = BaseWhere | LogicalWhere;
-type WhereDocumentOperator = "$contains" | "$not_contains" | LogicalOperator;
+type WhereDocumentOperator = '$contains' | '$not_contains' | LogicalOperator;
 type WhereDocument = {
-    [key in WhereDocumentOperator]?: LiteralValue | LiteralNumber | WhereDocument[];
+  [key in WhereDocumentOperator]?: LiteralValue | LiteralNumber | WhereDocument[];
 };
 
 export interface ChromaConfig {
   // Add Chroma-specific configs here if needed
   where?: Where;
-  whereDocument?: WhereDocument
+  whereDocument?: WhereDocument;
 }
 
 // Union type for all database-specific configs

--- a/packages/rag/src/tools/vector-query-database-config.test.ts
+++ b/packages/rag/src/tools/vector-query-database-config.test.ts
@@ -1,0 +1,190 @@
+import { RuntimeContext } from '@mastra/core/runtime-context';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { vectorQuerySearch } from '../utils';
+import type { DatabaseConfig } from './types';
+import { createVectorQueryTool } from './vector-query';
+
+vi.mock('../utils', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    vectorQuerySearch: vi.fn().mockResolvedValue({
+      results: [{ metadata: { text: 'test result' }, vector: [1, 2, 3] }],
+    }),
+  };
+});
+
+describe('createVectorQueryTool with database-specific configurations', () => {
+  const mockModel = { name: 'test-model' } as any;
+  const mockMastra = {
+    getVector: vi.fn(() => ({})),
+    getLogger: vi.fn(() => ({
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should pass Pinecone configuration to vectorQuerySearch', async () => {
+    const databaseConfig: DatabaseConfig = {
+      pinecone: {
+        namespace: 'test-namespace',
+        sparseVector: {
+          indices: [0, 1, 2],
+          values: [0.1, 0.2, 0.3],
+        },
+      },
+    };
+
+    const tool = createVectorQueryTool({
+      vectorStoreName: 'pinecone',
+      indexName: 'testIndex',
+      model: mockModel,
+      databaseConfig,
+    });
+
+    const runtimeContext = new RuntimeContext();
+
+    await tool.execute({
+      context: { queryText: 'test query', topK: 5 },
+      mastra: mockMastra as any,
+      runtimeContext,
+    });
+
+    expect(vectorQuerySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseConfig,
+      }),
+    );
+  });
+
+  it('should pass pgVector configuration to vectorQuerySearch', async () => {
+    const databaseConfig: DatabaseConfig = {
+      pgvector: {
+        minScore: 0.7,
+        ef: 200,
+        probes: 10,
+      },
+    };
+
+    const tool = createVectorQueryTool({
+      vectorStoreName: 'postgres',
+      indexName: 'testIndex',
+      model: mockModel,
+      databaseConfig,
+    });
+
+    const runtimeContext = new RuntimeContext();
+
+    await tool.execute({
+      context: { queryText: 'test query', topK: 5 },
+      mastra: mockMastra as any,
+      runtimeContext,
+    });
+
+    expect(vectorQuerySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseConfig,
+      }),
+    );
+  });
+
+  it('should allow runtime context to override database configuration', async () => {
+    const initialConfig: DatabaseConfig = {
+      pinecone: {
+        namespace: 'initial-namespace',
+      },
+    };
+
+    const runtimeConfig: DatabaseConfig = {
+      pinecone: {
+        namespace: 'runtime-namespace',
+      },
+    };
+
+    const tool = createVectorQueryTool({
+      vectorStoreName: 'pinecone',
+      indexName: 'testIndex',
+      model: mockModel,
+      databaseConfig: initialConfig,
+    });
+
+    const runtimeContext = new RuntimeContext();
+    runtimeContext.set('databaseConfig', runtimeConfig);
+
+    await tool.execute({
+      context: { queryText: 'test query', topK: 5 },
+      mastra: mockMastra as any,
+      runtimeContext,
+    });
+
+    expect(vectorQuerySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseConfig: runtimeConfig, // Should use runtime config, not initial
+      }),
+    );
+  });
+
+  it('should work without database configuration (backward compatibility)', async () => {
+    const tool = createVectorQueryTool({
+      vectorStoreName: 'testStore',
+      indexName: 'testIndex',
+      model: mockModel,
+      // No databaseConfig provided
+    });
+
+    const runtimeContext = new RuntimeContext();
+
+    await tool.execute({
+      context: { queryText: 'test query', topK: 5 },
+      mastra: mockMastra as any,
+      runtimeContext,
+    });
+
+    expect(vectorQuerySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseConfig: undefined,
+      }),
+    );
+  });
+
+  it('should handle multiple database configurations', async () => {
+    const databaseConfig: DatabaseConfig = {
+      pinecone: {
+        namespace: 'test-namespace',
+      },
+      pgvector: {
+        minScore: 0.8,
+        ef: 100,
+      },
+      chroma: {
+        where: { category: 'documents' },
+      },
+    };
+
+    const tool = createVectorQueryTool({
+      vectorStoreName: 'multidb',
+      indexName: 'testIndex',
+      model: mockModel,
+      databaseConfig,
+    });
+
+    const runtimeContext = new RuntimeContext();
+
+    await tool.execute({
+      context: { queryText: 'test query', topK: 5 },
+      mastra: mockMastra as any,
+      runtimeContext,
+    });
+
+    expect(vectorQuerySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseConfig,
+      }),
+    );
+  });
+});

--- a/packages/rag/src/tools/vector-query.ts
+++ b/packages/rag/src/tools/vector-query.ts
@@ -25,6 +25,8 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
       const includeVectors: boolean = runtimeContext.get('includeVectors') ?? options.includeVectors ?? false;
       const includeSources: boolean = runtimeContext.get('includeSources') ?? options.includeSources ?? true;
       const reranker: RerankConfig = runtimeContext.get('reranker') ?? options.reranker;
+      const databaseConfig = runtimeContext.get('databaseConfig') ?? options.databaseConfig;
+
       if (!indexName) throw new Error(`indexName is required, got: ${indexName}`);
       if (!vectorStoreName) throw new Error(`vectorStoreName is required, got: ${vectorStoreName}`);
 
@@ -40,7 +42,7 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
         );
       }
       if (logger) {
-        logger.debug('[VectorQueryTool] execute called with:', { queryText, topK, filter });
+        logger.debug('[VectorQueryTool] execute called with:', { queryText, topK, filter, databaseConfig });
       }
       try {
         const topKValue =
@@ -74,7 +76,7 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
           })();
         }
         if (logger) {
-          logger.debug('Prepared vector query parameters', { queryText, topK: topKValue, queryFilter });
+          logger.debug('Prepared vector query parameters', { queryText, topK: topKValue, queryFilter, databaseConfig });
         }
 
         const { results } = await vectorQuerySearch({
@@ -85,6 +87,7 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
           queryFilter: Object.keys(queryFilter || {}).length > 0 ? queryFilter : undefined,
           topK: topKValue,
           includeVectors,
+          databaseConfig,
         });
         if (logger) {
           logger.debug('vectorQuerySearch returned results', { count: results.length });

--- a/packages/rag/src/utils/vector-search.ts
+++ b/packages/rag/src/utils/vector-search.ts
@@ -2,6 +2,7 @@ import type { MastraVector, QueryResult } from '@mastra/core/vector';
 import type { VectorFilter } from '@mastra/core/vector/filter';
 import { embed } from 'ai';
 import type { EmbeddingModel } from 'ai';
+import type { DatabaseConfig } from '../tools/types';
 
 interface VectorQuerySearchParams {
   indexName: string;
@@ -12,6 +13,8 @@ interface VectorQuerySearchParams {
   topK: number;
   includeVectors?: boolean;
   maxRetries?: number;
+  /** Database-specific configuration options */
+  databaseConfig?: DatabaseConfig;
 }
 
 interface VectorQuerySearchResult {
@@ -29,20 +32,72 @@ export const vectorQuerySearch = async ({
   topK,
   includeVectors = false,
   maxRetries = 2,
+  databaseConfig,
 }: VectorQuerySearchParams): Promise<VectorQuerySearchResult> => {
   const { embedding } = await embed({
     value: queryText,
     model,
     maxRetries,
   });
-  // Get relevant chunks from the vector database
-  const results = await vectorStore.query({
+
+  // Build query parameters with database-specific configurations
+  const queryParams: any = {
     indexName,
     queryVector: embedding,
     topK,
     filter: queryFilter,
     includeVector: includeVectors,
-  });
+  };
+
+  // Apply database-specific configurations
+  if (databaseConfig) {
+    // Pinecone-specific configurations
+    if (databaseConfig.pinecone) {
+      if (databaseConfig.pinecone.namespace) {
+        queryParams.namespace = databaseConfig.pinecone.namespace;
+      }
+      if (databaseConfig.pinecone.sparseVector) {
+        queryParams.sparseVector = databaseConfig.pinecone.sparseVector;
+      }
+    }
+
+    // pgVector-specific configurations
+    if (databaseConfig.pgvector) {
+      if (databaseConfig.pgvector.minScore !== undefined) {
+        queryParams.minScore = databaseConfig.pgvector.minScore;
+      }
+      if (databaseConfig.pgvector.ef !== undefined) {
+        queryParams.ef = databaseConfig.pgvector.ef;
+      }
+      if (databaseConfig.pgvector.probes !== undefined) {
+        queryParams.probes = databaseConfig.pgvector.probes;
+      }
+    }
+
+    // Chroma-specific configurations
+    if (databaseConfig.chroma) {
+      if (databaseConfig.chroma.where) {
+        queryParams.where = databaseConfig.chroma.where;
+      }
+      if (databaseConfig.chroma.whereDocument) {
+        queryParams.whereDocument = databaseConfig.chroma.whereDocument;
+      }
+    }
+
+    // Handle any additional database configs
+    Object.keys(databaseConfig).forEach(dbName => {
+      if (!['pinecone', 'pgvector', 'chroma'].includes(dbName)) {
+        // For unknown database types, merge the config directly
+        const config = databaseConfig[dbName];
+        if (config && typeof config === 'object') {
+          Object.assign(queryParams, config);
+        }
+      }
+    });
+  }
+
+  // Get relevant chunks from the vector database
+  const results = await vectorStore.query(queryParams);
 
   return { results, queryEmbedding: embedding };
 };

--- a/packages/rag/src/utils/vector-search.ts
+++ b/packages/rag/src/utils/vector-search.ts
@@ -28,7 +28,7 @@ enum DatabaseType {
   Chroma = 'chroma',
 }
 
-const DATABASE_TYPE_MAP = Object.keys(DatabaseType)
+const DATABASE_TYPE_MAP = Object.keys(DatabaseType);
 
 // Helper function to handle vector query search
 export const vectorQuerySearch = async ({
@@ -56,7 +56,7 @@ export const vectorQuerySearch = async ({
     filter: queryFilter,
     includeVector: includeVectors,
   };
-  
+
   // Get relevant chunks from the vector database
   const results = await vectorStore.query({ ...queryParams, ...databaseSpecificParams(databaseConfig) });
 


### PR DESCRIPTION
## Description

- there was no way to set DB specific configuration for RAG for certain db providers
- adds `databaseConfig` property to createVectorQueryTool
- uses runtimeContext to override `databaseConfig` for query specific configuration.
- adds documentation
- adds db properties for chroma, pg, and pinecone. adds a way to make it extensible if needed.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
