### PR TITLE
Do not set content-type header when making POST/PUT requests without a body. fixes #6077

### DIFF
--- a/.changeset/afraid-beds-see.md
+++ b/.changeset/afraid-beds-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': minor
+---
+
+Do not set content-type header when making POST/PUT requests without a body

--- a/.changeset/afraid-beds-see.md
+++ b/.changeset/afraid-beds-see.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/client-js': minor
+'@mastra/client-js': patch
 ---
 
 Do not set content-type header when making POST/PUT requests without a body

--- a/client-sdks/client-js/src/resources/base.ts
+++ b/client-sdks/client-js/src/resources/base.ts
@@ -24,7 +24,9 @@ export class BaseResource {
         const response = await fetch(`${baseUrl.replace(/\/$/, '')}${path}`, {
           ...options,
           headers: {
-            ...(options.method === 'POST' || options.method === 'PUT' ? { 'content-type': 'application/json' } : {}),
+            ...(options.body && (options.method === 'POST' || options.method === 'PUT')
+              ? { 'content-type': 'application/json' }
+              : {}),
             ...headers,
             ...options.headers,
             // TODO: Bring this back once we figure out what we/users need to do to make this work with cross-origin requests


### PR DESCRIPTION
## Description

Check that there's a body before setting the content-type header

## Related Issue(s)

#6077 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
