### PR TITLE
feat: abstract link usage for cloud + playground

### DIFF
--- a/.changeset/slick-trees-train.md
+++ b/.changeset/slick-trees-train.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+abstract Link component between cloud and core

--- a/packages/cli/src/playground/src/App.tsx
+++ b/packages/cli/src/playground/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, BrowserRouter, Outlet } from 'react-router';
+import { Routes, Route, BrowserRouter, Outlet, Link } from 'react-router';
 
 import { Layout } from '@/components/layout';
 
@@ -30,7 +30,7 @@ import { useState } from 'react';
 import { QueryClient } from '@tanstack/react-query';
 import { McpServerPage } from './pages/mcps/[serverId]';
 import { WorkflowGraphLayout } from './pages/workflows/layouts/workflow-graph-layout';
-import { MastraClientProvider } from '@mastra/playground-ui';
+import { LinkComponentProvider, MastraClientProvider } from '@mastra/playground-ui';
 import VNextNetwork from './pages/networks/network/v-next';
 import { NavigateTo } from './lib/react-router';
 
@@ -41,123 +41,125 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <PostHogProvider>
         <MastraClientProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route
-                element={
-                  <Layout>
-                    <Outlet />
-                  </Layout>
-                }
-              >
-                <Route path="/networks" element={<Networks />} />
+          <LinkComponentProvider Link={Link}>
+            <BrowserRouter>
+              <Routes>
                 <Route
-                  path="/networks/v-next/:networkId"
-                  element={<NavigateTo to="/networks/v-next/:networkId/chat" />}
-                />
-                <Route
-                  path="/networks/v-next/:networkId"
                   element={
-                    <NetworkLayout isVNext>
+                    <Layout>
                       <Outlet />
-                    </NetworkLayout>
+                    </Layout>
                   }
                 >
-                  <Route path="chat" element={<VNextNetwork />} />
-                  <Route path="chat/:threadId" element={<VNextNetwork />} />
-                </Route>
-                <Route path="/networks/:networkId" element={<NavigateTo to="/networks/:networkId/chat" />} />
-                <Route
-                  path="/networks/:networkId"
-                  element={
-                    <NetworkLayout>
-                      <Outlet />
-                    </NetworkLayout>
-                  }
-                >
-                  <Route path="chat" element={<Network />} />
-                </Route>
-              </Route>
-
-              <Route
-                element={
-                  <Layout>
-                    <Outlet />
-                  </Layout>
-                }
-              >
-                <Route path="/agents" element={<Agents />} />
-                <Route path="/agents/:agentId" element={<NavigateTo to="/agents/:agentId/chat" />} />
-                <Route
-                  path="/agents/:agentId"
-                  element={
-                    <AgentLayout>
-                      <Outlet />
-                    </AgentLayout>
-                  }
-                >
-                  <Route path="chat" element={<Agent />} />
-                  <Route path="chat/:threadId" element={<Agent />} />
-                  <Route path="evals" element={<AgentEvalsPage />} />
-                  <Route path="traces" element={<AgentTracesPage />} />
-                </Route>
-                <Route path="/tools" element={<Tools />} />
-                <Route path="/tools/:agentId/:toolId" element={<AgentTool />} />
-                <Route path="/tools/all/:toolId" element={<Tool />} />
-                <Route path="/mcps" element={<MCPs />} />
-
-                <Route path="/mcps/:serverId" element={<McpServerPage />} />
-                <Route path="/mcps/:serverId/tools/:toolId" element={<MCPServerToolExecutor />} />
-
-                <Route path="/workflows" element={<Workflows />} />
-                <Route path="/workflows/:workflowId" element={<NavigateTo to="/workflows/:workflowId/graph" />} />
-
-                <Route path="/workflows/:workflowId" element={<Outlet />}>
+                  <Route path="/networks" element={<Networks />} />
                   <Route
-                    path="traces"
-                    element={
-                      <WorkflowLayout>
-                        <WorkflowTracesPage />
-                      </WorkflowLayout>
-                    }
+                    path="/networks/v-next/:networkId"
+                    element={<NavigateTo to="/networks/v-next/:networkId/chat" />}
                   />
-
                   <Route
-                    path="/workflows/:workflowId/graph"
+                    path="/networks/v-next/:networkId"
                     element={
-                      <WorkflowLayout>
-                        <WorkflowGraphLayout>
-                          <Outlet />
-                        </WorkflowGraphLayout>
-                      </WorkflowLayout>
+                      <NetworkLayout isVNext>
+                        <Outlet />
+                      </NetworkLayout>
                     }
                   >
-                    <Route path="/workflows/:workflowId/graph" element={<Workflow />} />
-                    <Route path="/workflows/:workflowId/graph/:runId" element={<Workflow />} />
+                    <Route path="chat" element={<VNextNetwork />} />
+                    <Route path="chat/:threadId" element={<VNextNetwork />} />
+                  </Route>
+                  <Route path="/networks/:networkId" element={<NavigateTo to="/networks/:networkId/chat" />} />
+                  <Route
+                    path="/networks/:networkId"
+                    element={
+                      <NetworkLayout>
+                        <Outlet />
+                      </NetworkLayout>
+                    }
+                  >
+                    <Route path="chat" element={<Network />} />
                   </Route>
                 </Route>
 
                 <Route
