### PR TITLE
chore: migrate agui example to @ag-ui/mastra and deprecate @mastra/agui

### DIFF
--- a/.changeset/bitter-carrots-itch.md
+++ b/.changeset/bitter-carrots-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/agui': patch
+---
+
+Added deprecation message to readme of @mastra/agui to switch to @ag-ui/mastra

--- a/examples/agui/package.json
+++ b/examples/agui/package.json
@@ -16,7 +16,7 @@
     "@copilotkit/react-core": "^1.8.10",
     "@copilotkit/react-ui": "^1.8.10",
     "@copilotkit/runtime": "^1.8.10",
-    "@mastra/agui": "latest",
+    "@ag-ui/mastra": "latest",
     "@mastra/core": "latest",
     "@mastra/libsql": "latest",
     "@mastra/loggers": "latest",
@@ -29,7 +29,6 @@
   "pnpm": {
     "overrides": {
       "@mastra/core": "link:../../packages/core",
-      "@mastra/agui": "link:../../packages/agui",
       "@mastra/libsql": "link:../../stores/libsql",
       "@mastra/loggers": "link:../../packages/loggers",
       "@mastra/memory": "link:../../packages/memory",

--- a/examples/agui/pnpm-lock.yaml
+++ b/examples/agui/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   '@mastra/core': link:../../packages/core
-  '@mastra/agui': link:../../packages/agui
   '@mastra/libsql': link:../../stores/libsql
   '@mastra/loggers': link:../../packages/loggers
   '@mastra/memory': link:../../packages/memory
@@ -16,6 +15,9 @@ importers:
 
   .:
     dependencies:
+      '@ag-ui/mastra':
+        specifier: latest
+        version: 0.0.4(@copilotkit/runtime@1.8.11(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.98.0(ws@8.18.2)(zod@3.25.67))(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.6.5)(axios@1.9.0)(google-auth-library@8.9.0)(ibm-cloud-sdk-core@5.3.2)(ignore@5.3.2)(jsonwebtoken@9.0.2)(playwright@1.52.0)(react@19.1.0)(ws@8.18.2))(@mastra/core@..+packages+core)(zod@3.25.67)
       '@ai-sdk/openai':
         specifier: ^1.3.22
         version: 1.3.22(zod@3.25.67)
@@ -28,9 +30,6 @@ importers:
       '@copilotkit/runtime':
         specifier: ^1.8.10
         version: 1.8.11(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.98.0(ws@8.18.2)(zod@3.25.67))(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.6.5)(axios@1.9.0)(google-auth-library@8.9.0)(ibm-cloud-sdk-core@5.3.2)(ignore@5.3.2)(jsonwebtoken@9.0.2)(playwright@1.52.0)(react@19.1.0)(ws@8.18.2)
-      '@mastra/agui':
-        specifier: link:../../packages/agui
-        version: link:../../packages/agui
       '@mastra/core':
         specifier: link:../../packages/core
         version: link:../../packages/core
@@ -106,14 +105,33 @@ packages:
   '@ag-ui/client@0.0.27':
     resolution: {integrity: sha512-W7PX/C40dxeCdf/j9lSL6TI8IEpWct/Fn9JkZdX3zXFf5rPN+RpckRKhYTC0ZstMi909oTww7SHVsVm7exPReg==}
 
+  '@ag-ui/client@0.0.35':
+    resolution: {integrity: sha512-rHtMQSU232dZeVx9qAGt1+j4ar4RWqwFanXcyNxAwbAh0XrY7VZeXFBDUeazy1LtBoViS7xehX8V1Ssf1a+bUw==}
+
   '@ag-ui/core@0.0.27':
     resolution: {integrity: sha512-I8i0qsamIVaOhPZ11bz7a+JQ7DIwIhLCon2EYWHikgcLiWzfZNBJhlVBR6Fn29tv3Ost4p6wYWQy84WzAhjJ+Q==}
+
+  '@ag-ui/core@0.0.35':
+    resolution: {integrity: sha512-YAqrln3S3fdo+Hs5FFQPODXiBttyilv/E3xSSHCuxqC0Y/Fp3+VqyDx97BorO3NVp2VKZ9cG2nsO3cbmcTwkQw==}
 
   '@ag-ui/encoder@0.0.27':
     resolution: {integrity: sha512-GO42BDdi9pmNsfhPlMQeSxGFfMJJg/Jvgng/N/5elHEfEOjGVtOCkDPpN4lirkuBoXEh/hW6gIgYAXDu/HuZJA==}
 
+  '@ag-ui/encoder@0.0.35':
+    resolution: {integrity: sha512-Ym0h0ZKIiD1Ld3+e3v/WQSogY62xs72ysoEBW1kt+dDs79QazBsW5ZlcBBj2DelEs9NrczQLxTVEvrkcvhrHqA==}
+
+  '@ag-ui/mastra@0.0.4':
+    resolution: {integrity: sha512-PVfOVZzxxtalHrj9ZGpk7e1N9FTqCr7DQHdxGG9pWL43bTOxpAwW9BPnUbqVFcsuSb71ArQ1lpPoPzfb+oLrag==}
+    peerDependencies:
+      '@copilotkit/runtime': ^1.8.13
+      '@mastra/core': ^0.10.10
+      zod: ^3.25.67
+
   '@ag-ui/proto@0.0.27':
     resolution: {integrity: sha512-bgF2DGqU+DvcNKF3gOlT97kZmhHNB0lWfjkJQ6ONxMtmWlSVYAE97LCtdTIjXEhnHyqi3QQBQ0BEXJ74q7QMcg==}
+
+  '@ag-ui/proto@0.0.35':
+    resolution: {integrity: sha512-+rz3LAYHcR3D2xVgRKa7QE5mp+cwmZs6j+1XxG5dT7HNdg51uKea12L57EVY2bxE3JzpAvCIgOjFEmQCNH82pw==}
 
   '@ai-sdk/openai@1.3.22':
     resolution: {integrity: sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw==}
@@ -130,6 +148,12 @@ packages:
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1019,6 +1043,11 @@ packages:
   '@lukeed/uuid@2.0.1':
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
+
+  '@mastra/client-js@0.10.14':
+    resolution: {integrity: sha512-CEDCYjEJg7irX96Zr0hhGDt1NBdlumnr21zFByknZEkc+Udbt9KihMQjVcCuO5KWDc9rsdb1Dd1/WylcsW1DXQ==}
+    peerDependencies:
+      zod: ^3.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3217,7 +3246,24 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.67
 
+  '@ag-ui/client@0.0.35':
+    dependencies:
+      '@ag-ui/core': 0.0.35
+      '@ag-ui/encoder': 0.0.35
+      '@ag-ui/proto': 0.0.35
+      '@types/uuid': 10.0.0
+      fast-json-patch: 3.1.1
+      rxjs: 7.8.1
+      untruncate-json: 0.0.1
+      uuid: 11.1.0
+      zod: 3.25.67
+
   '@ag-ui/core@0.0.27':
+    dependencies:
+      rxjs: 7.8.1
+      zod: 3.25.67
+
+  '@ag-ui/core@0.0.35':
     dependencies:
       rxjs: 7.8.1
       zod: 3.25.67
@@ -3227,9 +3273,29 @@ snapshots:
       '@ag-ui/core': 0.0.27
       '@ag-ui/proto': 0.0.27
 
+  '@ag-ui/encoder@0.0.35':
+    dependencies:
+      '@ag-ui/core': 0.0.35
+      '@ag-ui/proto': 0.0.35
+
+  '@ag-ui/mastra@0.0.4(@copilotkit/runtime@1.8.11(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.98.0(ws@8.18.2)(zod@3.25.67))(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.6.5)(axios@1.9.0)(google-auth-library@8.9.0)(ibm-cloud-sdk-core@5.3.2)(ignore@5.3.2)(jsonwebtoken@9.0.2)(playwright@1.52.0)(react@19.1.0)(ws@8.18.2))(@mastra/core@..+packages+core)(zod@3.25.67)':
+    dependencies:
+      '@ag-ui/client': 0.0.35
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
+      '@copilotkit/runtime': 1.8.11(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.98.0(ws@8.18.2)(zod@3.25.67))(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.6.5)(axios@1.9.0)(google-auth-library@8.9.0)(ibm-cloud-sdk-core@5.3.2)(ignore@5.3.2)(jsonwebtoken@9.0.2)(playwright@1.52.0)(react@19.1.0)(ws@8.18.2)
+      '@mastra/client-js': 0.10.14(zod@3.25.67)
+      '@mastra/core': link:../../packages/core
+      rxjs: 7.8.1
+      zod: 3.25.67
+
   '@ag-ui/proto@0.0.27':
     dependencies:
       '@ag-ui/core': 0.0.27
+      '@bufbuild/protobuf': 2.4.0
+
+  '@ag-ui/proto@0.0.35':
+    dependencies:
+      '@ag-ui/core': 0.0.35
       '@bufbuild/protobuf': 2.4.0
 
   '@ai-sdk/openai@1.3.22(zod@3.25.67)':
@@ -3248,6 +3314,13 @@ snapshots:
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -4025,6 +4098,17 @@ snapshots:
   '@lukeed/uuid@2.0.1':
     dependencies:
       '@lukeed/csprng': 1.1.0
+
+  '@mastra/client-js@0.10.14(zod@3.25.67)':
+    dependencies:
+      '@ag-ui/client': 0.0.27
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
+      '@lukeed/uuid': 2.0.1
+      '@mastra/core': link:../../packages/core
+      json-schema: 0.4.0
+      rxjs: 7.8.1
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5133,7 +5217,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.9.0(debug@4.4.0))
+      retry-axios: 2.6.0(axios@1.9.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -6029,7 +6113,7 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
-  retry-axios@2.6.0(axios@1.9.0(debug@4.4.0)):
+  retry-axios@2.6.0(axios@1.9.0):
     dependencies:
       axios: 1.9.0(debug@4.4.0)
 

--- a/examples/agui/src/mastra/index.ts
+++ b/examples/agui/src/mastra/index.ts
@@ -1,7 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
-import { registerCopilotKit } from '@mastra/agui';
+import { registerCopilotKit } from '@ag-ui/mastra';
 import { RuntimeContext } from '@mastra/core/runtime-context';
 import { weatherAgent } from './agents';
 import { myNetwork } from './network';

--- a/packages/agui/README.md
+++ b/packages/agui/README.md
@@ -1,5 +1,7 @@
 # @mastra/agui
 
+**⚠️ DEPRECATION NOTICE**: This package is deprecated. Please use [`@ag-ui/mastra`](https://www.npmjs.com/package/@ag-ui/mastra) instead.
+
 AGUI protocol helpers for Mastra - integrate Mastra agents and networks with AGUI-compatible interfaces.
 
 ## Overview


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Updated examples/agui to use new [@ag-ui/mastra](https://www.npmjs.com/package/@ag-ui/mastra) package.
Added deprecation warning to @mastra/agui README.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes #5689

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

Package changeover from @mastra/agui --> @ag-ui/mastra

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

Current [CopilotKit](https://mastra.ai/en/docs/frameworks/agentic-uis/copilotkit) docs point to the new package.
Old and new package implementations are consistent. Function imports/names have been verified to work the same in the agui example.
