### PR TITLE
feat(@mastra/core): format semantic recall system message to improve longmemeval scores

### DIFF
--- a/.changeset/fluffy-cooks-laugh.md
+++ b/.changeset/fluffy-cooks-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Format semantic recall messages grouped by dates and labeled by if they're from a different thread or not, to improve longmemeval scores


### PR DESCRIPTION
Formatting the messages here by adding dates, times, and wether or not the message is from a different thread dramatically improves longmemeval scores for semantic recall