-                  path="/workflows/legacy/:workflowId"
-                  element={<NavigateTo to="/workflows/legacy/:workflowId/graph" />}
-                />
-
-                <Route
-                  path="/workflows/legacy/:workflowId"
                   element={
-                    <LegacyWorkflowLayout>
+                    <Layout>
                       <Outlet />
-                    </LegacyWorkflowLayout>
+                    </Layout>
                   }
                 >
-                  <Route path="graph" element={<LegacyWorkflow />} />
-                  <Route path="traces" element={<LegacyWorkflowTracesPage />} />
+                  <Route path="/agents" element={<Agents />} />
+                  <Route path="/agents/:agentId" element={<NavigateTo to="/agents/:agentId/chat" />} />
+                  <Route
+                    path="/agents/:agentId"
+                    element={
+                      <AgentLayout>
+                        <Outlet />
+                      </AgentLayout>
+                    }
+                  >
+                    <Route path="chat" element={<Agent />} />
+                    <Route path="chat/:threadId" element={<Agent />} />
+                    <Route path="evals" element={<AgentEvalsPage />} />
+                    <Route path="traces" element={<AgentTracesPage />} />
+                  </Route>
+                  <Route path="/tools" element={<Tools />} />
+                  <Route path="/tools/:agentId/:toolId" element={<AgentTool />} />
+                  <Route path="/tools/all/:toolId" element={<Tool />} />
+                  <Route path="/mcps" element={<MCPs />} />
+
+                  <Route path="/mcps/:serverId" element={<McpServerPage />} />
+                  <Route path="/mcps/:serverId/tools/:toolId" element={<MCPServerToolExecutor />} />
+
+                  <Route path="/workflows" element={<Workflows />} />
+                  <Route path="/workflows/:workflowId" element={<NavigateTo to="/workflows/:workflowId/graph" />} />
+
+                  <Route path="/workflows/:workflowId" element={<Outlet />}>
+                    <Route
+                      path="traces"
+                      element={
+                        <WorkflowLayout>
+                          <WorkflowTracesPage />
+                        </WorkflowLayout>
+                      }
+                    />
+
+                    <Route
+                      path="/workflows/:workflowId/graph"
+                      element={
+                        <WorkflowLayout>
+                          <WorkflowGraphLayout>
+                            <Outlet />
+                          </WorkflowGraphLayout>
+                        </WorkflowLayout>
+                      }
+                    >
+                      <Route path="/workflows/:workflowId/graph" element={<Workflow />} />
+                      <Route path="/workflows/:workflowId/graph/:runId" element={<Workflow />} />
+                    </Route>
+                  </Route>
+
+                  <Route
+                    path="/workflows/legacy/:workflowId"
+                    element={<NavigateTo to="/workflows/legacy/:workflowId/graph" />}
+                  />
+
+                  <Route
+                    path="/workflows/legacy/:workflowId"
+                    element={
+                      <LegacyWorkflowLayout>
+                        <Outlet />
+                      </LegacyWorkflowLayout>
+                    }
+                  >
+                    <Route path="graph" element={<LegacyWorkflow />} />
+                    <Route path="traces" element={<LegacyWorkflowTracesPage />} />
+                  </Route>
+                  <Route path="/" element={<NavigateTo to="/agents" />} />
+                  <Route path="/runtime-context" element={<RuntimeContext />} />
                 </Route>
-                <Route path="/" element={<NavigateTo to="/agents" />} />
-                <Route path="/runtime-context" element={<RuntimeContext />} />
-              </Route>
-            </Routes>
-          </BrowserRouter>
+              </Routes>
+            </BrowserRouter>
+          </LinkComponentProvider>
         </MastraClientProvider>
       </PostHogProvider>
     </QueryClientProvider>

--- a/packages/cli/src/playground/src/lib/framework.tsx
+++ b/packages/cli/src/playground/src/lib/framework.tsx
@@ -1,0 +1,10 @@
+import { Link as RouterLink } from 'react-router';
+import { LinkComponent } from '@mastra/playground-ui';
+
+export const Link: LinkComponent = ({ children, href, ...props }) => {
+  return (
+    <RouterLink to={href} {...props}>
+      {children}
+    </RouterLink>
+  );
+};

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -28,3 +28,4 @@ export * from './components/ui/entry';
 export type { TraceContextType } from './domains/traces/context/trace-context';
 
 export * from './store/playground-store';
+export * from './lib/framework';

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -1,0 +1,22 @@
+import { AnchorHTMLAttributes, createContext, useContext } from 'react';
+
+export type LinkComponent = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => React.ReactNode;
+
+const LinkComponentContext = createContext<{
+  Link: LinkComponent;
+}>({
+  Link: () => null,
+});
+
+export interface LinkComponentProviderProps {
+  children: React.ReactNode;
+  Link: LinkComponent;
+}
+
+export const LinkComponentProvider = ({ children, Link }: LinkComponentProviderProps) => {
+  return <LinkComponentContext.Provider value={{ Link }}>{children}</LinkComponentContext.Provider>;
+};
+
+export const useLinkComponent = () => {
+  return useContext(LinkComponentContext);
+};


### PR DESCRIPTION
## Description

Abstract the usage of `Link` component for sharing between core / cloud so that we can share component and still make them able to navigate. Reminder: `react-router` (playground) and `nextjs` (cloud) don't have the same Link API (`to` on rr and `href` for nextjs)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
