### PR TITLE
fix(@mastra/memory): per-resource working memory config in agent tool

### DIFF
--- a/.changeset/afraid-crabs-invite.md
+++ b/.changeset/afraid-crabs-invite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed an issue where per-resource semantic recall wouldn't always be enabled properly in agent tool calls

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -758,14 +758,8 @@ Notes:
   public getTools(config?: MemoryConfig): Record<string, CoreTool> {
     const mergedConfig = this.getMergedThreadConfig(config);
     if (mergedConfig.workingMemory?.enabled) {
-      if (mergedConfig.workingMemory.schema) {
-        return {
-          updateWorkingMemory: updateWorkingMemoryTool({ format: 'json' }),
-        };
-      }
-
       return {
-        updateWorkingMemory: updateWorkingMemoryTool({ format: 'markdown' }),
+        updateWorkingMemory: updateWorkingMemoryTool(config),
       };
     }
     return {};

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -1,15 +1,14 @@
-import type { CoreTool } from '@mastra/core';
-import type { WorkingMemoryFormat } from '@mastra/core/memory';
+import type { CoreTool, MemoryConfig } from '@mastra/core';
 import { z } from 'zod';
 
-export const updateWorkingMemoryTool = ({ format }: { format: WorkingMemoryFormat }): CoreTool => ({
+export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig): CoreTool => ({
   description:
     'Update the working memory with new information. Always pass data as string to the memory field. Never pass an object.',
   parameters: z.object({
     memory: z
       .string()
       .describe(
-        `The ${format === 'json' ? 'JSON' : 'Markdown'} formatted working memory content to store. This MUST be a string. Never pass an object.`,
+        `The ${!!memoryConfig?.workingMemory?.schema ? 'JSON' : 'Markdown'} formatted working memory content to store. This MUST be a string. Never pass an object.`,
       ),
   }),
   execute: async (params: any) => {
@@ -35,6 +34,7 @@ export const updateWorkingMemoryTool = ({ format }: { format: WorkingMemoryForma
       threadId,
       resourceId: resourceId || thread.resourceId,
       workingMemory: workingMemory,
+      memoryConfig,
     });
 
     return { success: true };


### PR DESCRIPTION
Before this change, memory settings weren't being passed into updateWorkingMemory(), so the scope would be lost