### PR TITLE
fix(cli): navigation to vnext agent networks

### DIFF
--- a/.changeset/tame-phones-wash.md
+++ b/.changeset/tame-phones-wash.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Fix navigation to vnext AgentNetwork agents

--- a/packages/cli/src/playground/src/pages/networks/index.tsx
+++ b/packages/cli/src/playground/src/pages/networks/index.tsx
@@ -20,7 +20,9 @@ function Networks() {
           legacyNetworks={networks}
           networks={vNextNetworks}
           isLoading={isLoading || isVNextLoading}
-          onClickRow={networkId => navigate(`/networks/${networkId}/chat`)}
+          onClickRow={(networkId: string, isVNext: boolean) => {
+            navigate(isVNext ? `/networks/v-next/${networkId}/chat` : `/networks/${networkId}/chat`);
+          }}
         />
       </MainContentContent>
     </MainContentLayout>

--- a/packages/playground-ui/src/domains/networks/components/network-table/network-table.tsx
+++ b/packages/playground-ui/src/domains/networks/components/network-table/network-table.tsx
@@ -17,7 +17,7 @@ export interface NetworkTableProps {
   legacyNetworks: GetNetworkResponse[];
   networks: GetVNextNetworkResponse[];
   isLoading: boolean;
-  onClickRow: (networkId: string) => void;
+  onClickRow: (networkId: string, isVNext: boolean) => void;
 }
 
 export const NetworkTable = ({ legacyNetworks, networks, isLoading, onClickRow }: NetworkTableProps) => {
@@ -69,7 +69,7 @@ export const NetworkTable = ({ legacyNetworks, networks, isLoading, onClickRow }
         </Thead>
         <Tbody>
           {rows.map(row => (
-            <Row key={row.id} onClick={() => onClickRow(row.original.id)}>
+            <Row key={row.id} onClick={() => onClickRow(row.original.id, row.original.isVNext || false)}>
               {row.getVisibleCells().map(cell => (
                 <React.Fragment key={cell.id}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
## Description

We were defaulting to always send agent network requests to the legacy agent network even if we were using vNext AgentNetwork.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
