### PR TITLE
Composite Storage - use different storage adapters for diff primitives

### DIFF
--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -16,6 +16,7 @@ import {
 import type { TABLE_NAMES } from './constants';
 import type {
   EvalRow,
+  PaginationArgs,
   PaginationInfo,
   StorageColumn,
   StorageGetMessagesArg,
@@ -164,16 +165,16 @@ export abstract class MastraStorage extends MastraBase {
   async getResourceById(_: { resourceId: string }): Promise<StorageResourceType | null> {
     throw new Error(
       `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
-        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
-        `To use per-resource working memory, switch to one of these supported storage adapters.`,
+      `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+      `To use per-resource working memory, switch to one of these supported storage adapters.`,
     );
   }
 
   async saveResource(_: { resource: StorageResourceType }): Promise<StorageResourceType> {
     throw new Error(
       `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
-        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
-        `To use per-resource working memory, switch to one of these supported storage adapters.`,
+      `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+      `To use per-resource working memory, switch to one of these supported storage adapters.`,
     );
   }
 
@@ -184,8 +185,8 @@ export abstract class MastraStorage extends MastraBase {
   }): Promise<StorageResourceType> {
     throw new Error(
       `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
-        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
-        `To use per-resource working memory, switch to one of these supported storage adapters.`,
+      `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+      `To use per-resource working memory, switch to one of these supported storage adapters.`,
     );
   }
 
@@ -206,10 +207,10 @@ export abstract class MastraStorage extends MastraBase {
 
   abstract updateMessages(args: {
     messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
-      {
-        id: string;
-        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
-      }[];
+    {
+      id: string;
+      content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+    }[];
   }): Promise<MastraMessageV2[]>;
 
   abstract getTraces(args: StorageGetTracesArg): Promise<any[]>;
@@ -311,6 +312,11 @@ export abstract class MastraStorage extends MastraBase {
 
     return d ? d.snapshot : null;
   }
+
+  abstract getEvals(args: {
+    agentName?: string;
+    type?: 'test' | 'live';
+  } & PaginationArgs): Promise<PaginationInfo & { evals: EvalRow[] }>;
 
   abstract getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]>;
 

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -25,45 +25,6 @@ import type {
   WorkflowRuns,
 } from './types';
 
-export abstract class MastraMemoryStorage extends MastraBase {
-  constructor({ name }: { name: string }) {
-    super({
-      component: 'MEMORY_STORAGE',
-      name,
-    });
-  }
-
-  abstract getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
-  abstract getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
-  abstract getMessages({
-    threadId,
-    resourceId,
-    selectBy,
-    format,
-  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]>;
-
-  /**
-   * Resolves limit for how many messages to fetch
-   *
-   * @param last The number of messages to fetch
-   * @param defaultLimit The default limit to use if last is not provided
-   * @returns The resolved limit
-   */
-  protected resolveMessageLimit({
-    last,
-    defaultLimit,
-  }: {
-    last: number | false | undefined;
-    defaultLimit: number;
-  }): number {
-    // TODO: Figure out consistent default limit for all stores as some stores use 40 and some use no limit (Number.MAX_SAFE_INTEGER)
-    if (typeof last === 'number') return Math.max(0, last);
-    if (last === false) return 0;
-    return defaultLimit;
-  }
-}
-
-
 export abstract class MastraStorage extends MastraBase {
   protected hasInitialized: null | Promise<boolean> = null;
   protected shouldCacheInit = true;
@@ -150,7 +111,13 @@ export abstract class MastraStorage extends MastraBase {
     }
   }
 
-  abstract createTable({ tableName, schema }: { tableName: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void>;
+  abstract createTable({
+    tableName,
+    schema,
+  }: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+  }): Promise<void>;
 
   abstract clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void>;
 
@@ -197,16 +164,16 @@ export abstract class MastraStorage extends MastraBase {
   async getResourceById(_: { resourceId: string }): Promise<StorageResourceType | null> {
     throw new Error(
       `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
-      `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
-      `To use per-resource working memory, switch to one of these supported storage adapters.`,
+        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+        `To use per-resource working memory, switch to one of these supported storage adapters.`,
     );
   }
 
   async saveResource(_: { resource: StorageResourceType }): Promise<StorageResourceType> {
     throw new Error(
       `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
-      `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
-      `To use per-resource working memory, switch to one of these supported storage adapters.`,
+        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+        `To use per-resource working memory, switch to one of these supported storage adapters.`,
     );
   }
 
@@ -217,8 +184,8 @@ export abstract class MastraStorage extends MastraBase {
   }): Promise<StorageResourceType> {
     throw new Error(
       `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
-      `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
-      `To use per-resource working memory, switch to one of these supported storage adapters.`,
+        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+        `To use per-resource working memory, switch to one of these supported storage adapters.`,
     );
   }
 
@@ -239,10 +206,10 @@ export abstract class MastraStorage extends MastraBase {
 
   abstract updateMessages(args: {
     messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
-    {
-      id: string;
-      content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
-    }[];
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
   }): Promise<MastraMessageV2[]>;
 
   abstract getTraces(args: StorageGetTracesArg): Promise<any[]>;
@@ -369,117 +336,4 @@ export abstract class MastraStorage extends MastraBase {
   abstract getMessagesPaginated(
     args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },
   ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }>;
-}
-
-
-export class MastraCompositeStorage extends MastraStorage {
-  #stores: {
-    traces: MastraStorage,
-    conversations: MastraStorage,
-    workflows: MastraStorage,
-    scores: MastraStorage,
-  };
-
-  constructor(stores: {
-    traces: MastraStorage,
-    conversations: MastraStorage,
-    workflows: MastraStorage,
-    scores: MastraStorage,
-  }) {
-    super({
-      name: 'COMPOSITE_STORAGE',
-    });
-
-    this.#stores = stores;
-  }
-
-  async createTable({ tableName, schema }: { tableName: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void> {
-    if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.createTable({ tableName, schema });
-    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.createTable({ tableName, schema });
-    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.createTable({ tableName, schema });
-    } else if (tableName === TABLE_EVALS) {
-      await this.#stores.scores.createTable({ tableName, schema });
-    }
-  }
-
-  async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
-    if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.clearTable({ tableName });
-    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.clearTable({ tableName });
-    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.clearTable({ tableName });
-    } else if (tableName === TABLE_EVALS) {
-      await this.#stores.scores.clearTable({ tableName });
-    }
-  }
-
-  async alterTable(args: { tableName: TABLE_NAMES; schema: Record<string, StorageColumn>; ifNotExists: string[] }): Promise<void> {
-    if (args.tableName === TABLE_MESSAGES || args.tableName === TABLE_THREADS || args.tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.alterTable(args);
-    }
-    if (args.tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.alterTable(args);
-    }
-    if (args.tableName === TABLE_EVALS) {
-      await this.#stores.scores.alterTable(args);
-    }
-  }
-
-  async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
-    if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.insert({ tableName, record });
-    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.insert({ tableName, record });
-    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.insert({ tableName, record });
-    } else if (tableName === TABLE_EVALS) {
-      await this.#stores.scores.insert({ tableName, record });
-    }
-  }
-
-  async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
-    if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.batchInsert({ tableName, records });
-    }
-  }
-
-  async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
-    if (tableName === TABLE_TRACES) {
-      return this.#stores.traces.load({ tableName, keys });
-    }
-    if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      return this.#stores.conversations.load({ tableName, keys });
-    }
-    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      return this.#stores.workflows.load({ tableName, keys });
-    }
-    if (tableName === TABLE_EVALS) {
-      return this.#stores.scores.load({ tableName, keys });
-    }
-  }
-
-  async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
-    return this.#stores.conversations.getThreadById({ threadId });
-  }
-
-  async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
-    return this.#stores.conversations.getThreadsByResourceId({ resourceId });
-  }
-
-  async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
-    return this.#stores.conversations.saveThread({ thread });
-  }
-
-  async updateThread({ id, title, metadata }: { id: string; title: string; metadata: Record<string, unknown> }): Promise<StorageThreadType> {
-    return this.#stores.conversations.updateThread({ id, title, metadata });
-  }
-
-  async deleteThread({ threadId }: { threadId: string }): Promise<void> {
-    return this.#stores.conversations.deleteThread({ threadId });
-  }
-
 }

--- a/packages/core/src/storage/composite.ts
+++ b/packages/core/src/storage/composite.ts
@@ -21,6 +21,7 @@ import type {
   WorkflowRun,
   EvalRow,
   WorkflowRuns,
+  PaginationArgs,
 } from './types';
 
 export class MastraCompositeStorage extends MastraStorage {
@@ -189,10 +190,10 @@ export class MastraCompositeStorage extends MastraStorage {
 
   async updateMessages(args: {
     messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
-      {
-        id: string;
-        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
-      }[];
+    {
+      id: string;
+      content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+    }[];
   }): Promise<MastraMessageV2[]> {
     return this.#stores.conversations.updateMessages(args);
   }
@@ -225,6 +226,13 @@ export class MastraCompositeStorage extends MastraStorage {
 
   async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
     return this.#stores.scores.getEvalsByAgentName(agentName, type);
+  }
+
+  async getEvals(args: {
+    agentName?: string;
+    type?: 'test' | 'live';
+  } & PaginationArgs): Promise<PaginationInfo & { evals: EvalRow[] }> {
+    return this.#stores.scores.getEvals(args);
   }
 
   async getWorkflowRuns(args?: {

--- a/packages/core/src/storage/composite.ts
+++ b/packages/core/src/storage/composite.ts
@@ -1,0 +1,121 @@
+import { MastraStorage } from "./base";
+import {
+    TABLE_TRACES,
+    TABLE_MESSAGES,
+    TABLE_THREADS,
+    TABLE_RESOURCES,
+    TABLE_WORKFLOW_SNAPSHOT,
+    TABLE_EVALS,
+} from "./constants";
+import type { TABLE_NAMES, StorageColumn } from "./types";
+
+export class MastraCompositeStorage extends MastraStorage {
+    #stores: {
+        traces: MastraStorage,
+        conversations: MastraStorage,
+        workflows: MastraStorage,
+        scores: MastraStorage,
+    };
+
+    constructor(stores: {
+        traces: MastraStorage,
+        conversations: MastraStorage,
+        workflows: MastraStorage,
+        scores: MastraStorage,
+    }) {
+        super({
+            name: 'COMPOSITE_STORAGE',
+        });
+
+        this.#stores = stores;
+    }
+
+    async createTable({ tableName, schema }: { tableName: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void> {
+        if (tableName === TABLE_TRACES) {
+            await this.#stores.traces.createTable({ tableName, schema });
+        } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+            await this.#stores.conversations.createTable({ tableName, schema });
+        } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+            await this.#stores.workflows.createTable({ tableName, schema });
+        } else if (tableName === TABLE_EVALS) {
+            await this.#stores.scores.createTable({ tableName, schema });
+        }
+    }
+
+    async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
+        if (tableName === TABLE_TRACES) {
+            await this.#stores.traces.clearTable({ tableName });
+        } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+            await this.#stores.conversations.clearTable({ tableName });
+        } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+            await this.#stores.workflows.clearTable({ tableName });
+        } else if (tableName === TABLE_EVALS) {
+            await this.#stores.scores.clearTable({ tableName });
+        }
+    }
+
+    async alterTable(args: { tableName: TABLE_NAMES; schema: Record<string, StorageColumn>; ifNotExists: string[] }): Promise<void> {
+        if (args.tableName === TABLE_MESSAGES || args.tableName === TABLE_THREADS || args.tableName === TABLE_RESOURCES) {
+            await this.#stores.conversations.alterTable(args);
+        }
+        if (args.tableName === TABLE_WORKFLOW_SNAPSHOT) {
+            await this.#stores.workflows.alterTable(args);
+        }
+        if (args.tableName === TABLE_EVALS) {
+            await this.#stores.scores.alterTable(args);
+        }
+    }
+
+    async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+        if (tableName === TABLE_TRACES) {
+            await this.#stores.traces.insert({ tableName, record });
+        } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+            await this.#stores.conversations.insert({ tableName, record });
+        } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+            await this.#stores.workflows.insert({ tableName, record });
+        } else if (tableName === TABLE_EVALS) {
+            await this.#stores.scores.insert({ tableName, record });
+        }
+    }
+
+    async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+        if (tableName === TABLE_TRACES) {
+            await this.#stores.traces.batchInsert({ tableName, records });
+        }
+    }
+
+    async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
+        if (tableName === TABLE_TRACES) {
+            return this.#stores.traces.load({ tableName, keys });
+        }
+        if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+            return this.#stores.conversations.load({ tableName, keys });
+        }
+        if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+            return this.#stores.workflows.load({ tableName, keys });
+        }
+        if (tableName === TABLE_EVALS) {
+            return this.#stores.scores.load({ tableName, keys });
+        }
+    }
+
+    async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
+        return this.#stores.conversations.getThreadById({ threadId });
+    }
+
+    async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
+        return this.#stores.conversations.getThreadsByResourceId({ resourceId });
+    }
+
+    async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
+        return this.#stores.conversations.saveThread({ thread });
+    }
+
+    async updateThread({ id, title, metadata }: { id: string; title: string; metadata: Record<string, unknown> }): Promise<StorageThreadType> {
+        return this.#stores.conversations.updateThread({ id, title, metadata });
+    }
+
+    async deleteThread({ threadId }: { threadId: string }): Promise<void> {
+        return this.#stores.conversations.deleteThread({ threadId });
+    }
+}

--- a/packages/core/src/storage/composite.ts
+++ b/packages/core/src/storage/composite.ts
@@ -160,17 +160,12 @@ export class MastraCompositeStorage extends MastraStorage {
     return this.#stores.conversations.saveResource(args);
   }
 
-  async updateResource(_: {
+  async updateResource(args: {
     resourceId: string;
     workingMemory?: string;
     metadata?: Record<string, unknown>;
   }): Promise<StorageResourceType> {
-    return this.#stores.conversations.updateResource(_);
-    throw new Error(
-      `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
-        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
-        `To use per-resource working memory, switch to one of these supported storage adapters.`,
-    );
+    return this.#stores.conversations.updateResource(args);
   }
 
   async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;

--- a/packages/core/src/storage/composite.ts
+++ b/packages/core/src/storage/composite.ts
@@ -1,121 +1,267 @@
-import { MastraStorage } from "./base";
+import type { MastraMessageContentV2 } from '../agent/message-list';
+import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '../memory/types';
+import type { Trace } from '../telemetry';
+import type { WorkflowRunState } from '../workflows';
+import { MastraStorage } from './base';
 import {
-    TABLE_TRACES,
-    TABLE_MESSAGES,
-    TABLE_THREADS,
-    TABLE_RESOURCES,
-    TABLE_WORKFLOW_SNAPSHOT,
-    TABLE_EVALS,
-} from "./constants";
-import type { TABLE_NAMES, StorageColumn } from "./types";
+  TABLE_TRACES,
+  TABLE_MESSAGES,
+  TABLE_THREADS,
+  TABLE_RESOURCES,
+  TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_EVALS,
+} from './constants';
+import type { TABLE_NAMES } from './constants';
+import type {
+  StorageColumn,
+  StorageGetMessagesArg,
+  StorageGetTracesArg,
+  StorageResourceType,
+  PaginationInfo,
+  WorkflowRun,
+  EvalRow,
+  WorkflowRuns,
+} from './types';
 
 export class MastraCompositeStorage extends MastraStorage {
-    #stores: {
-        traces: MastraStorage,
-        conversations: MastraStorage,
-        workflows: MastraStorage,
-        scores: MastraStorage,
-    };
+  #stores: {
+    traces: MastraStorage;
+    conversations: MastraStorage;
+    workflows: MastraStorage;
+    scores: MastraStorage;
+  };
 
-    constructor(stores: {
-        traces: MastraStorage,
-        conversations: MastraStorage,
-        workflows: MastraStorage,
-        scores: MastraStorage,
-    }) {
-        super({
-            name: 'COMPOSITE_STORAGE',
-        });
+  constructor(stores: {
+    traces: MastraStorage;
+    conversations: MastraStorage;
+    workflows: MastraStorage;
+    scores: MastraStorage;
+  }) {
+    super({
+      name: 'COMPOSITE_STORAGE',
+    });
 
-        this.#stores = stores;
+    this.#stores = stores;
+  }
+
+  async createTable({
+    tableName,
+    schema,
+  }: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+  }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.createTable({ tableName, schema });
+    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.createTable({ tableName, schema });
+    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.createTable({ tableName, schema });
+    } else if (tableName === TABLE_EVALS) {
+      await this.#stores.scores.createTable({ tableName, schema });
     }
+  }
 
-    async createTable({ tableName, schema }: { tableName: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void> {
-        if (tableName === TABLE_TRACES) {
-            await this.#stores.traces.createTable({ tableName, schema });
-        } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-            await this.#stores.conversations.createTable({ tableName, schema });
-        } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-            await this.#stores.workflows.createTable({ tableName, schema });
-        } else if (tableName === TABLE_EVALS) {
-            await this.#stores.scores.createTable({ tableName, schema });
-        }
+  async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.clearTable({ tableName });
+    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.clearTable({ tableName });
+    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.clearTable({ tableName });
+    } else if (tableName === TABLE_EVALS) {
+      await this.#stores.scores.clearTable({ tableName });
     }
+  }
 
-    async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
-        if (tableName === TABLE_TRACES) {
-            await this.#stores.traces.clearTable({ tableName });
-        } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-            await this.#stores.conversations.clearTable({ tableName });
-        } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-            await this.#stores.workflows.clearTable({ tableName });
-        } else if (tableName === TABLE_EVALS) {
-            await this.#stores.scores.clearTable({ tableName });
-        }
+  async alterTable(args: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+    ifNotExists: string[];
+  }): Promise<void> {
+    if (args.tableName === TABLE_MESSAGES || args.tableName === TABLE_THREADS || args.tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.alterTable(args);
     }
+    if (args.tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.alterTable(args);
+    }
+    if (args.tableName === TABLE_EVALS) {
+      await this.#stores.scores.alterTable(args);
+    }
+  }
 
-    async alterTable(args: { tableName: TABLE_NAMES; schema: Record<string, StorageColumn>; ifNotExists: string[] }): Promise<void> {
-        if (args.tableName === TABLE_MESSAGES || args.tableName === TABLE_THREADS || args.tableName === TABLE_RESOURCES) {
-            await this.#stores.conversations.alterTable(args);
-        }
-        if (args.tableName === TABLE_WORKFLOW_SNAPSHOT) {
-            await this.#stores.workflows.alterTable(args);
-        }
-        if (args.tableName === TABLE_EVALS) {
-            await this.#stores.scores.alterTable(args);
-        }
+  async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.insert({ tableName, record });
+    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.insert({ tableName, record });
+    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.insert({ tableName, record });
+    } else if (tableName === TABLE_EVALS) {
+      await this.#stores.scores.insert({ tableName, record });
     }
+  }
 
-    async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
-        if (tableName === TABLE_TRACES) {
-            await this.#stores.traces.insert({ tableName, record });
-        } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-            await this.#stores.conversations.insert({ tableName, record });
-        } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-            await this.#stores.workflows.insert({ tableName, record });
-        } else if (tableName === TABLE_EVALS) {
-            await this.#stores.scores.insert({ tableName, record });
-        }
+  async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.batchInsert({ tableName, records });
     }
+  }
 
-    async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
-        if (tableName === TABLE_TRACES) {
-            await this.#stores.traces.batchInsert({ tableName, records });
-        }
+  async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
+    if (tableName === TABLE_TRACES) {
+      return this.#stores.traces.load({ tableName, keys });
     }
+    if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      return this.#stores.conversations.load({ tableName, keys });
+    }
+    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      return this.#stores.workflows.load({ tableName, keys });
+    }
+    if (tableName === TABLE_EVALS) {
+      return this.#stores.scores.load({ tableName, keys });
+    }
+    return null;
+  }
 
-    async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
-        if (tableName === TABLE_TRACES) {
-            return this.#stores.traces.load({ tableName, keys });
-        }
-        if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-            return this.#stores.conversations.load({ tableName, keys });
-        }
-        if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-            return this.#stores.workflows.load({ tableName, keys });
-        }
-        if (tableName === TABLE_EVALS) {
-            return this.#stores.scores.load({ tableName, keys });
-        }
-    }
+  async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
+    return this.#stores.conversations.getThreadById({ threadId });
+  }
 
-    async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
-        return this.#stores.conversations.getThreadById({ threadId });
-    }
+  async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
+    return this.#stores.conversations.getThreadsByResourceId({ resourceId });
+  }
 
-    async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
-        return this.#stores.conversations.getThreadsByResourceId({ resourceId });
-    }
+  async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
+    return this.#stores.conversations.saveThread({ thread });
+  }
 
-    async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
-        return this.#stores.conversations.saveThread({ thread });
-    }
+  async updateThread({
+    id,
+    title,
+    metadata,
+  }: {
+    id: string;
+    title: string;
+    metadata: Record<string, unknown>;
+  }): Promise<StorageThreadType> {
+    return this.#stores.conversations.updateThread({ id, title, metadata });
+  }
 
-    async updateThread({ id, title, metadata }: { id: string; title: string; metadata: Record<string, unknown> }): Promise<StorageThreadType> {
-        return this.#stores.conversations.updateThread({ id, title, metadata });
-    }
+  async deleteThread({ threadId }: { threadId: string }): Promise<void> {
+    return this.#stores.conversations.deleteThread({ threadId });
+  }
 
-    async deleteThread({ threadId }: { threadId: string }): Promise<void> {
-        return this.#stores.conversations.deleteThread({ threadId });
-    }
+  async getResourceById(_: { resourceId: string }): Promise<StorageResourceType | null> {
+    return this.#stores.conversations.getResourceById(_);
+  }
+
+  async saveResource(args: { resource: StorageResourceType }): Promise<StorageResourceType> {
+    return this.#stores.conversations.saveResource(args);
+  }
+
+  async updateResource(_: {
+    resourceId: string;
+    workingMemory?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<StorageResourceType> {
+    return this.#stores.conversations.updateResource(_);
+    throw new Error(
+      `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
+        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+        `To use per-resource working memory, switch to one of these supported storage adapters.`,
+    );
+  }
+
+  async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  async getMessages({
+    threadId,
+    resourceId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+    return this.#stores.conversations.getMessages({ threadId, resourceId, selectBy, format });
+  }
+
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+    return this.#stores.conversations.saveMessages(args);
+  }
+
+  async updateMessages(args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    return this.#stores.conversations.updateMessages(args);
+  }
+
+  async getTraces(args: StorageGetTracesArg): Promise<any[]> {
+    return this.#stores.traces.getTraces(args);
+  }
+
+  async persistWorkflowSnapshot({
+    workflowName,
+    runId,
+    snapshot,
+  }: {
+    workflowName: string;
+    runId: string;
+    snapshot: WorkflowRunState;
+  }): Promise<void> {
+    return await this.#stores.workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
+  }
+
+  async loadWorkflowSnapshot({
+    workflowName,
+    runId,
+  }: {
+    workflowName: string;
+    runId: string;
+  }): Promise<WorkflowRunState | null> {
+    return this.#stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+  }
+
+  async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
+    return this.#stores.scores.getEvalsByAgentName(agentName, type);
+  }
+
+  async getWorkflowRuns(args?: {
+    workflowName?: string;
+    fromDate?: Date;
+    toDate?: Date;
+    limit?: number;
+    offset?: number;
+    resourceId?: string;
+  }): Promise<WorkflowRuns> {
+    return this.#stores.workflows.getWorkflowRuns(args);
+  }
+
+  async getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null> {
+    return this.#stores.workflows.getWorkflowRunById(args);
+  }
+
+  async getTracesPaginated(args: StorageGetTracesArg): Promise<PaginationInfo & { traces: Trace[] }> {
+    return this.#stores.traces.getTracesPaginated(args);
+  }
+
+  async getThreadsByResourceIdPaginated(args: {
+    resourceId: string;
+    page: number;
+    perPage: number;
+  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+    return this.#stores.conversations.getThreadsByResourceIdPaginated(args);
+  }
+
+  async getMessagesPaginated(
+    args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },
+  ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }> {
+    return this.#stores.conversations.getMessagesPaginated(args);
+  }
 }

--- a/packages/core/src/storage/domains/base.ts
+++ b/packages/core/src/storage/domains/base.ts
@@ -1,16 +1,21 @@
 import { MastraBase } from '../../base';
-import type { TABLE_NAMES } from '../constants';
+
 import type { StorageColumn } from '../types';
+import type { MastraStore } from './store';
 
 export abstract class MastraStorageBase extends MastraBase {
   protected hasInitialized: null | Promise<boolean> = null;
   protected shouldCacheInit = true;
 
-  constructor({ name }: { name: string }) {
+  store: MastraStore;
+
+  constructor({ name, store }: { name: string; store: MastraStore }) {
     super({
       component: 'STORAGE',
       name,
     });
+
+    this.store = store;
   }
 
   public get supports(): {
@@ -22,22 +27,6 @@ export abstract class MastraStorageBase extends MastraBase {
       resourceWorkingMemory: false,
     };
   }
-
-  abstract initialize({ name, schema }: { name: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void>;
-
-  abstract teardown({ name }: { name: TABLE_NAMES }): Promise<void>;
-
-  abstract migrate(args: {
-    name: TABLE_NAMES;
-    schema: Record<string, StorageColumn>;
-    ifNotExists: string[];
-  }): Promise<void>;
-
-  abstract load<R>({ name, keys }: { name: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null>;
-
-  abstract insert({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void>;
-
-  abstract batchInsert({ name, records }: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void>;
 
   protected ensureDate(date: Date | string | undefined): Date | undefined {
     if (!date) return undefined;
@@ -68,39 +57,5 @@ export abstract class MastraStorageBase extends MastraBase {
     if (typeof last === 'number') return Math.max(0, last);
     if (last === false) return 0;
     return defaultLimit;
-  }
-
-  protected getSqlType(type: StorageColumn['type']): string {
-    switch (type) {
-      case 'text':
-        return 'TEXT';
-      case 'timestamp':
-        return 'TIMESTAMP';
-      case 'integer':
-        return 'INTEGER';
-      case 'bigint':
-        return 'BIGINT';
-      case 'jsonb':
-        return 'JSONB';
-      default:
-        return 'TEXT';
-    }
-  }
-
-  protected getDefaultValue(type: StorageColumn['type']): string {
-    switch (type) {
-      case 'text':
-      case 'uuid':
-        return "DEFAULT ''";
-      case 'timestamp':
-        return "DEFAULT '1970-01-01 00:00:00'";
-      case 'integer':
-      case 'bigint':
-        return 'DEFAULT 0';
-      case 'jsonb':
-        return "DEFAULT '{}'";
-      default:
-        return "DEFAULT ''";
-    }
   }
 }

--- a/packages/core/src/storage/domains/base.ts
+++ b/packages/core/src/storage/domains/base.ts
@@ -1,0 +1,88 @@
+import { MastraBase } from '../../base';
+
+export abstract class MastraStorageBase extends MastraBase {
+  protected hasInitialized: null | Promise<boolean> = null;
+  protected shouldCacheInit = true;
+
+  constructor({ name }: { name: string }) {
+    super({
+      component: 'STORAGE',
+      name,
+    });
+  }
+
+  public get supports(): {
+    selectByIncludeResourceScope: boolean;
+    resourceWorkingMemory: boolean;
+  } {
+    return {
+      selectByIncludeResourceScope: false,
+      resourceWorkingMemory: false,
+    };
+  }
+
+  protected ensureDate(date: Date | string | undefined): Date | undefined {
+    if (!date) return undefined;
+    return date instanceof Date ? date : new Date(date);
+  }
+
+  protected serializeDate(date: Date | string | undefined): string | undefined {
+    if (!date) return undefined;
+    const dateObj = this.ensureDate(date);
+    return dateObj?.toISOString();
+  }
+
+  /**
+   * Resolves limit for how many messages to fetch
+   *
+   * @param last The number of messages to fetch
+   * @param defaultLimit The default limit to use if last is not provided
+   * @returns The resolved limit
+   */
+  protected resolveMessageLimit({
+    last,
+    defaultLimit,
+  }: {
+    last: number | false | undefined;
+    defaultLimit: number;
+  }): number {
+    // TODO: Figure out consistent default limit for all stores as some stores use 40 and some use no limit (Number.MAX_SAFE_INTEGER)
+    if (typeof last === 'number') return Math.max(0, last);
+    if (last === false) return 0;
+    return defaultLimit;
+  }
+
+  protected getSqlType(type: StorageColumn['type']): string {
+    switch (type) {
+      case 'text':
+        return 'TEXT';
+      case 'timestamp':
+        return 'TIMESTAMP';
+      case 'integer':
+        return 'INTEGER';
+      case 'bigint':
+        return 'BIGINT';
+      case 'jsonb':
+        return 'JSONB';
+      default:
+        return 'TEXT';
+    }
+  }
+
+  protected getDefaultValue(type: StorageColumn['type']): string {
+    switch (type) {
+      case 'text':
+      case 'uuid':
+        return "DEFAULT ''";
+      case 'timestamp':
+        return "DEFAULT '1970-01-01 00:00:00'";
+      case 'integer':
+      case 'bigint':
+        return 'DEFAULT 0';
+      case 'jsonb':
+        return "DEFAULT '{}'";
+      default:
+        return "DEFAULT ''";
+    }
+  }
+}

--- a/packages/core/src/storage/domains/base.ts
+++ b/packages/core/src/storage/domains/base.ts
@@ -1,4 +1,6 @@
 import { MastraBase } from '../../base';
+import type { TABLE_NAMES } from '../constants';
+import type { StorageColumn } from '../types';
 
 export abstract class MastraStorageBase extends MastraBase {
   protected hasInitialized: null | Promise<boolean> = null;
@@ -20,6 +22,22 @@ export abstract class MastraStorageBase extends MastraBase {
       resourceWorkingMemory: false,
     };
   }
+
+  abstract initialize({ name, schema }: { name: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void>;
+
+  abstract teardown({ name }: { name: TABLE_NAMES }): Promise<void>;
+
+  abstract migrate(args: {
+    name: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+    ifNotExists: string[];
+  }): Promise<void>;
+
+  abstract load<R>({ name, keys }: { name: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null>;
+
+  abstract insert({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void>;
+
+  abstract batchInsert({ name, records }: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void>;
 
   protected ensureDate(date: Date | string | undefined): Date | undefined {
     if (!date) return undefined;

--- a/packages/core/src/storage/domains/composite.ts
+++ b/packages/core/src/storage/domains/composite.ts
@@ -56,25 +56,25 @@ export class MastraCompositeDomain extends MastraStorage {
     schema: Record<string, StorageColumn>;
   }): Promise<void> {
     if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.initialize({ name: tableName, schema });
+      await this.#stores.traces.store.initialize({ name: tableName, schema });
     } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.initialize({ name: tableName, schema });
+      await this.#stores.conversations.store.initialize({ name: tableName, schema });
     } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.initialize({ name: tableName, schema });
+      await this.#stores.workflows.store.initialize({ name: tableName, schema });
     } else if (tableName === TABLE_EVALS) {
-      await this.#stores.scores.initialize({ name: tableName, schema });
+      await this.#stores.scores.store.initialize({ name: tableName, schema });
     }
   }
 
   async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
     if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.teardown({ name: tableName });
+      await this.#stores.traces.store.teardown({ name: tableName });
     } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.teardown({ name: tableName });
+      await this.#stores.conversations.store.teardown({ name: tableName });
     } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.teardown({ name: tableName });
+      await this.#stores.workflows.store.teardown({ name: tableName });
     } else if (tableName === TABLE_EVALS) {
-      await this.#stores.scores.teardown({ name: tableName });
+      await this.#stores.scores.store.teardown({ name: tableName });
     }
   }
 
@@ -84,28 +84,28 @@ export class MastraCompositeDomain extends MastraStorage {
     ifNotExists: string[];
   }): Promise<void> {
     if (args.tableName === TABLE_TRACES) {
-      await this.#stores.traces.migrate({
+      await this.#stores.traces.store.migrate({
         name: args.tableName,
         schema: args.schema,
         ifNotExists: args.ifNotExists,
       });
     }
     if (args.tableName === TABLE_MESSAGES || args.tableName === TABLE_THREADS || args.tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.migrate({
+      await this.#stores.conversations.store.migrate({
         name: args.tableName,
         schema: args.schema,
         ifNotExists: args.ifNotExists,
       });
     }
     if (args.tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.migrate({
+      await this.#stores.workflows.store.migrate({
         name: args.tableName,
         schema: args.schema,
         ifNotExists: args.ifNotExists,
       });
     }
     if (args.tableName === TABLE_EVALS) {
-      await this.#stores.scores.migrate({
+      await this.#stores.scores.store.migrate({
         name: args.tableName,
         schema: args.schema,
         ifNotExists: args.ifNotExists,
@@ -115,40 +115,40 @@ export class MastraCompositeDomain extends MastraStorage {
 
   async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
     if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.insert({ name: tableName, record });
+      await this.#stores.traces.store.insert({ name: tableName, record });
     } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.insert({ name: tableName, record });
+      await this.#stores.conversations.store.insert({ name: tableName, record });
     } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.insert({ name: tableName, record });
+      await this.#stores.workflows.store.insert({ name: tableName, record });
     } else if (tableName === TABLE_EVALS) {
-      await this.#stores.scores.insert({ name: tableName, record });
+      await this.#stores.scores.store.insert({ name: tableName, record });
     }
   }
 
   async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
     if (tableName === TABLE_TRACES) {
-      await this.#stores.traces.batchInsert({ name: tableName, records });
+      await this.#stores.traces.store.batchInsert({ name: tableName, records });
     } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      await this.#stores.conversations.batchInsert({ name: tableName, records });
+      await this.#stores.conversations.store.batchInsert({ name: tableName, records });
     } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      await this.#stores.workflows.batchInsert({ name: tableName, records });
+      await this.#stores.workflows.store.batchInsert({ name: tableName, records });
     } else if (tableName === TABLE_EVALS) {
-      await this.#stores.scores.batchInsert({ name: tableName, records });
+      await this.#stores.scores.store.batchInsert({ name: tableName, records });
     }
   }
 
   async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
     if (tableName === TABLE_TRACES) {
-      return this.#stores.traces.load({ name: tableName, keys });
+      return this.#stores.traces.store.load({ name: tableName, keys });
     }
     if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
-      return this.#stores.conversations.load({ name: tableName, keys });
+      return this.#stores.conversations.store.load({ name: tableName, keys });
     }
     if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      return this.#stores.workflows.load({ name: tableName, keys });
+      return this.#stores.workflows.store.load({ name: tableName, keys });
     }
     if (tableName === TABLE_EVALS) {
-      return this.#stores.scores.load({ name: tableName, keys });
+      return this.#stores.scores.store.load({ name: tableName, keys });
     }
     return null;
   }

