### PR TITLE
refactor(pg): migrate from pg-promise to node-postgres

### DIFF
--- a/.changeset/flat-terms-pump.md
+++ b/.changeset/flat-terms-pump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': minor
+---
+
+replace the pg-promise library with pg (pg-pool) for database operations

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -94,14 +94,13 @@ The storage implementation handles schema creation and updates automatically. It
 
 ### Direct Database and Pool Access
 
-`PostgresStore` exposes both the underlying database object and the pg-promise instance as public fields:
+`PostgresStore` exposes the underlying PgPool instance as a public field:
 
 ```typescript
-store.db  // pg-promise database instance
-store.pgp // pg-promise main instance
+store.pool  // PgPool instance
 ```
 
-This enables direct queries and custom transaction management. When using these fields:
+This enables direct queries and custom transaction management. When using this field:
 - You are responsible for proper connection and transaction handling.
 - Closing the store (`store.close()`) will destroy the associated connection pool.
 - Direct access bypasses any additional logic or validation provided by PostgresStore methods.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3010,9 +3010,6 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.16.3
-      pg-promise:
-        specifier: ^11.15.0
-        version: 11.15.0(pg-query-stream@4.8.1(pg@8.16.3))
       xxhash-wasm:
         specifier: ^1.1.0
         version: 1.1.0
@@ -3046,7 +3043,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.2)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.2)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   stores/pinecone:
     dependencies:
@@ -11170,10 +11167,6 @@ packages:
     resolution: {integrity: sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==}
     engines: {node: '>=12.0.0'}
 
-  assert-options@0.8.3:
-    resolution: {integrity: sha512-s6v4HnA+vYSGO4eZX+F+I3gvF74wPk+m6Z1Q3w1Dsg4Pnv/R24vhKAasoMVZGvDpOOfTg1Qz4ptZnEbuy95XsQ==}
-    engines: {node: '>=14.0.0'}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -15774,18 +15767,9 @@ packages:
   pg-connection-string@2.9.1:
     resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
 
-  pg-cursor@2.15.3:
-    resolution: {integrity: sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==}
-    peerDependencies:
-      pg: ^8
-
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
-
-  pg-minify@1.8.0:
-    resolution: {integrity: sha512-jO/oJOununpx8DzKgvSsWm61P8JjwXlaxSlbbfTBo1nvSWoo/+I6qZYaSN96jm/KDwa5d+JMQwPGgcP6HXDRow==}
-    engines: {node: '>=16.0.0'}
 
   pg-numeric@1.0.2:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
@@ -15796,19 +15780,8 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
-  pg-promise@11.15.0:
-    resolution: {integrity: sha512-EUXpXn90yPVPKxQH4qqUAEVcApd2tp/JdR3wG6LzBUgaXTUYqwmuXG4vFhhZTCctzhfzRA20EbORb9H4aAgUHA==}
-    engines: {node: '>=16.0'}
-    peerDependencies:
-      pg-query-stream: 4.10.3
-
   pg-protocol@1.10.3:
     resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
