### PR TITLE
Fix dynamodb getMessages to correctly return last n messages when `limit` is passed

### DIFF
--- a/.changeset/tricky-snakes-invent.md
+++ b/.changeset/tricky-snakes-invent.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dynamodb': patch
+---
+
+Fix getMessages to correctly return last n messages when `limit` is passed

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -532,10 +532,10 @@ export class DynamoDBStore extends MastraStorage {
 
       // Apply the 'last' limit if provided
       if (selectBy?.last && typeof selectBy.last === 'number') {
-        // Use ElectroDB's limit parameter (descending sort assumed on GSI SK)
-        // Ensure GSI sk (createdAt) is sorted descending for 'last' to work correctly
-        // Assuming default sort is ascending on SK, use reverse: true for descending
-        const results = await query.go({ limit: selectBy.last, reverse: true });
+        // Use ElectroDB's limit parameter
+        // DDB GSIs are sorted in ascending order
+        // Use ElectroDB's order parameter to sort in descending order to retrieve 'latest' messages
+        const results = await query.go({ limit: selectBy.last, order: 'desc' });
         // Use arrow function in map to preserve 'this' context for parseMessageData
         const list = new MessageList({ threadId, resourceId }).add(
           results.data.map((data: any) => this.parseMessageData(data)),


### PR DESCRIPTION
## Description

- Currently the DDB implementation always returns the first n messages in a thread.

## Related Issue(s)

#4634 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
