### PR TITLE
fix: Added embedder to memory-with-pg example

### DIFF
--- a/examples/memory-with-pg/src/mastra/agents/index.ts
+++ b/examples/memory-with-pg/src/mastra/agents/index.ts
@@ -26,6 +26,7 @@ export const memory = new Memory({
       messageRange: 2,
     },
   },
+  embedder: openai.embedding('text-embedding-3-small'),
 });
 
 export const chefAgent = new Agent({


### PR DESCRIPTION
## Description

I noticed while working on another issue that the `memory-with-pg` example was outdated and wouldn't run without modification, as it had semantic recall enabled but no embedder. This simply adds an embedder to the example.

## Related Issue(s)

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
