### PR TITLE
fix: Fix schema support to PostgreSQL scores and workflows storage

### DIFF
--- a/.changeset/slow-bugs-tell.md
+++ b/.changeset/slow-bugs-tell.md
@@ -1,0 +1,5 @@
+---
+"@mastra/pg": patch
+---
+
+fix: Fix schema support to PostgreSQL scores and workflows storage

--- a/stores/pg/src/storage/domains/scores/index.ts
+++ b/stores/pg/src/storage/domains/scores/index.ts
@@ -4,6 +4,7 @@ import type { ScoreRowData } from '@mastra/core/scores';
 import { ScoresStorage, TABLE_SCORERS } from '@mastra/core/storage';
 import type { IDatabase } from 'pg-promise';
 import type { StoreOperationsPG } from '../operations';
+import { getTableName } from '../utils';
 
 function transformScoreRow(row: Record<string, any>): ScoreRowData {
   let input = undefined;
@@ -26,16 +27,29 @@ function transformScoreRow(row: Record<string, any>): ScoreRowData {
 export class ScoresPG extends ScoresStorage {
   public client: IDatabase<{}>;
   private operations: StoreOperationsPG;
+  private schema?: string;
 
-  constructor({ client, operations }: { client: IDatabase<{}>; operations: StoreOperationsPG }) {
+  constructor({
+    client,
+    operations,
+    schema,
+  }: {
+    client: IDatabase<{}>;
+    operations: StoreOperationsPG;
+    schema?: string;
+  }) {
     super();
     this.client = client;
     this.operations = operations;
+    this.schema = schema;
   }
 
   async getScoreById({ id }: { id: string }): Promise<ScoreRowData | null> {
     try {
-      const result = await this.client.oneOrNone<ScoreRowData>(`SELECT * FROM ${TABLE_SCORERS} WHERE id = $1`, [id]);
+      const result = await this.client.oneOrNone<ScoreRowData>(
+        `SELECT * FROM ${getTableName({ indexName: TABLE_SCORERS, schemaName: this.schema })} WHERE id = $1`,
+        [id],
+      );
 
       return transformScoreRow(result!);
     } catch (error) {
@@ -59,7 +73,7 @@ export class ScoresPG extends ScoresStorage {
   }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
     try {
       const total = await this.client.oneOrNone<{ count: string }>(
-        `SELECT COUNT(*) FROM ${TABLE_SCORERS} WHERE "scorerId" = $1`,
+        `SELECT COUNT(*) FROM ${getTableName({ indexName: TABLE_SCORERS, schemaName: this.schema })} WHERE "scorerId" = $1`,
         [scorerId],
       );
       if (total?.count === '0' || !total?.count) {
@@ -75,7 +89,7 @@ export class ScoresPG extends ScoresStorage {
       }
 
       const result = await this.client.manyOrNone<ScoreRowData>(
-        `SELECT * FROM ${TABLE_SCORERS} WHERE "scorerId" = $1 LIMIT $2 OFFSET $3`,
+        `SELECT * FROM ${getTableName({ indexName: TABLE_SCORERS, schemaName: this.schema })} WHERE "scorerId" = $1 LIMIT $2 OFFSET $3`,
         [scorerId, pagination.perPage, pagination.page * pagination.perPage],
       );
       return {
@@ -135,7 +149,7 @@ export class ScoresPG extends ScoresStorage {
   }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
     try {
       const total = await this.client.oneOrNone<{ count: string }>(
-        `SELECT COUNT(*) FROM ${TABLE_SCORERS} WHERE "runId" = $1`,
+        `SELECT COUNT(*) FROM ${getTableName({ indexName: TABLE_SCORERS, schemaName: this.schema })} WHERE "runId" = $1`,
         [runId],
       );
       console.log(`total: ${total?.count}`);
@@ -153,7 +167,7 @@ export class ScoresPG extends ScoresStorage {
       }
 
       const result = await this.client.manyOrNone<ScoreRowData>(
-        `SELECT * FROM ${TABLE_SCORERS} WHERE "runId" = $1 LIMIT $2 OFFSET $3`,
+        `SELECT * FROM ${getTableName({ indexName: TABLE_SCORERS, schemaName: this.schema })} WHERE "runId" = $1 LIMIT $2 OFFSET $3`,
         [runId, pagination.perPage, pagination.page * pagination.perPage],
       );
       return {
@@ -188,7 +202,7 @@ export class ScoresPG extends ScoresStorage {
   }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
     try {
       const total = await this.client.oneOrNone<{ count: string }>(
-        `SELECT COUNT(*) FROM ${TABLE_SCORERS} WHERE "entityId" = $1 AND "entityType" = $2`,
+        `SELECT COUNT(*) FROM ${getTableName({ indexName: TABLE_SCORERS, schemaName: this.schema })} WHERE "entityId" = $1 AND "entityType" = $2`,
         [entityId, entityType],
       );
 
@@ -205,7 +219,7 @@ export class ScoresPG extends ScoresStorage {
       }
 
       const result = await this.client.manyOrNone<ScoreRowData>(
-        `SELECT * FROM ${TABLE_SCORERS} WHERE "entityId" = $1 AND "entityType" = $2 LIMIT $3 OFFSET $4`,
+        `SELECT * FROM ${getTableName({ indexName: TABLE_SCORERS, schemaName: this.schema })} WHERE "entityId" = $1 AND "entityType" = $2 LIMIT $3 OFFSET $4`,
         [entityId, entityType, pagination.perPage, pagination.page * pagination.perPage],
       );
       return {

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -57,7 +57,7 @@ export class WorkflowsPG extends WorkflowsStorage {
     try {
       const now = new Date().toISOString();
       await this.client.none(
-        `INSERT INTO ${TABLE_WORKFLOW_SNAPSHOT} (workflow_name, run_id, snapshot, "createdAt", "updatedAt")
+        `INSERT INTO ${getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: this.schema })} (workflow_name, run_id, snapshot, "createdAt", "updatedAt")
                  VALUES ($1, $2, $3, $4, $5)
                  ON CONFLICT (workflow_name, run_id) DO UPDATE
                  SET snapshot = $3, "updatedAt" = $5`,
@@ -129,8 +129,8 @@ export class WorkflowsPG extends WorkflowsStorage {
 
       // Get results
       const query = `
-          SELECT * FROM ${getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: this.schema })} 
-          ${whereClause} 
+          SELECT * FROM ${getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: this.schema })}
+          ${whereClause}
         `;
 
       const queryValues = values;
@@ -220,8 +220,8 @@ export class WorkflowsPG extends WorkflowsStorage {
 
       // Get results
       const query = `
-          SELECT * FROM ${getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: this.schema })} 
-          ${whereClause} 
+          SELECT * FROM ${getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: this.schema })}
+          ${whereClause}
           ORDER BY "createdAt" DESC
           ${limit !== undefined && offset !== undefined ? ` LIMIT $${paramIndex} OFFSET $${paramIndex + 1}` : ''}
         `;

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -6,5 +6,6 @@ import { PostgresStore } from '.';
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 
 createTestSuite(new PostgresStore(TEST_CONFIG));
+createTestSuite(new PostgresStore({ ...TEST_CONFIG, schemaName: 'my_schema' }));
 
 pgTests();

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -96,7 +96,7 @@ export class PostgresStore extends MastraStorage {
       this.client = this.db;
 
       const operations = new StoreOperationsPG({ client: this.client, schemaName: this.schema });
-      const scores = new ScoresPG({ client: this.client, operations });
+      const scores = new ScoresPG({ client: this.client, operations, schema: this.schema });
       const traces = new TracesPG({ client: this.client, operations, schema: this.schema });
       const workflows = new WorkflowsPG({ client: this.client, operations, schema: this.schema });
       const legacyEvals = new LegacyEvalsPG({ client: this.client, schema: this.schema });


### PR DESCRIPTION
## Description

Currently persisting workflow snapshots fails when using a PostgreSQL Schema, this is due to the table missing the schema name. I also noticed that scores were missing the schema name

Changes: 

- Updates `ScoresPG` class to accept schema parameter and use getTableName utility for proper table name resolution with schema support.
- Updates `WorkflowsPG.persistWorkflowSnapshot` to include schema in table name. 
- Runs test cases against schema-less DB, and DB with schema.
- Ensures constraints are unique across schemas. This is a blocker for tests without destroying the test instance and creating again between runs. Or running them in isolation... Also allow for running many mastra instances on the same DB, but in different schemas.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#6413 
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
