### PR TITLE
fix: pg storage should select resourceId when getMessages (#5824)

### DIFF
--- a/.changeset/curly-adults-sing.md
+++ b/.changeset/curly-adults-sing.md
@@ -1,0 +1,5 @@
+---
+"@mastra/pg": patch
+---
+
+fix: pg storage should select resourceId when getMessages

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -258,7 +258,10 @@ describe('PostgresStore', () => {
       const thread = createSampleThread();
       await store.saveThread({ thread });
 
-      const messages = [createSampleMessageV1({ threadId: thread.id }), createSampleMessageV1({ threadId: thread.id })];
+      const messages = [
+        createSampleMessageV1({ threadId: thread.id, resourceId: thread.resourceId }),
+        createSampleMessageV1({ threadId: thread.id, resourceId: thread.resourceId }),
+      ];
 
       // Save messages
       const savedMessages = await store.saveMessages({ messages });
@@ -267,11 +270,7 @@ describe('PostgresStore', () => {
       // Retrieve messages
       const retrievedMessages = await store.getMessages({ threadId: thread.id, format: 'v1' });
       expect(retrievedMessages).toHaveLength(2);
-      const checkMessages = messages.map(m => {
-        const { resourceId, ...rest } = m;
-        return rest;
-      });
-      expect(retrievedMessages).toEqual(expect.arrayContaining(checkMessages));
+      expect(retrievedMessages).toEqual(expect.arrayContaining(messages));
     });
 
     it('should handle empty message array', async () => {
@@ -1821,8 +1820,8 @@ describe('PostgresStore', () => {
         await store.saveThread({ thread });
 
         const messages = [
-          createSampleMessageV1({ threadId: thread.id }),
-          createSampleMessageV1({ threadId: thread.id }),
+          createSampleMessageV1({ threadId: thread.id, resourceId: thread.resourceId }),
+          createSampleMessageV1({ threadId: thread.id, resourceId: thread.resourceId }),
         ];
 
         // Save messages
@@ -1832,11 +1831,7 @@ describe('PostgresStore', () => {
         // Retrieve messages
         const retrievedMessages = await store.getMessagesPaginated({ threadId: thread.id, format: 'v1' });
         expect(retrievedMessages.messages).toHaveLength(2);
-        const checkMessages = messages.map(m => {
-          const { resourceId, ...rest } = m;
-          return rest;
-        });
-        expect(retrievedMessages.messages).toEqual(expect.arrayContaining(checkMessages));
+        expect(retrievedMessages.messages).toEqual(expect.arrayContaining(messages));
       });
 
       it('should maintain message order', async () => {

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -938,7 +938,7 @@ export class PostgresStore extends MastraStorage {
   ): Promise<MastraMessageV1[] | MastraMessageV2[]> {
     const { threadId, format, selectBy } = args;
 
-    const selectStatement = `SELECT id, content, role, type, "createdAt", thread_id AS "threadId"`;
+    const selectStatement = `SELECT id, content, role, type, "createdAt", thread_id AS "threadId", "resourceId"`;
     const orderByStatement = `ORDER BY "createdAt" DESC`;
     const limit = this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
 
@@ -1015,7 +1015,7 @@ export class PostgresStore extends MastraStorage {
     const fromDate = dateRange?.start;
     const toDate = dateRange?.end;
 
-    const selectStatement = `SELECT id, content, role, type, "createdAt", thread_id AS "threadId"`;
+    const selectStatement = `SELECT id, content, role, type, "createdAt", thread_id AS "threadId", "resourceId"`;
     const orderByStatement = `ORDER BY "createdAt" DESC`;
 
     const messages: MastraMessageV2[] = [];


### PR DESCRIPTION
## Description

pg storage should select resourceId when getMessages

copy of #5824

## Related Issue(s)

#5782 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

---------

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