--- a/packages/core/src/storage/domains/composite.ts
+++ b/packages/core/src/storage/domains/composite.ts
@@ -1,0 +1,291 @@
+import type { MastraMessageContentV2 } from '../../agent';
+import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '../../memory/types';
+import type { Trace } from '../../telemetry';
+import type { WorkflowRunState } from '../../workflows';
+import { MastraStorage } from '../base';
+import {
+  TABLE_TRACES,
+  TABLE_MESSAGES,
+  TABLE_THREADS,
+  TABLE_RESOURCES,
+  TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_EVALS,
+} from '../constants';
+import type { TABLE_NAMES } from '../constants';
+import type {
+  StorageColumn,
+  StorageGetMessagesArg,
+  StorageGetTracesArg,
+  StorageResourceType,
+  PaginationInfo,
+  WorkflowRun,
+  EvalRow,
+  WorkflowRuns,
+} from '../types';
+import type { MastraConversationsStorage } from './conversations';
+import type { MastraScoresStorage } from './scores';
+import type { MastraTracesStorage } from './traces';
+import type { MastraWorkflowsStorage } from './workflows';
+
+export class MastraCompositeDomain extends MastraStorage {
+  #stores: {
+    traces: MastraTracesStorage;
+    conversations: MastraConversationsStorage;
+    workflows: MastraWorkflowsStorage;
+    scores: MastraScoresStorage;
+  };
+
+  constructor(stores: {
+    traces: MastraTracesStorage;
+    conversations: MastraConversationsStorage;
+    workflows: MastraWorkflowsStorage;
+    scores: MastraScoresStorage;
+  }) {
+    super({
+      name: 'COMPOSITE_DOMAIN_STORAGE',
+    });
+
+    this.#stores = stores;
+  }
+
+  async createTable({
+    tableName,
+    schema,
+  }: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+  }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.initialize({ name: tableName, schema });
+    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.initialize({ name: tableName, schema });
+    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.initialize({ name: tableName, schema });
+    } else if (tableName === TABLE_EVALS) {
+      await this.#stores.scores.initialize({ name: tableName, schema });
+    }
+  }
+
+  async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.teardown({ name: tableName });
+    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.teardown({ name: tableName });
+    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.teardown({ name: tableName });
+    } else if (tableName === TABLE_EVALS) {
+      await this.#stores.scores.teardown({ name: tableName });
+    }
+  }
+
+  async alterTable(args: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+    ifNotExists: string[];
+  }): Promise<void> {
+    if (args.tableName === TABLE_TRACES) {
+      await this.#stores.traces.migrate({
+        name: args.tableName,
+        schema: args.schema,
+        ifNotExists: args.ifNotExists,
+      });
+    }
+    if (args.tableName === TABLE_MESSAGES || args.tableName === TABLE_THREADS || args.tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.migrate({
+        name: args.tableName,
+        schema: args.schema,
+        ifNotExists: args.ifNotExists,
+      });
+    }
+    if (args.tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.migrate({
+        name: args.tableName,
+        schema: args.schema,
+        ifNotExists: args.ifNotExists,
+      });
+    }
+    if (args.tableName === TABLE_EVALS) {
+      await this.#stores.scores.migrate({
+        name: args.tableName,
+        schema: args.schema,
+        ifNotExists: args.ifNotExists,
+      });
+    }
+  }
+
+  async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.insert({ name: tableName, record });
+    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.insert({ name: tableName, record });
+    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.insert({ name: tableName, record });
+    } else if (tableName === TABLE_EVALS) {
+      await this.#stores.scores.insert({ name: tableName, record });
+    }
+  }
+
+  async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+    if (tableName === TABLE_TRACES) {
+      await this.#stores.traces.batchInsert({ name: tableName, records });
+    } else if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      await this.#stores.conversations.batchInsert({ name: tableName, records });
+    } else if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      await this.#stores.workflows.batchInsert({ name: tableName, records });
+    } else if (tableName === TABLE_EVALS) {
+      await this.#stores.scores.batchInsert({ name: tableName, records });
+    }
+  }
+
+  async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
+    if (tableName === TABLE_TRACES) {
+      return this.#stores.traces.load({ name: tableName, keys });
+    }
+    if (tableName === TABLE_MESSAGES || tableName === TABLE_THREADS || tableName === TABLE_RESOURCES) {
+      return this.#stores.conversations.load({ name: tableName, keys });
+    }
+    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      return this.#stores.workflows.load({ name: tableName, keys });
+    }
+    if (tableName === TABLE_EVALS) {
+      return this.#stores.scores.load({ name: tableName, keys });
+    }
+    return null;
+  }
+
+  async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
+    return this.#stores.conversations.getThreadById({ threadId });
+  }
+
+  async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
+    return this.#stores.conversations.getThreadsByResourceId({ resourceId });
+  }
+
+  async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
+    return this.#stores.conversations.saveThread({ thread });
+  }
+
+  async updateThread({
+    id,
+    title,
+    metadata,
+  }: {
+    id: string;
+    title: string;
+    metadata: Record<string, unknown>;
+  }): Promise<StorageThreadType> {
+    return this.#stores.conversations.updateThread({ id, title, metadata });
+  }
+
+  async deleteThread({ threadId }: { threadId: string }): Promise<void> {
+    return this.#stores.conversations.deleteThread({ threadId });
+  }
+
+  async getResourceById(_: { resourceId: string }): Promise<StorageResourceType | null> {
+    return this.#stores.conversations.getResourceById(_);
+  }
+
+  async saveResource(args: { resource: StorageResourceType }): Promise<StorageResourceType> {
+    return this.#stores.conversations.saveResource(args);
+  }
+
+  async updateResource(args: {
+    resourceId: string;
+    workingMemory?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<StorageResourceType> {
+    return this.#stores.conversations.updateResource(args);
+  }
+
+  async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  async getMessages({
+    threadId,
+    resourceId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+    return this.#stores.conversations.getMessages({ threadId, resourceId, selectBy, format });
+  }
+
+  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  async saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+    return this.#stores.conversations.saveMessages(args);
+  }
+
+  async updateMessages(args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]> {
+    return this.#stores.conversations.updateMessages(args);
+  }
+
+  async getTraces(args: StorageGetTracesArg): Promise<any[]> {
+    return this.#stores.traces.getTraces(args);
+  }
+
+  async persistWorkflowSnapshot({
+    workflowName,
+    runId,
+    snapshot,
+  }: {
+    workflowName: string;
+    runId: string;
+    snapshot: WorkflowRunState;
+  }): Promise<void> {
+    return await this.#stores.workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
+  }
+
+  async loadWorkflowSnapshot({
+    workflowName,
+    runId,
+  }: {
+    workflowName: string;
+    runId: string;
+  }): Promise<WorkflowRunState | null> {
+    return this.#stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+  }
+
+  async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
+    return this.#stores.scores.getEvalsByAgentName(agentName, type);
+  }
+
+  async getWorkflowRuns(args?: {
+    workflowName?: string;
+    fromDate?: Date;
+    toDate?: Date;
+    limit?: number;
+    offset?: number;
+    resourceId?: string;
+  }): Promise<WorkflowRuns> {
+    return this.#stores.workflows.getWorkflowRuns(args);
+  }
+
+  async getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null> {
+    return this.#stores.workflows.getWorkflowRunById(args);
+  }
+
+  async getTracesPaginated(args: StorageGetTracesArg): Promise<PaginationInfo & { traces: Trace[] }> {
+    return this.#stores.traces.getTracesPaginated(args);
+  }
+
+  async getThreadsByResourceIdPaginated(args: {
+    resourceId: string;
+    page: number;
+    perPage: number;
+  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+    return this.#stores.conversations.getThreadsByResourceIdPaginated(args);
+  }
+
+  async getMessagesPaginated(
+    args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },
+  ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }> {
+    return this.#stores.conversations.getMessagesPaginated(args);
+  }
+}

--- a/packages/core/src/storage/domains/conversations.ts
+++ b/packages/core/src/storage/domains/conversations.ts
@@ -2,10 +2,11 @@ import type { MastraMessageContentV2, MastraMessageV2 } from '../../agent';
 import type { MastraMessageV1, StorageThreadType } from '../../memory/types';
 import type { StorageGetMessagesArg, PaginationInfo, StorageResourceType } from '../types';
 import { MastraStorageBase } from './base';
+import type { MastraStore } from './store';
 
 export abstract class MastraConversationsStorage extends MastraStorageBase {
-  constructor() {
-    super({ name: 'CONVERSATIONS' });
+  constructor({ store }: { store: MastraStore }) {
+    super({ name: 'CONVERSATIONS', store });
   }
 
   abstract getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;

--- a/packages/core/src/storage/domains/conversations.ts
+++ b/packages/core/src/storage/domains/conversations.ts
@@ -1,0 +1,61 @@
+import type { MastraMessageContentV2, MastraMessageV2 } from '../../agent';
+import type { StorageThreadType } from '../../memory/types';
+import type { StorageGetMessagesArg, PaginationInfo } from '../types';
+import { MastraStorageBase } from './base';
+
+export abstract class MastraConversationsStorage extends MastraStorageBase {
+  constructor() {
+    super({ name: 'CONVERSATIONS' });
+  }
+
+  abstract getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+  abstract getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+  abstract getMessages({
+    threadId,
+    resourceId,
+    selectBy,
+    format,
+  }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]>;
+
+  abstract saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+  abstract saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+  abstract saveMessages(
+    args: { messages: MastraMessageV1[]; format?: undefined | 'v1' } | { messages: MastraMessageV2[]; format: 'v2' },
+  ): Promise<MastraMessageV2[] | MastraMessageV1[]>;
+
+  abstract updateMessages(args: {
+    messages: Partial<Omit<MastraMessageV2, 'createdAt'>> &
+      {
+        id: string;
+        content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+      }[];
+  }): Promise<MastraMessageV2[]>;
+
+  abstract getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null>;
+
+  abstract getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]>;
+
+  abstract saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType>;
+
+  abstract updateThread({
+    id,
+    title,
+    metadata,
+  }: {
+    id: string;
+    title: string;
+    metadata: Record<string, unknown>;
+  }): Promise<StorageThreadType>;
+
+  abstract deleteThread({ threadId }: { threadId: string }): Promise<void>;
+
+  abstract getThreadsByResourceIdPaginated(args: {
+    resourceId: string;
+    page: number;
+    perPage: number;
+  }): Promise<PaginationInfo & { threads: StorageThreadType[] }>;
+
+  abstract getMessagesPaginated(
+    args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },
+  ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }>;
+}

--- a/packages/core/src/storage/domains/conversations.ts
+++ b/packages/core/src/storage/domains/conversations.ts
@@ -1,6 +1,6 @@
 import type { MastraMessageContentV2, MastraMessageV2 } from '../../agent';
-import type { StorageThreadType } from '../../memory/types';
-import type { StorageGetMessagesArg, PaginationInfo } from '../types';
+import type { MastraMessageV1, StorageThreadType } from '../../memory/types';
+import type { StorageGetMessagesArg, PaginationInfo, StorageResourceType } from '../types';
 import { MastraStorageBase } from './base';
 
 export abstract class MastraConversationsStorage extends MastraStorageBase {
@@ -58,4 +58,32 @@ export abstract class MastraConversationsStorage extends MastraStorageBase {
   abstract getMessagesPaginated(
     args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },
   ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }>;
+
+  async getResourceById(_: { resourceId: string }): Promise<StorageResourceType | null> {
+    throw new Error(
+      `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
+        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+        `To use per-resource working memory, switch to one of these supported storage adapters.`,
+    );
+  }
+
+  async saveResource(_: { resource: StorageResourceType }): Promise<StorageResourceType> {
+    throw new Error(
+      `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
+        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+        `To use per-resource working memory, switch to one of these supported storage adapters.`,
+    );
+  }
+
+  async updateResource(_: {
+    resourceId: string;
+    workingMemory?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<StorageResourceType> {
+    throw new Error(
+      `Resource working memory is not supported by this storage adapter (${this.constructor.name}). ` +
+        `Supported storage adapters: LibSQL (@mastra/libsql), PostgreSQL (@mastra/pg), Upstash (@mastra/upstash). ` +
+        `To use per-resource working memory, switch to one of these supported storage adapters.`,
+    );
+  }
 }

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -1,0 +1,5 @@
+export * from './base';
+export * from './conversations';
+export * from './traces';
+export * from './workflows';
+export * from './scores';

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -1,5 +1,7 @@
 export * from './base';
 export * from './conversations';
+export * from './composite';
 export * from './traces';
 export * from './workflows';
 export * from './scores';
+export * from './store';

--- a/packages/core/src/storage/domains/scores.ts
+++ b/packages/core/src/storage/domains/scores.ts
@@ -1,4 +1,4 @@
-import type { EvalRow } from '../types';
+import type { EvalRow, PaginationArgs, PaginationInfo } from '../types';
 import { MastraStorageBase } from './base';
 import type { MastraStore } from './store';
 
@@ -6,6 +6,11 @@ export abstract class MastraScoresStorage extends MastraStorageBase {
   constructor({ store }: { store: MastraStore }) {
     super({ name: 'SCORES', store });
   }
+
+  abstract getEvals(args: {
+    agentName?: string;
+    type?: 'test' | 'live';
+  } & PaginationArgs): Promise<PaginationInfo & { evals: EvalRow[] }>;
 
   abstract getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]>;
 }

--- a/packages/core/src/storage/domains/scores.ts
+++ b/packages/core/src/storage/domains/scores.ts
@@ -1,0 +1,10 @@
+import type { EvalRow } from '../types';
+import { MastraStorageBase } from './base';
+
+export abstract class MastraScoresStorage extends MastraStorageBase {
+  constructor() {
+    super({ name: 'SCORES' });
+  }
+
+  abstract getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]>;
+}

--- a/packages/core/src/storage/domains/scores.ts
+++ b/packages/core/src/storage/domains/scores.ts
@@ -1,9 +1,10 @@
 import type { EvalRow } from '../types';
 import { MastraStorageBase } from './base';
+import type { MastraStore } from './store';
 
 export abstract class MastraScoresStorage extends MastraStorageBase {
-  constructor() {
-    super({ name: 'SCORES' });
+  constructor({ store }: { store: MastraStore }) {
+    super({ name: 'SCORES', store });
   }
 
   abstract getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]>;

--- a/packages/core/src/storage/domains/store.ts
+++ b/packages/core/src/storage/domains/store.ts
@@ -59,4 +59,6 @@ export abstract class MastraStore extends MastraBase {
         return "DEFAULT ''";
     }
   }
+
+  abstract hasAttribute(name: string, key: string): Promise<boolean>;
 }

