### PR TITLE
fix(@mastra/mcp-docs-server): add storage instance to memory config

### DIFF
--- a/.changeset/hot-eagles-kneel.md
+++ b/.changeset/hot-eagles-kneel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-docs-server': minor
+---
+
+include storage instance to memory config

--- a/docs/src/course/01-first-agent/15-installing-memory.md
+++ b/docs/src/course/01-first-agent/15-installing-memory.md
@@ -1,11 +1,13 @@
 # Installing Memory
 
-First, we need to install the Mastra memory package to add memory capabilities to our agent. Run the following command in your terminal:
+First, we need to install the Mastra memory package to add memory capabilities to our agent. We also install a storage adapter to persist the memory data. We will use the `libsql` storage adapter. Run the following command in your terminal:
 
 ```bash
-npm install @mastra/memory
+npm install @mastra/memory @mastra/libsql
 ```
 
 The `@mastra/memory` package provides a simple yet powerful memory system for your Mastra agents. It allows your agent to remember previous conversations and maintain context across multiple interactions.
 
-This package is separate from the core Mastra package to keep the framework modular and allow you to only include the features you need in your project.
+The `@mastra/libsql` package is one of many storage adapters that persists the memory data to an `SQLite` database.
+
+This packages are separate from the core Mastra package to keep the framework modular and allow you to only include the features you need in your project.

--- a/docs/src/course/01-first-agent/15-installing-memory.md
+++ b/docs/src/course/01-first-agent/15-installing-memory.md
@@ -10,4 +10,4 @@ The `@mastra/memory` package provides a simple yet powerful memory system for yo
 
 The `@mastra/libsql` package is one of many storage adapters that persists the memory data to an `SQLite` database.
 
-This packages are separate from the core Mastra package to keep the framework modular and allow you to only include the features you need in your project.
+These packages are separate from the core Mastra package to keep the framework modular and allow you to only include the features you need in your project.

--- a/docs/src/course/01-first-agent/16-adding-memory-to-agent.md
+++ b/docs/src/course/01-first-agent/16-adding-memory-to-agent.md
@@ -2,16 +2,17 @@
 
 Now, let's update our agent to include memory. Open your `agents/index.ts` file and make the following changes:
 
-1. Import the Memory class:
+1. Import the Memory and LibSQLStore classes:
 
 ```typescript
 import { Agent } from "@mastra/core";
 import { openai } from "@ai-sdk/openai";
 import { Memory } from "@mastra/memory";
+import { LibSQLStore } from "@mastra/libsql";
 import { getTransactionsTool } from "../tools";
 ```
 
-2. Add memory to your agent:
+2. Add memory to your agent configured by a storage instance:
 
 ```typescript
 export const financialAgent = new Agent({
@@ -21,8 +22,12 @@ export const financialAgent = new Agent({
   `,
   model: openai("gpt-4o"),
   tools: { getTransactionsTool },
-  memory: new Memory(), // Add memory here
+  memory: new Memory({
+    storage: new LibSQLStore({
+      url: "../../memory.db", // local file-system database. Location is relative to the output directory `.mastra/output`
+    }),
+  }), // Add memory here
 });
 ```
 
-By adding the `memory` property to your agent configuration, you're enabling it to remember previous conversations. The `Memory` class from the `@mastra/memory` package provides a simple way to add memory capabilities to your agent.
+By adding the `memory` property to your agent configuration, you're enabling it to remember previous conversations. The `Memory` class from the `@mastra/memory` package provides a simple way to add memory capabilities to your agent. The `LibSQLStore` class from `@mastra/libsql` persists the memory data to a `SQLite` database.

--- a/docs/src/course/03-agent-memory/04-creating-basic-memory-agent.md
+++ b/docs/src/course/03-agent-memory/04-creating-basic-memory-agent.md
@@ -7,10 +7,15 @@ Create or update your `src/mastra/agents/index.ts` file:
 ```typescript
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
+import { LibSQLStore } from "@mastra/libsql";
 import { openai } from "@ai-sdk/openai";
 
 // Create a basic memory instance
-const memory = new Memory();
+const memory = new Memory({
+  storage: new LibSQLStore({
+    url: "../../memory.db",
+  }),
+});
 
 // Create an agent with memory
 export const memoryAgent = new Agent({

--- a/docs/src/course/03-agent-memory/08-configuring-conversation-history.md
+++ b/docs/src/course/03-agent-memory/08-configuring-conversation-history.md
@@ -6,12 +6,13 @@ By default, the `Memory` instance includes the last 40 messages from the current
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { openai } from "@ai-sdk/openai";
+import { LibSQLStore } from "@mastra/libsql";
 
 // Create a memory instance with custom conversation history settings
-import { Agent } from "@mastra/core/agent";
-import { Memory } from "@mastra/memory";
-import { LibSQLStore } from "@mastra/libsql";
-import { openai } from "@ai-sdk/openai";
+const memory = new Memory({
+  storage: new LibSQLStore({
+    url: "../../memory.db",
+  }),
   options: {
     lastMessages: 20, // Include the last 20 messages in the context
   },

--- a/docs/src/course/03-agent-memory/08-configuring-conversation-history.md
+++ b/docs/src/course/03-agent-memory/08-configuring-conversation-history.md
@@ -8,10 +8,10 @@ import { Memory } from "@mastra/memory";
 import { openai } from "@ai-sdk/openai";
 
 // Create a memory instance with custom conversation history settings
-const memory = new Memory({
-  storage: new LibSQLStore({
-    url: "../../memory.db",
-  }),
+import { Agent } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+import { LibSQLStore } from "@mastra/libsql";
+import { openai } from "@ai-sdk/openai";
   options: {
     lastMessages: 20, // Include the last 20 messages in the context
   },

--- a/docs/src/course/03-agent-memory/08-configuring-conversation-history.md
+++ b/docs/src/course/03-agent-memory/08-configuring-conversation-history.md
@@ -9,6 +9,9 @@ import { openai } from "@ai-sdk/openai";
 
 // Create a memory instance with custom conversation history settings
 const memory = new Memory({
+  storage: new LibSQLStore({
+    url: "../../memory.db",
+  }),
   options: {
     lastMessages: 20, // Include the last 20 messages in the context
   },

--- a/docs/src/course/03-agent-memory/10-storage-configuration.md
+++ b/docs/src/course/03-agent-memory/10-storage-configuration.md
@@ -4,13 +4,13 @@ Conversation history relies on a storage adapter to persist messages. By default
 
 ```typescript
 import { Memory } from "@mastra/memory";
-import { LibSQLStore } from "@mastra/core/storage/libsql";
+import { LibSQLStore } from "@mastra/libsql";
 
 const memory = new Memory({
   // Configure storage
   storage: new LibSQLStore({
     config: {
-      url: "file:memory.db", // Local database
+      url: "file:../../memory.db", // Local database. Relative to the output folder
     },
   }),
   options: {


### PR DESCRIPTION
## Description

Add `LibSQLStore` storage instance to `Memory` config in course content.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
