### PR TITLE
Allow D1Store to be configured using an inline client implementation

### DIFF
--- a/.changeset/five-socks-fix.md
+++ b/.changeset/five-socks-fix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloudflare-d1': patch
+---
+
+Allow D1Store to be configured using an inline client implementation

--- a/stores/cloudflare-d1/README.md
+++ b/stores/cloudflare-d1/README.md
@@ -54,6 +54,21 @@ const store = new D1Store({
 });
 ```
 
+### Or you can pass any client implementation you want
+
+```typescript
+import { D1Store } from '@mastra/cloudflare-d1';
+
+const store = new D1Store({
+  client: {
+    query: ({ sql, params }) => {
+      // do something
+    },
+  },
+  tablePrefix: 'mastra_', // optional
+});
+```
+
 ## Supported Methods
 
 ### Thread Operations


### PR DESCRIPTION
## Description
Copy of #5591 

This PR adds support for custom D1 clients in the CloudflareD1Store by introducing a new `D1ClientConfig` configuration option. This allows users to inject their own D1-compatible client implementation, enabling integration with custom HTTP endpoints that follow the D1 query interface without requiring the full Cloudflare SDK.

The change adds a third configuration option alongside the existing REST API and Workers Binding configurations, making the storage layer more flexible while maintaining backward compatibility.

## Related Issue(s)

<!-- No specific issue referenced -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

---------

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
