### PR TITLE
✏️ Fix "does they" typo in maxSteps docs

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -217,7 +217,7 @@ const response = await myAgent.generate(
     {
       role: "user",
       content:
-        "If a taxi driver earns $9461 per hour and works 12 hours a day, how much does they earn in one day?",
+        "If a taxi driver earns $9461 per hour and works 12 hours a day, how much do they earn in one day?",
     },
   ],
   {

--- a/docs/src/content/ja/docs/agents/overview.mdx
+++ b/docs/src/content/ja/docs/agents/overview.mdx
@@ -217,7 +217,7 @@ const response = await myAgent.generate(
     {
       role: "user",
       content:
-        "If a taxi driver earns $9461 per hour and works 12 hours a day, how much does they earn in one day?",
+        "If a taxi driver earns $9461 per hour and works 12 hours a day, how much do they earn in one day?",
     },
   ],
   {


### PR DESCRIPTION
## Description

This fixes a small typo where "does they" should be "do they". This appears in the [docs here](https://mastra.ai/en/docs/agents/overview#:~:text=how%20much%20does%20they%20earn%20in%20one%20day) 
## Related Issue(s)

- Fixes #4770 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

