### PR TITLE
fix create-run async docs link

### DIFF
--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -172,7 +172,7 @@ const result = await run.start({
 
 console.log(JSON.stringify(result, null, 2));
 ```
-> see [createRunAsync](/reference/workflows/create-run-async) and [start](/reference/workflows/start) for more information.
+> see [createRunAsync](/reference/workflows/create-run) and [start](/reference/workflows/start) for more information.
 
 To trigger this workflow, run the following:
 


### PR DESCRIPTION
Looks like this link was updated recently to point to a page that doesn't exist 