### PR TITLE
Fix tools glob by only capturing js/ts files

### DIFF
--- a/.changeset/modern-ways-end.md
+++ b/.changeset/modern-ways-end.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix globbing of tools to only capture js/ts files

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/agents/index.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/agents/index.ts
@@ -1,10 +1,11 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
 import { helloWorldTool, toolUsingNativeBindings, toolWithNativeBindingPackageDep } from '@inner/inner-tools';
+import { calculatorTool } from '@/tools/calculator-tool';
 
 export const innerAgent = new Agent({
   name: 'inner-agent',
-  instructions: 'You are a helpful assistant',
+  instructions: 'You are a helpful assistant.',
   model: openai('gpt-4o'),
-  tools: [helloWorldTool, toolUsingNativeBindings, toolWithNativeBindingPackageDep],
+  tools: [helloWorldTool, toolUsingNativeBindings, toolWithNativeBindingPackageDep, calculatorTool],
 });

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/calculator-tool.README.md
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/calculator-tool.README.md
@@ -1,0 +1,3 @@
+# Calculator tool
+
+A simple tool that sums up 2 digits

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/calculator-tool.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/calculator-tool.ts
@@ -1,0 +1,10 @@
+import { createTool } from '@mastra/core/tools';
+
+export const calculatorTool = createTool({
+  id: 'calculator',
+  description: 'A tool that sums up 2 numbers',
+  execute: async ({ context }) => {
+    const { a, b } = context;
+    return a + b;
+  },
+});

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/calculator-tool.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/calculator-tool.ts
@@ -1,8 +1,13 @@
 import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
 
 export const calculatorTool = createTool({
   id: 'calculator',
   description: 'A tool that sums up 2 numbers',
+  inputSchema: z.object({
+    a: z.number(),
+    b: z.number(),
+  }),
   execute: async ({ context }) => {
     const { a, b } = context;
     return a + b;

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -21,7 +21,7 @@ export async function build({
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(rootDir, dir)) : join(rootDir, 'src', 'mastra');
   const outputDirectory = join(rootDir, '.mastra');
 
-  const defaultToolsPath = join(mastraDir, 'tools/**/*');
+  const defaultToolsPath = join(mastraDir, 'tools/**/*.{js,ts}');
   const discoveredTools = [defaultToolsPath, ...(tools ?? [])];
 
   try {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -150,7 +150,7 @@ export async function dev({
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(process.cwd(), dir)) : join(process.cwd(), 'src', 'mastra');
   const dotMastraPath = join(rootDir, '.mastra');
 
-  const defaultToolsPath = join(mastraDir, 'tools/**/*');
+  const defaultToolsPath = join(mastraDir, 'tools/**/*.{js,ts}');
   const discoveredTools = [defaultToolsPath, ...(tools || [])];
 
   const fileService = new FileService();


### PR DESCRIPTION

## Description

<!-- Provide a brief description of the changes in this PR -->
Currently, our globs tries to bundle any file inside tools, I scoped it only to support .js/.ts files, which we should've done initially.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
