### PR TITLE
fix(core): fix tool call as first message in memory context sent to LLM

### DIFF
--- a/.changeset/neat-nails-clean.md
+++ b/.changeset/neat-nails-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix memory message context for when LLM providers throw an error if the first message is a tool call.

--- a/.github/workflows/test-memory.yml
+++ b/.github/workflows/test-memory.yml
@@ -87,3 +87,4 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}

--- a/packages/memory/integration-tests/package.json
+++ b/packages/memory/integration-tests/package.json
@@ -29,11 +29,12 @@
     "dev": "mastra dev"
   },
   "dependencies": {
+    "@ai-sdk/google": "^1.2.19",
     "@ai-sdk/openai": "^1.3.0",
     "@ai-sdk/react": "^1.2.1",
     "@mastra/fastembed": "workspace:*",
-    "@mastra/memory": "workspace:*",
     "@mastra/libsql": "workspace:*",
+    "@mastra/memory": "workspace:*",
     "@mastra/pg": "workspace:*",
     "@mastra/upstash": "workspace:*",
     "dotenv": "^16.4.7",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
+    "@mastra/core": "workspace:*",
     "@testing-library/react": "^16.2.0",
     "@types/node": "^20.17.27",
     "ai": "^4.2.2",
@@ -50,8 +52,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "typescript": "^5.8.2",
-    "vitest": "^3.2.2",
-    "@mastra/core": "workspace:*"
+    "vitest": "^3.2.2"
   },
   "peerDependencies": {
     "@mastra/core": "^0.10.0-alpha.0"

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { memoryProcessorAgent, weatherAgent } from './mastra/agents/weather';
 import { weatherTool, weatherToolCity } from './mastra/tools/weather';
+import { MockStore } from '@mastra/core/storage';
 
 describe('Agent Memory Tests', () => {
   const dbFile = 'file:mastra-agent.db';
@@ -386,10 +387,7 @@ describe('Agent.fetchMemory', () => {
 
 describe('Agent memory test gemini', () => {
   const memory = new Memory({
-    storage: new LibSQLStore({
-      // stores telemetry, evals, ... into memory storage, if it needs to persist, change to file:../mastra.db
-      url: 'file:../../memory.db',
-    }),
+    storage: new MockStore(),
     options: {
       threads: {
         generateTitle: false,
@@ -425,7 +423,5 @@ describe('Agent memory test gemini', () => {
         memory: { resource, thread },
       }),
     ).resolves.not.toThrow();
-
-    // console.log(`request body: ${JSON.stringify(JSON.parse(response.request.body || '{}' as string).contents, null, 2)}`);
   });
 });

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { openai } from '@ai-sdk/openai';
 import { google } from '@ai-sdk/google';
+import { openai } from '@ai-sdk/openai';
 import { Mastra } from '@mastra/core';
 import type { CoreMessage } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -5,6 +5,7 @@ import { Mastra } from '@mastra/core';
 import type { CoreMessage } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { RuntimeContext } from '@mastra/core/runtime-context';
+import { MockStore } from '@mastra/core/storage';
 import { fastembed } from '@mastra/fastembed';
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
@@ -12,7 +13,6 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { memoryProcessorAgent, weatherAgent } from './mastra/agents/weather';
 import { weatherTool, weatherToolCity } from './mastra/tools/weather';
-import { MockStore } from '@mastra/core/storage';
 
 describe('Agent Memory Tests', () => {
   const dbFile = 'file:mastra-agent.db';

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { openai } from '@ai-sdk/openai';
+import { google } from '@ai-sdk/google';
 import { Mastra } from '@mastra/core';
 import type { CoreMessage } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
@@ -10,7 +11,7 @@ import { Memory } from '@mastra/memory';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { memoryProcessorAgent, weatherAgent } from './mastra/agents/weather';
-import { weatherTool } from './mastra/tools/weather';
+import { weatherTool, weatherToolCity } from './mastra/tools/weather';
 
 describe('Agent Memory Tests', () => {
   const dbFile = 'file:mastra-agent.db';
@@ -380,5 +381,51 @@ describe('Agent.fetchMemory', () => {
 
     expect(result.messages).toEqual([]);
     expect(result.threadId).toBe(threadId);
+  });
+});
+
+describe('Agent memory test gemini', () => {
+  const memory = new Memory({
+    storage: new LibSQLStore({
+      // stores telemetry, evals, ... into memory storage, if it needs to persist, change to file:../mastra.db
+      url: 'file:../../memory.db',
+    }),
+    options: {
+      threads: {
+        generateTitle: false,
+      },
+      lastMessages: 2,
+    },
+  });
+
+  const agent = new Agent({
+    name: 'gemini-agent',
+    instructions:
+      'You are a weather agent. When asked about weather in any city, use the get_weather tool with the city name.',
+    model: google.chat('gemini-2.5-flash-preview-05-20'),
+    memory,
+    tools: { get_weather: weatherToolCity },
+  });
+
+  const resource = 'weatherAgent-memory-test';
+  const thread = new Date().getTime().toString();
+
+  it('should not throw error when using gemini', async () => {
+    // generate two messages in the db
+    await agent.generate(`What's the weather in Tokyo?`, {
+      memory: { resource, thread },
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // Will throw if the messages sent to the agent aren't cleaned up because a tool call message will be the first message sent to the agent
+    // Which some providers like gemini will not allow.
+    await expect(
+      agent.generate(`What's the weather in London?`, {
+        memory: { resource, thread },
+      }),
+    ).resolves.not.toThrow();
+
+    // console.log(`request body: ${JSON.stringify(JSON.parse(response.request.body || '{}' as string).contents, null, 2)}`);
   });
 });

--- a/packages/memory/integration-tests/src/mastra/tools/weather.ts
+++ b/packages/memory/integration-tests/src/mastra/tools/weather.ts
@@ -11,3 +11,14 @@ export const weatherTool = createTool({
     return `The weather in ${postalCode} is sunny. It is currently 70 degrees and feels like 65 degrees.`;
   },
 });
+
+export const weatherToolCity = createTool({
+  id: 'get_weather_city',
+  description: 'Get the weather for a given location',
+  inputSchema: z.object({
+    city: z.string().describe('The location to get the weather for'),
+  }),
+  execute: async ({ context: { city } }) => {
+    return `The weather in ${city} is sunny. It is currently 70 degrees and feels like 65 degrees.`;
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,7 +488,7 @@ importers:
         version: 7.52.8(@types/node@20.19.0)
       '@rollup/plugin-image':
         specifier: ^3.0.3
-        version: 3.0.3(rollup@3.29.5)
+        version: 3.0.3(rollup@4.43.0)
       '@size-limit/preset-small-lib':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
@@ -552,7 +552,7 @@ importers:
         version: 7.52.8(@types/node@20.19.0)
       '@rollup/plugin-image':
         specifier: ^3.0.3
-        version: 3.0.3(rollup@4.43.0)
+        version: 3.0.3(rollup@3.29.5)
       '@size-limit/preset-small-lib':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
@@ -1969,6 +1969,9 @@ importers:
 
   packages/memory/integration-tests:
     dependencies:
+      '@ai-sdk/google':
+        specifier: ^1.2.19
+        version: 1.2.19(zod@3.25.57)
       '@ai-sdk/openai':
         specifier: ^1.3.0
         version: 1.3.22(zod@3.25.57)
@@ -3560,6 +3563,12 @@ packages:
 
   '@ai-sdk/cohere@1.2.10':
     resolution: {integrity: sha512-OaUwd5xj4bxSO8hdCbX1a5uUlTouU8FcodSuRON6xDSsmjZIvQL4O2G1XzcidxiQVL8JQuA+M0tHZOwGxSL96A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/google@1.2.19':
+    resolution: {integrity: sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -18240,6 +18249,12 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.57)
       zod: 3.25.57
 
+  '@ai-sdk/google@1.2.19(zod@3.25.57)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.57)
+      zod: 3.25.57
+
   '@ai-sdk/openai@1.3.22(zod@3.25.57)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -30091,7 +30106,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.10.0(debug@4.4.1))
+      retry-axios: 2.6.0(axios@1.10.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -33611,7 +33626,7 @@ snapshots:
   ret@0.4.3:
     optional: true
 
-  retry-axios@2.6.0(axios@1.10.0(debug@4.4.1)):
+  retry-axios@2.6.0(axios@1.10.0):
     dependencies:
       axios: 1.10.0(debug@4.4.1)
 


### PR DESCRIPTION
## Description

Some LLM providers like gemini, throw an error if you pass a tool call message as the first message in context. Here we truncate the messages passed to the LLM until the first message is no longer a tool call.


<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
