### PR TITLE
Pg promise to pg pool

### DIFF
--- a/.changeset/grumpy-horses-ring.md
+++ b/.changeset/grumpy-horses-ring.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': minor
+---
+
+Updated PostgresStore to use the pg-pool package rather than pg-promise to help resolve an issue on Cloudflare Workers. If you're manually managing queries using the exposed pgPromise instance, remove all references to store.pgp and update your syntax to using pg-pool queries rather than pg-promise methods.

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -94,17 +94,16 @@ The storage implementation handles schema creation and updates automatically. It
 
 ### Direct Database and Pool Access
 
-`PostgresStore` exposes both the underlying database object and the pg-promise instance as public fields:
+`PostgresStore` exposes both the underlying database pool object as a public field:
 
 ```typescript
-store.db  // pg-promise database instance
-store.pgp // pg-promise main instance
+store.db; // pg-pool pool instance
 ```
 
 This enables direct queries and custom transaction management. When using these fields:
+
 - You are responsible for proper connection and transaction handling.
 - Closing the store (`store.close()`) will destroy the associated connection pool.
 - Direct access bypasses any additional logic or validation provided by PostgresStore methods.
 
 This approach is intended for advanced scenarios where low-level access is required.
-

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -94,7 +94,7 @@ The storage implementation handles schema creation and updates automatically. It
 
 ### Direct Database and Pool Access
 
