### PR TITLE
Minor Documentation Fixes: Typo Corrections in Local Dev and Workflow Guides

### DIFF
--- a/docs/src/content/en/docs/local-dev/mastra-dev.mdx
+++ b/docs/src/content/en/docs/local-dev/mastra-dev.mdx
@@ -152,7 +152,7 @@ This architecture allows you to start developing immediately without setting up 
 
 ### Model settings
 
-The local devleopment server also lets you configure the model settings in Overview > Model Settings.
+The local development server also lets you configure the model settings in Overview > Model Settings.
 
 You can configure the following settings:
 

--- a/docs/src/content/en/docs/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/docs/workflows/inngest-workflow.mdx
@@ -86,7 +86,7 @@ const incrementStep = createStep({
 
 ### Creating the Workflow
 
-Compose the steps into a workflow using the `dountil` loop pattern. The createWorkflow function creates a function on inngest server that is invokable.
+Compose the steps into a workflow using the `dountil` loop pattern. The createWorkflow function creates a function on inngest server that is invocable.
 
 ```ts showLineNumbers copy filename="src/mastra/workflows/index.ts"
 // workflow that is registered as a function on inngest server


### PR DESCRIPTION


Description:  
This pull request addresses minor documentation issues by correcting typos in two files:
- Fixed a typo in the word "development" in the local development server documentation.
- Corrected the spelling of "invocable" in the workflow creation guide.

These changes improve the clarity and professionalism of the documentation. No functional code changes are included.