### PR TITLE
fix(mcp, core): mcp tool type return value

### DIFF
--- a/.changeset/swift-lights-eat.md
+++ b/.changeset/swift-lights-eat.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/mcp': patch
+---
+
+Fix MCP tool output schema type and return value

--- a/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
@@ -313,7 +313,7 @@ Workflows will use their `inputSchema` for the tool's input.
 
 You can define an `outputSchema` for your tools to enforce a specific structure for the tool's output. This is useful for ensuring that the tool returns data in a consistent and predictable format, which can then be validated by the client.
 
-When a tool includes an `outputSchema`, its `execute` function **must** return an object containing a `structuredContent` property. The value of `structuredContent` must conform to the `outputSchema`. Mastra will automatically validate this output on both the server and client sides.
+When a tool includes an `outputSchema`, its `execute` function **must** return an object. The value of the object must conform to the `outputSchema`. Mastra will automatically validate this output on both the server and client sides.
 
 Here's an example of a tool with an `outputSchema`:
 
@@ -331,12 +331,10 @@ export const structuredTool = createTool({
     timestamp: z.string().describe('An ISO timestamp.'),
   }),
   execute: async ({ input }) => {
-    // When outputSchema is defined, you must return a structuredContent object
+    // When outputSchema is defined, you must return an object
     return {
-      structuredContent: {
-        processedInput: `processed: ${input}`,
-        timestamp: new Date().toISOString(),
-      },
+      processedInput: `processed: ${input}`,
+      timestamp: new Date().toISOString(),
     };
   },
 });

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -52,15 +52,17 @@ export interface ToolExecutionContext<TSchemaIn extends z.ZodSchema | undefined 
   runtimeContext: RuntimeContext;
 }
 
+// Helper type to determine the return type based on whether there's an output schema
+type ToolExecuteReturnType<TSchemaOut extends z.ZodSchema | undefined> = TSchemaOut extends z.ZodSchema
+  ? z.infer<TSchemaOut> | { structuredContent: z.infer<TSchemaOut> }
+  : unknown;
+
 export interface ToolAction<
   TSchemaIn extends z.ZodSchema | undefined = undefined,
   TSchemaOut extends z.ZodSchema | undefined = undefined,
   TContext extends ToolExecutionContext<TSchemaIn> = ToolExecutionContext<TSchemaIn>,
 > extends IAction<string, TSchemaIn, TSchemaOut, TContext, ToolExecutionOptions> {
   description: string;
-  execute?: (
-    context: TContext,
-    options?: ToolExecutionOptions,
-  ) => Promise<TSchemaOut extends z.ZodSchema ? z.infer<TSchemaOut> : unknown>;
+  execute?: (context: TContext, options?: ToolExecutionOptions) => Promise<ToolExecuteReturnType<TSchemaOut>>;
   mastra?: Mastra;
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -52,17 +52,15 @@ export interface ToolExecutionContext<TSchemaIn extends z.ZodSchema | undefined 
   runtimeContext: RuntimeContext;
 }
 
-// Helper type to determine the return type based on whether there's an output schema
-type ToolExecuteReturnType<TSchemaOut extends z.ZodSchema | undefined> = TSchemaOut extends z.ZodSchema
-  ? z.infer<TSchemaOut> | { structuredContent: z.infer<TSchemaOut> }
-  : unknown;
-
 export interface ToolAction<
   TSchemaIn extends z.ZodSchema | undefined = undefined,
   TSchemaOut extends z.ZodSchema | undefined = undefined,
   TContext extends ToolExecutionContext<TSchemaIn> = ToolExecutionContext<TSchemaIn>,
 > extends IAction<string, TSchemaIn, TSchemaOut, TContext, ToolExecutionOptions> {
   description: string;
-  execute?: (context: TContext, options?: ToolExecutionOptions) => Promise<ToolExecuteReturnType<TSchemaOut>>;
+  execute?: (
+    context: TContext,
+    options?: ToolExecutionOptions,
+  ) => Promise<TSchemaOut extends z.ZodSchema ? z.infer<TSchemaOut> : unknown>;
   mastra?: Mastra;
 }

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -1712,10 +1712,8 @@ describe('MCPServer with Tool Output Schema', () => {
         timestamp: z.string(),
       }),
       execute: async ({ input }: { input: string }) => ({
-        structuredContent: {
-          processedInput: `processed: ${input}`,
-          timestamp: mockDateISO,
-        },
+        processedInput: `processed: ${input}`,
+        timestamp: mockDateISO,
       }),
     },
   };

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -281,10 +281,17 @@ export class MCPServer extends MCPServerBase {
         const response: CallToolResult = { isError: false, content: [] };
 
         if (tool.outputSchema) {
-          if (!result.structuredContent) {
-            throw new Error(`Tool ${request.params.name} has an output schema but no structured content was provided.`);
+          // Handle both cases: tools that return { structuredContent: ... } and tools that return the plain object
+          let structuredContent;
+          if (result && typeof result === 'object' && 'structuredContent' in result) {
+            // Tool returned { structuredContent: ... } format (MCP-aware tool)
+            structuredContent = result.structuredContent;
+          } else {
+            // Tool returned plain object, wrap it automatically for backward compatibility
+            structuredContent = result;
           }
-          const outputValidation = tool.outputSchema.validate?.(result.structuredContent ?? {});
+
+          const outputValidation = tool.outputSchema.validate?.(structuredContent ?? {});
           if (outputValidation && !outputValidation.success) {
             this.logger.warn(`CallTool: Invalid structured content for '${request.params.name}'`, {
               errors: outputValidation.error,
@@ -293,7 +300,7 @@ export class MCPServer extends MCPServerBase {
               `Invalid structured content for tool ${request.params.name}: ${JSON.stringify(outputValidation.error)}`,
             );
           }
-          response.structuredContent = result.structuredContent;
+          response.structuredContent = structuredContent;
         }
 
         if (response.structuredContent) {


### PR DESCRIPTION
## Description

Handle the structuredObject value needed by MCP tool automatically so tools can be written for either MCP or non-MCP in the same way. The also fixes the type of the execute function.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
