### PR TITLE
paul/grwth-345-remove-legacy-workflows-from-navigation

### DIFF
--- a/docs/src/content/en/docs/_meta.ts
+++ b/docs/src/content/en/docs/_meta.ts
@@ -8,6 +8,7 @@ const meta = {
   "workflows-legacy": {
     title: "Workflows (Legacy)",
     theme: { collapsed: true },
+    display: "hidden",
   },
   "networks-vnext": { title: "Networks (vNext)" },
   rag: { title: "RAG" },

--- a/docs/src/content/en/docs/workflows-legacy/overview.mdx
+++ b/docs/src/content/en/docs/workflows-legacy/overview.mdx
@@ -7,14 +7,14 @@ description: "Workflows in Mastra help you orchestrate complex sequences of oper
 
 All the legacy workflow documentation is available on the links below.
 
-- [Steps](/docs/workflows-legacy/steps)
-- [Control Flow](/docs/workflows-legacy/control-flow)
-- [Variables](/docs/workflows-legacy/variables)
-- [Suspend & Resume](/docs/workflows-legacy/suspend-and-resume)
-- [Dynamic Workflows](/docs/workflows-legacy/dynamic-workflows)
-- [Error Handling](/docs/workflows-legacy/error-handling)
-- [Nested Workflows](/docs/workflows-legacy/nested-workflows)
-- [Runtime/Dynamic Variables](/docs/workflows-legacy/runtime-variables)
+- [Steps](/docs/workflows-legacy/steps/)
+- [Control Flow](/docs/workflows-legacy/control-flow/)
+- [Variables](/docs/workflows-legacy/variables/)
+- [Suspend & Resume](/docs/workflows-legacy/suspend-and-resume/)
+- [Dynamic Workflows](/docs/workflows-legacy/dynamic-workflows/)
+- [Error Handling](/docs/workflows-legacy/error-handling/)
+- [Nested Workflows](/docs/workflows-legacy/nested-workflows/)
+- [Runtime/Dynamic Variables](/docs/workflows-legacy/runtime-variables/)
 
 Workflows in Mastra help you orchestrate complex sequences of operations with features like branching, parallel execution, resource suspension, and more.
 

--- a/docs/src/content/en/docs/workflows-legacy/overview.mdx
+++ b/docs/src/content/en/docs/workflows-legacy/overview.mdx
@@ -5,6 +5,17 @@ description: "Workflows in Mastra help you orchestrate complex sequences of oper
 
 # Handling Complex LLM Operations with Workflows (Legacy)
 
+All the legacy workflow documentation is available on the links below.
+
+- [Steps](/docs/workflows-legacy/steps)
+- [Control Flow](/docs/workflows-legacy/control-flow)
+- [Variables](/docs/workflows-legacy/variables)
+- [Suspend & Resume](/docs/workflows-legacy/suspend-and-resume)
+- [Dynamic Workflows](/docs/workflows-legacy/dynamic-workflows)
+- [Error Handling](/docs/workflows-legacy/error-handling)
+- [Nested Workflows](/docs/workflows-legacy/nested-workflows)
+- [Runtime/Dynamic Variables](/docs/workflows-legacy/runtime-variables)
+
 Workflows in Mastra help you orchestrate complex sequences of operations with features like branching, parallel execution, resource suspension, and more.
 
 ## When to use workflows

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -303,4 +303,7 @@ const result = await run.start({
 - [Suspend and Resume workflow example](../../examples/workflows/human-in-the-loop.mdx)
 
 
+## Workflows (Legacy)
+
+For legacy workflow documentation, see [Workflows (Legacy)](/docs/workflows-legacy/overview).
 

--- a/docs/src/content/en/reference/_meta.ts
+++ b/docs/src/content/en/reference/_meta.ts
@@ -9,7 +9,10 @@ const meta: Meta = {
   agents: "Agents",
   tools: "Tools",
   workflows: "Workflows",
-  legacyWorkflows: "Legacy Workflows",
+  legacyWorkflows: {
+    title: "Legacy Workflows",
+    display: "hidden",
+  },
   networks: "Networks",
   memory: "Memory",
   storage: "Storage",


### PR DESCRIPTION
## Description

- Remove the Legacy Workflows Overview page from the main navigation.
- Remove the Legacy Workflows Overview page from the /examples navigation.
- Add a short sentence at the bottom of the main Workflows Overview page linking to the Legacy Workflows Overview.
- Ensure all legacy workflow docs pages are linked from the Legacy Workflows Overview page.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
