### PR TITLE
fix(dynamodb): change saveThread from create to upsert to handle updates (#5668)

### DIFF
--- a/.changeset/fruity-moments-arrive.md
+++ b/.changeset/fruity-moments-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dynamodb': minor
+---
+
+Change DynamoDB saveThread from create to upsert to handle updates.

--- a/stores/dynamodb/src/storage/index.test.ts
+++ b/stores/dynamodb/src/storage/index.test.ts
@@ -481,6 +481,123 @@ describe('DynamoDBStore Integration Tests', () => {
         expect(updatedThread).toBeDefined();
         expect(updatedThread!.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
       });
+
+      test('saveThread upsert: should create new thread when thread does not exist', async () => {
+        const threadId = `upsert-new-${randomUUID()}`;
+        const now = new Date();
+        const thread: StorageThreadType = {
+          id: threadId,
+          resourceId: 'resource-upsert-new',
+          title: 'New Thread via Upsert',
+          createdAt: now,
+          updatedAt: now,
+          metadata: { operation: 'create', test: true },
+        };
+
+        // Save the thread (should create new)
+        await expect(store.saveThread({ thread })).resolves.not.toThrow();
+
+        // Verify the thread was created
+        const retrieved = await store.getThreadById({ threadId });
+        expect(retrieved).toBeDefined();
+        expect(retrieved?.id).toBe(threadId);
+        expect(retrieved?.title).toBe('New Thread via Upsert');
+        expect(retrieved?.resourceId).toBe('resource-upsert-new');
+        expect(retrieved?.metadata).toEqual({ operation: 'create', test: true });
+      });
+
+      test('saveThread upsert: should update existing thread when thread already exists', async () => {
+        const threadId = `upsert-update-${randomUUID()}`;
+        const initialCreatedAt = new Date();
+
+        // Create initial thread
+        const initialThread: StorageThreadType = {
+          id: threadId,
+          resourceId: 'resource-upsert-initial',
+          title: 'Initial Thread Title',
+          createdAt: initialCreatedAt,
+          updatedAt: initialCreatedAt,
+          metadata: { operation: 'initial', version: 1 },
+        };
+        await store.saveThread({ thread: initialThread });
+
+        // Wait a small amount to ensure different timestamp
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Update the thread with same ID but different data
+        const updatedThread: StorageThreadType = {
+          id: threadId,
+          resourceId: 'resource-upsert-updated',
+          title: 'Updated Thread Title',
+          createdAt: initialCreatedAt, // Keep original creation time
+          updatedAt: new Date(), // New update time
+          metadata: { operation: 'update', version: 2 },
+        };
+        await expect(store.saveThread({ thread: updatedThread })).resolves.not.toThrow();
+
+        // Verify the thread was updated
+        const retrieved = await store.getThreadById({ threadId });
+        expect(retrieved).toBeDefined();
+        expect(retrieved?.id).toBe(threadId);
+        expect(retrieved?.title).toBe('Updated Thread Title');
+        expect(retrieved?.resourceId).toBe('resource-upsert-updated');
+        expect(retrieved?.metadata).toEqual({ operation: 'update', version: 2 });
+
+        // updatedAt should be newer than the initial creation time
+        expect(retrieved?.updatedAt.getTime()).toBeGreaterThan(initialCreatedAt.getTime());
+        // createdAt should remain the same or be the initial creation time
+        expect(retrieved?.createdAt.getTime()).toBeLessThanOrEqual(retrieved!.updatedAt.getTime());
+      });
+
+      test('saveThread upsert: should handle complex metadata updates', async () => {
+        const threadId = `upsert-metadata-${randomUUID()}`;
+        const initialMetadata = {
+          user: 'initial-user',
+          tags: ['initial', 'test'],
+          count: 1,
+        };
+
+        // Create initial thread with complex metadata
+        const initialThread: StorageThreadType = {
+          id: threadId,
+          resourceId: 'resource-metadata-test',
+          title: 'Metadata Test Thread',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: initialMetadata,
+        };
+        await store.saveThread({ thread: initialThread });
+
+        // Wait a small amount to ensure different timestamp
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Update with completely different metadata structure
+        const updatedMetadata = {
+          user: 'updated-user',
+          settings: { theme: 'light', language: 'ja', notifications: true },
+          tags: ['updated', 'upsert', 'complex'],
+          count: 5,
+          newField: { nested: { deeply: 'value' } },
+        };
+
+        const updatedThread: StorageThreadType = {
+          id: threadId,
+          resourceId: 'resource-metadata-test',
+          title: 'Updated Metadata Thread',
+          createdAt: initialThread.createdAt,
+          updatedAt: new Date(),
+          metadata: updatedMetadata,
+        };
+        await expect(store.saveThread({ thread: updatedThread })).resolves.not.toThrow();
+
+        // Verify the metadata was completely replaced
+        const retrieved = await store.getThreadById({ threadId });
+        expect(retrieved).toBeDefined();
+        expect(retrieved?.metadata).toEqual(updatedMetadata);
+        expect(retrieved?.metadata?.user).toBe('updated-user');
+        expect(retrieved?.metadata?.tags).toEqual(['updated', 'upsert', 'complex']);
+        expect(retrieved?.title).toBe('Updated Metadata Thread');
+      });
     });
 
     describe('Batch Operations', () => {

--- a/stores/dynamodb/src/storage/index.test.ts
+++ b/stores/dynamodb/src/storage/index.test.ts
@@ -545,8 +545,8 @@ describe('DynamoDBStore Integration Tests', () => {
 
         // updatedAt should be newer than the initial creation time
         expect(retrieved?.updatedAt.getTime()).toBeGreaterThan(initialCreatedAt.getTime());
-        // createdAt should remain the same or be the initial creation time
-        expect(retrieved?.createdAt.getTime()).toBeLessThanOrEqual(retrieved!.updatedAt.getTime());
+        // createdAt should remain exactly equal to the initial creation time
+        expect(retrieved?.createdAt.getTime()).toBe(initialCreatedAt.getTime());
       });
 
       test('saveThread upsert: should handle complex metadata updates', async () => {

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -598,7 +598,7 @@ export class DynamoDBStore extends MastraStorage {
     };
 
     try {
-      await this.service.entities.thread.create(threadData).go();
+      await this.service.entities.thread.upsert(threadData).go();
 
       return {
         id: thread.id,


### PR DESCRIPTION
## Description

Changed DynamoDB's saveThread operation from create to upsert to fix conditional request errors when updating existing threads with automatic title generation.

- Modified `stores/dynamodb/src/storage/index.ts` to use upsert operation instead of create for thread saves, aligning with other store implementations
- Added comprehensive test coverage in `stores/dynamodb/src/storage/index.test.ts` for both new thread creation and updates
- This change ensures consistent behavior across different storage backends when handling thread updates

## Related Issue(s)

#5668

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
