### PR TITLE
fix(dynamodb): handle Date objects in createdAt/updatedAt fields

### DIFF
--- a/.changeset/pink-lobsters-speak.md
+++ b/.changeset/pink-lobsters-speak.md
@@ -1,0 +1,5 @@
+---
+"@mastra/dynamodb": patch
+---
+
+fix(dynamodb): handle Date objects in createdAt/updatedAt fields

--- a/stores/dynamodb/src/storage/index.test.ts
+++ b/stores/dynamodb/src/storage/index.test.ts
@@ -644,6 +644,37 @@ describe('DynamoDBStore Integration Tests', () => {
       expect(allTraces.length).toBe(3);
     });
 
+    test('should handle Date objects for createdAt/updatedAt fields in batchTraceInsert', async () => {
+      // This test specifically verifies the bug from the issue where Date objects
+      // were passed instead of ISO strings and ElectroDB validation failed
+      const now = new Date();
+      const traceWithDateObjects = {
+        id: `trace-${randomUUID()}`,
+        parentSpanId: `span-${randomUUID()}`,
+        traceId: `traceid-${randomUUID()}`,
+        name: 'test-trace-with-dates',
+        scope: 'default-tracer',
+        kind: 1,
+        startTime: now.getTime(),
+        endTime: now.getTime() + 100,
+        status: JSON.stringify({ code: 0 }),
+        attributes: JSON.stringify({ key: 'value' }),
+        events: JSON.stringify([]),
+        links: JSON.stringify([]),
+        // These are Date objects, not ISO strings - this should be handled by ElectroDB attribute setters
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      // This should not throw a validation error due to Date object type
+      await expect(store.batchTraceInsert({ records: [traceWithDateObjects] })).resolves.not.toThrow();
+
+      // Verify the trace was saved correctly
+      const allTraces = await store.getTraces({ name: 'test-trace-with-dates', page: 1, perPage: 10 });
+      expect(allTraces.length).toBe(1);
+      expect(allTraces[0].name).toBe('test-trace-with-dates');
+    });
+
     test('should retrieve traces filtered by name using GSI', async () => {
       const trace1 = sampleTrace('trace-filter-name', 'scope-X');
       const trace2 = sampleTrace('trace-filter-name', 'scope-Y', Date.now() + 10);
@@ -724,6 +755,40 @@ describe('DynamoDBStore Integration Tests', () => {
         metadata: JSON.stringify({ custom: 'eval_meta' }),
       };
     };
+
+    test('should handle Date objects for createdAt/updatedAt fields in eval batchInsert', async () => {
+      // Test that eval entity properly handles Date objects in createdAt/updatedAt fields
+      const now = new Date();
+      const evalWithDateObjects = {
+        entity: 'eval',
+        agent_name: 'test-agent-dates',
+        input: 'Test input',
+        output: 'Test output',
+        result: JSON.stringify({ score: 0.95 }),
+        metric_name: 'test-metric',
+        instructions: 'Test instructions',
+        global_run_id: `global-${randomUUID()}`,
+        run_id: `run-${randomUUID()}`,
+        created_at: now, // Date object instead of ISO string
+        // These are Date objects, not ISO strings - should be handled by ElectroDB attribute setters
+        createdAt: now,
+        updatedAt: now,
+        metadata: JSON.stringify({ test: 'meta' }),
+      };
+
+      // This should not throw a validation error due to Date object type
+      await expect(
+        store.batchInsert({
+          tableName: TABLE_EVALS,
+          records: [evalWithDateObjects],
+        }),
+      ).resolves.not.toThrow();
+
+      // Verify the eval was saved correctly
+      const evals = await store.getEvalsByAgentName('test-agent-dates');
+      expect(evals.length).toBe(1);
+      expect(evals[0].agentName).toBe('test-agent-dates');
+    });
 
     test('should retrieve evals by agent name using GSI and filter by type', async () => {
       const agent1 = 'eval-agent-1';
@@ -1065,6 +1130,32 @@ describe('DynamoDBStore Integration Tests', () => {
         expect(loaded.title).toBe('Generic Test Thread');
         expect(loaded.metadata).toEqual({ generic: true });
       }
+    });
+
+    test('insert() should handle Date objects for createdAt/updatedAt fields', async () => {
+      // Test that individual insert method properly handles Date objects in date fields
+      const now = new Date();
+      const recordWithDates = {
+        id: `thread-${randomUUID()}`,
+        resourceId: `resource-${randomUUID()}`,
+        title: 'Thread with Date Objects',
+        // These are Date objects, not ISO strings - should be handled by preprocessing
+        createdAt: now,
+        updatedAt: now,
+        metadata: JSON.stringify({ test: 'with-dates' }),
+      };
+
+      // This should not throw a validation error due to Date object type
+      await expect(genericStore.insert({ tableName: TABLE_THREADS, record: recordWithDates })).resolves.not.toThrow();
+
+      // Verify the record was saved correctly
+      const loaded = await genericStore.load<StorageThreadType>({
+        tableName: TABLE_THREADS,
+        keys: { id: recordWithDates.id },
+      });
+      expect(loaded).not.toBeNull();
+      expect(loaded?.id).toBe(recordWithDates.id);
+      expect(loaded?.title).toBe('Thread with Date Objects');
     });
 
     test('load() should return null for non-existent record', async () => {

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -181,6 +181,29 @@ export class DynamoDBStore extends MastraStorage {
   }
 
   /**
+   * Pre-processes a record to ensure Date objects are converted to ISO strings
+   * This is necessary because ElectroDB validation happens before setters are applied
+   */
+  private preprocessRecord(record: Record<string, any>): Record<string, any> {
+    const processed = { ...record };
+
+    // Convert Date objects to ISO strings for date fields
+    // This prevents ElectroDB validation errors that occur when Date objects are passed
+    // to string-typed attributes, even when the attribute has a setter that converts dates
+    if (processed.createdAt instanceof Date) {
+      processed.createdAt = processed.createdAt.toISOString();
+    }
+    if (processed.updatedAt instanceof Date) {
+      processed.updatedAt = processed.updatedAt.toISOString();
+    }
+    if (processed.created_at instanceof Date) {
+      processed.created_at = processed.created_at.toISOString();
+    }
+
+    return processed;
+  }
+
+  /**
    * Clear all items from a logical "table" (entity type)
    */
   async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
@@ -275,8 +298,8 @@ export class DynamoDBStore extends MastraStorage {
     }
 
     try {
-      // Add the entity type to the record before creating
-      const dataToSave = { entity: entityName, ...record };
+      // Add the entity type to the record and preprocess before creating
+      const dataToSave = { entity: entityName, ...this.preprocessRecord(record) };
       await this.service.entities[entityName].create(dataToSave).go();
     } catch (error) {
       this.logger.error('Failed to insert record', { tableName, error });
@@ -295,8 +318,8 @@ export class DynamoDBStore extends MastraStorage {
       throw new Error(`No entity defined for ${tableName}`);
     }
 
-    // Add entity type to each record
-    const recordsToSave = records.map(rec => ({ entity: entityName, ...rec }));
+    // Add entity type and preprocess each record
+    const recordsToSave = records.map(rec => ({ entity: entityName, ...this.preprocessRecord(rec) }));
 
     // ElectroDB has batch limits of 25 items, so we need to chunk
     const batchSize = 25;


### PR DESCRIPTION
## Description

- Add preprocessing to convert Date objects to ISO strings before ElectroDB validation
- Fix validation errors when Date objects are passed to insert/batchInsert methods
- Extract shared preprocessRecord helper to avoid code duplication
- Add tests for Date object handling in all insertion methods

Fixes issue where ElectroDB validation would fail with "Invalid value type at entity path: 'createdAt'. Received value of type 'object', expected 'string'" when Date objects were passed instead of ISO strings.

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/4638

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
