### PR TITLE
[MongoDB] scorers save as object

### DIFF
--- a/.changeset/rare-melons-fail.md
+++ b/.changeset/rare-melons-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+fix: mongodb save scores as an object

--- a/stores/_test-utils/src/domains/scores/index.ts
+++ b/stores/_test-utils/src/domains/scores/index.ts
@@ -29,6 +29,9 @@ export function createScoresTest({ storage }: { storage: MastraStorage }) {
       expect(allScoresByScorerId?.scores.map(e => e.runId)).toEqual(
         expect.arrayContaining([score1.runId, score2.runId, score3.runId]),
       );
+      expect(allScoresByScorerId?.scores.map(s => s.scorer.id)).toEqual(
+        expect.arrayContaining([score1.scorer.id, score2.scorer.id, score3.scorer.id]),
+      );
 
       // Test getting scores for non-existent scorer
       const nonExistentScores = await storage.getScoresByScorerId({

--- a/stores/_test-utils/src/factory.ts
+++ b/stores/_test-utils/src/factory.ts
@@ -9,7 +9,7 @@ import {
   TABLE_SCORERS,
   TABLE_TRACES,
 } from '@mastra/core/storage';
-// import { createScoresTest } from './domains/scores';
+import { createScoresTest } from './domains/scores';
 import { createMemoryTest } from './domains/memory';
 import { createWorkflowsTests } from './domains/workflows';
 import { createTraceTests } from './domains/traces';
@@ -20,6 +20,8 @@ export * from './domains/workflows/data';
 export * from './domains/evals/data';
 export * from './domains/scores/data';
 export * from './domains/traces/data';
+
+const STORES_WITH_RUN_SCORES_TESTS = ['MongoDBStore'];
 
 export function createTestSuite(storage: MastraStorage) {
   describe(storage.constructor.name, () => {
@@ -54,6 +56,8 @@ export function createTestSuite(storage: MastraStorage) {
 
     createMemoryTest({ storage });
 
-    // createScoresTest({ storage });
+    if (STORES_WITH_RUN_SCORES_TESTS.includes(storage.constructor.name)) {
+      createScoresTest({ storage });
+    }
   });
 }

--- a/stores/mongodb/src/storage/domains/scores/index.ts
+++ b/stores/mongodb/src/storage/domains/scores/index.ts
@@ -142,26 +142,26 @@ export class ScoresStorageMongoDB extends ScoresStorage {
         scorerId: score.scorerId,
         traceId: score.traceId || '',
         runId: score.runId,
-        scorer: typeof score.scorer === 'string' ? score.scorer : JSON.stringify(score.scorer),
+        scorer: typeof score.scorer === 'string' ? safelyParseJSON(score.scorer) : score.scorer,
         extractStepResult:
           typeof score.extractStepResult === 'string'
-            ? score.extractStepResult
-            : JSON.stringify(score.extractStepResult),
+            ? safelyParseJSON(score.extractStepResult)
+            : score.extractStepResult,
         analyzeStepResult:
           typeof score.analyzeStepResult === 'string'
-            ? score.analyzeStepResult
-            : JSON.stringify(score.analyzeStepResult),
+            ? safelyParseJSON(score.analyzeStepResult)
+            : score.analyzeStepResult,
         score: score.score,
         reason: score.reason,
         extractPrompt: score.extractPrompt,
         analyzePrompt: score.analyzePrompt,
         reasonPrompt: score.reasonPrompt,
-        input: typeof score.input === 'string' ? score.input : JSON.stringify(score.input),
-        output: typeof score.output === 'string' ? score.output : JSON.stringify(score.output),
+        input: typeof score.input === 'string' ? safelyParseJSON(score.input) : score.input,
+        output: typeof score.output === 'string' ? safelyParseJSON(score.output) : score.output,
         additionalContext: score.additionalContext,
         runtimeContext:
-          typeof score.runtimeContext === 'string' ? score.runtimeContext : JSON.stringify(score.runtimeContext),
-        entity: typeof score.entity === 'string' ? score.entity : JSON.stringify(score.entity),
+          typeof score.runtimeContext === 'string' ? safelyParseJSON(score.runtimeContext) : score.runtimeContext,
+        entity: typeof score.entity === 'string' ? safelyParseJSON(score.entity) : score.entity,
         source: score.source,
         resourceId: score.resourceId || '',
         threadId: score.threadId || '',


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
MongoDB does not stringify them, but stores them as Objects. This makes it easier to create queries.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
https://discord.com/channels/1309558646228779139/1397961674748592279

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
