### PR TITLE
fix(cli): handle new thread navigation

### DIFF
--- a/.changeset/long-chicken-dance.md
+++ b/.changeset/long-chicken-dance.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+'create-mastra': patch
+'@mastra/playground-ui': patch
+---
+
+Fix thread creation in playground

--- a/packages/cli/src/playground/src/pages/agents/agent/index.tsx
+++ b/packages/cli/src/playground/src/pages/agents/agent/index.tsx
@@ -31,7 +31,7 @@ function Agent() {
   } = useThreads({ resourceid: agentId!, agentId: agentId!, isMemoryEnabled: !!memory?.result });
 
   useEffect(() => {
-    if (memory?.result && !threadId) {
+    if (memory?.result && (!threadId || threadId === 'new')) {
       // use @lukeed/uuid because we don't need a cryptographically secure uuid (this is a debugging local uuid)
       // using crypto.randomUUID() on a domain without https (ex a local domain like local.lan:4111) will cause a TypeError
       navigate(`/agents/${agentId}/chat/${uuid()}`);


### PR DESCRIPTION
## Description

We now navigate to /new as the threadId, but that case wasn't handled, so the threadId would just always be `new`
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
