### PR TITLE
update rollup config for external dependencies

### DIFF
--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -254,8 +254,7 @@ async function bundleExternals(
       }),
       nodeResolve({
         preferBuiltins: true,
-        exportConditions: ['node', 'import', 'require'],
-        mainFields: ['module', 'main'],
+        exportConditions: ['node'],
       }),
       // hono is imported from deployer, so we need to resolve from here instead of the project root
       aliasHono(),


### PR DESCRIPTION
## Description 

Remove require condition from rollup bundling in bundleExternals
I verified my build works after this change.

## Related Issue(s)

#5651 was reported the dependency mustache of Langfuse wasn't built properly by rollup. This was still broken after [PR 568](https://github.com/mastra-ai/mastra/pull/5678).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
