### PR TITLE
feat(@mastra/memory, @mastra/core, @mastra/libsql, @mastra/pg): add episodic memory for long-term agent recall

### DIFF
--- a/.changeset/cuddly-ways-try.md
+++ b/.changeset/cuddly-ways-try.md
@@ -1,0 +1,13 @@
+---
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/memory': patch
+'@mastra/dynamodb': patch
+'@mastra/upstash': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mssql': patch
+'@mastra/pg': patch
+---
+
+Added a new "episodic" memory feature

--- a/docs/src/content/en/docs/memory/_meta.ts
+++ b/docs/src/content/en/docs/memory/_meta.ts
@@ -1,5 +1,6 @@
 const meta = {
   overview: "Overview",
+  "episodic-memory": "Episodic Memory",
   "semantic-recall": "Semantic Recall",
   "working-memory": "Working Memory",
   "memory-processors": "Memory Processors",

--- a/docs/src/content/en/docs/memory/episodic-memory.mdx
+++ b/docs/src/content/en/docs/memory/episodic-memory.mdx
@@ -53,8 +53,7 @@ const memory = new Memory({
   options: {
     episodicMemory: {
       enabled: true,
-      maxEpisodesInContext: 5,
-      includeCategories: true,
+      lastEpisodes: 5,
     },
   },
   storage: myStorage,
@@ -64,8 +63,7 @@ const memory = new Memory({
 ### Configuration Options
 
 - **enabled**: Whether episodic memory is active
-- **maxEpisodesInContext**: Maximum episodes to include in system context (default: 5)
-- **includeCategories**: Whether to show categories in system message (default: true)
+- **lastEpisodes**: Number of recent episodes to include in system context (default: 5)
 
 ## Agent Integration
 
@@ -150,29 +148,12 @@ Other storage adapters will need to be updated to support episodic memory featur
 
 ## Best Practices
 
-### Categories
+Agents are equipped with episodic memory tools that include built-in guidance for:
+- Selecting appropriate categories for different types of memories
+- Scoring significance based on the importance of information
+- Creating meaningful relationships between episodes
 
-Use consistent, meaningful categories:
-- **Life Events**: `life-event`, `milestone`, `achievement`
-- **Personal**: `family`, `relationship`, `personal`
-- **Professional**: `work`, `career`, `education`
-- **Health**: `health`, `medical`, `fitness`
-- **Interests**: `hobbies`, `preferences`, `goals`
-
-### Significance Scoring
-
-- **1.0**: Critical information (allergies, medical conditions)
-- **0.8-0.9**: Major life events (job changes, moves)
-- **0.6-0.7**: Important preferences or recurring activities
-- **0.4-0.5**: Notable but less critical information
-- **0.2-0.3**: Minor details worth remembering
-
-### Linking Episodes
-
-Create relationships to build a knowledge graph:
-- Link cause and effect relationships
-- Group related events with sequences
-- Connect similar experiences across time
+The agent tools automatically handle these decisions based on context and content.
 
 ## Integration with Other Memory Features
 

--- a/docs/src/content/en/docs/memory/episodic-memory.mdx
+++ b/docs/src/content/en/docs/memory/episodic-memory.mdx
@@ -1,0 +1,184 @@
+# Episodic Memory
+
+Episodic memory enables agents to create and recall long-term memories that persist across all conversations with a user. Unlike conversation history which is scoped to individual threads, episodes represent significant events, facts, or experiences that agents can reference in any future interaction.
+
+## How It Works
+
+When episodic memory is enabled, agents can:
+- Automatically detect and store significant information from conversations
+- Create structured memories with titles, summaries, and categories
+- Link related episodes to form knowledge graphs
+- Retrieve relevant episodes based on context or direct queries
+
+Episodes are stored at the resource (user) level, making them available across all threads and conversations.
+
+## Key Concepts
+
+### Episode Structure
+
+Each episode contains:
+- **Title**: A brief descriptive title
+- **Short Summary**: One-line summary of the episode
+- **Detailed Summary**: Complete description with context
+- **Categories**: Semantic organization (e.g., "work", "health", "family")
+- **Significance**: Score from 0-1 indicating importance
+- **Message IDs**: Links to source conversation messages
+- **Timestamps**: Created and updated dates
+
+### Context Fields
+
+Episodes can include additional context:
+- **Causal Context**: Why something happened or what led to it
+- **Spatial Context**: Where events occurred (location, environment)
+- **Sequence ID**: Groups related episodes together
+- **Relationships**: Typed connections to other episodes
+
+### Relationship Types
+
+Episodes can be linked with specific relationship types:
+- `caused-by`: One event led to another
+- `leads-to`: Expected future consequence
+- `part-of`: Component of a larger event
+- `similar-to`: Related but distinct events
+- `related-to`: General relationship
+
+## Configuration
+
+Enable episodic memory when creating a Memory instance:
+
+```typescript filename="src/mastra/agents/index.ts"
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: {
+      enabled: true,
+      maxEpisodesInContext: 5,
+      includeCategories: true,
+    },
+  },
+  storage: myStorage,
+});
+```
+
+### Configuration Options
+
+- **enabled**: Whether episodic memory is active
+- **maxEpisodesInContext**: Maximum episodes to include in system context (default: 5)
+- **includeCategories**: Whether to show categories in system message (default: true)
+
+## Agent Integration
+
+### Automatic Episode Creation
+
+When episodic memory is enabled, agents have access to episode management tools. They can create episodes when they detect significant information:
+
+```typescript
+const agent = new Agent({
+  name: "MemoryAgent",
+  instructions: `You are a helpful assistant with long-term memory.
+    When users share important information about themselves, their life events,
+    preferences, or significant experiences, create episodes to remember them.`,
+  model: myModel,
+  memory,
+});
+```
+
+### Episode Tools
+
+Agents automatically receive these tools when episodic memory is enabled:
+- **createEpisode**: Store new memories
+- **searchEpisodes**: Find relevant past memories
+- **updateEpisode**: Modify existing memories
+- **linkEpisodes**: Connect related memories
+- **getRelatedEpisodes**: Explore memory connections
+
+### System Message Integration
+
+The most significant episodes are automatically included in the agent's system message:
+
+```
+## Episodic Memory (Long-term memories for this user)
+
+**Promoted to Senior Manager** (2024-01-15)
+User got promoted to Senior Engineering Manager at TechCorp
+Categories: work, life-event
+
+**Allergic to peanuts** (2024-01-10)
+User has severe peanut allergy and carries an EpiPen
+Categories: health, important
+```
+
+## Manual Episode Management
+
+You can also manage episodes programmatically:
+
+```typescript
+// Create an episode
+const episode = await memory.createEpisode({
+  resourceId: "user-123",
+  threadId: "thread-456",
+  title: "Started marathon training",
+  shortSummary: "User began training for first marathon",
+  detailedSummary: "User started a 16-week marathon training program...",
+  categories: ["health", "goals"],
+  significance: 0.8,
+  spatialContext: "Local running trails and gym",
+});
+
+// Link related episodes
+await memory.linkEpisodes({
+  episodeId1: episode.id,
+  episodeId2: "previous-fitness-goal-id",
+  relationshipType: "leads-to",
+});
+
+// Get episodes by category
+const healthEpisodes = await memory.getEpisodesByCategory({
+  resourceId: "user-123",
+  category: "health",
+});
+```
+
+## Storage Requirements
+
+Episodic memory requires a storage adapter that supports the episodes table. Currently supported:
+- LibSQL
+- PostgreSQL
+
+Other storage adapters will need to be updated to support episodic memory features.
+
+## Best Practices
+
+### Categories
+
+Use consistent, meaningful categories:
+- **Life Events**: `life-event`, `milestone`, `achievement`
+- **Personal**: `family`, `relationship`, `personal`
+- **Professional**: `work`, `career`, `education`
+- **Health**: `health`, `medical`, `fitness`
+- **Interests**: `hobbies`, `preferences`, `goals`
+
+### Significance Scoring
+
+- **1.0**: Critical information (allergies, medical conditions)
+- **0.8-0.9**: Major life events (job changes, moves)
+- **0.6-0.7**: Important preferences or recurring activities
+- **0.4-0.5**: Notable but less critical information
+- **0.2-0.3**: Minor details worth remembering
+
+### Linking Episodes
+
+Create relationships to build a knowledge graph:
+- Link cause and effect relationships
+- Group related events with sequences
+- Connect similar experiences across time
+
+## Integration with Other Memory Features
+
+Episodic memory complements other memory features:
+- **Working Memory**: Maintains current conversation context
+- **Semantic Recall**: Retrieves relevant past messages
+- **Episodic Memory**: Provides long-term factual memories
+
+Together, these create a comprehensive memory system that enables natural, context-aware conversations that span multiple interactions over time.

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -6,9 +6,11 @@ Memory is how agents manage the context that's available to them, it's a condens
 
 The context window is the total information visible to the language model at any given time.
 
-In Mastra, context is broken up into three parts: system instructions and information about the user ([working memory](./working-memory.mdx)), recent messages ([message history](#conversation-history)), and older messages that are relevant to the user’s query ([semantic recall](./semantic-recall.mdx)).
+In Mastra, context is broken up into four parts: system instructions and information about the user ([working memory](./working-memory.mdx)), long-term memories about the user ([episodic memory](./episodic-memory.mdx)), recent messages ([message history](#conversation-history)), and older messages that are relevant to the user's query ([semantic recall](./semantic-recall.mdx)).
 
 Working memory can persist at different scopes - either per conversation thread (default) or across all threads for the same user (resource-scoped), enabling persistent user profiles that remember context across conversations.
+
+Episodic memory stores significant events, facts, and experiences that persist across all conversations, allowing agents to build long-term knowledge about users.
 
 In addition, we provide [memory processors](./memory-processors.mdx) to trim context or remove information if the context is too long.
 
@@ -166,6 +168,10 @@ For more details on enabling and configuring tracing, see [Tracing](../observabi
 
 ## Next Steps
 
-Now that you understand the core concepts, continue to [semantic recall](./semantic-recall.mdx) to learn how to add RAG memory to your Mastra agents.
+Now that you understand the core concepts, explore these memory features:
+
+- [Episodic Memory](./episodic-memory.mdx) - Enable agents to create and recall long-term memories
+- [Semantic Recall](./semantic-recall.mdx) - Add RAG memory to retrieve relevant past messages
+- [Working Memory](./working-memory.mdx) - Maintain persistent user context
 
 Alternatively you can visit the [configuration reference](../../reference/memory/Memory.mdx) for available options, or browse [usage examples](../../examples/memory/use-chat.mdx).

--- a/docs/src/content/en/examples/memory/_meta.ts
+++ b/docs/src/content/en/examples/memory/_meta.ts
@@ -3,6 +3,7 @@ const meta = {
   "memory-with-pg": "Memory with PostgreSQL",
   "memory-with-upstash": "Memory with Upstash",
   "memory-with-mem0": "Memory with Mem0",
+  "episodic-memory": "Episodic Memory",
   "streaming-working-memory": "Streaming Working Memory",
   "streaming-working-memory-advanced": "Streaming Working Memory (Advanced)",
   "streaming-working-memory-structured": "Streaming Structured Working Memory",

--- a/docs/src/content/en/examples/memory/episodic-memory.mdx
+++ b/docs/src/content/en/examples/memory/episodic-memory.mdx
@@ -14,8 +14,7 @@ export const memory = new Memory({
   options: {
     episodicMemory: {
       enabled: true,
-      maxEpisodesInContext: 5,
-      includeCategories: true,
+      lastEpisodes: 5,
     },
   },
   storage: new LibSQLStore({

--- a/docs/src/content/en/examples/memory/episodic-memory.mdx
+++ b/docs/src/content/en/examples/memory/episodic-memory.mdx
@@ -1,0 +1,358 @@
+# Episodic Memory Examples
+
+This page demonstrates various ways to use episodic memory in your Mastra agents.
+
+## Basic Setup
+
+First, configure memory with episodic memory enabled:
+
+```typescript filename="src/mastra/memory.ts"
+import { Memory } from "@mastra/memory";
+import { LibSQLStore } from "@mastra/libsql";
+
+export const memory = new Memory({
+  options: {
+    episodicMemory: {
+      enabled: true,
+      maxEpisodesInContext: 5,
+      includeCategories: true,
+    },
+  },
+  storage: new LibSQLStore({
+    url: "file:../mastra.db",
+  }),
+});
+```
+
+## Agent with Automatic Episode Creation
+
+Create an agent that automatically detects and stores important information:
+
+```typescript filename="src/mastra/agents/personal-assistant.ts"
+import { Agent } from "@mastra/core/agent";
+import { openai } from "@ai-sdk/openai";
+import { memory } from "../memory";
+
+export const personalAssistant = new Agent({
+  name: "PersonalAssistant",
+  instructions: `You are a personal AI assistant with long-term memory.
+    
+    When users share:
+    - Life events (job changes, moves, achievements)
+    - Health information (allergies, conditions, medications)
+    - Personal details (family, relationships, preferences)
+    - Goals and aspirations
+    - Important dates or recurring events
+    
+    Use the createEpisode tool to store these as long-term memories.
+    
+    When relevant, search your episodic memory to provide personalized responses
+    based on what you know about the user.`,
+  model: openai("gpt-4o"),
+  memory,
+});
+```
+
+## Manual Episode Creation
+
+Create episodes programmatically in your application:
+
+```typescript filename="examples/create-episodes.ts"
+import { memory } from "../src/mastra/memory";
+
+async function createUserProfile(userId: string, threadId: string) {
+  // Create a health-related episode
+  const allergyEpisode = await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Severe peanut allergy",
+    shortSummary: "User has life-threatening peanut allergy",
+    detailedSummary: "User mentioned they have a severe peanut allergy and must carry an EpiPen at all times. Even trace amounts can trigger anaphylaxis.",
+    categories: ["health", "important", "medical"],
+    significance: 1.0, // Critical information
+  });
+
+  // Create a work-related episode
+  const jobEpisode = await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Senior Engineer at TechCorp",
+    shortSummary: "Works as Senior Software Engineer at TechCorp",
+    detailedSummary: "User is a Senior Software Engineer at TechCorp, working on the platform team. They specialize in distributed systems and have been there for 2 years.",
+    categories: ["work", "career"],
+    significance: 0.8,
+    spatialContext: "San Francisco, CA - TechCorp HQ",
+  });
+
+  // Create a personal goal episode
+  const goalEpisode = await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Training for first marathon",
+    shortSummary: "Currently training for NYC Marathon",
+    detailedSummary: "User started a 16-week training program for their first marathon. Running 4 times per week, with long runs on Saturdays.",
+    categories: ["health", "goals", "fitness"],
+    significance: 0.7,
+    causalContext: "Decided to get in better shape after turning 30",
+  });
+
+  return { allergyEpisode, jobEpisode, goalEpisode };
+}
+```
+
+## Linking Related Episodes
+
+Create relationships between episodes to build a knowledge graph:
+
+```typescript filename="examples/link-episodes.ts"
+async function linkLifeEvents(userId: string, threadId: string) {
+  // Create related episodes
+  const moveEpisode = await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Moved to San Francisco",
+    shortSummary: "Relocated to SF for new job",
+    detailedSummary: "User moved from Seattle to San Francisco in January 2024",
+    categories: ["life-event", "location"],
+    significance: 0.9,
+    spatialContext: "San Francisco, CA",
+  });
+
+  const jobEpisode = await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Started at TechCorp",
+    shortSummary: "Began Senior Engineer role",
+    detailedSummary: "Started new position as Senior Software Engineer at TechCorp",
+    categories: ["work", "life-event"],
+    significance: 0.9,
+    causalContext: "Moved to SF for this opportunity",
+  });
+
+  // Link the episodes
+  await memory.linkEpisodes({
+    episodeId1: moveEpisode.id,
+    episodeId2: jobEpisode.id,
+    relationshipType: "leads-to",
+  });
+
+  // Find related episodes
+  const related = await memory.getRelatedEpisodes({
+    episodeId: moveEpisode.id,
+  });
+  
+  console.log(`Found ${related.length} related episodes`);
+}
+```
+
+## Episode Sequences
+
+Group related episodes into sequences:
+
+```typescript filename="examples/episode-sequences.ts"
+import { randomUUID } from "crypto";
+
+async function createTravelDiary(userId: string, threadId: string) {
+  const tripSequenceId = randomUUID();
+  
+  // Day 1
+  await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Japan Trip: Arrived in Tokyo",
+    shortSummary: "Landed at Narita, checked into Shinjuku hotel",
+    detailedSummary: "Smooth flight, took Narita Express to Shinjuku. Hotel has amazing city views.",
+    categories: ["travel", "vacation"],
+    sequenceId: tripSequenceId,
+    spatialContext: "Tokyo, Japan - Shinjuku District",
+    significance: 0.7,
+  });
+
+  // Day 2
+  await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Japan Trip: Explored Asakusa",
+    shortSummary: "Visited Senso-ji temple and tried street food",
+    detailedSummary: "Beautiful temple, crowded but worth it. Had takoyaki and taiyaki from street vendors.",
+    categories: ["travel", "vacation", "culture"],
+    sequenceId: tripSequenceId,
+    spatialContext: "Tokyo, Japan - Asakusa District",
+    significance: 0.6,
+  });
+
+  // Day 3
+  await memory.createEpisode({
+    resourceId: userId,
+    threadId,
+    title: "Japan Trip: Mount Fuji Day Trip",
+    shortSummary: "Took bus tour to Mt. Fuji 5th station",
+    detailedSummary: "Clear weather, stunning views. Altitude was challenging but manageable.",
+    categories: ["travel", "vacation", "nature"],
+    sequenceId: tripSequenceId,
+    spatialContext: "Mount Fuji, Japan",
+    significance: 0.8,
+  });
+
+  // Get all episodes in the sequence
+  const tripEpisodes = await memory.getEpisodesInSequence({
+    sequenceId: tripSequenceId,
+    resourceId: userId,
+  });
+  
+  console.log(`Trip diary has ${tripEpisodes.length} entries`);
+}
+```
+
+## Searching and Filtering Episodes
+
+Find episodes by various criteria:
+
+```typescript filename="examples/search-episodes.ts"
+async function searchUserMemories(userId: string) {
+  // Get all episodes for a user
+  const allEpisodes = await memory.listEpisodes({
+    resourceId: userId,
+  });
+
+  // Get episodes by category
+  const healthEpisodes = await memory.getEpisodesByCategory({
+    resourceId: userId,
+    category: "health",
+  });
+
+  // Get all categories
+  const categories = await memory.getEpisodeCategories({
+    resourceId: userId,
+  });
+
+  // Filter by significance
+  const importantEpisodes = allEpisodes.filter(
+    episode => episode.significance && episode.significance >= 0.8
+  );
+
+  // Search by date range
+  const recentEpisodes = allEpisodes.filter(episode => {
+    const daysSinceCreated = 
+      (Date.now() - episode.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+    return daysSinceCreated <= 30;
+  });
+
+  return {
+    total: allEpisodes.length,
+    health: healthEpisodes.length,
+    important: importantEpisodes.length,
+    recent: recentEpisodes.length,
+    categories,
+  };
+}
+```
+
+## Cross-Thread Memory Access
+
+Episodes persist across all conversations:
+
+```typescript filename="examples/cross-thread-memory.ts"
+async function demonstrateCrossThreadMemory(userId: string) {
+  // Thread 1: User shares information
+  const thread1 = await memory.createThread({
+    id: randomUUID(),
+    resourceId: userId,
+    title: "Initial conversation",
+  });
+
+  await memory.createEpisode({
+    resourceId: userId,
+    threadId: thread1.id,
+    title: "Favorite coffee order",
+    shortSummary: "Oat milk latte, no sugar",
+    detailedSummary: "User always orders a large oat milk latte with an extra shot, no sugar",
+    categories: ["preferences", "food"],
+    significance: 0.4,
+  });
+
+  // Thread 2: Different conversation, same user
+  const thread2 = await memory.createThread({
+    id: randomUUID(),
+    resourceId: userId,
+    title: "New conversation",
+  });
+
+  // Episodes are available in the new thread
+  const episodes = await memory.listEpisodes({
+    resourceId: userId,
+  });
+
+  // Agent can reference the coffee preference in any thread
+  const coffeePreference = episodes.find(ep => 
+    ep.title.includes("coffee")
+  );
+  
+  console.log("User's coffee preference:", coffeePreference?.shortSummary);
+}
+```
+
+## Updating Episodes
+
+Modify existing episodes as information changes:
+
+```typescript filename="examples/update-episodes.ts"
+async function updateUserInformation(userId: string) {
+  // Find existing episode
+  const episodes = await memory.listEpisodes({ resourceId: userId });
+  const jobEpisode = episodes.find(ep => 
+    ep.categories.includes("work") && ep.title.includes("TechCorp")
+  );
+
+  if (jobEpisode) {
+    // Update with promotion
+    await memory.updateEpisode({
+      id: jobEpisode.id,
+      title: "Engineering Manager at TechCorp",
+      shortSummary: "Promoted to Engineering Manager at TechCorp",
+      detailedSummary: "User was promoted from Senior Engineer to Engineering Manager in March 2024. Now leads a team of 6 engineers.",
+      significance: 0.9, // Increased significance
+    });
+  }
+}
+```
+
+## Integration with Agent Conversations
+
+Example of how agents use episodic memory in practice:
+
+```typescript filename="examples/agent-conversation.ts"
+import { personalAssistant } from "../src/mastra/agents/personal-assistant";
+
+async function conversationExample(userId: string) {
+  const thread = await memory.createThread({
+    id: randomUUID(),
+    resourceId: userId,
+    title: "Planning dinner",
+  });
+
+  // User mentions their allergy (agent will create an episode)
+  const response1 = await personalAssistant.generate(
+    "I'm severely allergic to peanuts - even trace amounts can be dangerous.",
+    { threadId: thread.id, resourceId: userId }
+  );
+
+  // Later conversation - agent remembers the allergy
+  const response2 = await personalAssistant.generate(
+    "Can you suggest some Thai restaurants for dinner?",
+    { threadId: thread.id, resourceId: userId }
+  );
+  
+  // Agent will warn about peanut usage in Thai cuisine
+  console.log(response2.text);
+}
+```
+
+## Best Practices
+
+1. **Use consistent categories** across your application
+2. **Set appropriate significance scores** based on information importance
+3. **Link related episodes** to build comprehensive user knowledge
+4. **Include context fields** (causal, spatial) for richer memories
+5. **Use sequences** for temporally related events
+6. **Update episodes** as information changes rather than creating duplicates

--- a/docs/src/content/en/reference/memory/Memory.mdx
+++ b/docs/src/content/en/reference/memory/Memory.mdx
@@ -57,6 +57,13 @@ const memory = new Memory({
 `,
     },
 
+    // Episodic memory configuration
+    episodicMemory: {
+      enabled: true,
+      maxEpisodesInContext: 5,
+      includeCategories: true,
+    },
+
     // Thread configuration
     threads: {
       generateTitle: true, // Enable title generation using agent's model
@@ -290,6 +297,15 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
         "{ enabled: false, template: '# User Information\\n- **First Name**:\\n- **Last Name**:\\n...' }",
     },
     {
+      name: "episodicMemory",
+      type: "{ enabled: boolean; maxEpisodesInContext?: number; includeCategories?: boolean }",
+      description:
+        "Configuration for episodic memory feature that enables long-term memory storage. When enabled, agents can create and recall significant events, facts, and experiences that persist across all conversations. maxEpisodesInContext controls how many episodes are included in the system message (default: 5). includeCategories determines whether to show episode categories in the system message (default: true).",
+      isOptional: true,
+      defaultValue:
+        "{ enabled: false, maxEpisodesInContext: 5, includeCategories: true }",
+    },
+    {
       name: "threads",
       type: "{ generateTitle?: boolean | { model: LanguageModelV1 | ((ctx: RuntimeContext) => LanguageModelV1 | Promise<LanguageModelV1>), instructions?: string | ((ctx: RuntimeContext) => string | Promise<string>) } }",
       description:
@@ -302,11 +318,25 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
 
 ### Related
 
+#### Documentation
 - [Getting Started with Memory](/docs/memory/overview.mdx)
+- [Episodic Memory](/docs/memory/episodic-memory.mdx)
 - [Semantic Recall](/docs/memory/semantic-recall.mdx)
 - [Working Memory](/docs/memory/working-memory.mdx)
 - [Memory Processors](/docs/memory/memory-processors.mdx)
+
+#### Thread Methods
 - [createThread](/reference/memory/createThread.mdx)
 - [query](/reference/memory/query.mdx)
 - [getThreadById](/reference/memory/getThreadById.mdx)
 - [getThreadsByResourceId](/reference/memory/getThreadsByResourceId.mdx)
+
+#### Episode Methods
+- [createEpisode](/reference/memory/createEpisode.mdx)
+- [listEpisodes](/reference/memory/listEpisodes.mdx)
+- [updateEpisode](/reference/memory/updateEpisode.mdx)
+- [linkEpisodes](/reference/memory/linkEpisodes.mdx)
+- [getRelatedEpisodes](/reference/memory/getRelatedEpisodes.mdx)
+- [getEpisodesInSequence](/reference/memory/getEpisodesInSequence.mdx)
+- [getEpisodesByCategory](/reference/memory/getEpisodesByCategory.mdx)
+- [getEpisodeCategories](/reference/memory/getEpisodeCategories.mdx)

--- a/docs/src/content/en/reference/memory/Memory.mdx
+++ b/docs/src/content/en/reference/memory/Memory.mdx
@@ -60,8 +60,7 @@ const memory = new Memory({
     // Episodic memory configuration
     episodicMemory: {
       enabled: true,
-      maxEpisodesInContext: 5,
-      includeCategories: true,
+      lastEpisodes: 5,
     },
 
     // Thread configuration
@@ -298,12 +297,12 @@ Mastra supports many embedding models through the [Vercel AI SDK](https://sdk.ve
     },
     {
       name: "episodicMemory",
-      type: "{ enabled: boolean; maxEpisodesInContext?: number; includeCategories?: boolean }",
+      type: "{ enabled: boolean; lastEpisodes?: number }",
       description:
-        "Configuration for episodic memory feature that enables long-term memory storage. When enabled, agents can create and recall significant events, facts, and experiences that persist across all conversations. maxEpisodesInContext controls how many episodes are included in the system message (default: 5). includeCategories determines whether to show episode categories in the system message (default: true).",
+        "Configuration for episodic memory feature that enables long-term memory storage. When enabled, agents can create and recall significant events, facts, and experiences that persist across all conversations. lastEpisodes controls how many episodes are included in the system message (default: 5).",
       isOptional: true,
       defaultValue:
-        "{ enabled: false, maxEpisodesInContext: 5, includeCategories: true }",
+        "{ enabled: false, lastEpisodes: 5 }",
     },
     {
       name: "threads",

--- a/docs/src/content/en/reference/memory/_meta.ts
+++ b/docs/src/content/en/reference/memory/_meta.ts
@@ -4,6 +4,14 @@ const meta = {
   query: ".query()",
   getThreadById: ".getThreadById()",
   getThreadsByResourceId: ".getThreadsByResourceId()",
+  createEpisode: ".createEpisode()",
+  listEpisodes: ".listEpisodes()",
+  updateEpisode: ".updateEpisode()",
+  linkEpisodes: ".linkEpisodes()",
+  getRelatedEpisodes: ".getRelatedEpisodes()",
+  getEpisodesInSequence: ".getEpisodesInSequence()",
+  getEpisodesByCategory: ".getEpisodesByCategory()",
+  getEpisodeCategories: ".getEpisodeCategories()",
 };
 
 export default meta;

--- a/docs/src/content/en/reference/memory/createEpisode.mdx
+++ b/docs/src/content/en/reference/memory/createEpisode.mdx
@@ -1,0 +1,190 @@
+# createEpisode
+
+Creates a new episode in the episodic memory system. Episodes represent significant events, facts, or experiences that persist across all conversations for a given resource.
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+const episode = await memory.createEpisode({
+  resourceId: "user-123",
+  threadId: "thread-456",
+  title: "Allergic to peanuts",
+  shortSummary: "User has severe peanut allergy",
+  detailedSummary: "User mentioned they have a severe peanut allergy and carry an EpiPen. Even trace amounts can trigger anaphylaxis.",
+  categories: ["health", "important"],
+  significance: 1.0,
+  causalContext: "Discovered after allergic reaction in childhood",
+  spatialContext: "Applies everywhere - must avoid all peanut products",
+});
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "resourceId",
+      type: "string",
+      description:
+        "Identifier for the resource (user) this episode belongs to",
+      isOptional: false,
+    },
+    {
+      name: "threadId",
+      type: "string",
+      description:
+        "ID of the thread where this episode was created or discovered",
+      isOptional: false,
+    },
+    {
+      name: "title",
+      type: "string",
+      description: "Brief descriptive title for the episode",
+      isOptional: false,
+    },
+    {
+      name: "shortSummary",
+      type: "string",
+      description: "One-line summary of the episode",
+      isOptional: false,
+    },
+    {
+      name: "detailedSummary",
+      type: "string",
+      description: "Complete description with full context",
+      isOptional: false,
+    },
+    {
+      name: "categories",
+      type: "string[]",
+      description:
+        "Array of category labels for semantic organization (e.g., 'health', 'work', 'family')",
+      isOptional: false,
+    },
+    {
+      name: "messageIds",
+      type: "string[]",
+      description:
+        "IDs of messages that contributed to this episode",
+      isOptional: true,
+      defaultValue: "[]",
+    },
+    {
+      name: "causalContext",
+      type: "string",
+      description:
+        "Why this happened or what led to it",
+      isOptional: true,
+    },
+    {
+      name: "spatialContext",
+      type: "string",
+      description:
+        "Where this occurred (location, environment)",
+      isOptional: true,
+    },
+    {
+      name: "relatedEpisodeIds",
+      type: "string[]",
+      description:
+        "IDs of other episodes that relate to this one",
+      isOptional: true,
+    },
+    {
+      name: "sequenceId",
+      type: "string",
+      description:
+        "UUID to group related episodes in a sequence",
+      isOptional: true,
+    },
+    {
+      name: "significance",
+      type: "number",
+      description:
+        "Score from 0-1 indicating importance (1.0 = critical)",
+      isOptional: true,
+      defaultValue: "0.5",
+    },
+    {
+      name: "metadata",
+      type: "Record<string, any>",
+      description: "Additional custom metadata",
+      isOptional: true,
+    },
+  ]}
+/>
+
+## Returns
+
+Returns a `StorageEpisodeType` object containing:
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier of the created episode",
+    },
+    {
+      name: "resourceId",
+      type: "string",
+      description: "Resource ID associated with the episode",
+    },
+    {
+      name: "threadId",
+      type: "string",
+      description: "Thread ID where the episode was created",
+    },
+    {
+      name: "title",
+      type: "string",
+      description: "Title of the episode",
+    },
+    {
+      name: "shortSummary",
+      type: "string",
+      description: "Brief summary of the episode",
+    },
+    {
+      name: "detailedSummary",
+      type: "string",
+      description: "Full description of the episode",
+    },
+    {
+      name: "categories",
+      type: "string[]",
+      description: "Category labels for the episode",
+    },
+    {
+      name: "significance",
+      type: "number",
+      description: "Importance score (0-1)",
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp when the episode was created",
+    },
+    {
+      name: "updatedAt",
+      type: "Date",
+      description: "Timestamp when the episode was last updated",
+    },
+  ]}
+/>
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [listEpisodes](/reference/memory/listEpisodes.mdx)
+- [updateEpisode](/reference/memory/updateEpisode.mdx)
+- [linkEpisodes](/reference/memory/linkEpisodes.mdx)

--- a/docs/src/content/en/reference/memory/getEpisodeCategories.mdx
+++ b/docs/src/content/en/reference/memory/getEpisodeCategories.mdx
@@ -1,0 +1,76 @@
+# getEpisodeCategories
+
+Retrieves a list of all unique categories used across all episodes for a specific resource.
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+// Get all categories used by the user
+const categories = await memory.getEpisodeCategories({
+  resourceId: "user-123",
+});
+
+console.log("Episode categories:", categories);
+// Output: ["health", "work", "family", "travel", "goals", ...]
+
+// Use categories to create a filtering UI
+const episodesByCategory = {};
+for (const category of categories) {
+  episodesByCategory[category] = await memory.getEpisodesByCategory({
+    resourceId: "user-123",
+    category,
+  });
+}
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "resourceId",
+      type: "string",
+      description:
+        "Identifier for the resource (user) whose episode categories to retrieve",
+      isOptional: false,
+    },
+  ]}
+/>
+
+## Returns
+
+Returns an array of unique category strings.
+
+<PropertiesTable
+  content={[
+    {
+      name: "categories",
+      type: "string[]",
+      description: "Array of unique category names used across all episodes for the resource",
+    },
+  ]}
+/>
+
+## Implementation Details
+
+The categories are extracted from:
+1. All episodes stored for the resource
+2. The resource's metadata (accumulated categories)
+
+This ensures that even if all episodes in a category are deleted, the category history is preserved.
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [getEpisodesByCategory](/reference/memory/getEpisodesByCategory.mdx)
+- [createEpisode](/reference/memory/createEpisode.mdx)
+- [listEpisodes](/reference/memory/listEpisodes.mdx)

--- a/docs/src/content/en/reference/memory/getEpisodesByCategory.mdx
+++ b/docs/src/content/en/reference/memory/getEpisodesByCategory.mdx
@@ -1,0 +1,87 @@
+# getEpisodesByCategory
+
+Retrieves all episodes for a resource that belong to a specific category.
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+// Get all health-related episodes
+const healthEpisodes = await memory.getEpisodesByCategory({
+  resourceId: "user-123",
+  category: "health",
+});
+
+// Get all work-related episodes
+const workEpisodes = await memory.getEpisodesByCategory({
+  resourceId: "user-123",
+  category: "work",
+});
+
+// Filter by significance
+const importantHealthEvents = healthEpisodes.filter(
+  episode => episode.significance && episode.significance >= 0.8
+);
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "resourceId",
+      type: "string",
+      description:
+        "Identifier for the resource (user) whose episodes to retrieve",
+      isOptional: false,
+    },
+    {
+      name: "category",
+      type: "string",
+      description:
+        "Category name to filter by (case-sensitive)",
+      isOptional: false,
+    },
+  ]}
+/>
+
+## Returns
+
+Returns an array of `StorageEpisodeType` objects that have the specified category, sorted by creation date (newest first).
+
+<PropertiesTable
+  content={[
+    {
+      name: "episodes",
+      type: "StorageEpisodeType[]",
+      description: "Array of episodes matching the category",
+    },
+  ]}
+/>
+
+## Common Categories
+
+Recommended category naming conventions:
+
+- **Life Events**: `life-event`, `milestone`, `achievement`
+- **Health**: `health`, `medical`, `fitness`, `important`
+- **Work**: `work`, `career`, `education`, `professional`
+- **Personal**: `family`, `relationship`, `personal`
+- **Location**: `location`, `travel`, `move`
+- **Interests**: `hobbies`, `preferences`, `goals`
+- **Financial**: `financial`, `investment`, `purchase`
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [listEpisodes](/reference/memory/listEpisodes.mdx)
+- [getEpisodeCategories](/reference/memory/getEpisodeCategories.mdx)
+- [createEpisode](/reference/memory/createEpisode.mdx)

--- a/docs/src/content/en/reference/memory/getEpisodesInSequence.mdx
+++ b/docs/src/content/en/reference/memory/getEpisodesInSequence.mdx
@@ -1,0 +1,96 @@
+# getEpisodesInSequence
+
+Retrieves all episodes that belong to the same sequence, sorted by creation date.
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+import { randomUUID } from "crypto";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+// Create episodes in a sequence
+const tripSequenceId = randomUUID();
+
+await memory.createEpisode({
+  resourceId: "user-123",
+  threadId: "thread-456",
+  title: "Day 1: Arrived in Tokyo",
+  shortSummary: "Landed and checked into hotel",
+  detailedSummary: "Smooth flight, took train to Shinjuku",
+  categories: ["travel", "vacation"],
+  sequenceId: tripSequenceId,
+});
+
+await memory.createEpisode({
+  resourceId: "user-123",
+  threadId: "thread-456",
+  title: "Day 2: Visited temples",
+  shortSummary: "Explored Asakusa district",
+  detailedSummary: "Visited Senso-ji temple and tried street food",
+  categories: ["travel", "vacation", "culture"],
+  sequenceId: tripSequenceId,
+});
+
+// Get all episodes in the trip sequence
+const tripEpisodes = await memory.getEpisodesInSequence({
+  sequenceId: tripSequenceId,
+  resourceId: "user-123",
+});
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "sequenceId",
+      type: "string",
+      description:
+        "UUID of the sequence to retrieve episodes for",
+      isOptional: false,
+    },
+    {
+      name: "resourceId",
+      type: "string",
+      description:
+        "Resource ID to filter episodes (ensures episodes belong to the correct user)",
+      isOptional: false,
+    },
+  ]}
+/>
+
+## Returns
+
+Returns an array of `StorageEpisodeType` objects belonging to the sequence, sorted by creation date (oldest first).
+
+<PropertiesTable
+  content={[
+    {
+      name: "episodes",
+      type: "StorageEpisodeType[]",
+      description: "Array of episodes in the sequence, ordered chronologically",
+    },
+  ]}
+/>
+
+## Use Cases
+
+Sequences are useful for:
+- **Travel diaries**: Day-by-day travel experiences
+- **Project timelines**: Progress updates on long-term projects
+- **Medical history**: Series of related medical events
+- **Learning progress**: Stages of learning a new skill
+- **Multi-part events**: Conference days, workshop sessions
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [createEpisode](/reference/memory/createEpisode.mdx)
+- [listEpisodes](/reference/memory/listEpisodes.mdx)

--- a/docs/src/content/en/reference/memory/getRelatedEpisodes.mdx
+++ b/docs/src/content/en/reference/memory/getRelatedEpisodes.mdx
@@ -1,0 +1,86 @@
+# getRelatedEpisodes
+
+Retrieves all episodes that are directly related to a specific episode through established relationships.
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+// Get all episodes related to a specific episode
+const relatedEpisodes = await memory.getRelatedEpisodes({
+  episodeId: "episode-123",
+});
+
+// Process related episodes by relationship type
+relatedEpisodes.forEach(episode => {
+  const relationship = episode.relationships?.find(
+    rel => rel.episodeId === "episode-123"
+  );
+  console.log(`${episode.title} - Relationship: ${relationship?.type}`);
+});
+
+// Get related episodes including indirect relationships
+const allRelated = await memory.getRelatedEpisodes({
+  episodeId: "episode-123",
+  includeIndirect: true,
+});
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "episodeId",
+      type: "string",
+      description:
+        "ID of the episode to find relationships for",
+      isOptional: false,
+    },
+    {
+      name: "includeIndirect",
+      type: "boolean",
+      description:
+        "Whether to include episodes related through intermediate episodes (transitive relationships)",
+      isOptional: true,
+      defaultValue: "false",
+    },
+  ]}
+/>
+
+## Returns
+
+Returns an array of `StorageEpisodeType` objects representing the related episodes. Each episode will include its relationship information in the `relationships` field.
+
+<PropertiesTable
+  content={[
+    {
+      name: "episodes",
+      type: "StorageEpisodeType[]",
+      description: "Array of related episodes with their full details and relationship information",
+    },
+  ]}
+/>
+
+## Indirect Relationships
+
+When `includeIndirect` is true, the method will:
+1. Find all directly related episodes
+2. For each related episode, find their related episodes
+3. Return the combined set (excluding the original episode)
+
+This is useful for exploring broader connections in the knowledge graph.
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [linkEpisodes](/reference/memory/linkEpisodes.mdx)
+- [createEpisode](/reference/memory/createEpisode.mdx)

--- a/docs/src/content/en/reference/memory/linkEpisodes.mdx
+++ b/docs/src/content/en/reference/memory/linkEpisodes.mdx
@@ -1,0 +1,80 @@
+# linkEpisodes
+
+Creates a typed relationship between two episodes. This allows building a knowledge graph of related memories.
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+// Link two episodes with a causal relationship
+await memory.linkEpisodes({
+  episodeId1: "episode-move-to-sf",
+  episodeId2: "episode-new-job",
+  relationshipType: "leads-to",
+});
+
+// The move to SF led to the new job
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "episodeId1",
+      type: "string",
+      description:
+        "ID of the first episode in the relationship",
+      isOptional: false,
+    },
+    {
+      name: "episodeId2",
+      type: "string",
+      description:
+        "ID of the second episode in the relationship",
+      isOptional: false,
+    },
+    {
+      name: "relationshipType",
+      type: "'caused-by' | 'leads-to' | 'part-of' | 'similar-to' | 'related-to'",
+      description:
+        "Type of relationship between the episodes",
+      isOptional: false,
+    },
+  ]}
+/>
+
+## Relationship Types
+
+- **`caused-by`**: Episode 2 was caused by Episode 1
+- **`leads-to`**: Episode 1 leads to Episode 2
+- **`part-of`**: Episode 2 is part of Episode 1
+- **`similar-to`**: The episodes are similar in nature
+- **`related-to`**: General relationship between episodes
+
+## Returns
+
+Returns void. The relationship is stored bidirectionally:
+- Episode 1 will have Episode 2 in its relationships
+- Episode 2 will have Episode 1 in its relationships
+
+## Error Handling
+
+Throws an error if:
+- Either episode does not exist
+- The episodes are already linked with the same relationship type
+- The storage operation fails
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [createEpisode](/reference/memory/createEpisode.mdx)
+- [getRelatedEpisodes](/reference/memory/getRelatedEpisodes.mdx)

--- a/docs/src/content/en/reference/memory/listEpisodes.mdx
+++ b/docs/src/content/en/reference/memory/listEpisodes.mdx
@@ -1,0 +1,126 @@
+# listEpisodes
+
+Retrieves all episodes for a specific resource, sorted by creation date (newest first).
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+// Get all episodes for a user
+const episodes = await memory.listEpisodes({
+  resourceId: "user-123",
+});
+
+// Filter episodes by significance
+const importantEpisodes = episodes.filter(
+  episode => episode.significance && episode.significance >= 0.8
+);
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "resourceId",
+      type: "string",
+      description:
+        "Identifier for the resource (user) whose episodes to retrieve",
+      isOptional: false,
+    },
+  ]}
+/>
+
+## Returns
+
+Returns an array of `StorageEpisodeType` objects, each containing:
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier of the episode",
+    },
+    {
+      name: "resourceId",
+      type: "string",
+      description: "Resource ID associated with the episode",
+    },
+    {
+      name: "threadId",
+      type: "string",
+      description: "Thread ID where the episode was created",
+    },
+    {
+      name: "title",
+      type: "string",
+      description: "Title of the episode",
+    },
+    {
+      name: "shortSummary",
+      type: "string",
+      description: "Brief summary of the episode",
+    },
+    {
+      name: "detailedSummary",
+      type: "string",
+      description: "Full description of the episode",
+    },
+    {
+      name: "categories",
+      type: "string[]",
+      description: "Category labels for the episode",
+    },
+    {
+      name: "significance",
+      type: "number | undefined",
+      description: "Importance score (0-1)",
+    },
+    {
+      name: "causalContext",
+      type: "string | undefined",
+      description: "Why this happened or what led to it",
+    },
+    {
+      name: "spatialContext",
+      type: "string | undefined",
+      description: "Where this occurred",
+    },
+    {
+      name: "relationships",
+      type: "EpisodeRelationship[] | undefined",
+      description: "Relationships to other episodes",
+    },
+    {
+      name: "sequenceId",
+      type: "string | undefined",
+      description: "ID of the sequence this episode belongs to",
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp when the episode was created",
+    },
+    {
+      name: "updatedAt",
+      type: "Date",
+      description: "Timestamp when the episode was last updated",
+    },
+  ]}
+/>
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [createEpisode](/reference/memory/createEpisode.mdx)
+- [getEpisodesByCategory](/reference/memory/getEpisodesByCategory.mdx)
+- [getEpisodesInSequence](/reference/memory/getEpisodesInSequence.mdx)

--- a/docs/src/content/en/reference/memory/updateEpisode.mdx
+++ b/docs/src/content/en/reference/memory/updateEpisode.mdx
@@ -1,0 +1,122 @@
+# updateEpisode
+
+Updates an existing episode with new information. Only the fields provided will be updated; other fields remain unchanged.
+
+## Usage Example
+
+```typescript
+import { Memory } from "@mastra/memory";
+
+const memory = new Memory({
+  options: {
+    episodicMemory: { enabled: true }
+  }
+});
+
+// Update an episode with new information
+await memory.updateEpisode({
+  id: "episode-123",
+  title: "Engineering Manager at TechCorp",
+  shortSummary: "Promoted to Engineering Manager",
+  detailedSummary: "User was promoted from Senior Engineer to Engineering Manager in March 2024. Now leads a team of 6 engineers.",
+  significance: 0.9, // Increased significance due to promotion
+  categories: ["work", "career", "milestone"], // Added milestone category
+});
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description:
+        "Unique identifier of the episode to update",
+      isOptional: false,
+    },
+    {
+      name: "title",
+      type: "string",
+      description: "New title for the episode",
+      isOptional: true,
+    },
+    {
+      name: "shortSummary",
+      type: "string",
+      description: "New brief summary",
+      isOptional: true,
+    },
+    {
+      name: "detailedSummary",
+      type: "string",
+      description: "New detailed description",
+      isOptional: true,
+    },
+    {
+      name: "categories",
+      type: "string[]",
+      description:
+        "New category labels (replaces existing categories)",
+      isOptional: true,
+    },
+    {
+      name: "causalContext",
+      type: "string",
+      description:
+        "Updated causal context",
+      isOptional: true,
+    },
+    {
+      name: "spatialContext",
+      type: "string",
+      description:
+        "Updated spatial context",
+      isOptional: true,
+    },
+    {
+      name: "relatedEpisodeIds",
+      type: "string[]",
+      description:
+        "Updated list of related episode IDs",
+      isOptional: true,
+    },
+    {
+      name: "sequenceId",
+      type: "string",
+      description:
+        "Updated sequence ID",
+      isOptional: true,
+    },
+    {
+      name: "significance",
+      type: "number",
+      description:
+        "Updated significance score (0-1)",
+      isOptional: true,
+    },
+    {
+      name: "metadata",
+      type: "Record<string, any>",
+      description: "Updated custom metadata",
+      isOptional: true,
+    },
+  ]}
+/>
+
+## Returns
+
+Returns void. The episode is updated in the storage system.
+
+## Error Handling
+
+Throws an error if:
+- The episode with the given ID does not exist
+- The storage operation fails
+
+### Related
+
+- [Memory Class Reference](/reference/memory/Memory.mdx)
+- [Episodic Memory Guide](/docs/memory/episodic-memory.mdx)
+- [createEpisode](/reference/memory/createEpisode.mdx)
+- [listEpisodes](/reference/memory/listEpisodes.mdx)

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -79,6 +79,11 @@ export type MemoryConfig = {
         scope?: 'thread' | 'resource';
       };
   workingMemory?: WorkingMemory;
+  episodicMemory?: {
+    enabled: boolean;
+    maxEpisodesInContext?: number;
+    includeCategories?: boolean;
+  };
   threads?: {
     generateTitle?:
       | boolean
@@ -123,4 +128,30 @@ export type WorkingMemoryFormat = 'json' | 'markdown';
 export type WorkingMemoryTemplate = {
   format: WorkingMemoryFormat;
   content: string;
+};
+
+export type EpisodeRelationship = {
+  episodeId: string;
+  type: 'caused-by' | 'leads-to' | 'part-of' | 'similar-to' | 'related-to';
+  metadata?: Record<string, any>;
+};
+
+export type StorageEpisodeType = {
+  id: string;
+  resourceId: string;
+  threadId: string;
+  title: string;
+  shortSummary: string;
+  detailedSummary: string;
+  categories: string[];
+  messageIds: string[];
+  causalContext?: string; // Why this happened, what led to it
+  spatialContext?: string; // Where it occurred (location, environment)
+  relatedEpisodeIds?: string[]; // Episodes that relate to this one
+  relationships?: EpisodeRelationship[]; // Detailed relationship information
+  sequenceId?: string; // For episodes that are part of a sequence
+  significance?: number; // Score indicating importance/surprise (0-1)
+  metadata?: Record<string, any>;
+  createdAt: Date;
+  updatedAt: Date;
 };

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -81,8 +81,7 @@ export type MemoryConfig = {
   workingMemory?: WorkingMemory;
   episodicMemory?: {
     enabled: boolean;
-    maxEpisodesInContext?: number;
-    includeCategories?: boolean;
+    lastEpisodes?: number;
   };
   threads?: {
     generateTitle?:

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -6,6 +6,7 @@ export const TABLE_MESSAGES = 'mastra_messages';
 export const TABLE_THREADS = 'mastra_threads';
 export const TABLE_TRACES = 'mastra_traces';
 export const TABLE_RESOURCES = 'mastra_resources';
+export const TABLE_EPISODES = 'mastra_episodes';
 
 export type TABLE_NAMES =
   | typeof TABLE_WORKFLOW_SNAPSHOT
@@ -13,7 +14,8 @@ export type TABLE_NAMES =
   | typeof TABLE_MESSAGES
   | typeof TABLE_THREADS
   | typeof TABLE_TRACES
-  | typeof TABLE_RESOURCES;
+  | typeof TABLE_RESOURCES
+  | typeof TABLE_EPISODES;
 
 export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> = {
   [TABLE_WORKFLOW_SNAPSHOT]: {
@@ -107,6 +109,25 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
   [TABLE_RESOURCES]: {
     id: { type: 'text', nullable: false, primaryKey: true },
     workingMemory: { type: 'text', nullable: true },
+    metadata: { type: 'jsonb', nullable: true },
+    createdAt: { type: 'timestamp', nullable: false },
+    updatedAt: { type: 'timestamp', nullable: false },
+  },
+  [TABLE_EPISODES]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    resourceId: { type: 'text', nullable: false },
+    threadId: { type: 'text', nullable: false },
+    title: { type: 'text', nullable: false },
+    shortSummary: { type: 'text', nullable: false },
+    detailedSummary: { type: 'text', nullable: false },
+    categories: { type: 'text', nullable: false }, // JSON array
+    messageIds: { type: 'text', nullable: false }, // JSON array
+    causalContext: { type: 'text', nullable: true },
+    spatialContext: { type: 'text', nullable: true },
+    relatedEpisodeIds: { type: 'text', nullable: true }, // JSON array
+    relationships: { type: 'text', nullable: true }, // JSON array of EpisodeRelationship
+    sequenceId: { type: 'text', nullable: true },
+    significance: { type: 'text', nullable: true }, // Store as text for compatibility
     metadata: { type: 'jsonb', nullable: true },
     createdAt: { type: 'timestamp', nullable: false },
     updatedAt: { type: 'timestamp', nullable: false },

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -22,6 +22,7 @@ export class MockStore extends MastraStorage {
     mastra_threads: {},
     mastra_traces: {},
     mastra_resources: {},
+    mastra_episodes: {},
   };
 
   constructor() {

--- a/packages/memory/integration-tests/src/episodic-memory.test.ts
+++ b/packages/memory/integration-tests/src/episodic-memory.test.ts
@@ -1,0 +1,282 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openai } from '@ai-sdk/openai';
+import { Agent } from '@mastra/core/agent';
+import { fastembed } from '@mastra/fastembed';
+import { LibSQLVector, LibSQLStore } from '@mastra/libsql';
+import { Memory } from '@mastra/memory';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { config } from 'dotenv';
+
+config({ path: '.env.test' });
+
+const resourceId = 'test-resource';
+
+describe('Episodic Memory Integration Tests', () => {
+  let memory: Memory;
+  let storage: LibSQLStore;
+  let vector: LibSQLVector;
+  let agent: Agent;
+
+  beforeEach(async () => {
+    const dbPath = join(await mkdtemp(join(tmpdir(), `memory-episodic-test-${Date.now()}`)), 'test.db');
+    
+    storage = new LibSQLStore({
+      url: `file:${dbPath}`,
+    });
+    vector = new LibSQLVector({
+      connectionUrl: `file:${dbPath}`,
+    });
+
+    memory = new Memory({
+      options: {
+        episodicMemory: {
+          enabled: true,
+          maxEpisodesInContext: 5,
+          includeCategories: true,
+        },
+        workingMemory: {
+          enabled: true,
+          template: `# User Information
+- **First Name**: 
+- **Last Name**: 
+- **Location**: 
+`,
+        },
+        lastMessages: 10,
+        semanticRecall: {
+          topK: 3,
+          messageRange: 2,
+        },
+        threads: {
+          generateTitle: false,
+        },
+      },
+      storage,
+      vector,
+      embedder: fastembed,
+    });
+
+    agent = new Agent({
+      name: 'Episodic Memory Test Agent',
+      instructions: 'You are a helpful AI agent. Use episodic memory to remember important events and facts about the user.',
+      model: openai('gpt-4o'),
+      memory,
+    });
+  });
+
+  afterEach(async () => {
+    //@ts-ignore
+    await storage.client.close();
+    //@ts-ignore
+    await vector.turso.close();
+  });
+
+  it('should create an episode through agent conversation', async () => {
+    const thread = await memory.createThread({
+      id: randomUUID(),
+      title: 'Episode Test Thread',
+      resourceId,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Have a conversation that should trigger episode creation
+    await agent.generate('I just got promoted to Senior Engineering Manager at TechCorp!', {
+      threadId: thread.id,
+      resourceId,
+    });
+
+    // Check if episodes were created
+    const episodes = await memory.listEpisodes({ resourceId });
+    expect(episodes.length).toBeGreaterThan(0);
+    
+    const episode = episodes[0];
+    expect(episode.title).toBeTruthy();
+    expect(episode.categories).toContain('work');
+  });
+
+  it('should use episodes in subsequent conversations', async () => {
+    const thread1 = await memory.createThread({
+      id: randomUUID(),
+      title: 'First Thread',
+      resourceId,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Create an episode directly
+    await memory.createEpisode({
+      resourceId,
+      threadId: thread1.id,
+      title: 'User loves hiking',
+      shortSummary: 'User enjoys hiking in the mountains',
+      detailedSummary: 'The user expressed a deep passion for hiking, particularly in mountainous regions. They mentioned hiking every weekend.',
+      categories: ['hobbies', 'outdoor-activities'],
+      messageIds: [],
+      significance: 0.8,
+    });
+
+    // Create a new thread to test episode recall
+    const thread2 = await memory.createThread({
+      id: randomUUID(),
+      title: 'Second Thread',
+      resourceId,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Ask about hobbies in the new thread
+    const response = await agent.generate('What do you remember about my hobbies?', {
+      threadId: thread2.id,
+      resourceId,
+    });
+
+    expect(response.text.toLowerCase()).toContain('hiking');
+  });
+
+  it('should link related episodes', async () => {
+    const thread = await memory.createThread({
+      id: randomUUID(),
+      title: 'Relationship Test Thread',
+      resourceId,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Create two related episodes
+    const episode1 = await memory.createEpisode({
+      resourceId,
+      threadId: thread.id,
+      title: 'Moved to San Francisco',
+      shortSummary: 'User relocated to San Francisco',
+      detailedSummary: 'User moved to San Francisco for a new job opportunity.',
+      categories: ['life-event', 'location'],
+      messageIds: [],
+      spatialContext: 'San Francisco, CA',
+      significance: 0.9,
+    });
+
+    const episode2 = await memory.createEpisode({
+      resourceId,
+      threadId: thread.id,
+      title: 'Started at TechCorp',
+      shortSummary: 'User began working at TechCorp',
+      detailedSummary: 'User started their new position as Senior Engineer at TechCorp headquarters.',
+      categories: ['work', 'life-event'],
+      messageIds: [],
+      causalContext: 'Moved to SF for this job opportunity',
+      spatialContext: 'San Francisco, CA - TechCorp HQ',
+      significance: 0.9,
+    });
+
+    // Link the episodes
+    await memory.linkEpisodes({
+      episodeId1: episode1.id,
+      episodeId2: episode2.id,
+      relationshipType: 'leads-to',
+    });
+
+    // Get related episodes
+    const related = await memory.getRelatedEpisodes({
+      episodeId: episode1.id,
+    });
+
+    expect(related).toHaveLength(1);
+    expect(related[0].id).toBe(episode2.id);
+    
+    // Check that the relationship was stored on episode1
+    const updatedEpisode1 = await memory.storage.getEpisodeById({ id: episode1.id });
+    expect(updatedEpisode1?.relationships).toHaveLength(1);
+    expect(updatedEpisode1?.relationships?.[0]?.episodeId).toBe(episode2.id);
+    expect(updatedEpisode1?.relationships?.[0]?.type).toBe('leads-to');
+  });
+
+  it('should include episode context in system message', async () => {
+    const thread = await memory.createThread({
+      id: randomUUID(),
+      title: 'Context Test Thread',
+      resourceId,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Create an episode with significance
+    await memory.createEpisode({
+      resourceId,
+      threadId: thread.id,
+      title: 'Allergic to peanuts',
+      shortSummary: 'User has severe peanut allergy',
+      detailedSummary: 'User mentioned they have a severe peanut allergy and carry an EpiPen.',
+      categories: ['health', 'important'],
+      messageIds: [],
+      significance: 1.0,
+    });
+
+    // Get system message
+    const systemMessage = await memory.getSystemMessage({
+      threadId: thread.id,
+      resourceId,
+    });
+
+    expect(systemMessage.toLowerCase()).toContain('episodic memory');
+    expect(systemMessage).toContain('peanut');
+    expect(systemMessage).toContain('health, important');
+  });
+
+  it('should handle episode sequences', async () => {
+    const thread = await memory.createThread({
+      id: randomUUID(),
+      title: 'Sequence Test Thread',
+      resourceId,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const sequenceId = randomUUID();
+
+    // Create episodes in a sequence
+    const episode1 = await memory.createEpisode({
+      resourceId,
+      threadId: thread.id,
+      title: 'Trip Day 1: Arrived in Paris',
+      shortSummary: 'First day of Paris vacation',
+      detailedSummary: 'Arrived at Charles de Gaulle airport, checked into hotel near the Eiffel Tower.',
+      categories: ['travel', 'vacation'],
+      messageIds: [],
+      sequenceId,
+      spatialContext: 'Paris, France',
+      significance: 0.7,
+    });
+
+    const episode2 = await memory.createEpisode({
+      resourceId,
+      threadId: thread.id,
+      title: 'Trip Day 2: Louvre Museum',
+      shortSummary: 'Visited the Louvre',
+      detailedSummary: 'Spent the day at the Louvre Museum, saw the Mona Lisa and other masterpieces.',
+      categories: ['travel', 'vacation', 'culture'],
+      messageIds: [],
+      sequenceId,
+      spatialContext: 'Louvre Museum, Paris',
+      significance: 0.8,
+    });
+
+    // Get episodes in sequence
+    const sequenceEpisodes = await memory.getEpisodesInSequence({
+      sequenceId,
+      resourceId,
+    });
+
+    expect(sequenceEpisodes).toHaveLength(2);
+    expect(sequenceEpisodes.every(ep => ep.sequenceId === sequenceId)).toBe(true);
+  });
+});

--- a/packages/memory/integration-tests/src/episodic-memory.test.ts
+++ b/packages/memory/integration-tests/src/episodic-memory.test.ts
@@ -34,8 +34,7 @@ describe('Episodic Memory Integration Tests', () => {
       options: {
         episodicMemory: {
           enabled: true,
-          maxEpisodesInContext: 5,
-          includeCategories: true,
+          lastEpisodes: 5,
         },
         workingMemory: {
           enabled: true,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1311,13 +1311,12 @@ ${
     resourceId: string;
     config: NonNullable<MemoryConfig['episodicMemory']>;
   }): Promise<string | null> {
-    const maxEpisodes = config.maxEpisodesInContext || 5;
-    const includeCategories = config.includeCategories !== false;
+    const lastEpisodes = config.lastEpisodes || 5;
 
     // Get recent episodes for context
     const episodes = await this.listEpisodes({
       resourceId,
-      limit: maxEpisodes,
+      limit: lastEpisodes,
     });
 
     if (episodes.length === 0) {
@@ -1342,15 +1341,15 @@ Available tools:
 
     const episodesList = episodes
       .map(ep => {
-        const cats = includeCategories && ep.categories.length > 0 ? ` [${ep.categories.join(', ')}]` : '';
+        const cats = ep.categories.length > 0 ? ` [${ep.categories.join(', ')}]` : '';
         const causal = ep.causalContext ? ` (because: ${ep.causalContext})` : '';
         return `- ${ep.title}${cats}: ${ep.shortSummary}${causal}`;
       })
       .join('\n');
 
-    const categories = includeCategories ? await this.getEpisodeCategories({ resourceId }) : [];
+    const categories = await this.getEpisodeCategories({ resourceId });
     const categoryInfo =
-      includeCategories && categories.length > 0 ? `\nAvailable categories: ${categories.join(', ')}` : '';
+      categories.length > 0 ? `\nAvailable categories: ${categories.join(', ')}` : '';
 
     return `EPISODIC_MEMORY_SYSTEM_INSTRUCTION:
 You have access to the user's episodic memory. Recent episodes:

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -3,7 +3,13 @@ import type { CoreTool, MastraMessageV1 } from '@mastra/core';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV2 } from '@mastra/core/agent';
 import { MastraMemory } from '@mastra/core/memory';
-import type { MemoryConfig, SharedMemoryConfig, StorageThreadType, WorkingMemoryTemplate, StorageEpisodeType } from '@mastra/core/memory';
+import type {
+  MemoryConfig,
+  SharedMemoryConfig,
+  StorageThreadType,
+  WorkingMemoryTemplate,
+  StorageEpisodeType,
+} from '@mastra/core/memory';
 import type { StorageGetMessagesArg } from '@mastra/core/storage';
 import { embedMany } from 'ai';
 import type { CoreMessage, TextPart, UIMessage } from 'ai';
@@ -1050,7 +1056,7 @@ ${
     if (categories.length > 0) {
       const existingCategories = await this.storage.getCategoriesForResource({ resourceId });
       const newCategories = categories.filter(cat => !existingCategories.includes(cat));
-      
+
       if (newCategories.length > 0) {
         const resource = await this.storage.getResourceById({ resourceId });
         if (resource) {
@@ -1065,7 +1071,7 @@ ${
         }
       }
     }
-    
+
     return episode;
   }
 
@@ -1125,7 +1131,7 @@ ${
       if (episode) {
         const existingCategories = await this.storage.getCategoriesForResource({ resourceId: episode.resourceId });
         const newCategories = updates.categories.filter(cat => !existingCategories.includes(cat));
-        
+
         if (newCategories.length > 0) {
           const resource = await this.storage.getResourceById({ resourceId: episode.resourceId });
           if (resource) {
@@ -1175,17 +1181,17 @@ ${
     // Update episode1 to include episode2 in its relatedEpisodeIds and relationships
     const relatedIds1 = episode1.relatedEpisodeIds || [];
     const relationships1 = episode1.relationships || [];
-    
+
     if (!relatedIds1.includes(episodeId2)) {
       relatedIds1.push(episodeId2);
       relationships1.push({
         episodeId: episodeId2,
         type: relationshipType,
       });
-      
+
       await this.storage.updateEpisode({
         id: episodeId1,
-        updates: { 
+        updates: {
           relatedEpisodeIds: relatedIds1,
           relationships: relationships1,
         },
@@ -1196,17 +1202,17 @@ ${
     if (relationshipType === 'related-to' || relationshipType === 'similar-to') {
       const relatedIds2 = episode2.relatedEpisodeIds || [];
       const relationships2 = episode2.relationships || [];
-      
+
       if (!relatedIds2.includes(episodeId1)) {
         relatedIds2.push(episodeId1);
         relationships2.push({
           episodeId: episodeId1,
           type: relationshipType,
         });
-        
+
         await this.storage.updateEpisode({
           id: episodeId2,
-          updates: { 
+          updates: {
             relatedEpisodeIds: relatedIds2,
             relationships: relationships2,
           },
@@ -1250,9 +1256,7 @@ ${
       return [];
     }
 
-    const relatedEpisodes = await Promise.all(
-      episode.relatedEpisodeIds.map(id => this.storage.getEpisodeById({ id }))
-    );
+    const relatedEpisodes = await Promise.all(episode.relatedEpisodeIds.map(id => this.storage.getEpisodeById({ id })));
 
     const directRelated = relatedEpisodes.filter(ep => ep !== null) as StorageEpisodeType[];
 
@@ -1267,9 +1271,9 @@ ${
         const secondLevel = await Promise.all(
           relatedEp.relatedEpisodeIds
             .filter(id => id !== episodeId && !episode.relatedEpisodeIds?.includes(id))
-            .map(id => this.storage.getEpisodeById({ id }))
+            .map(id => this.storage.getEpisodeById({ id })),
         );
-        
+
         secondLevel.forEach(ep => {
           if (ep && !indirectRelated.has(ep.id)) {
             indirectRelated.set(ep.id, ep);
@@ -1345,9 +1349,8 @@ Available tools:
       .join('\n');
 
     const categories = includeCategories ? await this.getEpisodeCategories({ resourceId }) : [];
-    const categoryInfo = includeCategories && categories.length > 0 
-      ? `\nAvailable categories: ${categories.join(', ')}` 
-      : '';
+    const categoryInfo =
+      includeCategories && categories.length > 0 ? `\nAvailable categories: ${categories.join(', ')}` : '';
 
     return `EPISODIC_MEMORY_SYSTEM_INSTRUCTION:
 You have access to the user's episodic memory. Recent episodes:

--- a/packages/memory/src/tools/episodic-memory.ts
+++ b/packages/memory/src/tools/episodic-memory.ts
@@ -1,0 +1,323 @@
+import type { CoreTool } from '@mastra/core';
+import type { MemoryConfig } from '@mastra/core/memory';
+import { z } from 'zod';
+
+/**
+ * Tool for creating new episodes from conversation context
+ */
+export const createEpisodeTool = (config?: MemoryConfig): CoreTool => {
+  return {
+    description: 'Create a new memory episode to remember important information from this conversation',
+    parameters: z.object({
+      title: z.string().describe('A concise, descriptive title for this episode'),
+      shortSummary: z
+        .string()
+        .describe('A brief 1-2 sentence summary of the episode that will be shown in episode lists'),
+      detailedSummary: z
+        .string()
+        .describe('A detailed summary of the episode including key facts, context, and relevant details'),
+      categories: z
+        .array(z.string())
+        .describe(
+          'Categories to organize this episode (e.g., "life-event", "family", "work", "health", "travel", "preference", "story")',
+        ),
+      causalContext: z
+        .string()
+        .optional()
+        .describe('Why this happened or what led to this event/situation'),
+      spatialContext: z
+        .string()
+        .optional()
+        .describe('Where this occurred - location, place, or environment'),
+      relatedEpisodeIds: z
+        .array(z.string())
+        .optional()
+        .describe('IDs of other episodes that relate to this one'),
+      sequenceId: z
+        .string()
+        .optional()
+        .describe('ID to group episodes that are part of the same sequence or story'),
+      significance: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe('How significant/important this episode is (0-1, where 1 is most significant)'),
+      messageIds: z
+        .array(z.string())
+        .optional()
+        .describe('IDs of specific messages to link to this episode. If not provided, recent messages will be used'),
+    }),
+    execute: async (params: any) => {
+      const { context, memory, threadId, resourceId } = params;
+      const { title, shortSummary, detailedSummary, categories, causalContext, spatialContext, relatedEpisodeIds, sequenceId, significance, messageIds } = context;
+      if (!memory) {
+        throw new Error('Memory is required to create episodes');
+      }
+      if (!threadId || !resourceId) {
+        throw new Error('Thread ID and Resource ID are required to create episodes');
+      }
+
+      await memory.createEpisode({
+        resourceId,
+        threadId,
+        title,
+        shortSummary,
+        detailedSummary,
+        categories,
+        causalContext,
+        spatialContext,
+        relatedEpisodeIds,
+        sequenceId,
+        significance,
+        messageIds,
+      });
+
+      return {
+        success: true,
+        message: `Episode "${title}" created successfully`,
+      };
+    },
+  };
+};
+
+/**
+ * Tool for retrieving detailed information about a specific episode
+ */
+export const getEpisodeTool = (config?: MemoryConfig): CoreTool => {
+  return {
+    description: 'Retrieve detailed information about a specific memory episode',
+    parameters: z.object({
+      episodeId: z.string().describe('The ID of the episode to retrieve'),
+    }),
+    execute: async (params: any) => {
+      const { context, memory } = params;
+      const { episodeId } = context;
+      if (!memory) {
+        throw new Error('Memory is required to retrieve episodes');
+      }
+
+      const episode = await memory.getEpisode({ id: episodeId });
+
+      if (!episode) {
+        return {
+          error: 'Episode not found',
+        };
+      }
+
+      return {
+        episode: {
+          id: episode.id,
+          title: episode.title,
+          shortSummary: episode.shortSummary,
+          detailedSummary: episode.detailedSummary,
+          categories: episode.categories,
+          causalContext: episode.causalContext,
+          spatialContext: episode.spatialContext,
+          relatedEpisodeIds: episode.relatedEpisodeIds,
+          sequenceId: episode.sequenceId,
+          significance: episode.significance,
+          messageIds: episode.messageIds,
+          createdAt: episode.createdAt,
+          updatedAt: episode.updatedAt,
+          metadata: episode.metadata,
+        },
+      };
+    },
+  };
+};
+
+/**
+ * Tool for listing episodes with optional category filtering
+ */
+export const listEpisodesTool = (config?: MemoryConfig): CoreTool => {
+  return {
+    description: 'List memory episodes for the current user, optionally filtered by category',
+    parameters: z.object({
+      category: z
+        .string()
+        .optional()
+        .describe('Filter episodes by category (e.g., "family", "work", "travel")'),
+      limit: z.number().optional().default(10).describe('Maximum number of episodes to return'),
+    }),
+    execute: async (params: any) => {
+      const { context, memory, resourceId } = params;
+      const { category, limit } = context;
+      if (!memory) {
+        throw new Error('Memory is required to list episodes');
+      }
+      if (!resourceId) {
+        throw new Error('Resource ID is required to list episodes');
+      }
+
+      const episodes = await memory.listEpisodes({
+        resourceId,
+        category,
+        limit,
+      });
+
+      return {
+        episodes: episodes.map((ep: any) => ({
+          id: ep.id,
+          title: ep.title,
+          shortSummary: ep.shortSummary,
+          categories: ep.categories,
+          createdAt: ep.createdAt,
+        })),
+        total: episodes.length,
+      };
+    },
+  };
+};
+
+/**
+ * Tool for updating existing episodes
+ */
+export const updateEpisodeTool = (config?: MemoryConfig): CoreTool => {
+  return {
+    description: 'Update an existing memory episode with new information',
+    parameters: z.object({
+      episodeId: z.string().describe('The ID of the episode to update'),
+      title: z.string().optional().describe('New title for the episode'),
+      shortSummary: z.string().optional().describe('New short summary'),
+      detailedSummary: z.string().optional().describe('New detailed summary'),
+      categories: z.array(z.string()).optional().describe('New categories'),
+      causalContext: z.string().optional().describe('New causal context - why this happened'),
+      spatialContext: z.string().optional().describe('New spatial context - where this occurred'),
+      relatedEpisodeIds: z.array(z.string()).optional().describe('New related episode IDs'),
+      sequenceId: z.string().optional().describe('New sequence ID'),
+      significance: z.number().min(0).max(1).optional().describe('New significance score (0-1)'),
+      messageIds: z.array(z.string()).optional().describe('New message IDs to link'),
+    }),
+    execute: async (params: any) => {
+      const { context, memory } = params;
+      const { episodeId, ...updates } = context;
+      if (!memory) {
+        throw new Error('Memory is required to update episodes');
+      }
+
+      await memory.updateEpisode({
+        id: episodeId,
+        updates,
+      });
+
+      return {
+        success: true,
+        message: `Episode "${episodeId}" updated successfully`,
+      };
+    },
+  };
+};
+
+/**
+ * Tool for getting available episode categories
+ */
+export const getEpisodeCategoresTool = (config?: MemoryConfig): CoreTool => {
+  return {
+    description: 'Get the list of available episode categories for the current user',
+    parameters: z.object({}),
+    execute: async (params: any) => {
+      const { memory, resourceId } = params;
+      if (!memory) {
+        throw new Error('Memory is required to get categories');
+      }
+      if (!resourceId) {
+        throw new Error('Resource ID is required to get categories');
+      }
+
+      const categories = await memory.getEpisodeCategories({ resourceId });
+
+      return {
+        categories,
+        suggestedCategories: [
+          'life-event',
+          'family',
+          'work',
+          'health',
+          'travel',
+          'preference',
+          'story',
+          'hobby',
+          'relationship',
+          'achievement',
+        ],
+      };
+    },
+  };
+};
+
+/**
+ * Tool for linking episodes together
+ */
+export const linkEpisodesTool = (config?: MemoryConfig): CoreTool => {
+  return {
+    description: 'Link two memory episodes together with a relationship',
+    parameters: z.object({
+      episodeId1: z.string().describe('The ID of the first episode'),
+      episodeId2: z.string().describe('The ID of the second episode'),
+      relationshipType: z
+        .enum(['caused-by', 'leads-to', 'part-of', 'similar-to', 'related-to'])
+        .optional()
+        .default('related-to')
+        .describe('The type of relationship between the episodes'),
+    }),
+    execute: async (params: any) => {
+      const { context, memory } = params;
+      const { episodeId1, episodeId2, relationshipType } = context;
+      if (!memory) {
+        throw new Error('Memory is required to link episodes');
+      }
+
+      await memory.linkEpisodes({
+        episodeId1,
+        episodeId2,
+        relationshipType,
+      });
+
+      return {
+        success: true,
+        message: `Episodes linked successfully with relationship: ${relationshipType}`,
+      };
+    },
+  };
+};
+
+/**
+ * Tool for getting related episodes
+ */
+export const getRelatedEpisodesTool = (config?: MemoryConfig): CoreTool => {
+  return {
+    description: 'Get all episodes related to a specific episode',
+    parameters: z.object({
+      episodeId: z.string().describe('The ID of the episode to find relations for'),
+      includeIndirect: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe('Include episodes that are indirectly related (related to related episodes)'),
+    }),
+    execute: async (params: any) => {
+      const { context, memory } = params;
+      const { episodeId, includeIndirect } = context;
+      if (!memory) {
+        throw new Error('Memory is required to get related episodes');
+      }
+
+      const relatedEpisodes = await memory.getRelatedEpisodes({
+        episodeId,
+        includeIndirect,
+      });
+
+      return {
+        episodes: relatedEpisodes.map((ep: any) => ({
+          id: ep.id,
+          title: ep.title,
+          shortSummary: ep.shortSummary,
+          categories: ep.categories,
+          relationshipType: ep.metadata?.relationships?.[episodeId]?.type || 'related-to',
+        })),
+        total: relatedEpisodes.length,
+      };
+    },
+  };
+};

--- a/packages/memory/src/tools/episodic-memory.ts
+++ b/packages/memory/src/tools/episodic-memory.ts
@@ -7,7 +7,24 @@ import { z } from 'zod';
  */
 export const createEpisodeTool = (config?: MemoryConfig): CoreTool => {
   return {
-    description: 'Create a new memory episode to remember important information from this conversation',
+    description: `Create a new memory episode to remember important information from this conversation.
+
+Category Guidelines:
+- Life Events: "life-event", "milestone", "achievement"
+- Personal: "family", "relationship", "personal"
+- Professional: "work", "career", "education"
+- Health: "health", "medical", "fitness", "important"
+- Interests: "hobbies", "preferences", "goals"
+- Other: "travel", "financial", "story"
+
+Significance Scoring:
+- 1.0: Critical information (allergies, medical conditions)
+- 0.8-0.9: Major life events (job changes, moves)
+- 0.6-0.7: Important preferences or recurring activities
+- 0.4-0.5: Notable but less critical information
+- 0.2-0.3: Minor details worth remembering
+
+Create episodes when users share significant life events, stories, preferences, or important facts.`,
     parameters: z.object({
       title: z.string().describe('A concise, descriptive title for this episode'),
       shortSummary: z
@@ -19,7 +36,7 @@ export const createEpisodeTool = (config?: MemoryConfig): CoreTool => {
       categories: z
         .array(z.string())
         .describe(
-          'Categories to organize this episode (e.g., "life-event", "family", "work", "health", "travel", "preference", "story")',
+          'Categories to organize this episode. Use consistent categories like: life-event, family, work, health, travel, preference, story, hobby, relationship, achievement, milestone, medical, fitness, career, education, financial',
         ),
       causalContext: z.string().optional().describe('Why this happened or what led to this event/situation'),
       spatialContext: z.string().optional().describe('Where this occurred - location, place, or environment'),
@@ -30,7 +47,7 @@ export const createEpisodeTool = (config?: MemoryConfig): CoreTool => {
         .min(0)
         .max(1)
         .optional()
-        .describe('How significant/important this episode is (0-1, where 1 is most significant)'),
+        .describe('How significant/important this episode is. Use: 1.0 for critical info (allergies), 0.8-0.9 for major life events, 0.6-0.7 for important preferences, 0.4-0.5 for notable info, 0.2-0.3 for minor details'),
       messageIds: z
         .array(z.string())
         .optional()
@@ -247,7 +264,16 @@ export const getEpisodeCategoresTool = (config?: MemoryConfig): CoreTool => {
  */
 export const linkEpisodesTool = (config?: MemoryConfig): CoreTool => {
   return {
-    description: 'Link two memory episodes together with a relationship',
+    description: `Link two memory episodes together with a relationship.
+
+Relationship Types:
+- "caused-by": One event led to another (e.g., "moved to SF" caused-by "got job at TechCorp")
+- "leads-to": Expected future consequence (e.g., "started training" leads-to "run marathon")
+- "part-of": Component of a larger event (e.g., "visited Louvre" part-of "Paris vacation")
+- "similar-to": Related but distinct events (e.g., two different promotions)
+- "related-to": General relationship (default for other connections)
+
+Use relationships to build a knowledge graph of the user's experiences and connect cause-effect chains.`,
     parameters: z.object({
       episodeId1: z.string().describe('The ID of the first episode'),
       episodeId2: z.string().describe('The ID of the second episode'),

--- a/packages/memory/src/tools/episodic-memory.ts
+++ b/packages/memory/src/tools/episodic-memory.ts
@@ -21,22 +21,10 @@ export const createEpisodeTool = (config?: MemoryConfig): CoreTool => {
         .describe(
           'Categories to organize this episode (e.g., "life-event", "family", "work", "health", "travel", "preference", "story")',
         ),
-      causalContext: z
-        .string()
-        .optional()
-        .describe('Why this happened or what led to this event/situation'),
-      spatialContext: z
-        .string()
-        .optional()
-        .describe('Where this occurred - location, place, or environment'),
-      relatedEpisodeIds: z
-        .array(z.string())
-        .optional()
-        .describe('IDs of other episodes that relate to this one'),
-      sequenceId: z
-        .string()
-        .optional()
-        .describe('ID to group episodes that are part of the same sequence or story'),
+      causalContext: z.string().optional().describe('Why this happened or what led to this event/situation'),
+      spatialContext: z.string().optional().describe('Where this occurred - location, place, or environment'),
+      relatedEpisodeIds: z.array(z.string()).optional().describe('IDs of other episodes that relate to this one'),
+      sequenceId: z.string().optional().describe('ID to group episodes that are part of the same sequence or story'),
       significance: z
         .number()
         .min(0)
@@ -50,7 +38,18 @@ export const createEpisodeTool = (config?: MemoryConfig): CoreTool => {
     }),
     execute: async (params: any) => {
       const { context, memory, threadId, resourceId } = params;
-      const { title, shortSummary, detailedSummary, categories, causalContext, spatialContext, relatedEpisodeIds, sequenceId, significance, messageIds } = context;
+      const {
+        title,
+        shortSummary,
+        detailedSummary,
+        categories,
+        causalContext,
+        spatialContext,
+        relatedEpisodeIds,
+        sequenceId,
+        significance,
+        messageIds,
+      } = context;
       if (!memory) {
         throw new Error('Memory is required to create episodes');
       }
@@ -134,10 +133,7 @@ export const listEpisodesTool = (config?: MemoryConfig): CoreTool => {
   return {
     description: 'List memory episodes for the current user, optionally filtered by category',
     parameters: z.object({
-      category: z
-        .string()
-        .optional()
-        .describe('Filter episodes by category (e.g., "family", "work", "travel")'),
+      category: z.string().optional().describe('Filter episodes by category (e.g., "family", "work", "travel")'),
       limit: z.number().optional().default(10).describe('Maximum number of episodes to return'),
     }),
     execute: async (params: any) => {

--- a/stores/_test-utils/src/default-tests.ts
+++ b/stores/_test-utils/src/default-tests.ts
@@ -3,7 +3,13 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from
 import type { MetricResult } from '@mastra/core/eval';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import type { MastraStorage, StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
-import { TABLE_WORKFLOW_SNAPSHOT, TABLE_EVALS, TABLE_MESSAGES, TABLE_THREADS, TABLE_EPISODES } from '@mastra/core/storage';
+import {
+  TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_EVALS,
+  TABLE_MESSAGES,
+  TABLE_THREADS,
+  TABLE_EPISODES,
+} from '@mastra/core/storage';
 import { MastraMessageV1, MastraMessageV2, StorageThreadType, StorageEpisodeType } from '@mastra/core';
 import { MastraMessageContentV2 } from '@mastra/core/agent';
 
@@ -217,7 +223,7 @@ export function createTestSuite(storage: MastraStorage) {
       await storage.clearTable({ tableName: TABLE_EVALS });
       await storage.clearTable({ tableName: TABLE_MESSAGES });
       await storage.clearTable({ tableName: TABLE_THREADS });
-      
+
       // Clear episodes table if supported
       if (storage.supports.resourceEpisodicMemory) {
         await storage.clearTable({ tableName: TABLE_EPISODES });
@@ -230,7 +236,7 @@ export function createTestSuite(storage: MastraStorage) {
       await storage.clearTable({ tableName: TABLE_EVALS });
       await storage.clearTable({ tableName: TABLE_MESSAGES });
       await storage.clearTable({ tableName: TABLE_THREADS });
-      
+
       // Clear episodes table if supported
       if (storage.supports.resourceEpisodicMemory) {
         await storage.clearTable({ tableName: TABLE_EPISODES });
@@ -1617,10 +1623,10 @@ export function createTestSuite(storage: MastraStorage) {
         }
 
         const episode = createSampleEpisode();
-        
+
         // Save episode
         await storage.saveEpisode({ episode });
-        
+
         // Retrieve episode
         const retrieved = await storage.getEpisodeById({ id: episode.id });
         expect(retrieved).toBeTruthy();
@@ -1647,12 +1653,12 @@ export function createTestSuite(storage: MastraStorage) {
           createSampleEpisode({ resourceId }),
           createSampleEpisode({ resourceId: `other-${randomUUID()}` }), // Different resource
         ];
-        
+
         // Save all episodes
         for (const episode of episodes) {
           await storage.saveEpisode({ episode });
         }
-        
+
         // Get episodes for specific resource
         const resourceEpisodes = await storage.getEpisodesByResourceId({ resourceId });
         expect(resourceEpisodes).toHaveLength(3);
@@ -1670,22 +1676,22 @@ export function createTestSuite(storage: MastraStorage) {
           createSampleEpisode({ resourceId, date: new Date() }),
           createSampleEpisode({ resourceId, date: new Date() }),
         ];
-        
+
         // Modify categories
         episodes[0].categories = ['work', 'important'];
         episodes[1].categories = ['personal', 'family'];
         episodes[2].categories = ['work', 'meeting'];
-        
+
         // Save all episodes
         for (const episode of episodes) {
           await storage.saveEpisode({ episode });
         }
-        
+
         // Get episodes by category
         const workEpisodes = await storage.getEpisodesByCategory({ resourceId, category: 'work' });
         expect(workEpisodes).toHaveLength(2);
         expect(workEpisodes.every(ep => ep.categories.includes('work'))).toBe(true);
-        
+
         const familyEpisodes = await storage.getEpisodesByCategory({ resourceId, category: 'family' });
         expect(familyEpisodes).toHaveLength(1);
         expect(familyEpisodes[0].categories).toContain('family');
@@ -1698,7 +1704,7 @@ export function createTestSuite(storage: MastraStorage) {
 
         const episode = createSampleEpisode();
         await storage.saveEpisode({ episode });
-        
+
         // Update episode
         const updates = {
           title: 'Updated Title',
@@ -1706,9 +1712,9 @@ export function createTestSuite(storage: MastraStorage) {
           categories: ['updated', 'test'],
           significance: 0.9,
         };
-        
+
         await storage.updateEpisode({ id: episode.id, updates });
-        
+
         // Verify updates
         const updated = await storage.getEpisodeById({ id: episode.id });
         expect(updated?.title).toBe(updates.title);
@@ -1731,17 +1737,17 @@ export function createTestSuite(storage: MastraStorage) {
           createSampleEpisode({ resourceId }),
           createSampleEpisode({ resourceId }),
         ];
-        
+
         // Set different categories
         episodes[0].categories = ['work', 'meeting'];
         episodes[1].categories = ['personal', 'health'];
         episodes[2].categories = ['work', 'project', 'meeting'];
-        
+
         // Save all episodes
         for (const episode of episodes) {
           await storage.saveEpisode({ episode });
         }
-        
+
         // Get all categories for resource
         const categories = await storage.getCategoriesForResource({ resourceId });
         expect(categories).toContain('work');
@@ -1781,21 +1787,21 @@ export function createTestSuite(storage: MastraStorage) {
         const episode1 = createSampleEpisode();
         const episode2 = createSampleEpisode();
         const episode3 = createSampleEpisode();
-        
+
         // Set up relationships
         episode1.relatedEpisodeIds = [episode2.id, episode3.id];
         episode2.relatedEpisodeIds = [episode1.id];
-        
+
         // Save episodes
         await storage.saveEpisode({ episode: episode1 });
         await storage.saveEpisode({ episode: episode2 });
         await storage.saveEpisode({ episode: episode3 });
-        
+
         // Verify relationships are stored
         const retrieved1 = await storage.getEpisodeById({ id: episode1.id });
         expect(retrieved1?.relatedEpisodeIds).toContain(episode2.id);
         expect(retrieved1?.relatedEpisodeIds).toContain(episode3.id);
-        
+
         const retrieved2 = await storage.getEpisodeById({ id: episode2.id });
         expect(retrieved2?.relatedEpisodeIds).toContain(episode1.id);
       });
@@ -1807,29 +1813,29 @@ export function createTestSuite(storage: MastraStorage) {
 
         const resourceId = `resource-${randomUUID()}`;
         const sequenceId = `sequence-${randomUUID()}`;
-        
+
         const episodes = [
           createSampleEpisode({ resourceId, date: new Date('2024-01-01') }),
           createSampleEpisode({ resourceId, date: new Date('2024-01-02') }),
           createSampleEpisode({ resourceId, date: new Date('2024-01-03') }),
           createSampleEpisode({ resourceId, date: new Date('2024-01-04') }), // Not in sequence
         ];
-        
+
         // Assign sequence to first 3 episodes
         episodes[0].sequenceId = sequenceId;
         episodes[1].sequenceId = sequenceId;
         episodes[2].sequenceId = sequenceId;
         episodes[3].sequenceId = undefined;
-        
+
         // Save all episodes
         for (const episode of episodes) {
           await storage.saveEpisode({ episode });
         }
-        
+
         // Retrieve all episodes and filter by sequence
         const allEpisodes = await storage.getEpisodesByResourceId({ resourceId });
         const sequenceEpisodes = allEpisodes.filter(ep => ep.sequenceId === sequenceId);
-        
+
         expect(sequenceEpisodes).toHaveLength(3);
         expect(sequenceEpisodes.every(ep => ep.sequenceId === sequenceId)).toBe(true);
       });

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -13,6 +13,7 @@ import {
   TABLE_THREADS,
   TABLE_TRACES,
   TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_EPISODES,
 } from '@mastra/core/storage';
 import type {
   EvalRow,
@@ -28,7 +29,7 @@ import type {
 import type { Trace } from '@mastra/core/telemetry';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 
-type SUPPORTED_TABLE_NAMES = Exclude<TABLE_NAMES, typeof TABLE_RESOURCES>;
+type SUPPORTED_TABLE_NAMES = Exclude<TABLE_NAMES, typeof TABLE_RESOURCES | typeof TABLE_EPISODES>;
 
 function safelyParseJSON(jsonString: string): any {
   try {

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -1,5 +1,5 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
-import type { StorageThreadType, MastraMessageV2 } from '@mastra/core/memory';
+import type { StorageThreadType, MastraMessageV2, StorageEpisodeType } from '@mastra/core/memory';
 import type {
   TABLE_MESSAGES,
   TABLE_THREADS,
@@ -7,6 +7,7 @@ import type {
   TABLE_EVALS,
   TABLE_TRACES,
   TABLE_RESOURCES,
+  TABLE_EPISODES,
   TABLE_NAMES,
   EvalRow,
   StorageResourceType,
@@ -74,6 +75,7 @@ export type RecordTypes = {
   [TABLE_EVALS]: EvalRow;
   [TABLE_TRACES]: any;
   [TABLE_RESOURCES]: StorageResourceType;
+  [TABLE_EPISODES]: StorageEpisodeType;
 };
 
 export type ListOptions = {

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -12,6 +12,7 @@ import {
   TABLE_WORKFLOW_SNAPSHOT,
   TABLE_EVALS,
   TABLE_TRACES,
+  TABLE_EPISODES,
 } from '@mastra/core/storage';
 import type {
   EvalRow,
@@ -39,7 +40,7 @@ export interface DynamoDBStoreConfig {
   };
 }
 
-type SUPPORTED_TABLE_NAMES = Exclude<TABLE_NAMES, typeof TABLE_RESOURCES>;
+type SUPPORTED_TABLE_NAMES = Exclude<TABLE_NAMES, typeof TABLE_RESOURCES | typeof TABLE_EPISODES>;
 
 // Define a type for our service that allows string indexing
 type MastraService = Service<Record<string, any>> & {

--- a/stores/libsql/src/storage/index.test.ts
+++ b/stores/libsql/src/storage/index.test.ts
@@ -604,9 +604,9 @@ describe('LibSQLStore Episode Features', () => {
       episode.categories = ['work', 'important', 'milestone'];
       episode.messageIds = ['msg-1', 'msg-2', 'msg-3'];
       episode.relatedEpisodeIds = ['ep-1', 'ep-2'];
-      
+
       await store.saveEpisode({ episode });
-      
+
       const retrieved = await store.getEpisodeById({ id: episode.id });
       expect(retrieved).toBeTruthy();
       expect(Array.isArray(retrieved!.categories)).toBe(true);
@@ -622,9 +622,9 @@ describe('LibSQLStore Episode Features', () => {
       episode.categories = [];
       episode.messageIds = [];
       episode.relatedEpisodeIds = [];
-      
+
       await store.saveEpisode({ episode });
-      
+
       const retrieved = await store.getEpisodeById({ id: episode.id });
       expect(retrieved!.categories).toEqual([]);
       expect(retrieved!.messageIds).toEqual([]);
@@ -642,9 +642,9 @@ describe('LibSQLStore Episode Features', () => {
         },
         timestamp: new Date().toISOString(),
       };
-      
+
       await store.saveEpisode({ episode });
-      
+
       const retrieved = await store.getEpisodeById({ id: episode.id });
       expect(retrieved!.metadata).toEqual(episode.metadata);
     });
@@ -655,9 +655,9 @@ describe('LibSQLStore Episode Features', () => {
       const resourceId = `resource-${randomUUID()}`;
       const episode = createSampleEpisode({ resourceId });
       episode.categories = ['work', 'project'];
-      
+
       await store.saveEpisode({ episode });
-      
+
       // Check resource was created with categories
       const resource = await store.getResourceById({ resourceId });
       expect(resource).toBeTruthy();
@@ -668,17 +668,17 @@ describe('LibSQLStore Episode Features', () => {
 
     it('should update resource categories when new categories are added', async () => {
       const resourceId = `resource-${randomUUID()}`;
-      
+
       // Save first episode
       const episode1 = createSampleEpisode({ resourceId });
       episode1.categories = ['work', 'meeting'];
       await store.saveEpisode({ episode: episode1 });
-      
+
       // Save second episode with new categories
       const episode2 = createSampleEpisode({ resourceId });
       episode2.categories = ['personal', 'meeting']; // 'meeting' is duplicate
       await store.saveEpisode({ episode: episode2 });
-      
+
       // Check categories are properly merged
       const categories = await store.getCategoriesForResource({ resourceId });
       expect(categories).toContain('work');
@@ -691,15 +691,15 @@ describe('LibSQLStore Episode Features', () => {
       const resourceId = `resource-${randomUUID()}`;
       const episode = createSampleEpisode({ resourceId });
       episode.categories = ['work'];
-      
+
       await store.saveEpisode({ episode });
-      
+
       // Update episode with new categories
       await store.updateEpisode({
         id: episode.id,
         updates: { categories: ['personal', 'health'] },
       });
-      
+
       // Check categories were updated
       const categories = await store.getCategoriesForResource({ resourceId });
       expect(categories).toContain('work'); // Original still there
@@ -711,12 +711,12 @@ describe('LibSQLStore Episode Features', () => {
   describe('Episode update error handling', () => {
     it('should throw error when updating non-existent episode', async () => {
       const nonExistentId = `episode-${randomUUID()}`;
-      
+
       await expect(
         store.updateEpisode({
           id: nonExistentId,
           updates: { title: 'New Title' },
-        })
+        }),
       ).rejects.toThrow('EPISODE_NOT_FOUND');
     });
   });
@@ -724,25 +724,21 @@ describe('LibSQLStore Episode Features', () => {
   describe('Episode ordering', () => {
     it('should return episodes ordered by createdAt descending', async () => {
       const resourceId = `resource-${randomUUID()}`;
-      const dates = [
-        new Date('2024-01-01'),
-        new Date('2024-01-03'),
-        new Date('2024-01-02'),
-      ];
-      
-      const episodes = dates.map((date, i) => 
-        createSampleEpisode({ 
-          resourceId, 
+      const dates = [new Date('2024-01-01'), new Date('2024-01-03'), new Date('2024-01-02')];
+
+      const episodes = dates.map((date, i) =>
+        createSampleEpisode({
+          resourceId,
           date,
           id: `episode-${i}`,
-        })
+        }),
       );
-      
+
       // Save in random order
       for (const episode of episodes) {
         await store.saveEpisode({ episode });
       }
-      
+
       // Get episodes - should be ordered by createdAt desc
       const retrieved = await store.getEpisodesByResourceId({ resourceId });
       expect(retrieved).toHaveLength(3);
@@ -757,13 +753,13 @@ describe('LibSQLStore Episode Features', () => {
       const resourceId = `resource-${randomUUID()}`;
       const episode = createSampleEpisode({ resourceId });
       episode.categories = ['Work', 'IMPORTANT', 'MileStone'];
-      
+
       await store.saveEpisode({ episode });
-      
+
       // Exact case match
       const workEpisodes = await store.getEpisodesByCategory({ resourceId, category: 'Work' });
       expect(workEpisodes).toHaveLength(1);
-      
+
       // Different case - should not match
       const workLowercase = await store.getEpisodesByCategory({ resourceId, category: 'work' });
       expect(workLowercase).toHaveLength(0);
@@ -771,32 +767,32 @@ describe('LibSQLStore Episode Features', () => {
 
     it('should filter episodes with JSON_EACH correctly', async () => {
       const resourceId = `resource-${randomUUID()}`;
-      
+
       // Create episodes with overlapping categories
       const episodes = [
         createSampleEpisode({ resourceId }),
         createSampleEpisode({ resourceId }),
         createSampleEpisode({ resourceId }),
       ];
-      
+
       episodes[0].categories = ['alpha', 'beta'];
       episodes[1].categories = ['beta', 'gamma'];
       episodes[2].categories = ['gamma', 'delta'];
-      
+
       for (const episode of episodes) {
         await store.saveEpisode({ episode });
       }
-      
+
       // Test each category
       const alphaEpisodes = await store.getEpisodesByCategory({ resourceId, category: 'alpha' });
       expect(alphaEpisodes).toHaveLength(1);
-      
+
       const betaEpisodes = await store.getEpisodesByCategory({ resourceId, category: 'beta' });
       expect(betaEpisodes).toHaveLength(2);
-      
+
       const gammaEpisodes = await store.getEpisodesByCategory({ resourceId, category: 'gamma' });
       expect(gammaEpisodes).toHaveLength(2);
-      
+
       const deltaEpisodes = await store.getEpisodesByCategory({ resourceId, category: 'delta' });
       expect(deltaEpisodes).toHaveLength(1);
     });

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1553,7 +1553,7 @@ export class LibSQLStore extends MastraStorage {
   private async _updateResourceCategories(resourceId: string, newCategories: string[]): Promise<void> {
     // Get or create resource
     let resource = await this.getResourceById({ resourceId });
-    
+
     if (!resource) {
       // Create resource if it doesn't exist
       resource = await this.saveResource({
@@ -1570,7 +1570,7 @@ export class LibSQLStore extends MastraStorage {
       // Update existing resource with new categories
       const existingCategories = (resource.metadata?.episodeCategories || []) as string[];
       const allCategories = [...new Set([...existingCategories, ...newCategories])];
-      
+
       await this.updateResource({
         resourceId,
         metadata: {
@@ -1595,12 +1595,22 @@ export class LibSQLStore extends MastraStorage {
       ...result,
       categories: typeof result.categories === 'string' ? JSON.parse(result.categories) : result.categories,
       messageIds: typeof result.messageIds === 'string' ? JSON.parse(result.messageIds) : result.messageIds,
-      relatedEpisodeIds: result.relatedEpisodeIds ? 
-        (typeof result.relatedEpisodeIds === 'string' ? JSON.parse(result.relatedEpisodeIds) : result.relatedEpisodeIds) : undefined,
-      relationships: result.relationships ? 
-        (typeof result.relationships === 'string' ? JSON.parse(result.relationships) : result.relationships) : undefined,
+      relatedEpisodeIds: result.relatedEpisodeIds
+        ? typeof result.relatedEpisodeIds === 'string'
+          ? JSON.parse(result.relatedEpisodeIds)
+          : result.relatedEpisodeIds
+        : undefined,
+      relationships: result.relationships
+        ? typeof result.relationships === 'string'
+          ? JSON.parse(result.relationships)
+          : result.relationships
+        : undefined,
       significance: result.significance ? parseFloat(result.significance) : undefined,
-      metadata: result.metadata ? (typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata) : undefined,
+      metadata: result.metadata
+        ? typeof result.metadata === 'string'
+          ? JSON.parse(result.metadata)
+          : result.metadata
+        : undefined,
       createdAt: new Date(result.createdAt),
       updatedAt: new Date(result.updatedAt),
     };
@@ -1633,7 +1643,13 @@ export class LibSQLStore extends MastraStorage {
     }));
   }
 
-  async getEpisodesByCategory({ resourceId, category }: { resourceId: string; category: string }): Promise<StorageEpisodeType[]> {
+  async getEpisodesByCategory({
+    resourceId,
+    category,
+  }: {
+    resourceId: string;
+    category: string;
+  }): Promise<StorageEpisodeType[]> {
     const result = await this.client.execute({
       sql: `SELECT * FROM ${TABLE_EPISODES} WHERE resourceId = ? AND EXISTS (
         SELECT 1 FROM json_each(categories) WHERE value = ?
@@ -1746,7 +1762,7 @@ export class LibSQLStore extends MastraStorage {
       sql: `UPDATE ${TABLE_EPISODES} SET ${updateFields.join(', ')} WHERE id = ?`,
       args: values,
     });
-    
+
     // Update resource categories if episode categories were updated
     if (updates.categories !== undefined && updates.categories.length > 0) {
       await this._updateResourceCategories(existingEpisode.resourceId, updates.categories);

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -129,10 +129,12 @@ export class MSSQLStore extends MastraStorage {
   public get supports(): {
     selectByIncludeResourceScope: boolean;
     resourceWorkingMemory: boolean;
+    resourceEpisodicMemory: boolean;
   } {
     return {
       selectByIncludeResourceScope: true,
       resourceWorkingMemory: true,
+      resourceEpisodicMemory: false,
     };
   }
 

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -104,10 +104,12 @@ export class PostgresStore extends MastraStorage {
   public get supports(): {
     selectByIncludeResourceScope: boolean;
     resourceWorkingMemory: boolean;
+    resourceEpisodicMemory: boolean;
   } {
     return {
       selectByIncludeResourceScope: true,
       resourceWorkingMemory: true,
+      resourceEpisodicMemory: false,
     };
   }
 

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -46,10 +46,12 @@ export class UpstashStore extends MastraStorage {
   public get supports(): {
     selectByIncludeResourceScope: boolean;
     resourceWorkingMemory: boolean;
+    resourceEpisodicMemory: boolean;
   } {
     return {
       selectByIncludeResourceScope: true,
       resourceWorkingMemory: true,
+      resourceEpisodicMemory: false,
     };
   }
 


### PR DESCRIPTION
  Introduces episodic memory to Mastra, enabling agents to create and recall long-term episodic memories that persist across all conversations with a user.

  What's new

  - Episode storage: Agents can now store significant events, facts, and experiences as structured episodes
  - Rich context: Episodes include causal context (why things happened), spatial context (where they occurred), and significance scoring
  - Relationship management: Episodes can be linked with typed relationships (caused-by, leads-to, part-of, similar-to, related-to)
  - Agent tools: Seven new tools for creating, updating, and querying episodes (vibe coded this, seems like too many, will probably slim this down)
  - Automatic context: Most significant episodes are included in agent system messages

  Configuration
```ts
  const memory = new Memory({
    options: {
      episodicMemory: {
        enabled: true,
        lastEpisodes: 5, // Number of episodes in context
      },
    },
  });
```
  Implementation

  - Full episodic memory support in LibSQL storage adapter
  - Integration tests and comprehensive documentation
  - API designed to extend to other storage adapters

