### PR TITLE
fix(schema-compat): allow for object.passthrough

### DIFF
--- a/.changeset/sixty-stars-lick.md
+++ b/.changeset/sixty-stars-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Allow for object.passthrough in schema compat (aka MCP tool support).

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -58,6 +58,7 @@ const allSchemas = {
       age: z.number().gte(18),
     }),
   }),
+  objectPassthrough: z.object({}).passthrough().describe('add something in this object'),
 
   // Optional and nullable
   optional: z.string().optional(),

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.ts
@@ -45,7 +45,7 @@ export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
       const innerZodType = this.processZodType(value._def.innerType);
       return innerZodType.nullable();
     } else if (isObj(value)) {
-      return this.defaultZodObjectHandler(value);
+      return this.defaultZodObjectHandler(value, { passthrough: false });
     } else if (isArr(value)) {
       return this.defaultZodArrayHandler(value);
     } else if (isUnion(value)) {

--- a/packages/schema-compat/src/schema-compatibility.ts
+++ b/packages/schema-compat/src/schema-compatibility.ts
@@ -232,7 +232,10 @@ export abstract class SchemaCompatLayer {
    * @param value - The Zod object to process
    * @returns The processed Zod object
    */
-  public defaultZodObjectHandler(value: ZodObject<any, any, any>): ZodObject<any, any, any> {
+  public defaultZodObjectHandler(
+    value: ZodObject<any, any, any>,
+    options: { passthrough?: boolean } = { passthrough: true },
+  ): ZodObject<any, any, any> {
     const processedShape = Object.entries(value.shape).reduce<Record<string, ZodTypeAny>>((acc, [key, propValue]) => {
       acc[key] = this.processZodType(propValue as ZodTypeAny);
       return acc;
@@ -250,6 +253,11 @@ export abstract class SchemaCompatLayer {
     if (value.description) {
       result = result.describe(value.description);
     }
+
+    if (options.passthrough && value._def.unknownKeys === 'passthrough') {
+      result = result.passthrough();
+    }
+
     return result;
   }
 


### PR DESCRIPTION
## Description

Initially we didn't allow for passthrough as it's not a good pattern for writing tools as LLM's do much better with explicitly typed schemas. However some people try to use MCP servers that use this and because of that it fails every time. This PR allows for passthroughs to be used (except with OpenAI reasoning models as those throw errors when passthroughs are used). using an MCP that uses object.passthrough will not give you good performance, but at least they will work sometimes.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
