### PR TITLE
fix(docs): change code highlight in memory overview and update japanese version

### DIFF
--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -24,7 +24,7 @@ npm install @mastra/memory@latest
 
 **2. Create an agent and attach a `Memory` instance:**
 
-```typescript filename="src/mastra/agents/index.ts" {10-14}
+```typescript filename="src/mastra/agents/index.ts" {6-18}
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { openai } from "@ai-sdk/openai";

--- a/docs/src/content/ja/docs/memory/overview.mdx
+++ b/docs/src/content/ja/docs/memory/overview.mdx
@@ -24,17 +24,24 @@ npm install @mastra/memory@latest
 
 **2. エージェントを作成し、`Memory`インスタンスを接続します：**
 
-```typescript filename="src/mastra/agents/index.ts" {10}
+```typescript filename="src/mastra/agents/index.ts" {6-18}
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { openai } from "@ai-sdk/openai";
+import { LibSQLStore } from "@mastra/libsql";
+
+// Initialize memory with LibSQLStore for persistence
+const memory = new Memory({
+  storage: new LibSQLStore({
+    url: "file:../mastra.db", // Or your database URL
+  }),
+});
 
 export const myMemoryAgent = new Agent({
   name: "MemoryAgent",
   instructions: "...",
   model: openai("gpt-4o"),
-
-  memory: new Memory(),
+  memory,
 });
 ```
 


### PR DESCRIPTION
## Description

The current code highlight in step 2 on this page https://mastra.ai/en/docs/memory/overview does not make sense.
I've changed it to highlight the code blocks required for the memory agent.

I wanted to apply this change to the japanese version as well and recognized, the code example is a bit different. Therefore I copied it over from the english version.

## Type of Change

- [x] Documentation update
