### PR TITLE
Updating VSCode MCP instructions

### DIFF
--- a/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
@@ -51,7 +51,7 @@ To add the MCP Docs Server to an existing project, install it manually.
 
 - **Cursor**: Edit `.cursor/mcp.json` in your project root, or `~/.cursor/mcp.json` for global configuration
 - **Windsurf**: Edit `~/.codeium/windsurf/mcp_config.json` (only supports global configuration)
-- **VSCode**: Edit `~/.vscode/mcp.json` in your project root
+- **VSCode**: Either move the created `.vscode` folder into the top-level of your workspace or open the created folder as your new workspace root. Edit `~/.vscode/mcp.json` in your project root.
   Add the following configuration:
 
 ### MacOS/Linux
@@ -194,7 +194,7 @@ In both IDEs it may take a minute for the MCP server to start the first time as 
   className="rounded-lg"
 />
 
-MCP only works in Agent mode in VSCode. Once you are in agent mode, open the `mcp.json` file and click the "start" button.
+MCP only works in Agent mode in VSCode. Once you are in agent mode, open the `mcp.json` file and click the "start" button. Note that the "start" button will only appear if the `.vscode` folder containing `mcp.json` is in your workspace root, or the highest level of the in-editor file explorer.
 
 <br />
 <img


### PR DESCRIPTION
## Description

VSCode is super picky about the location of the `.vscode` folder that holds `mcp.json`. The folder must be in your workspace root for VSCode to discover it, but the commands to initialize Mastra projects (either the course or the main script) create a new folder within your current workspace, putting the generated `.vscode` folder in a location that VSCode does not recognize. This PR simply changes the course and MCP documentation to instruct users to either move the folder or change their workspace to get the MCP server running.

## Related Issue(s)

#6215 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
