### PR TITLE
fix: reduce footer z-index to prevent it from overlapping the mobile nav

### DIFF
--- a/docs/src/components/footer.tsx
+++ b/docs/src/components/footer.tsx
@@ -65,7 +65,7 @@ export const Footer = () => {
     <T id="components.footer.0">
       <footer
         data-state={!showFooter}
-        className="flex z-30  mx-auto bg-[#fafafa] dark:bg-transparent border-[var(--light-border-muted)]  dark:border-t-[var(--border)]  relative w-full border-t-[0.5px] flex-col items-center pt-8 lg:pt-[5rem] pb-24 md:pb-32 footer data-[state=false]:mt-8 "
+        className="flex z-10 mx-auto bg-[#fafafa] dark:bg-transparent border-[var(--light-border-muted)]  dark:border-t-[var(--border)]  relative w-full border-t-[0.5px] flex-col items-center pt-8 lg:pt-[5rem] pb-24 md:pb-32 footer data-[state=false]:mt-8 "
       >
         <div className="flex max-w-(--nextra-content-width) pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)] flex-col lg:flex-row gap-16 lg:gap-0 w-full justify-between">
           <div className="dark:text-white">


### PR DESCRIPTION
## Description

reduce footer z-index to prevent it from overlapping the mobile nav


https://github.com/user-attachments/assets/5d50d357-adb0-47ef-9daa-5f0f6c7aa506



## Related Issue(s)

#6313

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
