### PR TITLE
refactor(@mastra/core): split out single-message methods from MessageList to new Message class

### DIFF
--- a/.changeset/split-message-class-11191.md
+++ b/.changeset/split-message-class-11191.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": minor
+"@mastra/memory": patch
+---
+
+Extract Message utility class from MessageList

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -46,7 +46,7 @@ import type {
 } from './types';
 
 export { MessageList };
-export { Message } from './message';
+export { Message } from './message-list/message';
 export * from './types';
 type IDGenerator = () => string;
 

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -46,6 +46,7 @@ import type {
 } from './types';
 
 export { MessageList };
+export { Message } from './message';
 export * from './types';
 type IDGenerator = () => string;
 

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -5,6 +5,7 @@ import type { MastraMessageV1 } from '../../memory';
 import { isCoreMessage, isUiMessage } from '../../utils';
 import { convertToV1Messages } from './prompt/convert-to-mastra-v1';
 import { convertDataContentToBase64String } from './prompt/data-content';
+import { Message as MastraMessage } from '../message';
 
 export type MastraMessageContentV2 = {
   format: 2; // format 2 === UIMessage in AI SDK v4
@@ -90,7 +91,7 @@ export class MessageList {
     const currentUserMessages = this.all.core().filter(m => m.role === 'user');
     const content = currentUserMessages.at(-1)?.content;
     if (!content) return null;
-    return MessageList.coreContentToString(content);
+    return MastraMessage.coreContentToString(content);
   }
   public get get() {
     return {
@@ -103,7 +104,7 @@ export class MessageList {
   private all = {
     v2: () => this.messages,
     v1: () => convertToV1Messages(this.messages),
-    ui: () => this.messages.map(MessageList.toUIMessage),
+    ui: () => this.messages.map(MastraMessage.toUIMessage),
     core: () => this.convertToCoreMessages(this.all.ui()),
     prompt: () => {
       const coreMessages = this.all.core();
@@ -120,13 +121,13 @@ export class MessageList {
   private remembered = {
     v2: () => this.messages.filter(m => this.memoryMessages.has(m)),
     v1: () => convertToV1Messages(this.remembered.v2()),
-    ui: () => this.remembered.v2().map(MessageList.toUIMessage),
+    ui: () => this.remembered.v2().map(MastraMessage.toUIMessage),
     core: () => this.convertToCoreMessages(this.remembered.ui()),
   };
   private input = {
     v2: () => this.messages.filter(m => this.newUserMessages.has(m)),
     v1: () => convertToV1Messages(this.input.v2()),
-    ui: () => this.input.v2().map(MessageList.toUIMessage),
+    ui: () => this.input.v2().map(MastraMessage.toUIMessage),
     core: () => this.convertToCoreMessages(this.input.ui()),
   };
   private response = {
@@ -198,76 +199,12 @@ export class MessageList {
     if (tag) {
       if (!this.taggedSystemMessages[tag]) return false;
       return this.taggedSystemMessages[tag].some(
-        m => MessageList.cacheKeyFromContent(m.content) === MessageList.cacheKeyFromContent(message.content),
+        m => MastraMessage.cacheKeyFromContent(m.content) === MastraMessage.cacheKeyFromContent(message.content),
       );
     }
     return this.systemMessages.some(
-      m => MessageList.cacheKeyFromContent(m.content) === MessageList.cacheKeyFromContent(message.content),
+      m => MastraMessage.cacheKeyFromContent(m.content) === MastraMessage.cacheKeyFromContent(message.content),
     );
-  }
-  private static toUIMessage(m: MastraMessageV2): UIMessage {
-    const experimentalAttachments: UIMessage['experimental_attachments'] = m.content.experimental_attachments
-      ? [...m.content.experimental_attachments]
-      : [];
-    const contentString =
-      typeof m.content.content === `string` && m.content.content !== ''
-        ? m.content.content
-        : m.content.parts.reduce((prev, part) => {
-            if (part.type === `text`) {
-              // return only the last text part like AI SDK does
-              return part.text;
-            }
-            return prev;
-          }, '');
-
-    const parts: MastraMessageContentV2['parts'] = [];
-    if (m.content.parts.length) {
-      for (const part of m.content.parts) {
-        if (part.type === `file`) {
-          experimentalAttachments.push({
-            contentType: part.mimeType,
-            url: part.data,
-          });
-        } else {
-          parts.push(part);
-        }
-      }
-    }
-
-    if (parts.length === 0 && experimentalAttachments.length > 0) {
-      // make sure we have atleast one part so this message doesn't get removed when converting to core message
-      parts.push({ type: 'text', text: '' });
-    }
-
-    if (m.role === `user`) {
-      return {
-        id: m.id,
-        role: m.role,
-        content: m.content.content || contentString,
-        createdAt: m.createdAt,
-        parts,
-        experimental_attachments: experimentalAttachments,
-      };
-    } else if (m.role === `assistant`) {
-      return {
-        id: m.id,
-        role: m.role,
-        content: m.content.content || contentString,
-        createdAt: m.createdAt,
-        parts,
-        reasoning: undefined,
-        toolInvocations: `toolInvocations` in m.content ? m.content.toolInvocations : undefined,
-      };
-    }
-
-    return {
-      id: m.id,
-      role: m.role,
-      content: m.content.content || contentString,
-      createdAt: m.createdAt,
-      parts,
-      experimental_attachments: experimentalAttachments,
-    };
   }
   private getMessageById(id: string) {
     return this.messages.find(m => m.id === id);
@@ -284,12 +221,12 @@ export class MessageList {
 
     return {
       exists: true,
-      shouldReplace: !MessageList.messagesAreEqual(existingMessage, message),
+      shouldReplace: !MastraMessage.messagesAreEqual(existingMessage, message),
       id: existingMessage.id,
     };
   }
   private addOne(message: MessageInput, messageSource: MessageSource) {
-    if (message.role === `system` && MessageList.isVercelCoreMessage(message)) return this.addSystem(message);
+    if (message.role === `system` && MastraMessage.isVercelCoreMessage(message)) return this.addSystem(message);
     if (message.role === `system`) {
       throw new Error(
         `A non-CoreMessage system message was added - this is not supported as we didn't expect this could happen. Please open a Github issue and let us know what you did to get here. This is the non-CoreMessage system message we received:
@@ -328,7 +265,7 @@ ${JSON.stringify(message, null, 2)}`,
     if (messageSource === `memory`) {
       for (const existingMessage of this.messages) {
         // don't double store any messages
-        if (MessageList.messagesAreEqual(existingMessage, messageV2)) {
+        if (MastraMessage.messagesAreEqual(existingMessage, messageV2)) {
           return;
         }
       }
@@ -393,7 +330,7 @@ ${JSON.stringify(message, null, 2)}`,
           // if there's no part at this index yet in the existing message we're merging into
           !latestMessage.content.parts[index] ||
           // or there is and the parts are not identical
-          MessageList.cacheKeyFromParts([latestMessage.content.parts[index]]) !== MessageList.cacheKeyFromParts([part])
+          MastraMessage.cacheKeyFromParts([latestMessage.content.parts[index]]) !== MastraMessage.cacheKeyFromParts([part])
         ) {
           // For all other part types that aren't already present, simply push them to the latest message's parts
           latestMessage.content.parts.push(part);
@@ -483,16 +420,16 @@ ${JSON.stringify(message, null, 2)}`,
       );
     }
 
-    if (MessageList.isMastraMessageV1(message)) {
+    if (MastraMessage.isMastraMessageV1(message)) {
       return this.mastraMessageV1ToMastraMessageV2(message, messageSource);
     }
-    if (MessageList.isMastraMessageV2(message)) {
+    if (MastraMessage.isMastraMessageV2(message)) {
       return this.hydrateMastraMessageV2Fields(message);
     }
-    if (MessageList.isVercelCoreMessage(message)) {
+    if (MastraMessage.isVercelCoreMessage(message)) {
       return this.vercelCoreMessageToMastraMessageV2(message, messageSource);
     }
-    if (MessageList.isVercelUIMessage(message)) {
+    if (MastraMessage.isVercelUIMessage(message)) {
       return this.vercelUIMessageToMastraMessageV2(message, messageSource);
     }
 
@@ -578,7 +515,7 @@ ${JSON.stringify(message, null, 2)}`,
 
     return {
       id: message.id || this.newMessageId(),
-      role: MessageList.getRole(message),
+      role: MastraMessage.getRole(message),
       createdAt: this.generateCreatedAt(messageSource, message.createdAt),
       threadId: this.memoryInfo?.threadId,
       resourceId: this.memoryInfo?.resourceId,
@@ -687,156 +624,11 @@ ${JSON.stringify(message, null, 2)}`,
 
     return {
       id,
-      role: MessageList.getRole(coreMessage),
+      role: MastraMessage.getRole(coreMessage),
       createdAt: this.generateCreatedAt(messageSource),
       threadId: this.memoryInfo?.threadId,
       resourceId: this.memoryInfo?.resourceId,
       content,
     };
-  }
-
-  static isVercelUIMessage(msg: MessageInput): msg is UIMessage {
-    return !MessageList.isMastraMessage(msg) && isUiMessage(msg);
-  }
-  static isVercelCoreMessage(msg: MessageInput): msg is CoreMessage {
-    return !MessageList.isMastraMessage(msg) && isCoreMessage(msg);
-  }
-  static isMastraMessage(msg: MessageInput): msg is MastraMessageV2 | MastraMessageV1 {
-    return MessageList.isMastraMessageV2(msg) || MessageList.isMastraMessageV1(msg);
-  }
-  static isMastraMessageV1(msg: MessageInput): msg is MastraMessageV1 {
-    return !MessageList.isMastraMessageV2(msg) && (`threadId` in msg || `resourceId` in msg);
-  }
-  static isMastraMessageV2(msg: MessageInput): msg is MastraMessageV2 {
-    return Boolean(
-      msg.content &&
-        !Array.isArray(msg.content) &&
-        typeof msg.content !== `string` &&
-        // any newly saved Mastra message v2 shape will have content: { format: 2 }
-        `format` in msg.content &&
-        msg.content.format === 2,
-    );
-  }
-  private static getRole(message: MessageInput): MastraMessageV2['role'] {
-    if (message.role === `assistant` || message.role === `tool`) return `assistant`;
-    if (message.role === `user`) return `user`;
-    // TODO: how should we handle data role?
-    throw new Error(
-      `BUG: add handling for message role ${message.role} in message ${JSON.stringify(message, null, 2)}`,
-    );
-  }
-  private static cacheKeyFromParts(parts: UIMessage['parts']): string {
-    let key = ``;
-    for (const part of parts) {
-      key += part.type;
-      if (part.type === `text`) {
-        // TODO: we may need to hash this with something like xxhash instead of using length
-        // for 99.999% of cases this will be fine though because we're comparing messages that have the same ID already.
-        key += part.text.length;
-      }
-      if (part.type === `tool-invocation`) {
-        key += part.toolInvocation.toolCallId;
-        key += part.toolInvocation.state;
-      }
-      if (part.type === `reasoning`) {
-        // TODO: we may need to hash this with something like xxhash instead of using length
-        // for 99.999% of cases this will be fine though because we're comparing messages that have the same ID already.
-        key += part.reasoning.length;
-        key += part.details.reduce((prev, current) => {
-          if (current.type === `text`) {
-            return prev + current.text.length + (current.signature?.length || 0);
-          }
-          return prev;
-        }, 0);
-      }
-      if (part.type === `file`) {
-        // TODO: we may need to hash this with something like xxhash instead of using length
-        // for 99.999% of cases this will be fine though because we're comparing messages that have the same ID already.
-        key += part.data.length;
-        key += part.mimeType;
-      }
-    }
-    return key;
-  }
-  private static coreContentToString(content: CoreMessage['content']): string {
-    if (typeof content === `string`) return content;
-
-    return content.reduce((p, c) => {
-      if (c.type === `text`) {
-        p += c.text;
-      }
-      return p;
-    }, '');
-  }
-  private static cacheKeyFromContent(content: CoreMessage['content']): string {
-    if (typeof content === `string`) return content;
-    let key = ``;
-    for (const part of content) {
-      key += part.type;
-      if (part.type === `text`) {
-        key += part.text.length;
-      }
-      if (part.type === `reasoning`) {
-        key += part.text.length;
-      }
-      if (part.type === `tool-call`) {
-        key += part.toolCallId;
-        key += part.toolName;
-      }
-      if (part.type === `tool-result`) {
-        key += part.toolCallId;
-        key += part.toolName;
-      }
-      if (part.type === `file`) {
-        key += part.filename;
-        key += part.mimeType;
-      }
-      if (part.type === `image`) {
-        key += part.image instanceof URL ? part.image.toString() : part.image.toString().length;
-        key += part.mimeType;
-      }
-      if (part.type === `redacted-reasoning`) {
-        key += part.data.length;
-      }
-    }
-    return key;
-  }
-  private static messagesAreEqual(one: MessageInput, two: MessageInput) {
-    const oneUI = MessageList.isVercelUIMessage(one) && one;
-    const twoUI = MessageList.isVercelUIMessage(two) && two;
-    if (oneUI && !twoUI) return false;
-    if (oneUI && twoUI) {
-      return MessageList.cacheKeyFromParts(one.parts) === MessageList.cacheKeyFromParts(two.parts);
-    }
-
-    const oneCM = MessageList.isVercelCoreMessage(one) && one;
-    const twoCM = MessageList.isVercelCoreMessage(two) && two;
-    if (oneCM && !twoCM) return false;
-    if (oneCM && twoCM) {
-      return MessageList.cacheKeyFromContent(oneCM.content) === MessageList.cacheKeyFromContent(twoCM.content);
-    }
-
-    const oneMM1 = MessageList.isMastraMessageV1(one) && one;
-    const twoMM1 = MessageList.isMastraMessageV1(two) && two;
-    if (oneMM1 && !twoMM1) return false;
-    if (oneMM1 && twoMM1) {
-      return (
-        oneMM1.id === twoMM1.id &&
-        MessageList.cacheKeyFromContent(oneMM1.content) === MessageList.cacheKeyFromContent(twoMM1.content)
-      );
-    }
-
-    const oneMM2 = MessageList.isMastraMessageV2(one) && one;
-    const twoMM2 = MessageList.isMastraMessageV2(two) && two;
-    if (oneMM2 && !twoMM2) return false;
-    if (oneMM2 && twoMM2) {
-      return (
-        oneMM2.id === twoMM2.id &&
-        MessageList.cacheKeyFromParts(oneMM2.content.parts) === MessageList.cacheKeyFromParts(twoMM2.content.parts)
-      );
-    }
-
-    // default to it did change. we'll likely never reach this codepath
-    return true;
   }
 }

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -2,10 +2,9 @@ import { randomUUID } from 'crypto';
 import { convertToCoreMessages } from 'ai';
 import type { CoreMessage, CoreSystemMessage, IDGenerator, Message, ToolCallPart, ToolInvocation, UIMessage } from 'ai';
 import type { MastraMessageV1 } from '../../memory';
-import { isCoreMessage, isUiMessage } from '../../utils';
+import { Message as MastraMessage } from './message';
 import { convertToV1Messages } from './prompt/convert-to-mastra-v1';
 import { convertDataContentToBase64String } from './prompt/data-content';
-import { Message as MastraMessage } from '../message';
 
 export type MastraMessageContentV2 = {
   format: 2; // format 2 === UIMessage in AI SDK v4
@@ -330,7 +329,8 @@ ${JSON.stringify(message, null, 2)}`,
           // if there's no part at this index yet in the existing message we're merging into
           !latestMessage.content.parts[index] ||
           // or there is and the parts are not identical
-          MastraMessage.cacheKeyFromParts([latestMessage.content.parts[index]]) !== MastraMessage.cacheKeyFromParts([part])
+          MastraMessage.cacheKeyFromParts([latestMessage.content.parts[index]]) !==
+            MastraMessage.cacheKeyFromParts([part])
         ) {
           // For all other part types that aren't already present, simply push them to the latest message's parts
           latestMessage.content.parts.push(part);

--- a/packages/core/src/agent/message-list/message.ts
+++ b/packages/core/src/agent/message-list/message.ts
@@ -1,6 +1,6 @@
 import type { CoreMessage, UIMessage } from 'ai';
-import { isCoreMessage, isUiMessage } from '../../utils';
 import type { MastraMessageV1 } from '../../memory';
+import { isCoreMessage, isUiMessage } from '../../utils';
 import type { MessageInput, MastraMessageV2 } from '../message-list';
 
 export class Message {
@@ -223,3 +223,4 @@ export class Message {
     };
   }
 }
+

--- a/packages/core/src/agent/message/index.ts
+++ b/packages/core/src/agent/message/index.ts
@@ -1,0 +1,225 @@
+import type { CoreMessage, UIMessage } from 'ai';
+import { isCoreMessage, isUiMessage } from '../../utils';
+import type { MastraMessageV1 } from '../../memory';
+import type { MessageInput, MastraMessageV2 } from '../message-list';
+
+export class Message {
+  static isVercelUIMessage(msg: MessageInput): msg is UIMessage {
+    return !Message.isMastraMessage(msg) && isUiMessage(msg);
+  }
+
+  static isVercelCoreMessage(msg: MessageInput): msg is CoreMessage {
+    return !Message.isMastraMessage(msg) && isCoreMessage(msg);
+  }
+
+  static isMastraMessage(msg: MessageInput): msg is MastraMessageV2 | MastraMessageV1 {
+    return Message.isMastraMessageV2(msg) || Message.isMastraMessageV1(msg);
+  }
+
+  static isMastraMessageV1(msg: MessageInput): msg is MastraMessageV1 {
+    return !Message.isMastraMessageV2(msg) && (`threadId` in msg || `resourceId` in msg);
+  }
+
+  static isMastraMessageV2(msg: MessageInput): msg is MastraMessageV2 {
+    return Boolean(
+      msg.content &&
+        !Array.isArray(msg.content) &&
+        typeof msg.content !== `string` &&
+        // any newly saved Mastra message v2 shape will have content: { format: 2 }
+        `format` in msg.content &&
+        msg.content.format === 2,
+    );
+  }
+
+  static getRole(message: MessageInput): MastraMessageV2['role'] {
+    if (message.role === `assistant` || message.role === `tool`) return `assistant`;
+    if (message.role === `user`) return `user`;
+    // TODO: how should we handle data role?
+    throw new Error(
+      `BUG: add handling for message role ${message.role} in message ${JSON.stringify(message, null, 2)}`,
+    );
+  }
+
+  static cacheKeyFromParts(parts: UIMessage['parts']): string {
+    let key = ``;
+    for (const part of parts) {
+      key += part.type;
+      if (part.type === `text`) {
+        // TODO: we may need to hash this with something like xxhash instead of using length
+        // for 99.999% of cases this will be fine though because we're comparing messages that have the same ID already.
+        key += part.text.length;
+      }
+      if (part.type === `tool-invocation`) {
+        key += part.toolInvocation.toolCallId;
+        key += part.toolInvocation.state;
+      }
+      if (part.type === `reasoning`) {
+        // TODO: we may need to hash this with something like xxhash instead of using length
+        // for 99.999% of cases this will be fine though because we're comparing messages that have the same ID already.
+        key += part.reasoning.length;
+        key += part.details.reduce((prev, current) => {
+          if (current.type === `text`) {
+            return prev + current.text.length + (current.signature?.length || 0);
+          }
+          return prev;
+        }, 0);
+      }
+      if (part.type === `file`) {
+        // TODO: we may need to hash this with something like xxhash instead of using length
+        // for 99.999% of cases this will be fine though because we're comparing messages that have the same ID already.
+        key += part.data.length;
+        key += part.mimeType;
+      }
+    }
+    return key;
+  }
+
+  static coreContentToString(content: CoreMessage['content']): string {
+    if (typeof content === `string`) return content;
+
+    return content.reduce((p, c) => {
+      if (c.type === `text`) {
+        p += c.text;
+      }
+      return p;
+    }, '');
+  }
+
+  static cacheKeyFromContent(content: CoreMessage['content']): string {
+    if (typeof content === `string`) return content;
+    let key = ``;
+    for (const part of content) {
+      key += part.type;
+      if (part.type === `text`) {
+        key += part.text.length;
+      }
+      if (part.type === `reasoning`) {
+        key += part.text.length;
+      }
+      if (part.type === `tool-call`) {
+        key += part.toolCallId;
+        key += part.toolName;
+      }
+      if (part.type === `tool-result`) {
+        key += part.toolCallId;
+        key += part.toolName;
+      }
+      if (part.type === `file`) {
+        key += part.filename;
+        key += part.mimeType;
+      }
+      if (part.type === `image`) {
+        key += part.image instanceof URL ? part.image.toString() : part.image.toString().length;
+        key += part.mimeType;
+      }
+      if (part.type === `redacted-reasoning`) {
+        key += part.data.length;
+      }
+    }
+    return key;
+  }
+
+  static messagesAreEqual(one: MessageInput, two: MessageInput) {
+    const oneUI = Message.isVercelUIMessage(one) && one;
+    const twoUI = Message.isVercelUIMessage(two) && two;
+    if (oneUI && !twoUI) return false;
+    if (oneUI && twoUI) {
+      return Message.cacheKeyFromParts(one.parts) === Message.cacheKeyFromParts(two.parts);
+    }
+
+    const oneCM = Message.isVercelCoreMessage(one) && one;
+    const twoCM = Message.isVercelCoreMessage(two) && two;
+    if (oneCM && !twoCM) return false;
+    if (oneCM && twoCM) {
+      return Message.cacheKeyFromContent(oneCM.content) === Message.cacheKeyFromContent(twoCM.content);
+    }
+
+    const oneMM1 = Message.isMastraMessageV1(one) && one;
+    const twoMM1 = Message.isMastraMessageV1(two) && two;
+    if (oneMM1 && !twoMM1) return false;
+    if (oneMM1 && twoMM1) {
+      return (
+        oneMM1.id === twoMM1.id &&
+        Message.cacheKeyFromContent(oneMM1.content) === Message.cacheKeyFromContent(twoMM1.content)
+      );
+    }
+
+    const oneMM2 = Message.isMastraMessageV2(one) && one;
+    const twoMM2 = Message.isMastraMessageV2(two) && two;
+    if (oneMM2 && !twoMM2) return false;
+    if (oneMM2 && twoMM2) {
+      return (
+        oneMM2.id === twoMM2.id &&
+        Message.cacheKeyFromParts(oneMM2.content.parts) === Message.cacheKeyFromParts(twoMM2.content.parts)
+      );
+    }
+
+    // default to it did change. we'll likely never reach this codepath
+    return true;
+  }
+
+  static toUIMessage(m: MastraMessageV2): UIMessage {
+    const experimentalAttachments: UIMessage['experimental_attachments'] = m.content.experimental_attachments
+      ? [...m.content.experimental_attachments]
+      : [];
+    const contentString =
+      typeof m.content.content === `string` && m.content.content !== ''
+        ? m.content.content
+        : m.content.parts.reduce((prev, part) => {
+            if (part.type === `text`) {
+              // return only the last text part like AI SDK does
+              return part.text;
+            }
+            return prev;
+          }, '');
+
+    const parts: MastraMessageV2['content']['parts'] = [];
+    if (m.content.parts.length) {
+      for (const part of m.content.parts) {
+        if (part.type === `file`) {
+          experimentalAttachments.push({
+            contentType: part.mimeType,
+            url: part.data,
+          });
+        } else {
+          parts.push(part);
+        }
+      }
+    }
+
+    if (parts.length === 0 && experimentalAttachments.length > 0) {
+      // make sure we have atleast one part so this message doesn't get removed when converting to core message
+      parts.push({ type: 'text', text: '' });
+    }
+
+    if (m.role === `user`) {
+      return {
+        id: m.id,
+        role: m.role,
+        content: m.content.content || contentString,
+        createdAt: m.createdAt,
+        parts,
+        experimental_attachments: experimentalAttachments,
+      };
+    } else if (m.role === `assistant`) {
+      return {
+        id: m.id,
+        role: m.role,
+        content: m.content.content || contentString,
+        createdAt: m.createdAt,
+        parts,
+        reasoning: undefined,
+        toolInvocations: `toolInvocations` in m.content ? m.content.toolInvocations : undefined,
+      };
+    }
+
+    return {
+      id: m.id,
+      role: m.role,
+      content: m.content.content || contentString,
+      createdAt: m.createdAt,
+      parts,
+      experimental_attachments: experimentalAttachments,
+    };
+  }
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,6 +1,6 @@
 import { deepMerge } from '@mastra/core';
 import type { CoreTool, MastraMessageV1 } from '@mastra/core';
-import { MessageList } from '@mastra/core/agent';
+import { MessageList, Message } from '@mastra/core/agent';
 import type { MastraMessageV2 } from '@mastra/core/agent';
 import { MastraMemory } from '@mastra/core/memory';
 import type { MemoryConfig, SharedMemoryConfig, StorageThreadType, WorkingMemoryTemplate } from '@mastra/core/memory';
@@ -458,7 +458,7 @@ export class Memory extends MastraMemory {
     // Then strip working memory tags from all messages
     const updatedMessages = messages
       .map(m => {
-        if (MessageList.isMastraMessageV1(m)) {
+        if (Message.isMastraMessageV1(m)) {
           return this.updateMessageToHideWorkingMemory(m);
         }
         // add this to prevent "error saving undefined in the db" if a project is on an earlier storage version but new memory/storage
@@ -480,7 +480,7 @@ export class Memory extends MastraMemory {
         updatedMessages.map(async message => {
           let textForEmbedding: string | null = null;
 
-          if (MessageList.isMastraMessageV2(message)) {
+          if (Message.isMastraMessageV2(message)) {
             if (
               message.content.content &&
               typeof message.content.content === 'string' &&
@@ -496,7 +496,7 @@ export class Memory extends MastraMemory {
                 .trim();
               if (joined) textForEmbedding = joined;
             }
-          } else if (MessageList.isMastraMessageV1(message)) {
+          } else if (Message.isMastraMessageV1(message)) {
             if (message.content && typeof message.content === 'string' && message.content.trim() !== '') {
               textForEmbedding = message.content;
             } else if (message.content && Array.isArray(message.content) && message.content.length > 0) {


### PR DESCRIPTION
Small refactor - we'll likely expand this to move more logic for each individual message and start creating `new Message` instances in a follow up PR