### PR TITLE
fix: show workflow steps when attached to an agent

### DIFF
--- a/.changeset/five-hornets-throw.md
+++ b/.changeset/five-hornets-throw.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+fix the tools not showing on workflows attached to agents

--- a/packages/cli/src/playground/src/domains/agents/workflow-list.tsx
+++ b/packages/cli/src/playground/src/domains/agents/workflow-list.tsx
@@ -9,7 +9,7 @@ export interface WorkflowListProps {
 
 export function WorkflowList({ workflows, agentId }: WorkflowListProps) {
   return (
-    <ul>
+    <ul className="space-y-2">
       {workflows.map(workflow => (
         <li key={workflow.id}>
           <WorkflowEntity workflow={workflow} agentId={agentId} />

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -116,6 +116,15 @@ export async function getAgentByIdHandler({
             ...acc,
             [key]: {
               name: workflow.name,
+              steps: Object.entries(workflow.steps).reduce<any>((acc, [key, step]) => {
+                return {
+                  ...acc,
+                  [key]: {
+                    id: step.id,
+                    description: step.description,
+                  },
+                };
+              }, {}),
             },
           };
         }, {});


### PR DESCRIPTION
## Description

This PR adds the steps count on workflows attached to an agent even if the workflow is not registered in the config.

In the following example, `anotherWorkflow` does not exist in my config:

```js
export const mastra = new Mastra({
  workflows: { weatherWorkflow, helloWorldWorkflow },
 /* ... */
});

```

**Before (see bottom right cornet 0 steps)**
![CleanShot 2025-06-11 at 10 44 44@2x](https://github.com/user-attachments/assets/ca1efda9-904a-4679-9f2a-3b23bf542931)


**After (see bottom right corner 1 step)**

![CleanShot 2025-06-11 at 10 42 43@2x](https://github.com/user-attachments/assets/517b5345-9b23-443d-99fe-acb35d7275e8)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
