### PR TITLE
fix(mastra): install with specific pre-v5 versions

### DIFF
--- a/.changeset/light-rats-join.md
+++ b/.changeset/light-rats-join.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Install specific ai v4 deps when scaffolding a project

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -12,6 +12,7 @@ import {
   createComponentsDir,
   createMastraDir,
   getAISDKPackage,
+  getAISDKPackageVersion,
   getAPIKey,
   writeAPIKey,
   writeCodeSample,
@@ -88,10 +89,11 @@ export const init = async ({
     const key = await getAPIKey(llmProvider || 'openai');
 
     const aiSdkPackage = getAISDKPackage(llmProvider);
+    const aiSdkPackageVersion = getAISDKPackageVersion(llmProvider);
     const depsService = new DepsService();
     const pm = depsService.packageManager;
     const installCommand = getPackageManagerInstallCommand(pm);
-    await exec(`${pm} ${installCommand} ${aiSdkPackage}`);
+    await exec(`${pm} ${installCommand} ${aiSdkPackage}@${aiSdkPackageVersion}`);
 
     if (configureEditorWithDocsMCP) {
       await installMastraDocsMCPServer({

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -23,6 +23,14 @@ const exec = util.promisify(child_process.exec);
 export type LLMProvider = 'openai' | 'anthropic' | 'groq' | 'google' | 'cerebras';
 export type Components = 'agents' | 'workflows' | 'tools';
 
+export const getAISDKPackageVersion = (llmProvider: LLMProvider) => {
+  switch (llmProvider) {
+    case 'cerebras':
+      return '^0.2.14';
+    default:
+      return '^1.0.0';
+  }
+};
 export const getAISDKPackage = (llmProvider: LLMProvider) => {
   switch (llmProvider) {
     case 'openai':


### PR DESCRIPTION
V5 is out on latest, for now we need to pin v4 versions when scaffolding https://x.com/lgrammel/status/1950953197675155850