### PR TITLE
fix(docs): paul/grwth-311-fix-hidden-h3s

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -311,6 +311,11 @@ header nav:nth-child(2) {
   }
 }
 
+/* Hack for Tabs / Nextra auto-inserted h3s */
+div[role="tabpanel"] > h3:first-child {
+  display: none;
+}
+
 /*****Main Content******/
 
 aside {


### PR DESCRIPTION
## Description

- Add specific rule to hide only first-child h3 of auto-inserted Nextra Tabs component. 

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
