### PR TITLE
fix: retry dev server only if server is ready

### DIFF
--- a/.changeset/brave-seas-wash.md
+++ b/.changeset/brave-seas-wash.md
@@ -1,0 +1,8 @@
+---
+'@mastra/deployer': patch
+'mastra': patch
+---
+
+Reset retry-count on code change and only retry if server actually is running
+
+Fixes #4563

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -3128,6 +3128,14 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
       if (options?.playground) {
         logger.info(`👨‍💻 Playground available at http://${host}:${port}/`);
       }
+
+      if (process.send) {
+        process.send({
+          type: 'server-ready',
+          port,
+          host,
+        });
+      }
     },
   );
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Reset retry-count on code change and only retry if server actually is running

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

Fixes #4563

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
