### PR TITLE
fix: wrong redirects in react-router

### DIFF
--- a/.changeset/free-rooms-go.md
+++ b/.changeset/free-rooms-go.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'@mastra/core': patch
+---
+
+fix redirection when clicking on the playground breadcrumbs

--- a/packages/cli/src/playground/src/App.tsx
+++ b/packages/cli/src/playground/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, BrowserRouter, Navigate, Outlet } from 'react-router';
+import { Routes, Route, BrowserRouter, Outlet } from 'react-router';
 
 import { Layout } from '@/components/layout';
 
@@ -32,6 +32,7 @@ import { McpServerPage } from './pages/mcps/[serverId]';
 import { WorkflowGraphLayout } from './pages/workflows/layouts/workflow-graph-layout';
 import { MastraClientProvider } from '@mastra/playground-ui';
 import VNextNetwork from './pages/networks/network/v-next';
+import { NavigateTo } from './lib/react-router';
 
 function App() {
   const [queryClient] = useState(() => new QueryClient());
@@ -52,7 +53,7 @@ function App() {
                 <Route path="/networks" element={<Networks />} />
                 <Route
                   path="/networks/v-next/:networkId"
-                  element={<Navigate to="/networks/v-next/:networkId/chat" />}
+                  element={<NavigateTo to="/networks/v-next/:networkId/chat" />}
                 />
                 <Route
                   path="/networks/v-next/:networkId"
@@ -65,7 +66,7 @@ function App() {
                   <Route path="chat" element={<VNextNetwork />} />
                   <Route path="chat/:threadId" element={<VNextNetwork />} />
                 </Route>
-                <Route path="/networks/:networkId" element={<Navigate to="/networks/:networkId/chat" />} />
+                <Route path="/networks/:networkId" element={<NavigateTo to="/networks/:networkId/chat" />} />
                 <Route
                   path="/networks/:networkId"
                   element={
@@ -86,7 +87,7 @@ function App() {
                 }
               >
                 <Route path="/agents" element={<Agents />} />
-                <Route path="/agents/:agentId" element={<Navigate to="/agents/:agentId/chat" />} />
+                <Route path="/agents/:agentId" element={<NavigateTo to="/agents/:agentId/chat" />} />
                 <Route
                   path="/agents/:agentId"
                   element={
@@ -109,7 +110,7 @@ function App() {
                 <Route path="/mcps/:serverId/tools/:toolId" element={<MCPServerToolExecutor />} />
 
                 <Route path="/workflows" element={<Workflows />} />
-                <Route path="/workflows/:workflowId" element={<Navigate to="/workflows/:workflowId/graph" />} />
+                <Route path="/workflows/:workflowId" element={<NavigateTo to="/workflows/:workflowId/graph" />} />
 
                 <Route path="/workflows/:workflowId" element={<Outlet />}>
                   <Route
@@ -138,7 +139,7 @@ function App() {
 
                 <Route
                   path="/workflows/legacy/:workflowId"
-                  element={<Navigate to="/workflows/legacy/:workflowId/graph" />}
+                  element={<NavigateTo to="/workflows/legacy/:workflowId/graph" />}
                 />
 
                 <Route
@@ -152,7 +153,7 @@ function App() {
                   <Route path="graph" element={<LegacyWorkflow />} />
                   <Route path="traces" element={<LegacyWorkflowTracesPage />} />
                 </Route>
-                <Route path="/" element={<Navigate to="/agents" />} />
+                <Route path="/" element={<NavigateTo to="/agents" />} />
                 <Route path="/runtime-context" element={<RuntimeContext />} />
               </Route>
             </Routes>

--- a/packages/cli/src/playground/src/domains/workflows/workflow-header.tsx
+++ b/packages/cli/src/playground/src/domains/workflows/workflow-header.tsx
@@ -13,6 +13,10 @@ export function WorkflowHeader({
   isLegacy?: boolean;
   runId?: string;
 }) {
+  const workflowLink = isLegacy ? `/workflows/legacy/${workflowId}/legacy` : `/workflows/${workflowId}`;
+
+  console.log('workflowLink', workflowLink);
+
   return (
     <div className="shrink-0">
       <Header>
@@ -20,7 +24,7 @@ export function WorkflowHeader({
           <Crumb as={Link} to={`/workflows`}>
             Workflows
           </Crumb>
-          <Crumb as={Link} to={`/workflows${isLegacy ? '/legacy' : ''}/${workflowId}`} isCurrent={!runId}>
+          <Crumb as={Link} to={workflowLink} isCurrent={!runId}>
             {workflowName}
           </Crumb>
 

--- a/packages/cli/src/playground/src/domains/workflows/workflow-header.tsx
+++ b/packages/cli/src/playground/src/domains/workflows/workflow-header.tsx
@@ -15,8 +15,6 @@ export function WorkflowHeader({
 }) {
   const workflowLink = isLegacy ? `/workflows/legacy/${workflowId}/legacy` : `/workflows/${workflowId}`;
 
-  console.log('workflowLink', workflowLink);
-
   return (
     <div className="shrink-0">
       <Header>

--- a/packages/cli/src/playground/src/domains/workflows/workflow-header.tsx
+++ b/packages/cli/src/playground/src/domains/workflows/workflow-header.tsx
@@ -13,8 +13,6 @@ export function WorkflowHeader({
   isLegacy?: boolean;
   runId?: string;
 }) {
-  const workflowLink = isLegacy ? `/workflows/legacy/${workflowId}/legacy` : `/workflows/${workflowId}`;
-
   return (
     <div className="shrink-0">
       <Header>
@@ -22,7 +20,7 @@ export function WorkflowHeader({
           <Crumb as={Link} to={`/workflows`}>
             Workflows
           </Crumb>
-          <Crumb as={Link} to={workflowLink} isCurrent={!runId}>
+          <Crumb as={Link} to={`/workflows${isLegacy ? '/legacy' : ''}/${workflowId}`} isCurrent={!runId}>
             {workflowName}
           </Crumb>
 

--- a/packages/cli/src/playground/src/lib/react-router.tsx
+++ b/packages/cli/src/playground/src/lib/react-router.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { Navigate, NavigateOptions, useParams } from 'react-router';
+
+export interface NavigateToProps {
+  to: string;
+  options?: NavigateOptions;
+}
+
+export const NavigateTo = ({ to, options }: NavigateToProps) => {
+  const params = useParams();
+
+  const newUrl = useMemo(() => {
+    const extractedRouteParams = extractRouteParams(to);
+    let newUrl = to;
+
+    for (const param of extractedRouteParams) {
+      newUrl = newUrl.replace(`:${param}`, params[param] as string);
+    }
+
+    return newUrl;
+  }, [to, params]);
+
+  return <Navigate to={newUrl} {...options} />;
+};
+
+function extractRouteParams(path: string): string[] {
+  const params: string[] = [];
+  const segments = path.split('/');
+
+  for (const segment of segments) {
+    if (segment.startsWith(':')) {
+      params.push(segment.slice(1)); // Remove the ':' prefix
+    }
+  }
+
+  return params;
+}

--- a/packages/cli/src/playground/src/lib/react-router.tsx
+++ b/packages/cli/src/playground/src/lib/react-router.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { Navigate, NavigateOptions, useParams } from 'react-router';
 
 export interface NavigateToProps {
@@ -9,16 +8,12 @@ export interface NavigateToProps {
 export const NavigateTo = ({ to, options }: NavigateToProps) => {
   const params = useParams();
 
-  const newUrl = useMemo(() => {
-    const extractedRouteParams = extractRouteParams(to);
-    let newUrl = to;
+  const extractedRouteParams = extractRouteParams(to);
+  let newUrl = to;
 
-    for (const param of extractedRouteParams) {
-      newUrl = newUrl.replace(`:${param}`, params[param] as string);
-    }
-
-    return newUrl;
-  }, [to, params]);
+  for (const param of extractedRouteParams) {
+    newUrl = newUrl.replace(`:${param}`, params[param] as string);
+  }
 
   return <Navigate to={newUrl} {...options} />;
 };


### PR DESCRIPTION
## Description

react-router <Navigate> component does not seem to allow for redirecting parameterized routes. https://reactrouter.com/api/components/Navigate#navigate

In this situation, I'm creating an intermediate components that read the `to=` props and map every attributes (e.g: `:workflowId` to a value passed in `useParams`.

https://github.com/mastra-ai/mastra/issues/5662

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