-`PostgresStore` exposes both the underlying database pool object as a public field:
+`PostgresStore` exposes the underlying database pool object as a public field:
 
 ```typescript
 store.db; // pg-pool pool instance

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,7 +576,7 @@ importers:
         version: 7.52.8(@types/node@20.19.2)
       '@rollup/plugin-image':
         specifier: ^3.0.3
-        version: 3.0.3(rollup@3.29.5)
+        version: 3.0.3(rollup@4.45.0)
       '@size-limit/preset-small-lib':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
@@ -640,7 +640,7 @@ importers:
         version: 7.52.8(@types/node@20.19.2)
       '@rollup/plugin-image':
         specifier: ^3.0.3
-        version: 3.0.3(rollup@4.45.0)
+        version: 3.0.3(rollup@3.29.5)
       '@size-limit/preset-small-lib':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
@@ -3010,9 +3010,9 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.16.3
-      pg-promise:
-        specifier: ^11.15.0
-        version: 11.15.0(pg-query-stream@4.8.1(pg@8.16.3))
+      pg-pool:
+        specifier: ^3.10.1
+        version: 3.10.1(pg@8.16.3)
       xxhash-wasm:
         specifier: ^1.1.0
         version: 1.1.0
@@ -3035,6 +3035,9 @@ importers:
       '@types/pg':
         specifier: ^8.15.4
         version: 8.15.4
+      '@types/pg-pool':
+        specifier: ^2.0.6
+        version: 2.0.6
       eslint:
         specifier: ^9.30.1
         version: 9.31.0(jiti@2.4.2)
@@ -11170,10 +11173,6 @@ packages:
     resolution: {integrity: sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==}
     engines: {node: '>=12.0.0'}
 
-  assert-options@0.8.3:
-    resolution: {integrity: sha512-s6v4HnA+vYSGO4eZX+F+I3gvF74wPk+m6Z1Q3w1Dsg4Pnv/R24vhKAasoMVZGvDpOOfTg1Qz4ptZnEbuy95XsQ==}
-    engines: {node: '>=14.0.0'}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -15786,18 +15785,9 @@ packages:
   pg-connection-string@2.9.1:
     resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
 
-  pg-cursor@2.15.3:
-    resolution: {integrity: sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==}
-    peerDependencies:
-      pg: ^8
-
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
-
-  pg-minify@1.8.0:
-    resolution: {integrity: sha512-jO/oJOununpx8DzKgvSsWm61P8JjwXlaxSlbbfTBo1nvSWoo/+I6qZYaSN96jm/KDwa5d+JMQwPGgcP6HXDRow==}
-    engines: {node: '>=16.0.0'}
 
   pg-numeric@1.0.2:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
@@ -15808,19 +15798,8 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
-  pg-promise@11.15.0:
-    resolution: {integrity: sha512-EUXpXn90yPVPKxQH4qqUAEVcApd2tp/JdR3wG6LzBUgaXTUYqwmuXG4vFhhZTCctzhfzRA20EbORb9H4aAgUHA==}
-    engines: {node: '>=16.0'}
-    peerDependencies:
-      pg-query-stream: 4.10.3
-
   pg-protocol@1.10.3:
     resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
-
-  pg-query-stream@4.8.1:
-    resolution: {integrity: sha512-kZo6C6HSzYFF6mlwl+etDk5QZD9CMdlHUXpof6PkK9+CHHaBLvOd2lZMwErOOpC/ldg4thrAojS8sG1B8PZ9Yw==}
-    peerDependencies:
-      pg: ^8
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -16950,10 +16929,6 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
-
-  spex@3.4.1:
-    resolution: {integrity: sha512-Br0Mu3S+c70kr4keXF+6K4B8ohR+aJjI9s7SbdsI3hliE1Riz4z+FQk7FQL+r7X1t90KPkpuKwQyITpCIQN9mg==}
-    engines: {node: '>=14.0.0'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -27871,8 +27846,6 @@ snapshots:
       pvutils: 1.1.3
       tslib: 2.8.1
 
-  assert-options@0.8.3: {}
-
   assertion-error@2.0.1: {}
 
   assistant-stream@0.0.21:
@@ -30995,7 +30968,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.10.0)
+      retry-axios: 2.6.0(axios@1.10.0(debug@4.4.1))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -33597,13 +33570,7 @@ snapshots:
 
   pg-connection-string@2.9.1: {}
 
-  pg-cursor@2.15.3(pg@8.16.3):
-    dependencies:
-      pg: 8.16.3
-
   pg-int8@1.0.1: {}
-
-  pg-minify@1.8.0: {}
 
   pg-numeric@1.0.2: {}
 
@@ -33611,22 +33578,7 @@ snapshots:
     dependencies:
       pg: 8.16.3
 
-  pg-promise@11.15.0(pg-query-stream@4.8.1(pg@8.16.3)):
-    dependencies:
-      assert-options: 0.8.3
-      pg: 8.16.3
-      pg-minify: 1.8.0
-      pg-query-stream: 4.8.1(pg@8.16.3)
-      spex: 3.4.1
-    transitivePeerDependencies:
-      - pg-native
-
   pg-protocol@1.10.3: {}
-
-  pg-query-stream@4.8.1(pg@8.16.3):
-    dependencies:
-      pg: 8.16.3
-      pg-cursor: 2.15.3(pg@8.16.3)
 
   pg-types@2.2.0:
     dependencies:
@@ -34418,7 +34370,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.10.0):
+  retry-axios@2.6.0(axios@1.10.0(debug@4.4.1)):
     dependencies:
       axios: 1.10.0(debug@4.4.1)
 
@@ -35006,8 +34958,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  spex@3.4.1: {}
 
   split2@4.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3010,6 +3010,9 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.16.3
+      pg-connection-string:
+        specifier: ^2.9.1
+        version: 2.9.1
       pg-pool:
         specifier: ^3.10.1
         version: 3.10.1(pg@8.16.3)
@@ -29082,7 +29085,7 @@ snapshots:
       eslint-config-prettier: 8.10.0(eslint@8.57.1)
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.27.7))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.7))(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(jest@29.7.0(@types/node@20.19.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.2)(typescript@5.8.3)))(typescript@5.8.3)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(jest@29.7.0(@types/node@20.19.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.2)(typescript@5.8.3)))(typescript@5.8.3)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -29563,7 +29566,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(jest@29.7.0(@types/node@20.19.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.2)(typescript@5.8.3)))(typescript@5.8.3):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(jest@29.7.0(@types/node@20.19.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.2)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3010,9 +3010,6 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.16.3
-      pg-connection-string:
-        specifier: ^2.9.1
-        version: 2.9.1
       xxhash-wasm:
         specifier: ^1.1.0
         version: 1.1.0
@@ -3035,9 +3032,6 @@ importers:
       '@types/pg':
         specifier: ^8.15.4
         version: 8.15.4
-      '@types/pg-pool':
-        specifier: ^2.0.6
-        version: 2.0.6
       eslint:
         specifier: ^9.30.1
         version: 9.31.0(jiti@2.4.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3013,9 +3013,6 @@ importers:
       pg-connection-string:
         specifier: ^2.9.1
         version: 2.9.1
-      pg-pool:
-        specifier: ^3.10.1
-        version: 3.10.1(pg@8.16.3)
       xxhash-wasm:
         specifier: ^1.1.0
         version: 1.1.0
@@ -3052,7 +3049,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.2)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.2)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   stores/pinecone:
     dependencies:
@@ -21542,7 +21539,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21570,7 +21567,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -28901,6 +28898,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -29757,7 +29758,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -30911,7 +30912,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -30932,7 +30933,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -35624,7 +35625,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       esbuild: 0.25.5
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -36035,7 +36036,7 @@ snapshots:
   vite-node@3.2.4(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -36168,6 +36169,49 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.2
       '@vitest/ui': 3.2.3(vitest@3.2.4)
+      jsdom: 26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.2)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.2
       jsdom: 26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - jiti

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -37,7 +37,6 @@
     "async-mutex": "^0.5.0",
     "pg": "^8.16.3",
     "pg-connection-string": "^2.9.1",
-    "pg-pool": "^3.10.1",
     "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "pg": "^8.16.3",
-    "pg-connection-string": "^2.9.1",
     "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {
@@ -46,7 +45,6 @@
     "@microsoft/api-extractor": "^7.52.8",
     "@types/node": "^20.19.0",
     "@types/pg": "^8.15.4",
-    "@types/pg-pool": "^2.0.6",
     "eslint": "^9.30.1",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "pg": "^8.16.3",
-    "pg-promise": "^11.15.0",
+    "pg-pool": "^3.10.1",
     "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {
@@ -46,6 +46,7 @@
     "@microsoft/api-extractor": "^7.52.8",
     "@types/node": "^20.19.0",
     "@types/pg": "^8.15.4",
+    "@types/pg-pool": "^2.0.6",
     "eslint": "^9.30.1",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "pg": "^8.16.3",
+    "pg-connection-string": "^2.9.1",
     "pg-pool": "^3.10.1",
     "xxhash-wasm": "^1.1.0"
   },

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -20,8 +20,7 @@ import {
   TABLE_TRACES,
 } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
-import type { Client } from 'pg';
-import Pool from 'pg-pool';
+import { Pool } from 'pg';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
 
 import { PostgresStore } from '.';
@@ -2193,7 +2192,7 @@ describe('PostgresStore', () => {
     const schemaRestrictedUser = 'mastra_schema_restricted_storage';
     const restrictedPassword = 'test123';
     const testSchema = 'testSchema';
-    let adminDb: Pool<Client>;
+    let adminDb: Pool;
 
     beforeAll(async () => {
       // Create a separate pool for admin operations

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -20,12 +20,12 @@ import {
   TABLE_TRACES,
 } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
+import type { Client } from 'pg';
+import Pool from 'pg-pool';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
 
 import { PostgresStore } from '.';
 import type { PostgresConfig } from '.';
-import Pool from 'pg-pool';
-import { Client } from 'pg';
 
 const TEST_CONFIG: PostgresConfig = {
   host: process.env.POSTGRES_HOST || 'localhost',
@@ -2193,9 +2193,7 @@ describe('PostgresStore', () => {
     const schemaRestrictedUser = 'mastra_schema_restricted_storage';
     const restrictedPassword = 'test123';
     const testSchema = 'testSchema';
-
     let adminDb: Pool<Client>;
-    const url = new URL(connectionString);
 
     beforeAll(async () => {
       // Create a separate pool for admin operations

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -20,7 +20,6 @@ import {
   TABLE_TRACES,
 } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
-// import pgPromise from 'pg-promise';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
 
 import { PostgresStore } from '.';
@@ -68,25 +67,11 @@ describe('PostgresStore', () => {
       expect(typeof testDB.db.query).toBe('function');
     });
 
-    // it('should expose pgp field as public', () => {
-    //   expect(testDB.pgp).toBeDefined();
-    //   expect(typeof testDB.pgp).toBe('function');
-    //   expect(testDB.pgp.end).toBeDefined();
-    //   expect(typeof testDB.pgp.end).toBe('function');
-    // });
-
     it('should allow direct database queries via public db field', async () => {
       const result = await testDB.db.query('SELECT 1 as test');
       expect(result.rows.length).toBe(1);
       expect(result.rows[0].test).toBe(1);
     });
-
-    // it('should allow access to pgp utilities via public pgp field', () => {
-    //   const helpers = testDB.pgp.helpers;
-    //   expect(helpers).toBeDefined();
-    //   expect(helpers.insert).toBeDefined();
-    //   expect(helpers.update).toBeDefined();
-    // });
 
     it('should maintain connection state through public db field', async () => {
       // Test multiple queries to ensure connection state

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,5 +1,4 @@
 import type { ConnectionOptions } from 'tls';
-import { parseIntoClientConfig } from 'pg-connection-string';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2, MastraMessageV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -80,7 +79,7 @@ export class PostgresStore extends MastraStorage {
 
       let poolConfig: PoolConfig;
       if ('connectionString' in config) {
-        poolConfig = parseIntoClientConfig(config.connectionString);
+        poolConfig = { connectionString: config.connectionString };
       } else {
         poolConfig = {
           host: config.host,

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -27,8 +27,7 @@ import type {
 } from '@mastra/core/storage';
 import { parseSqlIdentifier, parseFieldKey } from '@mastra/core/utils';
 import type { WorkflowRunState } from '@mastra/core/workflows';
-import type { Client } from 'pg';
-import Pool from 'pg-pool';
+import { Pool, type PoolConfig, type PoolClient } from 'pg';
 
 export type PostgresConfig = {
   schemaName?: string;
@@ -47,7 +46,7 @@ export type PostgresConfig = {
 );
 
 export class PostgresStore extends MastraStorage {
-  public db: Pool<Client>;
+  public db: Pool;
   private closed: boolean = false;
   private schema?: string;
   private setupSchemaPromise: Promise<void> | null = null;
@@ -79,7 +78,7 @@ export class PostgresStore extends MastraStorage {
       super({ name: 'PostgresStore' });
       this.schema = config.schemaName;
 
-      let poolConfig: Pool.Config<Client>;
+      let poolConfig: PoolConfig;
       if ('connectionString' in config) {
         poolConfig = parseIntoClientConfig(config.connectionString);
       } else {
@@ -554,7 +553,7 @@ export class PostgresStore extends MastraStorage {
   }: {
     tableName: TABLE_NAMES;
     record: Record<string, any>;
-    connectedClient?: Client;
+    connectedClient?: PoolClient;
   }): Promise<void> {
     try {
       const columns = Object.keys(record).map(col => parseSqlIdentifier(col, 'column name'));

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -40,9 +40,7 @@ export type PostgresConfig = {
   schemaName?: string;
 } & (
   | (Omit<PoolConfig, keyof requiredFields> & requiredFields)
-  | {
-      connectionString: string;
-    }
+  | (Omit<PoolConfig, 'connectionString'> & { connectionString: string })
 );
 
 export class PostgresStore extends MastraStorage {


### PR DESCRIPTION
## Description

The `PostgresStore` class is now implemented using `pg-pool` instead of `pg-promise`. 

Note: I did leave a comment about error handling that I wasn't clear on. It's on `line 1753` of `stores/pg/src/storage/index.ts`. The `tx` call there originally did not have any custom error handling--it was the only one not wrapped in a `try...catch`. Of course, the function itself would throw an error, which will not happen now since I'm catching that block to execute the rollback manually. My inclination is that we should be throwing a `MastraError` there in the same way we are in all other transactions, but I wasn't sure what details to include in said error.

## Related Issue(s)

[#5738 ](https://github.com/mastra-ai/mastra/issues/5738)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

Most functionality remains unchanged, but any users who were directly accessing the exposed `db` or `pgp` attributes on instances of `PostgresStore` would need to refactor to use `pg-pool` syntax instead.

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works

No additional tests were added, but tests reliant on `pg-promise` syntax were refactored to use `pg-pool` syntax.