### PR TITLE
ci(@mastra/mcp-docs-server): re-enable and fix broken test

### DIFF
--- a/packages/mcp-docs-server/src/tools/__tests__/changes.test.ts
+++ b/packages/mcp-docs-server/src/tools/__tests__/changes.test.ts
@@ -105,12 +105,11 @@ describe('changesTool', () => {
       expect(hasPreReleaseVersion).toBe(true);
     });
 
-    // TODO: this is not working properly for alpha tags in headers
-    it.skip('should handle well-structured changelog entries', async () => {
+    it('should handle well-structured changelog entries', async () => {
       const result = await callTool(tools.mastra_mastraChanges, { package: '@mastra/core' });
 
       // Split into version sections
-      const sections = result.split(/##\s+v?\d+\.\d+\.\d+/);
+      const sections = result.split(/##\s+v?\d+\.\d+\.\d+\n/);
       sections.slice(1).forEach(section => {
         if (!section.includes('more lines hidden')) {
           // Each section should have at least one category and entry


### PR DESCRIPTION
We skipped this test last week to get unblock. Turns out we just needed to tweak the test regex to make it work again