### PR TITLE
docs: AI SDK v5 beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ voice/**/test-data/
 
 serviceAccount.json
 tsup.config.bundled_*
+CLAUDE.local.md

--- a/docs/src/content/en/docs/frameworks/_meta.ts
+++ b/docs/src/content/en/docs/frameworks/_meta.ts
@@ -5,6 +5,7 @@ const meta = {
   },
   servers: "Servers",
   "web-frameworks": "Web Frameworks",
+  "ai-sdk-v5": "AI SDK v5 (beta)",
 };
 
 export default meta;

--- a/docs/src/content/en/docs/frameworks/ai-sdk-v5.mdx
+++ b/docs/src/content/en/docs/frameworks/ai-sdk-v5.mdx
@@ -1,0 +1,63 @@
+# AI SDK v5 (beta) Migration Guide
+
+This guide covers Mastra-specific considerations when migrating from AI SDK v4 to v5 beta.
+
+Please add any feedback or bug reports to the [AI SDK v5 mega issue in Github.](https://github.com/mastra-ai/mastra/issues/5470)
+
+## Official Migration Guide
+
+**Follow the official [AI SDK v5 Migration Guide](https://v5.ai-sdk.dev/docs/migration-guides/migration-guide-5-0)** for all AI SDK core breaking changes, package updates, and API changes.
+
+This guide covers only the Mastra-specific aspects of the migration.
+
+## Warnings
+
+- **Data compatibility**: New data stored in v5 format will no longer work if you downgrade from the beta
+- **Backup recommendation**: Keep DB backups from before you upgrade to v5 beta
+- **Production use**: Wait for the AI SDK v5 stable release before using in production applications
+- **Prerelease status**: The Mastra `ai-v5` tag is a prerelease version and may have bugs
+
+## Memory Storage
+
+Your existing AI SDK v4 data will run through our internal `MessageList` class which handles converting to/from various message formats.
+This includes converting from AI SDK v4->v5. This means you don't need to run any DB migrations and your data will be translated on the fly and will just work when you upgrade.
+
+
+## Migration Strategy
+
+Migrating to AI SDK v5 with Mastra involves updating both your **backend** (Mastra server) and **frontend**.
+We provides a compatibility mode to handle stream format conversion during the transition.
+
+### Backend Upgrade
+
+Bump Mastra to the new `ai-v5` prerelease version for all Mastra packages:
+
+```bash npm2yarn copy
+npm i mastra@ai-v5 @mastra/core@ai-v5 @mastra/memory@ai-v5 [etc]
+```
+
+Then configure your Mastra instance with v4 compatibility so you existing frontend will continue to work:
+
+```typescript
+import { Mastra } from '@mastra/core';
+
+export const mastra = new Mastra({
+  agents: { myAgent },
+  aiSdkCompat: 'v4', // <- add this for compatibility
+});
+```
+
+**Dependencies**: You will need to upgrade all AI SDK dependencies to use the new v5 beta versions in your backend when you bump to the Mastra `ai-v5` prerelease tag. In most cases this will only involve bumping your model provider packages. For example: `npm i @ai-sdk/openai@2.0.0-beta.1` - refer to the [AI SDK v5 documentation](https://v5.ai-sdk.dev/docs/migration-guides/migration-guide-5-0) for more info. Some model providers do not yet have V5 versions (Openrouter for example).
+
+### Frontend Upgrade
+
+When you're ready, remove the compatibility flag and upgrade your frontend:
+
+1. Remove `aiSdkCompat: 'v4'` from your Mastra configuration
+2. Follow the AI SDK guide on upgrading your frontend dependencies
+3. Update your frontend code for v5 breaking changes
+
+## Discussion and Bug Reports
+
+Please add any feedback or bug reports to the [AI SDK v5 mega issue in Github.](https://github.com/mastra-ai/mastra/issues/5470)
+

--- a/docs/src/content/en/docs/frameworks/ai-sdk-v5.mdx
+++ b/docs/src/content/en/docs/frameworks/ai-sdk-v5.mdx
@@ -36,7 +36,7 @@ Bump Mastra to the new `ai-v5` prerelease version for all Mastra packages:
 npm i mastra@ai-v5 @mastra/core@ai-v5 @mastra/memory@ai-v5 [etc]
 ```
 
-Then configure your Mastra instance with v4 compatibility so you existing frontend will continue to work:
+Then configure your Mastra instance with v4 compatibility so your existing frontend will continue to work:
 
 ```typescript
 import { Mastra } from '@mastra/core';

--- a/docs/src/content/en/docs/frameworks/ai-sdk-v5.mdx
+++ b/docs/src/content/en/docs/frameworks/ai-sdk-v5.mdx
@@ -26,7 +26,7 @@ This includes converting from AI SDK v4->v5. This means you don't need to run an
 ## Migration Strategy
 
 Migrating to AI SDK v5 with Mastra involves updating both your **backend** (Mastra server) and **frontend**.
-We provides a compatibility mode to handle stream format conversion during the transition.
+We provide a compatibility mode to handle stream format conversion during the transition.
 
 ### Backend Upgrade
 


### PR DESCRIPTION
This PR copies the docs from https://github.com/mastra-ai/mastra/pull/4512 so users can start trying the new `ai-v5` Mastra prerelease packages with AI SDK v5 beta.

