### PR TITLE
change how dedupe works for libsql and pg

### DIFF
--- a/.changeset/rich-crabs-scream.md
+++ b/.changeset/rich-crabs-scream.md
@@ -1,0 +1,6 @@
+---
+"@mastra/libsql": patch
+"@mastra/pg": patch
+---
+
+change how dedupe works for libsql and pg

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -554,15 +554,12 @@ export class LibSQLStore extends MastraStorage {
     const finalQuery = unionQueries.join(' UNION ALL ') + ' ORDER BY "createdAt" ASC';
     const includedResult = await this.client.execute({ sql: finalQuery, args: params });
     const includedRows = includedResult.rows?.map(row => this.parseRow(row));
-    const dedupedRows = Object.values(
-      includedRows.reduce(
-        (acc, row) => {
-          acc[row.id] = row;
-          return acc;
-        },
-        {} as Record<string, MastraMessageV2>,
-      ),
-    );
+    const seen = new Set<string>();
+    const dedupedRows = includedRows.filter(row => {
+      if (seen.has(row.id)) return false;
+      seen.add(row.id);
+      return true;
+    });
     return dedupedRows;
   }
 

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -761,15 +761,12 @@ export class PostgresStore extends MastraStorage {
         }
         const finalQuery = unionQueries.join(' UNION ALL ') + ' ORDER BY "createdAt" ASC';
         const includedRows = await this.db.manyOrNone(finalQuery, params);
-        const dedupedRows = Object.values(
-          includedRows.reduce(
-            (acc, row) => {
-              acc[row.id] = row;
-              return acc;
-            },
-            {} as Record<string, (typeof includedRows)[0]>,
-          ),
-        );
+        const seen = new Set<string>();
+        const dedupedRows = includedRows.filter(row => {
+          if (seen.has(row.id)) return false;
+          seen.add(row.id);
+          return true;
+        });
         rows = dedupedRows;
       } else {
         const limit = typeof selectBy?.last === `number` ? selectBy.last : 40;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Small change to how messages are deduped when using selectBy.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
