### PR TITLE
fix(@mastra/core): don't send full file/image urls during thread title gen

### DIFF
--- a/.changeset/silver-pots-doubt.md
+++ b/.changeset/silver-pots-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Now that UIMessages are stored, we added a check to make sure large text files or source urls are not sent to the LLM for thread title generation.


### PR DESCRIPTION
Now that we store UIMessages, we need to make sure we're not sending full file/image parts during title gen as that can use a lot of tokens.