### PR TITLE
fix(create-mastra): scaffold zod 3 

### DIFF
--- a/.changeset/kind-carrots-grab.md
+++ b/.changeset/kind-carrots-grab.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Scaffold create-mastra projects with zod@^4 to prevent package version conflicts during install
+Scaffold create-mastra projects with zod@^3 to prevent package version conflicts during install

--- a/.changeset/kind-carrots-grab.md
+++ b/.changeset/kind-carrots-grab.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Scaffold create-mastra projects with zod@^4 to prevent package version conflicts during install

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -134,7 +134,7 @@ export const createMastraProject = async ({
 
     s.start(`Installing ${pm} dependencies`);
     try {
-      await exec(`${pm} ${installCommand} zod`);
+      await exec(`${pm} ${installCommand} zod@^3`);
       await exec(`${pm} ${installCommand} typescript @types/node --save-dev`);
       await exec(`echo '{
   "compilerOptions": {


### PR DESCRIPTION
Zod 4 came out earlier today https://www.npmjs.com/package/zod

since we're just installing any latest zod during scaffolding, it leads to package conflicts like this:
```
Project creation failed: Failed to install Mastra CLI: Failed to install mastra (tried @alpha and @latest): Command failed: npm install --save-dev mastra@latest
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: yoyo@1.0.0
npm error Found: zod@4.0.0
npm error node_modules/zod
npm error   zod@"^4.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer zod@"^3.0.0" from @mastra/core@0.10.11
npm error node_modules/@mastra/core
npm error   peer @mastra/core@"^0.10.2-alpha.0" from mastra@0.10.11
npm error   node_modules/mastra
npm error     dev mastra@"0.10.11" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
```