### PR TITLE
fix: update deprecated PgVector constructor usage to new object syntax

### DIFF
--- a/docs/src/content/ja/docs/rag/overview.mdx
+++ b/docs/src/content/ja/docs/rag/overview.mdx
@@ -42,7 +42,7 @@ const { embeddings } = await embedMany({
 });
 
 // 4. Store in vector database
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 await pgVector.upsert({
   indexName: "embeddings",
   vectors: embeddings,

--- a/docs/src/content/ja/docs/rag/retrieval.mdx
+++ b/docs/src/content/ja/docs/rag/retrieval.mdx
@@ -37,7 +37,7 @@ const { embedding } = await embed({
 });
 
 // Query vector store
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING });
 const results = await pgVector.query({
   indexName: "embeddings",
   queryVector: embedding,

--- a/docs/src/content/ja/docs/rag/vector-databases.mdx
+++ b/docs/src/content/ja/docs/rag/vector-databases.mdx
@@ -16,7 +16,7 @@ import { Tabs } from "nextra/components";
     ```ts filename="vector-store.ts" showLineNumbers copy
       import { PgVector } from '@mastra/pg';
 
-    const store = new PgVector(process.env.POSTGRES_CONNECTION_STRING)
+    const store = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING })
     await store.createIndex({
     indexName: "myCollection",
     dimension: 1536,

--- a/docs/src/content/ja/examples/memory/memory-with-pg.mdx
+++ b/docs/src/content/ja/examples/memory/memory-with-pg.mdx
@@ -29,7 +29,7 @@ const memory = new Memory({
     database,
     password,
   }),
-  vector: new PgVector(connectionString),
+  vector: new PgVector({ connectionString }),
   options: {
     lastMessages: 10,
     semanticRecall: {

--- a/docs/src/content/ja/examples/rag/query/hybrid-vector-search.mdx
+++ b/docs/src/content/ja/examples/rag/query/hybrid-vector-search.mdx
@@ -53,7 +53,7 @@ import { openai } from "@ai-sdk/openai";
 接続文字列を使ってPgVectorを初期化します：
 
 ```typescript copy showLineNumbers{4} filename="src/index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 ```
 
 ## 使用例

--- a/docs/src/content/ja/examples/rag/rerank/rerank-rag.mdx
+++ b/docs/src/content/ja/examples/rag/rerank/rerank-rag.mdx
@@ -81,7 +81,7 @@ export const ragAgent = new Agent({
 以下のコンポーネントを使って PgVector と Mastra をインスタンス化します。
 
 ```typescript copy showLineNumbers{29} filename="index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/docs/src/content/ja/examples/rag/rerank/rerank.mdx
+++ b/docs/src/content/ja/examples/rag/rerank/rerank.mdx
@@ -72,7 +72,7 @@ const { embeddings } = await embedMany({
   model: openai.embedding("text-embedding-3-small"),
 });
 
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 await pgVector.createIndex({
   indexName: "embeddings",
   dimension: 1536,

--- a/docs/src/content/ja/examples/rag/upsert/upsert-embeddings.mdx
+++ b/docs/src/content/ja/examples/rag/upsert/upsert-embeddings.mdx
@@ -29,7 +29,7 @@ import { GithubLink } from "@/components/github-link";
       model: openai.embedding("text-embedding-3-small"),
     });
 
-    const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+    const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
     await pgVector.createIndex({
       indexName: "test_index",

--- a/docs/src/content/ja/examples/rag/usage/basic-rag.mdx
+++ b/docs/src/content/ja/examples/rag/usage/basic-rag.mdx
@@ -76,7 +76,7 @@ export const ragAgent = new Agent({
 すべてのコンポーネントを使って PgVector と Mastra をインスタンス化します。
 
 ```typescript copy showLineNumbers{23} filename="src/index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/docs/src/content/ja/examples/rag/usage/cleanup-rag.mdx
+++ b/docs/src/content/ja/examples/rag/usage/cleanup-rag.mdx
@@ -113,7 +113,7 @@ const ragAgent = new Agent({
 以下のコンポーネントを使って PgVector と Mastra をインスタンス化します。
 
 ```typescript copy showLineNumbers{41} filename="index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/docs/src/content/ja/examples/rag/usage/cot-rag.mdx
+++ b/docs/src/content/ja/examples/rag/usage/cot-rag.mdx
@@ -96,7 +96,7 @@ FINAL ANSWER:
 すべてのコンポーネントを使って PgVector と Mastra をインスタンス化します。
 
 ```typescript copy showLineNumbers{36} filename="index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/docs/src/content/ja/examples/rag/usage/cot-workflow-rag.mdx
+++ b/docs/src/content/ja/examples/rag/usage/cot-workflow-rag.mdx
@@ -256,7 +256,7 @@ ragWorkflow.commit();
 すべてのコンポーネントを使って PgVector と Mastra をインスタンス化します。
 
 ```typescript copy showLineNumbers{169} filename="index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/docs/src/content/ja/examples/rag/usage/filter-rag.mdx
+++ b/docs/src/content/ja/examples/rag/usage/filter-rag.mdx
@@ -163,7 +163,7 @@ export const ragAgent = new Agent({
 以下のコンポーネントを使って PgVector と Mastra をインスタンス化します。
 
 ```typescript copy showLineNumbers{69} filename="index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/docs/src/content/ja/examples/rag/usage/graph-rag.mdx
+++ b/docs/src/content/ja/examples/rag/usage/graph-rag.mdx
@@ -92,7 +92,7 @@ If the context doesn't contain enough information to fully answer the question, 
 以下のコンポーネントを使って PgVector と Mastra をインスタンス化します。
 
 ```typescript copy showLineNumbers{36} filename="index.ts"
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/docs/src/content/ja/guides/guide/research-assistant.mdx
+++ b/docs/src/content/ja/guides/guide/research-assistant.mdx
@@ -129,7 +129,7 @@ import { PgVector } from "@mastra/pg";
 import { researchAgent } from "./agents/researchAgent";
 
 // Initialize Mastra instance
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING!);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING! });
 export const mastra = new Mastra({
   agents: { researchAgent },
   vectors: { pgVector },

--- a/docs/src/content/ja/reference/rag/metadata-filters.mdx
+++ b/docs/src/content/ja/reference/rag/metadata-filters.mdx
@@ -12,7 +12,7 @@ Mastra は、すべてのベクトルストアで統一されたメタデータ�
 ```typescript
 import { PgVector } from "@mastra/pg";
 
-const store = new PgVector(connectionString);
+const store = new PgVector({ connectionString });
 
 const results = await store.query({
   indexName: "my_index",

--- a/packages/deployer/src/build/plugins/__fixtures__/mastra-with-extra-code.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/mastra-with-extra-code.js
@@ -23,7 +23,7 @@ export const ragAgent = new Agent({
   tools: { vectorQueryTool },
 });
 
-const pgVector = new PgVector(process.env.POSTGRES_CONNECTION_STRING);
+const pgVector = new PgVector({ connectionString: process.env.POSTGRES_CONNECTION_STRING });
 
 export const mastra = new Mastra({
   agents: { ragAgent },

--- a/stores/pg/README.md
+++ b/stores/pg/README.md
@@ -20,7 +20,7 @@ npm install @mastra/pg
 ```typescript
 import { PgVector } from '@mastra/pg';
 
-const vectorStore = new PgVector('postgresql://user:pass@localhost:5432/db');
+const vectorStore = new PgVector({ connectionString: 'postgresql://user:pass@localhost:5432/db' });
 
 // Create a new table with vector support
 await vectorStore.createIndex({


### PR DESCRIPTION
## Description

This PR completes the migration from the deprecated PgVector constructor pattern to the new object-based syntax. While PR #4286 updated most instances, this PR addresses the remaining occurrences found in documentation and fixture files.

Changes the deprecated constructor:
```js
new PgVector(connectionString)
```

To the new object-based syntax:

```js
new PgVector({ connectionString: connectionString })
```

## Related Issue(s)

Follow-up to #4286

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

All instances now use the correct object syntax, ensuring compatibility with the latest PgVector API and preventing deprecation warnings.