### PR TITLE
fix(docs): border of elements in light mode

### DIFF
--- a/docs/gt.config.json
+++ b/docs/gt.config.json
@@ -12,6 +12,6 @@
     }
   },
   "locales": ["ja"],
-  "projectId": "87a3e295-8ed3-43c1-9ddf-2f8a434b79e7",
+  "projectId": "48751091-773e-4a3e-8c83-5c3906117b30",
   "_versionId": "09b076bef944e00e2c564e838bda36e6a060f9fe9048b63e739a0525fa81f47e"
 }

--- a/docs/src/app/[locale]/layout.tsx
+++ b/docs/src/app/[locale]/layout.tsx
@@ -8,7 +8,7 @@ import { fonts } from "../font/setup";
 import "../globals.css";
 
 import { PostHogProvider } from "@/analytics/posthog-provider";
-import { CookieConsent } from "@/components/cookie-consent";
+import { CookieConsent } from "@/components/cookie/cookie-consent";
 import { NextraLayout } from "@/components/nextra-layout";
 import { GTProvider } from "gt-next";
 import { CustomHead } from "@/components/custom-head";
@@ -64,7 +64,6 @@ export default async function RootLayout({
           <PostHogProvider>
             <NextraLayout stars={stars} locale={locale} pageMap={pageMap}>
               <NuqsAdapter>{children}</NuqsAdapter>
-              {/* {<DocsChat />} */}
             </NextraLayout>
           </PostHogProvider>
           <Toaster />

--- a/docs/src/components/cards/card-grid.tsx
+++ b/docs/src/components/cards/card-grid.tsx
@@ -3,9 +3,7 @@ import Link from "next/link";
 
 export const CardGrid = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 content-stretch gap-4 py-4">
-      {children}
-    </div>
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 py-4">{children}</div>
   );
 };
 
@@ -19,16 +17,13 @@ export const CardGridItem = ({
   href: string;
 }) => {
   return (
-    <div className="relative isolate">
-      <Card className="h-full">
-        <Link href={href}>
-          <span className="absolute inset-0 z-10" />
-          <CardHeader>
-            <CardTitle>{title}</CardTitle>
-          </CardHeader>
-        </Link>
-        <CardContent>{description}</CardContent>
-      </Card>
-    </div>
+    <Card className="h-full shadow-none dark:border-[var(--border)] border-[var(--light-border-muted)]">
+      <Link href={href}>
+        <CardHeader>
+          <CardTitle className="text-lg">{title}</CardTitle>
+        </CardHeader>
+      </Link>
+      <CardContent className="text-sm">{description}</CardContent>
+    </Card>
   );
 };

--- a/docs/src/components/cookie/cookie-banner.tsx
+++ b/docs/src/components/cookie/cookie-banner.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Button } from "./ui/button";
+import { Button } from "../ui/button";
 
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { T } from "gt-next/client";

--- a/docs/src/components/cookie/cookie-consent.tsx
+++ b/docs/src/components/cookie/cookie-consent.tsx
@@ -4,7 +4,7 @@
 import Script from "next/script";
 import { useState } from "react";
 import { CookieBanner } from "./cookie-banner";
-import HubspotTracker from "./hubspot-tracker";
+import HubspotTracker from "../hubspot-tracker";
 
 declare global {
   interface Window {

--- a/docs/src/components/footer.tsx
+++ b/docs/src/components/footer.tsx
@@ -68,7 +68,7 @@ export const Footer = () => {
         className="flex z-30  mx-auto bg-[#fafafa] dark:bg-transparent border-[var(--light-border-muted)]  dark:border-t-[var(--border)]  relative w-full border-t-[0.5px] flex-col items-center pt-8 lg:pt-[5rem] pb-24 md:pb-32 footer data-[state=false]:mt-8 "
       >
         <div className="flex max-w-(--nextra-content-width) pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)] flex-col lg:flex-row gap-16 lg:gap-0 w-full justify-between">
-          <div>
+          <div className="dark:text-white">
             <Logo />
             <div className="md:hidden pt-10">
               <label


### PR DESCRIPTION
## Description

Fix border of guide cards in light mode.

Before:
![CleanShot 2025-07-01 at 12 24 00@2x](https://github.com/user-attachments/assets/8afa23b0-f2bd-43d4-ad8b-d7337bb439cd)

After fix:
![CleanShot 2025-07-01 at 12 23 51@2x](https://github.com/user-attachments/assets/14db6870-a96b-4bb4-99ca-08618a357551)

## Related Issue(s)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
