### PR TITLE
Fix: Correct typos in comments and descriptions

### DIFF
--- a/integrations/ragie/src/client/schemas.gen.ts
+++ b/integrations/ragie/src/client/schemas.gen.ts
@@ -1509,7 +1509,7 @@ export const RetrieveParamsSchema = {
       type: 'integer',
       title: 'Max Chunks Per Document',
       description:
-        'Maximum number of chunks to retrieve per document. Use this to increase the number of documents the final chunks are retreived from. This feature is in beta and may change in the future.',
+        'Maximum number of chunks to retrieve per document. Use this to increase the number of documents the final chunks are retrieved from. This feature is in beta and may change in the future.',
       examples: [0],
     },
     partition: {

--- a/stores/couchbase/src/vector/index.unit.test.ts
+++ b/stores/couchbase/src/vector/index.unit.test.ts
@@ -323,7 +323,7 @@ describe('Unit Testing CouchbaseVector', () => {
       expect(mockGetIndexFn).toHaveResolved();
 
       expect(stats.dimension).toBe(dimension);
-      expect(stats.metric).toBe('euclidean'); // similiarity(=="l2_norm") is mapped to euclidean in couchbase
+      expect(stats.metric).toBe('euclidean'); // similarity(=="l2_norm") is mapped to euclidean in couchbase
       expect(typeof stats.count).toBe('number');
     }, 50000);
 


### PR DESCRIPTION


### **Description:**

This PR contains minor typo fixes in comments and descriptions across the codebase.

- Corrected `retreived` to `retrieved` in `integrations/ragie/src/client/schemas.gen.ts`.
- Corrected `similiarity` to `similarity` in `stores/couchbase/src/vector/index.unit.test.ts`.