--- a/packages/core/src/storage/domains/store.ts
+++ b/packages/core/src/storage/domains/store.ts
@@ -1,0 +1,62 @@
+import { MastraBase } from '../../base';
+import type { TABLE_NAMES } from '../constants';
+import type { StorageColumn } from '../types';
+
+export abstract class MastraStore extends MastraBase {
+  constructor({ name }: { name: string }) {
+    super({
+      component: 'STORAGE',
+      name,
+    });
+  }
+
+  abstract initialize({ name, schema }: { name: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void>;
+
+  abstract teardown({ name }: { name: TABLE_NAMES }): Promise<void>;
+
+  abstract migrate(args: {
+    name: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+    ifNotExists: string[];
+  }): Promise<void>;
+
+  abstract load<R>({ name, keys }: { name: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null>;
+
+  abstract insert({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void>;
+
+  abstract batchInsert({ name, records }: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void>;
+
+  protected getSqlType(type: StorageColumn['type']): string {
+    switch (type) {
+      case 'text':
+        return 'TEXT';
+      case 'timestamp':
+        return 'TIMESTAMP';
+      case 'integer':
+        return 'INTEGER';
+      case 'bigint':
+        return 'BIGINT';
+      case 'jsonb':
+        return 'JSONB';
+      default:
+        return 'TEXT';
+    }
+  }
+
+  protected getDefaultValue(type: StorageColumn['type']): string {
+    switch (type) {
+      case 'text':
+      case 'uuid':
+        return "DEFAULT ''";
+      case 'timestamp':
+        return "DEFAULT '1970-01-01 00:00:00'";
+      case 'integer':
+      case 'bigint':
+        return 'DEFAULT 0';
+      case 'jsonb':
+        return "DEFAULT '{}'";
+      default:
+        return "DEFAULT ''";
+    }
+  }
+}

--- a/packages/core/src/storage/domains/traces.ts
+++ b/packages/core/src/storage/domains/traces.ts
@@ -1,0 +1,15 @@
+import type { Trace } from '../../telemetry';
+import type { PaginationInfo, StorageGetTracesArg } from '../types';
+import { MastraStorageBase } from './base';
+
+export abstract class MastraTracesStorage extends MastraStorageBase {
+  constructor() {
+    super({ name: 'TRACES' });
+  }
+
+  abstract insertTraces({ records }: { records: Record<string, any>[] }): Promise<void>;
+
+  abstract getTraces(args: StorageGetTracesArg): Promise<Trace[]>;
+
+  abstract getTracesPaginated(args: StorageGetTracesArg): Promise<PaginationInfo & { traces: Trace[] }>;
+}

--- a/packages/core/src/storage/domains/traces.ts
+++ b/packages/core/src/storage/domains/traces.ts
@@ -1,10 +1,11 @@
 import type { Trace } from '../../telemetry';
 import type { PaginationInfo, StorageGetTracesArg } from '../types';
 import { MastraStorageBase } from './base';
+import type { MastraStore } from './store';
 
 export abstract class MastraTracesStorage extends MastraStorageBase {
-  constructor() {
-    super({ name: 'TRACES' });
+  constructor({ store }: { store: MastraStore }) {
+    super({ name: 'TRACES', store });
   }
 
   abstract insertTraces({ records }: { records: Record<string, any>[] }): Promise<void>;

--- a/packages/core/src/storage/domains/workflows.ts
+++ b/packages/core/src/storage/domains/workflows.ts
@@ -1,4 +1,5 @@
 import type { WorkflowRunState } from '../../workflows';
+import type { WorkflowRun, WorkflowRuns } from '../types';
 import { MastraStorageBase } from './base';
 
 export abstract class MastraWorkflowsStorage extends MastraStorageBase {
@@ -17,7 +18,7 @@ export abstract class MastraWorkflowsStorage extends MastraStorageBase {
 
   abstract getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null>;
 
-  abstract async persistWorkflowSnapshot({
+  abstract persistWorkflowSnapshot({
     workflowName,
     runId,
     snapshot,
@@ -27,7 +28,7 @@ export abstract class MastraWorkflowsStorage extends MastraStorageBase {
     snapshot: WorkflowRunState;
   }): Promise<void>;
 
-  abstract async loadWorkflowSnapshot({
+  abstract loadWorkflowSnapshot({
     workflowName,
     runId,
   }: {

--- a/packages/core/src/storage/domains/workflows.ts
+++ b/packages/core/src/storage/domains/workflows.ts
@@ -1,10 +1,11 @@
 import type { WorkflowRunState } from '../../workflows';
 import type { WorkflowRun, WorkflowRuns } from '../types';
 import { MastraStorageBase } from './base';
+import type { MastraStore } from './store';
 
 export abstract class MastraWorkflowsStorage extends MastraStorageBase {
-  constructor() {
-    super({ name: 'WORKFLOWS' });
+  constructor({ store }: { store: MastraStore }) {
+    super({ name: 'WORKFLOWS', store });
   }
 
   abstract getWorkflowRuns(args?: {

--- a/packages/core/src/storage/domains/workflows.ts
+++ b/packages/core/src/storage/domains/workflows.ts
@@ -1,0 +1,37 @@
+import type { WorkflowRunState } from '../../workflows';
+import { MastraStorageBase } from './base';
+
+export abstract class MastraWorkflowsStorage extends MastraStorageBase {
+  constructor() {
+    super({ name: 'WORKFLOWS' });
+  }
+
+  abstract getWorkflowRuns(args?: {
+    workflowName?: string;
+    fromDate?: Date;
+    toDate?: Date;
+    limit?: number;
+    offset?: number;
+    resourceId?: string;
+  }): Promise<WorkflowRuns>;
+
+  abstract getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null>;
+
+  abstract async persistWorkflowSnapshot({
+    workflowName,
+    runId,
+    snapshot,
+  }: {
+    workflowName: string;
+    runId: string;
+    snapshot: WorkflowRunState;
+  }): Promise<void>;
+
+  abstract async loadWorkflowSnapshot({
+    workflowName,
+    runId,
+  }: {
+    workflowName: string;
+    runId: string;
+  }): Promise<WorkflowRunState | null>;
+}

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,4 +1,5 @@
 export * from './base';
+export * from './composite';
 export * from './types';
 export * from './constants';
 export * from './mock';

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,5 +1,6 @@
 export * from './base';
 export * from './composite';
+export * from './domains';
 export * from './types';
 export * from './constants';
 export * from './mock';

--- a/stores/libsql/src/storage/domains/conversations.ts
+++ b/stores/libsql/src/storage/domains/conversations.ts
@@ -1,0 +1,780 @@
+import type { Client, InValue } from '@libsql/client';
+import { MessageList } from '@mastra/core/agent';
+import type { MastraMessageContentV2, MastraMessageV2 } from '@mastra/core/agent';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
+import {
+    TABLE_MESSAGES,
+    TABLE_THREADS,
+    TABLE_RESOURCES,
+    MastraConversationsStorage,
+} from '@mastra/core/storage';
+import type {
+    PaginationArgs,
+    PaginationInfo,
+    StorageGetMessagesArg,
+    StorageResourceType,
+} from '@mastra/core/storage';
+import { parseSqlIdentifier } from '@mastra/core/utils';
+import type { LibSQLInternalStore } from './store';
+
+
+export class ConversationsStorage extends MastraConversationsStorage {
+    #client: Client;
+    constructor({ client, store }: { client: Client; store: LibSQLInternalStore }) {
+        super({ store });
+        this.#client = client;
+    }
+
+    async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
+        try {
+            const result = await this.store.load<StorageThreadType>({
+                name: TABLE_THREADS,
+                keys: { id: threadId },
+            });
+
+            if (!result) {
+                return null;
+            }
+
+            return {
+                ...result,
+                metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
+            };
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_GET_THREAD_BY_ID_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { threadId },
+                },
+                error,
+            );
+        }
+    }
+
+    /**
+     * @deprecated use getThreadsByResourceIdPaginated instead for paginated results.
+     */
+    public async getThreadsByResourceId(args: { resourceId: string }): Promise<StorageThreadType[]> {
+        const { resourceId } = args;
+
+        try {
+            const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
+            const queryParams: InValue[] = [resourceId];
+
+            const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
+                id: row.id as string,
+                resourceId: row.resourceId as string,
+                title: row.title as string,
+                createdAt: new Date(row.createdAt as string), // Convert string to Date
+                updatedAt: new Date(row.updatedAt as string), // Convert string to Date
+                metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
+            });
+
+            // Non-paginated path
+            const result = await this.#client.execute({
+                sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC`,
+                args: queryParams,
+            });
+
+            if (!result.rows) {
+                return [];
+            }
+            return result.rows.map(mapRowToStorageThreadType);
+        } catch (error) {
+            const mastraError = new MastraError(
+                {
+                    id: 'LIBSQL_STORE_GET_THREADS_BY_RESOURCE_ID_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { resourceId },
+                },
+                error,
+            );
+            this.logger?.trackException?.(mastraError);
+            this.logger?.error?.(mastraError.toString());
+            return [];
+        }
+    }
+
+    public async getThreadsByResourceIdPaginated(
+        args: {
+            resourceId: string;
+        } & PaginationArgs,
+    ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+        const { resourceId, page = 0, perPage = 100 } = args;
+
+        try {
+            const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
+            const queryParams: InValue[] = [resourceId];
+
+            const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
+                id: row.id as string,
+                resourceId: row.resourceId as string,
+                title: row.title as string,
+                createdAt: new Date(row.createdAt as string), // Convert string to Date
+                updatedAt: new Date(row.updatedAt as string), // Convert string to Date
+                metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
+            });
+
+            const currentOffset = page * perPage;
+
+            const countResult = await this.#client.execute({
+                sql: `SELECT COUNT(*) as count ${baseQuery}`,
+                args: queryParams,
+            });
+            const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+            if (total === 0) {
+                return {
+                    threads: [],
+                    total: 0,
+                    page,
+                    perPage,
+                    hasMore: false,
+                };
+            }
+
+            const dataResult = await this.#client.execute({
+                sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC LIMIT ? OFFSET ?`,
+                args: [...queryParams, perPage, currentOffset],
+            });
+
+            const threads = (dataResult.rows || []).map(mapRowToStorageThreadType);
+
+            return {
+                threads,
+                total,
+                page,
+                perPage,
+                hasMore: currentOffset + threads.length < total,
+            };
+        } catch (error) {
+            const mastraError = new MastraError(
+                {
+                    id: 'LIBSQL_STORE_GET_THREADS_BY_RESOURCE_ID_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { resourceId },
+                },
+                error,
+            );
+            this.logger?.trackException?.(mastraError);
+            this.logger?.error?.(mastraError.toString());
+            return { threads: [], total: 0, page, perPage, hasMore: false };
+        }
+    }
+
+    async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
+        try {
+            await this.store.insert({
+                name: TABLE_THREADS,
+                record: {
+                    ...thread,
+                    metadata: JSON.stringify(thread.metadata),
+                },
+            });
+
+            return thread;
+        } catch (error) {
+            const mastraError = new MastraError(
+                {
+                    id: 'LIBSQL_STORE_SAVE_THREAD_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { threadId: thread.id },
+                },
+                error,
+            );
+            this.logger?.trackException?.(mastraError);
+            this.logger?.error?.(mastraError.toString());
+            throw mastraError;
+        }
+    }
+
+    async updateThread({
+        id,
+        title,
+        metadata,
+    }: {
+        id: string;
+        title: string;
+        metadata: Record<string, unknown>;
+    }): Promise<StorageThreadType> {
+        const thread = await this.getThreadById({ threadId: id });
+        if (!thread) {
+            throw new MastraError({
+                id: 'LIBSQL_STORE_UPDATE_THREAD_FAILED_THREAD_NOT_FOUND',
+                domain: ErrorDomain.STORAGE,
+                category: ErrorCategory.USER,
+                text: `Thread ${id} not found`,
+                details: {
+                    status: 404,
+                    threadId: id,
+                },
+            });
+        }
+
+        const updatedThread = {
+            ...thread,
+            title,
+            metadata: {
+                ...thread.metadata,
+                ...metadata,
+            },
+        };
+
+        try {
+            await this.#client.execute({
+                sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = ? WHERE id = ?`,
+                args: [title, JSON.stringify(updatedThread.metadata), id],
+            });
+
+            return updatedThread;
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_UPDATE_THREAD_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    text: `Failed to update thread ${id}`,
+                    details: { threadId: id },
+                },
+                error,
+            );
+        }
+    }
+
+    async deleteThread({ threadId }: { threadId: string }): Promise<void> {
+        // Delete messages for this thread (manual step)
+        try {
+            await this.#client.execute({
+                sql: `DELETE FROM ${TABLE_MESSAGES} WHERE thread_id = ?`,
+                args: [threadId],
+            });
+            await this.#client.execute({
+                sql: `DELETE FROM ${TABLE_THREADS} WHERE id = ?`,
+                args: [threadId],
+            });
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_DELETE_THREAD_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { threadId },
+                },
+                error,
+            );
+        }
+        // TODO: Need to check if CASCADE is enabled so that messages will be automatically deleted due to CASCADE constraint
+    }
+
+    private parseRow(row: any): MastraMessageV2 {
+        let content = row.content;
+        try {
+            content = JSON.parse(row.content);
+        } catch {
+            // use content as is if it's not JSON
+        }
+        const result = {
+            id: row.id,
+            content,
+            role: row.role,
+            createdAt: new Date(row.createdAt as string),
+            threadId: row.thread_id,
+            resourceId: row.resourceId,
+        } as MastraMessageV2;
+        if (row.type && row.type !== `v2`) result.type = row.type;
+        return result;
+    }
+
+    private async _getIncludedMessages({
+        threadId,
+        selectBy,
+    }: {
+        threadId: string;
+        selectBy: StorageGetMessagesArg['selectBy'];
+    }) {
+        const include = selectBy?.include;
+        if (!include) return null;
+
+        const unionQueries: string[] = [];
+        const params: any[] = [];
+
+        for (const inc of include) {
+            const { id, withPreviousMessages = 0, withNextMessages = 0 } = inc;
+            // if threadId is provided, use it, otherwise use threadId from args
+            const searchId = inc.threadId || threadId;
+            unionQueries.push(
+                `
+                SELECT * FROM (
+                  WITH numbered_messages AS (
+                    SELECT
+                      id, content, role, type, "createdAt", thread_id, "resourceId",
+                      ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) as row_num
+                    FROM "${TABLE_MESSAGES}"
+                    WHERE thread_id = ?
+                  ),
+                  target_positions AS (
+                    SELECT row_num as target_pos
+                    FROM numbered_messages
+                    WHERE id = ?
+                  )
+                  SELECT DISTINCT m.*
+                  FROM numbered_messages m
+                  CROSS JOIN target_positions t
+                  WHERE m.row_num BETWEEN (t.target_pos - ?) AND (t.target_pos + ?)
+                ) 
+                `, // Keep ASC for final sorting after fetching context
+            );
+            params.push(searchId, id, withPreviousMessages, withNextMessages);
+        }
+        const finalQuery = unionQueries.join(' UNION ALL ') + ' ORDER BY "createdAt" ASC';
+        const includedResult = await this.#client.execute({ sql: finalQuery, args: params });
+        const includedRows = includedResult.rows?.map(row => this.parseRow(row));
+        const seen = new Set<string>();
+        const dedupedRows = includedRows.filter(row => {
+            if (seen.has(row.id)) return false;
+            seen.add(row.id);
+            return true;
+        });
+        return dedupedRows;
+    }
+
+    /**
+     * @deprecated use getMessagesPaginated instead for paginated results.
+     */
+    public async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+    public async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+    public async getMessages({
+        threadId,
+        selectBy,
+        format,
+    }: StorageGetMessagesArg & {
+        format?: 'v1' | 'v2';
+    }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+        try {
+            const messages: MastraMessageV2[] = [];
+            const limit = this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
+            if (selectBy?.include?.length) {
+                const includeMessages = await this._getIncludedMessages({ threadId, selectBy });
+                if (includeMessages) {
+                    messages.push(...includeMessages);
+                }
+            }
+
+            const excludeIds = messages.map(m => m.id);
+            const remainingSql = `
+            SELECT 
+              id, 
+              content, 
+              role, 
+              type,
+              "createdAt", 
+              thread_id,
+              "resourceId"
+            FROM "${TABLE_MESSAGES}"
+            WHERE thread_id = ?
+            ${excludeIds.length ? `AND id NOT IN (${excludeIds.map(() => '?').join(', ')})` : ''}
+            ORDER BY "createdAt" DESC
+            LIMIT ?
+          `;
+            const remainingArgs = [threadId, ...(excludeIds.length ? excludeIds : []), limit];
+            const remainingResult = await this.#client.execute({ sql: remainingSql, args: remainingArgs });
+            if (remainingResult.rows) {
+                messages.push(...remainingResult.rows.map((row: any) => this.parseRow(row)));
+            }
+            messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+            const list = new MessageList().add(messages, 'memory');
+            if (format === `v2`) return list.get.all.v2();
+            return list.get.all.v1();
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_GET_MESSAGES_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { threadId },
+                },
+                error,
+            );
+        }
+    }
+
+    public async getMessagesPaginated(
+        args: StorageGetMessagesArg & {
+            format?: 'v1' | 'v2';
+        },
+    ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }> {
+        const { threadId, format, selectBy } = args;
+        const { page = 0, perPage: perPageInput, dateRange } = selectBy?.pagination || {};
+        const perPage =
+            perPageInput !== undefined ? perPageInput : this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
+        const fromDate = dateRange?.start;
+        const toDate = dateRange?.end;
+
+        const messages: MastraMessageV2[] = [];
+
+        if (selectBy?.include?.length) {
+            try {
+                const includeMessages = await this._getIncludedMessages({ threadId, selectBy });
+                if (includeMessages) {
+                    messages.push(...includeMessages);
+                }
+            } catch (error) {
+                throw new MastraError(
+                    {
+                        id: 'LIBSQL_STORE_GET_MESSAGES_PAGINATED_GET_INCLUDE_MESSAGES_FAILED',
+                        domain: ErrorDomain.STORAGE,
+                        category: ErrorCategory.THIRD_PARTY,
+                        details: { threadId },
+                    },
+                    error,
+                );
+            }
+        }
+
+        try {
+            const currentOffset = page * perPage;
+
+            const conditions: string[] = [`thread_id = ?`];
+            const queryParams: InValue[] = [threadId];
+
+            if (fromDate) {
+                conditions.push(`"createdAt" >= ?`);
+                queryParams.push(fromDate.toISOString());
+            }
+            if (toDate) {
+                conditions.push(`"createdAt" <= ?`);
+                queryParams.push(toDate.toISOString());
+            }
+            const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+            const countResult = await this.#client.execute({
+                sql: `SELECT COUNT(*) as count FROM ${TABLE_MESSAGES} ${whereClause}`,
+                args: queryParams,
+            });
+            const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+            if (total === 0 && messages.length === 0) {
+                return {
+                    messages: [],
+                    total: 0,
+                    page,
+                    perPage,
+                    hasMore: false,
+                };
+            }
+
+            const excludeIds = messages.map(m => m.id);
+            const excludeIdsParam = excludeIds.map((_, idx) => `$${idx + queryParams.length + 1}`).join(', ');
+
+            const dataResult = await this.#client.execute({
+                sql: `SELECT id, content, role, type, "createdAt", "resourceId", "thread_id" FROM ${TABLE_MESSAGES} ${whereClause} ${excludeIds.length ? `AND id NOT IN (${excludeIdsParam})` : ''} ORDER BY "createdAt" DESC LIMIT ? OFFSET ?`,
+                args: [...queryParams, ...excludeIds, perPage, currentOffset],
+            });
+
+            messages.push(...(dataResult.rows || []).map((row: any) => this.parseRow(row)));
+
+            const messagesToReturn =
+                format === 'v1'
+                    ? new MessageList().add(messages, 'memory').get.all.v1()
+                    : new MessageList().add(messages, 'memory').get.all.v2();
+
+            return {
+                messages: messagesToReturn,
+                total,
+                page,
+                perPage,
+                hasMore: currentOffset + messages.length < total,
+            };
+        } catch (error) {
+            const mastraError = new MastraError(
+                {
+                    id: 'LIBSQL_STORE_GET_MESSAGES_PAGINATED_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { threadId },
+                },
+                error,
+            );
+            this.logger?.trackException?.(mastraError);
+            this.logger?.error?.(mastraError.toString());
+            return { messages: [], total: 0, page, perPage, hasMore: false };
+        }
+    }
+
+    async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+    async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+    async saveMessages({
+        messages,
+        format,
+    }:
+        | { messages: MastraMessageV1[]; format?: undefined | 'v1' }
+        | { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+        if (messages.length === 0) return messages;
+
+        try {
+            const threadId = messages[0]?.threadId;
+            if (!threadId) {
+                throw new Error('Thread ID is required');
+            }
+
+            // Prepare batch statements for all messages
+            const batchStatements = messages.map(message => {
+                const time = message.createdAt || new Date();
+                if (!message.threadId) {
+                    throw new Error(
+                        `Expected to find a threadId for message, but couldn't find one. An unexpected error has occurred.`,
+                    );
+                }
+                if (!message.resourceId) {
+                    throw new Error(
+                        `Expected to find a resourceId for message, but couldn't find one. An unexpected error has occurred.`,
+                    );
+                }
+                return {
+                    sql: `INSERT INTO ${TABLE_MESSAGES} (id, thread_id, content, role, type, createdAt, resourceId) 
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                      thread_id=excluded.thread_id,
+                      content=excluded.content,
+                      role=excluded.role,
+                      type=excluded.type,
+                      resourceId=excluded.resourceId
+                  `,
+                    args: [
+                        message.id,
+                        message.threadId!,
+                        typeof message.content === 'object' ? JSON.stringify(message.content) : message.content,
+                        message.role,
+                        message.type || 'v2',
+                        time instanceof Date ? time.toISOString() : time,
+                        message.resourceId,
+                    ],
+                };
+            });
+
+            const now = new Date().toISOString();
+            batchStatements.push({
+                sql: `UPDATE ${TABLE_THREADS} SET updatedAt = ? WHERE id = ?`,
+                args: [now, threadId],
+            });
+
+            // Execute all inserts in a single batch
+            await this.#client.batch(batchStatements, 'write');
+
+            const list = new MessageList().add(messages, 'memory');
+            if (format === `v2`) return list.get.all.v2();
+            return list.get.all.v1();
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_SAVE_MESSAGES_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                },
+                error,
+            );
+        }
+    }
+
+    async updateMessages({
+        messages,
+    }: {
+        messages: (Partial<Omit<MastraMessageV2, 'createdAt'>> & {
+            id: string;
+            content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+        })[];
+    }): Promise<MastraMessageV2[]> {
+        if (messages.length === 0) {
+            return [];
+        }
+
+        const messageIds = messages.map(m => m.id);
+        const placeholders = messageIds.map(() => '?').join(',');
+
+        const selectSql = `SELECT * FROM ${TABLE_MESSAGES} WHERE id IN (${placeholders})`;
+        const existingResult = await this.#client.execute({ sql: selectSql, args: messageIds });
+        const existingMessages: MastraMessageV2[] = existingResult.rows.map(row => this.parseRow(row));
+
+        if (existingMessages.length === 0) {
+            return [];
+        }
+
+        const batchStatements = [];
+        const threadIdsToUpdate = new Set<string>();
+        const columnMapping: Record<string, string> = {
+            threadId: 'thread_id',
+        };
+
+        for (const existingMessage of existingMessages) {
+            const updatePayload = messages.find(m => m.id === existingMessage.id);
+            if (!updatePayload) continue;
+
+            const { id, ...fieldsToUpdate } = updatePayload;
+            if (Object.keys(fieldsToUpdate).length === 0) continue;
+
+            threadIdsToUpdate.add(existingMessage.threadId!);
+            if (updatePayload.threadId && updatePayload.threadId !== existingMessage.threadId) {
+                threadIdsToUpdate.add(updatePayload.threadId);
+            }
+
+            const setClauses = [];
+            const args: InValue[] = [];
+            const updatableFields = { ...fieldsToUpdate };
+
+            // Special handling for the 'content' field to merge instead of overwrite
+            if (updatableFields.content) {
+                const newContent = {
+                    ...existingMessage.content,
+                    ...updatableFields.content,
+                    // Deep merge metadata if it exists on both
+                    ...(existingMessage.content?.metadata && updatableFields.content.metadata
+                        ? {
+                            metadata: {
+                                ...existingMessage.content.metadata,
+                                ...updatableFields.content.metadata,
+                            },
+                        }
+                        : {}),
+                };
+                setClauses.push(`${parseSqlIdentifier('content', 'column name')} = ?`);
+                args.push(JSON.stringify(newContent));
+                delete updatableFields.content;
+            }
+
+            for (const key in updatableFields) {
+                if (Object.prototype.hasOwnProperty.call(updatableFields, key)) {
+                    const dbKey = columnMapping[key] || key;
+                    setClauses.push(`${parseSqlIdentifier(dbKey, 'column name')} = ?`);
+                    let value = updatableFields[key as keyof typeof updatableFields];
+
+                    if (typeof value === 'object' && value !== null) {
+                        value = JSON.stringify(value);
+                    }
+                    args.push(value as InValue);
+                }
+            }
+
+            if (setClauses.length === 0) continue;
+
+            args.push(id);
+
+            const sql = `UPDATE ${TABLE_MESSAGES} SET ${setClauses.join(', ')} WHERE id = ?`;
+            batchStatements.push({ sql, args });
+        }
+
+        if (batchStatements.length === 0) {
+            return existingMessages;
+        }
+
+        const now = new Date().toISOString();
+        for (const threadId of threadIdsToUpdate) {
+            if (threadId) {
+                batchStatements.push({
+                    sql: `UPDATE ${TABLE_THREADS} SET updatedAt = ? WHERE id = ?`,
+                    args: [now, threadId],
+                });
+            }
+        }
+
+        await this.#client.batch(batchStatements, 'write');
+
+        const updatedResult = await this.#client.execute({ sql: selectSql, args: messageIds });
+        return updatedResult.rows.map(row => this.parseRow(row));
+    }
+
+    async getResourceById({ resourceId }: { resourceId: string }): Promise<StorageResourceType | null> {
+        const result = await this.store.load<StorageResourceType>({
+            name: TABLE_RESOURCES,
+            keys: { id: resourceId },
+        });
+
+        if (!result) {
+            return null;
+        }
+
+        return {
+            ...result,
+            // Ensure workingMemory is always returned as a string, even if auto-parsed as JSON
+            workingMemory:
+                typeof result.workingMemory === 'object' ? JSON.stringify(result.workingMemory) : result.workingMemory,
+            metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
+        };
+    }
+
+    async saveResource({ resource }: { resource: StorageResourceType }): Promise<StorageResourceType> {
+        await this.store.insert({
+            name: TABLE_RESOURCES,
+            record: {
+                ...resource,
+                metadata: JSON.stringify(resource.metadata),
+            },
+        });
+
+        return resource;
+    }
+
+    async updateResource({
+        resourceId,
+        workingMemory,
+        metadata,
+    }: {
+        resourceId: string;
+        workingMemory?: string;
+        metadata?: Record<string, unknown>;
+    }): Promise<StorageResourceType> {
+        const existingResource = await this.getResourceById({ resourceId });
+
+        if (!existingResource) {
+            // Create new resource if it doesn't exist
+            const newResource: StorageResourceType = {
+                id: resourceId,
+                workingMemory,
+                metadata: metadata || {},
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            };
+            return this.saveResource({ resource: newResource });
+        }
+
+        const updatedResource = {
+            ...existingResource,
+            workingMemory: workingMemory !== undefined ? workingMemory : existingResource.workingMemory,
+            metadata: {
+                ...existingResource.metadata,
+                ...metadata,
+            },
+            updatedAt: new Date(),
+        };
+
+        const updates: string[] = [];
+        const values: InValue[] = [];
+
+        if (workingMemory !== undefined) {
+            updates.push('workingMemory = ?');
+            values.push(workingMemory);
+        }
+
+        if (metadata) {
+            updates.push('metadata = ?');
+            values.push(JSON.stringify(updatedResource.metadata));
+        }
+
+        updates.push('updatedAt = ?');
+        values.push(updatedResource.updatedAt.toISOString());
+
+        values.push(resourceId);
+
+        await this.#client.execute({
+            sql: `UPDATE ${TABLE_RESOURCES} SET ${updates.join(', ')} WHERE id = ?`,
+            args: values,
+        });
+
+        return updatedResource;
+    }
+}   

--- a/stores/libsql/src/storage/domains/scores.ts
+++ b/stores/libsql/src/storage/domains/scores.ts
@@ -1,0 +1,151 @@
+import type { Client, InValue } from "@libsql/client";
+import { ErrorCategory, ErrorDomain, MastraError } from "@mastra/core/error";
+import type { MetricResult, TestInfo } from "@mastra/core/eval";
+import { MastraScoresStorage, TABLE_EVALS, } from "@mastra/core/storage";
+import type { EvalRow, PaginationArgs, PaginationInfo } from "@mastra/core/storage";
+import type { LibSQLInternalStore } from "./store";
+
+export class ScoresStorage extends MastraScoresStorage {
+    #client: Client;
+    constructor({ client, store }: { client: Client; store: LibSQLInternalStore }) {
+        super({ store });
+        this.#client = client;
+    }
+
+    private transformEvalRow(row: Record<string, any>): EvalRow {
+        const resultValue = JSON.parse(row.result as string);
+        const testInfoValue = row.test_info ? JSON.parse(row.test_info as string) : undefined;
+
+        if (!resultValue || typeof resultValue !== 'object' || !('score' in resultValue)) {
+            throw new Error(`Invalid MetricResult format: ${JSON.stringify(resultValue)}`);
+        }
+
+        return {
+            input: row.input as string,
+            output: row.output as string,
+            result: resultValue as MetricResult,
+            agentName: row.agent_name as string,
+            metricName: row.metric_name as string,
+            instructions: row.instructions as string,
+            testInfo: testInfoValue as TestInfo,
+            globalRunId: row.global_run_id as string,
+            runId: row.run_id as string,
+            createdAt: row.created_at as string,
+        };
+    }
+
+
+    /** @deprecated use getEvals instead */
+    async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
+        try {
+            const baseQuery = `SELECT * FROM ${TABLE_EVALS} WHERE agent_name = ?`;
+            const typeCondition =
+                type === 'test'
+                    ? " AND test_info IS NOT NULL AND test_info->>'testPath' IS NOT NULL"
+                    : type === 'live'
+                        ? " AND (test_info IS NULL OR test_info->>'testPath' IS NULL)"
+                        : '';
+
+            const result = await this.#client.execute({
+                sql: `${baseQuery}${typeCondition} ORDER BY created_at DESC`,
+                args: [agentName],
+            });
+
+            return result.rows?.map(row => this.transformEvalRow(row)) ?? [];
+        } catch (error) {
+            // Handle case where table doesn't exist yet
+            if (error instanceof Error && error.message.includes('no such table')) {
+                return [];
+            }
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_GET_EVALS_BY_AGENT_NAME_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: { agentName },
+                },
+                error,
+            );
+        }
+    }
+
+    async getEvals(
+        options: {
+            agentName?: string;
+            type?: 'test' | 'live';
+        } & PaginationArgs = {},
+    ): Promise<PaginationInfo & { evals: EvalRow[] }> {
+        const { agentName, type, page = 0, perPage = 100, dateRange } = options;
+        const fromDate = dateRange?.start;
+        const toDate = dateRange?.end;
+
+        const conditions: string[] = [];
+        const queryParams: InValue[] = [];
+
+        if (agentName) {
+            conditions.push(`agent_name = ?`);
+            queryParams.push(agentName);
+        }
+
+        if (type === 'test') {
+            conditions.push(`(test_info IS NOT NULL AND json_extract(test_info, '$.testPath') IS NOT NULL)`);
+        } else if (type === 'live') {
+            conditions.push(`(test_info IS NULL OR json_extract(test_info, '$.testPath') IS NULL)`);
+        }
+
+        if (fromDate) {
+            conditions.push(`created_at >= ?`);
+            queryParams.push(fromDate.toISOString());
+        }
+
+        if (toDate) {
+            conditions.push(`created_at <= ?`);
+            queryParams.push(toDate.toISOString());
+        }
+
+        const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+        try {
+            const countResult = await this.#client.execute({
+                sql: `SELECT COUNT(*) as count FROM ${TABLE_EVALS} ${whereClause}`,
+                args: queryParams,
+            });
+            const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+            const currentOffset = page * perPage;
+            const hasMore = currentOffset + perPage < total;
+
+            if (total === 0) {
+                return {
+                    evals: [],
+                    total: 0,
+                    page,
+                    perPage,
+                    hasMore: false,
+                };
+            }
+
+            const dataResult = await this.#client.execute({
+                sql: `SELECT * FROM ${TABLE_EVALS} ${whereClause} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+                args: [...queryParams, perPage, currentOffset],
+            });
+
+            return {
+                evals: dataResult.rows?.map(row => this.transformEvalRow(row)) ?? [],
+                total,
+                page,
+                perPage,
+                hasMore,
+            };
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_GET_EVALS_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                },
+                error,
+            );
+        }
+    }
+}

--- a/stores/libsql/src/storage/domains/store.ts
+++ b/stores/libsql/src/storage/domains/store.ts
@@ -1,0 +1,279 @@
+import type { Client, InValue } from '@libsql/client';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { MastraStore, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
+import { parseSqlIdentifier } from '@mastra/core/utils';
+
+export class LibSQLInternalStore extends MastraStore {
+  #client: Client;
+  #maxRetries: number;
+  #initialBackoffMs: number;
+  constructor({
+    client,
+    maxRetries,
+    initialBackoffMs,
+  }: {
+    client: Client /**
+     * Maximum number of retries for write operations if an SQLITE_BUSY error occurs.
+     * @default 5
+     */;
+    maxRetries?: number;
+    /**
+     * Initial backoff time in milliseconds for retrying write operations on SQLITE_BUSY.
+     * The backoff time will double with each retry (exponential backoff).
+     * @default 100
+     */
+    initialBackoffMs?: number;
+  }) {
+    super({ name: 'LIBSQL' });
+    this.#client = client;
+    this.#maxRetries = maxRetries ?? 5;
+    this.#initialBackoffMs = initialBackoffMs ?? 100;
+  }
+
+  private async executeWriteOperationWithRetry<T>(
+    operationFn: () => Promise<T>,
+    operationDescription: string,
+  ): Promise<T> {
+    let retries = 0;
+
+    while (true) {
+      try {
+        return await operationFn();
+      } catch (error: any) {
+        if (
+          error.message &&
+          (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) &&
+          retries < this.#maxRetries
+        ) {
+          retries++;
+          const backoffTime = this.#initialBackoffMs * Math.pow(2, retries - 1);
+          this.logger.warn(
+            `LibSQLStore: Encountered SQLITE_BUSY during ${operationDescription}. Retrying (${retries}/${this.#maxRetries}) in ${backoffTime}ms...`,
+          );
+          await new Promise(resolve => setTimeout(resolve, backoffTime));
+        } else {
+          this.logger.error(`LibSQLStore: Error during ${operationDescription} after ${retries} retries: ${error}`);
+          throw error;
+        }
+      }
+    }
+  }
+
+  private prepareStatement({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): {
+    sql: string;
+    args: InValue[];
+  } {
+    const parsedTableName = parseSqlIdentifier(name, 'table name');
+    const columns = Object.keys(record).map(col => parseSqlIdentifier(col, 'column name'));
+    const values = Object.values(record).map(v => {
+      if (typeof v === `undefined`) {
+        // returning an undefined value will cause libsql to throw
+        return null;
+      }
+      if (v instanceof Date) {
+        return v.toISOString();
+      }
+      return typeof v === 'object' ? JSON.stringify(v) : v;
+    });
+    const placeholders = values.map(() => '?').join(', ');
+
+    return {
+      sql: `INSERT OR REPLACE INTO ${parsedTableName} (${columns.join(', ')}) VALUES (${placeholders})`,
+      args: values,
+    };
+  }
+
+  private async doInsert({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+    await this.#client.execute(
+      this.prepareStatement({
+        name,
+        record,
+      }),
+    );
+  }
+
+  public insert(args: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+    return this.executeWriteOperationWithRetry(() => this.doInsert(args), `insert into table ${args.name}`);
+  }
+
+  private async doBatchInsert({ name, records }: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+    if (records.length === 0) return;
+    const batchStatements = records.map(r => this.prepareStatement({ name, record: r }));
+    await this.#client.batch(batchStatements, 'write');
+  }
+
+  public batchInsert(args: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+    return this.executeWriteOperationWithRetry(
+      () => this.doBatchInsert(args),
+      `batch insert into table ${args.name}`,
+    ).catch(error => {
+      throw new MastraError(
+        {
+          id: 'LIBSQL_STORE_BATCH_INSERT_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: {
+            name: args.name,
+          },
+        },
+        error,
+      );
+    });
+  }
+
+  private getCreateTableSQL(tableName: TABLE_NAMES, schema: Record<string, StorageColumn>): string {
+    const parsedTableName = parseSqlIdentifier(tableName, 'table name');
+    const columns = Object.entries(schema).map(([name, col]) => {
+      const parsedColumnName = parseSqlIdentifier(name, 'column name');
+      let type = col.type.toUpperCase();
+      if (type === 'TEXT') type = 'TEXT';
+      if (type === 'TIMESTAMP') type = 'TEXT'; // Store timestamps as ISO strings
+      // if (type === 'BIGINT') type = 'INTEGER';
+
+      const nullable = col.nullable ? '' : 'NOT NULL';
+      const primaryKey = col.primaryKey ? 'PRIMARY KEY' : '';
+
+      return `${parsedColumnName} ${type} ${nullable} ${primaryKey}`.trim();
+    });
+
+    // For workflow_snapshot table, create a composite primary key
+    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+      const stmnt = `CREATE TABLE IF NOT EXISTS ${parsedTableName} (
+                    ${columns.join(',\n')},
+                    PRIMARY KEY (workflow_name, run_id)
+                )`;
+      return stmnt;
+    }
+
+    return `CREATE TABLE IF NOT EXISTS ${parsedTableName} (${columns.join(', ')})`;
+  }
+
+  async initialize({ name, schema }: { name: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void> {
+    try {
+      this.logger.debug(`Creating database table`, { name, operation: 'schema init' });
+      const sql = this.getCreateTableSQL(name, schema);
+      await this.#client.execute(sql);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: 'LIBSQL_STORE_CREATE_TABLE_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: {
+            name,
+          },
+        },
+        error,
+      );
+    }
+  }
+
+  async teardown({ name }: { name: TABLE_NAMES }): Promise<void> {
+    const parsedTableName = parseSqlIdentifier(name, 'table name');
+    try {
+      await this.#client.execute(`DELETE FROM ${parsedTableName}`);
+    } catch (e) {
+      const mastraError = new MastraError(
+        {
+          id: 'LIBSQL_STORE_CLEAR_TABLE_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: {
+            name,
+          },
+        },
+        e,
+      );
+      this.logger?.trackException?.(mastraError);
+      this.logger?.error?.(mastraError.toString());
+    }
+  }
+
+  /**
+   * Alters table schema to add columns if they don't exist
+   * @param tableName Name of the table
+   * @param schema Schema of the table
+   * @param ifNotExists Array of column names to add if they don't exist
+   */
+  async migrate({
+    name,
+    schema,
+    ifNotExists,
+  }: {
+    name: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+    ifNotExists: string[];
+  }): Promise<void> {
+    const parsedTableName = parseSqlIdentifier(name, 'table name');
+
+    try {
+      // 1. Get existing columns using PRAGMA
+      const pragmaQuery = `PRAGMA table_info(${parsedTableName})`;
+      const result = await this.#client.execute(pragmaQuery);
+      const existingColumnNames = new Set(result.rows.map((row: any) => row.name.toLowerCase()));
+
+      // 2. Add missing columns
+      for (const columnName of ifNotExists) {
+        if (!existingColumnNames.has(columnName.toLowerCase()) && schema[columnName]) {
+          const columnDef = schema[columnName];
+          const sqlType = this.getSqlType(columnDef.type); // ensure this exists or implement
+          const nullable = columnDef.nullable === false ? 'NOT NULL' : '';
+          // In SQLite, you must provide a DEFAULT if adding a NOT NULL column to a non-empty table
+          const defaultValue = columnDef.nullable === false ? this.getDefaultValue(columnDef.type) : '';
+          const alterSql =
+            `ALTER TABLE ${parsedTableName} ADD COLUMN "${columnName}" ${sqlType} ${nullable} ${defaultValue}`.trim();
+
+          await this.#client.execute(alterSql);
+          this.logger?.debug?.(`Added column ${columnName} to table ${parsedTableName}`);
+        }
+      }
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: 'LIBSQL_STORE_ALTER_TABLE_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: {
+            name,
+          },
+        },
+        error,
+      );
+    }
+  }
+
+  async load<R>({ name, keys }: { name: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
+    const parsedTableName = parseSqlIdentifier(name, 'table name');
+
+    const parsedKeys = Object.keys(keys).map(key => parseSqlIdentifier(key, 'column name'));
+
+    const conditions = parsedKeys.map(key => `${key} = ?`).join(' AND ');
+    const values = Object.values(keys);
+
+    const result = await this.#client.execute({
+      sql: `SELECT * FROM ${parsedTableName} WHERE ${conditions} ORDER BY createdAt DESC LIMIT 1`,
+      args: values,
+    });
+
+    if (!result.rows || result.rows.length === 0) {
+      return null;
+    }
+
+    const row = result.rows[0];
+    // Checks whether the string looks like a JSON object ({}) or array ([])
+    // If the string starts with { or [, it assumes it's JSON and parses it
+    // Otherwise, it just returns, preventing unintended number conversions
+    const parsed = Object.fromEntries(
+      Object.entries(row || {}).map(([k, v]) => {
+        try {
+          return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
+        } catch {
+          return [k, v];
+        }
+      }),
+    );
+
+    return parsed as R;
+  }
+}

