### PR TITLE
Fix provider tools to check for output schema before attaching to tool 

### DIFF
--- a/.changeset/lovely-dancers-exist.md
+++ b/.changeset/lovely-dancers-exist.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix provider tools to check for output schema before attaching to tool 

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -66,13 +66,15 @@ export class CoreToolBuilder extends MastraBase {
       typeof tool.id === 'string' &&
       tool.id.includes('.')
     ) {
+      const parameters = this.getParameters();
+      const outputSchema = this.getOutputSchema();
       return {
         type: 'provider-defined' as const,
         id: tool.id,
         args: ('args' in this.originalTool ? this.originalTool.args : {}) as Record<string, unknown>,
         description: tool.description,
-        parameters: convertZodSchemaToAISDKSchema(this.getParameters()),
-        outputSchema: convertZodSchemaToAISDKSchema(this.getOutputSchema()),
+        parameters: convertZodSchemaToAISDKSchema(parameters),
+        ...(outputSchema ? { outputSchema: convertZodSchemaToAISDKSchema(outputSchema) } : {}),
         execute: this.originalTool.execute
           ? this.createExecute(
               this.originalTool,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes an issue with provider-defined tools where adding tools such as websearchpreview would break stream calls, due to a zod issue when converting outputschema from zod schema to aisdkschema.
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
