### PR TITLE
fix: primitive output in new workflow UX

### DIFF
--- a/.changeset/tasty-pens-walk.md
+++ b/.changeset/tasty-pens-walk.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+fix workflow output when the schema is a primitive

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -213,12 +213,12 @@ export function WorkflowTrigger({ workflowId, setRunId }: { workflowId: string; 
           })}
       </div>
 
-      {watchResultToUse && (
+      {result && (
         <div className="p-5 border-b-sm border-border1">
           <WorkflowJsonDialog result={restResult} />
         </div>
       )}
-      {watchResultToUse && <WorkflowResultSection result={watchResultToUse} workflow={workflow} />}
+      {result && <WorkflowResultSection result={result} workflow={workflow} />}
     </div>
   );
 }
@@ -232,6 +232,23 @@ const WorkflowResultSection = ({ result, workflow }: WorkflowResultSectionProps)
   const workflowState = result.payload.workflowState as ExtendedWorkflowWatchResult['payload']['workflowState'] & {
     result: unknown | null;
   };
+
+  if (
+    typeof workflowState.result === 'string' ||
+    typeof workflowState.result === 'number' ||
+    typeof workflowState.result === 'boolean'
+  ) {
+    return (
+      <div className="flex flex-col gap-1 p-5">
+        <div className="flex items-center gap-2">
+          <Txt as="label" htmlFor="string-result" variant="ui-sm" className="text-icon3">
+            Workflow Result
+          </Txt>
+        </div>
+        <Input id="string-result" defaultValue={String(workflowState.result)} />
+      </div>
+    );
+  }
 
   const hasResult = Object.keys(workflowState.result || {}).length > 0;
   if (!hasResult) return null;
@@ -268,6 +285,7 @@ const WorkflowResultFinishedStep = ({ stepResult, stepDefinition }: WorkflowResu
 
   try {
     const zodObjectSchema = resolveSerializedZodOutput(jsonSchemaToZod(parse(stepDefinition.outputSchema)));
+
     if (zodObjectSchema?._def?.typeName === 'ZodString') {
       return (
         <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Description

Follow up on https://github.com/mastra-ai/mastra/pull/4665 

When the final output of a workflow is just a primitive (and not an object containing steps), the ui crashes.

This PR safe checks for primitives output and just show a textfield in this situation.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
