### PR TITLE
Remove need for project ID for LangWatch

### DIFF
--- a/docs/src/content/en/reference/observability/providers/langwatch.mdx
+++ b/docs/src/content/en/reference/observability/providers/langwatch.mdx
@@ -13,7 +13,6 @@ To use LangWatch with Mastra, configure these environment variables:
 
 ```env
 LANGWATCH_API_KEY=your_api_key
-LANGWATCH_PROJECT_ID=your_project_id
 ```
 
 ## Implementation
@@ -32,8 +31,7 @@ export const mastra = new Mastra({
     export: {
       type: "custom",
       exporter: new LangWatchExporter({
-        apiKey: process.env.LANGWATCH_API_KEY,
-        projectId: process.env.LANGWATCH_PROJECT_ID,
+        apiKey: process.env.LANGWATCH_API_KEY
       }),
     },
   },

--- a/docs/src/content/ja/reference/observability/providers/langwatch.mdx
+++ b/docs/src/content/ja/reference/observability/providers/langwatch.mdx
@@ -13,7 +13,6 @@ LangWatchをMastraで使用するには、次の環境変数を設定してく�
 
 ```env
 LANGWATCH_API_KEY=your_api_key
-LANGWATCH_PROJECT_ID=your_project_id
 ```
 
 ## 実装
@@ -32,8 +31,7 @@ export const mastra = new Mastra({
     export: {
       type: "custom",
       exporter: new LangWatchExporter({
-        apiKey: process.env.LANGWATCH_API_KEY,
-        projectId: process.env.LANGWATCH_PROJECT_ID,
+        apiKey: process.env.LANGWATCH_API_KEY
       }),
     },
   },


### PR DESCRIPTION
## Description

There is no need for the project ID for the setup of LangWatch. Doesn't exist in the params.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
