### PR TITLE
docs: add authentication context documentation for MCP tools

### DIFF
--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -848,9 +848,18 @@ When tools are executed within an MCP server context, they receive an additional
 ```typescript
 execute: async ({ context }, options) => {
   // context contains the tool's input parameters
-  // options contains server capabilities like elicitation
+  // options contains server capabilities like elicitation and authentication info
   
-  const result = await options.elicitation.sendRequest({
+  // Destructure the options to access both elicitation and extra
+  const { elicitation, extra } = options;
+  
+  // Access authentication information (when available)
+  if (extra?.authInfo) {
+    console.log('Authenticated request from:', extra.authInfo.clientId);
+  }
+  
+  // Use elicitation capabilities
+  const result = await elicitation.sendRequest({
     message: "Please provide information",
     requestedSchema: { /* schema */ }
   });
@@ -891,10 +900,14 @@ const server = new MCPServer({
       }),
       execute: async ({ context }, options) => {
         const { reason } = context;
+        
+        // Destructure to access both elicitation and extra
+        const { elicitation, extra } = options;
+        console.log('Request from session:', extra?.sessionId);
 
         try {
-          // Request user input via elicitation through the options parameter
-          const result = await options.elicitation.sendRequest({
+          // Request user input via elicitation
+          const result = await elicitation.sendRequest({
             message: reason 
               ? `Please provide your contact information. ${reason}`
               : 'Please provide your contact information',
@@ -1002,10 +1015,20 @@ The elicitation functionality is available through the `options` parameter in to
 
 ```typescript
 // Within a tool's execute function
-options.elicitation.sendRequest({
-  message: string,           // Message to display to user
-  requestedSchema: object    // JSON schema defining expected response structure
-}): Promise<ElicitResult>
+execute: async ({ context }, options) => {
+  const { elicitation, extra } = options;
+  
+  // Use elicitation for user input
+  const result = await elicitation.sendRequest({
+    message: string,           // Message to display to user
+    requestedSchema: object    // JSON schema defining expected response structure
+  }): Promise<ElicitResult>
+  
+  // Access authentication info if needed
+  if (extra?.authInfo) {
+    // Use extra.authInfo.token, extra.authInfo.clientId, etc.
+  }
+}
 ```
 
 Note that elicitation is **session-aware** when using HTTP-based transports (SSE or HTTP). This means that when multiple clients are connected to the same server, elicitation requests are routed to the correct client session that initiated the tool execution.
@@ -1018,6 +1041,122 @@ type ElicitResult = {
   content?: any; // Only present when action is 'accept'
 }
 ```
