### PR TITLE
fix(deployer): improve tsconfig path resolution for monorepos

### DIFF
--- a/.changeset/chilly-ties-stare.md
+++ b/.changeset/chilly-ties-stare.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Improve nested ts-config paths resolution for NX users

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -10,7 +10,6 @@ const PLUGIN_NAME = 'tsconfig-paths';
 export type PluginOptions = Omit<RegisterOptions, 'loggerID'> & { localResolve?: boolean };
 
 export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }: PluginOptions = {}): Plugin {
-  let handler: ReturnType<typeof createHandler>;
   const handlerCache = new Map<string, ReturnType<typeof createHandler>>();
 
   // Find tsconfig.json file starting from a directory and walking up
@@ -106,18 +105,6 @@ export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }:
 
   return {
     name: PLUGIN_NAME,
-    buildStart() {
-      // Only create a global handler if a specific tsConfigPath was provided
-      if (tsConfigPath) {
-        handler = createHandler({
-          log: () => {},
-          tsConfigPath,
-          respectCoreModule,
-          falllback: moduleName => fs.existsSync(moduleName),
-        });
-      }
-      return;
-    },
     async resolveId(request, importer, options) {
       if (!importer || request.startsWith('\0')) {
         return null;

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -11,15 +11,111 @@ export type PluginOptions = Omit<RegisterOptions, 'loggerID'> & { localResolve?:
 
 export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }: PluginOptions = {}): Plugin {
   let handler: ReturnType<typeof createHandler>;
+  const handlerCache = new Map<string, ReturnType<typeof createHandler>>();
+
+  // Find tsconfig.json file starting from a directory and walking up
+  function findTsConfigForFile(filePath: string): string | null {
+    let currentDir = path.dirname(filePath);
+    const root = path.parse(currentDir).root;
+
+    while (currentDir !== root) {
+      const tsConfigPath = path.join(currentDir, 'tsconfig.json');
+
+      if (fs.existsSync(tsConfigPath)) {
+        // Check if this tsconfig has path mappings
+        if (hasPaths(tsConfigPath)) {
+          return tsConfigPath;
+        }
+      }
+
+      // Also check for tsconfig.base.json (common in NX)
+      const tsConfigBasePath = path.join(currentDir, 'tsconfig.base.json');
+      if (fs.existsSync(tsConfigBasePath)) {
+        if (hasPaths(tsConfigBasePath)) {
+          return tsConfigBasePath;
+        }
+      }
+
+      currentDir = path.dirname(currentDir);
+    }
+
+    return null;
+  }
+
+  // Check if a tsconfig file has path mappings
+  function hasPaths(tsConfigPath: string): boolean {
+    try {
+      const config = JSON.parse(fs.readFileSync(tsConfigPath, 'utf8'));
+      return !!(config.compilerOptions?.paths && Object.keys(config.compilerOptions.paths).length > 0);
+    } catch {
+      return false;
+    }
+  }
+
+  // Get or create handler for a specific tsconfig file
+  function getHandlerForFile(filePath: string): ReturnType<typeof createHandler> | null {
+    // If a specific tsConfigPath was provided, use it
+    if (tsConfigPath && typeof tsConfigPath === 'string') {
+      if (!handlerCache.has(tsConfigPath)) {
+        handlerCache.set(
+          tsConfigPath,
+          createHandler({
+            log: () => {},
+            tsConfigPath,
+            respectCoreModule,
+            falllback: moduleName => fs.existsSync(moduleName),
+          }),
+        );
+      }
+      return handlerCache.get(tsConfigPath)!;
+    }
+
+    // Find appropriate tsconfig for this file
+    const configPath = findTsConfigForFile(filePath);
+    if (!configPath) {
+      return null;
+    }
+
+    // Cache handlers to avoid recreation
+    if (!handlerCache.has(configPath)) {
+      handlerCache.set(
+        configPath,
+        createHandler({
+          log: () => {},
+          tsConfigPath: configPath,
+          respectCoreModule,
+          falllback: moduleName => fs.existsSync(moduleName),
+        }),
+      );
+    }
+
+    return handlerCache.get(configPath)!;
+  }
+
+  // Simple alias resolution using dynamic handler
+  function resolveAlias(request: string, importer: string): string | null | undefined {
+    // Get the appropriate handler for this file
+    const dynamicHandler = getHandlerForFile(importer);
+    if (!dynamicHandler) {
+      return null;
+    }
+
+    const resolved = dynamicHandler(request, normalize(importer));
+    return resolved;
+  }
+
   return {
     name: PLUGIN_NAME,
     buildStart() {
-      handler = createHandler({
-        log: () => {},
-        tsConfigPath,
-        respectCoreModule,
-        falllback: moduleName => fs.existsSync(moduleName),
-      });
+      // Only create a global handler if a specific tsConfigPath was provided
+      if (tsConfigPath) {
+        handler = createHandler({
+          log: () => {},
+          tsConfigPath,
+          respectCoreModule,
+          falllback: moduleName => fs.existsSync(moduleName),
+        });
+      }
       return;
     },
     async resolveId(request, importer, options) {
@@ -27,7 +123,7 @@ export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }:
         return null;
       }
 
-      const moduleName = handler?.(request, normalize(importer));
+      const moduleName = resolveAlias(request, importer);
       // No tsconfig alias found, so we need to resolve it normally
       if (!moduleName) {
         let importerMeta: { [PLUGIN_NAME]?: { resolved?: boolean } } = {};
@@ -79,9 +175,17 @@ export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }:
         };
       }
 
+      // Always pass through bundler's resolution to ensure proper path normalization
+      const resolved = await this.resolve(moduleName, importer, { skipSelf: true, ...options });
+
+      if (!resolved) {
+        return null;
+      }
+
       return {
-        id: moduleName,
+        ...resolved,
         meta: {
+          ...resolved.meta,
           [PLUGIN_NAME]: {
             resolved: true,
           },


### PR DESCRIPTION
## Description

This PR improves tsconfig path resolutions for monorepos like NX which make heavy use of Typescript path aliases. The current implementation only works one level deep with resolving path aliases. If a library in an NX monorepo that was imported had other imports to additional libraries anything at depth +1 would not resolve properly.

I've been able to verify that this is working correctly in our NX monorepo which has a deeply nested tree of imports that need to resolve via Typescript path aliases.

## Related Issue(s)

#1996 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path resolution for nested TypeScript configurations in NX-based projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->