### PR TITLE
feat(memory): enhance thread retrieval with sorting options in libsql and pg (#5624)

### DIFF
--- a/.changeset/lemon-doors-grab.md
+++ b/.changeset/lemon-doors-grab.md
@@ -1,0 +1,10 @@
+---
+'@mastra/deployer': patch
+'@mastra/memory': patch
+'@mastra/server': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+enhance thread retrieval with sorting options in libsql and pg

--- a/docs/src/content/en/reference/memory/getThreadsByResourceId.mdx
+++ b/docs/src/content/en/reference/memory/getThreadsByResourceId.mdx
@@ -1,6 +1,6 @@
 # getThreadsByResourceId Reference
 
-The `getThreadsByResourceId` function retrieves all threads associated with a specific resource ID from storage.
+The `getThreadsByResourceId` function retrieves all threads associated with a specific resource ID from storage. Threads can be sorted by creation or modification time in ascending or descending order.
 
 ## Usage Example
 
@@ -9,8 +9,16 @@ import { Memory } from "@mastra/core/memory";
 
 const memory = new Memory(config);
 
+// Basic usage - returns threads sorted by createdAt DESC (default)
 const threads = await memory.getThreadsByResourceId({
   resourceId: "resource-123",
+});
+
+// Custom sorting by updatedAt in ascending order
+const threadsByUpdate = await memory.getThreadsByResourceId({
+  resourceId: "resource-123",
+  orderBy: "updatedAt",
+  sortDirection: "ASC",
 });
 ```
 
@@ -24,8 +32,32 @@ const threads = await memory.getThreadsByResourceId({
       description: "The ID of the resource whose threads are to be retrieved.",
       isOptional: false,
     },
+    {
+      name: "orderBy",
+      type: "ThreadOrderBy",
+      description: "Field to sort threads by. Accepts 'createdAt' or 'updatedAt'. Default: 'createdAt'",
+      isOptional: true,
+    },
+    {
+      name: "sortDirection",
+      type: "ThreadSortDirection", 
+      description: "Sort order direction. Accepts 'ASC' or 'DESC'. Default: 'DESC'",
+      isOptional: true,
+    },
   ]}
 />
+
+## Type Definitions
+
+```typescript
+type ThreadOrderBy = 'createdAt' | 'updatedAt';
+type ThreadSortDirection = 'ASC' | 'DESC';
+
+interface ThreadSortOptions {
+  orderBy?: ThreadOrderBy;
+  sortDirection?: ThreadSortDirection;
+}
+```
 
 ## Returns
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -4,7 +4,7 @@ import { MessageList } from '../agent/message-list';
 import type { MastraMessageV2 } from '../agent/message-list';
 import { MastraBase } from '../base';
 import type { Mastra } from '../mastra';
-import type { MastraStorage, StorageGetMessagesArg } from '../storage';
+import type { MastraStorage, StorageGetMessagesArg, ThreadSortOptions } from '../storage';
 import { augmentWithInit } from '../storage/storageWithInit';
 import type { CoreTool } from '../tools';
 import { deepMerge } from '../utils';
@@ -256,7 +256,21 @@ export abstract class MastraMemory extends MastraBase {
    */
   abstract getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null>;
 
-  abstract getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]>;
+  /**
+   * Retrieves all threads that belong to the specified resource.
+   * @param resourceId - The unique identifier of the resource
+   * @param orderBy - Which timestamp field to sort by (`'createdAt'` or `'updatedAt'`);
+   *                  defaults to `'createdAt'`
+   * @param sortDirection - Sort order for the results (`'ASC'` or `'DESC'`);
+   *                        defaults to `'DESC'`
+   * @returns Promise resolving to an array of matching threads; resolves to an empty array
+   *          if the resource has no threads
+   */
+  abstract getThreadsByResourceId({
+    resourceId,
+    orderBy,
+    sortDirection,
+  }: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]>;
 
   /**
    * Saves or updates a thread

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -32,6 +32,7 @@ import type {
   StorageGetMessagesArg,
   StorageResourceType,
   StoragePagination,
+  ThreadSortOptions,
   WorkflowRun,
   WorkflowRuns,
   StorageGetTracesArg,
@@ -206,7 +207,11 @@ export abstract class MastraStorage extends MastraBase {
 
   abstract getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null>;
 
-  abstract getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]>;
+  abstract getThreadsByResourceId({
+    resourceId,
+    orderBy,
+    sortDirection,
+  }: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]>;
 
   abstract saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType>;
 
@@ -438,11 +443,13 @@ export abstract class MastraStorage extends MastraBase {
 
   abstract getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null>;
 
-  abstract getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }>;
+  abstract getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }>;
 
   abstract getMessagesPaginated(
     args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -1,4 +1,4 @@
-import type { StorageColumn } from './types';
+import type { StorageColumn, ThreadOrderBy, ThreadSortDirection } from './types';
 
 export const TABLE_WORKFLOW_SNAPSHOT = 'mastra_workflow_snapshot';
 export const TABLE_EVALS = 'mastra_evals';

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -1,7 +1,14 @@
 import type { MastraMessageContentV2 } from '../../../agent';
 import { MastraBase } from '../../../base';
 import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '../../../memory/types';
-import type { StorageGetMessagesArg, PaginationInfo, StorageResourceType, ThreadSortOptions } from '../../types';
+import type {
+  StorageGetMessagesArg,
+  PaginationInfo,
+  StorageResourceType,
+  ThreadOrderBy,
+  ThreadSortDirection,
+  ThreadSortOptions,
+} from '../../types';
 
 export abstract class MemoryStorage extends MastraBase {
   constructor() {
@@ -93,4 +100,22 @@ export abstract class MemoryStorage extends MastraBase {
         `To use per-resource working memory, switch to one of these supported storage adapters.`,
     );
   }
+
+  protected castThreadOrderBy(v: unknown): ThreadOrderBy {
+    return (v as string) in THREAD_ORDER_BY_SET ? (v as ThreadOrderBy) : 'createdAt';
+  }
+
+  protected castThreadSortDirection(v: unknown): ThreadSortDirection {
+    return (v as string) in THREAD_THREAD_SORT_DIRECTION_SET ? (v as ThreadSortDirection) : 'DESC';
+  }
 }
+
+const THREAD_ORDER_BY_SET: Record<ThreadOrderBy, true> = {
+  createdAt: true,
+  updatedAt: true,
+};
+
+const THREAD_THREAD_SORT_DIRECTION_SET: Record<ThreadSortDirection, true> = {
+  ASC: true,
+  DESC: true,
+};

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -1,7 +1,7 @@
 import type { MastraMessageContentV2 } from '../../../agent';
 import { MastraBase } from '../../../base';
 import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '../../../memory/types';
-import type { StorageGetMessagesArg, PaginationInfo, StorageResourceType } from '../../types';
+import type { StorageGetMessagesArg, PaginationInfo, StorageResourceType, ThreadSortOptions } from '../../types';
 
 export abstract class MemoryStorage extends MastraBase {
   constructor() {
@@ -13,7 +13,9 @@ export abstract class MemoryStorage extends MastraBase {
 
   abstract getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null>;
 
-  abstract getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]>;
+  abstract getThreadsByResourceId({
+    resourceId,
+  }: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]>;
 
   abstract saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType>;
 
@@ -52,11 +54,13 @@ export abstract class MemoryStorage extends MastraBase {
       }[];
   }): Promise<MastraMessageV2[]>;
 
-  abstract getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }>;
+  abstract getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }>;
 
   abstract getMessagesPaginated(
     args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -9,7 +9,6 @@ import type {
   ThreadSortDirection,
   ThreadSortOptions,
 } from '../../types';
-import { castThreadOrderBy, castThreadSortDirection } from '../../types';
 import type { StoreOperations } from '../operations';
 import { MemoryStorage } from './base';
 
@@ -54,7 +53,11 @@ export class InMemoryMemory extends MemoryStorage {
     this.logger.debug(`MockStore: getThreadsByResourceId called for ${resourceId}`);
     // Mock implementation - find threads by resourceId
     const threads = Array.from(this.collection.threads.values()).filter((t: any) => t.resourceId === resourceId);
-    const sortedThreads = this.sortThreads(threads, castThreadOrderBy(orderBy), castThreadSortDirection(sortDirection));
+    const sortedThreads = this.sortThreads(
+      threads,
+      this.castThreadOrderBy(orderBy),
+      this.castThreadSortDirection(sortDirection),
+    );
     return sortedThreads.map(thread => ({
       ...thread,
       metadata: thread.metadata ? { ...thread.metadata } : thread.metadata,
@@ -364,7 +367,11 @@ export class InMemoryMemory extends MemoryStorage {
     this.logger.debug(`MockStore: getThreadsByResourceIdPaginated called for ${resourceId}`);
     // Mock implementation - find threads by resourceId
     const threads = Array.from(this.collection.threads.values()).filter((t: any) => t.resourceId === resourceId);
-    const sortedThreads = this.sortThreads(threads, castThreadOrderBy(orderBy), castThreadSortDirection(sortDirection));
+    const sortedThreads = this.sortThreads(
+      threads,
+      this.castThreadOrderBy(orderBy),
+      this.castThreadSortDirection(sortDirection),
+    );
     const clonedThreads = sortedThreads.map(thread => ({
       ...thread,
       metadata: thread.metadata ? { ...thread.metadata } : thread.metadata,

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -1,6 +1,15 @@
 import { MessageList } from '../../../agent/message-list';
 import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '../../../memory/types';
-import type { PaginationInfo, StorageGetMessagesArg, StorageMessageType, StorageResourceType } from '../../types';
+import type {
+  PaginationInfo,
+  StorageGetMessagesArg,
+  StorageMessageType,
+  StorageResourceType,
+  ThreadOrderBy,
+  ThreadSortDirection,
+  ThreadSortOptions,
+} from '../../types';
+import { castThreadOrderBy, castThreadSortDirection } from '../../types';
 import type { StoreOperations } from '../operations';
 import { MemoryStorage } from './base';
 
@@ -37,11 +46,16 @@ export class InMemoryMemory extends MemoryStorage {
     return thread ? { ...thread, metadata: thread.metadata ? { ...thread.metadata } : thread.metadata } : null;
   }
 
-  async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
+  async getThreadsByResourceId({
+    resourceId,
+    orderBy,
+    sortDirection,
+  }: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
     this.logger.debug(`MockStore: getThreadsByResourceId called for ${resourceId}`);
     // Mock implementation - find threads by resourceId
     const threads = Array.from(this.collection.threads.values()).filter((t: any) => t.resourceId === resourceId);
-    return threads.map(thread => ({
+    const sortedThreads = this.sortThreads(threads, castThreadOrderBy(orderBy), castThreadSortDirection(sortDirection));
+    return sortedThreads.map(thread => ({
       ...thread,
       metadata: thread.metadata ? { ...thread.metadata } : thread.metadata,
     })) as StorageThreadType[];
@@ -339,24 +353,28 @@ export class InMemoryMemory extends MemoryStorage {
     return updatedMessages;
   }
 
-  async getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
-    this.logger.debug(`MockStore: getThreadsByResourceIdPaginated called for ${args.resourceId}`);
+  async getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+    const { resourceId, page, perPage, orderBy, sortDirection } = args;
+    this.logger.debug(`MockStore: getThreadsByResourceIdPaginated called for ${resourceId}`);
     // Mock implementation - find threads by resourceId
-    const threads = Array.from(this.collection.threads.values()).filter((t: any) => t.resourceId === args.resourceId);
-    const clonedThreads = threads.map(thread => ({
+    const threads = Array.from(this.collection.threads.values()).filter((t: any) => t.resourceId === resourceId);
+    const sortedThreads = this.sortThreads(threads, castThreadOrderBy(orderBy), castThreadSortDirection(sortDirection));
+    const clonedThreads = sortedThreads.map(thread => ({
       ...thread,
       metadata: thread.metadata ? { ...thread.metadata } : thread.metadata,
     })) as StorageThreadType[];
     return {
-      threads: clonedThreads.slice(args.page * args.perPage, (args.page + 1) * args.perPage),
+      threads: clonedThreads.slice(page * perPage, (page + 1) * perPage),
       total: clonedThreads.length,
-      page: args.page,
-      perPage: args.perPage,
-      hasMore: clonedThreads.length > (args.page + 1) * args.perPage,
+      page: page,
+      perPage: perPage,
+      hasMore: clonedThreads.length > (page + 1) * perPage,
     };
   }
 
@@ -568,5 +586,18 @@ export class InMemoryMemory extends MemoryStorage {
 
     this.collection.resources.set(resourceId, resource);
     return resource;
+  }
+
+  private sortThreads(threads: any[], orderBy: ThreadOrderBy, sortDirection: ThreadSortDirection): any[] {
+    return threads.sort((a, b) => {
+      const aValue = new Date(a[orderBy]).getTime();
+      const bValue = new Date(b[orderBy]).getTime();
+
+      if (sortDirection === 'ASC') {
+        return aValue - bValue;
+      } else {
+        return bValue - aValue;
+      }
+    });
   }
 }

--- a/packages/core/src/storage/mock.test.ts
+++ b/packages/core/src/storage/mock.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { InMemoryStore } from './mock';
+import type { StorageThreadType } from '../memory/types';
+
+describe('InMemoryStore - Thread Sorting', () => {
+  let store: InMemoryStore;
+  const resourceId = 'test-resource-id';
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+
+    // Create test threads with different dates
+    const threads: StorageThreadType[] = [
+      {
+        id: 'thread-1',
+        resourceId,
+        title: 'Thread 1',
+        createdAt: new Date('2024-01-01T10:00:00Z'),
+        updatedAt: new Date('2024-01-03T10:00:00Z'),
+        metadata: {},
+      },
+      {
+        id: 'thread-2',
+        resourceId,
+        title: 'Thread 2',
+        createdAt: new Date('2024-01-02T10:00:00Z'),
+        updatedAt: new Date('2024-01-02T10:00:00Z'),
+        metadata: {},
+      },
+      {
+        id: 'thread-3',
+        resourceId,
+        title: 'Thread 3',
+        createdAt: new Date('2024-01-03T10:00:00Z'),
+        updatedAt: new Date('2024-01-01T10:00:00Z'),
+        metadata: {},
+      },
+    ];
+
+    // Save threads to store
+    for (const thread of threads) {
+      await store.saveThread({ thread });
+    }
+  });
+
+  describe('getThreadsByResourceId', () => {
+    it('should sort by createdAt DESC by default', async () => {
+      const threads = await store.getThreadsByResourceId({ resourceId });
+
+      expect(threads).toHaveLength(3);
+      expect(threads[0].id).toBe('thread-3'); // 2024-01-03 (latest)
+      expect(threads[1].id).toBe('thread-2'); // 2024-01-02
+      expect(threads[2].id).toBe('thread-1'); // 2024-01-01 (earliest)
+    });
+
+    it('should sort by createdAt ASC when specified', async () => {
+      const threads = await store.getThreadsByResourceId({
+        resourceId,
+        orderBy: 'createdAt',
+        sortDirection: 'ASC',
+      });
+
+      expect(threads).toHaveLength(3);
+      expect(threads[0].id).toBe('thread-1'); // 2024-01-01 (earliest)
+      expect(threads[1].id).toBe('thread-2'); // 2024-01-02
+      expect(threads[2].id).toBe('thread-3'); // 2024-01-03 (latest)
+    });
+
+    it('should sort by updatedAt DESC when specified', async () => {
+      const threads = await store.getThreadsByResourceId({
+        resourceId,
+        orderBy: 'updatedAt',
+        sortDirection: 'DESC',
+      });
+
+      expect(threads).toHaveLength(3);
+      expect(threads[0].id).toBe('thread-1'); // 2024-01-03 (latest updatedAt)
+      expect(threads[1].id).toBe('thread-2'); // 2024-01-02
+      expect(threads[2].id).toBe('thread-3'); // 2024-01-01 (earliest updatedAt)
+    });
+
+    it('should sort by updatedAt ASC when specified', async () => {
+      const threads = await store.getThreadsByResourceId({
+        resourceId,
+        orderBy: 'updatedAt',
+        sortDirection: 'ASC',
+      });
+
+      expect(threads).toHaveLength(3);
+      expect(threads[0].id).toBe('thread-3'); // 2024-01-01 (earliest updatedAt)
+      expect(threads[1].id).toBe('thread-2'); // 2024-01-02
+      expect(threads[2].id).toBe('thread-1'); // 2024-01-03 (latest updatedAt)
+    });
+
+    it('should handle empty results', async () => {
+      const threads = await store.getThreadsByResourceId({
+        resourceId: 'non-existent-resource',
+      });
+
+      expect(threads).toHaveLength(0);
+    });
+
+    it('should filter by resourceId correctly', async () => {
+      // Add a thread with different resourceId
+      await store.saveThread({
+        thread: {
+          id: 'thread-other',
+          resourceId: 'other-resource',
+          title: 'Other Thread',
+          createdAt: new Date('2024-01-04T10:00:00Z'),
+          updatedAt: new Date('2024-01-04T10:00:00Z'),
+          metadata: {},
+        },
+      });
+
+      const threads = await store.getThreadsByResourceId({ resourceId });
+
+      expect(threads).toHaveLength(3);
+      expect(threads.every(t => t.resourceId === resourceId)).toBe(true);
+    });
+  });
+
+  describe('getThreadsByResourceIdPaginated', () => {
+    it('should sort by createdAt DESC by default with pagination', async () => {
+      const result = await store.getThreadsByResourceIdPaginated({
+        resourceId,
+        page: 0,
+        perPage: 2,
+      });
+
+      expect(result.threads).toHaveLength(2);
+      expect(result.threads[0].id).toBe('thread-3'); // 2024-01-03 (latest)
+      expect(result.threads[1].id).toBe('thread-2'); // 2024-01-02
+      expect(result.total).toBe(3);
+      expect(result.page).toBe(0);
+      expect(result.perPage).toBe(2);
+      expect(result.hasMore).toBe(true);
+    });
+
+    it('should sort by updatedAt ASC with pagination', async () => {
+      const result = await store.getThreadsByResourceIdPaginated({
+        resourceId,
+        page: 0,
+        perPage: 2,
+        orderBy: 'updatedAt',
+        sortDirection: 'ASC',
+      });
+
+      expect(result.threads).toHaveLength(2);
+      expect(result.threads[0].id).toBe('thread-3'); // 2024-01-01 (earliest updatedAt)
+      expect(result.threads[1].id).toBe('thread-2'); // 2024-01-02
+      expect(result.total).toBe(3);
+      expect(result.hasMore).toBe(true);
+    });
+
+    it('should maintain sort order across pages', async () => {
+      // First page
+      const page1 = await store.getThreadsByResourceIdPaginated({
+        resourceId,
+        page: 0,
+        perPage: 2,
+        orderBy: 'createdAt',
+        sortDirection: 'ASC',
+      });
+
+      // Second page
+      const page2 = await store.getThreadsByResourceIdPaginated({
+        resourceId,
+        page: 1,
+        perPage: 2,
+        orderBy: 'createdAt',
+        sortDirection: 'ASC',
+      });
+
+      expect(page1.threads).toHaveLength(2);
+      expect(page1.threads[0].id).toBe('thread-1'); // 2024-01-01 (earliest)
+      expect(page1.threads[1].id).toBe('thread-2'); // 2024-01-02
+
+      expect(page2.threads).toHaveLength(1);
+      expect(page2.threads[0].id).toBe('thread-3'); // 2024-01-03 (latest)
+    });
+
+    it('should calculate pagination info correctly after sorting', async () => {
+      const result = await store.getThreadsByResourceIdPaginated({
+        resourceId,
+        page: 1,
+        perPage: 2,
+        orderBy: 'updatedAt',
+        sortDirection: 'DESC',
+      });
+
+      expect(result.threads).toHaveLength(1);
+      expect(result.threads[0].id).toBe('thread-3'); // Last item after sorting
+      expect(result.total).toBe(3);
+      expect(result.page).toBe(1);
+      expect(result.perPage).toBe(2);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('should handle empty results with pagination', async () => {
+      const result = await store.getThreadsByResourceIdPaginated({
+        resourceId: 'non-existent-resource',
+        page: 0,
+        perPage: 10,
+      });
+
+      expect(result.threads).toHaveLength(0);
+      expect(result.total).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -27,6 +27,7 @@ import type {
   StorageGetTracesPaginatedArg,
   StoragePagination,
   StorageResourceType,
+  ThreadSortOptions,
   WorkflowRun,
   WorkflowRuns,
 } from './types';
@@ -148,8 +149,12 @@ export class InMemoryStore extends MastraStorage {
     return this.stores.memory.getThreadById({ threadId });
   }
 
-  async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
-    return this.stores.memory.getThreadsByResourceId({ resourceId });
+  async getThreadsByResourceId({
+    resourceId,
+    orderBy,
+    sortDirection,
+  }: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
+    return this.stores.memory.getThreadsByResourceId({ resourceId, orderBy, sortDirection });
   }
 
   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
@@ -217,11 +222,13 @@ export class InMemoryStore extends MastraStorage {
     return this.stores.memory.updateMessages(args);
   }
 
-  async getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+  async getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
     return this.stores.memory.getThreadsByResourceIdPaginated(args);
   }
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -156,24 +156,6 @@ export interface ThreadSortOptions {
   sortDirection?: ThreadSortDirection;
 }
 
-const THREAD_ORDER_BY_SET = {
-  createdAt: true,
-  updatedAt: true,
-} satisfies Record<'createdAt' | 'updatedAt', true>;
+export type ThreadOrderBy = 'createdAt' | 'updatedAt';
 
-const THREAD_THREAD_SORT_DIRECTION_SET = {
-  ASC: true,
-  DESC: true,
-} satisfies Record<'ASC' | 'DESC', true>;
-
-export type ThreadOrderBy = keyof typeof THREAD_ORDER_BY_SET;
-
-export type ThreadSortDirection = keyof typeof THREAD_THREAD_SORT_DIRECTION_SET;
-
-export function castThreadOrderBy(v: unknown): ThreadOrderBy {
-  return (v as string) in THREAD_ORDER_BY_SET ? (v as ThreadOrderBy) : 'createdAt';
-}
-
-export function castThreadSortDirection(v: unknown): ThreadSortDirection {
-  return (v as string) in THREAD_THREAD_SORT_DIRECTION_SET ? (v as ThreadSortDirection) : 'DESC';
-}
+export type ThreadSortDirection = 'ASC' | 'DESC';

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -150,3 +150,30 @@ export type StorageMessageType = {
   createdAt: Date;
   resourceId: string | null;
 };
+
+export interface ThreadSortOptions {
+  orderBy?: ThreadOrderBy;
+  sortDirection?: ThreadSortDirection;
+}
+
+const THREAD_ORDER_BY_SET = {
+  createdAt: true,
+  updatedAt: true,
+} satisfies Record<'createdAt' | 'updatedAt', true>;
+
+const THREAD_THREAD_SORT_DIRECTION_SET = {
+  ASC: true,
+  DESC: true,
+} satisfies Record<'ASC' | 'DESC', true>;
+
+export type ThreadOrderBy = keyof typeof THREAD_ORDER_BY_SET;
+
+export type ThreadSortDirection = keyof typeof THREAD_THREAD_SORT_DIRECTION_SET;
+
+export function castThreadOrderBy(v: unknown): ThreadOrderBy {
+  return (v as string) in THREAD_ORDER_BY_SET ? (v as ThreadOrderBy) : 'createdAt';
+}
+
+export function castThreadSortDirection(v: unknown): ThreadSortDirection {
+  return (v as string) in THREAD_THREAD_SORT_DIRECTION_SET ? (v as ThreadSortDirection) : 'DESC';
+}

--- a/packages/deployer/src/server/handlers/routes/memory/handlers.ts
+++ b/packages/deployer/src/server/handlers/routes/memory/handlers.ts
@@ -1,5 +1,6 @@
 import type { Mastra } from '@mastra/core';
 import type { StorageGetMessagesArg, MastraMessageFormat } from '@mastra/core/storage';
+import { castThreadOrderBy, castThreadSortDirection } from '@mastra/core/storage';
 import {
   getMemoryStatusHandler as getOriginalMemoryStatusHandler,
   getMemoryConfigHandler as getOriginalMemoryConfigHandler,
@@ -63,12 +64,16 @@ export async function getThreadsHandler(c: Context) {
     const agentId = c.req.query('agentId');
     const resourceId = c.req.query('resourceid');
     const networkId = c.req.query('networkId');
+    const orderBy = castThreadOrderBy(c.req.query('orderBy'));
+    const sortDirection = castThreadSortDirection(c.req.query('sortDirection'));
 
     const result = await getOriginalThreadsHandler({
       mastra,
       agentId,
       resourceId,
       networkId,
+      orderBy,
+      sortDirection,
     });
 
     return c.json(result);

--- a/packages/deployer/src/server/handlers/routes/memory/handlers.ts
+++ b/packages/deployer/src/server/handlers/routes/memory/handlers.ts
@@ -1,6 +1,10 @@
 import type { Mastra } from '@mastra/core';
-import type { StorageGetMessagesArg, MastraMessageFormat } from '@mastra/core/storage';
-import { castThreadOrderBy, castThreadSortDirection } from '@mastra/core/storage';
+import type {
+  StorageGetMessagesArg,
+  MastraMessageFormat,
+  ThreadOrderBy,
+  ThreadSortDirection,
+} from '@mastra/core/storage';
 import {
   getMemoryStatusHandler as getOriginalMemoryStatusHandler,
   getMemoryConfigHandler as getOriginalMemoryConfigHandler,
@@ -64,8 +68,8 @@ export async function getThreadsHandler(c: Context) {
     const agentId = c.req.query('agentId');
     const resourceId = c.req.query('resourceid');
     const networkId = c.req.query('networkId');
-    const orderBy = castThreadOrderBy(c.req.query('orderBy'));
-    const sortDirection = castThreadSortDirection(c.req.query('sortDirection'));
+    const orderBy = c.req.query('orderBy') as ThreadOrderBy | undefined;
+    const sortDirection = c.req.query('sortDirection') as ThreadSortDirection | undefined;
 
     const result = await getOriginalThreadsHandler({
       mastra,

--- a/packages/deployer/src/server/handlers/routes/memory/router.ts
+++ b/packages/deployer/src/server/handlers/routes/memory/router.ts
@@ -62,6 +62,28 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
           required: true,
           schema: { type: 'string' },
         },
+        {
+          name: 'orderBy',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['createdAt', 'updatedAt'],
+            default: 'createdAt',
+          },
+          description: 'Field to sort by',
+        },
+        {
+          name: 'sortDirection',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['ASC', 'DESC'],
+            default: 'DESC',
+          },
+          description: 'Sort direction',
+        },
       ],
       responses: {
         200: {
@@ -406,6 +428,28 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
           in: 'query',
           required: true,
           schema: { type: 'string' },
+        },
+        {
+          name: 'orderBy',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['createdAt', 'updatedAt'],
+            default: 'createdAt',
+          },
+          description: 'Field to sort by',
+        },
+        {
+          name: 'sortDirection',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['ASC', 'DESC'],
+            default: 'DESC',
+          },
+          description: 'Sort direction',
         },
       ],
       responses: {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -4,7 +4,7 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV2 } from '@mastra/core/agent';
 import { MastraMemory } from '@mastra/core/memory';
 import type { MemoryConfig, SharedMemoryConfig, StorageThreadType, WorkingMemoryTemplate } from '@mastra/core/memory';
-import type { StorageGetMessagesArg } from '@mastra/core/storage';
+import type { StorageGetMessagesArg, ThreadSortOptions } from '@mastra/core/storage';
 import { embedMany } from 'ai';
 import type { CoreMessage, TextPart, UIMessage } from 'ai';
 import { Mutex } from 'async-mutex';
@@ -247,8 +247,12 @@ export class Memory extends MastraMemory {
     return this.storage.getThreadById({ threadId });
   }
 
-  async getThreadsByResourceId({ resourceId }: { resourceId: string }): Promise<StorageThreadType[]> {
-    return this.storage.getThreadsByResourceId({ resourceId });
+  async getThreadsByResourceId({
+    resourceId,
+    orderBy,
+    sortDirection,
+  }: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
+    return this.storage.getThreadsByResourceId({ resourceId, orderBy, sortDirection });
   }
 
   async saveThread({ thread }: { thread: StorageThreadType; memoryConfig?: MemoryConfig }): Promise<StorageThreadType> {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -2,6 +2,7 @@ import { generateEmptyFromSchema } from '@mastra/core';
 import type { StorageGetMessagesArg } from '@mastra/core';
 import type { RuntimeContext } from '@mastra/core/di';
 import type { MastraMemory } from '@mastra/core/memory';
+import type { ThreadSortOptions } from '@mastra/core/storage';
 import { HTTPException } from '../http-exception';
 import type { Context } from '../types';
 
@@ -94,7 +95,9 @@ export async function getThreadsHandler({
   resourceId,
   networkId,
   runtimeContext,
-}: Pick<MemoryContext, 'mastra' | 'agentId' | 'resourceId' | 'networkId' | 'runtimeContext'>) {
+  orderBy,
+  sortDirection,
+}: Pick<MemoryContext, 'mastra' | 'agentId' | 'resourceId' | 'networkId' | 'runtimeContext'> & ThreadSortOptions) {
   try {
     const memory = await getMemoryFromContext({ mastra, agentId, networkId, runtimeContext });
 
@@ -104,7 +107,11 @@ export async function getThreadsHandler({
 
     validateBody({ resourceId });
 
-    const threads = await memory.getThreadsByResourceId({ resourceId: resourceId! });
+    const threads = await memory.getThreadsByResourceId({
+      resourceId: resourceId!,
+      orderBy,
+      sortDirection,
+    });
     return threads;
   } catch (error) {
     return handleError(error, 'Error getting threads');

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -4,13 +4,20 @@ import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraMessageV2, StorageThreadType } from '@mastra/core/memory';
-import type { PaginationInfo, StorageGetMessagesArg, StorageResourceType } from '@mastra/core/storage';
+import type {
+  PaginationInfo,
+  StorageGetMessagesArg,
+  StorageResourceType,
+  ThreadSortOptions,
+} from '@mastra/core/storage';
 import {
   MemoryStorage,
   resolveMessageLimit,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
+  castThreadOrderBy,
+  castThreadSortDirection,
 } from '@mastra/core/storage';
 import type { StoreOperationsLibSQL } from '../operations';
 
@@ -569,8 +576,10 @@ export class MemoryLibSQL extends MemoryStorage {
   /**
    * @deprecated use getThreadsByResourceIdPaginated instead for paginated results.
    */
-  public async getThreadsByResourceId(args: { resourceId: string }): Promise<StorageThreadType[]> {
-    const { resourceId } = args;
+  public async getThreadsByResourceId(args: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
+    const resourceId = args.resourceId;
+    const orderBy = castThreadOrderBy(args.orderBy);
+    const sortDirection = castThreadSortDirection(args.sortDirection);
 
     try {
       const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
@@ -587,7 +596,7 @@ export class MemoryLibSQL extends MemoryStorage {
 
       // Non-paginated path
       const result = await this.client.execute({
-        sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC`,
+        sql: `SELECT * ${baseQuery} ORDER BY ${orderBy} ${sortDirection}`,
         args: queryParams,
       });
 
