### PR TITLE
chore: generate sourcemaps in dev build

### DIFF
--- a/.changeset/lemon-paws-dress.md
+++ b/.changeset/lemon-paws-dress.md
@@ -1,0 +1,6 @@
+---
+"mastra": patch
+"@mastra/deployer": patch
+---
+
+chore: generate sourcemaps in dev build

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -97,6 +97,7 @@ export class DevBundler extends Bundler {
       },
       {
         dir: outputDir,
+        sourcemap: true,
       },
     );
 

--- a/packages/deployer/src/build/serverOptions.ts
+++ b/packages/deployer/src/build/serverOptions.ts
@@ -101,6 +101,7 @@ export async function getServerOptions(entryFile: string, outputDir: string): Pr
     dir: outputDir,
     format: 'es',
     entryFileNames: '[name].mjs',
+    sourcemap: true,
   });
 
   if (result.hasCustomConfig) {


### PR DESCRIPTION
## Description

This pull request will change the functionality of `mastra dev` to generate sourcemaps as part for the build process for debugging the source code.

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/4572

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ x] I have added tests that prove my fix is effective or that my feature works
