### PR TITLE
refactor: extract traces fetch calls from playground ui

### DIFF
--- a/.changeset/huge-memes-punch.md
+++ b/.changeset/huge-memes-punch.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+move the fetch traces call to the playground instead of playground-ui

--- a/packages/cli/src/playground/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/cli/src/playground/src/domains/traces/hooks/use-traces.tsx
@@ -1,16 +1,14 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
+import { client } from '@/lib/client';
 
 import usePolling from '@/lib/polls';
 
-import type { RefinedTrace } from '@/domains/traces/types';
-import { refineTraces } from '@/domains/traces/utils';
-import { useMastraClient } from '@/contexts/mastra-client-context';
+import { RefinedTrace } from '@mastra/playground-ui';
+import { refineTraces } from '../utils/refine-traces';
 
 export const useTraces = (componentName: string, isWorkflow: boolean = false) => {
   const [traces, setTraces] = useState<RefinedTrace[]>([]);
-
-  const client = useMemo(() => useMastraClient(), []);
 
   const fetchFn = useCallback(async () => {
     try {

--- a/packages/cli/src/playground/src/domains/traces/utils/refine-traces.ts
+++ b/packages/cli/src/playground/src/domains/traces/utils/refine-traces.ts
@@ -1,0 +1,50 @@
+import { Span } from '@mastra/playground-ui';
+
+import { RefinedTrace } from '@mastra/playground-ui';
+
+export const refineTraces = (traces: Span[], isWorkflow: boolean = false): RefinedTrace[] => {
+  const listOfSpanIds = new Set<string>();
+
+  const newName = (name: string) => {
+    if (name?.startsWith('workflow.') && isWorkflow) {
+      return name?.split('.')?.slice(2)?.join('.');
+    }
+    if (name?.startsWith('agent.') && !isWorkflow) {
+      return name?.split('.')?.slice(1)?.join('.');
+    }
+    return name;
+  };
+
+  const groupedTraces = traces?.reduce<Record<string, Span[]>>((acc, curr) => {
+    const newCurr = { ...curr, name: newName(curr.name), duration: curr.endTime - curr.startTime };
+
+    listOfSpanIds.add(curr.id);
+
+    return { ...acc, [curr.traceId]: [...(acc[curr.traceId] || []), newCurr] };
+  }, {});
+
+  const tracesData = Object.entries(groupedTraces).map(([key, value]) => {
+    const parentSpan = value.find(span => !span.parentSpanId || !listOfSpanIds.has(span.parentSpanId));
+
+    const enrichedSpans = value.map(span => ({
+      ...span,
+      parentSpanId: parentSpan?.id === span.id ? null : span?.parentSpanId,
+    }));
+
+    const failedStatus = value.find(span => span.status.code !== 0)?.status;
+
+    const runId = value?.[0]?.attributes?.runId;
+
+    return {
+      traceId: key,
+      serviceName: parentSpan?.name || key,
+      duration: parentSpan?.duration || value.reduce((acc, curr) => acc + curr.duration, 0),
+      status: failedStatus || parentSpan?.status || value[0].status,
+      started: value[0].startTime,
+      trace: enrichedSpans,
+      runId: runId ? String(runId) : undefined,
+    };
+  });
+
+  return tracesData;
+};

--- a/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
+++ b/packages/cli/src/playground/src/pages/agents/agent/traces.tsx
@@ -1,11 +1,12 @@
-import { AgentTraces, useTraces } from '@mastra/playground-ui';
+import { AgentTraces } from '@mastra/playground-ui';
 import { useParams } from 'react-router';
 
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { useAgent } from '@/hooks/use-agents';
+import { useTraces } from '@/domains/traces/hooks/use-traces';
 
-function AgentTracesContent() {
+function AgentTracesPage() {
   const { agentId } = useParams();
   const { agent, isLoading: isAgentLoading } = useAgent(agentId!);
   const { traces, firstCallLoading, error } = useTraces(agent?.name || '');
@@ -19,10 +20,6 @@ function AgentTracesContent() {
   }
 
   return <AgentTraces traces={traces || []} error={error} className="h-[calc(100vh-40px)]" />;
-}
-
-function AgentTracesPage() {
-  return <AgentTracesContent />;
 }
 
 export default AgentTracesPage;

--- a/packages/cli/src/playground/src/pages/workflows/workflow/legacy/traces.tsx
+++ b/packages/cli/src/playground/src/pages/workflows/workflow/legacy/traces.tsx
@@ -1,12 +1,13 @@
 import { useParams } from 'react-router';
-import { useTraces, WorkflowTraces } from '@mastra/playground-ui';
+import { WorkflowTraces } from '@mastra/playground-ui';
 
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { WorkflowInformation } from '@/domains/workflows/workflow-information';
 import { useLegacyWorkflow } from '@/hooks/use-workflows';
+import { useTraces } from '@/domains/traces/hooks/use-traces';
 
-function WorkflowTracesContent() {
+function WorkflowTracesPage() {
   const { workflowId } = useParams();
   const { legacyWorkflow, isLoading: isWorkflowLoading } = useLegacyWorkflow(workflowId!);
 
@@ -27,10 +28,6 @@ function WorkflowTracesContent() {
   }
 
   return <WorkflowTraces traces={traces} error={error} />;
-}
-
-function WorkflowTracesPage() {
-  return <WorkflowTracesContent />;
 }
 
 export default WorkflowTracesPage;

--- a/packages/cli/src/playground/src/pages/workflows/workflow/traces.tsx
+++ b/packages/cli/src/playground/src/pages/workflows/workflow/traces.tsx
@@ -1,12 +1,13 @@
 import { useParams, useSearchParams } from 'react-router';
-import { useTraces, WorkflowTraces } from '@mastra/playground-ui';
+import { WorkflowTraces } from '@mastra/playground-ui';
 
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { WorkflowInformation } from '@/domains/workflows/workflow-information';
 import { useWorkflow } from '@/hooks/use-workflows';
+import { useTraces } from '@/domains/traces/hooks/use-traces';
 
-function WorkflowTracesContent() {
+function WorkflowTracesPage() {
   const { workflowId } = useParams();
   const [searchParams] = useSearchParams();
   const runId = searchParams.get('runId');
@@ -30,10 +31,6 @@ function WorkflowTracesContent() {
   }
 
   return <WorkflowTraces traces={traces} error={error} runId={runId || undefined} stepName={stepName || undefined} />;
-}
-
-function WorkflowTracesPage() {
-  return <WorkflowTracesContent />;
 }
 
 export default WorkflowTracesPage;

--- a/packages/playground-ui/src/domains/traces/utils.ts
+++ b/packages/playground-ui/src/domains/traces/utils.ts
@@ -65,53 +65,6 @@ export function cleanString(string: string) {
   );
 }
 
-export const refineTraces = (traces: Span[], isWorkflow: boolean = false): RefinedTrace[] => {
-  const listOfSpanIds = new Set<string>();
-
-  const newName = (name: string) => {
-    if (name?.startsWith('workflow.') && isWorkflow) {
-      return name?.split('.')?.slice(2)?.join('.');
-    }
-    if (name?.startsWith('agent.') && !isWorkflow) {
-      return name?.split('.')?.slice(1)?.join('.');
-    }
-    return name;
-  };
-
-  const groupedTraces = traces?.reduce<Record<string, Span[]>>((acc, curr) => {
-    const newCurr = { ...curr, name: newName(curr.name), duration: curr.endTime - curr.startTime };
-
-    listOfSpanIds.add(curr.id);
-
-    return { ...acc, [curr.traceId]: [...(acc[curr.traceId] || []), newCurr] };
-  }, {});
-
-  const tracesData = Object.entries(groupedTraces).map(([key, value]) => {
-    const parentSpan = value.find(span => !span.parentSpanId || !listOfSpanIds.has(span.parentSpanId));
-
-    const enrichedSpans = value.map(span => ({
-      ...span,
-      parentSpanId: parentSpan?.id === span.id ? null : span?.parentSpanId,
-    }));
-
-    const failedStatus = value.find(span => span.status.code !== 0)?.status;
-
-    const runId = value?.[0]?.attributes?.runId;
-
-    return {
-      traceId: key,
-      serviceName: parentSpan?.name || key,
-      duration: parentSpan?.duration || value.reduce((acc, curr) => acc + curr.duration, 0),
-      status: failedStatus || parentSpan?.status || value[0].status,
-      started: value[0].startTime,
-      trace: enrichedSpans,
-      runId: runId ? String(runId) : undefined,
-    };
-  });
-
-  return tracesData;
-};
-
 export const allowedAiSpanAttributes = [
   'operation.name',
   'ai.operationId',

--- a/packages/playground-ui/src/hooks/index.tsx
+++ b/packages/playground-ui/src/hooks/index.tsx
@@ -1,1 +1,0 @@
-export * from './use-traces';

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -21,9 +21,7 @@ export * from './ds/components/EmptyState/index';
 export * from './ds/icons/index';
 export * from './lib/polls';
 export * from './hooks/use-speech-recognition';
-export { useTraces } from './hooks/index';
 
 export type { TraceContextType } from './domains/traces/context/trace-context';
-export { refineTraces } from './domains/traces/utils';
 
 export * from './store/playground-store';


### PR DESCRIPTION
## Description

Move the traces fetch call to the playground instead of the playground-ui

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
