### PR TITLE
feat(memory, storage): updateMessages API and message metadata

### DIFF
--- a/.changeset/cuddly-ducks-cover.md
+++ b/.changeset/cuddly-ducks-cover.md
@@ -1,0 +1,15 @@
+---
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/memory': patch
+'@mastra/dynamodb': patch
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/lance': patch
+'@mastra/pg': patch
+---
+
+Add updateMessages API to storage classes (only support for PG and LibSQL for now) and to memory class. Additionally allow for metadata to be saved in the content field of a message.

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -15,6 +15,7 @@ export type MastraMessageContentV2 = {
   toolInvocations?: UIMessage['toolInvocations'];
   reasoning?: UIMessage['reasoning'];
   annotations?: UIMessage['annotations'];
+  metadata?: Record<string, unknown>;
 };
 
 export type MastraMessageV2 = {

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -1,4 +1,4 @@
-import type { MastraMessageV2 } from '../agent';
+import type { MastraMessageContentV2, MastraMessageV2 } from '../agent';
 import { MastraBase } from '../base';
 import type { MastraMessageV1, StorageThreadType } from '../memory/types';
 import type { Trace } from '../telemetry';
@@ -156,6 +156,14 @@ export abstract class MastraStorage extends MastraBase {
   abstract saveMessages(
     args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
   ): Promise<MastraMessageV2[] | MastraMessageV1[]>;
+
+  abstract updateMessages(args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]>;
 
   abstract getTraces(args: StorageGetTracesArg): Promise<any[]>;
 

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -141,6 +141,12 @@ export class MockStore extends MastraStorage {
     return list.get.all.v1();
   }
 
+  async updateMessages(args: { messages: Partial<MastraMessageV2> & { id: string }[] }): Promise<MastraMessageV2[]> {
+    this.logger.debug(`MockStore: updateMessages called with ${args.messages.length} messages`);
+    const messages = args.messages.map(m => this.data.mastra_messages[m.id]);
+    return messages;
+  }
+
   async getTraces({
     name,
     scope,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -703,4 +703,21 @@ Notes:
     }
     return {};
   }
+
+  /**
+   * Updates the metadata of a list of messages
+   * @param messages - The list of messages to update
+   * @returns The list of updated messages
+   */
+  public async updateMessages({
+    messages,
+  }: {
+    messages: Partial<MastraMessageV2> & { id: string }[];
+  }): Promise<MastraMessageV2[]> {
+    if (messages.length === 0) return [];
+
+    // TODO: Possibly handle updating the vector db here when a message is updated.
+
+    return this.storage.updateMessages({ messages });
+  }
 }

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -1,6 +1,7 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
 import { MessageList } from '@mastra/core/agent';
+import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
 import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '@mastra/core/memory';
 import {
@@ -1185,5 +1186,16 @@ export class ClickhouseStore extends MastraStorage {
 
   async close(): Promise<void> {
     await this.db.close();
+  }
+
+  async updateMessages(_args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    this.logger.error('updateMessages is not yet implemented in ClickhouseStore');
+    throw new Error('Method not implemented');
   }
 }

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -1,4 +1,5 @@
 import type { D1Database } from '@cloudflare/workers-types';
+import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
 import type { StorageThreadType, MastraMessageV1, MastraMessageV2 } from '@mastra/core/memory';
@@ -1509,5 +1510,16 @@ export class D1Store extends MastraStorage {
   async close(): Promise<void> {
     this.logger.debug('Closing D1 connection');
     // No explicit cleanup needed for D1
+  }
+
+  async updateMessages(_args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    this.logger.error('updateMessages is not yet implemented in CloudflareD1Store');
+    throw new Error('Method not implemented');
   }
 }

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -1,4 +1,5 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
+import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
 import type { StorageThreadType, MastraMessageV1, MastraMessageV2 } from '@mastra/core/memory';
 import {
@@ -1598,5 +1599,16 @@ export class CloudflareStore extends MastraStorage {
 
   async close(): Promise<void> {
     // No explicit cleanup needed
+  }
+
+  async updateMessages(_args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    this.logger.error('updateMessages is not yet implemented in CloudflareStore');
+    throw new Error('Method not implemented');
   }
 }

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
 import type { StorageThreadType, MastraMessageV2, MastraMessageV1 } from '@mastra/core/memory';
 
@@ -1134,5 +1135,16 @@ export class DynamoDBStore extends MastraStorage {
       // Optionally re-throw or handle as appropriate for your application's error handling strategy
       throw error;
     }
+  }
+
+  async updateMessages(_args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    this.logger.error('updateMessages is not yet implemented in DynamoDBStore');
+    throw new Error('Method not implemented');
   }
 }

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -1,5 +1,6 @@
 import { connect } from '@lancedb/lancedb';
 import type { Connection, ConnectionOptions, SchemaLike, FieldLike } from '@lancedb/lancedb';
+import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV1, MastraMessageV2, StorageThreadType, TraceType } from '@mastra/core/memory';
 import {
@@ -1013,5 +1014,16 @@ export class LanceStorage extends MastraStorage {
     _args: StorageGetMessagesArg,
   ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }> {
     throw new Error('Method not implemented.');
+  }
+
+  async updateMessages(_args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    this.logger.error('updateMessages is not yet implemented in LanceStore');
+    throw new Error('Method not implemented');
   }
 }

