### PR TITLE
[core] Fix/generate return types inference

### DIFF
--- a/.changeset/easy-bushes-tickle.md
+++ b/.changeset/easy-bushes-tickle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+fix: GenerateReturn type

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2027,7 +2027,9 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       });
 
       await after({
-        result,
+        result: result as unknown as OUTPUT extends undefined
+        ? GenerateTextResult<any, EXPERIMENTAL_OUTPUT>
+        : GenerateObjectResult<OUTPUT>,
         outputText: result.text,
       });
 
@@ -2044,7 +2046,9 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     const outputText = JSON.stringify(result.object);
 
     await after({
-      result,
+      result: result as unknown as OUTPUT extends undefined
+        ? GenerateTextResult<any, EXPERIMENTAL_OUTPUT>
+        : GenerateObjectResult<OUTPUT>,
       outputText,
       structuredOutput: true,
     });

--- a/packages/core/src/llm/model/base.types.ts
+++ b/packages/core/src/llm/model/base.types.ts
@@ -116,7 +116,9 @@ export type GenerateReturn<
   Tools extends ToolSet,
   Output extends ZodSchema | JSONSchema7 | undefined = undefined,
   StructuredOutput extends ZodSchema | JSONSchema7 | undefined = undefined,
-> = GenerateTextResult<Tools, StructuredOutput> | GenerateObjectResult<Output>;
+> = Output extends undefined
+  ? GenerateTextResult<Tools, StructuredOutput>
+  : GenerateObjectResult<Output>;
 // #endregion
 
 // #region streamText

--- a/packages/core/src/network/network.ts
+++ b/packages/core/src/network/network.ts
@@ -395,7 +395,7 @@ export class AgentNetwork extends MastraBase {
     this.logger.debug(`AgentNetwork: Routing with max steps: ${ops.maxSteps}`);
 
     // Generate a response using the routing agent
-    const result: GenerateReturn<any, OUTPUT, EXPERIMENTAL_OUTPUT> = await this.#routingAgent.generate(
+    const result = await this.#routingAgent.generate(
       messages,
       ops as AgentGenerateOptions<OUTPUT, EXPERIMENTAL_OUTPUT> & { output?: never; experimental_output?: never },
     );
@@ -403,7 +403,7 @@ export class AgentNetwork extends MastraBase {
     // Log completion
     this.logger.debug(`AgentNetwork: Generation complete with ${result.steps?.length || 0} steps`);
 
-    return result;
+    return result as unknown as GenerateReturn<any, OUTPUT, EXPERIMENTAL_OUTPUT>;
   }
 
   async stream<


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

The GenerateReturn type has been modified in this PR.
https://github.com/mastra-ai/mastra/pull/5965

before
```ts
export type GenerateReturn<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = Z extends undefined
  ? GenerateTextResult<any, Z extends ZodSchema ? z.infer<Z> : unknown>
  : GenerateObjectResult<Z extends ZodSchema ? z.infer<Z> : unknown>;
```

after
```ts
export type GenerateReturn<
  Tools extends ToolSet,
  Output extends ZodSchema | JSONSchema7 | undefined = undefined,
  StructuredOutput extends ZodSchema | JSONSchema7 | undefined = undefined,
> = GenerateTextResult<Tools, StructuredOutput> | GenerateObjectResult<Output>;
```

After the change, the return type could be GenerateTextResult even if Output is specified (in fact, it should be GenerateObjectResult<Output>).

This PR implements proper type inference by conditional type.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
https://discord.com/channels/1309558646228779139/1397597453523620008
Fixes #6231

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