+
+## Accessing Authentication Information
+
+When MCP clients connect to your server using HTTP-based transports (SSE or HTTP), they can include authentication information in their requests. This authentication context is automatically passed to your tools through the `options.extra` parameter.
+
+> **Note on naming**: The property is called `extra` because it follows the MCP SDK's `RequestHandlerExtra` naming convention. While the name isn't particularly descriptive, it contains important request metadata including authentication information, session details, and communication utilities.
+
+### Authentication Context Structure
+
+The `extra` parameter provides access to request-specific information:
+
+```typescript
+type MCPRequestHandlerExtra = {
+  authInfo?: {
+    token?: string;      // Authentication token (e.g., Bearer token)
+    clientId?: string;   // Client identifier
+    scopes?: string[];   // Authorization scopes
+  };
+  sessionId?: string;      // Unique session identifier
+  requestId?: string;      // Request identifier for tracking
+  signal: AbortSignal;     // For request cancellation
+  sendNotification: Function;  // Send notifications to client
+  sendRequest: Function;       // Send requests to client
+};
+```
+
+### Example: Building an Authenticated Tool
+
+Here's an example of a tool that uses authentication information to make personalized API calls:
+
+```typescript
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const userDataTool = createTool({
+  id: "getUserData",
+  description: "Fetches personalized user data using the authenticated context",
+  inputSchema: z.object({
+    dataType: z.enum(["profile", "settings", "activity"]),
+  }),
+  execute: async ({ context }, options) => {
+    const { dataType } = context;
+    
+    // Destructure to access extra from options
+    const { extra } = options;
+    
+    // Check if authentication info is available
+    if (!extra?.authInfo?.token) {
+      return "Authentication required. Please provide credentials.";
+    }
+    
+    try {
+      // Use the authentication token for API calls
+      const response = await fetch(`https://api.example.com/user/${dataType}`, {
+        headers: {
+          'Authorization': `Bearer ${extra.authInfo.token}`,
+          'X-Client-ID': extra.authInfo.clientId || 'unknown',
+        },
+        signal: extra.signal, // Use the abort signal for cancellation
+      });
+      
+      if (!response.ok) {
+        throw new Error(`API request failed: ${response.statusText}`);
+      }
+      
+      const data = await response.json();
+      return `User ${dataType}: ${JSON.stringify(data, null, 2)}`;
+      
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        return 'Request was cancelled';
+      }
+      return `Error fetching user data: ${error.message}`;
+    }
+  },
+});
+```
+
+### Authentication Flow
+
+1. **Client Configuration**: MCP clients include authentication headers when connecting:
+   ```typescript
+   const mcp = new MCPClient({
+     servers: {
+       myServer: {
+         url: new URL("https://my-mcp-server.com/mcp"),
+         requestInit: {
+           headers: {
+             Authorization: "Bearer user-specific-token",
+           },
+         },
+       },
+     },
+   });
+   ```
+
+2. **Server Reception**: The server's HTTP transport layer extracts authentication information from request headers
+
+3. **Tool Access**: Tools receive this information via `options.extra.authInfo`
+
+### Best Practices
+
+- **Always validate authentication**: Check if `extra.authInfo` exists before using it
+- **Handle missing authentication gracefully**: Return appropriate messages when auth is required but missing
+- **Use the abort signal**: Respect `extra.signal` for proper request cancellation
+- **Session awareness**: Authentication is session-specific, ensuring multi-tenant safety
+- **Don't log sensitive data**: Avoid logging tokens or other sensitive authentication information
+
+### Use Cases
+
+Common scenarios for authenticated MCP tools:
+
+- **Multi-tenant SaaS applications**: Different users get different data based on their auth tokens
+- **Personalized integrations**: Tools that fetch user-specific data from external APIs
+- **Secure operations**: Tools that need to verify user permissions before performing actions
+- **Rate-limited APIs**: Using client-specific tokens to manage API quotas
 
 ## Related Information
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1044,9 +1044,22 @@ type ElicitResult = {
 
 ## Authentication Context
 
-Tools can access authentication info from HTTP-based MCP clients via `options.extra`:
+Tools can access authentication info from HTTP-based MCP clients via `options.extra`. The auth info comes from headers sent by the MCP client:
 
 ```typescript
