### PR TITLE
[MongoDB] fix mongo storage trace query

### DIFF
--- a/.changeset/blue-friends-fly.md
+++ b/.changeset/blue-friends-fly.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+fix: mongo storage trace query

--- a/stores/mongodb/src/storage/index.test.ts
+++ b/stores/mongodb/src/storage/index.test.ts
@@ -937,8 +937,9 @@ describe('MongoDBStore', () => {
       const now = Date.now();
       const trace1 = sampleTrace('trace-filter-attribute-A', 'scope-X', now, { componentName: 'component-TARGET' });
       const trace2 = sampleTrace('trace-filter-attribute-B', 'scope-Y', now + 10, { componentName: 'component-OTHER' });
-      const trace3 = sampleTrace('trace-filter-attribute-C', 'scope-X', now + 20, {
+      const trace3 = sampleTrace('trace-filter-attribute-C', 'scope-Z', now + 20, {
         componentName: 'component-TARGET',
+        andFilterTest: 'TARGET',
       });
       await store.batchInsert({ tableName: TABLE_TRACES, records: [trace1, trace2, trace3] });
 
@@ -950,6 +951,14 @@ describe('MongoDBStore', () => {
       expect(filteredTraces.length).toBe(2);
       expect(filteredTraces[0].name).toBe('trace-filter-attribute-C');
       expect(filteredTraces[1].name).toBe('trace-filter-attribute-A');
+
+      const filteredTraces2 = await store.getTraces({
+        attributes: { componentName: 'component-TARGET', andFilterTest: 'TARGET' },
+        page: 0,
+        perPage: 10,
+      });
+      expect(filteredTraces2.length).toBe(1);
+      expect(filteredTraces2[0].name).toBe('trace-filter-attribute-C');
     });
 
     it('should retrieve traces filtered by scope', async () => {

--- a/stores/mongodb/src/storage/index.test.ts
+++ b/stores/mongodb/src/storage/index.test.ts
@@ -1,7 +1,13 @@
 import { randomUUID } from 'crypto';
 import type { MastraMessageV1, MastraMessageV2, MetricResult, WorkflowRunState } from '@mastra/core';
 import type { TABLE_NAMES } from '@mastra/core/storage';
-import { TABLE_EVALS, TABLE_MESSAGES, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
+import {
+  TABLE_EVALS,
+  TABLE_MESSAGES,
+  TABLE_THREADS,
+  TABLE_TRACES,
+  TABLE_WORKFLOW_SNAPSHOT,
+} from '@mastra/core/storage';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { MongoDBConfig } from './index';
 import { MongoDBStore } from './index';
@@ -23,6 +29,7 @@ class Test {
       await this.store.clearTable({ tableName: TABLE_MESSAGES });
       await this.store.clearTable({ tableName: TABLE_THREADS });
       await this.store.clearTable({ tableName: TABLE_EVALS });
+      await this.store.clearTable({ tableName: TABLE_TRACES });
     } catch (error) {
       // Ignore errors during table clearing
       console.warn('Error clearing tables:', error);
@@ -843,6 +850,143 @@ describe('MongoDBStore', () => {
       expect(page2.runs[0]!.workflowName).toBe(workflowName1);
       const snapshot = page2.runs[0]!.snapshot as WorkflowRunState;
       expect(snapshot.context?.[stepId1]?.status).toBe('completed');
+    });
+  });
+
+  describe('Trace Operations', () => {
+    const sampleTrace = (
+      name: string,
+      scope: string,
+      startTime = Date.now(),
+      attributes: Record<string, string> = {},
+    ) => ({
+      id: `trace-${randomUUID()}`,
+      parentSpanId: `span-${randomUUID()}`,
+      traceId: `traceid-${randomUUID()}`,
+      name,
+      scope,
+      kind: 1,
+      startTime: startTime,
+      endTime: startTime + 100,
+      status: JSON.stringify({ code: 0 }),
+      attributes: JSON.stringify({ key: 'value', scopeAttr: scope, ...attributes }),
+      events: JSON.stringify([{ name: 'event1', timestamp: startTime + 50 }]),
+      links: JSON.stringify([]),
+      createdAt: new Date(startTime).toISOString(),
+      updatedAt: new Date(startTime).toISOString(),
+    });
+
+    beforeEach(async () => {
+      const test = new Test(store).build();
+      await test.clearTables();
+    });
+
+    it('should batch insert and retrieve traces', async () => {
+      const trace1 = sampleTrace('trace-op-1', 'scope-A');
+      const trace2 = sampleTrace('trace-op-2', 'scope-A', Date.now() + 10);
+      const trace3 = sampleTrace('trace-op-3', 'scope-B', Date.now() + 20);
+      const records = [trace1, trace2, trace3];
+
+      await store.batchInsert({ tableName: TABLE_TRACES, records });
+
+      const allTraces = await store.getTraces();
+      expect(allTraces.length).toBe(3);
+    });
+
+    it('should handle Date objects for createdAt/updatedAt fields in batchInsert', async () => {
+      const now = new Date();
+      const traceWithDateObjects = {
+        id: `trace-${randomUUID()}`,
+        parentSpanId: `span-${randomUUID()}`,
+        traceId: `traceid-${randomUUID()}`,
+        name: 'test-trace-with-dates',
+        scope: 'default-tracer',
+        kind: 1,
+        startTime: now.getTime(),
+        endTime: now.getTime() + 100,
+        status: JSON.stringify({ code: 0 }),
+        attributes: JSON.stringify({ key: 'value' }),
+        events: JSON.stringify([]),
+        links: JSON.stringify([]),
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await store.batchInsert({ tableName: TABLE_TRACES, records: [traceWithDateObjects] });
+
+      const allTraces = await store.getTraces({ name: 'test-trace-with-dates', page: 0, perPage: 10 });
+      expect(allTraces.length).toBe(1);
+      expect(allTraces[0].name).toBe('test-trace-with-dates');
+    });
+
+    it('should retrieve traces filtered by name', async () => {
+      const now = Date.now();
+      const trace1 = sampleTrace('trace-filter-name', 'scope-X', now);
+      const trace2 = sampleTrace('trace-filter-name', 'scope-Y', now + 10);
+      const trace3 = sampleTrace('other-name', 'scope-X', now + 20);
+      await store.batchInsert({ tableName: TABLE_TRACES, records: [trace1, trace2, trace3] });
+
+      const filteredTraces = await store.getTraces({ name: 'trace-filter-name', page: 0, perPage: 10 });
+      expect(filteredTraces.length).toBe(2);
+      expect(filteredTraces.every(t => t.name === 'trace-filter-name')).toBe(true);
+      expect(filteredTraces[0].scope).toBe('scope-Y');
+      expect(filteredTraces[1].scope).toBe('scope-X');
+    });
+
+    it('should retrieve traces filtered by attributes', async () => {
+      const now = Date.now();
+      const trace1 = sampleTrace('trace-filter-attribute-A', 'scope-X', now, { componentName: 'component-TARGET' });
+      const trace2 = sampleTrace('trace-filter-attribute-B', 'scope-Y', now + 10, { componentName: 'component-OTHER' });
+      const trace3 = sampleTrace('trace-filter-attribute-C', 'scope-X', now + 20, {
+        componentName: 'component-TARGET',
+      });
+      await store.batchInsert({ tableName: TABLE_TRACES, records: [trace1, trace2, trace3] });
+
+      const filteredTraces = await store.getTraces({
+        attributes: { componentName: 'component-TARGET' },
+        page: 0,
+        perPage: 10,
+      });
+      expect(filteredTraces.length).toBe(2);
+      expect(filteredTraces[0].name).toBe('trace-filter-attribute-C');
+      expect(filteredTraces[1].name).toBe('trace-filter-attribute-A');
+    });
+
+    it('should retrieve traces filtered by scope', async () => {
+      const now = Date.now();
+      const trace1 = sampleTrace('trace-filter-scope-A', 'scope-TARGET', now);
+      const trace2 = sampleTrace('trace-filter-scope-B', 'scope-OTHER', now + 10);
+      const trace3 = sampleTrace('trace-filter-scope-C', 'scope-TARGET', now + 20);
+      await store.batchInsert({ tableName: TABLE_TRACES, records: [trace1, trace2, trace3] });
+
+      const filteredTraces = await store.getTraces({ scope: 'scope-TARGET', page: 0, perPage: 10 });
+      expect(filteredTraces.length).toBe(2);
+      expect(filteredTraces.every(t => t.scope === 'scope-TARGET')).toBe(true);
+      expect(filteredTraces[0].name).toBe('trace-filter-scope-C');
+      expect(filteredTraces[1].name).toBe('trace-filter-scope-A');
+    });
+
+    it('should handle pagination for getTraces', async () => {
+      const now = Date.now();
+      const traceData = Array.from({ length: 5 }, (_, i) => sampleTrace('trace-page', `scope-page`, now + i * 10));
+      await store.batchInsert({ tableName: TABLE_TRACES, records: traceData });
+
+      const page1 = await store.getTraces({ name: 'trace-page', page: 0, perPage: 2 });
+      expect(page1.length).toBe(2);
+      expect(page1[0]!.startTime).toBe(traceData[4]!.startTime);
+      expect(page1[1]!.startTime).toBe(traceData[3]!.startTime);
+
+      const page2 = await store.getTraces({ name: 'trace-page', page: 1, perPage: 2 });
+      expect(page2.length).toBe(2);
+      expect(page2[0]!.startTime).toBe(traceData[2]!.startTime);
+      expect(page2[1]!.startTime).toBe(traceData[1]!.startTime);
+
+      const page3 = await store.getTraces({ name: 'trace-page', page: 2, perPage: 2 });
+      expect(page3.length).toBe(1);
+      expect(page3[0]!.startTime).toBe(traceData[0]!.startTime);
+
+      const page4 = await store.getTraces({ name: 'trace-page', page: 3, perPage: 2 });
+      expect(page4.length).toBe(0);
     });
   });
 

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -508,13 +508,9 @@ export class MongoDBStore extends MastraStorage {
     }
 
     if (attributes) {
-      const attributeConditions = Object.keys(attributes).map(key => ({
-        attributes: new RegExp(`\"${key}\":\"${attributes[key]}\"`),
+      query['$and'] = Object.entries(attributes).map(([key, value]) => ({
+        attributes: new RegExp(`\"${key}\":\"${value}\"`),
       }));
-
-      if (attributeConditions.length > 0) {
-        query['$and'] = attributeConditions;
-      }
     }
 
     if (filters) {

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -500,7 +500,7 @@ export class MongoDBStore extends MastraStorage {
 
     const query: any = {};
     if (name) {
-      query['name'] = `%${name}%`;
+      query['name'] = new RegExp(name);
     }
 
     if (scope) {
@@ -509,7 +509,7 @@ export class MongoDBStore extends MastraStorage {
 
     if (attributes) {
       Object.keys(attributes).forEach(key => {
-        query[`attributes.${key}`] = attributes[key];
+        query[`attributes`] = new RegExp(`\"${key}\":\"${attributes[key]}\"`);
       });
     }
 

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -508,9 +508,13 @@ export class MongoDBStore extends MastraStorage {
     }
 
     if (attributes) {
-      Object.keys(attributes).forEach(key => {
-        query[`attributes`] = new RegExp(`\"${key}\":\"${attributes[key]}\"`);
-      });
+      const attributeConditions = Object.keys(attributes).map(key => ({
+        attributes: new RegExp(`\"${key}\":\"${attributes[key]}\"`),
+      }));
+
+      if (attributeConditions.length > 0) {
+        query['$and'] = attributeConditions;
+      }
     }
 
     if (filters) {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

mongodb uses regular expressions for wildcard queries 
Also, if the data is stored in bson format, you can access it with a format like `'attributes.key': value`, but if it is stringified, it is just a string, so must be queried as `\"attributes.key\":\"value\"`.

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