--- a/stores/libsql/src/storage/index.test.ts
+++ b/stores/libsql/src/storage/index.test.ts
@@ -8,6 +8,7 @@ import {
   resetRole,
 } from '@internal/storage-test-utils';
 import type { MastraMessageV1, StorageThreadType } from '@mastra/core';
+import type { MastraMessageV2, MastraMessageContentV2 } from '@mastra/core/agent';
 import { Mastra } from '@mastra/core/mastra';
 import { TABLE_EVALS, TABLE_TRACES, TABLE_MESSAGES, TABLE_THREADS } from '@mastra/core/storage';
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
@@ -360,5 +361,198 @@ describe('LibSQLStore Pagination Features', () => {
       expect(page3.total).toBe(17);
       expect(page3.hasMore).toBe(false);
     });
+  });
+});
+
+describe('LibSQLStore updateMessages', () => {
+  let store: LibSQLStore;
+  let thread: StorageThreadType;
+
+  const createSampleMessageV2 = ({
+    threadId,
+    resourceId,
+    role = 'user',
+    content,
+    createdAt,
+  }: {
+    threadId: string;
+    resourceId?: string;
+    role?: 'user' | 'assistant';
+    content?: Partial<MastraMessageContentV2>;
+    createdAt?: Date;
+  }): MastraMessageV2 => {
+    return {
+      id: randomUUID(),
+      threadId,
+      resourceId: resourceId || thread.resourceId,
+      role,
+      createdAt: createdAt || new Date(),
+      content: {
+        format: 2,
+        parts: content?.parts || [],
+        content: content?.content || `Sample content ${randomUUID()}`,
+        ...content,
+      },
+      type: 'v2',
+    };
+  };
+
+  beforeAll(async () => {
+    store = libsql;
+  });
+
+  beforeEach(async () => {
+    await store.clearTable({ tableName: TABLE_MESSAGES });
+    await store.clearTable({ tableName: TABLE_THREADS });
+    const threadData = createSampleThread();
+    thread = await store.saveThread({ thread: threadData as StorageThreadType });
+  });
+
+  it('should update a single field of a message (e.g., role)', async () => {
+    const originalMessage = createSampleMessageV2({ threadId: thread.id, role: 'user' });
+    await store.saveMessages({ messages: [originalMessage], format: 'v2' });
+
+    const updatedMessages = await store.updateMessages({
+      messages: [{ id: originalMessage.id, role: 'assistant' }],
+    });
+
+    expect(updatedMessages).toHaveLength(1);
+    expect(updatedMessages[0].role).toBe('assistant');
+
+    const fromDb = await store.getMessages({ threadId: thread.id, format: 'v2' });
+    expect(fromDb[0].role).toBe('assistant');
+  });
+
+  it('should update only the metadata within the content field, preserving other content fields', async () => {
+    const originalMessage = createSampleMessageV2({
+      threadId: thread.id,
+      content: { content: 'hello world', parts: [{ type: 'text', text: 'hello world' }] },
+    });
+    await store.saveMessages({ messages: [originalMessage], format: 'v2' });
+
+    const newMetadata = { someKey: 'someValue' };
+    await store.updateMessages({
+      messages: [{ id: originalMessage.id, content: { metadata: newMetadata } as any }],
+    });
+
+    const fromDb = await store.getMessages({ threadId: thread.id, format: 'v2' });
+    expect(fromDb).toHaveLength(1);
+    expect(fromDb[0].content.metadata).toEqual(newMetadata);
+    expect(fromDb[0].content.content).toBe('hello world');
+    expect(fromDb[0].content.parts).toEqual([{ type: 'text', text: 'hello world' }]);
+  });
+
+  it('should update only the content string within the content field, preserving metadata', async () => {
+    const originalMessage = createSampleMessageV2({
+      threadId: thread.id,
+      content: { metadata: { initial: true } },
+    });
+    await store.saveMessages({ messages: [originalMessage], format: 'v2' });
+
+    const newContentString = 'This is the new content string';
+    await store.updateMessages({
+      messages: [{ id: originalMessage.id, content: { content: newContentString } as any }],
+    });
+
+    const fromDb = await store.getMessages({ threadId: thread.id, format: 'v2' });
+    expect(fromDb[0].content.content).toBe(newContentString);
+    expect(fromDb[0].content.metadata).toEqual({ initial: true });
+  });
+
+  it('should deep merge metadata, not overwrite it', async () => {
+    const originalMessage = createSampleMessageV2({
+      threadId: thread.id,
+      content: { metadata: { initial: true }, content: 'old content' },
+    });
+    await store.saveMessages({ messages: [originalMessage], format: 'v2' });
+
+    const newMetadata = { updated: true };
+    await store.updateMessages({
+      messages: [{ id: originalMessage.id, content: { metadata: newMetadata } as any }],
+    });
+
+    const fromDb = await store.getMessages({ threadId: thread.id, format: 'v2' });
+    expect(fromDb[0].content.content).toBe('old content');
+    expect(fromDb[0].content.metadata).toEqual({ initial: true, updated: true });
+  });
+
+  it('should update multiple messages at once', async () => {
+    const msg1 = createSampleMessageV2({ threadId: thread.id, role: 'user' });
+    const msg2 = createSampleMessageV2({ threadId: thread.id, content: { content: 'original' } });
+    await store.saveMessages({ messages: [msg1, msg2], format: 'v2' });
+
+    await store.updateMessages({
+      messages: [
+        { id: msg1.id, role: 'assistant' },
+        { id: msg2.id, content: { content: 'updated' } as any },
+      ],
+    });
+
+    const fromDb = await store.getMessages({ threadId: thread.id, format: 'v2' });
+    const updatedMsg1 = fromDb.find(m => m.id === msg1.id)!;
+    const updatedMsg2 = fromDb.find(m => m.id === msg2.id)!;
+
+    expect(updatedMsg1.role).toBe('assistant');
+    expect(updatedMsg2.content.content).toBe('updated');
+  });
+
+  it('should update the parent thread updatedAt timestamp', async () => {
+    const originalMessage = createSampleMessageV2({ threadId: thread.id });
+    await store.saveMessages({ messages: [originalMessage], format: 'v2' });
+    const initialThread = await store.getThreadById({ threadId: thread.id });
+
+    await new Promise(r => setTimeout(r, 10));
+
+    await store.updateMessages({ messages: [{ id: originalMessage.id, role: 'assistant' }] });
+
+    const updatedThread = await store.getThreadById({ threadId: thread.id });
+
+    expect(new Date(updatedThread!.updatedAt).getTime()).toBeGreaterThan(new Date(initialThread!.updatedAt).getTime());
+  });
+
+  it('should update timestamps on both threads when moving a message', async () => {
+    const thread2 = await store.saveThread({ thread: createSampleThread() });
+    const message = createSampleMessageV2({ threadId: thread.id });
+    await store.saveMessages({ messages: [message], format: 'v2' });
+
+    const initialThread1 = await store.getThreadById({ threadId: thread.id });
+    const initialThread2 = await store.getThreadById({ threadId: thread2.id });
+
+    await new Promise(r => setTimeout(r, 10));
+
+    await store.updateMessages({
+      messages: [{ id: message.id, threadId: thread2.id }],
+    });
+
+    const updatedThread1 = await store.getThreadById({ threadId: thread.id });
+    const updatedThread2 = await store.getThreadById({ threadId: thread2.id });
+
+    expect(new Date(updatedThread1!.updatedAt).getTime()).toBeGreaterThan(
+      new Date(initialThread1!.updatedAt).getTime(),
+    );
+    expect(new Date(updatedThread2!.updatedAt).getTime()).toBeGreaterThan(
+      new Date(initialThread2!.updatedAt).getTime(),
+    );
+
+    // Verify the message was moved
+    const thread1Messages = await store.getMessages({ threadId: thread.id, format: 'v2' });
+    const thread2Messages = await store.getMessages({ threadId: thread2.id, format: 'v2' });
+    expect(thread1Messages).toHaveLength(0);
+    expect(thread2Messages).toHaveLength(1);
+    expect(thread2Messages[0].id).toBe(message.id);
+  });
+
+  it('should not fail when trying to update a non-existent message', async () => {
+    const originalMessage = createSampleMessageV2({ threadId: thread.id });
+    await store.saveMessages({ messages: [originalMessage], format: 'v2' });
+
+    await expect(
+      store.updateMessages({
+        messages: [{ id: randomUUID(), role: 'assistant' }],
+      }),
+    ).resolves.not.toThrow();
+
+    const fromDb = await store.getMessages({ threadId: thread.id, format: 'v2' });
+    expect(fromDb[0].role).toBe(originalMessage.role);
   });
 });

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -1,4 +1,5 @@
 import { MessageList } from '@mastra/core/agent';
