### PR TITLE
createRun() -> createRunAsync()

### DIFF
--- a/.changeset/poor-phones-open.md
+++ b/.changeset/poor-phones-open.md
@@ -1,0 +1,7 @@
+---
+'@mastra/inngest': patch
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+createRun() -> createRunAsync()

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -174,7 +174,7 @@ The following example demonstrates how to start a run with multiple inputs. Each
 ```typescript {6} filename="src/test-workflow.ts" showLineNumbers copy
 import { mastra } from "./mastra";
 
-const run = mastra.getWorkflow("testWorkflow").createRun();
+const run = await mastra.getWorkflow("testWorkflow").createRunAsync();
 
 const result = await run.start({
   inputData: [{ number: 10 }, { number: 100 }, { number: 200 }]

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -157,12 +157,12 @@ With the Mastra Dev Server running you can run the workflow from the Mastra Play
 
 #### Command line
 
-Create a run instance of any Mastra workflow using `createRun` and `start`:
+Create a run instance of any Mastra workflow using `createRunAsync` and `start`:
 
 ```typescript {3,5} filename="src/test-workflow.ts" showLineNumbers copy
 import { mastra } from "./mastra";
 
-const run = mastra.getWorkflow("testWorkflow").createRun();
+const run = await mastra.getWorkflow("testWorkflow").createRunAsync();
 
 const result = await run.start({
   inputData: {
@@ -172,7 +172,7 @@ const result = await run.start({
 
 console.log(JSON.stringify(result, null, 2));
 ```
-> see [createRun](/reference/workflows/create-run) and [start](/reference/workflows/start) for more information.
+> see [createRunAsync](/reference/workflows/create-run-async) and [start](/reference/workflows/start) for more information.
 
 To trigger this workflow, run the following:
 
@@ -189,7 +189,7 @@ Similar to the run method shown above, workflows can also be streamed:
 ```typescript {5} filename="src/test-workflow.ts" showLineNumbers copy
 import { mastra } from "./mastra";
 
-const run = mastra.getWorkflow("testWorkflow").createRun();
+const run = await mastra.getWorkflow("testWorkflow").createRunAsync();
 
 const result = await run.stream({
   inputData: {
@@ -211,7 +211,7 @@ A workflow can also be watched, allowing you to inspect each event that is emitt
 ```typescript {5} filename="src/test-workflow.ts" showLineNumbers copy
 import { mastra } from "./mastra";
 
-const run = mastra.getWorkflow("testWorkflow").createRun();
+const run = await mastra.getWorkflow("testWorkflow").createRunAsync();
 
 run.watch((event) => {
   console.log(event);

--- a/docs/src/content/en/docs/workflows/pausing-execution.mdx
+++ b/docs/src/content/en/docs/workflows/pausing-execution.mdx
@@ -46,7 +46,7 @@ workflow
     .then(step3)
     .commit();
 
-const run = await workflow.createRun()
+const run = await workflow.createRunAsync()
 run.start({})
 
 setTimeout(() => {

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -69,7 +69,7 @@ A workflow can be resumed by calling `resume` and providing the required `resume
 ```typescript {6,12,13,14} filename="src/test-workflow.ts" showLineNumbers copy
 import { mastra } from "./mastra";
 
-const run = mastra.getWorkflow("testWorkflow").createRun();
+const run = await mastra.getWorkflow("testWorkflow").createRunAsync();
 
 const result = await run.start({
   inputData: { suggestions: ["London", "Paris", "New York"] }
@@ -125,7 +125,7 @@ const dowhileWorkflow = createWorkflow({
   )
   .commit();
 
-const run = dowhileWorkflow.createRun();
+const run = await dowhileWorkflow.createRunAsync();
 const result = await run.start({ inputData: { value: 0 } });
 
 if (result.status === "suspended") {
@@ -148,7 +148,7 @@ import { RuntimeContext } from "@mastra/core/di";
 import { mastra } from "./mastra";
 
 const runtimeContext = new RuntimeContext();
-const run = mastra.getWorkflow("testWorkflow").createRun();
+const run = await mastra.getWorkflow("testWorkflow").createRunAsync();
 
 const result = await run.start({
   inputData: { suggestions: ["London", "Paris", "New York"] },

--- a/docs/src/content/en/docs/workflows/using-with-agents-and-tools.mdx
+++ b/docs/src/content/en/docs/workflows/using-with-agents-and-tools.mdx
@@ -238,7 +238,7 @@ export const cityCoordinatesTool = createTool({
 
     const workflow = mastra?.getWorkflow("cityStringWorkflow");
 
-    const run = workflow?.createRun();
+    const run = await workflow?.createRunAsync();
 
     const { result } = await run?.start({
       inputData: {

--- a/docs/src/content/en/examples/agents/multi-agent-workflow.mdx
+++ b/docs/src/content/en/examples/agents/multi-agent-workflow.mdx
@@ -111,7 +111,7 @@ const myWorkflow = createWorkflow({
 // Run steps sequentially.
 myWorkflow.then(copywriterStep).then(editorStep).commit();
 
-const run = myWorkflow.createRun();
+const run = await myWorkflow.createRunAsync();
 
 const res = await run.start({
   inputData: { topic: "React JavaScript frameworks" },

--- a/docs/src/content/en/examples/agents/workflow-as-tools.mdx
+++ b/docs/src/content/en/examples/agents/workflow-as-tools.mdx
@@ -127,7 +127,7 @@ export const startWeatherTool = createTool({
   }),
   execute: async ({ context }) => {
     const workflow = mastra.getWorkflow('weatherWorkflowWithSuspend');
-    const run = await workflow.createRun();
+    const run = await workflow.createRunAsync();
     await run.start({
       inputData: {},
     });
@@ -148,7 +148,7 @@ export const resumeWeatherTool = createTool({
   outputSchema: forecastSchema,
   execute: async ({ context }) => {
     const workflow = mastra.getWorkflow('weatherWorkflowWithSuspend');
-    const run = await workflow.createRun({
+    const run = await workflow.createRunAsync({
       runId: context.runId,
     });
     const result = await run.resume({

--- a/docs/src/content/en/examples/rag/usage/cot-workflow-rag.mdx
+++ b/docs/src/content/en/examples/rag/usage/cot-workflow-rag.mdx
@@ -321,7 +321,7 @@ const prompt = `
     Please base your answer only on the context provided in the tool. If the context doesn't contain enough information to fully answer the question, please state that explicitly.
     `;
 
-const { runId, start } = ragWorkflow.createRun();
+const { runId, start } = await ragWorkflow.createRunAsync();
 
 console.log("Run:", runId);
 

--- a/docs/src/content/en/examples/workflows/agent-and-tool-interop.mdx
+++ b/docs/src/content/en/examples/workflows/agent-and-tool-interop.mdx
@@ -234,7 +234,7 @@ Here, we'll get the weather workflow from the mastra instance, then create a run
 import { mastra } from "./";
 
 const workflow = mastra.getWorkflow("weatherWorkflow");
-const run = workflow.createRun();
+const run = await workflow.createRunAsync();
 
 // Start the workflow with Lagos as the location
 const result = await run.start({ inputData: { location: "Lagos" } });

--- a/docs/src/content/en/examples/workflows/array-as-input.mdx
+++ b/docs/src/content/en/examples/workflows/array-as-input.mdx
@@ -316,7 +316,7 @@ import { mastra } from "./";
 
 // GitHub repository to generate documentation for
 const ghRepoUrl = "https://github.com/mastra-ai/mastra";
-const run = mastra.getWorkflow("readmeGeneratorWorkflow").createRun();
+const run = await mastra.getWorkflow("readmeGeneratorWorkflow").createRunAsync();
 
 // Start the workflow with the repository URL as input
 const res = await run.start({ inputData: { repoUrl: ghRepoUrl } });

--- a/docs/src/content/en/examples/workflows/calling-agent.mdx
+++ b/docs/src/content/en/examples/workflows/calling-agent.mdx
@@ -273,7 +273,7 @@ Here, we'll get the activity planning workflow from the mastra instance, then cr
 import { mastra } from "./";
 
 const workflow = mastra.getWorkflow("activityPlanningWorkflow");
-const run = workflow.createRun();
+const run = await workflow.createRunAsync();
 
 // Start the workflow with New York as the city input
 const result = await run.start({ inputData: { city: "New York" } });

--- a/docs/src/content/en/examples/workflows/conditional-branching.mdx
+++ b/docs/src/content/en/examples/workflows/conditional-branching.mdx
@@ -345,7 +345,7 @@ Here, we'll get the activity planning workflow from the mastra instance, then cr
 import { mastra } from "./";
 
 const workflow = mastra.getWorkflow("activityPlanningWorkflow");
-const run = workflow.createRun();
+const run = await workflow.createRunAsync();
 
 // Start the workflow with a city
 // This will fetch weather and plan activities based on conditions

--- a/docs/src/content/en/examples/workflows/control-flow.mdx
+++ b/docs/src/content/en/examples/workflows/control-flow.mdx
@@ -132,7 +132,7 @@ Here, we'll get the increment workflow from the mastra instance, then create a r
 import { mastra } from "./";
 
 const workflow = mastra.getWorkflow("incrementWorkflow");
-const run = workflow.createRun();
+const run = await workflow.createRunAsync();
 
 // Start the workflow with initial value 0
 // This will increment until reaching 10

--- a/docs/src/content/en/examples/workflows/human-in-the-loop.mdx
+++ b/docs/src/content/en/examples/workflows/human-in-the-loop.mdx
@@ -208,7 +208,7 @@ import { select } from "@inquirer/prompts";
 import { humanInputStep } from "./workflows/human-in-the-loop-workflow";
 
 const workflow = mastra.getWorkflow("travelAgentWorkflow");
-const run = workflow.createRun({});
+const run = await workflow.createRunAsync();
 
 // Start the workflow with initial vacation description
 const result = await run.start({

--- a/docs/src/content/en/examples/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/examples/workflows/inngest-workflow.mdx
@@ -377,7 +377,7 @@ const srv = serve({
 });
 
 const workflow = mastra.getWorkflow("activityPlanningWorkflow");
-const run = workflow.createRun({});
+const run = await workflow.createRunAsync();
 
 // Start the workflow with the required input data (city name)
 // This will trigger the workflow steps and stream the result to the console

--- a/docs/src/content/en/examples/workflows/parallel-steps.mdx
+++ b/docs/src/content/en/examples/workflows/parallel-steps.mdx
@@ -407,7 +407,7 @@ Here, we'll get the weather workflow from the mastra instance, then create a run
 import { mastra } from "./";
 
 const workflow = mastra.getWorkflow("activityPlanningWorkflow");
-const run = workflow.createRun();
+const run = await workflow.createRunAsync();
 
 // Execute the workflow with a specific city
 // This will run through all steps and generate activity recommendations

--- a/docs/src/content/en/guides/guide/ai-recruiter.mdx
+++ b/docs/src/content/en/guides/guide/ai-recruiter.mdx
@@ -187,7 +187,7 @@ const mastra = new Mastra({
 });
 
 (async () => {
-  const run = mastra.getWorkflow("candidateWorkflow").createRun();
+  const run = await mastra.getWorkflow("candidateWorkflow").createRunAsync();
 
   console.log("Run", run.runId);
 

--- a/docs/src/content/en/reference/workflows/create-run.mdx
+++ b/docs/src/content/en/reference/workflows/create-run.mdx
@@ -31,7 +31,7 @@ const mastra = new Mastra({
   },
 });
 
-const run = mastra.getWorkflow("myWorkflow").createRun();
+const run = await mastra.getWorkflow("myWorkflow").createRunAsync();
 ```
 
 ## Parameters

--- a/docs/src/content/en/reference/workflows/resume.mdx
+++ b/docs/src/content/en/reference/workflows/resume.mdx
@@ -10,7 +10,7 @@ The `.resume()` method resumes a suspended workflow run with new data, allowing 
 ## Usage
 
 ```typescript
-const run = counterWorkflow.createRun();
+const run = await counterWorkflow.createRunAsync();
 const result = await run.start({ inputData: { startValue: 0 } });
 
 if (result.status === "suspended") {

--- a/docs/src/content/en/reference/workflows/start.mdx
+++ b/docs/src/content/en/reference/workflows/start.mdx
@@ -10,7 +10,7 @@ The `.start()` method starts a workflow run with input data, allowing you to exe
 ## Usage
 
 ```typescript
-const run = myWorkflow.createRun();
+const run = await myWorkflow.createRunAsync();
 
 // Start the workflow with input data
 const result = await run.start({

--- a/docs/src/content/en/reference/workflows/stream.mdx
+++ b/docs/src/content/en/reference/workflows/stream.mdx
@@ -10,7 +10,7 @@ The `.stream()` method allows you to monitor the execution of a workflow run, pr
 ## Usage
 
 ```typescript
-const run = myWorkflow.createRun();
+const run = await myWorkflow.createRunAsync();
 
 // Add a stream to monitor execution
 const result = run.stream({ inputData: {...} });

--- a/docs/src/content/en/reference/workflows/watch.mdx
+++ b/docs/src/content/en/reference/workflows/watch.mdx
@@ -10,7 +10,7 @@ The `.watch()` method allows you to monitor the execution of a workflow run, pro
 ## Usage
 
 ```typescript
-const run = myWorkflow.createRun();
+const run = await myWorkflow.createRunAsync();
 
 // Add a watcher to monitor execution
 run.watch(event => {

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -31,7 +31,7 @@ const mastra = new Mastra({
   },
 });
 
-const run = mastra.getWorkflow("myWorkflow").createRun();
+const run = await mastra.getWorkflow("myWorkflow").createRunAsync();
 ```
 
 ## API Reference
@@ -99,7 +99,11 @@ Validates and finalizes the workflow configuration. Must be called after adding 
 
 #### `createRun()`
 
-Creates a new workflow run instance, allowing you to execute the workflow with specific input data. Accepts optional run ID.
+Deprecated. Creates a new workflow run instance, allowing you to execute the workflow with specific input data. Accepts optional run ID.
+
+#### `createRunAsync()`
+
+Creates a new workflow run instance, allowing you to execute the workflow with specific input data. Accepts optional run ID. Stores a pending workflow run snapshot into storage.
 
 #### `execute()`
 

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -124,23 +124,25 @@ export type StreamEvent =
       id: string;
     };
 
+export type WorkflowRunStatus = 'running' | 'success' | 'failed' | 'suspended' | 'waiting' | 'pending';
+
 export type WatchEvent = {
   type: 'watch';
   payload: {
     currentStep?: {
       id: string;
-      status: 'running' | 'success' | 'failed' | 'suspended' | 'waiting';
+      status: WorkflowRunStatus;
       output?: Record<string, any>;
       resumePayload?: Record<string, any>;
       payload?: Record<string, any>;
       error?: string | Error;
     };
     workflowState: {
-      status: 'running' | 'success' | 'failed' | 'suspended' | 'waiting';
+      status: WorkflowRunStatus;
       steps: Record<
         string,
         {
-          status: 'running' | 'success' | 'failed' | 'suspended' | 'waiting';
+          status: WorkflowRunStatus;
           output?: Record<string, any>;
           payload?: Record<string, any>;
           resumePayload?: Record<string, any>;
@@ -176,7 +178,7 @@ export type ZodPathType<T extends z.ZodTypeAny, P extends string> =
 export interface WorkflowRunState {
   // Core state info
   runId: string;
-  status: 'success' | 'failed' | 'suspended' | 'running' | 'waiting';
+  status: WorkflowRunStatus;
   result?: Record<string, any>;
   error?: string | Error;
   value: Record<string, string>;

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -11,7 +11,6 @@ import { RuntimeContext } from '../di';
 import { MockStore } from '../storage/mock';
 import type { StreamEvent, WatchEvent } from './types';
 import { cloneStep, cloneWorkflow, createStep, createWorkflow, mapVariable } from './workflow';
-import { wrap } from 'module';
 
 const testStorage = new MockStore();
 

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -11,6 +11,7 @@ import { RuntimeContext } from '../di';
 import { MockStore } from '../storage/mock';
 import type { StreamEvent, WatchEvent } from './types';
 import { cloneStep, cloneWorkflow, createStep, createWorkflow, mapVariable } from './workflow';
+import { wrap } from 'module';
 
 const testStorage = new MockStore();
 
@@ -58,7 +59,7 @@ describe('Workflow', () => {
 
       const runId = 'test-run-id';
       let watchData: StreamEvent[] = [];
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId,
       });
 
@@ -232,7 +233,7 @@ describe('Workflow', () => {
         workflows: { 'test-workflow': promptEvalWorkflow },
       });
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       const { stream, getWorkflowState } = run.stream({ inputData: { input: 'test' } });
 
@@ -389,7 +390,7 @@ describe('Workflow', () => {
         .then(agentStep2)
         .commit();
 
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId: 'test-run-id',
       });
       const { stream } = await run.stream({
@@ -595,7 +596,7 @@ describe('Workflow', () => {
 
       const runId = 'test-run-id';
       let watchData: StreamEvent[] = [];
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId,
       });
 
@@ -721,7 +722,7 @@ describe('Workflow', () => {
 
       const runId = 'test-run-id';
       let watchData: StreamEvent[] = [];
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId,
       });
 
@@ -867,7 +868,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).then(step2).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { value: 'bail' } });
 
       expect(result.steps['step1']).toEqual({
@@ -880,7 +881,7 @@ describe('Workflow', () => {
 
       expect(result.steps['step2']).toBeUndefined();
 
-      const run2 = workflow.createRun();
+      const run2 = await workflow.createRunAsync();
       const result2 = await run2.start({ inputData: { value: 'no-bail' } });
 
       expect(result2.steps['step1']).toEqual({
@@ -968,7 +969,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(execute).toHaveBeenCalled();
@@ -1003,7 +1004,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(execute).toHaveBeenCalled();
@@ -1046,7 +1047,7 @@ describe('Workflow', () => {
 
       workflow.parallel([step1, step2]).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(step1Action).toHaveBeenCalled();
@@ -1093,7 +1094,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps).toEqual({
@@ -1134,7 +1135,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).then(step2).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { inputData: 'test-input' } });
 
         expect(result.steps.step1).toEqual({
@@ -1203,7 +1204,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).then(step2).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { inputValue: 'test-input' } });
 
         expect(step1Action).toHaveBeenCalled();
@@ -1254,7 +1255,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         await run.start({ inputData: { inputData: 'test-input' } });
 
         expect(execute).toHaveBeenCalledWith(
@@ -1296,7 +1297,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).then(step2).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { cool: 'test-input' } });
 
         expect(execute).toHaveBeenCalledWith(
@@ -1348,7 +1349,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).then(step2).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { cool: 'test-input' } });
 
         expect(execute).toHaveBeenCalledWith(
@@ -1413,7 +1414,7 @@ describe('Workflow', () => {
         const runtimeContext = new RuntimeContext<{ life: number }>();
         runtimeContext.set('life', 42);
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { cool: 'test-input' }, runtimeContext });
 
         expect(execute).toHaveBeenCalledWith(
@@ -1489,7 +1490,7 @@ describe('Workflow', () => {
           })
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { cool: 'test-input' } });
 
         if (result.status !== 'success') {
@@ -1552,7 +1553,7 @@ describe('Workflow', () => {
           .then(step2)
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         await run.start({ inputData: {} });
 
         expect(step2Action).toHaveBeenCalledWith(
@@ -1590,7 +1591,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).then(step2).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: {} });
 
         expect(result.steps).toEqual({
@@ -1640,7 +1641,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).then(step2).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: {} });
 
         expect(result.steps).toEqual({
@@ -1699,7 +1700,7 @@ describe('Workflow', () => {
           .then(step2)
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: {} });
 
         expect(result.steps).toMatchObject({
@@ -1766,7 +1767,7 @@ describe('Workflow', () => {
           .then(step2)
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { cool: 'test-input' } });
 
         expect(execute).toHaveBeenCalledWith(
@@ -1824,7 +1825,7 @@ describe('Workflow', () => {
           .then(step2)
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { cool: 'test-input' } });
 
         expect(execute).toHaveBeenCalledWith(
@@ -1915,7 +1916,7 @@ describe('Workflow', () => {
           .then(step4)
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { status: 'success' } });
 
         expect(step1Action).toHaveBeenCalled();
@@ -1959,7 +1960,7 @@ describe('Workflow', () => {
 
         workflow.then(step1).then(step2).commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         let result: Awaited<ReturnType<typeof run.start>> | undefined = undefined;
         try {
           result = await run.start({ inputData: {} });
@@ -2037,7 +2038,7 @@ describe('Workflow', () => {
           ])
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { status: 'success' } });
 
         expect(step1Action).toHaveBeenCalled();
@@ -2101,7 +2102,7 @@ describe('Workflow', () => {
           ])
           .commit();
 
-        const run = workflow.createRun();
+        const run = await workflow.createRunAsync();
         const result = await run.start({ inputData: { count: 5 } });
 
         expect(step2Action).toHaveBeenCalled();
@@ -2152,7 +2153,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).sleep(1000).then(step2).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       const result = await run.start({ inputData: {} });
       const endTime = Date.now();
@@ -2209,7 +2210,7 @@ describe('Workflow', () => {
         .then(step2)
         .commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       const result = await run.start({ inputData: {} });
       const endTime = Date.now();
@@ -2264,7 +2265,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).waitForEvent('hello-event', step2).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       setTimeout(() => {
         run.sendEvent('hello-event', { data: 'hello' });
@@ -2325,7 +2326,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).waitForEvent('hello-event', step2, { timeout: 1000 }).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       const result = await run.start({ inputData: {} });
       const endTime = Date.now();
@@ -2373,7 +2374,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       const result = await run.start({ inputData: {} });
 
@@ -2429,7 +2430,7 @@ describe('Workflow', () => {
         .then(step2)
         .commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await expect(run.start({ inputData: {} })).resolves.toMatchObject({
         steps: {
           step1: {
@@ -2492,7 +2493,7 @@ describe('Workflow', () => {
 
       workflow.parallel([step1, step2]).then(step3).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps).toMatchObject({
@@ -2561,7 +2562,7 @@ describe('Workflow', () => {
         .then(workflow)
         .commit();
 
-      const run = mainWorkflow.createRun();
+      const run = await mainWorkflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps).toMatchObject({
@@ -2658,7 +2659,7 @@ describe('Workflow', () => {
         })
         .commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(step2Action).toHaveBeenCalled();
@@ -2736,7 +2737,7 @@ describe('Workflow', () => {
         .then(finalStep)
         .commit();
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { target: 10, value: 0 } });
 
       expect(increment).toHaveBeenCalledTimes(12);
@@ -2804,7 +2805,7 @@ describe('Workflow', () => {
         .then(finalStep)
         .commit();
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { target: 10, value: 0 } });
 
       expect(increment).toHaveBeenCalledTimes(12);
@@ -2858,7 +2859,7 @@ describe('Workflow', () => {
 
       counterWorkflow.foreach(mapStep).then(finalStep).commit();
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: [{ value: 1 }, { value: 22 }, { value: 333 }] });
 
       const endTime = Date.now();
@@ -2926,7 +2927,7 @@ describe('Workflow', () => {
 
       counterWorkflow.foreach(mapStep, { concurrency: 3 }).then(finalStep).commit();
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: [{ value: 1 }, { value: 22 }, { value: 333 }] });
 
       const endTime = Date.now();
@@ -2996,7 +2997,7 @@ describe('Workflow', () => {
 
       counterWorkflow.foreach(mapStep, { concurrency: 2 }).then(finalStep).commit();
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: [{ value: 1 }, { value: 22 }, { value: 333 }] });
 
       const endTime = Date.now();
@@ -3127,7 +3128,7 @@ describe('Workflow', () => {
         ])
         .commit();
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 1 } });
 
       expect(start).toHaveBeenCalledTimes(1);
@@ -3241,7 +3242,7 @@ describe('Workflow', () => {
         ])
         .commit();
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 6 } });
 
       expect(start).toHaveBeenCalledTimes(1);
@@ -3298,7 +3299,7 @@ describe('Workflow', () => {
       ).rejects.toThrow();
 
       // Should pass validation
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({
         inputData: {
           required: 'test',
@@ -3371,7 +3372,7 @@ describe('Workflow', () => {
         ])
         .commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps['nested-a']).toEqual({
@@ -3426,7 +3427,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).then(step2).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps.step1).toEqual({
@@ -3485,7 +3486,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).then(step2).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps.step1).toEqual({
@@ -3542,10 +3543,12 @@ describe('Workflow', () => {
 
       workflow.then(step1).then(createStep(randomTool)).commit();
 
-      const result = await workflow.createRun().start({ inputData: {} });
+      const run = await workflow.createRunAsync();
+      const result = await run.start({ inputData: {} });
 
       expect(step1Action).toHaveBeenCalled();
       expect(toolAction).toHaveBeenCalled();
+      // @ts-ignore
       expect(result.steps.step1).toEqual({
         status: 'success',
         output: { name: 'step1' },
@@ -3553,6 +3556,7 @@ describe('Workflow', () => {
         startedAt: expect.any(Number),
         endedAt: expect.any(Number),
       });
+      // @ts-ignore
       expect(result.steps['random-tool']).toEqual({
         status: 'success',
         output: { name: 'step1' },
@@ -3594,7 +3598,7 @@ describe('Workflow', () => {
         watchData.push(JSON.parse(JSON.stringify(data)));
       };
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       // Start watching the workflow
       run.watch(onTransition);
@@ -3709,8 +3713,8 @@ describe('Workflow', () => {
         watchData.push(JSON.parse(JSON.stringify(data)));
       };
 
-      const run = workflow.createRun();
-      const run2 = workflow.createRun({ runId: run.runId });
+      const run = await workflow.createRunAsync();
+      const run2 = await workflow.createRunAsync({ runId: run.runId });
 
       // Start watching the workflow
       run2.watch(onTransition);
@@ -3822,7 +3826,7 @@ describe('Workflow', () => {
       const onTransition = vi.fn();
       const onTransition2 = vi.fn();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       run.watch(onTransition);
       run.watch(onTransition2);
@@ -3832,7 +3836,7 @@ describe('Workflow', () => {
       expect(onTransition).toHaveBeenCalledTimes(5);
       expect(onTransition2).toHaveBeenCalledTimes(5);
 
-      const run2 = workflow.createRun();
+      const run2 = await workflow.createRunAsync();
 
       run2.watch(onTransition2);
 
@@ -3841,7 +3845,7 @@ describe('Workflow', () => {
       expect(onTransition).toHaveBeenCalledTimes(5);
       expect(onTransition2).toHaveBeenCalledTimes(10);
 
-      const run3 = workflow.createRun();
+      const run3 = await workflow.createRunAsync();
 
       run3.watch(onTransition);
 
@@ -3883,7 +3887,7 @@ describe('Workflow', () => {
 
       workflow.then(step1).then(createStep(randomTool)).commit();
 
-      const { stream, getWorkflowState } = await workflow.createRun().stream({ inputData: {} });
+      const { stream, getWorkflowState } = (await workflow.createRunAsync()).stream({ inputData: {} });
 
       const values: StreamEvent[] = [];
       for await (const value of stream.values()) {
@@ -3999,8 +4003,8 @@ describe('Workflow', () => {
       })
         .then(step1)
         .commit();
-      const run = workflow.createRun();
-      const run2 = workflow.createRun({ runId: run.runId });
+      const run = await workflow.createRunAsync();
+      const run2 = await workflow.createRunAsync({ runId: run.runId });
 
       expect(run.runId).toBeDefined();
       expect(run2.runId).toBeDefined();
@@ -4086,7 +4090,7 @@ describe('Workflow', () => {
         workflows: { 'test-workflow': promptEvalWorkflow },
       });
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       // Create a promise to track when the workflow is ready to resume
       let resolveWorkflowSuspended: (value: unknown) => void;
@@ -4233,7 +4237,7 @@ describe('Workflow', () => {
         storage: testStorage,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       // Create a promise to track when the workflow is ready to resume
       let resolveWorkflowSuspended: (value: unknown) => void;
@@ -4422,7 +4426,7 @@ describe('Workflow', () => {
         storage: testStorage,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const started = run.start({ inputData: { input: 'test' } });
       let improvedResponseResultPromise: Promise<any | undefined>;
 
@@ -4591,7 +4595,7 @@ describe('Workflow', () => {
         workflows: { 'test-workflow': promptEvalWorkflow },
       });
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       const initialResult = await run.start({ inputData: { input: 'test' } });
       expect(initialResult.steps.promptAgent.status).toBe('suspended');
@@ -4788,7 +4792,7 @@ describe('Workflow', () => {
         workflows: { 'test-workflow': promptEvalWorkflow },
       });
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       const initialResult = await run.start({ inputData: { input: 'test' } });
       expect(initialResult.steps.promptAgent.status).toBe('suspended');
@@ -4856,7 +4860,7 @@ describe('Workflow', () => {
         workflows: { 'test-workflow': promptEvalWorkflow },
       });
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       const runtimeContext = new RuntimeContext();
       const initialResult = await run.start({ inputData: { input: 'test' }, runtimeContext });
@@ -4944,7 +4948,7 @@ describe('Workflow', () => {
         workflows: { dowhileWorkflow },
       });
 
-      const run = dowhileWorkflow.createRun();
+      const run = await dowhileWorkflow.createRunAsync();
       const result = await run.start({ inputData: { value: 0 } });
       expect(result.steps['simple-resume-workflow']).toMatchObject({
         status: 'suspended',
@@ -5012,10 +5016,10 @@ describe('Workflow', () => {
       });
 
       // Create a few runs
-      const run1 = workflow.createRun();
+      const run1 = await workflow.createRunAsync();
       await run1.start({ inputData: {} });
 
-      const run2 = workflow.createRun();
+      const run2 = await workflow.createRunAsync();
       await run2.start({ inputData: {} });
 
       const { runs, total } = await workflow.getWorkflowRuns();
@@ -5056,7 +5060,7 @@ describe('Workflow', () => {
       });
 
       // Create a few runs
-      const run1 = workflow.createRun();
+      const run1 = await workflow.createRunAsync();
       await run1.start({ inputData: {} });
 
       const { runs, total } = await workflow.getWorkflowRuns();
@@ -5096,7 +5100,7 @@ describe('Workflow', () => {
       });
 
       // Access new instance properties directly - should work without warning
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({ inputData: {} });
 
       expect(telemetry).toBeDefined();
@@ -5199,7 +5203,7 @@ describe('Workflow', () => {
         .then(agentStep2)
         .commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({
         inputData: { prompt1: 'Capital of France, just the name', prompt2: 'Capital of UK, just the name' },
       });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -25,6 +25,7 @@ import type {
   DynamicMapping,
   StreamEvent,
   WorkflowRunState,
+  WorkflowRunStatus,
 } from './types';
 
 export type DefaultEngineType = {};
@@ -993,6 +994,61 @@ export class Workflow<
       });
 
     this.#runs.set(runIdToUse, run);
+
+    this.mastra?.getLogger().warn('createRun() is deprecated. Use createRunAsync() instead.');
+
+    return run;
+  }
+
+  /**
+   * Creates a new workflow run instance and stores a snapshot of the workflow in the storage
+   * @param options Optional configuration for the run
+   * @returns A Run instance that can be used to execute the workflow
+   */
+  async createRunAsync(options?: { runId?: string }): Promise<Run<TEngineType, TSteps, TInput, TOutput>> {
+    if (this.stepFlow.length === 0) {
+      throw new Error(
+        'Execution flow of workflow is not defined. Add steps to the workflow via .then(), .branch(), etc.',
+      );
+    }
+    if (!this.executionGraph.steps) {
+      throw new Error('Uncommitted step flow changes detected. Call .commit() to register the steps.');
+    }
+    const runIdToUse = options?.runId || randomUUID();
+
+    // Return a new Run instance with object parameters
+    const run =
+      this.#runs.get(runIdToUse) ??
+      new Run({
+        workflowId: this.id,
+        runId: runIdToUse,
+        executionEngine: this.executionEngine,
+        executionGraph: this.executionGraph,
+        mastra: this.#mastra,
+        retryConfig: this.retryConfig,
+        serializedStepGraph: this.serializedStepGraph,
+        cleanup: () => this.#runs.delete(runIdToUse),
+      });
+
+    this.#runs.set(runIdToUse, run);
+
+    await this.mastra?.getStorage()?.persistWorkflowSnapshot({
+      workflowName: this.id,
+      runId: runIdToUse,
+      snapshot: {
+        runId: runIdToUse,
+        status: 'pending',
+        value: {},
+        context: {},
+        activePaths: [],
+        serializedStepGraph: this.serializedStepGraph,
+        suspendedPaths: {},
+        result: undefined,
+        error: undefined,
+        // @ts-ignore
+        timestamp: Date.now(),
+      },
+    });
 
     return run;
   }

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -25,7 +25,6 @@ import type {
   DynamicMapping,
   StreamEvent,
   WorkflowRunState,
-  WorkflowRunStatus,
 } from './types';
 
 export type DefaultEngineType = {};

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -219,7 +219,7 @@ export async function createWorkflowRunHandler({
       throw new HTTPException(404, { message: 'Workflow not found' });
     }
 
-    const run = workflow.createRun({ runId: prevRunId });
+    const run = await workflow.createRunAsync({ runId: prevRunId });
 
     return { runId: run.runId };
   } catch (error) {
@@ -248,7 +248,7 @@ export async function startAsyncWorkflowHandler({
       throw new HTTPException(404, { message: 'Workflow not found' });
     }
 
-    const _run = workflow.createRun({ runId });
+    const _run = await workflow.createRunAsync({ runId });
     const result = await _run.start({
       inputData,
       runtimeContext,
@@ -290,7 +290,7 @@ export async function startWorkflowRunHandler({
       throw new HTTPException(404, { message: 'Workflow run not found' });
     }
 
-    const _run = workflow.createRun({ runId });
+    const _run = await workflow.createRunAsync({ runId });
     void _run.start({
       inputData,
       runtimeContext,
@@ -328,7 +328,7 @@ export async function watchWorkflowHandler({
       throw new HTTPException(404, { message: 'Workflow run not found' });
     }
 
-    const _run = workflow.createRun({ runId });
+    const _run = await workflow.createRunAsync({ runId });
     let unwatch: () => void;
     let asyncRef: NodeJS.Immediate | null = null;
     const stream = new ReadableStream<string>({
@@ -387,7 +387,7 @@ export async function streamWorkflowHandler({
       throw new HTTPException(404, { message: 'Workflow not found' });
     }
 
-    const run = workflow.createRun({ runId });
+    const run = await workflow.createRunAsync({ runId });
     const result = run.stream({
       inputData,
       runtimeContext,
@@ -433,7 +433,7 @@ export async function resumeAsyncWorkflowHandler({
       throw new HTTPException(404, { message: 'Workflow run not found' });
     }
 
-    const _run = workflow.createRun({ runId });
+    const _run = await workflow.createRunAsync({ runId });
     const result = await _run.resume({
       step: body.step,
       resumeData: body.resumeData,
@@ -481,7 +481,7 @@ export async function resumeWorkflowHandler({
       throw new HTTPException(404, { message: 'Workflow run not found' });
     }
 
-    const _run = workflow.createRun({ runId });
+    const _run = await workflow.createRunAsync({ runId });
 
     void _run.resume({
       step: body.step,

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -110,7 +110,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { value: 'bail' } });
 
       await new Promise(resolve => setTimeout(resolve, 2000));
@@ -125,7 +125,7 @@ describe('MastraInngestWorkflow', () => {
 
       expect(result.steps['step2']).toBeUndefined();
 
-      const run2 = workflow.createRun();
+      const run2 = await workflow.createRunAsync();
       const result2 = await run2.start({ inputData: { value: 'no-bail' } });
 
       srv.close();
@@ -198,7 +198,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(execute).toHaveBeenCalled();
@@ -273,7 +273,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(step1Action).toHaveBeenCalled();
@@ -354,7 +354,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(executionOrder).toMatchObject(['step1', 'step2']);
@@ -428,7 +428,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       const result = await run.start({ inputData: {} });
       const endTime = Date.now();
@@ -520,7 +520,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       const result = await run.start({ inputData: {} });
       const endTime = Date.now();
@@ -610,7 +610,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       setTimeout(() => {
         run.sendEvent('hello-event', { data: 'hello' });
@@ -704,7 +704,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const startTime = Date.now();
       const result = await run.start({ inputData: {} });
       const endTime = Date.now();
@@ -789,7 +789,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { inputData: 'test-input' } });
 
       expect(result.steps.step1).toMatchObject({ status: 'success', output: { result: 'success' } });
@@ -876,7 +876,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { inputValue: 'test-input' } });
 
       expect(step1Action).toHaveBeenCalled();
@@ -943,7 +943,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({ inputData: { inputData: 'test-input' } });
 
       expect(execute).toHaveBeenCalledWith(
@@ -1018,7 +1018,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { cool: 'test-input' } });
 
       expect(execute).toHaveBeenCalledWith(
@@ -1100,7 +1100,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({ inputData: {} });
 
       expect(step2Action).toHaveBeenCalledWith(
@@ -1203,7 +1203,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { status: 'success' } });
       srv.close();
 
@@ -1279,7 +1279,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       let result: Awaited<ReturnType<typeof run.start>> | undefined = undefined;
       try {
         result = await run.start({ inputData: {} });
@@ -1384,7 +1384,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { status: 'success' } });
       srv.close();
 
@@ -1467,7 +1467,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { count: 5 } });
       srv.close();
 
@@ -1535,7 +1535,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       await expect(run.start({ inputData: {} })).resolves.toMatchObject({
         steps: {
@@ -1619,7 +1619,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps).toMatchObject({
@@ -1713,7 +1713,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = mainWorkflow.createRun();
+      const run = await mainWorkflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps).toMatchObject({
@@ -1841,7 +1841,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(step2Action).toHaveBeenCalled();
@@ -1943,7 +1943,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { target: 10, value: 0 } });
 
       expect(increment).toHaveBeenCalledTimes(12);
@@ -2046,7 +2046,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { target: 10, value: 0 } });
 
       expect(increment).toHaveBeenCalledTimes(12);
@@ -2135,7 +2135,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: [{ value: 1 }, { value: 22 }, { value: 333 }] });
 
       const endTime = Date.now();
@@ -2288,7 +2288,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 1 } });
 
       expect(start).toHaveBeenCalledTimes(1);
@@ -2437,7 +2437,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 6 } });
 
       expect(start).toHaveBeenCalledTimes(1);
@@ -2503,7 +2503,7 @@ describe('MastraInngestWorkflow', () => {
       ).rejects.toThrow();
 
       // Should pass validation
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({
         inputData: {
           required: 'test',
@@ -2609,7 +2609,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps['nested-a']).toMatchObject({ status: 'success', output: { result: 'success3' } });
@@ -2675,7 +2675,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps.step1).toMatchObject({ status: 'success', output: { result: 'success' } });
@@ -2732,7 +2732,7 @@ describe('MastraInngestWorkflow', () => {
 
       workflow.then(step1).then(step2).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: {} });
 
       expect(result.steps.step1).toMatchObject({ status: 'success', output: { result: 'success' } });
@@ -2807,7 +2807,8 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const result = await workflow.createRun().start({ inputData: {} });
+      const run = await workflow.createRunAsync();
+      const result = await run.start({ inputData: {} });
 
       srv.close();
 
@@ -2878,7 +2879,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       // Start watching the workflow
       let cnt = 0;
@@ -3067,7 +3068,7 @@ describe('MastraInngestWorkflow', () => {
       const onTransition = vi.fn();
       const onTransition2 = vi.fn();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       run.watch(onTransition);
       run.watch(onTransition2);
@@ -3077,7 +3078,7 @@ describe('MastraInngestWorkflow', () => {
       expect(onTransition).toHaveBeenCalledTimes(5);
       expect(onTransition2).toHaveBeenCalledTimes(5);
 
-      const run2 = workflow.createRun();
+      const run2 = await workflow.createRunAsync();
 
       run2.watch(onTransition2);
 
@@ -3086,7 +3087,7 @@ describe('MastraInngestWorkflow', () => {
       expect(onTransition).toHaveBeenCalledTimes(5);
       expect(onTransition2).toHaveBeenCalledTimes(10);
 
-      const run3 = workflow.createRun();
+      const run3 = await workflow.createRunAsync();
 
       run3.watch(onTransition);
 
@@ -3121,8 +3122,8 @@ describe('MastraInngestWorkflow', () => {
         outputSchema: z.object({}),
         steps: [],
       });
-      const run = workflow.createRun();
-      const run2 = workflow.createRun({ runId: run.runId });
+      const run = await workflow.createRunAsync();
+      const run2 = await workflow.createRunAsync({ runId: run.runId });
 
       expect(run.runId).toBeDefined();
       expect(run2.runId).toBeDefined();
@@ -3236,7 +3237,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       // Create a promise to track when the workflow is ready to resume
       let resolveWorkflowSuspended: (value: unknown) => void;
@@ -3386,7 +3387,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
 
       const started = run.start({ inputData: { input: 'test' } });
 
@@ -3588,7 +3589,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const started = run.start({ inputData: { input: 'test' } });
       let improvedResponseResultPromise: Promise<any | undefined>;
 
@@ -3782,7 +3783,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       const initialResult = await run.start({ inputData: { input: 'test' } });
       expect(initialResult.steps.promptAgent.status).toBe('suspended');
@@ -3911,7 +3912,7 @@ describe('MastraInngestWorkflow', () => {
       await new Promise(resolve => setTimeout(resolve, 2000));
 
       // Access new instance properties directly - should work without warning
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({ inputData: {} });
 
       expect(telemetry).toBeDefined();
@@ -4014,7 +4015,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({
         inputData: { prompt1: 'Capital of France, just the name', prompt2: 'Capital of UK, just the name' },
       });
@@ -4151,7 +4152,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({
         inputData: { prompt1: 'Capital of France, just the name', prompt2: 'Capital of UK, just the name' },
       });
@@ -4294,7 +4295,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 0 } });
 
       srv.close();
@@ -4446,7 +4447,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 0 } });
 
       srv.close();
@@ -4605,7 +4606,7 @@ describe('MastraInngestWorkflow', () => {
           port: (ctx as any).handlerPort,
         });
 
-        const run = counterWorkflow.createRun();
+        const run = await counterWorkflow.createRunAsync();
         const result = await run.start({ inputData: { startValue: 0 } });
 
         srv.close();
@@ -4764,7 +4765,7 @@ describe('MastraInngestWorkflow', () => {
           port: (ctx as any).handlerPort,
         });
 
-        const run = counterWorkflow.createRun();
+        const run = await counterWorkflow.createRunAsync();
         const result = await run.start({ inputData: { startValue: 0 } });
 
         srv.close();
@@ -4961,7 +4962,7 @@ describe('MastraInngestWorkflow', () => {
           port: (ctx as any).handlerPort,
         });
 
-        const run = counterWorkflow.createRun();
+        const run = await counterWorkflow.createRunAsync();
         const result = await run.start({ inputData: { startValue: 1 } });
 
         srv.close();
@@ -5115,7 +5116,7 @@ describe('MastraInngestWorkflow', () => {
         });
         await new Promise(resolve => setTimeout(resolve, 2000));
 
-        const run = counterWorkflow.createRun();
+        const run = await counterWorkflow.createRunAsync();
         const result = await run.start({ inputData: { startValue: 0 } });
 
         expect(begin).toHaveBeenCalledTimes(1);
@@ -5265,7 +5266,7 @@ describe('MastraInngestWorkflow', () => {
           port: (ctx as any).handlerPort,
         });
 
-        const run = counterWorkflow.createRun();
+        const run = await counterWorkflow.createRunAsync();
         const result = await run.start({ inputData: { startValue: 0 } });
         const results = result.steps;
 
@@ -5447,7 +5448,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 0 } });
 
       expect(passthroughStep.execute).toHaveBeenCalledTimes(2);
@@ -5609,7 +5610,7 @@ describe('MastraInngestWorkflow', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 2000));
 
-      const run = counterWorkflow.createRun();
+      const run = await counterWorkflow.createRunAsync();
       const result = await run.start({ inputData: { startValue: 0 } });
 
       srv.close();
@@ -5685,7 +5686,7 @@ describe('MastraInngestWorkflow', () => {
       await new Promise(resolve => setTimeout(resolve, 2000));
 
       // Access new instance properties directly - should work without warning
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({ inputData: {} });
 
       srv.close();
@@ -5746,7 +5747,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({ runtimeContext });
 
       srv.close();
@@ -5799,7 +5800,7 @@ describe('MastraInngestWorkflow', () => {
       });
       workflow.then(step).commit();
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       await run.start({ runtimeContext });
 
       const resumeruntimeContext = new RuntimeContext();
@@ -5871,7 +5872,7 @@ describe('MastraInngestWorkflow', () => {
         port: (ctx as any).handlerPort,
       });
 
-      const run = workflow.createRun();
+      const run = await workflow.createRunAsync();
       const result = await run.start({});
 
       srv.close();
@@ -5942,7 +5943,7 @@ describe('MastraInngestWorkflow', () => {
 
       const runId = 'test-run-id';
       let watchData: StreamEvent[] = [];
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId,
       });
 
@@ -6105,7 +6106,7 @@ describe('MastraInngestWorkflow', () => {
 
       const runId = 'test-run-id';
       let watchData: StreamEvent[] = [];
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId,
       });
 
@@ -6270,7 +6271,7 @@ describe('MastraInngestWorkflow', () => {
 
       const runId = 'test-run-id';
       let watchData: StreamEvent[] = [];
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId,
       });
 
@@ -6495,7 +6496,7 @@ describe('MastraInngestWorkflow', () => {
 
       await new Promise(resolve => setTimeout(resolve, 1000));
 
-      const run = promptEvalWorkflow.createRun();
+      const run = await promptEvalWorkflow.createRunAsync();
 
       const { stream, getWorkflowState } = run.stream({ inputData: { input: 'test' } });
 
@@ -6684,10 +6685,10 @@ describe('MastraInngestWorkflow', () => {
 
       await new Promise(resolve => setTimeout(resolve, 1000));
 
-      const run = workflow.createRun({
+      const run = await workflow.createRunAsync({
         runId: 'test-run-id',
       });
-      const { stream } = await run.stream({
+      const { stream } = run.stream({
         inputData: {
           prompt1: 'Capital of France, just the name',
           prompt2: 'Capital of UK, just the name',


### PR DESCRIPTION
## Description

Introduces a new async operation `createRunAsync()` that also stores a `pending` workflow state into storage. As such, `createRun` is deprecated and will `logger.warn()`.

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/4951

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