-
-  pg-query-stream@4.8.1:
-    resolution: {integrity: sha512-kZo6C6HSzYFF6mlwl+etDk5QZD9CMdlHUXpof6PkK9+CHHaBLvOd2lZMwErOOpC/ldg4thrAojS8sG1B8PZ9Yw==}
-    peerDependencies:
-      pg: ^8
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -16938,10 +16911,6 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
-
-  spex@3.4.1:
-    resolution: {integrity: sha512-Br0Mu3S+c70kr4keXF+6K4B8ohR+aJjI9s7SbdsI3hliE1Riz4z+FQk7FQL+r7X1t90KPkpuKwQyITpCIQN9mg==}
-    engines: {node: '>=14.0.0'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -21552,7 +21521,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21580,7 +21549,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -27842,8 +27811,6 @@ snapshots:
       pvutils: 1.1.3
       tslib: 2.8.1
 
-  assert-options@0.8.3: {}
-
   assertion-error@2.0.1: {}
 
   assistant-stream@0.0.21:
@@ -28896,6 +28863,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -29752,7 +29723,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -30906,7 +30877,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -30927,7 +30898,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -33521,13 +33492,7 @@ snapshots:
 
   pg-connection-string@2.9.1: {}
 
-  pg-cursor@2.15.3(pg@8.16.3):
-    dependencies:
-      pg: 8.16.3
-
   pg-int8@1.0.1: {}
-
-  pg-minify@1.8.0: {}
 
   pg-numeric@1.0.2: {}
 
@@ -33535,22 +33500,7 @@ snapshots:
     dependencies:
       pg: 8.16.3
 
-  pg-promise@11.15.0(pg-query-stream@4.8.1(pg@8.16.3)):
-    dependencies:
-      assert-options: 0.8.3
-      pg: 8.16.3
-      pg-minify: 1.8.0
-      pg-query-stream: 4.8.1(pg@8.16.3)
-      spex: 3.4.1
-    transitivePeerDependencies:
-      - pg-native
-
   pg-protocol@1.10.3: {}
-
-  pg-query-stream@4.8.1(pg@8.16.3):
-    dependencies:
-      pg: 8.16.3
-      pg-cursor: 2.15.3(pg@8.16.3)
 
   pg-types@2.2.0:
     dependencies:
@@ -34931,8 +34881,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  spex@3.4.1: {}
-
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
@@ -35595,7 +35543,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       esbuild: 0.25.5
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -36006,7 +35954,7 @@ snapshots:
   vite-node@3.2.4(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -36139,6 +36087,49 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.2
       '@vitest/ui': 3.2.3(vitest@3.2.4)
+      jsdom: 26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.2)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@20.19.2)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.2
       jsdom: 26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - jiti

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "pg": "^8.16.3",
-    "pg-promise": "^11.15.0",
     "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -49,7 +49,14 @@ describe('PostgresStore', () => {
   describe('Public Fields Access', () => {
     let testDB: PostgresStore;
     beforeAll(async () => {
-      testDB = new PostgresStore(TEST_CONFIG);
+      testDB = new PostgresStore({
+        ...TEST_CONFIG,
+        pgPoolOptions: {
+          max: 10,
+          idleTimeoutMillis: 10000,
+          connectionTimeoutMillis: 4000,
+        },
+      });
     });
     afterAll(async () => {
       try {
@@ -66,6 +73,9 @@ describe('PostgresStore', () => {
       expect(typeof testDB.pool.query).toBe('function');
       expect(testDB.pool.end).toBeDefined();
       expect(typeof testDB.pool.end).toBe('function');
+      expect(testDB.pool.options.max).toBe(10);
+      expect(testDB.pool.options.idleTimeoutMillis).toBe(10000);
+      expect(testDB.pool.options.connectionTimeoutMillis).toBe(4000);
     });
 
     it('should allow direct database queries via public db field', async () => {

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -2204,7 +2204,7 @@ describe('PostgresStore', () => {
     let adminDb: Client;
 
     beforeAll(async () => {
-      // Create a separate pg-promise instance for admin operations
+      // Create a separate pg instance for admin operations
       adminDb = new Client(connectionString);
       await adminDb.connect();
 

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -73,13 +73,6 @@ describe('PostgresStore', () => {
       expect(result.test).toBe(1);
     });
 
-    // it.skip('should allow access to pgp utilities via public pgp field', () => {
-    //   const helpers = testDB.pgp.helpers;
-    //   expect(helpers).toBeDefined();
-    //   expect(helpers.insert).toBeDefined();
-    //   expect(helpers.update).toBeDefined();
-    // });
-
     it('should maintain connection state through public db field', async () => {
       // Test multiple queries to ensure connection state
       const result1 = await testDB.pool.one('SELECT NOW() as timestamp1');


### PR DESCRIPTION
## Description

This PR replaces the pg-promise library with pg (pg-pool) for database operations. The changes include:

- Removed pg-promise dependency
- Implemented PgPool and PgHelper classes to maintain similar API surface
- Updated all database queries to use the new implementation
- Modified transaction handling to use explicit client management
- Updated tests to reflect the new database client usage

The migration provides backward compatibility with existing functionality and is compliant with Cloudflare PostgreSQL drivers (see https://developers.cloudflare.com/hyperdrive/examples/connect-to-postgres/#supported-drivers).

A full deployment was tested using the agent code located at https://github.com/alsts/setmindset-agent which involves:
- a Supabase connection
- a Cloudflare worker

The agent was tested using the original query available in issue #5353

https://setmindset-agent.*******.workers.dev/api/memory/threads/weather-agent-thread-001/messages?agentId=weatherAgent

Which returned the expected output:
```json
{"error":"Thread not found"}
```
instead of:
```
Error creating table mastra_traces: TypeError: CloudflareSocket is not a constructor This suggests an incompatibility between @mastra/pg and the Cloudflare Workers runtime.
```

## Related Issue(s)

fixes #5738

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
