### PR TITLE
fix(@mastra/core): ensure context messages aren't saved to db

### DIFF
--- a/.changeset/cuddly-bananas-accept.md
+++ b/.changeset/cuddly-bananas-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Ensure context messages aren't saved to the storage db

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -935,7 +935,7 @@ export class Agent<
             role: 'system',
             content: instructions || `${this.instructions}.`,
           })
-          .add(context || [], 'user');
+          .add(context || [], 'context');
 
         if (!memory || (!threadId && !resourceId)) {
           messageList.add(messages, 'user');
@@ -1018,7 +1018,7 @@ export class Agent<
         const processedList = new MessageList({ threadId, resourceId })
           .addSystem(instructions || `${this.instructions}.`)
           .addSystem(memorySystemMessage)
-          .add(context || [], 'user')
+          .add(context || [], 'context')
           .add(processedMemoryMessages, 'memory')
           .add(messageList.get.input.v2(), 'user')
           .get.all.prompt();

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -28,7 +28,7 @@ export type MastraMessageV2 = {
 };
 
 type MessageInput = UIMessage | Message | MastraMessageV1 | CoreMessage | MastraMessageV2;
-type MessageSource = 'memory' | 'response' | 'user' | 'system';
+type MessageSource = 'memory' | 'response' | 'user' | 'system' | 'context';
 type MemoryInfo = { threadId: string; resourceId?: string };
 
 export class MessageList {
@@ -45,6 +45,7 @@ export class MessageList {
   private memoryMessages = new Set<MastraMessageV2>();
   private newUserMessages = new Set<MastraMessageV2>();
   private newResponseMessages = new Set<MastraMessageV2>();
+  private userContextMessages = new Set<MastraMessageV2>();
 
   private generateMessageId?: IDGenerator;
 
@@ -417,6 +418,8 @@ ${JSON.stringify(message, null, 2)}`,
         this.newResponseMessages.add(messageV2);
       } else if (messageSource === `user`) {
         this.newUserMessages.add(messageV2);
+      } else if (messageSource === `context`) {
+        this.userContextMessages.add(messageV2);
       } else {
         throw new Error(`Missing message source for message ${messageV2}`);
       }


### PR DESCRIPTION
@webfansplz noticed this in https://github.com/mastra-ai/mastra/issues/4373#issuecomment-2939908947

With new MessageList work, messages passed to the context arg in stream/generate were being saved to the storage db