### PR TITLE
fix: Gemini 2.5 pro experimental model has been removed

### DIFF
--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -55,7 +55,7 @@ export const getProviderImportAndModelItem = (llmProvider: LLMProvider) => {
     modelItem = `groq('llama-3.3-70b-versatile')`;
   } else if (llmProvider === 'google') {
     providerImport = `import { google } from '${getAISDKPackage(llmProvider)}';`;
-    modelItem = `google('gemini-2.5-pro-exp-03-25')`;
+    modelItem = `google('gemini-2.5-pro')`;
   } else if (llmProvider === 'cerebras') {
     providerImport = `import { cerebras } from '${getAISDKPackage(llmProvider)}';`;
     modelItem = `cerebras('llama-3.3-70b')`;


### PR DESCRIPTION
## Description

The existing default Google Gemini model was relying on an experimental model version of Gemini 2.5 pro. However, these experimental LLMs versions get swapped out for newer versions and have other restrictions like rate limits. The `gemini-2.5-pro-exp-03-25` doesn't exist anymore and this fix replaces the now defunct model with Gemini primary `gemini-2.5-pro` model.

Source: https://ai.google.dev/gemini-api/docs/models#experimental-models

## Why this change

I scaffolded a new project with the Mastra CLI and my Google configuration for the default Weather agent template relied on the old defunct model which created a poor onboarding DX as a first-time user. I was able to debug via the playground to figure out this root cause:

<img width="994" height="281" alt="image" src="https://github.com/user-attachments/assets/ca6ad546-cd88-40d3-9f9d-e845c80e9e07" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
