### PR TITLE
fix(core, memory): fix fetchMemory regression

### DIFF
--- a/.changeset/early-tomatoes-eat.md
+++ b/.changeset/early-tomatoes-eat.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+"@mastra/memory": patch
+---
+
+fix(core, memory): fix fetchMemory regression

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -603,8 +603,25 @@ export class Agent<
 
       messageList.add(memoryMessages, 'memory');
 
+      const systemMessage =
+        messageList
+          .getSystemMessages()
+          ?.map(m => m.content)
+          ?.join(`\n`) ?? undefined;
+
+      const processedMemoryMessages = memory.processMessages({
+        // these will be processed
+        messages: messageList.get.remembered.v1() as CoreMessage[],
+        // these are here for inspecting but shouldn't be returned by the processor
+        // - ex TokenLimiter needs to measure all tokens even though it's only processing remembered messages
+        newMessages: messageList.get.input.v1() as CoreMessage[],
+        systemMessage,
+        memorySystemMessage: memorySystemMessage || undefined,
+      });
+
       return {
         threadId: thread.id,
+        messages: processedMemoryMessages,
       };
     }
 

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { openai } from '@ai-sdk/openai';
-import { CoreMessage, Mastra } from '@mastra/core';
+import { Mastra } from '@mastra/core';
+import type { CoreMessage } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { RuntimeContext } from '@mastra/core/runtime-context';
 import { fastembed } from '@mastra/fastembed';
@@ -8,8 +9,8 @@ import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { weatherTool } from './mastra/tools/weather';
 import { memoryProcessorAgent, weatherAgent } from './mastra/agents/weather';
+import { weatherTool } from './mastra/tools/weather';
 
 describe('Agent Memory Tests', () => {
   const dbFile = 'file:mastra-agent.db';

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -9,7 +9,7 @@ import { Memory } from '@mastra/memory';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { weatherTool } from './mastra/tools/weather';
-import { memoryProcessorAgent } from './mastra/agents/weather';
+import { memoryProcessorAgent, weatherAgent } from './mastra/agents/weather';
 
 describe('Agent Memory Tests', () => {
   const dbFile = 'file:mastra-agent.db';
@@ -319,4 +319,68 @@ describe('Agent with message processors', () => {
         .length,
     ).toBe(4);
   }, 30_000);
+});
+
+describe('Agent.fetchMemory', () => {
+  it('should return messages from memory', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'fetch-memory-test';
+
+    const response = await weatherAgent.generate('Just a simple greeting to populate memory.', {
+      threadId,
+      resourceId,
+    });
+
+    // @ts-expect-error fetchMemory is deprecated and for internal use.
+    const { messages } = await weatherAgent.fetchMemory({ threadId, resourceId });
+
+    expect(messages).toBeDefined();
+    if (!messages) return;
+
+    expect(messages.length).toBe(2); // user message + assistant response
+
+    const userMessage = messages.find(m => m.role === 'user');
+    expect(userMessage).toBeDefined();
+    if (!userMessage) return;
+    expect(userMessage.content).toEqual('Just a simple greeting to populate memory.');
+
+    const assistantMessage = messages.find(m => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    if (!assistantMessage) return;
+    expect(assistantMessage.content).toEqual([{ type: 'text', text: response.text }]);
+  }, 30_000);
+
+  it('should apply processors when fetching memory', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'fetch-memory-processor-test';
+
+    await memoryProcessorAgent.generate('What is the weather in London?', { threadId, resourceId });
+
+    // @ts-expect-error fetchMemory is deprecated and for internal use.
+    const { messages } = await memoryProcessorAgent.fetchMemory({ threadId, resourceId });
+
+    expect(messages).toBeDefined();
+    if (!messages) return;
+
+    const hasToolRelatedMessage = messages.some(
+      m => m.role === 'tool' || (Array.isArray(m.content) && m.content.some(c => c.type === 'tool-call')),
+    );
+    expect(hasToolRelatedMessage).toBe(false);
+
+    const userMessage = messages.find(m => m.role === 'user');
+    expect(userMessage).toBeDefined();
+    if (!userMessage) return;
+    expect(userMessage.content).toEqual('What is the weather in London?');
+  }, 30_000);
+
+  it('should return nothing if thread does not exist', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'fetch-memory-no-thread';
+
+    // @ts-expect-error fetchMemory is deprecated and for internal use.
+    const result = await weatherAgent.fetchMemory({ threadId, resourceId });
+
+    expect(result.messages).toBeUndefined();
+    expect(result.threadId).toBe(threadId);
+  });
 });

--- a/packages/memory/integration-tests/src/mastra/agents/weather.ts
+++ b/packages/memory/integration-tests/src/mastra/agents/weather.ts
@@ -3,6 +3,7 @@ import { createTool } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
+import { ToolCallFilter } from '@mastra/memory/processors';
 import { z } from 'zod';
 import { weatherTool } from '../tools/weather';
 
@@ -36,5 +37,39 @@ export const weatherAgent = new Agent({
       description: 'Returns the contents of the users clipboard',
       inputSchema: z.object({}),
     }),
+  },
+});
+
+const memoryWithProcessor = new Memory({
+  embedder: openai.embedding('text-embedding-3-small'),
+  storage: new LibSQLStore({
+    url: 'file:mastra.db',
+  }),
+  vector: new LibSQLVector({
+    connectionUrl: 'file:mastra.db',
+  }),
+  options: {
+    semanticRecall: {
+      topK: 20,
+      messageRange: {
+        before: 10,
+        after: 10,
+      },
+    },
+    lastMessages: 20,
+    threads: {
+      generateTitle: true,
+    },
+  },
+  processors: [new ToolCallFilter()],
+});
+
+export const memoryProcessorAgent = new Agent({
+  name: 'test-processor',
+  instructions: 'You are a test agent that uses a memory processor to filter out all messages.',
+  model: openai('gpt-4o'),
+  memory: memoryWithProcessor,
+  tools: {
+    get_weather: weatherTool,
   },
 });

--- a/packages/memory/integration-tests/src/mastra/agents/weather.ts
+++ b/packages/memory/integration-tests/src/mastra/agents/weather.ts
@@ -66,7 +66,7 @@ const memoryWithProcessor = new Memory({
 
 export const memoryProcessorAgent = new Agent({
   name: 'test-processor',
-  instructions: 'You are a test agent that uses a memory processor to filter out all messages.',
+  instructions: 'You are a test agent that uses a memory processor to filter out tool call messages.',
   model: openai('gpt-4o'),
   memory: memoryWithProcessor,
   tools: {

--- a/packages/memory/integration-tests/src/mastra/index.ts
+++ b/packages/memory/integration-tests/src/mastra/index.ts
@@ -1,10 +1,11 @@
 import { Mastra } from '@mastra/core';
 import { LibSQLStore } from '@mastra/libsql';
-import { weatherAgent } from './agents/weather';
+import { memoryProcessorAgent, weatherAgent } from './agents/weather';
 
 export const mastra = new Mastra({
   agents: {
     test: weatherAgent,
+    testProcessor: memoryProcessorAgent,
   },
   storage: new LibSQLStore({
     url: 'file:mastra.db',


### PR DESCRIPTION
## Description

When we shipped MessageList support we added a regression to fetchMemory, we removed the message processor logic and we also removed returning messages at all. There were no tests for this API. Even though it is deprecated we still need to support it for now.

I added some tests for this API (as none existed) to prevent regressions.
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
