### PR TITLE
Fixed conflict between PRs that left reference to deprecated tools va…

### DIFF
--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -389,7 +389,7 @@ export async function createHonoServer(
   // Log routes
   app.route('/api/logs', logsRouter());
   // Tool routes
-  app.route('/api/tools', toolsRouter(bodyLimitOptions, tools));
+  app.route('/api/tools', toolsRouter(bodyLimitOptions, options.tools));
   // Vector routes
   app.route('/api/vector', vectorRouter(bodyLimitOptions));
 


### PR DESCRIPTION
…riable

## Description

Fixed an issue caused by two PRs being made to the deployer server in tandem resulting in one of the routes referencing a global `tools` variable that no longer exists.

## Related Issue(s)

Reported in Slack.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