@@ -611,12 +620,16 @@ export class MemoryLibSQL extends MemoryStorage {
     }
   }
 
-  public async getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+  public async getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
     const { resourceId, page = 0, perPage = 100 } = args;
+    const orderBy = castThreadOrderBy(args.orderBy);
+    const sortDirection = castThreadSortDirection(args.sortDirection);
 
     try {
       const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
@@ -650,7 +663,7 @@ export class MemoryLibSQL extends MemoryStorage {
       }
 
       const dataResult = await this.client.execute({
-        sql: `SELECT * ${baseQuery} ORDER BY createdAt DESC LIMIT ? OFFSET ?`,
+        sql: `SELECT * ${baseQuery} ORDER BY ${orderBy} ${sortDirection} LIMIT ? OFFSET ?`,
         args: [...queryParams, perPage, currentOffset],
       });
 

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -16,8 +16,6 @@ import {
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
-  castThreadOrderBy,
-  castThreadSortDirection,
 } from '@mastra/core/storage';
 import type { StoreOperationsLibSQL } from '../operations';
 
@@ -578,8 +576,8 @@ export class MemoryLibSQL extends MemoryStorage {
    */
   public async getThreadsByResourceId(args: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
     const resourceId = args.resourceId;
-    const orderBy = castThreadOrderBy(args.orderBy);
-    const sortDirection = castThreadSortDirection(args.sortDirection);
+    const orderBy = this.castThreadOrderBy(args.orderBy);
+    const sortDirection = this.castThreadSortDirection(args.sortDirection);
 
     try {
       const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;
@@ -628,8 +626,8 @@ export class MemoryLibSQL extends MemoryStorage {
     } & ThreadSortOptions,
   ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
     const { resourceId, page = 0, perPage = 100 } = args;
-    const orderBy = castThreadOrderBy(args.orderBy);
-    const sortDirection = castThreadSortDirection(args.sortDirection);
+    const orderBy = this.castThreadOrderBy(args.orderBy);
+    const sortDirection = this.castThreadSortDirection(args.sortDirection);
 
     try {
       const baseQuery = `FROM ${TABLE_THREADS} WHERE resourceId = ?`;

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -17,6 +17,7 @@ import type {
   WorkflowRuns,
   StorageGetTracesArg,
   StorageDomains,
+  ThreadSortOptions,
 } from '@mastra/core/storage';
 
 import type { Trace } from '@mastra/core/telemetry';
@@ -175,15 +176,17 @@ export class LibSQLStore extends MastraStorage {
   /**
    * @deprecated use getThreadsByResourceIdPaginated instead for paginated results.
    */
-  public async getThreadsByResourceId(args: { resourceId: string }): Promise<StorageThreadType[]> {
+  public async getThreadsByResourceId(args: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
     return this.stores.memory.getThreadsByResourceId(args);
   }
 
-  public async getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+  public async getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
     return this.stores.memory.getThreadsByResourceIdPaginated(args);
   }
 

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -8,8 +8,15 @@ import {
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
+  castThreadOrderBy,
+  castThreadSortDirection,
 } from '@mastra/core/storage';
-import type { StorageGetMessagesArg, PaginationInfo, StorageResourceType } from '@mastra/core/storage';
+import type {
+  StorageGetMessagesArg,
+  PaginationInfo,
+  StorageResourceType,
+  ThreadSortOptions,
+} from '@mastra/core/storage';
 import type { IDatabase } from 'pg-promise';
 import type { StoreOperationsPG } from '../operations';
 import { getTableName, getSchemaName } from '../utils';
@@ -73,15 +80,17 @@ export class MemoryPG extends MemoryStorage {
   /**
    * @deprecated use getThreadsByResourceIdPaginated instead
    */
-  public async getThreadsByResourceId(args: { resourceId: string }): Promise<StorageThreadType[]> {
-    const { resourceId } = args;
+  public async getThreadsByResourceId(args: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
+    const resourceId = args.resourceId;
+    const orderBy = castThreadOrderBy(args.orderBy);
+    const sortDirection = castThreadSortDirection(args.sortDirection);
 
     try {
       const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.schema) });
       const baseQuery = `FROM ${tableName} WHERE "resourceId" = $1`;
       const queryParams: any[] = [resourceId];
 
-      const dataQuery = `SELECT id, "resourceId", title, metadata, "createdAt", "updatedAt" ${baseQuery} ORDER BY "createdAt" DESC`;
+      const dataQuery = `SELECT id, "resourceId", title, metadata, "createdAt", "updatedAt" ${baseQuery} ORDER BY "${orderBy}" ${sortDirection}`;
       const rows = await this.client.manyOrNone(dataQuery, queryParams);
       return (rows || []).map(thread => ({
         ...thread,
@@ -95,12 +104,16 @@ export class MemoryPG extends MemoryStorage {
     }
   }
 
-  public async getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+  public async getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
     const { resourceId, page = 0, perPage: perPageInput } = args;
+    const orderBy = castThreadOrderBy(args.orderBy);
+    const sortDirection = castThreadSortDirection(args.sortDirection);
     try {
       const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.schema) });
       const baseQuery = `FROM ${tableName} WHERE "resourceId" = $1`;
@@ -122,7 +135,7 @@ export class MemoryPG extends MemoryStorage {
         };
       }
 
-      const dataQuery = `SELECT id, "resourceId", title, metadata, "createdAt", "updatedAt" ${baseQuery} ORDER BY "createdAt" DESC LIMIT $2 OFFSET $3`;
+      const dataQuery = `SELECT id, "resourceId", title, metadata, "createdAt", "updatedAt" ${baseQuery} ORDER BY "${orderBy}" ${sortDirection} LIMIT $2 OFFSET $3`;
       const rows = await this.client.manyOrNone(dataQuery, [...queryParams, perPage, currentOffset]);
 
       const threads = (rows || []).map(thread => ({

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -8,8 +8,6 @@ import {
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
-  castThreadOrderBy,
-  castThreadSortDirection,
 } from '@mastra/core/storage';
 import type {
   StorageGetMessagesArg,
@@ -82,8 +80,8 @@ export class MemoryPG extends MemoryStorage {
    */
   public async getThreadsByResourceId(args: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
     const resourceId = args.resourceId;
-    const orderBy = castThreadOrderBy(args.orderBy);
-    const sortDirection = castThreadSortDirection(args.sortDirection);
+    const orderBy = this.castThreadOrderBy(args.orderBy);
+    const sortDirection = this.castThreadSortDirection(args.sortDirection);
 
     try {
       const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.schema) });
@@ -112,8 +110,8 @@ export class MemoryPG extends MemoryStorage {
     } & ThreadSortOptions,
   ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
     const { resourceId, page = 0, perPage: perPageInput } = args;
-    const orderBy = castThreadOrderBy(args.orderBy);
-    const sortDirection = castThreadSortDirection(args.sortDirection);
+    const orderBy = this.castThreadOrderBy(args.orderBy);
+    const sortDirection = this.castThreadSortDirection(args.sortDirection);
     try {
       const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.schema) });
       const baseQuery = `FROM ${tableName} WHERE "resourceId" = $1`;

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -17,6 +17,7 @@ import type {
   PaginationArgs,
   StoragePagination,
   StorageDomains,
+  ThreadSortOptions,
 } from '@mastra/core/storage';
 import type { Trace } from '@mastra/core/telemetry';
 import type { WorkflowRunState } from '@mastra/core/workflows';
@@ -212,15 +213,17 @@ export class PostgresStore extends MastraStorage {
   /**
    * @deprecated use getThreadsByResourceIdPaginated instead
    */
-  public async getThreadsByResourceId(args: { resourceId: string }): Promise<StorageThreadType[]> {
+  public async getThreadsByResourceId(args: { resourceId: string } & ThreadSortOptions): Promise<StorageThreadType[]> {
     return this.stores.memory.getThreadsByResourceId(args);
   }
 
-  public async getThreadsByResourceIdPaginated(args: {
-    resourceId: string;
-    page: number;
-    perPage: number;
-  }): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
+  public async getThreadsByResourceIdPaginated(
+    args: {
+      resourceId: string;
+      page: number;
+      perPage: number;
+    } & ThreadSortOptions,
+  ): Promise<PaginationInfo & { threads: StorageThreadType[] }> {
     return this.stores.memory.getThreadsByResourceIdPaginated(args);
   }
 


### PR DESCRIPTION
## Description

We added **flexible sorting** to both `getThreadsByResourceId` and `getThreadsByResourceIdPaginated`.
With this update, threads can be sorted by the `createdAt` or `updatedAt` field in ascending (**ASC**) or descending (**DESC**) order.

### Key Changes

* **Added type definitions**: `ThreadSortOptions`, `ThreadOrderBy`, and `ThreadSortDirection`
* **Set default values**: Default sort is `createdAt DESC`
* **API extensions**:

  * `getThreadsByResourceId({ resourceId, orderBy?, sortDirection? })`
  * `getThreadsByResourceIdPaginated({ resourceId, page, perPage, orderBy?, sortDirection? })`
* **HTTP API support**: Deployer and Server endpoints now accept the query parameters `orderBy` and `sortDirection`
* **OpenAPI spec update**: Added sorting parameters to the API documentation

### Sort Options

* `orderBy`: `'createdAt'` | `'updatedAt'` (Default: `'createdAt'`)
* `sortDirection`: `'ASC'` | `'DESC'` (Default: `'DESC'`)

### Implementation Scope

* **Core**: Abstract memory and storage classes
* **Memory Package**: Concrete implementation
* **LibSQL Store**: Production database implementation (**fully implemented**)
* **PostgreSQL Store**: Production database implementation (**fully implemented**)
* **Mock Store**: Test mock implementation (**fully implemented**)
* **Server/Deployer**: HTTP API support
* **Comprehensive tests**: Verified sorting in LibSQL and PostgreSQL storage

### Implementation Status

Full support for `ThreadSortOptions` is already live in the **LibSQL** and **PostgreSQL** stores.
If the design and API surface look good, we will roll out the same feature to the following stores next:

**Supported Stores:**

* **libsql** – LibSQL/Turso Database ✅
* **pg** – PostgreSQL ✅

**Planned Stores:**

* **cloudflare** – Cloudflare
* **cloudflare‑d1** – Cloudflare D1
* **dynamodb** – Amazon DynamoDB
* **lance** – Lance
* **mongodb** – MongoDB
* **upstash** – Upstash

**Not Planned Stores:**

* **astra** – DataStax Astra DB （vector only）
* **chroma** – Chroma Vector Database （vector only）
* **clickhouse** – ClickHouse（Not support getThreadsByResourceId & getThreadsByResourceIdPaginated）
* **couchbase** – Couchbase（vector only）
* **opensearch** – OpenSearch（vector only）
* **pinecone** – Pinecone（vector only）
* **qdrant** – Qdrant（vector only）
* **turbopuffer** – Turbopuffer（vector only）
* **vectorize** – Vectorize（vector only）

## Related Issue(s)

#5624

## Type of Change

* [ ] Bug fix (non‑breaking change that fixes an issue)
* [x] New feature (non‑breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [ ] Test update

## Checklist

* [x] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my feature works as intended
