### PR TITLE
fix(@mastra/mcp-docs-server): remove @latest as it seems to cause npx caching issues

### DIFF
--- a/.changeset/nine-zoos-enjoy.md
+++ b/.changeset/nine-zoos-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@mastra/mcp-docs-server': patch
+'mastra': patch
+---
+
+Removed @latest from @mastra/mcp-docs-server scaffolded configuration for Windsurf/Cursor/VSCode. There is an npx caching issue that causes @latest to break the MCP server for many users, and for now removing @latest makes it work. We will debug this more but for now having a working docs server is more important than it updating every time users start their IDE.

--- a/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
@@ -70,7 +70,7 @@ Each tab shows the exact JSON structure and file paths needed for that IDE's MCP
   "mcpServers": {
     "mastra": {
       "command": "npx",
-      "args": ["-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -82,7 +82,7 @@ Each tab shows the exact JSON structure and file paths needed for that IDE's MCP
   "mcpServers": {
     "mastra": {
       "command": "npx",
-      "args": ["-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -94,7 +94,7 @@ Each tab shows the exact JSON structure and file paths needed for that IDE's MCP
   "servers": {
     "mastra": {
       "command": "npx",
-      "args": ["-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["-y", "@mastra/mcp-docs-server"]
       "type": "stdio"
     }
   }
@@ -119,7 +119,7 @@ Each tab shows the Windows-specific command structure needed for that IDE's MCP 
   "mcpServers": {
     "mastra": {
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -131,7 +131,7 @@ Each tab shows the Windows-specific command structure needed for that IDE's MCP 
   "mcpServers": {
     "mastra": {
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -143,7 +143,7 @@ Each tab shows the Windows-specific command structure needed for that IDE's MCP 
   "servers": {
     "mastra": {
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server@latest"],
+      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server"],
       "type": "stdio"
     }
   }

--- a/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
@@ -94,7 +94,7 @@ Each tab shows the exact JSON structure and file paths needed for that IDE's MCP
   "servers": {
     "mastra": {
       "command": "npx",
-      "args": ["-y", "@mastra/mcp-docs-server"]
+      "args": ["-y", "@mastra/mcp-docs-server"],
       "type": "stdio"
     }
   }

--- a/docs/src/content/en/reference/cli/mcp-docs-server.mdx
+++ b/docs/src/content/en/reference/cli/mcp-docs-server.mdx
@@ -12,7 +12,7 @@ line or configured inside an MCP-aware IDE such as Cursor or Windsurf.
 ## Running from the CLI
 
 ```bash
-npx -y @mastra/mcp-docs-server@latest
+npx -y @mastra/mcp-docs-server
 ```
 
 The command above runs a stdio based MCP server. The process will keep
@@ -25,19 +25,19 @@ be pointed at the `@wong2/mcp-cli` package for exploration.
 Rebuild the docs before serving (useful if you've modified docs locally):
 
 ```bash
-REBUILD_DOCS_ON_START=true npx -y @mastra/mcp-docs-server@latest
+REBUILD_DOCS_ON_START=true npx -y @mastra/mcp-docs-server
 ```
 
 Enable verbose logging while experimenting:
 
 ```bash
-DEBUG=1 npx -y @mastra/mcp-docs-server@latest
+DEBUG=1 npx -y @mastra/mcp-docs-server
 ```
 
 Serve blog posts from a custom domain:
 
 ```bash
-BLOG_URL=https://my-blog.example npx -y @mastra/mcp-docs-server@latest
+BLOG_URL=https://my-blog.example npx -y @mastra/mcp-docs-server
 ```
 
 ## Environment variables

--- a/packages/cli/src/commands/init/mcp-docs-server-install.ts
+++ b/packages/cli/src/commands/init/mcp-docs-server-install.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { ensureFile, readJSON, writeJSON } from 'fs-extra/esm';
 
-const args = ['-y', '@mastra/mcp-docs-server@latest'];
+const args = ['-y', '@mastra/mcp-docs-server'];
 const createMcpConfig = (editor: Editor) => {
   if (editor === 'vscode') {
     return {

--- a/packages/mcp-docs-server/README.md
+++ b/packages/mcp-docs-server/README.md
@@ -15,7 +15,7 @@ MacOS/Linux
   "mcpServers": {
     "mastra": {
       "command": "npx",
-      "args": ["-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -28,7 +28,7 @@ Windows
   "mcpServers": {
     "mastra": {
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -48,7 +48,7 @@ MacOS/Linux
   "mcpServers": {
     "mastra": {
       "command": "npx",
-      "args": ["-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -61,7 +61,7 @@ Windows
   "mcpServers": {
     "mastra": {
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server@latest"]
+      "args": ["/c", "npx", "-y", "@mastra/mcp-docs-server"]
     }
   }
 }
@@ -83,7 +83,7 @@ const mcp = new MCPClient({
   servers: {
     mastra: {
       command: 'npx',
-      args: ['-y', '@mastra/mcp-docs-server@latest'],
+      args: ['-y', '@mastra/mcp-docs-server'],
     },
   },
 });


### PR DESCRIPTION
We've seen many reports that having `@latest` is causing the docs server to fail to start. For now lets remove `@latest` from docs and scaffolding