### PR TITLE
fix(@mastra/mcp-docs-server): reduce number of used tokens for code examples

### DIFF
--- a/.changeset/clever-foxes-dance.md
+++ b/.changeset/clever-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@mastra/mcp-docs-server": patch
+---
+
+Slimmed down the number of tokens in each code example by removing extra keys from package.json files and adding an mcp docs config file into code examples to intentionally exclude some files - for ex the agent-network example went from 1300 LOC to 300

--- a/examples/agent-network/.mcp-docs.json
+++ b/examples/agent-network/.mcp-docs.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["mastra/agents/**", "mastra/tools/**", "workflows/step*.ts"]
+}

--- a/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
+++ b/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
@@ -5,6 +5,36 @@ import { fromPackageRoot, fromRepoRoot, log } from '../utils.js';
 const EXAMPLES_SOURCE = fromRepoRoot('examples');
 const OUTPUT_DIR = fromPackageRoot('.docs/organized/code-examples');
 
+interface ExampleConfig {
+  ignore?: string[];
+  include?: string[];
+  maxLines?: number;
+}
+
+/**
+ * Load example-specific configuration
+ */
+async function loadExampleConfig(examplePath: string): Promise<ExampleConfig> {
+  try {
+    const configPath = path.join(examplePath, '.mcp-docs.json');
+    const configContent = await fs.readFile(configPath, 'utf-8');
+    return JSON.parse(configContent);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Check if a file path matches any ignore patterns
+ */
+function shouldIgnoreFile(filePath: string, ignorePatterns: string[] = []): boolean {
+  return ignorePatterns.some(pattern => {
+    // Support simple glob patterns
+    const regex = pattern.replace(/\*/g, '.*').replace(/\?/g, '.').replace(/\//g, '\\/');
+    return new RegExp(regex).test(filePath);
+  });
+}
+
 /**
  * Scans example directories and creates flattened code example files
  */
@@ -27,24 +57,47 @@ export async function prepareCodeExamples() {
     const examplePath = path.join(EXAMPLES_SOURCE, dir.name);
     const outputFile = path.join(OUTPUT_DIR, `${dir.name}.md`);
 
+    // Load example-specific configuration
+    const config = await loadExampleConfig(examplePath);
+
     // Collect all relevant files
     const files: { path: string; content: string }[] = [];
 
-    // First add package.json if it exists
-    try {
-      const packageJson = await fs.readFile(path.join(examplePath, 'package.json'), 'utf-8');
-      files.push({
-        path: 'package.json',
-        content: packageJson,
-      });
-    } catch {
-      // Skip if no package.json
+    // First add package.json if it exists and not ignored
+    if (!shouldIgnoreFile('package.json', config.ignore)) {
+      try {
+        const packageJsonContent = await fs.readFile(path.join(examplePath, 'package.json'), 'utf-8');
+        const packageJson = JSON.parse(packageJsonContent);
+
+        for (const key of [
+          'scripts',
+          'private',
+          'type',
+          'description',
+          'version',
+          'main',
+          'pnpm',
+          'packageManager',
+          'keywords',
+          'author',
+          'license',
+        ]) {
+          if (key in packageJson) delete packageJson[key];
+        }
+
+        files.push({
+          path: 'package.json',
+          content: JSON.stringify(packageJson, null, 2),
+        });
+      } catch {
+        // Skip if no package.json
+      }
     }
 
     // Then scan for TypeScript files in src
     try {
       const srcPath = path.join(examplePath, 'src');
-      await scanDirectory(srcPath, srcPath, files);
+      await scanDirectory(srcPath, srcPath, files, config.ignore);
     } catch {
       // Skip if no src directory
     }
@@ -57,8 +110,8 @@ export async function prepareCodeExamples() {
 
       const totalLines = output.split('\n').length;
 
-      // Skip if total lines would exceed 1000
-      const limit = 1000;
+      // Skip if total lines would exceed limit
+      const limit = config.maxLines || 1000;
       if (totalLines > limit) {
         log(`Skipping ${dir.name}: ${totalLines} lines exceeds limit of ${limit}`);
         continue;
@@ -73,21 +126,70 @@ export async function prepareCodeExamples() {
 /**
  * Recursively scan a directory for TypeScript files
  */
-async function scanDirectory(basePath: string, currentPath: string, files: { path: string; content: string }[]) {
+async function scanDirectory(
+  basePath: string,
+  currentPath: string,
+  files: { path: string; content: string }[],
+  ignorePatterns?: string[],
+) {
   const entries = await fs.readdir(currentPath, { withFileTypes: true });
+  const depth = path.relative(basePath, currentPath).split(path.sep).filter(Boolean).length;
 
+  // Prioritize important files
+  const importantFiles = ['index.ts', 'mastra.ts', 'agent.ts', 'workflow.ts', 'tool.ts'];
+  const isImportantFile = (name: string) => importantFiles.some(f => name.endsWith(f));
+
+  // First pass: collect important files
   for (const entry of entries) {
     const fullPath = path.join(currentPath, entry.name);
     const relativePath = path.relative(basePath, fullPath);
 
-    if (entry.isDirectory()) {
-      await scanDirectory(basePath, fullPath, files);
-    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+    // Skip if file matches ignore patterns
+    if (shouldIgnoreFile(relativePath, ignorePatterns)) {
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.ts') && isImportantFile(entry.name)) {
       const content = await fs.readFile(fullPath, 'utf-8');
       files.push({
         path: relativePath,
         content,
       });
+    }
+  }
+
+  // Second pass: handle directories (limit depth to 2)
+  if (depth < 2) {
+    for (const entry of entries) {
+      const fullPath = path.join(currentPath, entry.name);
+      const relativePath = path.relative(basePath, fullPath);
+
+      // Skip if directory matches ignore patterns
+      if (entry.isDirectory() && !shouldIgnoreFile(relativePath, ignorePatterns)) {
+        await scanDirectory(basePath, fullPath, files, ignorePatterns);
+      }
+    }
+  }
+
+  // Third pass: add remaining .ts files if we still have room
+  for (const entry of entries) {
+    const fullPath = path.join(currentPath, entry.name);
+    const relativePath = path.relative(basePath, fullPath);
+
+    // Skip if file matches ignore patterns
+    if (shouldIgnoreFile(relativePath, ignorePatterns)) {
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.ts') && !isImportantFile(entry.name)) {
+      // Check if we already added this file
+      if (!files.some(f => f.path === relativePath)) {
+        const content = await fs.readFile(fullPath, 'utf-8');
+        files.push({
+          path: relativePath,
+          content,
+        });
+      }
     }
   }
 }

--- a/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
+++ b/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
@@ -7,7 +7,6 @@ const OUTPUT_DIR = fromPackageRoot('.docs/organized/code-examples');
 
 interface ExampleConfig {
   ignore?: string[];
-  include?: string[];
   maxLines?: number;
 }
 

--- a/packages/mcp-docs-server/src/tools/__tests__/examples.test.ts
+++ b/packages/mcp-docs-server/src/tools/__tests__/examples.test.ts
@@ -1,4 +1,6 @@
+import fs from 'node:fs/promises';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { fromPackageRoot } from '../../utils.js';
 import { callTool, mcp } from './test-setup';
 
 describe('examplesTool', () => {
@@ -152,6 +154,41 @@ describe('examplesTool', () => {
       });
       // Should not throw, and should suggest or return content related to 'agent'
       expect(result.toLowerCase()).toMatch(/agent/);
+    });
+
+    it('should have all expected examples in the .docs/organized/code-examples directory', async () => {
+      // Get the path to the examples directory
+      const docsExamplesDir = fromPackageRoot('.docs/organized/code-examples');
+
+      // Get all .md files from the docs examples directory
+      const docsExampleFiles = await fs.readdir(docsExamplesDir);
+      const docsExamples = docsExampleFiles
+        .filter(file => file.endsWith('.md'))
+        .map(file => file.replace('.md', ''))
+        .sort();
+
+      // Check that each source example has a corresponding docs file
+      // (unless it was skipped due to size limits)
+      const skippedExamples = ['dane', 'travel-app', 'yc-directory']; // Known large examples that are skipped
+
+      for (const skipped of skippedExamples) {
+        expect(docsExamples).not.toContain(skipped);
+      }
+
+      // Also verify that we have at least some expected examples
+      const expectedExamples = [
+        'quick-start',
+        'agent',
+        'agent-network',
+        'bird-checker-with-express',
+        'bird-checker-with-nextjs',
+        'memory-todo-agent',
+        'weather-agent',
+      ];
+
+      for (const example of expectedExamples) {
+        expect(docsExamples).toContain(example);
+      }
     });
   });
 });


### PR DESCRIPTION
Tests on main are failing because the agent-network code example grew and exceeded the max # LOC for an mcp-docs code example.
This PR lowers the number of lines included by selectively removing package.json lines, and adding a config file to examples to intentionally exclude unneeded files