### PR TITLE
Fix: Only require authorization for protected paths

### DIFF
--- a/.changeset/plain-cases-rush.md
+++ b/.changeset/plain-cases-rush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Only enforce authorization on protected routes

--- a/packages/deployer/src/server/handlers/auth/index.ts
+++ b/packages/deployer/src/server/handlers/auth/index.ts
@@ -71,6 +71,10 @@ export const authorizationMiddleware = async (c: ContextWithMastra, next: Next) 
   const path = c.req.path;
   const method = c.req.method;
 
+  if (!isProtectedPath(c.req.path, c.req.method, authConfig)) {
+    return next();
+  }
+
   // Skip for public routes
   if (canAccessPublicly(path, method, authConfig)) {
     return next();


### PR DESCRIPTION
## Summary
- Fixed authorization middleware to only enforce auth on protected routes
- Previously, auth was being checked for all routes even if they were public

## Test plan
- [ ] Verify public routes work without authentication
- [ ] Verify protected routes still require authentication
- [ ] Run existing test suite to ensure no regression