--- a/stores/libsql/src/storage/domains/store.ts
+++ b/stores/libsql/src/storage/domains/store.ts
@@ -31,6 +31,13 @@ export class LibSQLInternalStore extends MastraStore {
     this.#initialBackoffMs = initialBackoffMs ?? 100;
   }
 
+  public async hasAttribute(name: string, key: string): Promise<boolean> {
+    const result = await this.#client.execute({
+      sql: `PRAGMA table_info(${name})`,
+    });
+    return (await result.rows)?.some((row: any) => row.name === key);
+  }
+
   private async executeWriteOperationWithRetry<T>(
     operationFn: () => Promise<T>,
     operationDescription: string,

--- a/stores/libsql/src/storage/domains/store.ts
+++ b/stores/libsql/src/storage/domains/store.ts
@@ -5,282 +5,294 @@ import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 
 export class LibSQLInternalStore extends MastraStore {
-  #client: Client;
-  #maxRetries: number;
-  #initialBackoffMs: number;
-  constructor({
-    client,
-    maxRetries,
-    initialBackoffMs,
-  }: {
-    client: Client /**
+    #client: Client;
+    #maxRetries: number;
+    #initialBackoffMs: number;
+    constructor({
+        client,
+        maxRetries,
+        initialBackoffMs,
+    }: {
+        client: Client /**
      * Maximum number of retries for write operations if an SQLITE_BUSY error occurs.
      * @default 5
      */;
-    maxRetries?: number;
-    /**
-     * Initial backoff time in milliseconds for retrying write operations on SQLITE_BUSY.
-     * The backoff time will double with each retry (exponential backoff).
-     * @default 100
-     */
-    initialBackoffMs?: number;
-  }) {
-    super({ name: 'LIBSQL' });
-    this.#client = client;
-    this.#maxRetries = maxRetries ?? 5;
-    this.#initialBackoffMs = initialBackoffMs ?? 100;
-  }
-
-  public async hasAttribute(name: string, key: string): Promise<boolean> {
-    const result = await this.#client.execute({
-      sql: `PRAGMA table_info(${name})`,
-    });
-    return (await result.rows)?.some((row: any) => row.name === key);
-  }
-
-  private async executeWriteOperationWithRetry<T>(
-    operationFn: () => Promise<T>,
-    operationDescription: string,
-  ): Promise<T> {
-    let retries = 0;
-
-    while (true) {
-      try {
-        return await operationFn();
-      } catch (error: any) {
-        if (
-          error.message &&
-          (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) &&
-          retries < this.#maxRetries
-        ) {
-          retries++;
-          const backoffTime = this.#initialBackoffMs * Math.pow(2, retries - 1);
-          this.logger.warn(
-            `LibSQLStore: Encountered SQLITE_BUSY during ${operationDescription}. Retrying (${retries}/${this.#maxRetries}) in ${backoffTime}ms...`,
-          );
-          await new Promise(resolve => setTimeout(resolve, backoffTime));
-        } else {
-          this.logger.error(`LibSQLStore: Error during ${operationDescription} after ${retries} retries: ${error}`);
-          throw error;
-        }
-      }
+        maxRetries?: number;
+        /**
+         * Initial backoff time in milliseconds for retrying write operations on SQLITE_BUSY.
+         * The backoff time will double with each retry (exponential backoff).
+         * @default 100
+         */
+        initialBackoffMs?: number;
+    }) {
+        super({ name: 'LIBSQL' });
+        this.#client = client;
+        this.#maxRetries = maxRetries ?? 5;
+        this.#initialBackoffMs = initialBackoffMs ?? 100;
     }
-  }
 
-  private prepareStatement({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): {
-    sql: string;
-    args: InValue[];
-  } {
-    const parsedTableName = parseSqlIdentifier(name, 'table name');
-    const columns = Object.keys(record).map(col => parseSqlIdentifier(col, 'column name'));
-    const values = Object.values(record).map(v => {
-      if (typeof v === `undefined`) {
-        // returning an undefined value will cause libsql to throw
-        return null;
-      }
-      if (v instanceof Date) {
-        return v.toISOString();
-      }
-      return typeof v === 'object' ? JSON.stringify(v) : v;
-    });
-    const placeholders = values.map(() => '?').join(', ');
+    protected getSqlType(type: StorageColumn['type']): string {
+        switch (type) {
+            case 'bigint':
+                return 'INTEGER'; // SQLite uses INTEGER for all integer sizes
+            case 'jsonb':
+                return 'TEXT'; // Store JSON as TEXT in SQLite
+            default:
+                return super.getSqlType(type);
+        }
+    }
 
-    return {
-      sql: `INSERT OR REPLACE INTO ${parsedTableName} (${columns.join(', ')}) VALUES (${placeholders})`,
-      args: values,
-    };
-  }
 
-  private async doInsert({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
-    await this.#client.execute(
-      this.prepareStatement({
-        name,
-        record,
-      }),
-    );
-  }
+    public async hasAttribute(name: string, key: string): Promise<boolean> {
+        const result = await this.#client.execute({
+            sql: `PRAGMA table_info(${name})`,
+        });
+        return (await result.rows)?.some((row: any) => row.name === key);
+    }
 
-  public insert(args: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
-    return this.executeWriteOperationWithRetry(() => this.doInsert(args), `insert into table ${args.name}`);
-  }
+    private async executeWriteOperationWithRetry<T>(
+        operationFn: () => Promise<T>,
+        operationDescription: string,
+    ): Promise<T> {
+        let retries = 0;
 
-  private async doBatchInsert({ name, records }: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
-    if (records.length === 0) return;
-    const batchStatements = records.map(r => this.prepareStatement({ name, record: r }));
-    await this.#client.batch(batchStatements, 'write');
-  }
+        while (true) {
+            try {
+                return await operationFn();
+            } catch (error: any) {
+                if (
+                    error.message &&
+                    (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) &&
+                    retries < this.#maxRetries
+                ) {
+                    retries++;
+                    const backoffTime = this.#initialBackoffMs * Math.pow(2, retries - 1);
+                    this.logger.warn(
+                        `LibSQLStore: Encountered SQLITE_BUSY during ${operationDescription}. Retrying (${retries}/${this.#maxRetries}) in ${backoffTime}ms...`,
+                    );
+                    await new Promise(resolve => setTimeout(resolve, backoffTime));
+                } else {
+                    this.logger.error(`LibSQLStore: Error during ${operationDescription} after ${retries} retries: ${error}`);
+                    throw error;
+                }
+            }
+        }
+    }
 
