### PR TITLE
fix: don't send content-type header when body is FormData

### DIFF
--- a/.changeset/flat-melons-attend.md
+++ b/.changeset/flat-melons-attend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Should not send content type if body instance of FormData

--- a/client-sdks/client-js/src/resources/base.ts
+++ b/client-sdks/client-js/src/resources/base.ts
@@ -24,7 +24,9 @@ export class BaseResource {
         const response = await fetch(`${baseUrl.replace(/\/$/, '')}${path}`, {
           ...options,
           headers: {
-            ...(options.body && (options.method === 'POST' || options.method === 'PUT')
+            ...(options.body &&
+            !(options.body instanceof FormData) &&
+            (options.method === 'POST' || options.method === 'PUT')
               ? { 'content-type': 'application/json' }
               : {}),
             ...headers,


### PR DESCRIPTION
## Summary
- Fixed an issue where Content-Type header was being sent when the body is an instance of FormData
- FormData automatically sets the correct Content-Type with boundary, so setting it manually causes issues

## Test plan
- [x] Verify that requests with FormData bodies work correctly
- [x] Ensure other request types still receive appropriate Content-Type headers
- [x] Test multipart form uploads

Fixes #6061