### PR TITLE
Scorer Fast Follow

### DIFF
--- a/.changeset/eager-deer-play.md
+++ b/.changeset/eager-deer-play.md
@@ -1,0 +1,7 @@
+---
+'@mastra/evals': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Fast follow scorers fixing input types, improve llm scorer reliability, fix ui to display scores that are 0

--- a/packages/cli/src/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/cli/src/playground/src/pages/scorers/scorer/index.tsx
@@ -376,7 +376,7 @@ function ScoreItem({
   const timeStr = format(new Date(score.createdAt), 'h:mm:ss bb');
   const inputPrev = score?.input?.[0]?.content || score?.input?.[0]?.ingredient || '';
   const outputPrev = score?.output?.text || score?.output?.object?.result || '';
-  const scorePrev = score?.score ? Math.round(score?.score * 100) / 100 : 'n/a';
+  const scorePrev = score?.score ? Math.round(score?.score * 100) / 100 : '0';
   const entityIcon = score?.entityType === 'WORKFLOW' ? <WorkflowIcon /> : <AgentIcon />; // score?.score?.toFixed(2) || `N/A`;
 
   return (
@@ -488,7 +488,7 @@ function ScoreDetails({
               <em>
                 Score <ArrowRightIcon />
               </em>
-              <b>{score?.score || 'n/a'}</b>
+              <b>{score?.score ?? 'n/a'}</b>
               <em>
                 Reason <ArrowRightIcon />
               </em>

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,6 +1,6 @@
 import type { Metric, MetricResult } from '../eval/metric';
 import type { TestInfo } from '../eval/types';
-import type { ScoringInput } from '../scores';
+import type { ScoringHookInput } from '../scores';
 
 import mitt from './mitt';
 import type { Handler } from './mitt';
@@ -36,14 +36,14 @@ type GenerationHookData = {
 
 export function registerHook(hook: AvailableHooks.ON_EVALUATION, action: Handler<EvaluationHookData>): void;
 export function registerHook(hook: AvailableHooks.ON_GENERATION, action: Handler<GenerationHookData>): void;
-export function registerHook(hook: AvailableHooks.ON_SCORER_RUN, action: Handler<ScoringInput>): void;
+export function registerHook(hook: AvailableHooks.ON_SCORER_RUN, action: Handler<ScoringHookInput>): void;
 export function registerHook(hook: `${AvailableHooks}`, action: Handler<any>): void {
   hooks.on(hook, action);
 }
 
 export function executeHook(hook: AvailableHooks.ON_EVALUATION, action: EvaluationHookData): void;
 export function executeHook(hook: AvailableHooks.ON_GENERATION, action: GenerationHookData): void;
-export function executeHook(hook: AvailableHooks.ON_SCORER_RUN, action: ScoringInput): void;
+export function executeHook(hook: AvailableHooks.ON_SCORER_RUN, action: ScoringHookInput): void;
 export function executeHook(hook: `${AvailableHooks}`, data: unknown): void {
   // do not block the main thread
   setImmediate(() => {

--- a/packages/core/src/mastra/hooks.ts
+++ b/packages/core/src/mastra/hooks.ts
@@ -1,9 +1,9 @@
 import type { Mastra } from '..';
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
-import type { ScoringInput } from '../scores';
+import type { ScoringHookInput } from '../scores';
 
 export function createOnScorerHook(mastra: Mastra) {
-  return async (hookData: ScoringInput) => {
+  return async (hookData: ScoringHookInput) => {
     if (!mastra.getStorage()) {
       return;
     }
@@ -51,10 +51,10 @@ export function createOnScorerHook(mastra: Mastra) {
       output,
     });
 
-    const { structuredOutput, ...rest } = score;
-
+    const { structuredOutput, ...rest } = hookData;
     await storage?.saveScore({
       ...rest,
+      ...score,
       entityId,
       scorerId: hookData.scorer.id,
       metadata: {

--- a/packages/core/src/scores/base.test.ts
+++ b/packages/core/src/scores/base.test.ts
@@ -25,19 +25,10 @@ describe('MastraScorer', () => {
     // Base scoring input for tests
     baseScoringInput = {
       runId: 'test-run-id',
-      scorer: { name: 'test-scorer' },
       input: [{ message: 'test input' }],
       output: { response: 'test output' },
-      metadata: { version: '1.0' },
       additionalContext: { context: 'test' },
-      source: 'TEST',
-      entity: { id: 'entity-1' },
-      entityType: 'AGENT',
       runtimeContext: { runtime: 'test' },
-      structuredOutput: true,
-      traceId: 'trace-123',
-      resourceId: 'resource-123',
-      threadId: 'thread-123',
     };
   });
 
@@ -110,7 +101,6 @@ describe('MastraScorer', () => {
         extractStepResult: undefined,
       });
       expect(result).toMatchObject({
-        ...baseScoringInput,
         extractStepResult: undefined,
         score: 0.8,
         analyzeStepResult: { results: [{ result: 'good', reason: 'quality analysis' }] },
@@ -133,7 +123,6 @@ describe('MastraScorer', () => {
         extractStepResult: { extractedData: 'test' },
       });
       expect(result).toMatchObject({
-        ...baseScoringInput,
         extractStepResult: { extractedData: 'test' },
         score: 0.8,
         analyzeStepResult: { results: [{ result: 'good', reason: 'quality analysis' }] },
@@ -162,7 +151,6 @@ describe('MastraScorer', () => {
         score: 0.8,
       });
       expect(result).toMatchObject({
-        ...baseScoringInput,
         extractStepResult: { extractedData: 'test' },
         score: 0.8,
         analyzeStepResult: { results: [{ result: 'good', reason: 'quality analysis' }] },
@@ -193,7 +181,6 @@ describe('MastraScorer', () => {
       });
 
       expect(result).toMatchObject({
-        ...baseScoringInput,
         extractStepResult: undefined,
         score: 0.9,
         analyzeStepResult: { analysis: 'detailed analysis' },
@@ -223,7 +210,6 @@ describe('MastraScorer', () => {
       });
 
       expect(result).toMatchObject({
-        ...baseScoringInput,
         extractStepResult: undefined,
         score: 0.7,
         analyzeStepResult: { additionalInfo: 'some info' },
@@ -248,7 +234,6 @@ describe('MastraScorer', () => {
         score: 0.8,
       });
       expect(result).toMatchObject({
-        ...baseScoringInput,
         extractStepResult: undefined,
         score: 0.8,
         analyzeStepResult: { results: [{ result: 'good', reason: 'quality analysis' }] },
@@ -311,25 +296,6 @@ describe('MastraScorer', () => {
 
       expect(result1).toEqual(result2);
       expect(mockAnalyzeFn).toHaveBeenCalledTimes(2);
-    });
-
-    it('should pass through all input data to the result', async () => {
-      const scorer = new MastraScorer({
-        name: 'test-scorer',
-        description: 'A test scorer',
-        analyze: mockAnalyzeFn,
-      });
-
-      const customInput = {
-        ...baseScoringInput,
-        customField: 'custom value',
-        nested: { data: 'nested value' },
-      };
-
-      const result = await scorer.run(customInput as any);
-
-      expect(result).toMatchObject(customInput);
-      expect(result.score).toBe(0.8);
     });
   });
 });

--- a/packages/core/src/scores/base.ts
+++ b/packages/core/src/scores/base.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { createStep, createWorkflow } from '../workflows';
 import { scoreResultSchema, scoringExtractStepResultSchema } from './types';
@@ -10,7 +11,6 @@ import type {
   ScoringInputWithExtractStepResultAndScoreAndReason,
   ScoringSamplingConfig,
 } from './types';
-import { randomUUID } from 'crypto';
 
 export class MastraScorer {
   name: string;

--- a/packages/core/src/scores/base.ts
+++ b/packages/core/src/scores/base.ts
@@ -130,7 +130,7 @@ export class MastraScorer {
       );
     }
 
-    return { ...input, runId, ...execution.result };
+    return { runId, ...execution.result };
   }
 }
 export type MastraScorerEntry = {

--- a/packages/core/src/scores/hooks.ts
+++ b/packages/core/src/scores/hooks.ts
@@ -1,6 +1,6 @@
 import { AvailableHooks, executeHook } from '../hooks';
 import type { MastraScorerEntry } from './base';
-import type { ScoringEntityType, ScoringHookInput, ScoringInput, ScoringSource } from './types';
+import type { ScoringEntityType, ScoringHookInput, ScoringSource } from './types';
 
 export function runScorer({
   runId,

--- a/packages/core/src/scores/hooks.ts
+++ b/packages/core/src/scores/hooks.ts
@@ -1,6 +1,6 @@
 import { AvailableHooks, executeHook } from '../hooks';
 import type { MastraScorerEntry } from './base';
-import type { ScoringEntityType, ScoringInput, ScoringSource } from './types';
+import type { ScoringEntityType, ScoringHookInput, ScoringInput, ScoringSource } from './types';
 
 export function runScorer({
   runId,
@@ -45,7 +45,7 @@ export function runScorer({
     return;
   }
 
-  const payload: ScoringInput = {
+  const payload: ScoringHookInput = {
     scorer: {
       id: scorerId,
       name: scorerObject.scorer.name,

--- a/packages/core/src/scores/types.ts
+++ b/packages/core/src/scores/types.ts
@@ -13,14 +13,22 @@ export type ScoringPrompts = {
 
 export type ScoringInput = {
   runId?: string;
-  scorer?: Record<string, any>;
+  input: Record<string, any>[];
+  output: Record<string, any>;
+  additionalContext?: Record<string, any>;
+  runtimeContext?: Record<string, any>;
+};
+
+export type ScoringHookInput = {
+  runId?: string;
+  scorer: Record<string, any>;
   input: Record<string, any>[];
   output: Record<string, any>;
   metadata?: Record<string, any>;
   additionalContext?: Record<string, any>;
-  source?: ScoringSource;
-  entity?: Record<string, any>;
-  entityType?: ScoringEntityType;
+  source: ScoringSource;
+  entity: Record<string, any>;
+  entityType: ScoringEntityType;
   runtimeContext?: Record<string, any>;
   structuredOutput?: boolean;
   traceId?: string;
@@ -63,13 +71,14 @@ export type ScoringInputWithExtractStepResultAndScoreAndReason =
     reasonPrompt?: string;
   };
 
-export type ScoreRowData = ScoringInputWithExtractStepResultAndScoreAndReason & {
-  id: string;
-  entityId: string;
-  scorerId: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
+export type ScoreRowData = ScoringInputWithExtractStepResultAndScoreAndReason &
+  ScoringHookInput & {
+    id: string;
+    entityId: string;
+    scorerId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  };
 
 export type ExtractionStepFn = (input: ScoringInput) => Promise<Record<string, any>>;
 

--- a/packages/core/src/scores/types.ts
+++ b/packages/core/src/scores/types.ts
@@ -12,16 +12,16 @@ export type ScoringPrompts = {
 };
 
 export type ScoringInput = {
-  runId: string;
-  scorer: Record<string, any>;
+  runId?: string;
+  scorer?: Record<string, any>;
   input: Record<string, any>[];
   output: Record<string, any>;
   metadata?: Record<string, any>;
   additionalContext?: Record<string, any>;
-  source: ScoringSource;
-  entity: Record<string, any>;
-  entityType: ScoringEntityType;
-  runtimeContext: Record<string, any>;
+  source?: ScoringSource;
+  entity?: Record<string, any>;
+  entityType?: ScoringEntityType;
+  runtimeContext?: Record<string, any>;
   structuredOutput?: boolean;
   traceId?: string;
   resourceId?: string;
@@ -43,6 +43,7 @@ export const scoreResultSchema = z.object({
 export type ScoringAnalyzeStepResult = z.infer<typeof scoreResultSchema>;
 
 export type ScoringInputWithExtractStepResult<TExtract = any> = ScoringInput & {
+  runId: string;
   extractStepResult?: TExtract;
   extractPrompt?: string;
 };

--- a/packages/evals/src/scorers/llm/answer-relevancy/index.ts
+++ b/packages/evals/src/scorers/llm/answer-relevancy/index.ts
@@ -48,7 +48,7 @@ export function createAnswerRelevancyScorer({
     },
     analyze: {
       description: 'Score the relevance of the statements to the input',
-      outputSchema: z.array(z.object({ result: z.string(), reason: z.string() })),
+      outputSchema: z.object({ results: z.array(z.object({ result: z.string(), reason: z.string() })) }),
       createPrompt: ({ run }) => createScorePrompt(JSON.stringify(run.input), run.extractStepResult?.statements || []),
     },
     reason: {
@@ -58,20 +58,20 @@ export function createAnswerRelevancyScorer({
           input: run.input.map(input => input.content).join(', '),
           output: run.output.text,
           score: run.score,
-          results: run.analyzeStepResult,
+          results: run.analyzeStepResult.results,
           scale: options.scale,
         });
       },
     },
     calculateScore: ({ run }) => {
-      if (!run.analyzeStepResult || run.analyzeStepResult.length === 0) {
+      if (!run.analyzeStepResult || run.analyzeStepResult.results.length === 0) {
         return 0;
       }
 
-      const numberOfResults = run.analyzeStepResult.length;
+      const numberOfResults = run.analyzeStepResult.results.length;
 
       let relevancyCount = 0;
-      for (const { result } of run.analyzeStepResult) {
+      for (const { result } of run.analyzeStepResult.results) {
         if (result.trim().toLowerCase() === 'yes') {
           relevancyCount++;
         } else if (result.trim().toLowerCase() === 'unsure') {

--- a/packages/evals/src/scorers/llm/faithfulness/index.ts
+++ b/packages/evals/src/scorers/llm/faithfulness/index.ts
@@ -39,7 +39,7 @@ export function createFaithfulnessScorer({
     },
     analyze: {
       description: 'Score the relevance of the statements to the input',
-      outputSchema: z.array(z.object({ verdict: z.string(), reason: z.string() })),
+      outputSchema: z.object({ verdicts: z.array(z.object({ verdict: z.string(), reason: z.string() })) }),
       createPrompt: ({ run }) => {
         const prompt = createFaithfulnessAnalyzePrompt({
           claims: run.extractStepResult || [],
@@ -49,8 +49,8 @@ export function createFaithfulnessScorer({
       },
     },
     calculateScore: ({ run }) => {
-      const totalClaims = run.analyzeStepResult.length;
-      const supportedClaims = run.analyzeStepResult.filter(v => v.verdict === 'yes').length;
+      const totalClaims = run.analyzeStepResult.verdicts.length;
+      const supportedClaims = run.analyzeStepResult.verdicts.filter(v => v.verdict === 'yes').length;
 
       if (totalClaims === 0) {
         return 0;
@@ -69,7 +69,7 @@ export function createFaithfulnessScorer({
           context: options?.context || [],
           score: run.score,
           scale: options?.scale || 1,
-          verdicts: run.analyzeStepResult || [],
+          verdicts: run.analyzeStepResult?.verdicts || [],
         });
         return prompt;
       },

--- a/packages/evals/src/scorers/llm/hallucination/index.ts
+++ b/packages/evals/src/scorers/llm/hallucination/index.ts
@@ -40,7 +40,9 @@ export function createHallucinationScorer({
     },
     analyze: {
       description: 'Score the relevance of the statements to the input',
-      outputSchema: z.array(z.object({ statement: z.string(), verdict: z.string(), reason: z.string() })),
+      outputSchema: z.object({
+        verdicts: z.array(z.object({ statement: z.string(), verdict: z.string(), reason: z.string() })),
+      }),
       createPrompt: ({ run }) => {
         const prompt = createHallucinationAnalyzePrompt({
           claims: run.extractStepResult.claims,
@@ -50,8 +52,8 @@ export function createHallucinationScorer({
       },
     },
     calculateScore: ({ run }) => {
-      const totalStatements = run.analyzeStepResult.length;
-      const contradictedStatements = run.analyzeStepResult.filter(v => v.verdict === 'yes').length;
+      const totalStatements = run.analyzeStepResult.verdicts.length;
+      const contradictedStatements = run.analyzeStepResult.verdicts.filter(v => v.verdict === 'yes').length;
 
       if (totalStatements === 0) {
         return 0;
@@ -70,7 +72,7 @@ export function createHallucinationScorer({
           context: run?.additionalContext?.context || [],
           score: run.score,
           scale: options?.scale || 1,
-          verdicts: run.analyzeStepResult || [],
+          verdicts: run.analyzeStepResult?.verdicts || [],
         });
         return prompt;
       },

--- a/packages/evals/src/scorers/utils.ts
+++ b/packages/evals/src/scorers/utils.ts
@@ -23,19 +23,9 @@ export type TestCaseWithContext = TestCase & {
 
 export const createTestRun = (input: string, output: string, context?: string[]): ScoringInput => {
   return {
-    runId: 'test-run-id',
-    traceId: 'test-trace-id',
-    scorer: {},
     input: [{ role: 'user', content: input }],
     output: { role: 'assistant', text: output },
-    metadata: {},
     additionalContext: { context },
-    resourceId: 'test-resource-id',
-    threadId: 'test-thread-id',
-    source: 'LIVE',
-    entity: {},
-    entityType: 'AGENT',
     runtimeContext: {},
-    structuredOutput: false,
   };
 };


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

This PR is a fast follow for scorers and implements the following:
1. update score run input type which now only requires a input and output args along with other optional arguments
2. create a scoreHookInput type which was previously the scoreInput type.
3. update playground to display `0` instead of `n/a` if the score is 0
4. Increase accuracy for llm scorers. They would occasionally fail if they the schema didn't match the output schema.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
