### PR TITLE
Remove erroneous reassignment of `Mastra.prototype.#vectors`

### DIFF
--- a/.changeset/twelve-penguins-rhyme.md
+++ b/.changeset/twelve-penguins-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Remove erroneous reassignment of `Mastra.prototype.#vectors`

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -195,10 +195,6 @@ export class Mastra<
       this.#vectors = vectors as TVectors;
     }
 
-    if (config?.vectors) {
-      this.#vectors = config.vectors;
-    }
-
     if (config?.networks) {
       this.#networks = config.networks;
     }


### PR DESCRIPTION
## Description

Removes an `if` block that reassigns `Mastra.prototype.#vectors`.

## Related Issue(s)

#6022 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
