### PR TITLE
Fix tools bundling for Cloudflare Workers compatibility

### DIFF
--- a/.changeset/late-onions-call.md
+++ b/.changeset/late-onions-call.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+Added support for individual tool calling in cloudflare
+
+We're now bundling tools differently to make it compatible with other node runtimes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Test
         working-directory: ./e2e-tests/monorepo
-        run: pnpm test run
+        run: pnpm test
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
@@ -241,7 +241,7 @@ jobs:
 
       - name: Test
         working-directory: ./e2e-tests/create-mastra
-        run: pnpm test run
+        run: pnpm test
 
   e2e-commonjs:
     name: E2E CommonJS
@@ -286,7 +286,7 @@ jobs:
 
       - name: Test
         working-directory: ./e2e-tests/commonjs
-        run: pnpm test run
+        run: pnpm test
 
   e2e-kitchen-sink:
     name: E2E kitchen-sink

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Test
         working-directory: ./e2e-tests/monorepo
-        run: pnpm test
+        run: pnpm test run
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
@@ -241,7 +241,7 @@ jobs:
 
       - name: Test
         working-directory: ./e2e-tests/create-mastra
-        run: pnpm test
+        run: pnpm test run
 
   e2e-commonjs:
     name: E2E CommonJS
@@ -286,7 +286,7 @@ jobs:
 
       - name: Test
         working-directory: ./e2e-tests/commonjs
-        run: pnpm test
+        run: pnpm test run
 
   e2e-kitchen-sink:
     name: E2E kitchen-sink

--- a/e2e-tests/commonjs/package.json
+++ b/e2e-tests/commonjs/package.json
@@ -13,6 +13,6 @@
     "vitest": "^3.2.3"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest run"
   }
 }

--- a/e2e-tests/commonjs/setup.ts
+++ b/e2e-tests/commonjs/setup.ts
@@ -12,7 +12,8 @@ import { publishPackages } from '../_local-registry-setup/publish';
 export default async function setup(project: TestProject) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const rootDir = join(__dirname, '..', '..');
-  const teardown = await prepareMonorepo(rootDir, globby);
+  const tag = 'commonjs-e2e-test';
+  const teardown = await prepareMonorepo(rootDir, globby, tag);
 
   const verdaccioPath = require.resolve('verdaccio/bin/verdaccio');
   const port = await getPort();
