### PR TITLE
fix(pg, libsql): get messages paginated

### DIFF
--- a/.changeset/smart-pens-unite.md
+++ b/.changeset/smart-pens-unite.md
@@ -1,0 +1,6 @@
+---
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Fix LibSQLStore and PgStore getMessagesPaginated implementation

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -298,6 +298,20 @@ messageSource: ${messageSource}
 ${JSON.stringify(message, null, 2)}`,
       );
     }
+    // Some storage providers store this as a json string and some others as an object. Make sure it's always an object here.
+    if (typeof (message as MastraMessageV2)?.content?.content === 'string') {
+      try {
+        (message as MastraMessageV2).content.content = JSON.parse((message as MastraMessageV2).content.content!);
+      } catch {
+        /* ignore */
+      }
+    } else if (typeof message?.content === 'string') {
+      try {
+        message.content = JSON.parse(message.content);
+      } catch {
+        /* ignore */
+      }
+    }
 
     const messageV2 = this.inputToMastraMessageV2(message, messageSource);
 

--- a/stores/_test-utils/src/default-tests.ts
+++ b/stores/_test-utils/src/default-tests.ts
@@ -359,7 +359,6 @@ export function createTestSuite(storage: MastraStorage) {
 
         const messages = [
           createSampleMessageV1({ threadId: thread.id }),
-          // @ts-ignore
           { ...createSampleMessageV1({ threadId: thread.id }), id: null }, // This will cause an error
         ] as MastraMessageV1[];
 
@@ -1320,7 +1319,6 @@ export function createTestSuite(storage: MastraStorage) {
 
         const messages = [
           createSampleMessageV1({ threadId: thread.id }),
-          // @ts-ignore
           { ...createSampleMessageV1({ threadId: thread.id }), id: null }, // This will cause an error
         ] as MastraMessageV1[];
 

--- a/stores/_test-utils/src/default-tests.ts
+++ b/stores/_test-utils/src/default-tests.ts
@@ -1262,4 +1262,232 @@ export function createTestSuite(storage: MastraStorage) {
       ).resolves.not.toThrow();
     });
   });
+
+  describe('getMessagesPaginated', () => {
+    describe('Message Operations', () => {
+      it('should save and retrieve messages', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const messages = [
+          createSampleMessageV1({ threadId: thread.id }),
+          createSampleMessageV1({ threadId: thread.id }),
+        ];
+
+        // Save messages
+        const savedMessages = await storage.saveMessages({ messages });
+
+        expect(savedMessages).toEqual(messages);
+
+        // Retrieve messages
+        const retrievedMessages = await storage.getMessagesPaginated({ threadId: thread.id, format: 'v1' });
+
+        expect(retrievedMessages.messages).toHaveLength(2);
+
+        expect(retrievedMessages.messages).toEqual(expect.arrayContaining(messages));
+      });
+
+      it('should handle empty message array', async () => {
+        const result = await storage.saveMessages({ messages: [] });
+        expect(result).toEqual([]);
+      });
+
+      it('should maintain message order', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const messages = [
+          createSampleMessageV1({ threadId: thread.id, content: 'First' }),
+          createSampleMessageV1({ threadId: thread.id, content: 'Second' }),
+          createSampleMessageV1({ threadId: thread.id, content: 'Third' }),
+        ];
+
+        await storage.saveMessages({ messages });
+
+        const retrievedMessages = await storage.getMessagesPaginated({ threadId: thread.id, format: 'v1' });
+
+        expect(retrievedMessages.messages).toHaveLength(3);
+
+        // Verify order is maintained
+        retrievedMessages.messages.forEach((msg, idx) => {
+          expect(msg.content[0].text).toBe(messages[idx].content[0].text);
+        });
+      });
+
+      it('should rollback on error during message save', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const messages = [
+          createSampleMessageV1({ threadId: thread.id }),
+          // @ts-ignore
+          { ...createSampleMessageV1({ threadId: thread.id }), id: null }, // This will cause an error
+        ] as MastraMessageV1[];
+
+        await expect(storage.saveMessages({ messages })).rejects.toThrow();
+
+        // Verify no messages were saved
+        const savedMessages = await storage.getMessagesPaginated({ threadId: thread.id, format: 'v1' });
+        expect(savedMessages.messages).toHaveLength(0);
+      });
+
+      it('should retrieve messages w/ next/prev messages by message id + resource id', async () => {
+        const messages: MastraMessageV2[] = [
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'First', parts: [{ type: 'text', text: 'First' }] },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'Second', parts: [{ type: 'text', text: 'Second' }] },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'Third', parts: [{ type: 'text', text: 'Third' }] },
+            resourceId: 'cross-thread-resource',
+          }),
+
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'Fourth', parts: [{ type: 'text', text: 'Fourth' }] },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'Fifth', parts: [{ type: 'text', text: 'Fifth' }] },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'Sixth', parts: [{ type: 'text', text: 'Sixth' }] },
+            resourceId: 'cross-thread-resource',
+          }),
+
+          createSampleMessageV2({
+            threadId: 'thread-three',
+            content: { content: 'Seventh', parts: [{ type: 'text', text: 'Seventh' }] },
+            resourceId: 'other-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-three',
+            content: { content: 'Eighth', parts: [{ type: 'text', text: 'Eighth' }] },
+            resourceId: 'other-resource',
+          }),
+        ];
+
+        await storage.saveMessages({ messages: messages, format: 'v2' });
+
+        const retrievedMessages = await storage.getMessagesPaginated({ threadId: 'thread-one', format: 'v2' });
+        expect(retrievedMessages.messages).toHaveLength(3);
+        const contentParts = retrievedMessages.messages.map((m: any) =>
+          m.content.parts.filter((p: any) => p.type === 'text').map((p: any) => p.text),
+        );
+        expect(contentParts).toEqual([['First'], ['Second'], ['Third']]);
+
+        const retrievedMessages2 = await storage.getMessagesPaginated({ threadId: 'thread-two', format: 'v2' });
+        expect(retrievedMessages2.messages).toHaveLength(3);
+        const contentParts2 = retrievedMessages2.messages.map((m: any) =>
+          m.content.parts.filter((p: any) => p.type === 'text').map((p: any) => p.text),
+        );
+        expect(contentParts2).toEqual([['Fourth'], ['Fifth'], ['Sixth']]);
+
+        const retrievedMessages3 = await storage.getMessagesPaginated({ threadId: 'thread-three', format: 'v2' });
+        expect(retrievedMessages3.messages).toHaveLength(2);
+        const contentParts3 = retrievedMessages3.messages.map((m: any) =>
+          m.content.parts.filter((p: any) => p.type === 'text').map((p: any) => p.text),
+        );
+        expect(contentParts3).toEqual([['Seventh'], ['Eighth']]);
+
+        const { messages: crossThreadMessages } = await storage.getMessagesPaginated({
+          threadId: 'thread-doesnt-exist',
+          format: 'v2',
+          selectBy: {
+            last: 0,
+            include: [
+              {
+                id: messages[1].id,
+                threadId: 'thread-one',
+                withNextMessages: 2,
+                withPreviousMessages: 2,
+              },
+              {
+                id: messages[4].id,
+                threadId: 'thread-two',
+                withPreviousMessages: 2,
+                withNextMessages: 2,
+              },
+            ],
+          },
+        });
+
+        expect(crossThreadMessages).toHaveLength(6);
+        expect(crossThreadMessages.filter(m => m.threadId === `thread-one`)).toHaveLength(3);
+        expect(crossThreadMessages.filter(m => m.threadId === `thread-two`)).toHaveLength(3);
+
+        const { messages: crossThreadMessages2 } = await storage.getMessagesPaginated({
+          threadId: 'thread-one',
+          format: 'v2',
+          selectBy: {
+            last: 0,
+            include: [
+              {
+                id: messages[4].id,
+                threadId: 'thread-two',
+                withPreviousMessages: 1,
+                withNextMessages: 30,
+              },
+            ],
+          },
+        });
+
+        expect(crossThreadMessages2).toHaveLength(3);
+        expect(crossThreadMessages2.filter(m => m.threadId === `thread-one`)).toHaveLength(0);
+        expect(crossThreadMessages2.filter(m => m.threadId === `thread-two`)).toHaveLength(3);
+
+        const { messages: crossThreadMessages3 } = await storage.getMessagesPaginated({
+          threadId: 'thread-two',
+          format: 'v2',
+          selectBy: {
+            last: 0,
+            include: [
+              {
+                id: messages[1].id,
+                threadId: 'thread-one',
+                withNextMessages: 1,
+                withPreviousMessages: 1,
+              },
+            ],
+          },
+        });
+
+        expect(crossThreadMessages3).toHaveLength(3);
+        expect(crossThreadMessages3.filter(m => m.threadId === `thread-one`)).toHaveLength(3);
+        expect(crossThreadMessages3.filter(m => m.threadId === `thread-two`)).toHaveLength(0);
+      });
+
+      it('should update thread timestamp when saving messages', async () => {
+        const thread = createSampleThread();
+        await storage.saveThread({ thread });
+
+        const initialThread = await storage.getThreadById({ threadId: thread.id });
+        const initialUpdatedAt = new Date(initialThread!.updatedAt);
+
+        // Wait a bit to ensure timestamp difference
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const messages = [
+          createSampleMessageV1({ threadId: thread.id }),
+          createSampleMessageV1({ threadId: thread.id }),
+        ];
+        await storage.saveMessages({ messages });
+
+        // Verify thread updatedAt timestamp was updated
+        const updatedThread = await storage.getThreadById({ threadId: thread.id });
+        const newUpdatedAt = new Date(updatedThread!.updatedAt);
+        expect(newUpdatedAt.getTime()).toBeGreaterThan(initialUpdatedAt.getTime());
+      });
+    });
+  });
 }

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -239,8 +239,6 @@ describe('PostgresStore', () => {
       const retrievedMessages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(retrievedMessages).toHaveLength(3);
 
-      console.log(`nonpaginated`, JSON.stringify(retrievedMessages, null, 2));
-
       // Verify order is maintained
       retrievedMessages.forEach((msg, idx) => {
         expect((msg.content.parts[0] as any).text).toEqual(messageContent[idx]);

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -239,6 +239,8 @@ describe('PostgresStore', () => {
       const retrievedMessages = await store.getMessages({ threadId: thread.id, format: 'v2' });
       expect(retrievedMessages).toHaveLength(3);
 
+      console.log(`nonpaginated`, JSON.stringify(retrievedMessages, null, 2));
+
       // Verify order is maintained
       retrievedMessages.forEach((msg, idx) => {
         expect((msg.content.parts[0] as any).text).toEqual(messageContent[idx]);
@@ -1595,7 +1597,7 @@ describe('PostgresStore', () => {
       });
     });
 
-    describe.only('getMessages with pagination', () => {
+    describe('getMessages with pagination', () => {
       it('should return paginated messages with total count', async () => {
         const thread = createSampleThread();
         await store.saveThread({ thread });
@@ -1727,6 +1729,8 @@ describe('PostgresStore', () => {
 
         const retrievedMessages = await store.getMessagesPaginated({ threadId: thread.id, format: 'v2' });
         expect(retrievedMessages.messages).toHaveLength(3);
+
+        console.log(JSON.stringify(retrievedMessages.messages, null, 2));
 
         // Verify order is maintained
         retrievedMessages.messages.forEach((msg, idx) => {

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -1595,7 +1595,7 @@ describe('PostgresStore', () => {
       });
     });
 
-    describe('getMessages with pagination', () => {
+    describe.only('getMessages with pagination', () => {
       it('should return paginated messages with total count', async () => {
         const thread = createSampleThread();
         await store.saveThread({ thread });
@@ -1685,6 +1685,286 @@ describe('PostgresStore', () => {
             yesterday.toISOString().slice(0, 10),
           );
         }
+      });
+
+      it('should save and retrieve messages', async () => {
+        const thread = createSampleThread();
+        await store.saveThread({ thread });
+
+        const messages = [
+          createSampleMessageV1({ threadId: thread.id }),
+          createSampleMessageV1({ threadId: thread.id }),
+        ];
+
+        // Save messages
+        const savedMessages = await store.saveMessages({ messages });
+        expect(savedMessages).toEqual(messages);
+
+        // Retrieve messages
+        const retrievedMessages = await store.getMessagesPaginated({ threadId: thread.id, format: 'v1' });
+        expect(retrievedMessages.messages).toHaveLength(2);
+        const checkMessages = messages.map(m => {
+          const { resourceId, ...rest } = m;
+          return rest;
+        });
+        expect(retrievedMessages.messages).toEqual(expect.arrayContaining(checkMessages));
+      });
+
+      it('should maintain message order', async () => {
+        const thread = createSampleThread();
+        await store.saveThread({ thread });
+
+        const messageContent = ['First', 'Second', 'Third'];
+
+        const messages = messageContent.map(content =>
+          createSampleMessageV2({
+            threadId: thread.id,
+            content: { content, parts: [{ type: 'text', text: content }] },
+          }),
+        );
+
+        await store.saveMessages({ messages, format: 'v2' });
+
+        const retrievedMessages = await store.getMessagesPaginated({ threadId: thread.id, format: 'v2' });
+        expect(retrievedMessages.messages).toHaveLength(3);
+
+        // Verify order is maintained
+        retrievedMessages.messages.forEach((msg, idx) => {
+          expect((msg.content.parts[0] as any).text).toEqual(messageContent[idx]);
+        });
+      });
+
+      it('should rollback on error during message save', async () => {
+        const thread = createSampleThread();
+        await store.saveThread({ thread });
+
+        const messages = [
+          createSampleMessageV1({ threadId: thread.id }),
+          { ...createSampleMessageV1({ threadId: thread.id }), id: null } as any, // This will cause an error
+        ];
+
+        await expect(store.saveMessages({ messages })).rejects.toThrow();
+
+        // Verify no messages were saved
+        const savedMessages = await store.getMessagesPaginated({ threadId: thread.id, format: 'v2' });
+        expect(savedMessages.messages).toHaveLength(0);
+      });
+
+      it('should retrieve messages w/ next/prev messages by message id + resource id', async () => {
+        const thread = createSampleThread({ id: 'thread-one' });
+        await store.saveThread({ thread });
+
+        const thread2 = createSampleThread({ id: 'thread-two' });
+        await store.saveThread({ thread: thread2 });
+
+        const thread3 = createSampleThread({ id: 'thread-three' });
+        await store.saveThread({ thread: thread3 });
+
+        const messages: MastraMessageV2[] = [
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'First' },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'Second' },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'Third' },
+            resourceId: 'cross-thread-resource',
+          }),
+
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'Fourth' },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'Fifth' },
+            resourceId: 'cross-thread-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'Sixth' },
+            resourceId: 'cross-thread-resource',
+          }),
+
+          createSampleMessageV2({
+            threadId: 'thread-three',
+            content: { content: 'Seventh' },
+            resourceId: 'other-resource',
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-three',
+            content: { content: 'Eighth' },
+            resourceId: 'other-resource',
+          }),
+        ];
+
+        await store.saveMessages({ messages: messages, format: 'v2' });
+
+        const retrievedMessages = await store.getMessagesPaginated({ threadId: 'thread-one', format: 'v2' });
+        expect(retrievedMessages.messages).toHaveLength(3);
+        expect(retrievedMessages.messages.map((m: any) => m.content.parts[0].text)).toEqual([
+          'First',
+          'Second',
+          'Third',
+        ]);
+
+        const retrievedMessages2 = await store.getMessagesPaginated({ threadId: 'thread-two', format: 'v2' });
+        expect(retrievedMessages2.messages).toHaveLength(3);
+        expect(retrievedMessages2.messages.map((m: any) => m.content.parts[0].text)).toEqual([
+          'Fourth',
+          'Fifth',
+          'Sixth',
+        ]);
+
+        const retrievedMessages3 = await store.getMessagesPaginated({ threadId: 'thread-three', format: 'v2' });
+        expect(retrievedMessages3.messages).toHaveLength(2);
+        expect(retrievedMessages3.messages.map((m: any) => m.content.parts[0].text)).toEqual(['Seventh', 'Eighth']);
+
+        const { messages: crossThreadMessages } = await store.getMessagesPaginated({
+          threadId: 'thread-doesnt-exist',
+          format: 'v2',
+          selectBy: {
+            last: 0,
+            include: [
+              {
+                id: messages[1].id,
+                threadId: 'thread-one',
+                withNextMessages: 2,
+                withPreviousMessages: 2,
+              },
+              {
+                id: messages[4].id,
+                threadId: 'thread-two',
+                withPreviousMessages: 2,
+                withNextMessages: 2,
+              },
+            ],
+          },
+        });
+
+        expect(crossThreadMessages).toHaveLength(6);
+        expect(crossThreadMessages.filter(m => m.threadId === `thread-one`)).toHaveLength(3);
+        expect(crossThreadMessages.filter(m => m.threadId === `thread-two`)).toHaveLength(3);
+
+        const crossThreadMessages2: MastraMessageV2[] = await store.getMessages({
+          threadId: 'thread-one',
+          format: 'v2',
+          selectBy: {
+            last: 0,
+            include: [
+              {
+                id: messages[4].id,
+                threadId: 'thread-two',
+                withPreviousMessages: 1,
+                withNextMessages: 1,
+              },
+            ],
+          },
+        });
+
+        expect(crossThreadMessages2).toHaveLength(3);
+        expect(crossThreadMessages2.filter(m => m.threadId === `thread-one`)).toHaveLength(0);
+        expect(crossThreadMessages2.filter(m => m.threadId === `thread-two`)).toHaveLength(3);
+
+        const crossThreadMessages3: MastraMessageV2[] = await store.getMessages({
+          threadId: 'thread-two',
+          format: 'v2',
+          selectBy: {
+            last: 0,
+            include: [
+              {
+                id: messages[1].id,
+                threadId: 'thread-one',
+                withNextMessages: 1,
+                withPreviousMessages: 1,
+              },
+            ],
+          },
+        });
+
+        expect(crossThreadMessages3).toHaveLength(3);
+        expect(crossThreadMessages3.filter(m => m.threadId === `thread-one`)).toHaveLength(3);
+        expect(crossThreadMessages3.filter(m => m.threadId === `thread-two`)).toHaveLength(0);
+      });
+
+      it('should return messages using both last and include (cross-thread, deduped)', async () => {
+        const thread = createSampleThread({ id: 'thread-one' });
+        await store.saveThread({ thread });
+
+        const thread2 = createSampleThread({ id: 'thread-two' });
+        await store.saveThread({ thread: thread2 });
+
+        const now = new Date();
+
+        // Setup: create messages in two threads
+        const messages = [
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'A' },
+            createdAt: new Date(now.getTime()),
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'B' },
+            createdAt: new Date(now.getTime() + 1000),
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-one',
+            content: { content: 'C' },
+            createdAt: new Date(now.getTime() + 2000),
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'D' },
+            createdAt: new Date(now.getTime() + 3000),
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'E' },
+            createdAt: new Date(now.getTime() + 4000),
+          }),
+          createSampleMessageV2({
+            threadId: 'thread-two',
+            content: { content: 'F' },
+            createdAt: new Date(now.getTime() + 5000),
+          }),
+        ];
+        await store.saveMessages({ messages, format: 'v2' });
+
+        // Use last: 2 and include a message from another thread with context
+        const { messages: result } = await store.getMessagesPaginated({
+          threadId: 'thread-one',
+          format: 'v2',
+          selectBy: {
+            last: 2,
+            include: [
+              {
+                id: messages[4].id, // 'E' from thread-bar
+                threadId: 'thread-two',
+                withPreviousMessages: 1,
+                withNextMessages: 1,
+              },
+            ],
+          },
+        });
+
+        // Should include last 2 from thread-one and 3 from thread-two (D, E, F)
+        expect(result.map(m => m.content.content).sort()).toEqual(['B', 'C', 'D', 'E', 'F']);
+        // Should include 2 from thread-one
+        expect(result.filter(m => m.threadId === 'thread-one').map((m: any) => m.content.content)).toEqual(['B', 'C']);
+        // Should include 3 from thread-two
+        expect(result.filter(m => m.threadId === 'thread-two').map((m: any) => m.content.content)).toEqual([
+          'D',
+          'E',
+          'F',
+        ]);
       });
     });
 

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -1857,7 +1857,7 @@ describe('PostgresStore', () => {
         expect(crossThreadMessages.filter(m => m.threadId === `thread-one`)).toHaveLength(3);
         expect(crossThreadMessages.filter(m => m.threadId === `thread-two`)).toHaveLength(3);
 
-        const crossThreadMessages2: MastraMessageV2[] = await store.getMessages({
+        const crossThreadMessages2 = await store.getMessagesPaginated({
           threadId: 'thread-one',
           format: 'v2',
           selectBy: {
@@ -1873,11 +1873,11 @@ describe('PostgresStore', () => {
           },
         });
 
-        expect(crossThreadMessages2).toHaveLength(3);
-        expect(crossThreadMessages2.filter(m => m.threadId === `thread-one`)).toHaveLength(0);
-        expect(crossThreadMessages2.filter(m => m.threadId === `thread-two`)).toHaveLength(3);
+        expect(crossThreadMessages2.messages).toHaveLength(3);
+        expect(crossThreadMessages2.messages.filter(m => m.threadId === `thread-one`)).toHaveLength(0);
+        expect(crossThreadMessages2.messages.filter(m => m.threadId === `thread-two`)).toHaveLength(3);
 
-        const crossThreadMessages3: MastraMessageV2[] = await store.getMessages({
+        const crossThreadMessages3 = await store.getMessagesPaginated({
           threadId: 'thread-two',
           format: 'v2',
           selectBy: {
@@ -1893,9 +1893,9 @@ describe('PostgresStore', () => {
           },
         });
 
-        expect(crossThreadMessages3).toHaveLength(3);
-        expect(crossThreadMessages3.filter(m => m.threadId === `thread-one`)).toHaveLength(3);
-        expect(crossThreadMessages3.filter(m => m.threadId === `thread-two`)).toHaveLength(0);
+        expect(crossThreadMessages3.messages).toHaveLength(3);
+        expect(crossThreadMessages3.messages.filter(m => m.threadId === `thread-one`)).toHaveLength(3);
+        expect(crossThreadMessages3.messages.filter(m => m.threadId === `thread-two`)).toHaveLength(0);
       });
 
       it('should return messages using both last and include (cross-thread, deduped)', async () => {

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -1728,8 +1728,6 @@ describe('PostgresStore', () => {
         const retrievedMessages = await store.getMessagesPaginated({ threadId: thread.id, format: 'v2' });
         expect(retrievedMessages.messages).toHaveLength(3);
 
-        console.log(JSON.stringify(retrievedMessages.messages, null, 2));
-
         // Verify order is maintained
         retrievedMessages.messages.forEach((msg, idx) => {
           expect((msg.content.parts[0] as any).text).toEqual(messageContent[idx]);

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1024,7 +1024,10 @@ export class PostgresStore extends MastraStorage {
     }
 
     try {
-      const perPage = perPageInput !== undefined ? perPageInput : 40;
+      const perPage =
+        perPageInput !== undefined
+          ? perPageInput
+          : this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
       const currentOffset = page * perPage;
 
       const conditions: string[] = [`thread_id = $1`];
@@ -1045,7 +1048,7 @@ export class PostgresStore extends MastraStorage {
       const countResult = await this.db.one(countQuery, queryParams);
       const total = parseInt(countResult.count, 10);
 
-      if (total === 0) {
+      if (total === 0 && messages.length === 0) {
         return {
           messages: [],
           total: 0,
@@ -1055,10 +1058,14 @@ export class PostgresStore extends MastraStorage {
         };
       }
 
+      const excludeIds = messages.map(m => m.id);
+      const excludeIdsParam = excludeIds.map((_, idx) => `$${idx + paramIndex}`).join(', ');
+      paramIndex += excludeIds.length;
+
       const dataQuery = `${selectStatement} FROM ${this.getTableName(
         TABLE_MESSAGES,
-      )} ${whereClause} ${orderByStatement} LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
-      const rows = await this.db.manyOrNone(dataQuery, [...queryParams, perPage, currentOffset]);
+      )} ${whereClause} ${excludeIds.length ? `AND id NOT IN (${excludeIdsParam})` : ''}${orderByStatement} LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
+      const rows = await this.db.manyOrNone(dataQuery, [...queryParams, ...excludeIds, perPage, currentOffset]);
       messages.push(...(rows || []));
 
       const list = new MessageList().add(messages, 'memory');


### PR DESCRIPTION
## Description

Fix implementation of `getMessagesPaginated` for PgStore and LibSQLStore.

Copy getMessages tests and reimplement them as getMessagesPaginated test.
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
