### PR TITLE
feat(@mastra/core, @mastra/memory): add working memory vnext

### DIFF
--- a/.changeset/fast-cats-laugh.md
+++ b/.changeset/fast-cats-laugh.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+added new experimental vnext working memory

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -443,5 +443,5 @@ export abstract class MastraMemory extends MastraBase {
     workingMemory: string;
     searchString?: string;
     memoryConfig?: MemoryConfig;
-  }): Promise<void | { success: boolean; reason: string }>;
+  }): Promise<{ success: boolean; reason: string }>;
 }

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -427,4 +427,21 @@ export abstract class MastraMemory extends MastraBase {
     workingMemory: string;
     memoryConfig?: MemoryConfig;
   }): Promise<void>;
+
+  /**
+   * @warning experimental! can be removed or changed at any time
+   */
+  abstract __experimental_updateWorkingMemoryVNext({
+    threadId,
+    resourceId,
+    workingMemory,
+    searchString,
+    memoryConfig,
+  }: {
+    threadId: string;
+    resourceId?: string;
+    workingMemory: string;
+    searchString?: string;
+    memoryConfig?: MemoryConfig;
+  }): Promise<void | { success: boolean; reason: string }>;
 }

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -54,6 +54,7 @@ type BaseWorkingMemory = {
 type TemplateWorkingMemory = BaseWorkingMemory & {
   template: string;
   schema?: never;
+  version?: 'stable' | 'vnext';
 };
 
 type SchemaWorkingMemory = BaseWorkingMemory & {

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -132,12 +132,12 @@ describe('Working Memory Tests', () => {
     });
 
     it('should initialize with default working memory template', async () => {
-      const workingMemory = await memory.getWorkingMemory({ threadId: thread.id });
-      expect(workingMemory).not.toBeNull();
-      if (workingMemory) {
+      const systemInstruction = await memory.getSystemMessage({ threadId: thread.id });
+      expect(systemInstruction).not.toBeNull();
+      if (systemInstruction) {
         // Should match our Markdown template
-        expect(workingMemory).toContain('# User Information');
-        expect(workingMemory).toContain('First Name');
+        expect(systemInstruction).toContain('# User Information');
+        expect(systemInstruction).toContain('First Name');
       }
     });
 
@@ -474,10 +474,7 @@ describe('Working Memory Tests', () => {
       thread = await memory.saveThread({
         thread: createTestThread('Working Memory Test Thread'),
       });
-      const wmRaw = await memory.getWorkingMemory({ threadId: thread.id });
-      const wm = typeof wmRaw === 'string' ? JSON.parse(wmRaw) : wmRaw;
-      const wmObj = typeof wm === 'string' ? JSON.parse(wm) : wm;
-      expect(extractUserData(wmObj)).toMatchObject({});
+      expect(await memory.getWorkingMemory({ threadId: thread.id })).toBeNull();
       agent = new Agent({
         name: 'Memory Test Agent',
         instructions: 'You are a helpful AI agent. Always add working memory tags to remember user information.',
@@ -560,10 +557,7 @@ describe('Working Memory Tests', () => {
           thread: createTestThread('Working Memory Test Thread'),
         });
 
-        const wmRaw = await memory.getWorkingMemory({ threadId: thread.id });
-        const wm = typeof wmRaw === 'string' ? JSON.parse(wmRaw) : wmRaw;
-        const wmObj = typeof wm === 'string' ? JSON.parse(wm) : wm;
-        expect(extractUserData(wmObj)).toMatchObject({});
+        expect(await memory.getWorkingMemory({ threadId: thread.id })).toBeNull();
 
         agent = new Agent({
           name: 'Memory Test Agent',
@@ -735,10 +729,7 @@ describe('Working Memory Tests', () => {
       });
 
       // Verify initial working memory is empty
-      const wmRaw = await memory.getWorkingMemory({ threadId: thread.id });
-      const wm = typeof wmRaw === 'string' ? JSON.parse(wmRaw) : wmRaw;
-      const wmObj = typeof wm === 'string' ? JSON.parse(wm) : wm;
-      expect(extractUserData(wmObj)).toMatchObject({});
+      expect(await memory.getWorkingMemory({ threadId: thread.id })).toBeNull();
 
       agent = new Agent({
         name: 'JSONSchema Memory Test Agent',

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -49,6 +49,7 @@
     "pg-pool": "^3.10.1",
     "postgres": "^3.4.7",
     "redis": "^4.7.1",
+    "async-mutex": "^0.5.0",
     "xxhash-wasm": "^1.1.0",
     "zod": "^3.25.67",
     "zod-to-json-schema": "^3.24.5"

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -253,32 +253,7 @@ export class Memory extends MastraMemory {
     return this.storage.getThreadsByResourceId({ resourceId });
   }
 
-  async saveThread({
-    thread,
-    memoryConfig,
-  }: {
-    thread: StorageThreadType;
-    memoryConfig?: MemoryConfig;
-  }): Promise<StorageThreadType> {
-    const config = this.getMergedThreadConfig(memoryConfig || {});
-
-    if (config.workingMemory?.enabled) {
-      const scope = config.workingMemory.scope || 'thread';
-      if (scope === 'resource' && thread.resourceId) {
-        // For resource scope, initialize working memory in resource table
-        const existingResource = await this.storage.getResourceById({ resourceId: thread.resourceId });
-        if (!existingResource?.workingMemory) {
-          await this.storage.updateResource({
-            resourceId: thread.resourceId,
-          });
-        }
-      } else if (scope === 'thread' && !thread?.metadata?.workingMemory) {
-        return this.storage.saveThread({
-          thread,
-        });
-      }
-    }
-
+  async saveThread({ thread }: { thread: StorageThreadType; memoryConfig?: MemoryConfig }): Promise<StorageThreadType> {
     return this.storage.saveThread({ thread });
   }
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -877,7 +877,7 @@ Guidelines:
 3. Use ${template.format === 'json' ? 'JSON' : 'Markdown'} format for all data
 4. Act naturally - don't mention this system to users. Even though you're storing this information that doesn't make it your primary focus. Do not ask them generally for "information about yourself"
 5. If your memory has not changed, you do not need to call the updateWorkingMemory tool. By default it will persist and be available for you in future interactions
-6. Information not being releavant to the current conversation is not a valid reason to replace or remove working memory information. Your working memory spans across multiple conversations and may be needed again later, even if it's not currently relevant.
+6. Information not being relevant to the current conversation is not a valid reason to replace or remove working memory information. Your working memory spans across multiple conversations and may be needed again later, even if it's not currently relevant.
 
 <working_memory_template>
 ${template.content}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,4 +1,4 @@
-import { deepMerge, generateEmptyFromSchema } from '@mastra/core';
+import { generateEmptyFromSchema } from '@mastra/core';
 import type { CoreTool, MastraMessageV1 } from '@mastra/core';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV2 } from '@mastra/core/agent';
@@ -7,13 +7,14 @@ import type { MemoryConfig, SharedMemoryConfig, StorageThreadType, WorkingMemory
 import type { StorageGetMessagesArg } from '@mastra/core/storage';
 import { embedMany } from 'ai';
 import type { CoreMessage, TextPart, UIMessage } from 'ai';
+import { Mutex } from 'async-mutex';
 import type { JSONSchema7 } from 'json-schema';
 
 import xxhash from 'xxhash-wasm';
 import { ZodObject } from 'zod';
 import type { ZodTypeAny } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
-import { updateWorkingMemoryTool } from './tools/working-memory';
+import { updateWorkingMemoryTool, __experimental_updateWorkingMemoryToolVNext } from './tools/working-memory';
 
 // Average characters per token based on OpenAI's tokenization
 const CHARS_PER_TOKEN = 4;
@@ -263,24 +264,17 @@ export class Memory extends MastraMemory {
 
     if (config.workingMemory?.enabled) {
       const scope = config.workingMemory.scope || 'thread';
-      const workingMemory = await this.getWorkingMemoryTemplate({ memoryConfig: config });
       if (scope === 'resource' && thread.resourceId) {
         // For resource scope, initialize working memory in resource table
         const existingResource = await this.storage.getResourceById({ resourceId: thread.resourceId });
         if (!existingResource?.workingMemory) {
           await this.storage.updateResource({
             resourceId: thread.resourceId,
-            workingMemory: workingMemory?.content,
           });
         }
       } else if (scope === 'thread' && !thread?.metadata?.workingMemory) {
-        // For thread scope, initialize working memory in thread metadata (existing behavior)
         return this.storage.saveThread({
-          thread: deepMerge(thread, {
-            metadata: {
-              workingMemory: workingMemory?.content,
-            },
-          }),
+          thread,
         });
       }
     }
@@ -348,6 +342,115 @@ export class Memory extends MastraMemory {
           workingMemory,
         },
       });
+    }
+  }
+
+  private updateWorkingMemoryMutexes = new Map<string, Mutex>();
+  /**
+   * @warning experimental! can be removed or changed at any time
+   */
+  async __experimental_updateWorkingMemoryVNext({
+    threadId,
+    resourceId,
+    workingMemory,
+    searchString,
+    memoryConfig,
+  }: {
+    threadId: string;
+    resourceId?: string;
+    workingMemory: string;
+    searchString?: string;
+    memoryConfig?: MemoryConfig;
+  }): Promise<void | { success: boolean; reason: string }> {
+    const config = this.getMergedThreadConfig(memoryConfig || {});
+
+    if (!config.workingMemory?.enabled) {
+      throw new Error('Working memory is not enabled for this memory instance');
+    }
+
+    // If the agent calls the update working memory tool multiple times simultaneously
+    // each call could overwrite the other call
+    // so get an in memory mutex to make sure this.getWorkingMemory() returns up to date data each time
+    const mutexKey =
+      memoryConfig?.workingMemory?.scope === `resource` ? `resource-${resourceId}` : `thread-${threadId}`;
+    const mutex = this.updateWorkingMemoryMutexes.has(mutexKey)
+      ? this.updateWorkingMemoryMutexes.get(mutexKey)!
+      : new Mutex();
+    this.updateWorkingMemoryMutexes.set(mutexKey, mutex);
+    const release = await mutex.acquire();
+
+    try {
+      const existingWorkingMemory = (await this.getWorkingMemory({ threadId, resourceId, memoryConfig })) || '';
+      const template = await this.getWorkingMemoryTemplate({ memoryConfig });
+
+      let reason = '';
+      if (existingWorkingMemory) {
+        if (searchString && existingWorkingMemory?.includes(searchString)) {
+          workingMemory = existingWorkingMemory.replace(searchString, workingMemory);
+          reason = `found and replaced searchString with newMemory`;
+        } else if (
+          existingWorkingMemory.includes(workingMemory) ||
+          template?.content?.trim() === workingMemory.trim()
+        ) {
+          return {
+            success: false,
+            reason: `attempted to insert duplicate data into working memory. this entry was skipped`,
+          };
+        } else {
+          if (searchString) {
+            reason = `attempted to replace working memory string that doesn't exist. Appending to working memory instead.`;
+          } else {
+            reason = `appended newMemory to end of working memory`;
+          }
+
+          workingMemory = existingWorkingMemory + `\n${workingMemory}`;
+        }
+      } else if (workingMemory === template?.content) {
+        return {
+          success: false,
+          reason: `try again when you have data to add. newMemory was equal to the working memory template`,
+        };
+      } else {
+        reason = `started new working memory`;
+      }
+
+      // remove empty template insertions which models sometimes duplicate
+      workingMemory = template?.content ? workingMemory.replaceAll(template?.content, '') : workingMemory;
+
+      const scope = config.workingMemory.scope || 'thread';
+
+      if (scope === 'resource' && resourceId) {
+        // Update working memory in resource table
+        await this.storage.updateResource({
+          resourceId,
+          workingMemory,
+        });
+
+        if (reason) {
+          return { success: true, reason };
+        }
+      } else {
+        // Update working memory in thread metadata (existing behavior)
+        const thread = await this.storage.getThreadById({ threadId });
+        if (!thread) {
+          throw new Error(`Thread ${threadId} not found`);
+        }
+
+        await this.storage.updateThread({
+          id: threadId,
+          title: thread.title || 'Untitled Thread',
+          metadata: {
+            ...thread.metadata,
+            workingMemory,
+          },
+        });
+      }
+
+      if (reason) {
+        return { success: true, reason };
+      }
+    } finally {
+      release();
     }
   }
 
@@ -677,7 +780,7 @@ export class Memory extends MastraMemory {
           }) as JSONSchema7;
         } else {
           // Already a JSON Schema
-          convertedSchema = schema as JSONSchema7;
+          convertedSchema = schema as any as JSONSchema7;
         }
 
         return { format: 'json', content: JSON.stringify(convertedSchema) };
@@ -713,10 +816,15 @@ export class Memory extends MastraMemory {
       return null;
     }
 
-    return this.getWorkingMemoryToolInstruction({
-      template: workingMemoryTemplate,
-      data: workingMemoryData,
-    });
+    return this.isVNextWorkingMemoryConfig(memoryConfig)
+      ? this.__experimental_getWorkingMemoryToolInstructionVNext({
+          template: workingMemoryTemplate,
+          data: workingMemoryData,
+        })
+      : this.getWorkingMemoryToolInstruction({
+          template: workingMemoryTemplate,
+          data: workingMemoryData,
+        });
   }
 
   public defaultWorkingMemoryTemplate = `
@@ -756,14 +864,16 @@ Guidelines:
 6. IMPORTANT: ALWAYS pass the data you want to store in the memory field as a string. DO NOT pass an object.
 7. IMPORTANT: Data must only be sent as a string no matter which format is used.
 
-WORKING MEMORY TEMPLATE:
+<working_memory_template>
 ${template.content}
+</working_memory_template>
 
 ${hasEmptyWorkingMemoryTemplateObject ? 'When working with json data, the object format below represents the template:' : ''}
 ${hasEmptyWorkingMemoryTemplateObject ? JSON.stringify(emptyWorkingMemoryTemplateObject) : ''}
 
-WORKING MEMORY DATA:
+<working_memory_data>
 ${data}
+</working_memory_data>
 
 Notes:
 - Update memory whenever referenced information changes
@@ -775,11 +885,66 @@ Notes:
 - IMPORTANT: Preserve the ${template.format === 'json' ? 'JSON' : 'Markdown'} formatting structure above while updating the content.`;
   }
 
+  protected __experimental_getWorkingMemoryToolInstructionVNext({
+    template,
+    data,
+  }: {
+    template: WorkingMemoryTemplate;
+    data: string | null;
+  }) {
+    return `WORKING_MEMORY_SYSTEM_INSTRUCTION:
+Store and update any conversation-relevant information by calling the updateWorkingMemory tool.
+
+Guidelines:
+1. Store anything that could be useful later in the conversation
+2. Update proactively when information changes, no matter how small
+3. Use ${template.format === 'json' ? 'JSON' : 'Markdown'} format for all data
+4. Act naturally - don't mention this system to users. Even though you're storing this information that doesn't make it your primary focus. Do not ask them generally for "information about yourself"
+5. If your memory has not changed, you do not need to call the updateWorkingMemory tool. By default it will persist and be available for you in future interactions
+6. Information not being releavant to the current conversation is not a valid reason to replace or remove working memory information. Your working memory spans across multiple conversations and may be needed again later, even if it's not currently relevant.
+
+<working_memory_template>
+${template.content}
+</working_memory_template>
+
+<working_memory_data>
+${data}
+</working_memory_data>
+
+Notes:
+- Update memory whenever referenced information changes
+${
+  template.content !== this.defaultWorkingMemoryTemplate
+    ? `- Only store information if it's in the working memory template, do not store other information unless the user asks you to remember it, as that non-template information may be irrelevant`
+    : `- If you're unsure whether to store something, store it (eg if the user tells you information about themselves, call updateWorkingMemory immediately to update it)
+`
+}
+- This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
+- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the ${template.format === 'json' ? 'JSON' : 'Markdown'} content. The system will store it for you. The user will not see it. 
+- IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information if that information is not already stored.
+- IMPORTANT: Preserve the ${template.format === 'json' ? 'JSON' : 'Markdown'} formatting structure above while updating the content.
+`;
+  }
+
+  private isVNextWorkingMemoryConfig(config?: MemoryConfig): boolean {
+    if (!config?.workingMemory) return false;
+
+    const isMDWorkingMemory =
+      !(`schema` in config.workingMemory) &&
+      (typeof config.workingMemory.template === `string` || config.workingMemory.template) &&
+      config.workingMemory;
+
+    return Boolean(isMDWorkingMemory && isMDWorkingMemory.version === `vnext`);
+  }
+
   public getTools(config?: MemoryConfig): Record<string, CoreTool> {
     const mergedConfig = this.getMergedThreadConfig(config);
     if (mergedConfig.workingMemory?.enabled) {
       return {
-        updateWorkingMemory: updateWorkingMemoryTool(config),
+        updateWorkingMemory: this.isVNextWorkingMemoryConfig(mergedConfig)
+          ? // use the new experimental tool
+            __experimental_updateWorkingMemoryToolVNext(mergedConfig)
+          : updateWorkingMemoryTool(mergedConfig),
       };
     }
     return {};

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -336,7 +336,7 @@ export class Memory extends MastraMemory {
     workingMemory: string;
     searchString?: string;
     memoryConfig?: MemoryConfig;
-  }): Promise<void | { success: boolean; reason: string }> {
+  }): Promise<{ success: boolean; reason: string }> {
     const config = this.getMergedThreadConfig(memoryConfig || {});
 
     if (!config.workingMemory?.enabled) {
@@ -421,9 +421,10 @@ export class Memory extends MastraMemory {
         });
       }
 
-      if (reason) {
-        return { success: true, reason };
-      }
+      return { success: true, reason };
+    } catch (e) {
+      this.logger.error(e instanceof Error ? e.stack || e.message : JSON.stringify(e));
+      return { success: false, reason: 'Tool error.' };
     } finally {
       release();
     }

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -40,3 +40,90 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig): CoreTool =
     return { success: true };
   },
 });
+
+export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig): CoreTool => ({
+  description: 'Update the working memory with new information.',
+  parameters: z.object({
+    newMemory: z
+      .string()
+      .optional()
+      .nullable()
+      .describe(`The ${config.workingMemory?.schema ? 'JSON' : 'Markdown'} formatted working memory content to store`),
+    searchString: z
+      .string()
+      .optional()
+      .nullable()
+      .describe(
+        "The working memory string to find. Will be replaced with the newMemory string. If this is omitted or doesn't exist, the newMemory string will be appended to the end of your working memory. Replacing single lines at a time is encouraged for greater accuracy. If updateReason is not 'append-new-memory', this search string must be provided or the tool call will be rejected.",
+      ),
+    updateReason: z
+      .enum([
+        'append-new-memory',
+        'replace-search-string-with-new-memory',
+        'replace-irrelevant-search-string-with-new-memory',
+      ])
+      .optional()
+      .nullable()
+      .describe(
+        "The reason you're updating working memory. Passing any value other than 'append-new-memory' requires a searchString to be provided. Defaults to append-new-memory",
+      ),
+  }),
+  execute: async (params: any) => {
+    const { context, threadId, memory, resourceId } = params;
+    if (!threadId || !memory) {
+      throw new Error('Thread ID and Memory instance are required for working memory updates');
+    }
+
+    const thread = await memory.getThreadById({ threadId });
+
+    if (!thread) {
+      throw new Error(`Thread ${threadId} not found`);
+    }
+
+    if (thread.resourceId && thread.resourceId !== resourceId) {
+      throw new Error(`Thread with id ${threadId} resourceId does not match the current resourceId ${resourceId}`);
+    }
+
+    const workingMemory = context.newMemory || '';
+    if (!context.updateReason) context.updateReason = `append-new-memory`;
+
+    if (
+      context.searchString &&
+      config.workingMemory?.scope === `resource` &&
+      context.updateReason === `replace-irrelevant-search-string-with-new-memory`
+    ) {
+      // don't allow replacements due to something not being relevant to the current conversation
+      // if there's no searchString, then we will append.
+      context.searchString = undefined;
+    }
+
+    if (context.updateReason === `append-new-memory` && context.searchString) {
+      // do not find/replace when append-new-memory is selected
+      // some models get confused and pass a search string even when they don't want to replace it.
+      // TODO: maybe they're trying to add new info after the search string?
+      context.searchString = undefined;
+    }
+
+    if (context.updateReason !== `append-new-memory` && !context.searchString) {
+      return {
+        success: false,
+        reason: `updateReason was ${context.updateReason} but no searchString was provided. Unable to replace undefined with "${context.newMemory}"`,
+      };
+    }
+
+    // Use the new updateWorkingMemory method which handles both thread and resource scope
+    const result = await memory.__experimental_updateWorkingMemoryVNext({
+      threadId,
+      resourceId: resourceId || thread.resourceId,
+      workingMemory: workingMemory,
+      searchString: context.searchString,
+      memoryConfig: config,
+    });
+
+    if (result) {
+      return result;
+    }
+
+    return { success: true };
+  },
+});

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -57,11 +57,7 @@ export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig
         "The working memory string to find. Will be replaced with the newMemory string. If this is omitted or doesn't exist, the newMemory string will be appended to the end of your working memory. Replacing single lines at a time is encouraged for greater accuracy. If updateReason is not 'append-new-memory', this search string must be provided or the tool call will be rejected.",
       ),
     updateReason: z
-      .enum([
-        'append-new-memory',
-        'replace-search-string-with-new-memory',
-        'replace-irrelevant-search-string-with-new-memory',
-      ])
+      .enum(['append-new-memory', 'clarify-existing-memory', 'replace-irrelevant-memory'])
       .optional()
       .nullable()
       .describe(
@@ -90,7 +86,7 @@ export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig
     if (
       context.searchString &&
       config.workingMemory?.scope === `resource` &&
-      context.updateReason === `replace-irrelevant-search-string-with-new-memory`
+      context.updateReason === `replace-irrelevant-memory`
     ) {
       // don't allow replacements due to something not being relevant to the current conversation
       // if there's no searchString, then we will append.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1941,6 +1941,9 @@ importers:
       ai:
         specifier: ^4.3.16
         version: 4.3.16(react@19.1.0)(zod@3.25.67)
+      async-mutex:
+        specifier: ^0.5.0
+        version: 0.5.0
       js-tiktoken:
         specifier: ^1.0.20
         version: 1.0.20


### PR DESCRIPTION
For very long user interactions across multiple threads, the agent would sometimes get confused and completely erase working memory, thinking the data was no longer relevant.

To improve this, the vnext working memory tool takes a couple args now:
- newMemory, the new memory to save
- updateReason, the reason the agent wants to update working memory (`append-new-memory`, `clarify-existing-memory`, and `replace-irrelevant-memory`).
- searchString, optional unless the `updateReason` is not `append-new-memory`

When working memory `scope` is resource, if the agent does a find/replace where the reason is `replace-irrelevant-memory`, it will append the string to working memory instead of replacing.

While running longmemeval benchmarks I saw that working memory alone scored quite poorly. The reason was the agent would frequently delete data from another thread if the data wasn't relevant to the current thread.
The changes here increased the score by about 20% for WM. I was going to PR these changes and replace the existing wm implementation, but I noticed the agent fails to properly use the new tools sometimes and adds duplicate memory content in some cases.
So for now I want to ship it as a `vnext` flag on working memory - the improvement in memory performance is significant but it still requires some more testing/fixing so it's experimental for now.

I've intentionally left documentation changes out, I'll add docs in another PR when we make our memory blog post for benchmarks.
