### PR TITLE
chore: use the right inngest api endpoint in docker run

### DIFF
--- a/docs/src/content/en/docs/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/docs/workflows/inngest-workflow.mdx
@@ -163,7 +163,7 @@ export const mastra = new Mastra({
 ```sh
 docker run --rm -p 8288:8288 \
   inngest/inngest \
-  inngest dev -u http://host.docker.internal:4111/inngest/api
+  inngest dev -u http://host.docker.internal:4111/api/inngest
 ```
 
 > **Note:** The URL after `-u` tells the Inngest dev server where to find your Mastra `/api/inngest` endpoint.


### PR DESCRIPTION
## Description

Update docker run command in workflows/inngest-workflow to use the right endpoint defined in the mastra instance apiRoutes
```
docker run --rm -p 8288:8288 \   inngest/inngest \   inngest dev -u http://host.docker.internal:4111/inngest/api
```
to
```
docker run --rm -p 8288:8288 \   inngest/inngest \   inngest dev -u http://host.docker.internal:4111/api/inngest
```
heres the apiRoutes:
```
server: {
   connect to the mastra server
    host: "0.0.0.0",
    apiRoutes: [
      {
        path: "/api/inngest",
        method: "ALL",
        createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
      },
    ],
  },
```

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
