### PR TITLE
ci: only run schema compat tests when code is changed

### DIFF
--- a/.github/workflows/test-schema-compat.yml
+++ b/.github/workflows/test-schema-compat.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'packages/schema-compat/**'
+      - 'packages/schema-compat/src/**'
+      - 'packages/schema-compat/vitest.config.ts'
       - '.github/workflows/test-schema.yml'
 
 jobs:

--- a/.github/workflows/test-schema-compat.yml
+++ b/.github/workflows/test-schema-compat.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - 'packages/schema-compat/src/**'
       - 'packages/schema-compat/vitest.config.ts'
-      - '.github/workflows/test-schema.yml'
+      - '.github/workflows/test-schema-compat.yml'
 
 jobs:
   test:


### PR DESCRIPTION
Renovate is causing these tests to use tons of openrouter credits, limiting the tests to only run when code changes should help