### PR TITLE
Fix Typo in Example Usage of addInstructions Method

### DIFF
--- a/.changeset/friendly-melons-reply.md
+++ b/.changeset/friendly-melons-reply.md
@@ -1,0 +1,5 @@
+---
+"@mastra/voice-openai-realtime": patch
+---
+
+Fix Typo in Example Usage of addInstructions Method

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -193,7 +193,7 @@ export class OpenAIRealtimeVoice extends MastraVoice {
    *
    * @example
    * ```typescript
-   * voice.addInstuctions('You are a helpful assistant.');
+   * voice.addInstructions('You are a helpful assistant.');
    * ```
    */
   addInstructions(instructions?: string) {


### PR DESCRIPTION
## Description

 
This pull request corrects a minor typo in the example usage of the addInstructions method within the OpenAIRealtimeVoice class. The change ensures consistency and accuracy in the documentation by updating the method call from addInstuctions to addInstructions. No functional code was modified; this update is purely for documentation clarity.