### PR TITLE
fix(agent): improve error message for missing memory ids

### DIFF
--- a/.changeset/great-pumas-stay.md
+++ b/.changeset/great-pumas-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+improve error message for missing memory ids

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1395,7 +1395,7 @@ export class Agent<
               threadId: threadId || '',
               resourceId: resourceId || '',
             },
-            text: `A resourceId must be provided when passing a threadId and using Memory. Saw threadId ${threadId} but resourceId is ${resourceId}`,
+            text: `A resourceId and a threadId must be provided when using Memory. Saw threadId "${threadId}" and resourceId "${resourceId}"`,
           });
           this.logger.trackException(mastraError);
           this.logger.error(mastraError.toString());


### PR DESCRIPTION
## Description

Update error message to be more clear about requiring both resourceId and threadId when using Memory.

## Related Issue(s)

Discord: https://discord.com/channels/1309558646228779139/1398108185524568216/1398108185524568216

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
