### PR TITLE
Fix telemetry settings being ignored when calling Agent.generate with experimental_object

### DIFF
--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1558,6 +1558,7 @@ export class Agent<
         resourceId,
         memory: this.getMemory(),
         runtimeContext,
+        telemetry,
         ...args,
       });
 


### PR DESCRIPTION
## Description

When calling `generate` with `experimental_object`, the code path followed did not pass `telemetry` settings on to `__text`. This meant if `generate` was called with `experimental_object`, traces were sent without respecting the `telemetry` settings.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