-  public batchInsert(args: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
-    return this.executeWriteOperationWithRetry(
-      () => this.doBatchInsert(args),
-      `batch insert into table ${args.name}`,
-    ).catch(error => {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_BATCH_INSERT_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            name: args.name,
-          },
-        },
-        error,
-      );
-    });
-  }
+    private prepareStatement({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): {
+        sql: string;
+        args: InValue[];
+    } {
+        const parsedTableName = parseSqlIdentifier(name, 'table name');
+        const columns = Object.keys(record).map(col => parseSqlIdentifier(col, 'column name'));
+        const values = Object.values(record).map(v => {
+            if (typeof v === `undefined`) {
+                // returning an undefined value will cause libsql to throw
+                return null;
+            }
+            if (v instanceof Date) {
+                return v.toISOString();
+            }
+            return typeof v === 'object' ? JSON.stringify(v) : v;
+        });
+        const placeholders = values.map(() => '?').join(', ');
 
-  private getCreateTableSQL(tableName: TABLE_NAMES, schema: Record<string, StorageColumn>): string {
-    const parsedTableName = parseSqlIdentifier(tableName, 'table name');
-    const columns = Object.entries(schema).map(([name, col]) => {
-      const parsedColumnName = parseSqlIdentifier(name, 'column name');
-      let type = col.type.toUpperCase();
-      if (type === 'TEXT') type = 'TEXT';
-      if (type === 'TIMESTAMP') type = 'TEXT'; // Store timestamps as ISO strings
-      // if (type === 'BIGINT') type = 'INTEGER';
+        return {
+            sql: `INSERT OR REPLACE INTO ${parsedTableName} (${columns.join(', ')}) VALUES (${placeholders})`,
+            args: values,
+        };
+    }
 
-      const nullable = col.nullable ? '' : 'NOT NULL';
-      const primaryKey = col.primaryKey ? 'PRIMARY KEY' : '';
+    private async doInsert({ name, record }: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+        await this.#client.execute(
+            this.prepareStatement({
+                name,
+                record,
+            }),
+        );
+    }
 
-      return `${parsedColumnName} ${type} ${nullable} ${primaryKey}`.trim();
-    });
+    public insert(args: { name: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+        return this.executeWriteOperationWithRetry(() => this.doInsert(args), `insert into table ${args.name}`);
+    }
 
-    // For workflow_snapshot table, create a composite primary key
-    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      const stmnt = `CREATE TABLE IF NOT EXISTS ${parsedTableName} (
+    private async doBatchInsert({ name, records }: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+        if (records.length === 0) return;
+        const batchStatements = records.map(r => this.prepareStatement({ name, record: r }));
+        await this.#client.batch(batchStatements, 'write');
+    }
+
+    public batchInsert(args: { name: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+        return this.executeWriteOperationWithRetry(
+            () => this.doBatchInsert(args),
+            `batch insert into table ${args.name}`,
+        ).catch(error => {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_BATCH_INSERT_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: {
+                        name: args.name,
+                    },
+                },
+                error,
+            );
+        });
+    }
+
+    private getCreateTableSQL(tableName: TABLE_NAMES, schema: Record<string, StorageColumn>): string {
+        const parsedTableName = parseSqlIdentifier(tableName, 'table name');
+        const columns = Object.entries(schema).map(([name, col]) => {
+            const parsedColumnName = parseSqlIdentifier(name, 'column name');
+            let type = col.type.toUpperCase();
+            if (type === 'TEXT') type = 'TEXT';
+            if (type === 'TIMESTAMP') type = 'TEXT'; // Store timestamps as ISO strings
+            // if (type === 'BIGINT') type = 'INTEGER';
+
+            const nullable = col.nullable ? '' : 'NOT NULL';
+            const primaryKey = col.primaryKey ? 'PRIMARY KEY' : '';
+
+            return `${parsedColumnName} ${type} ${nullable} ${primaryKey}`.trim();
+        });
+
+        // For workflow_snapshot table, create a composite primary key
+        if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+            const stmnt = `CREATE TABLE IF NOT EXISTS ${parsedTableName} (
                     ${columns.join(',\n')},
                     PRIMARY KEY (workflow_name, run_id)
                 )`;
-      return stmnt;
-    }
-
-    return `CREATE TABLE IF NOT EXISTS ${parsedTableName} (${columns.join(', ')})`;
-  }
-
-  async initialize({ name, schema }: { name: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void> {
-    try {
-      this.logger.debug(`Creating database table`, { name, operation: 'schema init' });
-      const sql = this.getCreateTableSQL(name, schema);
-      await this.#client.execute(sql);
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_CREATE_TABLE_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            name,
-          },
-        },
-        error,
-      );
-    }
-  }
-
-  async teardown({ name }: { name: TABLE_NAMES }): Promise<void> {
-    const parsedTableName = parseSqlIdentifier(name, 'table name');
-    try {
-      await this.#client.execute(`DELETE FROM ${parsedTableName}`);
-    } catch (e) {
-      const mastraError = new MastraError(
-        {
-          id: 'LIBSQL_STORE_CLEAR_TABLE_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            name,
-          },
-        },
-        e,
-      );
-      this.logger?.trackException?.(mastraError);
-      this.logger?.error?.(mastraError.toString());
-    }
-  }
-
-  /**
-   * Alters table schema to add columns if they don't exist
-   * @param tableName Name of the table
-   * @param schema Schema of the table
-   * @param ifNotExists Array of column names to add if they don't exist
-   */
-  async migrate({
-    name,
-    schema,
-    ifNotExists,
-  }: {
-    name: TABLE_NAMES;
-    schema: Record<string, StorageColumn>;
-    ifNotExists: string[];
-  }): Promise<void> {
-    const parsedTableName = parseSqlIdentifier(name, 'table name');
-
-    try {
-      // 1. Get existing columns using PRAGMA
-      const pragmaQuery = `PRAGMA table_info(${parsedTableName})`;
-      const result = await this.#client.execute(pragmaQuery);
-      const existingColumnNames = new Set(result.rows.map((row: any) => row.name.toLowerCase()));
-
-      // 2. Add missing columns
-      for (const columnName of ifNotExists) {
-        if (!existingColumnNames.has(columnName.toLowerCase()) && schema[columnName]) {
-          const columnDef = schema[columnName];
-          const sqlType = this.getSqlType(columnDef.type); // ensure this exists or implement
-          const nullable = columnDef.nullable === false ? 'NOT NULL' : '';
-          // In SQLite, you must provide a DEFAULT if adding a NOT NULL column to a non-empty table
-          const defaultValue = columnDef.nullable === false ? this.getDefaultValue(columnDef.type) : '';
-          const alterSql =
-            `ALTER TABLE ${parsedTableName} ADD COLUMN "${columnName}" ${sqlType} ${nullable} ${defaultValue}`.trim();
-
-          await this.#client.execute(alterSql);
-          this.logger?.debug?.(`Added column ${columnName} to table ${parsedTableName}`);
+            return stmnt;
         }
-      }
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_ALTER_TABLE_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            name,
-          },
-        },
-        error,
-      );
-    }
-  }
 
-  async load<R>({ name, keys }: { name: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
-    const parsedTableName = parseSqlIdentifier(name, 'table name');
-
-    const parsedKeys = Object.keys(keys).map(key => parseSqlIdentifier(key, 'column name'));
-
-    const conditions = parsedKeys.map(key => `${key} = ?`).join(' AND ');
-    const values = Object.values(keys);
-
-    const result = await this.#client.execute({
-      sql: `SELECT * FROM ${parsedTableName} WHERE ${conditions} ORDER BY createdAt DESC LIMIT 1`,
-      args: values,
-    });
-
-    if (!result.rows || result.rows.length === 0) {
-      return null;
+        return `CREATE TABLE IF NOT EXISTS ${parsedTableName} (${columns.join(', ')})`;
     }
 
-    const row = result.rows[0];
-    // Checks whether the string looks like a JSON object ({}) or array ([])
-    // If the string starts with { or [, it assumes it's JSON and parses it
-    // Otherwise, it just returns, preventing unintended number conversions
-    const parsed = Object.fromEntries(
-      Object.entries(row || {}).map(([k, v]) => {
+    async initialize({ name, schema }: { name: TABLE_NAMES; schema: Record<string, StorageColumn> }): Promise<void> {
         try {
-          return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
-        } catch {
-          return [k, v];
+            this.logger.debug(`Creating database table`, { name, operation: 'schema init' });
+            const sql = this.getCreateTableSQL(name, schema);
+            await this.#client.execute(sql);
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_CREATE_TABLE_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: {
+                        name,
+                    },
+                },
+                error,
+            );
         }
-      }),
-    );
+    }
 
-    return parsed as R;
-  }
+    async teardown({ name }: { name: TABLE_NAMES }): Promise<void> {
+        const parsedTableName = parseSqlIdentifier(name, 'table name');
+        try {
+            await this.#client.execute(`DELETE FROM ${parsedTableName}`);
+        } catch (e) {
+            const mastraError = new MastraError(
+                {
+                    id: 'LIBSQL_STORE_CLEAR_TABLE_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: {
+                        name,
+                    },
+                },
+                e,
+            );
+            this.logger?.trackException?.(mastraError);
+            this.logger?.error?.(mastraError.toString());
+        }
+    }
+
+    /**
+     * Alters table schema to add columns if they don't exist
+     * @param tableName Name of the table
+     * @param schema Schema of the table
+     * @param ifNotExists Array of column names to add if they don't exist
+     */
+    async migrate({
+        name,
+        schema,
+        ifNotExists,
+    }: {
+        name: TABLE_NAMES;
+        schema: Record<string, StorageColumn>;
+        ifNotExists: string[];
+    }): Promise<void> {
+        const parsedTableName = parseSqlIdentifier(name, 'table name');
+
+        try {
+            // 1. Get existing columns using PRAGMA
+            const pragmaQuery = `PRAGMA table_info(${parsedTableName})`;
+            const result = await this.#client.execute(pragmaQuery);
+            const existingColumnNames = new Set(result.rows.map((row: any) => row.name.toLowerCase()));
+
+            // 2. Add missing columns
+            for (const columnName of ifNotExists) {
+                if (!existingColumnNames.has(columnName.toLowerCase()) && schema[columnName]) {
+                    const columnDef = schema[columnName];
+                    const sqlType = this.getSqlType(columnDef.type); // ensure this exists or implement
+                    const nullable = columnDef.nullable === false ? 'NOT NULL' : '';
+                    // In SQLite, you must provide a DEFAULT if adding a NOT NULL column to a non-empty table
+                    const defaultValue = columnDef.nullable === false ? this.getDefaultValue(columnDef.type) : '';
+                    const alterSql =
+                        `ALTER TABLE ${parsedTableName} ADD COLUMN "${columnName}" ${sqlType} ${nullable} ${defaultValue}`.trim();
+
+                    await this.#client.execute(alterSql);
+                    this.logger?.debug?.(`Added column ${columnName} to table ${parsedTableName}`);
+                }
+            }
+        } catch (error) {
+            throw new MastraError(
+                {
+                    id: 'LIBSQL_STORE_ALTER_TABLE_FAILED',
+                    domain: ErrorDomain.STORAGE,
+                    category: ErrorCategory.THIRD_PARTY,
+                    details: {
+                        name,
+                    },
+                },
+                error,
+            );
+        }
+    }
+
+    async load<R>({ name, keys }: { name: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
+        const parsedTableName = parseSqlIdentifier(name, 'table name');
+
+        const parsedKeys = Object.keys(keys).map(key => parseSqlIdentifier(key, 'column name'));
+
+        const conditions = parsedKeys.map(key => `${key} = ?`).join(' AND ');
+        const values = Object.values(keys);
+
+        const result = await this.#client.execute({
+            sql: `SELECT * FROM ${parsedTableName} WHERE ${conditions} ORDER BY createdAt DESC LIMIT 1`,
+            args: values,
+        });
+
+        if (!result.rows || result.rows.length === 0) {
+            return null;
+        }
+
+        const row = result.rows[0];
+        // Checks whether the string looks like a JSON object ({}) or array ([])
+        // If the string starts with { or [, it assumes it's JSON and parses it
+        // Otherwise, it just returns, preventing unintended number conversions
+        const parsed = Object.fromEntries(
+            Object.entries(row || {}).map(([k, v]) => {
+                try {
+                    return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
+                } catch {
+                    return [k, v];
+                }
+            }),
+        );
+
+        return parsed as R;
+    }
 }

--- a/stores/libsql/src/storage/domains/traces.ts
+++ b/stores/libsql/src/storage/domains/traces.ts
@@ -1,0 +1,181 @@
+import type { Client, InValue } from '@libsql/client';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { MastraTracesStorage, TABLE_TRACES } from '@mastra/core/storage';
+import type { PaginationInfo, PaginationArgs } from '@mastra/core/storage';
+import type { Trace } from '@mastra/core/telemetry';
+import { parseSqlIdentifier } from '@mastra/core/utils';
+import { safelyParseJSON } from '../utils';
+import type { LibSQLInternalStore } from './store';
+
+export class TracesStorage extends MastraTracesStorage {
+  #client: Client;
+  constructor({ client, store }: { client: Client; store: LibSQLInternalStore }) {
+    super({ store });
+    this.#client = client;
+  }
+
+  /**
+   * @deprecated use getTracesPaginated instead.
+   */
+  public async getTraces(args: {
+    name?: string;
+    scope?: string;
+    page: number;
+    perPage: number;
+    attributes?: Record<string, string>;
+    filters?: Record<string, any>;
+    fromDate?: Date;
+    toDate?: Date;
+  }): Promise<Trace[]> {
+    if (args.fromDate || args.toDate) {
+      (args as any).dateRange = {
+        start: args.fromDate,
+        end: args.toDate,
+      };
+    }
+    try {
+      const result = await this.getTracesPaginated(args);
+      return result.traces;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: 'LIBSQL_STORE_GET_TRACES_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  public async getTracesPaginated(
+    args: {
+      name?: string;
+      scope?: string;
+      attributes?: Record<string, string>;
+      filters?: Record<string, any>;
+    } & PaginationArgs,
+  ): Promise<PaginationInfo & { traces: Trace[] }> {
+    const { name, scope, page = 0, perPage = 100, attributes, filters, dateRange } = args;
+    const fromDate = dateRange?.start;
+    const toDate = dateRange?.end;
+    const currentOffset = page * perPage;
+
+    const queryArgs: InValue[] = [];
+    const conditions: string[] = [];
+
+    if (name) {
+      conditions.push('name LIKE ?');
+      queryArgs.push(`${name}%`);
+    }
+    if (scope) {
+      conditions.push('scope = ?');
+      queryArgs.push(scope);
+    }
+    if (attributes) {
+      Object.entries(attributes).forEach(([key, value]) => {
+        conditions.push(`json_extract(attributes, '$.${key}') = ?`);
+        queryArgs.push(value);
+      });
+    }
+    if (filters) {
+      Object.entries(filters).forEach(([key, value]) => {
+        conditions.push(`${parseSqlIdentifier(key, 'filter key')} = ?`);
+        queryArgs.push(value);
+      });
+    }
+    if (fromDate) {
+      conditions.push('createdAt >= ?');
+      queryArgs.push(fromDate.toISOString());
+    }
+    if (toDate) {
+      conditions.push('createdAt <= ?');
+      queryArgs.push(toDate.toISOString());
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    try {
+      const countResult = await this.#client.execute({
+        sql: `SELECT COUNT(*) as count FROM ${TABLE_TRACES} ${whereClause}`,
+        args: queryArgs,
+      });
+      const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+      if (total === 0) {
+        return {
+          traces: [],
+          total: 0,
+          page,
+          perPage,
+          hasMore: false,
+        };
+      }
+
+      const dataResult = await this.#client.execute({
+        sql: `SELECT * FROM ${TABLE_TRACES} ${whereClause} ORDER BY "startTime" DESC LIMIT ? OFFSET ?`,
+        args: [...queryArgs, perPage, currentOffset],
+      });
+
+      const traces =
+        dataResult.rows?.map(
+          row =>
+            ({
+              id: row.id,
+              parentSpanId: row.parentSpanId,
+              traceId: row.traceId,
+              name: row.name,
+              scope: row.scope,
+              kind: row.kind,
+              status: safelyParseJSON(row.status as string),
+              events: safelyParseJSON(row.events as string),
+              links: safelyParseJSON(row.links as string),
+              attributes: safelyParseJSON(row.attributes as string),
+              startTime: row.startTime,
+              endTime: row.endTime,
+              other: safelyParseJSON(row.other as string),
+              createdAt: row.createdAt,
+            }) as Trace,
+        ) ?? [];
+
+      return {
+        traces,
+        total,
+        page,
+        perPage,
+        hasMore: currentOffset + traces.length < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: 'LIBSQL_STORE_GET_TRACES_PAGINATED_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async insertTraces({ records }: { records: Record<string, any>[] }): Promise<void> {
+    try {
+      await this.store.insert({
+        name: TABLE_TRACES,
+        record: records,
+      });
+    } catch (error) {
+      const mastraError = new MastraError(
+        {
+          id: 'LIBSQL_STORE_INSERT_TRACES_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { recordsCount: records.length },
+        },
+        error,
+      );
+      this.logger?.trackException?.(mastraError);
+      this.logger?.error?.(mastraError.toString());
+      throw mastraError;
+    }
+  }
+}

--- a/stores/libsql/src/storage/domains/workflows.ts
+++ b/stores/libsql/src/storage/domains/workflows.ts
@@ -1,0 +1,196 @@
+import type { Client, InValue } from '@libsql/client';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import type { WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
+import { MastraWorkflowsStorage, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
+import type { WorkflowRunState } from '@mastra/core/workflows';
+import type { LibSQLInternalStore } from './store';
+
+export class WorkflowsStorage extends MastraWorkflowsStorage {
+  #client: Client;
+  constructor({ client, store }: { client: Client; store: LibSQLInternalStore }) {
+    super({ store });
+    this.#client = client;
+  }
+
+  async persistWorkflowSnapshot({
+    workflowName,
+    runId,
+    snapshot,
+  }: {
+    workflowName: string;
+    runId: string;
+    snapshot: WorkflowRunState;
+  }): Promise<void> {
+    const data = {
+      workflow_name: workflowName,
+      run_id: runId,
+      snapshot,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.logger.debug('Persisting workflow snapshot', { workflowName, runId, data });
+    await this.store.insert({
+      name: TABLE_WORKFLOW_SNAPSHOT,
+      record: data,
+    });
+  }
+
+  async loadWorkflowSnapshot({
+    workflowName,
+    runId,
+  }: {
+    workflowName: string;
+    runId: string;
+  }): Promise<WorkflowRunState | null> {
+    this.logger.debug('Loading workflow snapshot', { workflowName, runId });
+    const d = await this.store.load<{ snapshot: WorkflowRunState }>({
+      name: TABLE_WORKFLOW_SNAPSHOT,
+      keys: { workflow_name: workflowName, run_id: runId },
+    });
+
+    return d ? d.snapshot : null;
+  }
+
+  private parseWorkflowRun(row: Record<string, any>): WorkflowRun {
+    let parsedSnapshot: WorkflowRunState | string = row.snapshot as string;
+    if (typeof parsedSnapshot === 'string') {
+      try {
+        parsedSnapshot = JSON.parse(row.snapshot as string) as WorkflowRunState;
+      } catch (e) {
+        // If parsing fails, return the raw snapshot string
+        console.warn(`Failed to parse snapshot for workflow ${row.workflow_name}: ${e}`);
+      }
+    }
+    return {
+      workflowName: row.workflow_name as string,
+      runId: row.run_id as string,
+      snapshot: parsedSnapshot,
+      resourceId: row.resourceId as string,
+      createdAt: new Date(row.createdAt as string),
+      updatedAt: new Date(row.updatedAt as string),
+    };
+  }
+
+  async getWorkflowRunById({
+    runId,
+    workflowName,
+  }: {
+    runId: string;
+    workflowName?: string;
+  }): Promise<WorkflowRun | null> {
+    const conditions: string[] = [];
+    const args: (string | number)[] = [];
+
+    if (runId) {
+      conditions.push('run_id = ?');
+      args.push(runId);
+    }
+
+    if (workflowName) {
+      conditions.push('workflow_name = ?');
+      args.push(workflowName);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    try {
+      const result = await this.#client.execute({
+        sql: `SELECT * FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause}`,
+        args,
+      });
+
+      if (!result.rows?.[0]) {
+        return null;
+      }
+
+      return this.parseWorkflowRun(result.rows[0]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: 'LIBSQL_STORE_GET_WORKFLOW_RUN_BY_ID_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getWorkflowRuns({
+    workflowName,
+    fromDate,
+    toDate,
+    limit,
+    offset,
+    resourceId,
+  }: {
+    workflowName?: string;
+    fromDate?: Date;
+    toDate?: Date;
+    limit?: number;
+    offset?: number;
+    resourceId?: string;
+  } = {}): Promise<WorkflowRuns> {
+    try {
+      const conditions: string[] = [];
+      const args: InValue[] = [];
+
+      if (workflowName) {
+        conditions.push('workflow_name = ?');
+        args.push(workflowName);
+      }
+
+      if (fromDate) {
+        conditions.push('createdAt >= ?');
+        args.push(fromDate.toISOString());
+      }
+
+      if (toDate) {
+        conditions.push('createdAt <= ?');
+        args.push(toDate.toISOString());
+      }
+
+      if (resourceId) {
+        const hasResourceId = await this.store.hasAttribute(TABLE_WORKFLOW_SNAPSHOT, 'resourceId');
+        if (hasResourceId) {
+          conditions.push('resourceId = ?');
+          args.push(resourceId);
+        } else {
+          console.warn(`[${TABLE_WORKFLOW_SNAPSHOT}] resourceId column not found. Skipping resourceId filter.`);
+        }
+      }
+
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      let total = 0;
+      // Only get total count when using pagination
+      if (limit !== undefined && offset !== undefined) {
+        const countResult = await this.#client.execute({
+          sql: `SELECT COUNT(*) as count FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause}`,
+          args,
+        });
+        total = Number(countResult.rows?.[0]?.count ?? 0);
+      }
+
+      // Get results
+      const result = await this.#client.execute({
+        sql: `SELECT * FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause} ORDER BY createdAt DESC${limit !== undefined && offset !== undefined ? ` LIMIT ? OFFSET ?` : ''}`,
+        args: limit !== undefined && offset !== undefined ? [...args, limit, offset] : args,
+      });
+
+      const runs = (result.rows || []).map(row => this.parseWorkflowRun(row));
+
+      // Use runs.length as total when not paginating
+      return { runs, total: total || runs.length };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: 'LIBSQL_STORE_GET_WORKFLOW_RUNS_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1,45 +1,20 @@
 import { createClient } from '@libsql/client';
-import type { Client, InValue } from '@libsql/client';
-import { MessageList } from '@mastra/core/agent';
-import type { MastraMessageContentV2, MastraMessageV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import type { MetricResult, TestInfo } from '@mastra/core/eval';
-import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
+import type { Client } from '@libsql/client';
 import {
-  MastraStorage,
-  TABLE_EVALS,
-  TABLE_MESSAGES,
-  TABLE_THREADS,
-  TABLE_TRACES,
-  TABLE_RESOURCES,
-  TABLE_WORKFLOW_SNAPSHOT,
+  MastraCompositeDomain,
 } from '@mastra/core/storage';
-import type {
-  EvalRow,
-  PaginationArgs,
-  PaginationInfo,
-  StorageColumn,
-  StorageGetMessagesArg,
-  StorageResourceType,
-  TABLE_NAMES,
-  WorkflowRun,
-  WorkflowRuns,
-} from '@mastra/core/storage';
-import type { Trace } from '@mastra/core/telemetry';
-import { parseSqlIdentifier } from '@mastra/core/utils';
-import type { WorkflowRunState } from '@mastra/core/workflows';
 
-function safelyParseJSON(jsonString: string): any {
-  try {
-    return JSON.parse(jsonString);
-  } catch {
-    return {};
-  }
-}
+import { ConversationsStorage } from './domains/conversations';
+import { ScoresStorage } from './domains/scores';
+import { LibSQLInternalStore } from './domains/store';
+import { TracesStorage } from './domains/traces';
+import { WorkflowsStorage } from './domains/workflows';
 
 export interface LibSQLConfig {
-  url: string;
+  client?: Client;
+  url?: string;
   authToken?: string;
+
   /**
    * Maximum number of retries for write operations if an SQLITE_BUSY error occurs.
    * @default 5
@@ -53,35 +28,76 @@ export interface LibSQLConfig {
   initialBackoffMs?: number;
 }
 
-export class LibSQLStore extends MastraStorage {
-  private client: Client;
-  private readonly maxRetries: number;
-  private readonly initialBackoffMs: number;
-
+export class LibSQLStore extends MastraCompositeDomain {
+  store: LibSQLInternalStore;
+  client: Client;
   constructor(config: LibSQLConfig) {
-    super({ name: `LibSQLStore` });
 
-    this.maxRetries = config.maxRetries ?? 5;
-    this.initialBackoffMs = config.initialBackoffMs ?? 100;
+    let client: Client;
 
-    // need to re-init every time for in memory dbs or the tables might not exist
-    if (config.url.endsWith(':memory:')) {
-      this.shouldCacheInit = false;
+    if (config.client) {
+      client = config.client;
+    } else if (config.url) {
+      client = createClient({
+        url: config.url,
+        authToken: config.authToken,
+      });
+    } else {
+      throw new Error('No client or url provided');
     }
 
-    this.client = createClient(config);
+    const store = new LibSQLInternalStore({
+      client,
+      maxRetries: config.maxRetries,
+      initialBackoffMs: config.initialBackoffMs,
+    });
+
+    const conversations = new ConversationsStorage({
+      client,
+      store,
+    });
+
+    const workflows = new WorkflowsStorage({
+      client,
+      store,
+    });
+
+    const traces = new TracesStorage({
+      client,
+      store,
+    });
+
+    const scores = new ScoresStorage({
+      client,
+      store,
+    });
 
     // Set PRAGMAs for better concurrency, especially for file-based databases
     if (config.url.startsWith('file:') || config.url.includes(':memory:')) {
-      this.client
+      client
         .execute('PRAGMA journal_mode=WAL;')
         .then(() => this.logger.debug('LibSQLStore: PRAGMA journal_mode=WAL set.'))
         .catch(err => this.logger.warn('LibSQLStore: Failed to set PRAGMA journal_mode=WAL.', err));
-      this.client
+      client
         .execute('PRAGMA busy_timeout = 5000;') // 5 seconds
         .then(() => this.logger.debug('LibSQLStore: PRAGMA busy_timeout=5000 set.'))
         .catch(err => this.logger.warn('LibSQLStore: Failed to set PRAGMA busy_timeout.', err));
     }
+
+    super({
+      conversations,
+      workflows,
+      traces,
+      scores,
+    });
+
+    // need to re-init every time for in memory dbs or the tables might not exist
+    if (config.url?.endsWith(':memory:')) {
+      this.shouldCacheInit = false;
+    }
+
+    this.store = store;
+    this.client = client;
   }
 
   public get supports(): {
@@ -93,1464 +109,1480 @@ export class LibSQLStore extends MastraStorage {
       resourceWorkingMemory: true,
     };
   }
-
-  private getCreateTableSQL(tableName: TABLE_NAMES, schema: Record<string, StorageColumn>): string {
-    const parsedTableName = parseSqlIdentifier(tableName, 'table name');
-    const columns = Object.entries(schema).map(([name, col]) => {
-      const parsedColumnName = parseSqlIdentifier(name, 'column name');
-      let type = col.type.toUpperCase();
-      if (type === 'TEXT') type = 'TEXT';
-      if (type === 'TIMESTAMP') type = 'TEXT'; // Store timestamps as ISO strings
-      // if (type === 'BIGINT') type = 'INTEGER';
-
-      const nullable = col.nullable ? '' : 'NOT NULL';
-      const primaryKey = col.primaryKey ? 'PRIMARY KEY' : '';
-
-      return `${parsedColumnName} ${type} ${nullable} ${primaryKey}`.trim();
-    });
-
-    // For workflow_snapshot table, create a composite primary key
-    if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
-      const stmnt = `CREATE TABLE IF NOT EXISTS ${parsedTableName} (
-                ${columns.join(',\n')},
-                PRIMARY KEY (workflow_name, run_id)
-            )`;
-      return stmnt;
-    }
-
-    return `CREATE TABLE IF NOT EXISTS ${parsedTableName} (${columns.join(', ')})`;
-  }
-
-  async createTable({
-    tableName,
-    schema,
-  }: {
-    tableName: TABLE_NAMES;
-    schema: Record<string, StorageColumn>;
-  }): Promise<void> {
-    try {
-      this.logger.debug(`Creating database table`, { tableName, operation: 'schema init' });
-      const sql = this.getCreateTableSQL(tableName, schema);
-      await this.client.execute(sql);
-    } catch (error) {
-      // this.logger.error(`Error creating table ${tableName}: ${error}`);
-      // throw error;
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_CREATE_TABLE_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            tableName,
-          },
-        },
-        error,
-      );
-    }
-  }
-
-  protected getSqlType(type: StorageColumn['type']): string {
-    switch (type) {
-      case 'bigint':
-        return 'INTEGER'; // SQLite uses INTEGER for all integer sizes
-      case 'jsonb':
-        return 'TEXT'; // Store JSON as TEXT in SQLite
-      default:
-        return super.getSqlType(type);
-    }
-  }
-
-  /**
-   * Alters table schema to add columns if they don't exist
-   * @param tableName Name of the table
-   * @param schema Schema of the table
-   * @param ifNotExists Array of column names to add if they don't exist
-   */
-  async alterTable({
-    tableName,
-    schema,
-    ifNotExists,
-  }: {
-    tableName: TABLE_NAMES;
-    schema: Record<string, StorageColumn>;
-    ifNotExists: string[];
-  }): Promise<void> {
-    const parsedTableName = parseSqlIdentifier(tableName, 'table name');
-
-    try {
-      // 1. Get existing columns using PRAGMA
-      const pragmaQuery = `PRAGMA table_info(${parsedTableName})`;
-      const result = await this.client.execute(pragmaQuery);
-      const existingColumnNames = new Set(result.rows.map((row: any) => row.name.toLowerCase()));
-
-      // 2. Add missing columns
-      for (const columnName of ifNotExists) {
-        if (!existingColumnNames.has(columnName.toLowerCase()) && schema[columnName]) {
-          const columnDef = schema[columnName];
-          const sqlType = this.getSqlType(columnDef.type); // ensure this exists or implement
-          const nullable = columnDef.nullable === false ? 'NOT NULL' : '';
-          // In SQLite, you must provide a DEFAULT if adding a NOT NULL column to a non-empty table
-          const defaultValue = columnDef.nullable === false ? this.getDefaultValue(columnDef.type) : '';
-          const alterSql =
-            `ALTER TABLE ${parsedTableName} ADD COLUMN "${columnName}" ${sqlType} ${nullable} ${defaultValue}`.trim();
-
-          await this.client.execute(alterSql);
-          this.logger?.debug?.(`Added column ${columnName} to table ${parsedTableName}`);
-        }
-      }
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_ALTER_TABLE_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            tableName,
-          },
-        },
-        error,
-      );
-    }
-  }
-
-  async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
-    const parsedTableName = parseSqlIdentifier(tableName, 'table name');
-    try {
-      await this.client.execute(`DELETE FROM ${parsedTableName}`);
-    } catch (e) {
-      const mastraError = new MastraError(
-        {
-          id: 'LIBSQL_STORE_CLEAR_TABLE_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            tableName,
-          },
-        },
-        e,
-      );
-      this.logger?.trackException?.(mastraError);
-      this.logger?.error?.(mastraError.toString());
-    }
-  }
-
-  private prepareStatement({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): {
-    sql: string;
-    args: InValue[];
-  } {
-    const parsedTableName = parseSqlIdentifier(tableName, 'table name');
-    const columns = Object.keys(record).map(col => parseSqlIdentifier(col, 'column name'));
-    const values = Object.values(record).map(v => {
-      if (typeof v === `undefined`) {
-        // returning an undefined value will cause libsql to throw
-        return null;
-      }
-      if (v instanceof Date) {
-        return v.toISOString();
-      }
-      return typeof v === 'object' ? JSON.stringify(v) : v;
-    });
-    const placeholders = values.map(() => '?').join(', ');
-
-    return {
-      sql: `INSERT OR REPLACE INTO ${parsedTableName} (${columns.join(', ')}) VALUES (${placeholders})`,
-      args: values,
-    };
-  }
-
-  private async executeWriteOperationWithRetry<T>(
-    operationFn: () => Promise<T>,
-    operationDescription: string,
-  ): Promise<T> {
-    let retries = 0;
-
-    while (true) {
-      try {
-        return await operationFn();
-      } catch (error: any) {
-        if (
-          error.message &&
-          (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) &&
-          retries < this.maxRetries
-        ) {
-          retries++;
-          const backoffTime = this.initialBackoffMs * Math.pow(2, retries - 1);
-          this.logger.warn(
-            `LibSQLStore: Encountered SQLITE_BUSY during ${operationDescription}. Retrying (${retries}/${this.maxRetries}) in ${backoffTime}ms...`,
-          );
-          await new Promise(resolve => setTimeout(resolve, backoffTime));
-        } else {
-          this.logger.error(`LibSQLStore: Error during ${operationDescription} after ${retries} retries: ${error}`);
-          throw error;
-        }
-      }
-    }
-  }
-
-  public insert(args: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
-    return this.executeWriteOperationWithRetry(() => this.doInsert(args), `insert into table ${args.tableName}`);
-  }
-
-  private async doInsert({
-    tableName,
-    record,
-  }: {
-    tableName: TABLE_NAMES;
-    record: Record<string, any>;
-  }): Promise<void> {
-    await this.client.execute(
-      this.prepareStatement({
-        tableName,
-        record,
-      }),
-    );
-  }
-
-  public batchInsert(args: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
-    return this.executeWriteOperationWithRetry(
-      () => this.doBatchInsert(args),
-      `batch insert into table ${args.tableName}`,
-    ).catch(error => {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_BATCH_INSERT_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: {
-            tableName: args.tableName,
-          },
-        },
-        error,
-      );
-    });
-  }
-
-  private async doBatchInsert({
-    tableName,
-    records,
-  }: {
-    tableName: TABLE_NAMES;
-    records: Record<string, any>[];
-  }): Promise<void> {
-    if (records.length === 0) return;
-    const batchStatements = records.map(r => this.prepareStatement({ tableName, record: r }));
-    await this.client.batch(batchStatements, 'write');
-  }
-
-  async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
-    const parsedTableName = parseSqlIdentifier(tableName, 'table name');
-
-    const parsedKeys = Object.keys(keys).map(key => parseSqlIdentifier(key, 'column name'));
-
-    const conditions = parsedKeys.map(key => `${key} = ?`).join(' AND ');
-    const values = Object.values(keys);
-
-    const result = await this.client.execute({
-      sql: `SELECT * FROM ${parsedTableName} WHERE ${conditions} ORDER BY createdAt DESC LIMIT 1`,
-      args: values,
-    });
-
-    if (!result.rows || result.rows.length === 0) {
-      return null;
-    }
-
-    const row = result.rows[0];
-    // Checks whether the string looks like a JSON object ({}) or array ([])
-    // If the string starts with { or [, it assumes it's JSON and parses it
-    // Otherwise, it just returns, preventing unintended number conversions
-    const parsed = Object.fromEntries(
-      Object.entries(row || {}).map(([k, v]) => {
-        try {
-          return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
-        } catch {
-          return [k, v];
-        }
-      }),
-    );
-
-    return parsed as R;
-  }
-
-  async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
-    try {
-      const result = await this.load<StorageThreadType>({
-        tableName: TABLE_THREADS,
-        keys: { id: threadId },
-      });
-
-      if (!result) {
-        return null;
-      }
-
-      return {
-        ...result,
-        metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
-      };
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_THREAD_BY_ID_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { threadId },
-        },
-        error,
-      );
-    }
-  }
-
-  /**
-   * @deprecated use getThreadsByResourceIdPaginated instead for paginated results.
-   */
-  public async getThreadsByResourceId(args: { resourceId: string }): Promise<StorageThreadType[]> {
-    const { resourceId } = args;
-
-    try {
-      const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
-      const queryParams: InValue[] = [resourceId];
-
-      const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
-        id: row.id as string,
-        resourceId: row.resourceId as string,
-        title: row.title as string,
-        createdAt: new Date(row.createdAt as string), // Convert string to Date
-        updatedAt: new Date(row.updatedAt as string), // Convert string to Date
-        metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
-      });
-
-      // Non-paginated path
-      const result = await this.client.execute({
-        sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC`,
-        args: queryParams,
-      });
-
-      if (!result.rows) {
-        return [];
-      }
-      return result.rows.map(mapRowToStorageThreadType);
-    } catch (error) {
-      const mastraError = new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_THREADS_BY_RESOURCE_ID_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { resourceId },
-        },
-        error,
-      );
-      this.logger?.trackException?.(mastraError);
-      this.logger?.error?.(mastraError.toString());
-      return [];
-    }
-  }
-
-  public async getThreadsByResourceIdPaginated(
-    args: {
-      resourceId: string;
-    } & PaginationArgs,
-  ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
-    const { resourceId, page = 0, perPage = 100 } = args;
-
-    try {
-      const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
-      const queryParams: InValue[] = [resourceId];
-
-      const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
-        id: row.id as string,
-        resourceId: row.resourceId as string,
-        title: row.title as string,
-        createdAt: new Date(row.createdAt as string), // Convert string to Date
-        updatedAt: new Date(row.updatedAt as string), // Convert string to Date
-        metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
-      });
-
-      const currentOffset = page * perPage;
-
-      const countResult = await this.client.execute({
-        sql: `SELECT COUNT(*) as count ${baseQuery}`,
-        args: queryParams,
-      });
-      const total = Number(countResult.rows?.[0]?.count ?? 0);
-
-      if (total === 0) {
-        return {
-          threads: [],
-          total: 0,
-          page,
-          perPage,
-          hasMore: false,
-        };
-      }
-
-      const dataResult = await this.client.execute({
-        sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC LIMIT ? OFFSET ?`,
-        args: [...queryParams, perPage, currentOffset],
-      });
-
-      const threads = (dataResult.rows || []).map(mapRowToStorageThreadType);
-
-      return {
-        threads,
-        total,
-        page,
-        perPage,
-        hasMore: currentOffset + threads.length < total,
-      };
-    } catch (error) {
-      const mastraError = new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_THREADS_BY_RESOURCE_ID_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { resourceId },
-        },
-        error,
-      );
-      this.logger?.trackException?.(mastraError);
-      this.logger?.error?.(mastraError.toString());
-      return { threads: [], total: 0, page, perPage, hasMore: false };
-    }
-  }
-
-  async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
-    try {
-      await this.insert({
-        tableName: TABLE_THREADS,
-        record: {
-          ...thread,
-          metadata: JSON.stringify(thread.metadata),
-        },
-      });
-
-      return thread;
-    } catch (error) {
-      const mastraError = new MastraError(
-        {
-          id: 'LIBSQL_STORE_SAVE_THREAD_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { threadId: thread.id },
-        },
-        error,
-      );
-      this.logger?.trackException?.(mastraError);
-      this.logger?.error?.(mastraError.toString());
-      throw mastraError;
-    }
-  }
-
-  async updateThread({
-    id,
-    title,
-    metadata,
-  }: {
-    id: string;
-    title: string;
-    metadata: Record<string, unknown>;
-  }): Promise<StorageThreadType> {
-    const thread = await this.getThreadById({ threadId: id });
-    if (!thread) {
-      throw new MastraError({
-        id: 'LIBSQL_STORE_UPDATE_THREAD_FAILED_THREAD_NOT_FOUND',
-        domain: ErrorDomain.STORAGE,
-        category: ErrorCategory.USER,
-        text: `Thread ${id} not found`,
-        details: {
-          status: 404,
-          threadId: id,
-        },
-      });
-    }
-
-    const updatedThread = {
-      ...thread,
-      title,
-      metadata: {
-        ...thread.metadata,
-        ...metadata,
-      },
-    };
-
-    try {
-      await this.client.execute({
-        sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = ? WHERE id = ?`,
-        args: [title, JSON.stringify(updatedThread.metadata), id],
-      });
-
-      return updatedThread;
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_UPDATE_THREAD_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          text: `Failed to update thread ${id}`,
-          details: { threadId: id },
-        },
-        error,
-      );
-    }
-  }
-
-  async deleteThread({ threadId }: { threadId: string }): Promise<void> {
-    // Delete messages for this thread (manual step)
-    try {
-      await this.client.execute({
-        sql: `DELETE FROM ${TABLE_MESSAGES} WHERE thread_id = ?`,
-        args: [threadId],
-      });
-      await this.client.execute({
-        sql: `DELETE FROM ${TABLE_THREADS} WHERE id = ?`,
-        args: [threadId],
-      });
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_DELETE_THREAD_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { threadId },
-        },
-        error,
-      );
-    }
-    // TODO: Need to check if CASCADE is enabled so that messages will be automatically deleted due to CASCADE constraint
-  }
-
-  private parseRow(row: any): MastraMessageV2 {
-    let content = row.content;
-    try {
-      content = JSON.parse(row.content);
-    } catch {
-      // use content as is if it's not JSON
-    }
-    const result = {
-      id: row.id,
-      content,
-      role: row.role,
-      createdAt: new Date(row.createdAt as string),
-      threadId: row.thread_id,
-      resourceId: row.resourceId,
-    } as MastraMessageV2;
-    if (row.type && row.type !== `v2`) result.type = row.type;
-    return result;
-  }
-
-  private async _getIncludedMessages({
-    threadId,
-    selectBy,
-  }: {
-    threadId: string;
-    selectBy: StorageGetMessagesArg['selectBy'];
-  }) {
-    const include = selectBy?.include;
-    if (!include) return null;
-
-    const unionQueries: string[] = [];
-    const params: any[] = [];
-
-    for (const inc of include) {
-      const { id, withPreviousMessages = 0, withNextMessages = 0 } = inc;
-      // if threadId is provided, use it, otherwise use threadId from args
-      const searchId = inc.threadId || threadId;
-      unionQueries.push(
-        `
-            SELECT * FROM (
-              WITH numbered_messages AS (
-                SELECT
-                  id, content, role, type, "createdAt", thread_id, "resourceId",
-                  ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) as row_num
-                FROM "${TABLE_MESSAGES}"
-                WHERE thread_id = ?
-              ),
-              target_positions AS (
-                SELECT row_num as target_pos
-                FROM numbered_messages
-                WHERE id = ?
-              )
-              SELECT DISTINCT m.*
-              FROM numbered_messages m
-              CROSS JOIN target_positions t
-              WHERE m.row_num BETWEEN (t.target_pos - ?) AND (t.target_pos + ?)
-            ) 
-            `, // Keep ASC for final sorting after fetching context
-      );
-      params.push(searchId, id, withPreviousMessages, withNextMessages);
-    }
-    const finalQuery = unionQueries.join(' UNION ALL ') + ' ORDER BY "createdAt" ASC';
-    const includedResult = await this.client.execute({ sql: finalQuery, args: params });
-    const includedRows = includedResult.rows?.map(row => this.parseRow(row));
-    const seen = new Set<string>();
-    const dedupedRows = includedRows.filter(row => {
-      if (seen.has(row.id)) return false;
-      seen.add(row.id);
-      return true;
-    });
-    return dedupedRows;
-  }
-
-  /**
-   * @deprecated use getMessagesPaginated instead for paginated results.
-   */
-  public async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
-  public async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
-  public async getMessages({
-    threadId,
-    selectBy,
-    format,
-  }: StorageGetMessagesArg & {
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    try {
-      const messages: MastraMessageV2[] = [];
-      const limit = this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
-      if (selectBy?.include?.length) {
-        const includeMessages = await this._getIncludedMessages({ threadId, selectBy });
-        if (includeMessages) {
-          messages.push(...includeMessages);
-        }
-      }
-
-      const excludeIds = messages.map(m => m.id);
-      const remainingSql = `
-        SELECT 
-          id, 
-          content, 
-          role, 
-          type,
-          "createdAt", 
-          thread_id,
-          "resourceId"
-        FROM "${TABLE_MESSAGES}"
-        WHERE thread_id = ?
-        ${excludeIds.length ? `AND id NOT IN (${excludeIds.map(() => '?').join(', ')})` : ''}
-        ORDER BY "createdAt" DESC
-        LIMIT ?
-      `;
-      const remainingArgs = [threadId, ...(excludeIds.length ? excludeIds : []), limit];
-      const remainingResult = await this.client.execute({ sql: remainingSql, args: remainingArgs });
-      if (remainingResult.rows) {
-        messages.push(...remainingResult.rows.map((row: any) => this.parseRow(row)));
-      }
-      messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
-      const list = new MessageList().add(messages, 'memory');
-      if (format === `v2`) return list.get.all.v2();
-      return list.get.all.v1();
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_MESSAGES_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { threadId },
-        },
-        error,
-      );
-    }
-  }
-
-  public async getMessagesPaginated(
-    args: StorageGetMessagesArg & {
-      format?: 'v1' | 'v2';
-    },
-  ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }> {
-    const { threadId, format, selectBy } = args;
-    const { page = 0, perPage: perPageInput, dateRange } = selectBy?.pagination || {};
-    const perPage =
-      perPageInput !== undefined ? perPageInput : this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
-    const fromDate = dateRange?.start;
-    const toDate = dateRange?.end;
-
-    const messages: MastraMessageV2[] = [];
-
-    if (selectBy?.include?.length) {
-      try {
-        const includeMessages = await this._getIncludedMessages({ threadId, selectBy });
-        if (includeMessages) {
-          messages.push(...includeMessages);
-        }
-      } catch (error) {
-        throw new MastraError(
-          {
-            id: 'LIBSQL_STORE_GET_MESSAGES_PAGINATED_GET_INCLUDE_MESSAGES_FAILED',
-            domain: ErrorDomain.STORAGE,
-            category: ErrorCategory.THIRD_PARTY,
-            details: { threadId },
-          },
-          error,
-        );
-      }
-    }
-
-    try {
-      const currentOffset = page * perPage;
-
-      const conditions: string[] = [`thread_id = ?`];
-      const queryParams: InValue[] = [threadId];
-
-      if (fromDate) {
-        conditions.push(`"createdAt" >= ?`);
-        queryParams.push(fromDate.toISOString());
-      }
-      if (toDate) {
-        conditions.push(`"createdAt" <= ?`);
-        queryParams.push(toDate.toISOString());
-      }
-      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-      const countResult = await this.client.execute({
-        sql: `SELECT COUNT(*) as count FROM ${TABLE_MESSAGES} ${whereClause}`,
-        args: queryParams,
-      });
-      const total = Number(countResult.rows?.[0]?.count ?? 0);
-
-      if (total === 0 && messages.length === 0) {
-        return {
-          messages: [],
-          total: 0,
-          page,
-          perPage,
-          hasMore: false,
-        };
-      }
-
-      const excludeIds = messages.map(m => m.id);
-      const excludeIdsParam = excludeIds.map((_, idx) => `$${idx + queryParams.length + 1}`).join(', ');
-
-      const dataResult = await this.client.execute({
-        sql: `SELECT id, content, role, type, "createdAt", "resourceId", "thread_id" FROM ${TABLE_MESSAGES} ${whereClause} ${excludeIds.length ? `AND id NOT IN (${excludeIdsParam})` : ''} ORDER BY "createdAt" DESC LIMIT ? OFFSET ?`,
-        args: [...queryParams, ...excludeIds, perPage, currentOffset],
-      });
-
-      messages.push(...(dataResult.rows || []).map((row: any) => this.parseRow(row)));
-
-      const messagesToReturn =
-        format === 'v1'
-          ? new MessageList().add(messages, 'memory').get.all.v1()
-          : new MessageList().add(messages, 'memory').get.all.v2();
-
-      return {
-        messages: messagesToReturn,
-        total,
-        page,
-        perPage,
-        hasMore: currentOffset + messages.length < total,
-      };
-    } catch (error) {
-      const mastraError = new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_MESSAGES_PAGINATED_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { threadId },
-        },
-        error,
-      );
-      this.logger?.trackException?.(mastraError);
-      this.logger?.error?.(mastraError.toString());
-      return { messages: [], total: 0, page, perPage, hasMore: false };
-    }
-  }
-
-  async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
-  async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
-  async saveMessages({
-    messages,
-    format,
-  }:
-    | { messages: MastraMessageV1[]; format?: undefined | 'v1' }
-    | { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[] | MastraMessageV1[]> {
-    if (messages.length === 0) return messages;
-
-    try {
-      const threadId = messages[0]?.threadId;
-      if (!threadId) {
-        throw new Error('Thread ID is required');
-      }
-
-      // Prepare batch statements for all messages
-      const batchStatements = messages.map(message => {
-        const time = message.createdAt || new Date();
-        if (!message.threadId) {
-          throw new Error(
-            `Expected to find a threadId for message, but couldn't find one. An unexpected error has occurred.`,
-          );
-        }
-        if (!message.resourceId) {
-          throw new Error(
-            `Expected to find a resourceId for message, but couldn't find one. An unexpected error has occurred.`,
-          );
-        }
-        return {
-          sql: `INSERT INTO ${TABLE_MESSAGES} (id, thread_id, content, role, type, createdAt, resourceId) 
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                  thread_id=excluded.thread_id,
-                  content=excluded.content,
-                  role=excluded.role,
-                  type=excluded.type,
-                  resourceId=excluded.resourceId
-              `,
-          args: [
-            message.id,
-            message.threadId!,
-            typeof message.content === 'object' ? JSON.stringify(message.content) : message.content,
-            message.role,
-            message.type || 'v2',
-            time instanceof Date ? time.toISOString() : time,
-            message.resourceId,
-          ],
-        };
-      });
-
-      const now = new Date().toISOString();
-      batchStatements.push({
-        sql: `UPDATE ${TABLE_THREADS} SET updatedAt = ? WHERE id = ?`,
-        args: [now, threadId],
-      });
-
-      // Execute all inserts in a single batch
-      await this.client.batch(batchStatements, 'write');
-
-      const list = new MessageList().add(messages, 'memory');
-      if (format === `v2`) return list.get.all.v2();
-      return list.get.all.v1();
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_SAVE_MESSAGES_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-        },
-        error,
-      );
-    }
-  }
-
-  async updateMessages({
-    messages,
-  }: {
-    messages: (Partial<Omit<MastraMessageV2, 'createdAt'>> & {
-      id: string;
-      content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
-    })[];
-  }): Promise<MastraMessageV2[]> {
-    if (messages.length === 0) {
-      return [];
-    }
-
-    const messageIds = messages.map(m => m.id);
-    const placeholders = messageIds.map(() => '?').join(',');
-
-    const selectSql = `SELECT * FROM ${TABLE_MESSAGES} WHERE id IN (${placeholders})`;
-    const existingResult = await this.client.execute({ sql: selectSql, args: messageIds });
-    const existingMessages: MastraMessageV2[] = existingResult.rows.map(row => this.parseRow(row));
-
-    if (existingMessages.length === 0) {
-      return [];
-    }
-
-    const batchStatements = [];
-    const threadIdsToUpdate = new Set<string>();
-    const columnMapping: Record<string, string> = {
-      threadId: 'thread_id',
-    };
-
-    for (const existingMessage of existingMessages) {
-      const updatePayload = messages.find(m => m.id === existingMessage.id);
-      if (!updatePayload) continue;
-
-      const { id, ...fieldsToUpdate } = updatePayload;
-      if (Object.keys(fieldsToUpdate).length === 0) continue;
-
-      threadIdsToUpdate.add(existingMessage.threadId!);
-      if (updatePayload.threadId && updatePayload.threadId !== existingMessage.threadId) {
-        threadIdsToUpdate.add(updatePayload.threadId);
-      }
-
-      const setClauses = [];
-      const args: InValue[] = [];
-      const updatableFields = { ...fieldsToUpdate };
-
-      // Special handling for the 'content' field to merge instead of overwrite
-      if (updatableFields.content) {
-        const newContent = {
-          ...existingMessage.content,
-          ...updatableFields.content,
-          // Deep merge metadata if it exists on both
-          ...(existingMessage.content?.metadata && updatableFields.content.metadata
-            ? {
-                metadata: {
-                  ...existingMessage.content.metadata,
-                  ...updatableFields.content.metadata,
-                },
-              }
-            : {}),
-        };
-        setClauses.push(`${parseSqlIdentifier('content', 'column name')} = ?`);
-        args.push(JSON.stringify(newContent));
-        delete updatableFields.content;
-      }
-
-      for (const key in updatableFields) {
-        if (Object.prototype.hasOwnProperty.call(updatableFields, key)) {
-          const dbKey = columnMapping[key] || key;
-          setClauses.push(`${parseSqlIdentifier(dbKey, 'column name')} = ?`);
-          let value = updatableFields[key as keyof typeof updatableFields];
-
-          if (typeof value === 'object' && value !== null) {
-            value = JSON.stringify(value);
-          }
-          args.push(value as InValue);
-        }
-      }
-
-      if (setClauses.length === 0) continue;
-
-      args.push(id);
-
-      const sql = `UPDATE ${TABLE_MESSAGES} SET ${setClauses.join(', ')} WHERE id = ?`;
-      batchStatements.push({ sql, args });
-    }
-
-    if (batchStatements.length === 0) {
-      return existingMessages;
-    }
-
-    const now = new Date().toISOString();
-    for (const threadId of threadIdsToUpdate) {
-      if (threadId) {
-        batchStatements.push({
-          sql: `UPDATE ${TABLE_THREADS} SET updatedAt = ? WHERE id = ?`,
-          args: [now, threadId],
-        });
-      }
-    }
-
-    await this.client.batch(batchStatements, 'write');
-
-    const updatedResult = await this.client.execute({ sql: selectSql, args: messageIds });
-    return updatedResult.rows.map(row => this.parseRow(row));
-  }
-
-  private transformEvalRow(row: Record<string, any>): EvalRow {
-    const resultValue = JSON.parse(row.result as string);
-    const testInfoValue = row.test_info ? JSON.parse(row.test_info as string) : undefined;
-
-    if (!resultValue || typeof resultValue !== 'object' || !('score' in resultValue)) {
-      throw new Error(`Invalid MetricResult format: ${JSON.stringify(resultValue)}`);
-    }
-
-    return {
-      input: row.input as string,
-      output: row.output as string,
-      result: resultValue as MetricResult,
-      agentName: row.agent_name as string,
-      metricName: row.metric_name as string,
-      instructions: row.instructions as string,
-      testInfo: testInfoValue as TestInfo,
-      globalRunId: row.global_run_id as string,
-      runId: row.run_id as string,
-      createdAt: row.created_at as string,
-    };
-  }
-
-  /** @deprecated use getEvals instead */
-  async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
-    try {
-      const baseQuery = `SELECT * FROM ${TABLE_EVALS} WHERE agent_name = ?`;
-      const typeCondition =
-        type === 'test'
-          ? " AND test_info IS NOT NULL AND test_info->>'testPath' IS NOT NULL"
-          : type === 'live'
-            ? " AND (test_info IS NULL OR test_info->>'testPath' IS NULL)"
-            : '';
-
-      const result = await this.client.execute({
-        sql: `${baseQuery}${typeCondition} ORDER BY created_at DESC`,
-        args: [agentName],
-      });
-
-      return result.rows?.map(row => this.transformEvalRow(row)) ?? [];
-    } catch (error) {
-      // Handle case where table doesn't exist yet
-      if (error instanceof Error && error.message.includes('no such table')) {
-        return [];
-      }
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_EVALS_BY_AGENT_NAME_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-          details: { agentName },
-        },
-        error,
-      );
-    }
-  }
-
-  async getEvals(
-    options: {
-      agentName?: string;
-      type?: 'test' | 'live';
-    } & PaginationArgs = {},
-  ): Promise<PaginationInfo & { evals: EvalRow[] }> {
-    const { agentName, type, page = 0, perPage = 100, dateRange } = options;
-    const fromDate = dateRange?.start;
-    const toDate = dateRange?.end;
-
-    const conditions: string[] = [];
-    const queryParams: InValue[] = [];
-
-    if (agentName) {
-      conditions.push(`agent_name = ?`);
-      queryParams.push(agentName);
-    }
-
-    if (type === 'test') {
-      conditions.push(`(test_info IS NOT NULL AND json_extract(test_info, '$.testPath') IS NOT NULL)`);
-    } else if (type === 'live') {
-      conditions.push(`(test_info IS NULL OR json_extract(test_info, '$.testPath') IS NULL)`);
-    }
-
-    if (fromDate) {
-      conditions.push(`created_at >= ?`);
-      queryParams.push(fromDate.toISOString());
-    }
-
-    if (toDate) {
-      conditions.push(`created_at <= ?`);
-      queryParams.push(toDate.toISOString());
-    }
-
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-    try {
-      const countResult = await this.client.execute({
-        sql: `SELECT COUNT(*) as count FROM ${TABLE_EVALS} ${whereClause}`,
-        args: queryParams,
-      });
-      const total = Number(countResult.rows?.[0]?.count ?? 0);
-
-      const currentOffset = page * perPage;
-      const hasMore = currentOffset + perPage < total;
-
-      if (total === 0) {
-        return {
-          evals: [],
-          total: 0,
-          page,
-          perPage,
-          hasMore: false,
-        };
-      }
-
-      const dataResult = await this.client.execute({
-        sql: `SELECT * FROM ${TABLE_EVALS} ${whereClause} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
-        args: [...queryParams, perPage, currentOffset],
-      });
-
-      return {
-        evals: dataResult.rows?.map(row => this.transformEvalRow(row)) ?? [],
-        total,
-        page,
-        perPage,
-        hasMore,
-      };
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_EVALS_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-        },
-        error,
-      );
-    }
-  }
-
-  /**
-   * @deprecated use getTracesPaginated instead.
-   */
-  public async getTraces(args: {
-    name?: string;
-    scope?: string;
-    page: number;
-    perPage: number;
-    attributes?: Record<string, string>;
-    filters?: Record<string, any>;
-    fromDate?: Date;
-    toDate?: Date;
-  }): Promise<Trace[]> {
-    if (args.fromDate || args.toDate) {
-      (args as any).dateRange = {
-        start: args.fromDate,
-        end: args.toDate,
-      };
-    }
-    try {
-      const result = await this.getTracesPaginated(args);
-      return result.traces;
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_TRACES_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-        },
-        error,
-      );
-    }
-  }
-
-  public async getTracesPaginated(
-    args: {
-      name?: string;
-      scope?: string;
-      attributes?: Record<string, string>;
-      filters?: Record<string, any>;
-    } & PaginationArgs,
-  ): Promise<PaginationInfo & { traces: Trace[] }> {
-    const { name, scope, page = 0, perPage = 100, attributes, filters, dateRange } = args;
-    const fromDate = dateRange?.start;
-    const toDate = dateRange?.end;
-    const currentOffset = page * perPage;
-
-    const queryArgs: InValue[] = [];
-    const conditions: string[] = [];
-
-    if (name) {
-      conditions.push('name LIKE ?');
-      queryArgs.push(`${name}%`);
-    }
-    if (scope) {
-      conditions.push('scope = ?');
-      queryArgs.push(scope);
-    }
-    if (attributes) {
-      Object.entries(attributes).forEach(([key, value]) => {
-        conditions.push(`json_extract(attributes, '$.${key}') = ?`);
-        queryArgs.push(value);
-      });
-    }
-    if (filters) {
-      Object.entries(filters).forEach(([key, value]) => {
-        conditions.push(`${parseSqlIdentifier(key, 'filter key')} = ?`);
-        queryArgs.push(value);
-      });
-    }
-    if (fromDate) {
-      conditions.push('createdAt >= ?');
-      queryArgs.push(fromDate.toISOString());
-    }
-    if (toDate) {
-      conditions.push('createdAt <= ?');
-      queryArgs.push(toDate.toISOString());
-    }
-
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-    try {
-      const countResult = await this.client.execute({
-        sql: `SELECT COUNT(*) as count FROM ${TABLE_TRACES} ${whereClause}`,
-        args: queryArgs,
-      });
-      const total = Number(countResult.rows?.[0]?.count ?? 0);
-
-      if (total === 0) {
-        return {
-          traces: [],
-          total: 0,
-          page,
-          perPage,
-          hasMore: false,
-        };
-      }
-
-      const dataResult = await this.client.execute({
-        sql: `SELECT * FROM ${TABLE_TRACES} ${whereClause} ORDER BY "startTime" DESC LIMIT ? OFFSET ?`,
-        args: [...queryArgs, perPage, currentOffset],
-      });
-
-      const traces =
-        dataResult.rows?.map(
-          row =>
-            ({
-              id: row.id,
-              parentSpanId: row.parentSpanId,
-              traceId: row.traceId,
-              name: row.name,
-              scope: row.scope,
-              kind: row.kind,
-              status: safelyParseJSON(row.status as string),
-              events: safelyParseJSON(row.events as string),
-              links: safelyParseJSON(row.links as string),
-              attributes: safelyParseJSON(row.attributes as string),
-              startTime: row.startTime,
-              endTime: row.endTime,
-              other: safelyParseJSON(row.other as string),
-              createdAt: row.createdAt,
-            }) as Trace,
-        ) ?? [];
-
-      return {
-        traces,
-        total,
-        page,
-        perPage,
-        hasMore: currentOffset + traces.length < total,
-      };
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_TRACES_PAGINATED_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-        },
-        error,
-      );
-    }
-  }
-
-  async getWorkflowRuns({
-    workflowName,
-    fromDate,
-    toDate,
-    limit,
-    offset,
-    resourceId,
-  }: {
-    workflowName?: string;
-    fromDate?: Date;
-    toDate?: Date;
-    limit?: number;
-    offset?: number;
-    resourceId?: string;
-  } = {}): Promise<WorkflowRuns> {
-    try {
-      const conditions: string[] = [];
-      const args: InValue[] = [];
-
-      if (workflowName) {
-        conditions.push('workflow_name = ?');
-        args.push(workflowName);
-      }
-
-      if (fromDate) {
-        conditions.push('createdAt >= ?');
-        args.push(fromDate.toISOString());
-      }
-
-      if (toDate) {
-        conditions.push('createdAt <= ?');
-        args.push(toDate.toISOString());
-      }
-
-      if (resourceId) {
-        const hasResourceId = await this.hasColumn(TABLE_WORKFLOW_SNAPSHOT, 'resourceId');
-        if (hasResourceId) {
-          conditions.push('resourceId = ?');
-          args.push(resourceId);
-        } else {
-          console.warn(`[${TABLE_WORKFLOW_SNAPSHOT}] resourceId column not found. Skipping resourceId filter.`);
-        }
-      }
-
-      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-      let total = 0;
-      // Only get total count when using pagination
-      if (limit !== undefined && offset !== undefined) {
-        const countResult = await this.client.execute({
-          sql: `SELECT COUNT(*) as count FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause}`,
-          args,
-        });
-        total = Number(countResult.rows?.[0]?.count ?? 0);
-      }
-
-      // Get results
-      const result = await this.client.execute({
-        sql: `SELECT * FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause} ORDER BY createdAt DESC${limit !== undefined && offset !== undefined ? ` LIMIT ? OFFSET ?` : ''}`,
-        args: limit !== undefined && offset !== undefined ? [...args, limit, offset] : args,
-      });
-
-      const runs = (result.rows || []).map(row => this.parseWorkflowRun(row));
-
-      // Use runs.length as total when not paginating
-      return { runs, total: total || runs.length };
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_WORKFLOW_RUNS_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-        },
-        error,
-      );
-    }
-  }
-
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    const conditions: string[] = [];
-    const args: (string | number)[] = [];
-
-    if (runId) {
-      conditions.push('run_id = ?');
-      args.push(runId);
-    }
-
-    if (workflowName) {
-      conditions.push('workflow_name = ?');
-      args.push(workflowName);
-    }
-
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-    try {
-      const result = await this.client.execute({
-        sql: `SELECT * FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause}`,
-        args,
-      });
-
-      if (!result.rows?.[0]) {
-        return null;
-      }
-
-      return this.parseWorkflowRun(result.rows[0]);
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: 'LIBSQL_STORE_GET_WORKFLOW_RUN_BY_ID_FAILED',
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-        },
-        error,
-      );
-    }
-  }
-
-  async getResourceById({ resourceId }: { resourceId: string }): Promise<StorageResourceType | null> {
-    const result = await this.load<StorageResourceType>({
-      tableName: TABLE_RESOURCES,
-      keys: { id: resourceId },
-    });
-
-    if (!result) {
-      return null;
-    }
-
-    return {
-      ...result,
-      // Ensure workingMemory is always returned as a string, even if auto-parsed as JSON
-      workingMemory:
-        typeof result.workingMemory === 'object' ? JSON.stringify(result.workingMemory) : result.workingMemory,
-      metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
-    };
-  }
-
-  async saveResource({ resource }: { resource: StorageResourceType }): Promise<StorageResourceType> {
-    await this.insert({
-      tableName: TABLE_RESOURCES,
-      record: {
-        ...resource,
-        metadata: JSON.stringify(resource.metadata),
-      },
-    });
-
-    return resource;
-  }
-
-  async updateResource({
-    resourceId,
-    workingMemory,
-    metadata,
-  }: {
-    resourceId: string;
-    workingMemory?: string;
-    metadata?: Record<string, unknown>;
-  }): Promise<StorageResourceType> {
-    const existingResource = await this.getResourceById({ resourceId });
-
-    if (!existingResource) {
-      // Create new resource if it doesn't exist
-      const newResource: StorageResourceType = {
-        id: resourceId,
-        workingMemory,
-        metadata: metadata || {},
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-      return this.saveResource({ resource: newResource });
-    }
-
-    const updatedResource = {
-      ...existingResource,
-      workingMemory: workingMemory !== undefined ? workingMemory : existingResource.workingMemory,
-      metadata: {
-        ...existingResource.metadata,
-        ...metadata,
-      },
-      updatedAt: new Date(),
-    };
-
-    const updates: string[] = [];
-    const values: InValue[] = [];
-
-    if (workingMemory !== undefined) {
-      updates.push('workingMemory = ?');
-      values.push(workingMemory);
-    }
-
-    if (metadata) {
-      updates.push('metadata = ?');
-      values.push(JSON.stringify(updatedResource.metadata));
-    }
-
-    updates.push('updatedAt = ?');
-    values.push(updatedResource.updatedAt.toISOString());
-
-    values.push(resourceId);
-
-    await this.client.execute({
-      sql: `UPDATE ${TABLE_RESOURCES} SET ${updates.join(', ')} WHERE id = ?`,
-      args: values,
-    });
-
-    return updatedResource;
-  }
-
-  private async hasColumn(table: string, column: string): Promise<boolean> {
-    const result = await this.client.execute({
-      sql: `PRAGMA table_info(${table})`,
-    });
-    return (await result.rows)?.some((row: any) => row.name === column);
-  }
-
-  private parseWorkflowRun(row: Record<string, any>): WorkflowRun {
-    let parsedSnapshot: WorkflowRunState | string = row.snapshot as string;
-    if (typeof parsedSnapshot === 'string') {
-      try {
-        parsedSnapshot = JSON.parse(row.snapshot as string) as WorkflowRunState;
-      } catch (e) {
-        // If parsing fails, return the raw snapshot string
-        console.warn(`Failed to parse snapshot for workflow ${row.workflow_name}: ${e}`);
-      }
-    }
-    return {
-      workflowName: row.workflow_name as string,
-      runId: row.run_id as string,
-      snapshot: parsedSnapshot,
-      resourceId: row.resourceId as string,
-      createdAt: new Date(row.createdAt as string),
-      updatedAt: new Date(row.updatedAt as string),
-    };
-  }
 }
+// export class LibSQLStore extends MastraStorage {
+//   private client: Client;
+//   private readonly maxRetries: number;
+//   private readonly initialBackoffMs: number;
+
+//   constructor(config: LibSQLConfig) {
+//     super({ name: `LibSQLStore` });
+
+//     this.maxRetries = config.maxRetries ?? 5;
+//     this.initialBackoffMs = config.initialBackoffMs ?? 100;
+
+
+//   }
+
+
+
+//   private getCreateTableSQL(tableName: TABLE_NAMES, schema: Record<string, StorageColumn>): string {
+//     const parsedTableName = parseSqlIdentifier(tableName, 'table name');
+//     const columns = Object.entries(schema).map(([name, col]) => {
+//       const parsedColumnName = parseSqlIdentifier(name, 'column name');
+//       let type = col.type.toUpperCase();
+//       if (type === 'TEXT') type = 'TEXT';
+//       if (type === 'TIMESTAMP') type = 'TEXT'; // Store timestamps as ISO strings
+//       // if (type === 'BIGINT') type = 'INTEGER';
+
+//       const nullable = col.nullable ? '' : 'NOT NULL';
+//       const primaryKey = col.primaryKey ? 'PRIMARY KEY' : '';
+
+//       return `${parsedColumnName} ${type} ${nullable} ${primaryKey}`.trim();
+//     });
+
+//     // For workflow_snapshot table, create a composite primary key
+//     if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
+//       const stmnt = `CREATE TABLE IF NOT EXISTS ${parsedTableName} (
+//                 ${columns.join(',\n')},
+//                 PRIMARY KEY (workflow_name, run_id)
+//             )`;
+//       return stmnt;
+//     }
+
+//     return `CREATE TABLE IF NOT EXISTS ${parsedTableName} (${columns.join(', ')})`;
+//   }
+
+//   async createTable({
+//     tableName,
+//     schema,
+//   }: {
+//     tableName: TABLE_NAMES;
+//     schema: Record<string, StorageColumn>;
+//   }): Promise<void> {
+//     try {
+//       this.logger.debug(`Creating database table`, { tableName, operation: 'schema init' });
+//       const sql = this.getCreateTableSQL(tableName, schema);
+//       await this.client.execute(sql);
+//     } catch (error) {
+//       // this.logger.error(`Error creating table ${tableName}: ${error}`);
+//       // throw error;
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_CREATE_TABLE_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: {
+//             tableName,
+//           },
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   protected getSqlType(type: StorageColumn['type']): string {
+//     switch (type) {
+//       case 'bigint':
+//         return 'INTEGER'; // SQLite uses INTEGER for all integer sizes
+//       case 'jsonb':
+//         return 'TEXT'; // Store JSON as TEXT in SQLite
+//       default:
+//         return super.getSqlType(type);
+//     }
+//   }
+
+//   /**
+//    * Alters table schema to add columns if they don't exist
+//    * @param tableName Name of the table
+//    * @param schema Schema of the table
+//    * @param ifNotExists Array of column names to add if they don't exist
+//    */
+//   async alterTable({
+//     tableName,
+//     schema,
+//     ifNotExists,
+//   }: {
+//     tableName: TABLE_NAMES;
+//     schema: Record<string, StorageColumn>;
+//     ifNotExists: string[];
+//   }): Promise<void> {
+//     const parsedTableName = parseSqlIdentifier(tableName, 'table name');
+
+//     try {
+//       // 1. Get existing columns using PRAGMA
+//       const pragmaQuery = `PRAGMA table_info(${parsedTableName})`;
+//       const result = await this.client.execute(pragmaQuery);
+//       const existingColumnNames = new Set(result.rows.map((row: any) => row.name.toLowerCase()));
+
+//       // 2. Add missing columns
+//       for (const columnName of ifNotExists) {
+//         if (!existingColumnNames.has(columnName.toLowerCase()) && schema[columnName]) {
+//           const columnDef = schema[columnName];
+//           const sqlType = this.getSqlType(columnDef.type); // ensure this exists or implement
+//           const nullable = columnDef.nullable === false ? 'NOT NULL' : '';
+//           // In SQLite, you must provide a DEFAULT if adding a NOT NULL column to a non-empty table
+//           const defaultValue = columnDef.nullable === false ? this.getDefaultValue(columnDef.type) : '';
+//           const alterSql =
+//             `ALTER TABLE ${parsedTableName} ADD COLUMN "${columnName}" ${sqlType} ${nullable} ${defaultValue}`.trim();
+
+//           await this.client.execute(alterSql);
+//           this.logger?.debug?.(`Added column ${columnName} to table ${parsedTableName}`);
+//         }
+//       }
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_ALTER_TABLE_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: {
+//             tableName,
+//           },
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
+//     const parsedTableName = parseSqlIdentifier(tableName, 'table name');
+//     try {
+//       await this.client.execute(`DELETE FROM ${parsedTableName}`);
+//     } catch (e) {
+//       const mastraError = new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_CLEAR_TABLE_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: {
+//             tableName,
+//           },
+//         },
+//         e,
+//       );
+//       this.logger?.trackException?.(mastraError);
+//       this.logger?.error?.(mastraError.toString());
+//     }
+//   }
+
+//   private prepareStatement({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): {
+//     sql: string;
+//     args: InValue[];
+//   } {
+//     const parsedTableName = parseSqlIdentifier(tableName, 'table name');
+//     const columns = Object.keys(record).map(col => parseSqlIdentifier(col, 'column name'));
+//     const values = Object.values(record).map(v => {
+//       if (typeof v === `undefined`) {
+//         // returning an undefined value will cause libsql to throw
+//         return null;
+//       }
+//       if (v instanceof Date) {
+//         return v.toISOString();
+//       }
+//       return typeof v === 'object' ? JSON.stringify(v) : v;
+//     });
+//     const placeholders = values.map(() => '?').join(', ');
+
+//     return {
+//       sql: `INSERT OR REPLACE INTO ${parsedTableName} (${columns.join(', ')}) VALUES (${placeholders})`,
+//       args: values,
+//     };
+//   }
+
+//   private async executeWriteOperationWithRetry<T>(
+//     operationFn: () => Promise<T>,
+//     operationDescription: string,
+//   ): Promise<T> {
+//     let retries = 0;
+
+//     while (true) {
+//       try {
+//         return await operationFn();
+//       } catch (error: any) {
+//         if (
+//           error.message &&
+//           (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) &&
+//           retries < this.maxRetries
+//         ) {
+//           retries++;
+//           const backoffTime = this.initialBackoffMs * Math.pow(2, retries - 1);
+//           this.logger.warn(
+//             `LibSQLStore: Encountered SQLITE_BUSY during ${operationDescription}. Retrying (${retries}/${this.maxRetries}) in ${backoffTime}ms...`,
+//           );
+//           await new Promise(resolve => setTimeout(resolve, backoffTime));
+//         } else {
+//           this.logger.error(`LibSQLStore: Error during ${operationDescription} after ${retries} retries: ${error}`);
+//           throw error;
+//         }
+//       }
+//     }
+//   }
+
+//   public insert(args: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+//     return this.executeWriteOperationWithRetry(() => this.doInsert(args), `insert into table ${args.tableName}`);
+//   }
+
+//   private async doInsert({
+//     tableName,
+//     record,
+//   }: {
+//     tableName: TABLE_NAMES;
+//     record: Record<string, any>;
+//   }): Promise<void> {
+//     await this.client.execute(
+//       this.prepareStatement({
+//         tableName,
+//         record,
+//       }),
+//     );
+//   }
+
+//   public batchInsert(args: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+//     return this.executeWriteOperationWithRetry(
+//       () => this.doBatchInsert(args),
+//       `batch insert into table ${args.tableName}`,
+//     ).catch(error => {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_BATCH_INSERT_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: {
+//             tableName: args.tableName,
+//           },
+//         },
+//         error,
+//       );
+//     });
+//   }
+
+//   private async doBatchInsert({
+//     tableName,
+//     records,
+//   }: {
+//     tableName: TABLE_NAMES;
+//     records: Record<string, any>[];
+//   }): Promise<void> {
+//     if (records.length === 0) return;
+//     const batchStatements = records.map(r => this.prepareStatement({ tableName, record: r }));
+//     await this.client.batch(batchStatements, 'write');
+//   }
+
+//   async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, string> }): Promise<R | null> {
+//     const parsedTableName = parseSqlIdentifier(tableName, 'table name');
+
+//     const parsedKeys = Object.keys(keys).map(key => parseSqlIdentifier(key, 'column name'));
+
+//     const conditions = parsedKeys.map(key => `${key} = ?`).join(' AND ');
+//     const values = Object.values(keys);
+
+//     const result = await this.client.execute({
+//       sql: `SELECT * FROM ${parsedTableName} WHERE ${conditions} ORDER BY createdAt DESC LIMIT 1`,
+//       args: values,
+//     });
+
+//     if (!result.rows || result.rows.length === 0) {
+//       return null;
+//     }
+
+//     const row = result.rows[0];
+//     // Checks whether the string looks like a JSON object ({}) or array ([])
+//     // If the string starts with { or [, it assumes it's JSON and parses it
+//     // Otherwise, it just returns, preventing unintended number conversions
+//     const parsed = Object.fromEntries(
+//       Object.entries(row || {}).map(([k, v]) => {
+//         try {
+//           return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
+//         } catch {
+//           return [k, v];
+//         }
+//       }),
+//     );
+
+//     return parsed as R;
+//   }
+
+//   async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
+//     try {
+//       const result = await this.load<StorageThreadType>({
+//         tableName: TABLE_THREADS,
+//         keys: { id: threadId },
+//       });
+
+//       if (!result) {
+//         return null;
+//       }
+
+//       return {
+//         ...result,
+//         metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
+//       };
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_THREAD_BY_ID_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: { threadId },
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   /**
+//    * @deprecated use getThreadsByResourceIdPaginated instead for paginated results.
+//    */
+//   public async getThreadsByResourceId(args: { resourceId: string }): Promise<StorageThreadType[]> {
+//     const { resourceId } = args;
+
+//     try {
+//       const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
+//       const queryParams: InValue[] = [resourceId];
+
+//       const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
+//         id: row.id as string,
+//         resourceId: row.resourceId as string,
+//         title: row.title as string,
+//         createdAt: new Date(row.createdAt as string), // Convert string to Date
+//         updatedAt: new Date(row.updatedAt as string), // Convert string to Date
+//         metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
+//       });
+
+//       // Non-paginated path
+//       const result = await this.client.execute({
+//         sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC`,
+//         args: queryParams,
+//       });
+
+//       if (!result.rows) {
+//         return [];
+//       }
+//       return result.rows.map(mapRowToStorageThreadType);
+//     } catch (error) {
+//       const mastraError = new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_THREADS_BY_RESOURCE_ID_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: { resourceId },
+//         },
+//         error,
+//       );
+//       this.logger?.trackException?.(mastraError);
+//       this.logger?.error?.(mastraError.toString());
+//       return [];
+//     }
+//   }
+
+//   public async getThreadsByResourceIdPaginated(
+//     args: {
+//       resourceId: string;
+//     } & PaginationArgs,
+//   ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+//     const { resourceId, page = 0, perPage = 100 } = args;
+
+//     try {
+//       const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
+//       const queryParams: InValue[] = [resourceId];
+
+//       const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
+//         id: row.id as string,
+//         resourceId: row.resourceId as string,
+//         title: row.title as string,
+//         createdAt: new Date(row.createdAt as string), // Convert string to Date
+//         updatedAt: new Date(row.updatedAt as string), // Convert string to Date
+//         metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
+//       });
+
+//       const currentOffset = page * perPage;
+
+//       const countResult = await this.client.execute({
+//         sql: `SELECT COUNT(*) as count ${baseQuery}`,
+//         args: queryParams,
+//       });
+//       const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+//       if (total === 0) {
+//         return {
+//           threads: [],
+//           total: 0,
+//           page,
+//           perPage,
+//           hasMore: false,
+//         };
+//       }
+
+//       const dataResult = await this.client.execute({
+//         sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC LIMIT ? OFFSET ?`,
+//         args: [...queryParams, perPage, currentOffset],
+//       });
+
+//       const threads = (dataResult.rows || []).map(mapRowToStorageThreadType);
+
+//       return {
+//         threads,
+//         total,
+//         page,
+//         perPage,
+//         hasMore: currentOffset + threads.length < total,
+//       };
+//     } catch (error) {
+//       const mastraError = new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_THREADS_BY_RESOURCE_ID_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: { resourceId },
+//         },
+//         error,
+//       );
+//       this.logger?.trackException?.(mastraError);
+//       this.logger?.error?.(mastraError.toString());
+//       return { threads: [], total: 0, page, perPage, hasMore: false };
+//     }
+//   }
+
+//   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
+//     try {
+//       await this.insert({
+//         tableName: TABLE_THREADS,
+//         record: {
+//           ...thread,
+//           metadata: JSON.stringify(thread.metadata),
+//         },
+//       });
+
+//       return thread;
+//     } catch (error) {
+//       const mastraError = new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_SAVE_THREAD_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: { threadId: thread.id },
+//         },
+//         error,
+//       );
+//       this.logger?.trackException?.(mastraError);
+//       this.logger?.error?.(mastraError.toString());
+//       throw mastraError;
+//     }
+//   }
+
+//   async updateThread({
+//     id,
+//     title,
+//     metadata,
+//   }: {
+//     id: string;
+//     title: string;
+//     metadata: Record<string, unknown>;
+//   }): Promise<StorageThreadType> {
+//     const thread = await this.getThreadById({ threadId: id });
+//     if (!thread) {
+//       throw new MastraError({
+//         id: 'LIBSQL_STORE_UPDATE_THREAD_FAILED_THREAD_NOT_FOUND',
+//         domain: ErrorDomain.STORAGE,
+//         category: ErrorCategory.USER,
+//         text: `Thread ${id} not found`,
+//         details: {
+//           status: 404,
+//           threadId: id,
+//         },
+//       });
+//     }
+
+//     const updatedThread = {
+//       ...thread,
+//       title,
+//       metadata: {
+//         ...thread.metadata,
+//         ...metadata,
+//       },
+//     };
+
+//     try {
+//       await this.client.execute({
+//         sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = ? WHERE id = ?`,
+//         args: [title, JSON.stringify(updatedThread.metadata), id],
+//       });
+
+//       return updatedThread;
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_UPDATE_THREAD_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           text: `Failed to update thread ${id}`,
+//           details: { threadId: id },
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   async deleteThread({ threadId }: { threadId: string }): Promise<void> {
+//     // Delete messages for this thread (manual step)
+//     try {
+//       await this.client.execute({
+//         sql: `DELETE FROM ${TABLE_MESSAGES} WHERE thread_id = ?`,
+//         args: [threadId],
+//       });
+//       await this.client.execute({
+//         sql: `DELETE FROM ${TABLE_THREADS} WHERE id = ?`,
+//         args: [threadId],
+//       });
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_DELETE_THREAD_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: { threadId },
+//         },
+//         error,
+//       );
+//     }
+//     // TODO: Need to check if CASCADE is enabled so that messages will be automatically deleted due to CASCADE constraint
+//   }
+
+//   private parseRow(row: any): MastraMessageV2 {
+//     let content = row.content;
+//     try {
+//       content = JSON.parse(row.content);
+//     } catch {
+//       // use content as is if it's not JSON
+//     }
+//     const result = {
+//       id: row.id,
+//       content,
+//       role: row.role,
+//       createdAt: new Date(row.createdAt as string),
+//       threadId: row.thread_id,
+//       resourceId: row.resourceId,
+//     } as MastraMessageV2;
+//     if (row.type && row.type !== `v2`) result.type = row.type;
+//     return result;
+//   }
+
+//   private async _getIncludedMessages({
+//     threadId,
+//     selectBy,
+//   }: {
+//     threadId: string;
+//     selectBy: StorageGetMessagesArg['selectBy'];
+//   }) {
+//     const include = selectBy?.include;
+//     if (!include) return null;
+
+//     const unionQueries: string[] = [];
+//     const params: any[] = [];
+
+//     for (const inc of include) {
+//       const { id, withPreviousMessages = 0, withNextMessages = 0 } = inc;
+//       // if threadId is provided, use it, otherwise use threadId from args
+//       const searchId = inc.threadId || threadId;
+//       unionQueries.push(
+//         `
+//             SELECT * FROM (
+//               WITH numbered_messages AS (
+//                 SELECT
+//                   id, content, role, type, "createdAt", thread_id, "resourceId",
+//                   ROW_NUMBER() OVER (ORDER BY "createdAt" ASC) as row_num
+//                 FROM "${TABLE_MESSAGES}"
+//                 WHERE thread_id = ?
+//               ),
+//               target_positions AS (
+//                 SELECT row_num as target_pos
+//                 FROM numbered_messages
+//                 WHERE id = ?
+//               )
+//               SELECT DISTINCT m.*
+//               FROM numbered_messages m
+//               CROSS JOIN target_positions t
+//               WHERE m.row_num BETWEEN (t.target_pos - ?) AND (t.target_pos + ?)
+//             ) 
+//             `, // Keep ASC for final sorting after fetching context
+//       );
+//       params.push(searchId, id, withPreviousMessages, withNextMessages);
+//     }
+//     const finalQuery = unionQueries.join(' UNION ALL ') + ' ORDER BY "createdAt" ASC';
+//     const includedResult = await this.client.execute({ sql: finalQuery, args: params });
+//     const includedRows = includedResult.rows?.map(row => this.parseRow(row));
+//     const seen = new Set<string>();
+//     const dedupedRows = includedRows.filter(row => {
+//       if (seen.has(row.id)) return false;
+//       seen.add(row.id);
+//       return true;
+//     });
+//     return dedupedRows;
+//   }
+
+//   /**
+//    * @deprecated use getMessagesPaginated instead for paginated results.
+//    */
+//   public async getMessages(args: StorageGetMessagesArg & { format?: 'v1' }): Promise<MastraMessageV1[]>;
+//   public async getMessages(args: StorageGetMessagesArg & { format: 'v2' }): Promise<MastraMessageV2[]>;
+//   public async getMessages({
+//     threadId,
+//     selectBy,
+//     format,
+//   }: StorageGetMessagesArg & {
+//     format?: 'v1' | 'v2';
+//   }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+//     try {
+//       const messages: MastraMessageV2[] = [];
+//       const limit = this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
+//       if (selectBy?.include?.length) {
+//         const includeMessages = await this._getIncludedMessages({ threadId, selectBy });
+//         if (includeMessages) {
+//           messages.push(...includeMessages);
+//         }
+//       }
+
+//       const excludeIds = messages.map(m => m.id);
+//       const remainingSql = `
+//         SELECT 
+//           id, 
+//           content, 
+//           role, 
+//           type,
+//           "createdAt", 
+//           thread_id,
+//           "resourceId"
+//         FROM "${TABLE_MESSAGES}"
+//         WHERE thread_id = ?
+//         ${excludeIds.length ? `AND id NOT IN (${excludeIds.map(() => '?').join(', ')})` : ''}
+//         ORDER BY "createdAt" DESC
+//         LIMIT ?
+//       `;
+//       const remainingArgs = [threadId, ...(excludeIds.length ? excludeIds : []), limit];
+//       const remainingResult = await this.client.execute({ sql: remainingSql, args: remainingArgs });
+//       if (remainingResult.rows) {
+//         messages.push(...remainingResult.rows.map((row: any) => this.parseRow(row)));
+//       }
+//       messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+//       const list = new MessageList().add(messages, 'memory');
+//       if (format === `v2`) return list.get.all.v2();
+//       return list.get.all.v1();
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_MESSAGES_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: { threadId },
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   public async getMessagesPaginated(
+//     args: StorageGetMessagesArg & {
+//       format?: 'v1' | 'v2';
+//     },
+//   ): Promise<PaginationInfo & { messages: MastraMessageV1[] | MastraMessageV2[] }> {
+//     const { threadId, format, selectBy } = args;
+//     const { page = 0, perPage: perPageInput, dateRange } = selectBy?.pagination || {};
+//     const perPage =
+//       perPageInput !== undefined ? perPageInput : this.resolveMessageLimit({ last: selectBy?.last, defaultLimit: 40 });
+//     const fromDate = dateRange?.start;
+//     const toDate = dateRange?.end;
+
+//     const messages: MastraMessageV2[] = [];
+
+//     if (selectBy?.include?.length) {
+//       try {
+//         const includeMessages = await this._getIncludedMessages({ threadId, selectBy });
+//         if (includeMessages) {
+//           messages.push(...includeMessages);
+//         }
+//       } catch (error) {
+//         throw new MastraError(
+//           {
+//             id: 'LIBSQL_STORE_GET_MESSAGES_PAGINATED_GET_INCLUDE_MESSAGES_FAILED',
+//             domain: ErrorDomain.STORAGE,
+//             category: ErrorCategory.THIRD_PARTY,
+//             details: { threadId },
+//           },
+//           error,
+//         );
+//       }
+//     }
+
+//     try {
+//       const currentOffset = page * perPage;
+
+//       const conditions: string[] = [`thread_id = ?`];
+//       const queryParams: InValue[] = [threadId];
+
+//       if (fromDate) {
+//         conditions.push(`"createdAt" >= ?`);
+//         queryParams.push(fromDate.toISOString());
+//       }
+//       if (toDate) {
+//         conditions.push(`"createdAt" <= ?`);
+//         queryParams.push(toDate.toISOString());
+//       }
+//       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+//       const countResult = await this.client.execute({
+//         sql: `SELECT COUNT(*) as count FROM ${TABLE_MESSAGES} ${whereClause}`,
+//         args: queryParams,
+//       });
+//       const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+//       if (total === 0 && messages.length === 0) {
+//         return {
+//           messages: [],
+//           total: 0,
+//           page,
+//           perPage,
+//           hasMore: false,
+//         };
+//       }
+
+//       const excludeIds = messages.map(m => m.id);
+//       const excludeIdsParam = excludeIds.map((_, idx) => `$${idx + queryParams.length + 1}`).join(', ');
+
+//       const dataResult = await this.client.execute({
+//         sql: `SELECT id, content, role, type, "createdAt", "resourceId", "thread_id" FROM ${TABLE_MESSAGES} ${whereClause} ${excludeIds.length ? `AND id NOT IN (${excludeIdsParam})` : ''} ORDER BY "createdAt" DESC LIMIT ? OFFSET ?`,
+//         args: [...queryParams, ...excludeIds, perPage, currentOffset],
+//       });
+
+//       messages.push(...(dataResult.rows || []).map((row: any) => this.parseRow(row)));
+
+//       const messagesToReturn =
+//         format === 'v1'
+//           ? new MessageList().add(messages, 'memory').get.all.v1()
+//           : new MessageList().add(messages, 'memory').get.all.v2();
+
+//       return {
+//         messages: messagesToReturn,
+//         total,
+//         page,
+//         perPage,
+//         hasMore: currentOffset + messages.length < total,
+//       };
+//     } catch (error) {
+//       const mastraError = new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_MESSAGES_PAGINATED_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//           details: { threadId },
+//         },
+//         error,
+//       );
+//       this.logger?.trackException?.(mastraError);
+//       this.logger?.error?.(mastraError.toString());
+//       return { messages: [], total: 0, page, perPage, hasMore: false };
+//     }
+//   }
+
+//   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
+//   async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
+//   async saveMessages({
+//     messages,
+//     format,
+//   }:
+//     | { messages: MastraMessageV1[]; format?: undefined | 'v1' }
+//     | { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[] | MastraMessageV1[]> {
+//     if (messages.length === 0) return messages;
+
+//     try {
+//       const threadId = messages[0]?.threadId;
+//       if (!threadId) {
+//         throw new Error('Thread ID is required');
+//       }
+
+//       // Prepare batch statements for all messages
+//       const batchStatements = messages.map(message => {
+//         const time = message.createdAt || new Date();
+//         if (!message.threadId) {
+//           throw new Error(
+//             `Expected to find a threadId for message, but couldn't find one. An unexpected error has occurred.`,
+//           );
+//         }
+//         if (!message.resourceId) {
+//           throw new Error(
+//             `Expected to find a resourceId for message, but couldn't find one. An unexpected error has occurred.`,
+//           );
+//         }
+//         return {
+//           sql: `INSERT INTO ${TABLE_MESSAGES} (id, thread_id, content, role, type, createdAt, resourceId) 
+//                 VALUES (?, ?, ?, ?, ?, ?, ?)
+//                 ON CONFLICT(id) DO UPDATE SET
+//                   thread_id=excluded.thread_id,
+//                   content=excluded.content,
+//                   role=excluded.role,
+//                   type=excluded.type,
+//                   resourceId=excluded.resourceId
+//               `,
+//           args: [
+//             message.id,
+//             message.threadId!,
+//             typeof message.content === 'object' ? JSON.stringify(message.content) : message.content,
+//             message.role,
+//             message.type || 'v2',
+//             time instanceof Date ? time.toISOString() : time,
+//             message.resourceId,
+//           ],
+//         };
+//       });
+
+//       const now = new Date().toISOString();
+//       batchStatements.push({
+//         sql: `UPDATE ${TABLE_THREADS} SET updatedAt = ? WHERE id = ?`,
+//         args: [now, threadId],
+//       });
+
+//       // Execute all inserts in a single batch
+//       await this.client.batch(batchStatements, 'write');
+
+//       const list = new MessageList().add(messages, 'memory');
+//       if (format === `v2`) return list.get.all.v2();
+//       return list.get.all.v1();
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_SAVE_MESSAGES_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   async updateMessages({
+//     messages,
+//   }: {
+//     messages: (Partial<Omit<MastraMessageV2, 'createdAt'>> & {
+//       id: string;
+//       content?: { metadata?: MastraMessageContentV2['metadata']; content?: MastraMessageContentV2['content'] };
+//     })[];
+//   }): Promise<MastraMessageV2[]> {
+//     if (messages.length === 0) {
+//       return [];
+//     }
+
+//     const messageIds = messages.map(m => m.id);
+//     const placeholders = messageIds.map(() => '?').join(',');
+
+//     const selectSql = `SELECT * FROM ${TABLE_MESSAGES} WHERE id IN (${placeholders})`;
+//     const existingResult = await this.client.execute({ sql: selectSql, args: messageIds });
+//     const existingMessages: MastraMessageV2[] = existingResult.rows.map(row => this.parseRow(row));
+
+//     if (existingMessages.length === 0) {
+//       return [];
+//     }
+
+//     const batchStatements = [];
+//     const threadIdsToUpdate = new Set<string>();
+//     const columnMapping: Record<string, string> = {
+//       threadId: 'thread_id',
+//     };
+
+//     for (const existingMessage of existingMessages) {
+//       const updatePayload = messages.find(m => m.id === existingMessage.id);
+//       if (!updatePayload) continue;
+
+//       const { id, ...fieldsToUpdate } = updatePayload;
+//       if (Object.keys(fieldsToUpdate).length === 0) continue;
+
+//       threadIdsToUpdate.add(existingMessage.threadId!);
+//       if (updatePayload.threadId && updatePayload.threadId !== existingMessage.threadId) {
+//         threadIdsToUpdate.add(updatePayload.threadId);
+//       }
+
+//       const setClauses = [];
+//       const args: InValue[] = [];
+//       const updatableFields = { ...fieldsToUpdate };
+
+//       // Special handling for the 'content' field to merge instead of overwrite
+//       if (updatableFields.content) {
+//         const newContent = {
+//           ...existingMessage.content,
+//           ...updatableFields.content,
+//           // Deep merge metadata if it exists on both
+//           ...(existingMessage.content?.metadata && updatableFields.content.metadata
+//             ? {
+//               metadata: {
+//                 ...existingMessage.content.metadata,
+//                 ...updatableFields.content.metadata,
+//               },
+//             }
+//             : {}),
+//         };
+//         setClauses.push(`${parseSqlIdentifier('content', 'column name')} = ?`);
+//         args.push(JSON.stringify(newContent));
+//         delete updatableFields.content;
+//       }
+
+//       for (const key in updatableFields) {
+//         if (Object.prototype.hasOwnProperty.call(updatableFields, key)) {
+//           const dbKey = columnMapping[key] || key;
+//           setClauses.push(`${parseSqlIdentifier(dbKey, 'column name')} = ?`);
+//           let value = updatableFields[key as keyof typeof updatableFields];
+
+//           if (typeof value === 'object' && value !== null) {
+//             value = JSON.stringify(value);
+//           }
+//           args.push(value as InValue);
+//         }
+//       }
+
+//       if (setClauses.length === 0) continue;
+
+//       args.push(id);
+
+//       const sql = `UPDATE ${TABLE_MESSAGES} SET ${setClauses.join(', ')} WHERE id = ?`;
+//       batchStatements.push({ sql, args });
+//     }
+
+//     if (batchStatements.length === 0) {
+//       return existingMessages;
+//     }
+
+//     const now = new Date().toISOString();
+//     for (const threadId of threadIdsToUpdate) {
+//       if (threadId) {
+//         batchStatements.push({
+//           sql: `UPDATE ${TABLE_THREADS} SET updatedAt = ? WHERE id = ?`,
+//           args: [now, threadId],
+//         });
+//       }
+//     }
+
+//     await this.client.batch(batchStatements, 'write');
+
+//     const updatedResult = await this.client.execute({ sql: selectSql, args: messageIds });
+//     return updatedResult.rows.map(row => this.parseRow(row));
+//   }
+
+// private transformEvalRow(row: Record<string, any>): EvalRow {
+//   const resultValue = JSON.parse(row.result as string);
+//   const testInfoValue = row.test_info ? JSON.parse(row.test_info as string) : undefined;
+
+//   if (!resultValue || typeof resultValue !== 'object' || !('score' in resultValue)) {
+//     throw new Error(`Invalid MetricResult format: ${JSON.stringify(resultValue)}`);
+//   }
+
+//   return {
+//     input: row.input as string,
+//     output: row.output as string,
+//     result: resultValue as MetricResult,
+//     agentName: row.agent_name as string,
+//     metricName: row.metric_name as string,
+//     instructions: row.instructions as string,
+//     testInfo: testInfoValue as TestInfo,
+//     globalRunId: row.global_run_id as string,
+//     runId: row.run_id as string,
+//     createdAt: row.created_at as string,
+//   };
+// }
+
+// /** @deprecated use getEvals instead */
+// async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
+//   try {
+//     const baseQuery = `SELECT * FROM ${TABLE_EVALS} WHERE agent_name = ?`;
+//     const typeCondition =
+//       type === 'test'
+//         ? " AND test_info IS NOT NULL AND test_info->>'testPath' IS NOT NULL"
+//         : type === 'live'
+//           ? " AND (test_info IS NULL OR test_info->>'testPath' IS NULL)"
+//           : '';
+
+//     const result = await this.client.execute({
+//       sql: `${baseQuery}${typeCondition} ORDER BY created_at DESC`,
+//       args: [agentName],
+//     });
+
+//     return result.rows?.map(row => this.transformEvalRow(row)) ?? [];
+//   } catch (error) {
+//     // Handle case where table doesn't exist yet
+//     if (error instanceof Error && error.message.includes('no such table')) {
+//       return [];
+//     }
+//     throw new MastraError(
+//       {
+//         id: 'LIBSQL_STORE_GET_EVALS_BY_AGENT_NAME_FAILED',
+//         domain: ErrorDomain.STORAGE,
+//         category: ErrorCategory.THIRD_PARTY,
+//         details: { agentName },
+//       },
+//       error,
+//     );
+//   }
+// }
+
+// async getEvals(
+//   options: {
+//     agentName?: string;
+//     type?: 'test' | 'live';
+//   } & PaginationArgs = {},
+// ): Promise<PaginationInfo & { evals: EvalRow[] }> {
+//   const { agentName, type, page = 0, perPage = 100, dateRange } = options;
+//   const fromDate = dateRange?.start;
+//   const toDate = dateRange?.end;
+
+//   const conditions: string[] = [];
+//   const queryParams: InValue[] = [];
+
+//   if (agentName) {
+//     conditions.push(`agent_name = ?`);
+//     queryParams.push(agentName);
+//   }
+
+//   if (type === 'test') {
+//     conditions.push(`(test_info IS NOT NULL AND json_extract(test_info, '$.testPath') IS NOT NULL)`);
+//   } else if (type === 'live') {
+//     conditions.push(`(test_info IS NULL OR json_extract(test_info, '$.testPath') IS NULL)`);
+//   }
+
+//   if (fromDate) {
+//     conditions.push(`created_at >= ?`);
+//     queryParams.push(fromDate.toISOString());
+//   }
+
+//   if (toDate) {
+//     conditions.push(`created_at <= ?`);
+//     queryParams.push(toDate.toISOString());
+//   }
+
+//   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+//   try {
+//     const countResult = await this.client.execute({
+//       sql: `SELECT COUNT(*) as count FROM ${TABLE_EVALS} ${whereClause}`,
+//       args: queryParams,
+//     });
+//     const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+//     const currentOffset = page * perPage;
+//     const hasMore = currentOffset + perPage < total;
+
+//     if (total === 0) {
+//       return {
+//         evals: [],
+//         total: 0,
+//         page,
+//         perPage,
+//         hasMore: false,
+//       };
+//     }
+
+//     const dataResult = await this.client.execute({
+//       sql: `SELECT * FROM ${TABLE_EVALS} ${whereClause} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+//       args: [...queryParams, perPage, currentOffset],
+//     });
+
+//     return {
+//       evals: dataResult.rows?.map(row => this.transformEvalRow(row)) ?? [],
+//       total,
+//       page,
+//       perPage,
+//       hasMore,
+//     };
+//   } catch (error) {
+//     throw new MastraError(
+//       {
+//         id: 'LIBSQL_STORE_GET_EVALS_FAILED',
+//         domain: ErrorDomain.STORAGE,
+//         category: ErrorCategory.THIRD_PARTY,
+//       },
+//       error,
+//     );
+//   }
+// }
+
+//   /**
+//    * @deprecated use getTracesPaginated instead.
+//    */
+//   public async getTraces(args: {
+//     name?: string;
+//     scope?: string;
+//     page: number;
+//     perPage: number;
+//     attributes?: Record<string, string>;
+//     filters?: Record<string, any>;
+//     fromDate?: Date;
+//     toDate?: Date;
+//   }): Promise<Trace[]> {
+//     if (args.fromDate || args.toDate) {
+//       (args as any).dateRange = {
+//         start: args.fromDate,
+//         end: args.toDate,
+//       };
+//     }
+//     try {
+//       const result = await this.getTracesPaginated(args);
+//       return result.traces;
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_TRACES_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   public async getTracesPaginated(
+//     args: {
+//       name?: string;
+//       scope?: string;
+//       attributes?: Record<string, string>;
+//       filters?: Record<string, any>;
+//     } & PaginationArgs,
+//   ): Promise<PaginationInfo & { traces: Trace[] }> {
+//     const { name, scope, page = 0, perPage = 100, attributes, filters, dateRange } = args;
+//     const fromDate = dateRange?.start;
+//     const toDate = dateRange?.end;
+//     const currentOffset = page * perPage;
+
+//     const queryArgs: InValue[] = [];
+//     const conditions: string[] = [];
+
+//     if (name) {
+//       conditions.push('name LIKE ?');
+//       queryArgs.push(`${name}%`);
+//     }
+//     if (scope) {
+//       conditions.push('scope = ?');
+//       queryArgs.push(scope);
+//     }
+//     if (attributes) {
+//       Object.entries(attributes).forEach(([key, value]) => {
+//         conditions.push(`json_extract(attributes, '$.${key}') = ?`);
+//         queryArgs.push(value);
+//       });
+//     }
+//     if (filters) {
+//       Object.entries(filters).forEach(([key, value]) => {
+//         conditions.push(`${parseSqlIdentifier(key, 'filter key')} = ?`);
+//         queryArgs.push(value);
+//       });
+//     }
+//     if (fromDate) {
+//       conditions.push('createdAt >= ?');
+//       queryArgs.push(fromDate.toISOString());
+//     }
+//     if (toDate) {
+//       conditions.push('createdAt <= ?');
+//       queryArgs.push(toDate.toISOString());
+//     }
+
+//     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+//     try {
+//       const countResult = await this.client.execute({
+//         sql: `SELECT COUNT(*) as count FROM ${TABLE_TRACES} ${whereClause}`,
+//         args: queryArgs,
+//       });
+//       const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+//       if (total === 0) {
+//         return {
+//           traces: [],
+//           total: 0,
+//           page,
+//           perPage,
+//           hasMore: false,
+//         };
+//       }
+
+//       const dataResult = await this.client.execute({
+//         sql: `SELECT * FROM ${TABLE_TRACES} ${whereClause} ORDER BY "startTime" DESC LIMIT ? OFFSET ?`,
+//         args: [...queryArgs, perPage, currentOffset],
+//       });
+
+//       const traces =
+//         dataResult.rows?.map(
+//           row =>
+//             ({
+//               id: row.id,
+//               parentSpanId: row.parentSpanId,
+//               traceId: row.traceId,
+//               name: row.name,
+//               scope: row.scope,
+//               kind: row.kind,
+//               status: safelyParseJSON(row.status as string),
+//               events: safelyParseJSON(row.events as string),
+//               links: safelyParseJSON(row.links as string),
+//               attributes: safelyParseJSON(row.attributes as string),
+//               startTime: row.startTime,
+//               endTime: row.endTime,
+//               other: safelyParseJSON(row.other as string),
+//               createdAt: row.createdAt,
+//             }) as Trace,
+//         ) ?? [];
+
+//       return {
+//         traces,
+//         total,
+//         page,
+//         perPage,
+//         hasMore: currentOffset + traces.length < total,
+//       };
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_TRACES_PAGINATED_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   async getWorkflowRuns({
+//     workflowName,
+//     fromDate,
+//     toDate,
+//     limit,
+//     offset,
+//     resourceId,
+//   }: {
+//     workflowName?: string;
+//     fromDate?: Date;
+//     toDate?: Date;
+//     limit?: number;
+//     offset?: number;
+//     resourceId?: string;
+//   } = {}): Promise<WorkflowRuns> {
+//     try {
+//       const conditions: string[] = [];
+//       const args: InValue[] = [];
+
+//       if (workflowName) {
+//         conditions.push('workflow_name = ?');
+//         args.push(workflowName);
+//       }
+
+//       if (fromDate) {
+//         conditions.push('createdAt >= ?');
+//         args.push(fromDate.toISOString());
+//       }
+
+//       if (toDate) {
+//         conditions.push('createdAt <= ?');
+//         args.push(toDate.toISOString());
+//       }
+
+//       if (resourceId) {
+//         const hasResourceId = await this.hasColumn(TABLE_WORKFLOW_SNAPSHOT, 'resourceId');
+//         if (hasResourceId) {
+//           conditions.push('resourceId = ?');
+//           args.push(resourceId);
+//         } else {
+//           console.warn(`[${TABLE_WORKFLOW_SNAPSHOT}] resourceId column not found. Skipping resourceId filter.`);
+//         }
+//       }
+
+//       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+//       let total = 0;
+//       // Only get total count when using pagination
+//       if (limit !== undefined && offset !== undefined) {
+//         const countResult = await this.client.execute({
+//           sql: `SELECT COUNT(*) as count FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause}`,
+//           args,
+//         });
+//         total = Number(countResult.rows?.[0]?.count ?? 0);
+//       }
+
+//       // Get results
+//       const result = await this.client.execute({
+//         sql: `SELECT * FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause} ORDER BY createdAt DESC${limit !== undefined && offset !== undefined ? ` LIMIT ? OFFSET ?` : ''}`,
+//         args: limit !== undefined && offset !== undefined ? [...args, limit, offset] : args,
+//       });
+
+//       const runs = (result.rows || []).map(row => this.parseWorkflowRun(row));
+
+//       // Use runs.length as total when not paginating
+//       return { runs, total: total || runs.length };
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_WORKFLOW_RUNS_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   async getWorkflowRunById({
+//     runId,
+//     workflowName,
+//   }: {
+//     runId: string;
+//     workflowName?: string;
+//   }): Promise<WorkflowRun | null> {
+//     const conditions: string[] = [];
+//     const args: (string | number)[] = [];
+
+//     if (runId) {
+//       conditions.push('run_id = ?');
+//       args.push(runId);
+//     }
+
+//     if (workflowName) {
+//       conditions.push('workflow_name = ?');
+//       args.push(workflowName);
+//     }
+
+//     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+//     try {
+//       const result = await this.client.execute({
+//         sql: `SELECT * FROM ${TABLE_WORKFLOW_SNAPSHOT} ${whereClause}`,
+//         args,
+//       });
+
+//       if (!result.rows?.[0]) {
+//         return null;
+//       }
+
+//       return this.parseWorkflowRun(result.rows[0]);
+//     } catch (error) {
+//       throw new MastraError(
+//         {
+//           id: 'LIBSQL_STORE_GET_WORKFLOW_RUN_BY_ID_FAILED',
+//           domain: ErrorDomain.STORAGE,
+//           category: ErrorCategory.THIRD_PARTY,
+//         },
+//         error,
+//       );
+//     }
+//   }
+
+//   async getResourceById({ resourceId }: { resourceId: string }): Promise<StorageResourceType | null> {
+//     const result = await this.load<StorageResourceType>({
+//       tableName: TABLE_RESOURCES,
+//       keys: { id: resourceId },
+//     });
+
+//     if (!result) {
+//       return null;
+//     }
+
+//     return {
+//       ...result,
+//       // Ensure workingMemory is always returned as a string, even if auto-parsed as JSON
+//       workingMemory:
+//         typeof result.workingMemory === 'object' ? JSON.stringify(result.workingMemory) : result.workingMemory,
+//       metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
+//     };
+//   }
+
+//   async saveResource({ resource }: { resource: StorageResourceType }): Promise<StorageResourceType> {
+//     await this.insert({
+//       tableName: TABLE_RESOURCES,
+//       record: {
+//         ...resource,
+//         metadata: JSON.stringify(resource.metadata),
+//       },
+//     });
+
+//     return resource;
+//   }
+
+//   async updateResource({
+//     resourceId,
+//     workingMemory,
+//     metadata,
+//   }: {
+//     resourceId: string;
+//     workingMemory?: string;
+//     metadata?: Record<string, unknown>;
+//   }): Promise<StorageResourceType> {
+//     const existingResource = await this.getResourceById({ resourceId });
+
+//     if (!existingResource) {
+//       // Create new resource if it doesn't exist
+//       const newResource: StorageResourceType = {
+//         id: resourceId,
+//         workingMemory,
+//         metadata: metadata || {},
+//         createdAt: new Date(),
+//         updatedAt: new Date(),
+//       };
+//       return this.saveResource({ resource: newResource });
+//     }
+
+//     const updatedResource = {
+//       ...existingResource,
+//       workingMemory: workingMemory !== undefined ? workingMemory : existingResource.workingMemory,
+//       metadata: {
+//         ...existingResource.metadata,
+//         ...metadata,
+//       },
+//       updatedAt: new Date(),
+//     };
+
+//     const updates: string[] = [];
+//     const values: InValue[] = [];
+
+//     if (workingMemory !== undefined) {
+//       updates.push('workingMemory = ?');
+//       values.push(workingMemory);
+//     }
+
+//     if (metadata) {
+//       updates.push('metadata = ?');
+//       values.push(JSON.stringify(updatedResource.metadata));
+//     }
+
+//     updates.push('updatedAt = ?');
+//     values.push(updatedResource.updatedAt.toISOString());
+
+//     values.push(resourceId);
+
+//     await this.client.execute({
+//       sql: `UPDATE ${TABLE_RESOURCES} SET ${updates.join(', ')} WHERE id = ?`,
+//       args: values,
+//     });
+
+//     return updatedResource;
+//   }
+
+//   private async hasColumn(table: string, column: string): Promise<boolean> {
+//     const result = await this.client.execute({
+//       sql: `PRAGMA table_info(${table})`,
+//     });
+//     return (await result.rows)?.some((row: any) => row.name === column);
+//   }
+
+//   private parseWorkflowRun(row: Record<string, any>): WorkflowRun {
+//     let parsedSnapshot: WorkflowRunState | string = row.snapshot as string;
+//     if (typeof parsedSnapshot === 'string') {
+//       try {
+//         parsedSnapshot = JSON.parse(row.snapshot as string) as WorkflowRunState;
+//       } catch (e) {
+//         // If parsing fails, return the raw snapshot string
+//         console.warn(`Failed to parse snapshot for workflow ${row.workflow_name}: ${e}`);
+//       }
+//     }
+//     return {
+//       workflowName: row.workflow_name as string,
+//       runId: row.run_id as string,
+//       snapshot: parsedSnapshot,
+//       resourceId: row.resourceId as string,
+//       createdAt: new Date(row.createdAt as string),
+//       updatedAt: new Date(row.updatedAt as string),
+//     };
+//   }
+// }
 
 export { LibSQLStore as DefaultStorage };

--- a/stores/libsql/src/storage/utils.ts
+++ b/stores/libsql/src/storage/utils.ts
@@ -1,0 +1,7 @@
+export function safelyParseJSON(jsonString: string): any {
+  try {
+    return JSON.parse(jsonString);
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
Couple things happening in here to set the stage for future changes.

1. MastraCompositeStorage

This takes existing storage adapters and allows the user to create a composite of them by delegating different primitives to different storage adapters.

```
new MastraCompositeStorage({ stores: { traces: new LibSQLStore(), conversations: new PostgresStore() } })
```

2. Domain specific storage interfaces

Introduce interfaces for each domain

```
{
    traces: MastraTracesStorage;
    conversations: MastraConversationsStorage;
    workflows: MastraWorkflowsStorage;
    scores: MastraScoresStorage;
  };
```

This would allow Storage adapters to implement the relevant piece instead of all if irrelevant.