@@ -24,7 +25,6 @@ export default async function setup(project: TestProject) {
 
   console.log('registry', registry.toString());
 
-  const tag = 'commonjs-e2e-test';
   project.provide('tag', tag);
   project.provide('registry', registry.toString());
 

--- a/e2e-tests/create-mastra/setup.ts
+++ b/e2e-tests/create-mastra/setup.ts
@@ -12,7 +12,8 @@ import { publishPackages } from '../_local-registry-setup/publish';
 export default async function setup(project: TestProject) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const rootDir = join(__dirname, '..', '..');
-  const teardown = await prepareMonorepo(rootDir, globby);
+  const tag = 'create-mastra-e2e-test';
+  const teardown = await prepareMonorepo(rootDir, globby, tag);
 
   const verdaccioPath = require.resolve('verdaccio/bin/verdaccio');
   const port = await getPort();
@@ -24,7 +25,6 @@ export default async function setup(project: TestProject) {
 
   console.log('registry', registry.toString());
 
-  const tag = 'create-mastra-e2e-test';
   project.provide('tag', tag);
   project.provide('registry', registry.toString());
 

--- a/e2e-tests/kitchen-sink/setup.ts
+++ b/e2e-tests/kitchen-sink/setup.ts
@@ -14,7 +14,8 @@ const require = createRequire(import.meta.url);
 export default async function setup() {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const rootDir = join(__dirname, '..', '..');
-  const teardown = await prepareMonorepo(rootDir, globby);
+  const tag = 'kitchen-sink-e2e-test';
+  const teardown = await prepareMonorepo(rootDir, globby, tag);
 
   const verdaccioPath = require.resolve('verdaccio/bin/verdaccio');
   const port = await getPort();
@@ -24,8 +25,6 @@ export default async function setup() {
   const registry = await startRegistry(verdaccioPath, port, registryLocation);
 
   console.log('[Setup] Registry started at ', registry.toString());
-
-  const tag = 'kitchen-sink-e2e-test';
 
   console.log('[Setup] Publishing packages');
 

--- a/e2e-tests/monorepo/package.json
+++ b/e2e-tests/monorepo/package.json
@@ -13,7 +13,7 @@
     "vitest": "^3.2.3"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest run"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/e2e-tests/monorepo/setup.ts
+++ b/e2e-tests/monorepo/setup.ts
@@ -12,7 +12,8 @@ import { publishPackages } from '../_local-registry-setup/publish';
 export default async function setup(project: TestProject) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const rootDir = join(__dirname, '..', '..');
-  const teardown = await prepareMonorepo(rootDir, globby);
+  const tag = 'monorepo-test';
+  const teardown = await prepareMonorepo(rootDir, globby, tag);
 
   const verdaccioPath = require.resolve('verdaccio/bin/verdaccio');
   const port = await getPort();
@@ -22,7 +23,6 @@ export default async function setup(project: TestProject) {
   await copyFile(join(__dirname, '../_local-registry-setup/verdaccio.yaml'), join(registryLocation, 'verdaccio.yaml'));
   const registry = await startRegistry(verdaccioPath, port, registryLocation);
 
-  const tag = 'monorepo-test';
   project.provide('tag', tag);
   project.provide('registry', registry.toString());
 

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -104,6 +104,14 @@ async function analyze(
           if (id.startsWith('@mastra/server')) {
             return fileURLToPath(import.meta.resolve(id));
           }
+
+          // Tools is generated dependency, we don't want it to be handled by the bundler but instead read from disk at runtime
+          if (id === '#tools') {
+            return {
+              id: '#tools',
+              external: true,
+            };
+          }
         },
       } satisfies Plugin,
       json(),
@@ -142,11 +150,19 @@ async function analyze(
   }
 
   for (const o of output) {
-    if (o.type !== 'chunk' || o.dynamicImports.length === 0) {
+    if (o.type !== 'chunk') {
       continue;
     }
 
-    for (const dynamicImport of o.dynamicImports) {
+    // Tools is generated dependency, we don't want our analyzer to handle it
+    const dynamicImports = o.dynamicImports.filter(d => d !== '#tools');
+    if (!dynamicImports.length) {
+      continue;
+    }
+
+    console.log(dynamicImports);
+
+    for (const dynamicImport of dynamicImports) {
       if (!depsToOptimize.has(dynamicImport) && !isNodeBuiltin(dynamicImport)) {
         depsToOptimize.set(dynamicImport, ['*']);
       }

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -96,6 +96,17 @@ export async function getInputOptions(
           { find: /^\#mastra$/, replacement: normalizedEntryFile },
         ],
       }),
+      {
+        name: 'tools-rewriter',
+        resolveId(id: string) {
+          if (id === '#tools') {
+            return {
+              id: './tools.mjs',
+              external: true,
+            };
+          }
+        },
+      },
       esbuild({
         target: 'node20',
         platform,

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -340,11 +340,22 @@ export abstract class Bundler extends MastraBundler {
       );
 
       await bundler.write();
-      const toolsInputOptions = Array.from(Object.keys(inputOptions.input || {}))
+      const toolImports: string[] = [];
+      const toolsExports: string[] = [];
+      Array.from(Object.keys(inputOptions.input || {}))
         .filter(key => key.startsWith('tools/'))
-        .map(key => `./${key}.mjs`);
+        .forEach((key, index) => {
+          const toolExport = `tool${index}`;
+          toolImports.push(`import * as ${toolExport} from './${key}.mjs';`);
+          toolsExports.push(toolExport);
+        });
 
-      await writeFile(join(bundleLocation, 'tools.mjs'), `export const tools = ${JSON.stringify(toolsInputOptions)};`);
+      await writeFile(
+        join(bundleLocation, 'tools.mjs'),
+        `${toolImports}
+
+export const tools = [${toolsExports.join(', ')}]`,
+      );
       this.logger.info('Bundling Mastra done');
 
       this.logger.info('Copying public files');

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -352,7 +352,7 @@ export abstract class Bundler extends MastraBundler {
 
       await writeFile(
         join(bundleLocation, 'tools.mjs'),
-        `${toolImports}
+        `${toolImports.join('\n')}
 
 export const tools = [${toolsExports.join(', ')}]`,
       );

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -113,16 +113,8 @@ export async function createHonoServer(mastra: Mastra, options: ServerBundleOpti
 
   let tools: Record<string, any> = {};
   try {
-    const toolsPath = './tools.mjs';
-    const mastraToolsPaths = (await import(toolsPath)).tools;
-    const toolImports = mastraToolsPaths
-      ? await Promise.all(
-          // @ts-ignore
-          mastraToolsPaths.map(async toolPath => {
-            return import(toolPath);
-          }),
-        )
-      : [];
+    // @ts-expect-error Tools is generated dependency
+    const toolImports = (await import('#tools')).tools as Record<string, Function>[];
 
     tools = toolImports.reduce((acc, toolModule) => {
       Object.entries(toolModule).forEach(([key, tool]) => {


### PR DESCRIPTION
## Summary

- Fixed tools bundling to support individual tool calling in Cloudflare Workers
- Modified bundler to handle `#tools` as external dependency instead of bundling it
- Updated tools.mjs generation to properly export individual tools as modules
- Added tools-rewriter plugin to resolve `#tools` imports correctly

## Changes

- **packages/deployer/src/build/analyze.ts**: Added external handling for `#tools` dependency
- **packages/deployer/src/build/bundler.ts**: Added tools-rewriter plugin for proper resolution
- **packages/deployer/src/bundler/index.ts**: Updated tools.mjs generation to export individual tool modules
- **packages/deployer/src/server/index.ts**: Simplified tools import to use `#tools` directly
- **Added changeset**: Documents the patch for `@mastra/deployer`

## Test plan

- [ ] Test tool execution in Cloudflare Workers environment
- [ ] Verify tools are properly bundled and accessible
- [ ] Ensure no regression in other deployment targets

🤖 Generated with [Claude Code](https://claude.ai/code)