### PR TITLE
fix(client-js): update repository URL to point to monorepo

### DIFF
--- a/client-sdks/client-js/package.json
+++ b/client-sdks/client-js/package.json
@@ -19,7 +19,12 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "github:mastra-ai/client-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mastra-ai/mastra.git",
+    "directory": "client-sdks/client-js"
+  },
+  "homepage": "https://github.com/mastra-ai/mastra/tree/main/client-sdks/client-js#readme",
   "license": "Elastic-2.0",
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --clean --treeshake=smallest --splitting",


### PR DESCRIPTION
issue: https://github.com/mastra-ai/mastra/issues/4888

## Overview
Fixed incorrect repository and homepage URLs in `package.json` for the `@mastra/client-js` package.

## Changes
- Updated the `repository` field to specify the correct monorepo URL and directory
  - Fixed incorrect `github:mastra-ai/client-js` (404) to `https://github.com/mastra-ai/mastra.git`
  - Added `directory` field to explicitly indicate package location
- Updated the `homepage` field to point to the package's README in the monorepo

## Motivation
- Current repository URL on npmjs.com (https://www.npmjs.com/package/@mastra/client-js) returns 404
- Current homepage URL also returns 404
- These broken links make it difficult for users to find documentation and source code

## Impact
- This is a metadata-only change with no functional impact
- Fixes broken links on npmjs.com package page
- Improves package discoverability and documentation accessibility