+// Client sends auth headers
+const mcp = new MCPClient({
+  servers: {
+    myServer: {
+      url: new URL("https://server.com/mcp"),
+      requestInit: {
+        headers: { Authorization: "Bearer token" }
+      }
+    }
+  }
+});
+
+// Tool receives auth info
 execute: async ({ context }, options) => {
   const { extra } = options;
   
@@ -1065,7 +1078,7 @@ execute: async ({ context }, options) => {
 ```
 
 The `extra` object contains:
-- `authInfo`: Token, client ID, and scopes from the MCP client
+- `authInfo`: Token, client ID, and scopes extracted from client headers
 - `sessionId`: Session identifier
 - `signal`: AbortSignal for cancellation
 - `sendNotification`/`sendRequest`: MCP protocol functions

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1042,121 +1042,33 @@ type ElicitResult = {
 }
 ```
 
-## Accessing Authentication Information
+## Authentication Context
 
-When MCP clients connect to your server using HTTP-based transports (SSE or HTTP), they can include authentication information in their requests. This authentication context is automatically passed to your tools through the `options.extra` parameter.
-
-> **Note on naming**: The property is called `extra` because it follows the MCP SDK's `RequestHandlerExtra` naming convention. While the name isn't particularly descriptive, it contains important request metadata including authentication information, session details, and communication utilities.
-
-### Authentication Context Structure
-
-The `extra` parameter provides access to request-specific information:
+Tools can access authentication info from HTTP-based MCP clients via `options.extra`:
 
 ```typescript
-type MCPRequestHandlerExtra = {
-  authInfo?: {
-    token?: string;      // Authentication token (e.g., Bearer token)
-    clientId?: string;   // Client identifier
-    scopes?: string[];   // Authorization scopes
-  };
-  sessionId?: string;      // Unique session identifier
-  requestId?: string;      // Request identifier for tracking
-  signal: AbortSignal;     // For request cancellation
-  sendNotification: Function;  // Send notifications to client
-  sendRequest: Function;       // Send requests to client
-};
+execute: async ({ context }, options) => {
+  const { extra } = options;
+  
+  if (!extra?.authInfo?.token) {
+    return "Authentication required";
+  }
+  
+  // Use the auth token
+  const response = await fetch('/api/data', {
+    headers: { Authorization: `Bearer ${extra.authInfo.token}` },
+    signal: extra.signal,
+  });
+  
+  return response.json();
+}
 ```
 
-### Example: Building an Authenticated Tool
-
-Here's an example of a tool that uses authentication information to make personalized API calls:
-
-```typescript
-import { createTool } from "@mastra/core/tools";
-import { z } from "zod";
-
-export const userDataTool = createTool({
-  id: "getUserData",
-  description: "Fetches personalized user data using the authenticated context",
-  inputSchema: z.object({
-    dataType: z.enum(["profile", "settings", "activity"]),
-  }),
-  execute: async ({ context }, options) => {
-    const { dataType } = context;
-    
-    // Destructure to access extra from options
-    const { extra } = options;
-    
-    // Check if authentication info is available
-    if (!extra?.authInfo?.token) {
-      return "Authentication required. Please provide credentials.";
-    }
-    
-    try {
-      // Use the authentication token for API calls
-      const response = await fetch(`https://api.example.com/user/${dataType}`, {
-        headers: {
-          'Authorization': `Bearer ${extra.authInfo.token}`,
-          'X-Client-ID': extra.authInfo.clientId || 'unknown',
-        },
-        signal: extra.signal, // Use the abort signal for cancellation
-      });
-      
-      if (!response.ok) {
-        throw new Error(`API request failed: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
-      return `User ${dataType}: ${JSON.stringify(data, null, 2)}`;
-      
-    } catch (error) {
-      if (error.name === 'AbortError') {
-        return 'Request was cancelled';
-      }
-      return `Error fetching user data: ${error.message}`;
-    }
-  },
-});
-```
-
-### Authentication Flow
-
-1. **Client Configuration**: MCP clients include authentication headers when connecting:
-   ```typescript
-   const mcp = new MCPClient({
-     servers: {
-       myServer: {
-         url: new URL("https://my-mcp-server.com/mcp"),
-         requestInit: {
-           headers: {
-             Authorization: "Bearer user-specific-token",
-           },
-         },
-       },
-     },
-   });
-   ```
-
-2. **Server Reception**: The server's HTTP transport layer extracts authentication information from request headers
-
-3. **Tool Access**: Tools receive this information via `options.extra.authInfo`
-
-### Best Practices
-
-- **Always validate authentication**: Check if `extra.authInfo` exists before using it
-- **Handle missing authentication gracefully**: Return appropriate messages when auth is required but missing
-- **Use the abort signal**: Respect `extra.signal` for proper request cancellation
-- **Session awareness**: Authentication is session-specific, ensuring multi-tenant safety
-- **Don't log sensitive data**: Avoid logging tokens or other sensitive authentication information
-
-### Use Cases
-
-Common scenarios for authenticated MCP tools:
-
-- **Multi-tenant SaaS applications**: Different users get different data based on their auth tokens
-- **Personalized integrations**: Tools that fetch user-specific data from external APIs
-- **Secure operations**: Tools that need to verify user permissions before performing actions
-- **Rate-limited APIs**: Using client-specific tokens to manage API quotas
+The `extra` object contains:
+- `authInfo`: Token, client ID, and scopes from the MCP client
+- `sessionId`: Session identifier
+- `signal`: AbortSignal for cancellation
+- `sendNotification`/`sendRequest`: MCP protocol functions
 
 ## Related Information
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1044,22 +1044,9 @@ type ElicitResult = {
 
 ## Authentication Context
 
-Tools can access authentication info from HTTP-based MCP clients via `options.extra`. The auth info comes from headers sent by the MCP client:
+Tools can access request metadata via `options.extra` when using HTTP-based transports:
 
 ```typescript
-// Client sends auth headers
-const mcp = new MCPClient({
-  servers: {
-    myServer: {
-      url: new URL("https://server.com/mcp"),
-      requestInit: {
-        headers: { Authorization: "Bearer token" }
-      }
-    }
-  }
-});
-
-// Tool receives auth info
 execute: async ({ context }, options) => {
   const { extra } = options;
   
@@ -1078,10 +1065,21 @@ execute: async ({ context }, options) => {
 ```
 
 The `extra` object contains:
-- `authInfo`: Token, client ID, and scopes extracted from client headers
-- `sessionId`: Session identifier
+- `authInfo`: Authentication info (when provided by server middleware)
+- `sessionId`: Session identifier  
 - `signal`: AbortSignal for cancellation
 - `sendNotification`/`sendRequest`: MCP protocol functions
+
+> Note: To enable authentication, your HTTP server needs middleware that populates `req.auth` before calling `server.startHTTP()`. For example:
+> ```typescript
+> httpServer.createServer((req, res) => {
+>   // Add auth middleware
+>   req.auth = validateAuthToken(req.headers.authorization);
+>   
+>   // Then pass to MCP server
+>   await server.startHTTP({ url, httpPath, req, res });
+> });
+> ```
 
 ## Related Information
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -850,16 +850,13 @@ execute: async ({ context }, options) => {
   // context contains the tool's input parameters
   // options contains server capabilities like elicitation and authentication info
   
-  // Destructure the options to access both elicitation and extra
-  const { elicitation, extra } = options;
-  
   // Access authentication information (when available)
-  if (extra?.authInfo) {
-    console.log('Authenticated request from:', extra.authInfo.clientId);
+  if (options.extra?.authInfo) {
+    console.log('Authenticated request from:', options.extra.authInfo.clientId);
   }
   
   // Use elicitation capabilities
-  const result = await elicitation.sendRequest({
+  const result = await options.elicitation.sendRequest({
     message: "Please provide information",
     requestedSchema: { /* schema */ }
   });
@@ -901,13 +898,12 @@ const server = new MCPServer({
       execute: async ({ context }, options) => {
         const { reason } = context;
         
-        // Destructure to access both elicitation and extra
-        const { elicitation, extra } = options;
-        console.log('Request from session:', extra?.sessionId);
+        // Log session info if available
+        console.log('Request from session:', options.extra?.sessionId);
 
         try {
           // Request user input via elicitation
-          const result = await elicitation.sendRequest({
+          const result = await options.elicitation.sendRequest({
             message: reason 
               ? `Please provide your contact information. ${reason}`
               : 'Please provide your contact information',
@@ -1016,17 +1012,15 @@ The elicitation functionality is available through the `options` parameter in to
 ```typescript
 // Within a tool's execute function
 execute: async ({ context }, options) => {
-  const { elicitation, extra } = options;
-  
   // Use elicitation for user input
-  const result = await elicitation.sendRequest({
+  const result = await options.elicitation.sendRequest({
     message: string,           // Message to display to user
     requestedSchema: object    // JSON schema defining expected response structure
   }): Promise<ElicitResult>
   
   // Access authentication info if needed
-  if (extra?.authInfo) {
-    // Use extra.authInfo.token, extra.authInfo.clientId, etc.
+  if (options.extra?.authInfo) {
+    // Use options.extra.authInfo.token, etc.
   }
 }
 ```
@@ -1048,16 +1042,14 @@ Tools can access request metadata via `options.extra` when using HTTP-based tran
 
 ```typescript
 execute: async ({ context }, options) => {
-  const { extra } = options;
-  
-  if (!extra?.authInfo?.token) {
+  if (!options.extra?.authInfo?.token) {
     return "Authentication required";
   }
   
   // Use the auth token
   const response = await fetch('/api/data', {
-    headers: { Authorization: `Bearer ${extra.authInfo.token}` },
-    signal: extra.signal,
+    headers: { Authorization: `Bearer ${options.extra.authInfo.token}` },
+    signal: options.extra.signal,
   });
   
   return response.json();


### PR DESCRIPTION
Added documentation for the new authentication context feature in MCP tools. This explains how tools can access auth info via `options.extra` when using HTTP transports.

The docs show that auth middleware needs to populate `req.auth` before calling `server.startHTTP()`:

```typescript
// In your HTTP server
req.auth = validateAuthToken(req.headers.authorization);
await server.startHTTP({ url, httpPath, req, res });

// In your tool
execute: async ({ context }, options) => {
  const { extra } = options;
  if (!extra?.authInfo?.token) {
    return "Authentication required";
  }
  // Use extra.authInfo.token for authenticated requests
}
```

Closes #5510