### PR TITLE
[fix] Show chat thread custom title

### DIFF
--- a/packages/cli/src/playground/src/domains/agents/agent-sidebar.tsx
+++ b/packages/cli/src/playground/src/domains/agents/agent-sidebar.tsx
@@ -79,9 +79,8 @@ export function AgentSidebar({
           </ThreadItem>
 
           {reverseThreads.length === 0 && (
-            <Txt as="p" variant="ui-sm" className="text-icon3 py-3 px-5">
-              Your conversations will appear here
-              <br /> once you start chatting!
+            <Txt as="p" variant="ui-sm" className="text-icon3 py-3 px-5 max-w-[12rem]">
+              Your conversations will appear here once you start chatting!
             </Txt>
           )}
 
@@ -91,7 +90,7 @@ export function AgentSidebar({
             return (
               <ThreadItem isActive={isActive} key={thread.id}>
                 <ThreadLink as={Link} to={`/agents/${agentId}/chat/${thread.id}`}>
-                  <span className="text-muted-foreground">Chat from</span>
+                  <ThreadTitle title={thread.title} />
                   <span>{formatDay(thread.createdAt)}</span>
                 </ThreadLink>
 
@@ -118,4 +117,21 @@ export function AgentSidebar({
       </AlertDialog>
     </div>
   );
+}
+
+function isDefaultThreadName(name: string): boolean {
+  const defaultPattern = /^New Thread \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+  return defaultPattern.test(name);
+}
+
+function ThreadTitle({ title }: { title?: string }) {
+  if (!title) {
+    return null;
+  }
+
+  if (isDefaultThreadName(title)) {
+    return <span className="text-muted-foreground">Chat from</span>;
+  }
+
+  return <span className="truncate max-w-[14rem]">{title}</span>;
 }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

In https://github.com/mastra-ai/mastra/pull/4524 I mistakenly removed code presenting chat thread custom name, the fix bring the custom title back to UI. 

With fix when `generateTitle: true`

![CleanShot 2025-06-30 at 11 08 31](https://github.com/user-attachments/assets/7b405b3f-dd90-403c-aea8-e97329898da3)

With fix when `generateTitle: false`

![CleanShot 2025-06-30 at 11 05 06](https://github.com/user-attachments/assets/6a3f06bd-a2b1-4c9b-ba57-b50e191f7d55)



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

https://github.com/mastra-ai/mastra/issues/5487

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
