### PR TITLE
docs: Improve example of `createRun` and `start`

### DIFF
--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -170,7 +170,13 @@ const result = await run.start({
   }
 });
 
+// Dump the complete workflow result (includes status, steps and result)
 console.log(JSON.stringify(result, null, 2));
+
+// Get the workflow output value
+if (result.status === 'success') {
+  console.log(`output value: ${result.result.output}`);
+}
 ```
 > see [createRun](/reference/workflows/create-run) and [start](/reference/workflows/start) for more information.
 


### PR DESCRIPTION
## Description

Reading https://mastra.ai/en/docs/workflows/overview#command-line, I was confused when looking for how to retrieve the workflow output value. The example shows how to dump the entire WorkflowResult object, but this could lead readers to mistakenly think that result is the output data object itself.

To clarify this, I added comments and a code snippet to help readers understand how to properly retrieve the workflow output.

## Related Issue(s)

none

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] not applicable:
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