+import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
 import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '@mastra/core/memory';
 import type {
@@ -740,5 +741,16 @@ export class MongoDBStore extends MastraStorage {
 
   async close(): Promise<void> {
     await this.#client.close();
+  }
+
+  async updateMessages(_args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    this.logger.error('updateMessages is not yet implemented in MongoDBStore');
+    throw new Error('Method not implemented');
   }
 }

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,5 +1,5 @@
 import { MessageList } from '@mastra/core/agent';
-import type { MastraMessageV2 } from '@mastra/core/agent';
+import type { MastraMessageContentV2, MastraMessageV2 } from '@mastra/core/agent';
 import type { MetricResult } from '@mastra/core/eval';
 import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
 import {
@@ -1242,5 +1242,135 @@ export class PostgresStore extends MastraStorage {
       perPage,
       hasMore: currentOffset + (rows?.length ?? 0) < total,
     };
+  }
+
+  async updateMessages({
+    messages,
+  }: {
+    messages: (Partial<Omit<MastraMessageV2, 'createdAt'>> & {
+      id: string;
+      content?: {
+        metadata?: MastraMessageContentV2['metadata'];
+        content?: MastraMessageContentV2['content'];
+      };
+    })[];
+  }): Promise<MastraMessageV2[]> {
+    if (messages.length === 0) {
+      return [];
+    }
+
+    const messageIds = messages.map(m => m.id);
+
+    const selectQuery = `SELECT id, content, role, type, "createdAt", thread_id AS "threadId", "resourceId" FROM ${this.getTableName(
+      TABLE_MESSAGES,
+    )} WHERE id IN ($1:list)`;
+
+    const existingMessagesDb = await this.db.manyOrNone(selectQuery, [messageIds]);
+
+    if (existingMessagesDb.length === 0) {
+      return [];
+    }
+
+    // Parse content from string to object for merging
+    const existingMessages: MastraMessageV2[] = existingMessagesDb.map(msg => {
+      if (typeof msg.content === 'string') {
+        try {
+          msg.content = JSON.parse(msg.content);
+        } catch {
+          // ignore if not valid json
+        }
+      }
+      return msg as MastraMessageV2;
+    });
+
+    const threadIdsToUpdate = new Set<string>();
+
+    await this.db.tx(async t => {
+      const queries = [];
+      const columnMapping: Record<string, string> = {
+        threadId: 'thread_id',
+      };
+
+      for (const existingMessage of existingMessages) {
+        const updatePayload = messages.find(m => m.id === existingMessage.id);
+        if (!updatePayload) continue;
+
+        const { id, ...fieldsToUpdate } = updatePayload;
+        if (Object.keys(fieldsToUpdate).length === 0) continue;
+
+        threadIdsToUpdate.add(existingMessage.threadId!);
+        if (updatePayload.threadId && updatePayload.threadId !== existingMessage.threadId) {
+          threadIdsToUpdate.add(updatePayload.threadId);
+        }
+
+        const setClauses: string[] = [];
+        const values: any[] = [];
+        let paramIndex = 1;
+
+        const updatableFields = { ...fieldsToUpdate };
+
+        // Special handling for content: merge in code, then update the whole field
+        if (updatableFields.content) {
+          const newContent = {
+            ...existingMessage.content,
+            ...updatableFields.content,
+            // Deep merge metadata if it exists on both
+            ...(existingMessage.content?.metadata && updatableFields.content.metadata
+              ? {
+                  metadata: {
+                    ...existingMessage.content.metadata,
+                    ...updatableFields.content.metadata,
+                  },
+                }
+              : {}),
+          };
+          setClauses.push(`content = $${paramIndex++}`);
+          values.push(newContent);
+          delete updatableFields.content;
+        }
+
+        for (const key in updatableFields) {
+          if (Object.prototype.hasOwnProperty.call(updatableFields, key)) {
+            const dbColumn = columnMapping[key] || key;
+            setClauses.push(`"${dbColumn}" = $${paramIndex++}`);
+            values.push(updatableFields[key as keyof typeof updatableFields]);
+          }
+        }
+
+        if (setClauses.length > 0) {
+          values.push(id);
+          const sql = `UPDATE ${this.getTableName(
+            TABLE_MESSAGES,
+          )} SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`;
+          queries.push(t.none(sql, values));
+        }
+      }
+
+      if (threadIdsToUpdate.size > 0) {
+        queries.push(
+          t.none(`UPDATE ${this.getTableName(TABLE_THREADS)} SET "updatedAt" = NOW() WHERE id IN ($1:list)`, [
+            Array.from(threadIdsToUpdate),
+          ]),
+        );
+      }
+
+      if (queries.length > 0) {
+        await t.batch(queries);
+      }
+    });
+
+    // Re-fetch to return the fully updated messages
+    const updatedMessages = await this.db.manyOrNone<MastraMessageV2>(selectQuery, [messageIds]);
+
+    return (updatedMessages || []).map(message => {
+      if (typeof message.content === 'string') {
+        try {
+          message.content = JSON.parse(message.content);
+        } catch {
+          /* ignore */
+        }
+      }
+      return message;
+    });
   }
 }

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -1,6 +1,7 @@
 import { MessageList } from '@mastra/core/agent';
+import type { MastraMessageContentV2, MastraMessageV2 } from '@mastra/core/agent';
 import type { MetricResult, TestInfo } from '@mastra/core/eval';
-import type { StorageThreadType, MastraMessageV1, MastraMessageV2 } from '@mastra/core/memory';
+import type { StorageThreadType, MastraMessageV1 } from '@mastra/core/memory';
 import {
   MastraStorage,
   TABLE_MESSAGES,
@@ -1186,5 +1187,16 @@ export class UpstashStore extends MastraStorage {
 
   async close(): Promise<void> {
     // No explicit cleanup needed for Upstash Redis
+  }
+
+  async updateMessages(_args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    this.logger.error('updateMessages is not yet implemented in UpstashStore');
+    throw new Error('Method not implemented');
   }
 }


### PR DESCRIPTION
## Description

- adds metadata to messages under the `message.content` property.
- adds `memory.updateMessages` API to update messages (and add metadata)
- adds `storage.updateMessages` API to update messages (including metadata)
- Only implements for `PGStore` and `LibSQLStore` storage adapters for now.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
