### PR TITLE
Fix incorrect sample code for using OTEL NodeSDK

### DIFF
--- a/docs/src/content/en/docs/observability/nextjs-tracing.mdx
+++ b/docs/src/content/en/docs/observability/nextjs-tracing.mdx
@@ -56,7 +56,11 @@ npm install @opentelemetry/api langfuse-vercel
 2. Create an instrumentation file:
 
 ```ts filename="instrumentation.ts" copy
-import { ATTR_SERVICE_NAME, NodeSDK, resourceFromAttributes } from '@mastra/core/telemetry/otel-vendor';
+import {
+  NodeSDK,
+  ATTR_SERVICE_NAME,
+  resourceFromAttributes,
+} from "@mastra/core/telemetry/otel-vendor";
 import { LangfuseExporter } from "langfuse-vercel";
 
 export function register() {
@@ -66,7 +70,7 @@ export function register() {
 
   const sdk = new NodeSDK({
     resource: resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: 'ai',
+      [ATTR_SERVICE_NAME]: "ai",
     }),
     traceExporter: exporter,
   });

--- a/docs/src/content/en/docs/observability/nextjs-tracing.mdx
+++ b/docs/src/content/en/docs/observability/nextjs-tracing.mdx
@@ -56,11 +56,7 @@ npm install @opentelemetry/api langfuse-vercel
 2. Create an instrumentation file:
 
 ```ts filename="instrumentation.ts" copy
-import {
-  NodeSDK,
-  ATTR_SERVICE_NAME,
-  Resource,
-} from "@mastra/core/telemetry/otel-vendor";
+import { ATTR_SERVICE_NAME, NodeSDK, resourceFromAttributes } from '@mastra/core/telemetry/otel-vendor';
 import { LangfuseExporter } from "langfuse-vercel";
 
 export function register() {
@@ -69,8 +65,8 @@ export function register() {
   });
 
   const sdk = new NodeSDK({
-    resource: new Resource({
-      [ATTR_SERVICE_NAME]: "ai",
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: 'ai',
     }),
     traceExporter: exporter,
   });

--- a/docs/src/content/ja/docs/observability/nextjs-tracing.mdx
+++ b/docs/src/content/ja/docs/observability/nextjs-tracing.mdx
@@ -56,7 +56,11 @@ npm install @opentelemetry/api langfuse-vercel
 2. インストゥルメンテーションファイルを作成します。
 
 ```ts filename="instrumentation.ts" copy
-import { ATTR_SERVICE_NAME, NodeSDK, resourceFromAttributes } from '@mastra/core/telemetry/otel-vendor';
+import {
+  NodeSDK,
+  ATTR_SERVICE_NAME,
+  resourceFromAttributes,
+} from "@mastra/core/telemetry/otel-vendor";
 import { LangfuseExporter } from "langfuse-vercel";
 
 export function register() {
@@ -66,7 +70,7 @@ export function register() {
 
   const sdk = new NodeSDK({
     resource: resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: 'ai',
+      [ATTR_SERVICE_NAME]: "ai",
     }),
     traceExporter: exporter,
   });

--- a/docs/src/content/ja/docs/observability/nextjs-tracing.mdx
+++ b/docs/src/content/ja/docs/observability/nextjs-tracing.mdx
@@ -56,11 +56,7 @@ npm install @opentelemetry/api langfuse-vercel
 2. インストゥルメンテーションファイルを作成します。
 
 ```ts filename="instrumentation.ts" copy
-import {
-  NodeSDK,
-  ATTR_SERVICE_NAME,
-  Resource,
-} from "@mastra/core/telemetry/otel-vendor";
+import { ATTR_SERVICE_NAME, NodeSDK, resourceFromAttributes } from '@mastra/core/telemetry/otel-vendor';
 import { LangfuseExporter } from "langfuse-vercel";
 
 export function register() {
@@ -69,8 +65,8 @@ export function register() {
   });
 
   const sdk = new NodeSDK({
-    resource: new Resource({
-      [ATTR_SERVICE_NAME]: "ai",
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: 'ai',
     }),
     traceExporter: exporter,
   });


### PR DESCRIPTION
## Description

This change modifies the documentation for using OTEL NodeSDK. The [Resource type is not a class](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-resources/src/Resource.ts#L30) and [is not exported from `otel-vendor.ts`](https://github.com/mastra-ai/mastra/blob/4fd37fad96d6521fe8dad72d76508c5c1e614076/packages/core/src/telemetry/otel-vendor.ts). Changed to use `resourceFromAttributes` instead.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
