### PR TITLE
[MongoDB] trace mongo safeparse

### DIFF
--- a/.changeset/beige-trees-sleep.md
+++ b/.changeset/beige-trees-sleep.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+fix: trace mongo safeparse

--- a/stores/mongodb/src/storage/domains/traces/index.ts
+++ b/stores/mongodb/src/storage/domains/traces/index.ts
@@ -103,13 +103,13 @@ export class TracesStorageMongoDB extends TracesStorage {
         name: row.name,
         scope: row.scope,
         kind: row.kind,
-        status: safelyParseJSON(row.status as string),
-        events: safelyParseJSON(row.events as string),
-        links: safelyParseJSON(row.links as string),
-        attributes: safelyParseJSON(row.attributes as string),
+        status: typeof row.status === 'string' ? safelyParseJSON(row.status) : row.status,
+        events: typeof row.events === 'string' ? safelyParseJSON(row.events) : row.events,
+        links: typeof row.links === 'string' ? safelyParseJSON(row.links) : row.links,
+        attributes: typeof row.attributes === 'string' ? safelyParseJSON(row.attributes) : row.attributes,
         startTime: row.startTime,
         endTime: row.endTime,
-        other: safelyParseJSON(row.other as string),
+        other: typeof row.other === 'string' ? safelyParseJSON(row.other) : row.other,
         createdAt: row.createdAt,
       })) as Trace[];
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
https://github.com/mastra-ai/mastra/pull/6262
This is not sufficient: when retrieving a trace from the playground, it tries to parse the object and returns an empty object

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
