### PR TITLE
Fix dependency resolving with directories

### DIFF
--- a/.changeset/puny-rats-fall.md
+++ b/.changeset/puny-rats-fall.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix dependency resolving with directories
+
+Follow import from `import x from 'pkg/dir'` => `import x from 'pkg/dir/index.js'` 

--- a/e2e-tests/monorepo/template/apps/custom/package.json
+++ b/e2e-tests/monorepo/template/apps/custom/package.json
@@ -16,6 +16,7 @@
     "@ai-sdk/openai": "^1.3.22",
     "@mastra/core": "monorepo-test",
     "@inner/inner-tools": "workspace:*",
+    "date-fns": "^2.0.0",
     "lodash": "^4.17.21",
     "zod": "^3.25.67"
   },

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/lodash.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/lodash.ts
@@ -1,6 +1,7 @@
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
 import get from 'lodash/fp/get';
+import endOfDay from 'date-fns/endOfDay';
 
 export const lodashTool = createTool({
   id: 'lodash',
@@ -9,6 +10,6 @@ export const lodashTool = createTool({
     date: z.string(),
   }),
   execute: async context => {
-    return get('date', context.data);
+    return endOfDay(get('date', context.data));
   },
 });

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
@@ -73,6 +73,15 @@ export function nodeModulesExtensionResolver(): Plugin {
 
         return null;
       } catch (e) {
+        // try to do a node like resolve first
+        const resolved = safeResolve(id, importer);
+        if (resolved) {
+          return {
+            id: resolved,
+            external: true,
+          };
+        }
+
         for (const ext of ['.mjs', '.js', '.cjs']) {
           const resolved = safeResolve(id + ext, importer);
           if (resolved) {


### PR DESCRIPTION
## Summary
- Fixed dependency resolving for imports with directories
- Updated custom resolver to handle `import x from 'pkg/dir'` => `import x from 'pkg/dir/index.js'`
- Added date-fns as a test case for this resolution
