### PR TITLE
Improve resolving of dependencies when using tsconfigpaths

### DIFF
--- a/.changeset/major-lights-listen.md
+++ b/.changeset/major-lights-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Resolve dependency of tsConfigPath modules


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
When using tsconfigpaths in monorepo (not really sure why you would do it), we now resolve dependencies from the right place using dev.

Tsconfigpaths resolver, compiles ts files to js and inlines them in the bundle which breaks resolving as we're not resolving from the module anymore but rather from the .mastra/output dir.


## Related Issue(s)

Fixes #5584
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
