### PR TITLE
save runtimeContext in snapshot

### DIFF
--- a/.changeset/twelve-coats-matter.md
+++ b/.changeset/twelve-coats-matter.md
@@ -1,0 +1,6 @@
+---
+'@mastra/cloudflare': patch
+'@mastra/core': patch
+---
+
+Save runtimeContext in snapshot

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -56,6 +56,8 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     return runCount;
   }
 
+  protected runtimeContext: Record<string, any> = {};
+
   protected async fmtReturnValue<TOutput>(
     executionSpan: Span | undefined,
     emitter: Emitter,
@@ -149,6 +151,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       stepResults: Record<string, StepResult<any, any, any, any>>;
       resumePayload: any;
       resumePath: number[];
+      snapshotRuntimeContext?: Record<string, any>;
     };
     emitter: Emitter;
     retryConfig?: {
@@ -182,6 +185,10 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     if (resume?.resumePath) {
       startIdx = resume.resumePath[0]!;
       resume.resumePath.shift();
+    }
+
+    if (resume?.snapshotRuntimeContext) {
+      this.runtimeContext = { ...this.runtimeContext, ...resume.snapshotRuntimeContext };
     }
 
     const stepResults: Record<string, any> = resume?.stepResults || { input };
@@ -590,10 +597,19 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       try {
         let suspended: { payload: any } | undefined;
         let bailed: { payload: any } | undefined;
+
+        let runtimeContextToUse = runtimeContext;
+
+        Object.entries(this.runtimeContext).forEach(([key, value]) => {
+          if (!runtimeContextToUse.has(key)) {
+            runtimeContextToUse.set(key, value);
+          }
+        });
+
         const result = await runStep({
           runId,
           mastra: this.mastra!,
-          runtimeContext,
+          runtimeContext: runtimeContextToUse,
           inputData: prevOutput,
           runCount: this.getOrGenerateRunCount(step.id),
           resumeData: resume?.steps[0] === step.id ? resume?.resumePayload : undefined,
@@ -630,6 +646,13 @@ export class DefaultExecutionEngine extends ExecutionEngine {
           engine: {},
           abortSignal: abortController?.signal,
         });
+
+        let runtimeContextObj: Record<string, any> = {};
+        runtimeContext.forEach((value, key) => {
+          runtimeContextObj[key] = value;
+        });
+
+        this.runtimeContext = { ...this.runtimeContext, ...runtimeContextObj };
 
         if (suspended) {
           execResults = { status: 'suspended', suspendPayload: suspended.payload, suspendedAt: Date.now() };
@@ -1281,6 +1304,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
         suspendedPaths: executionContext.suspendedPaths,
         result,
         error,
+        runtimeContext: this.runtimeContext,
         // @ts-ignore
         timestamp: Date.now(),
       },

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -45,6 +45,7 @@ export abstract class ExecutionEngine extends MastraBase {
       stepResults: Record<string, StepResult<any, any, any, any>>;
       resumePayload: any;
       resumePath: number[];
+      snapshotRuntimeContext?: Record<string, any>;
     };
     emitter: Emitter;
     runtimeContext: RuntimeContext;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -181,6 +181,7 @@ export interface WorkflowRunState {
   status: WorkflowRunStatus;
   result?: Record<string, any>;
   error?: string | Error;
+  runtimeContext?: Record<string, any>;
   value: Record<string, string>;
   context: { input?: Record<string, any> } & Record<string, StepResult<any, any, any, any>>;
   serializedStepGraph: SerializedStepFlowEntry[];

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -5400,7 +5400,7 @@ describe('Workflow', () => {
       expect(promptAgentAction).toHaveBeenCalledTimes(2);
       expect(firstResumeResult.steps.runtimeContextAction.status).toBe('success');
       // @ts-ignore
-      expect(firstResumeResult.steps.runtimeContextAction.output).toEqual(['promptAgentAction']);
+      expect(firstResumeResult.steps.runtimeContextAction.output).toEqual(['first message', 'promptAgentAction']);
     });
 
     it('should work with custom runtimeContext - bug #4442', async () => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1550,6 +1550,7 @@ export class Run<
           resumePayload: params.resumeData,
           // @ts-ignore
           resumePath: snapshot?.suspendedPaths?.[steps?.[0]] as any,
+          snapshotRuntimeContext: snapshot?.runtimeContext,
         },
         emitter: {
           emit: (event: string, data: any) => {

--- a/stores/cloudflare/src/storage/binding-api.test.ts
+++ b/stores/cloudflare/src/storage/binding-api.test.ts
@@ -928,6 +928,7 @@ describe('CloudflareStore Workers Binding', () => {
         suspendedPaths: {},
         status: 'success',
         serializedStepGraph: [],
+        runtimeContext: {},
       };
 
       await store.persistWorkflowSnapshot({

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -1376,6 +1376,7 @@ export class CloudflareStore extends MastraStorage {
       status: data.status,
       result: data.result,
       error: data.error,
+      runtimeContext: data.runtimeContext || {},
     };
   }
 

--- a/stores/cloudflare/src/storage/test-utils.ts
+++ b/stores/cloudflare/src/storage/test-utils.ts
@@ -40,6 +40,7 @@ export const createSampleWorkflowSnapshot = (threadId: string, status: string, c
     runId,
     status: status as WorkflowRunState['status'],
     timestamp: timestamp.getTime(),
+    runtimeContext: {},
   };
   return { snapshot, runId, stepId };
 };


### PR DESCRIPTION
## Description

We now save runtimeContext is snapshot and make it available to use in step executions. 
So when a workflow is resumed, it'll have access to runtimeContext from before suspension

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
