### PR TITLE
fix(core): working memory with generate title

### DIFF
--- a/.changeset/great-toys-repair.md
+++ b/.changeset/great-toys-repair.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixes generateTitle overwriting working memory when both get used in the same LLM response cycle.

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1350,6 +1350,7 @@ export class Agent<
         const messageListResponses = new MessageList({ threadId, resourceId })
           .add(result.response.messages, 'response')
           .get.all.core();
+
         const usedWorkingMemory = messageListResponses?.some(
           m => m.role === 'tool' && m?.content?.some(c => c?.toolName === 'updateWorkingMemory'),
         );
@@ -1359,14 +1360,6 @@ export class Agent<
             ? await memory?.getThreadById({ threadId })
             : undefined
           : threadAfter;
-
-        this.logger.debug(`[Agent:${this.name}] - Thread after: ${JSON.stringify(thread)}`, {
-          responseMessages: result.response.messages,
-          messageListResponses,
-          threadAfter,
-          usedWorkingMemory,
-          thread,
-        });
 
         if (memory && resourceId && thread) {
           try {
@@ -1404,15 +1397,6 @@ export class Agent<
               if (!title) {
                 return;
               }
-
-              this.logger.debug(`[Agent:${this.name}] - Saving thread with title: ${title}`, {
-                runId,
-                threadId: thread.id,
-                resourceId,
-                memoryConfig,
-                title,
-                metadata: thread.metadata,
-              });
 
               return memory.createThread({
                 threadId: thread.id,

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -72,6 +72,7 @@ export class MessageList {
   }
 
   public add(messages: string | string[] | MessageInput | MessageInput[], messageSource: MessageSource) {
+    if (!messages) return this;
     for (const message of Array.isArray(messages) ? messages : [messages]) {
       this.addOne(
         typeof message === `string`


### PR DESCRIPTION
## Description

When working memory and generate title are used in the same LLM response cycle before we would fetch the thread, then the LLM would update working memory. But we'd use the same thread object we fetched before the thread was updated to pass to the saveThread call in generateTitle. Now we check if we've used working memory, and if we have we need to fetch an updated thread object.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
