### PR TITLE
[MongoDB]vectore query bug

### DIFF
--- a/.changeset/famous-parks-travel.md
+++ b/.changeset/famous-parks-travel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+fix: filter.\_id.\$in cannot be empty

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -327,7 +327,9 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
           .map(doc => doc._id)
           .toArray();
 
-        vectorSearch.filter = { _id: { $in: candidateIds } };
+        if (candidateIds.length > 0) {
+          vectorSearch.filter = { _id: { $in: candidateIds } };
+        }
       }
 
       // Build the aggregation pipeline


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

I get this error when chatting in the playground with semanticRecall enabled.

`Error: HTTP error! status: 500 - {"error":"PlanExecutor error during aggregation :: caused by :: "filter._id.$in" cannot be empty","cause":{"errorLabelSet":{},"errorResponse":{"ok":0,"errmsg":"PlanExecutor error during aggregation :: caused by :: "filter._id.$in" cannot be empty","code":8,"codeName":"UnknownError","$clusterTime":{"clusterTime":{"$timestamp":"7530994672705994753"},"signature":{"hash":"NGJpT+HQZV3Q/WJJXRlmEMRdiyM=","keyId":{"low":6,"high":1747985225,"unsigned":false}}},"operationTime":{"$timestamp":"7530994672705994753"}},"ok":0,"code":8,"codeName":"UnknownError","$clusterTime":{"clusterTime":{"$timestamp":"7530994672705994753"},"signature":{"hash":"NGJpT+HQZV3Q/WJJXRlmEMRdiyM=","keyId":{"low":6,"high":1747985225,"unsigned":false}}},"operationTime":{"$timestamp":"7530994672705994753"}},"stack":"Error: PlanExecutor error during aggregation :: caused by :: "filter._id.$in" cannot be empty\n at handleError`

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
