### PR TITLE
fix: remove space from name in `AgentNetwork`

### DIFF
--- a/examples/agui/src/mastra/network/index.ts
+++ b/examples/agui/src/mastra/network/index.ts
@@ -3,7 +3,7 @@ import { weatherAgent } from '../agents';
 import { openai } from '@ai-sdk/openai';
 
 export const myNetwork = new AgentNetwork({
-  name: 'My Network',
+  name: 'myNetwork',
   agents: [weatherAgent],
   model: openai('gpt-4o'),
   instructions: `


### PR DESCRIPTION
## Description

Bug where the network name contained a space, causing failures. Updated the name from `My Network` to `myNetwork` - thanks to @oriol on Discord.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)  
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
