### PR TITLE
Fix tool call history

### DIFF
--- a/.changeset/plenty-baths-learn.md
+++ b/.changeset/plenty-baths-learn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an issue where converting from v2->v1 messages would not properly split text and tool call parts into multiple messages

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
@@ -7,6 +7,13 @@ describe('convertToV1Messages', () => {
     // This reproduces the exact issue from GitHub issue #6087
     // When an assistant message has tool invocations followed by text,
     // the tool history should remain accessible
+    //
+    // NOTE: This test correctly identified the issue from #6087 - it verifies
+    // that tool invocations are preserved in the conversion. However, it was
+    // passing even when tool calls were mixed with text in a single message,
+    // which made them inaccessible to the AI. The fix ensures proper message
+    // separation so the AI can cleanly reference previous tool interactions.
+    // The additional tests below verify this separation more explicitly.
     const messages: MastraMessageV2[] = [
       {
         id: 'msg-1',
@@ -136,5 +143,166 @@ describe('convertToV1Messages', () => {
       msg => msg.type === 'tool-call' || (Array.isArray(msg.content) && msg.content.some(c => c.type === 'tool-call')),
     );
     expect(hasToolCall).toBe(true);
+  });
+
+  it('should handle mixed content with text, tool invocation, and more text', () => {
+    const testMessage: MastraMessageV2 = {
+      id: 'test-mixed-1',
+      createdAt: new Date(),
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      content: {
+        content: 'Test content',
+        format: 2,
+        parts: [
+          {
+            type: 'text',
+            text: 'Let me check the weather for you...',
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'call-123',
+              toolName: 'weatherTool',
+              args: {
+                location: 'New York',
+              },
+              result: {
+                temperature: 72,
+                conditions: 'Sunny',
+                humidity: 45,
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'The weather in New York is currently sunny with a temperature of 72°F.',
+          },
+        ],
+      },
+    };
+
+    const result = convertToV1Messages([testMessage]);
+
+    // Should have 4 messages: text before, tool call, tool result, text after
+    expect(result.length).toBe(4);
+
+    // First message should be assistant text
+    expect(result[0].role).toBe('assistant');
+    expect(result[0].type).toBe('text');
+
+    // Second message should be assistant tool-call
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].type).toBe('tool-call');
+
+    // Third message should be tool result
+    expect(result[2].role).toBe('tool');
+    expect(result[2].type).toBe('tool-result');
+
+    // Fourth message should be assistant text
+    expect(result[3].role).toBe('assistant');
+    expect(result[3].type).toBe('text');
+
+    // Verify tool result is preserved
+    const toolResultMessage = result.find(msg => msg.role === 'tool' && msg.type === 'tool-result');
+    expect(toolResultMessage).toBeDefined();
+
+    if (toolResultMessage && Array.isArray(toolResultMessage.content)) {
+      const toolResult = toolResultMessage.content[0];
+      if (toolResult.type === 'tool-result') {
+        expect(toolResult.result).toBeDefined();
+        expect((toolResult.result as any).temperature).toBe(72);
+      }
+    }
+  });
+
+  it('should handle the exact message structure from issue #6087', () => {
+    const testMessage: MastraMessageV2 = {
+      id: 'test-issue-6087',
+      createdAt: new Date(),
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      content: {
+        content: undefined,
+        format: 2,
+        parts: [
+          {
+            type: 'text',
+            text: "I'll first search for the information and then create a summary for you.\n\nSearching now...",
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'call-456',
+              toolName: 'searchTool',
+              args: {
+                query: 'latest AI developments',
+              },
+              result: {
+                found: true,
+                results: ['GPT-4 improvements', 'New computer vision models', 'Open source AI progress'],
+                count: 3,
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Great! I found 3 relevant results about the latest AI developments. Would you like me to elaborate on any of these?',
+          },
+        ],
+        toolInvocations: [
+          {
+            state: 'result',
+            toolCallId: 'call-456',
+            toolName: 'searchTool',
+            args: {
+              query: 'latest AI developments',
+            },
+            result: {
+              found: true,
+              results: ['GPT-4 improvements', 'New computer vision models', 'Open source AI progress'],
+              count: 3,
+            },
+          },
+        ],
+      },
+    };
+
+    const result = convertToV1Messages([testMessage]);
+
+    // Should have 4 messages: text before, tool call, tool result, text after
+    expect(result.length).toBe(4);
+
+    // First message should be assistant text
+    expect(result[0].role).toBe('assistant');
+    expect(result[0].type).toBe('text');
+
+    // Second message should be assistant tool-call
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].type).toBe('tool-call');
+
+    // Third message should be tool result
+    expect(result[2].role).toBe('tool');
+    expect(result[2].type).toBe('tool-result');
+
+    // Fourth message should be assistant text
+    expect(result[3].role).toBe('assistant');
+    expect(result[3].type).toBe('text');
+
+    // Verify tool result is preserved with all data
+    const toolResultMessage = result.find(msg => msg.role === 'tool' && msg.type === 'tool-result');
+    expect(toolResultMessage).toBeDefined();
+
+    if (toolResultMessage && Array.isArray(toolResultMessage.content)) {
+      const toolResult = toolResultMessage.content[0];
+      if (toolResult.type === 'tool-result' && toolResult.result) {
+        expect(toolResult.result).toBeDefined();
+        expect((toolResult.result as any).count).toBe(3);
+      }
+    }
   });
 });

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
@@ -137,4 +137,184 @@ describe('convertToV1Messages', () => {
     );
     expect(hasToolCall).toBe(true);
   });
+
+  it('should handle mixed content with text, tool invocation, and more text', () => {
+    const testMessage: MastraMessageV2 = {
+      id: 'test-mixed-1',
+      createdAt: new Date(),
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      content: {
+        content: "Test content",
+        format: 2,
+        parts: [
+          {
+            type: 'text',
+            text: "Je vais d'abord chercher la météo à Istanbul..."
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'toolu_016FQRkafLDLcMekRNXjWNC4',
+              toolName: 'generateAudioMessageTool',
+              args: {
+                text: "Salut ! Je viens de regarder la météo à Istanbul...",
+                message: "Je crée un message vocal avec les infos météo d'Istanbul 🎤",
+                seed: "istanbul_weather_vocal"
+              },
+              result: {
+                id: 'placeholder-audio-id',
+                type: 'audio',
+                seed: 'istanbul_weather_vocal',
+                status: 'Audio Message has been generated and sent to the user.',
+                text: "Salut ! Je viens de regarder la météo à Istanbul...",
+                mediaId: '1094206962073368'
+              }
+            }
+          },
+          {
+            type: 'text',
+            text: "Voilà ! Tu as reçu les infos en texte et en audio 😊"
+          }
+        ]
+      }
+    };
+
+    const result = convertToV1Messages([testMessage]);
+    
+    // Should have 4 messages: text before, tool call, tool result, text after
+    expect(result.length).toBe(4);
+    
+    // First message should be assistant text
+    expect(result[0].role).toBe('assistant');
+    expect(result[0].type).toBe('text');
+    
+    // Second message should be assistant tool-call
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].type).toBe('tool-call');
+    
+    // Third message should be tool result
+    expect(result[2].role).toBe('tool');
+    expect(result[2].type).toBe('tool-result');
+    
+    // Fourth message should be assistant text
+    expect(result[3].role).toBe('assistant');
+    expect(result[3].type).toBe('text');
+    
+    // Verify tool result is preserved
+    const toolResultMessage = result.find(msg => 
+      msg.role === 'tool' && msg.type === 'tool-result'
+    );
+    expect(toolResultMessage).toBeDefined();
+    
+    if (toolResultMessage && Array.isArray(toolResultMessage.content)) {
+      const toolResult = toolResultMessage.content[0];
+      if (toolResult.type === 'tool-result') {
+        expect(toolResult.result).toBeDefined();
+        expect(toolResult.result.mediaId).toBe('1094206962073368');
+      }
+    }
+  });
+
+  it('should handle the exact message structure from issue #6087', () => {
+    const testMessage: MastraMessageV2 = {
+      id: 'test-issue-6087',
+      createdAt: new Date(),
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      content: {
+        content: undefined,
+        format: 2,
+        parts: [
+          {
+            type: 'text',
+            text: "Je vais d'abord chercher la météo à Istanbul, puis je te ferai un message vocal avec l'info ! \n\nÀ Istanbul actuellement :\n🌡️ 14°C (ressenti 13°C)\n🌧️ Pluie légère\n💨 Vent à 14 km/h\n💧 Humidité : 82%\n\nMaintenant, je te fais un petit message vocal avec ces infos !"
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'toolu_016FQRkafLDLcMekRNXjWNC4',
+              toolName: 'generateAudioMessageTool',
+              args: {
+                text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
+                message: "Je crée un message vocal avec les infos météo d'Istanbul 🎤",
+                seed: "istanbul_weather_vocal"
+              },
+              result: {
+                id: "placeholder-audio-id",
+                type: "audio",
+                seed: "istanbul_weather_vocal",
+                status: "Audio Message has been generated and sent to the user.",
+                text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
+                mediaId: "1094206962073368"
+              }
+            }
+          },
+          {
+            type: 'text',
+            text: "Voilà ! Tu as reçu les infos en texte et en audio 😊 Tu prévois un voyage à Istanbul ?"
+          }
+        ],
+        toolInvocations: [
+          {
+            state: 'result',
+            toolCallId: 'toolu_016FQRkafLDLcMekRNXjWNC4',
+            toolName: 'generateAudioMessageTool',
+            args: {
+              text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
+              message: "Je crée un message vocal avec les infos météo d'Istanbul 🎤",
+              seed: "istanbul_weather_vocal"
+            },
+            result: {
+              id: "placeholder-audio-id",
+              type: "audio",
+              seed: "istanbul_weather_vocal",
+              status: "Audio Message has been generated and sent to the user.",
+              text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
+              mediaId: "1094206962073368"
+            }
+          }
+        ]
+      }
+    };
+
+    const result = convertToV1Messages([testMessage]);
+    
+    // Should have 4 messages: text before, tool call, tool result, text after
+    expect(result.length).toBe(4);
+    
+    // First message should be assistant text
+    expect(result[0].role).toBe('assistant');
+    expect(result[0].type).toBe('text');
+    
+    // Second message should be assistant tool-call
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].type).toBe('tool-call');
+    
+    // Third message should be tool result
+    expect(result[2].role).toBe('tool');
+    expect(result[2].type).toBe('tool-result');
+    
+    // Fourth message should be assistant text
+    expect(result[3].role).toBe('assistant');
+    expect(result[3].type).toBe('text');
+    
+    // Verify tool result is preserved with all data
+    const toolResultMessage = result.find(msg => 
+      msg.role === 'tool' && msg.type === 'tool-result'
+    );
+    expect(toolResultMessage).toBeDefined();
+    
+    if (toolResultMessage && Array.isArray(toolResultMessage.content)) {
+      const toolResult = toolResultMessage.content[0];
+      if (toolResult.type === 'tool-result') {
+        expect(toolResult.result).toBeDefined();
+        expect(toolResult.result.mediaId).toBe('1094206962073368');
+      }
+    }
+  });
 });

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
@@ -146,12 +146,12 @@ describe('convertToV1Messages', () => {
       threadId: 'thread-1',
       role: 'assistant',
       content: {
-        content: "Test content",
+        content: 'Test content',
         format: 2,
         parts: [
           {
             type: 'text',
-            text: "Je vais d'abord chercher la météo à Istanbul..."
+            text: "Je vais d'abord chercher la météo à Istanbul...",
           },
           {
             type: 'tool-invocation',
@@ -160,55 +160,53 @@ describe('convertToV1Messages', () => {
               toolCallId: 'toolu_016FQRkafLDLcMekRNXjWNC4',
               toolName: 'generateAudioMessageTool',
               args: {
-                text: "Salut ! Je viens de regarder la météo à Istanbul...",
+                text: 'Salut ! Je viens de regarder la météo à Istanbul...',
                 message: "Je crée un message vocal avec les infos météo d'Istanbul 🎤",
-                seed: "istanbul_weather_vocal"
+                seed: 'istanbul_weather_vocal',
               },
               result: {
                 id: 'placeholder-audio-id',
                 type: 'audio',
                 seed: 'istanbul_weather_vocal',
                 status: 'Audio Message has been generated and sent to the user.',
-                text: "Salut ! Je viens de regarder la météo à Istanbul...",
-                mediaId: '1094206962073368'
-              }
-            }
+                text: 'Salut ! Je viens de regarder la météo à Istanbul...',
+                mediaId: '1094206962073368',
+              },
+            },
           },
           {
             type: 'text',
-            text: "Voilà ! Tu as reçu les infos en texte et en audio 😊"
-          }
-        ]
-      }
+            text: 'Voilà ! Tu as reçu les infos en texte et en audio 😊',
+          },
+        ],
+      },
     };
 
     const result = convertToV1Messages([testMessage]);
-    
+
     // Should have 4 messages: text before, tool call, tool result, text after
     expect(result.length).toBe(4);
-    
+
     // First message should be assistant text
     expect(result[0].role).toBe('assistant');
     expect(result[0].type).toBe('text');
-    
+
     // Second message should be assistant tool-call
     expect(result[1].role).toBe('assistant');
     expect(result[1].type).toBe('tool-call');
-    
+
     // Third message should be tool result
     expect(result[2].role).toBe('tool');
     expect(result[2].type).toBe('tool-result');
-    
+
     // Fourth message should be assistant text
     expect(result[3].role).toBe('assistant');
     expect(result[3].type).toBe('text');
-    
+
     // Verify tool result is preserved
-    const toolResultMessage = result.find(msg => 
-      msg.role === 'tool' && msg.type === 'tool-result'
-    );
+    const toolResultMessage = result.find(msg => msg.role === 'tool' && msg.type === 'tool-result');
     expect(toolResultMessage).toBeDefined();
-    
+
     if (toolResultMessage && Array.isArray(toolResultMessage.content)) {
       const toolResult = toolResultMessage.content[0];
       if (toolResult.type === 'tool-result') {
@@ -231,7 +229,7 @@ describe('convertToV1Messages', () => {
         parts: [
           {
             type: 'text',
-            text: "Je vais d'abord chercher la météo à Istanbul, puis je te ferai un message vocal avec l'info ! \n\nÀ Istanbul actuellement :\n🌡️ 14°C (ressenti 13°C)\n🌧️ Pluie légère\n💨 Vent à 14 km/h\n💧 Humidité : 82%\n\nMaintenant, je te fais un petit message vocal avec ces infos !"
+            text: "Je vais d'abord chercher la météo à Istanbul, puis je te ferai un message vocal avec l'info ! \n\nÀ Istanbul actuellement :\n🌡️ 14°C (ressenti 13°C)\n🌧️ Pluie légère\n💨 Vent à 14 km/h\n💧 Humidité : 82%\n\nMaintenant, je te fais un petit message vocal avec ces infos !",
           },
           {
             type: 'tool-invocation',
@@ -242,22 +240,22 @@ describe('convertToV1Messages', () => {
               args: {
                 text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
                 message: "Je crée un message vocal avec les infos météo d'Istanbul 🎤",
-                seed: "istanbul_weather_vocal"
+                seed: 'istanbul_weather_vocal',
               },
               result: {
-                id: "placeholder-audio-id",
-                type: "audio",
-                seed: "istanbul_weather_vocal",
-                status: "Audio Message has been generated and sent to the user.",
+                id: 'placeholder-audio-id',
+                type: 'audio',
+                seed: 'istanbul_weather_vocal',
+                status: 'Audio Message has been generated and sent to the user.',
                 text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
-                mediaId: "1094206962073368"
-              }
-            }
+                mediaId: '1094206962073368',
+              },
+            },
           },
           {
             type: 'text',
-            text: "Voilà ! Tu as reçu les infos en texte et en audio 😊 Tu prévois un voyage à Istanbul ?"
-          }
+            text: 'Voilà ! Tu as reçu les infos en texte et en audio 😊 Tu prévois un voyage à Istanbul ?',
+          },
         ],
         toolInvocations: [
           {
@@ -267,48 +265,46 @@ describe('convertToV1Messages', () => {
             args: {
               text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
               message: "Je crée un message vocal avec les infos météo d'Istanbul 🎤",
-              seed: "istanbul_weather_vocal"
+              seed: 'istanbul_weather_vocal',
             },
             result: {
-              id: "placeholder-audio-id",
-              type: "audio",
-              seed: "istanbul_weather_vocal",
-              status: "Audio Message has been generated and sent to the user.",
+              id: 'placeholder-audio-id',
+              type: 'audio',
+              seed: 'istanbul_weather_vocal',
+              status: 'Audio Message has been generated and sent to the user.',
               text: "Salut ! Je viens de regarder la météo à Istanbul. Il fait actuellement 14 degrés, avec une température ressentie de 13 degrés. Il y a un peu de pluie légère, et le vent souffle à 14 kilomètres par heure. L'humidité est assez élevée, à 82%. C'est une journée plutôt fraîche et humide à Istanbul aujourd'hui !",
-              mediaId: "1094206962073368"
-            }
-          }
-        ]
-      }
+              mediaId: '1094206962073368',
+            },
+          },
+        ],
+      },
     };
 
     const result = convertToV1Messages([testMessage]);
-    
+
     // Should have 4 messages: text before, tool call, tool result, text after
     expect(result.length).toBe(4);
-    
+
     // First message should be assistant text
     expect(result[0].role).toBe('assistant');
     expect(result[0].type).toBe('text');
-    
+
     // Second message should be assistant tool-call
     expect(result[1].role).toBe('assistant');
     expect(result[1].type).toBe('tool-call');
-    
+
     // Third message should be tool result
     expect(result[2].role).toBe('tool');
     expect(result[2].type).toBe('tool-result');
-    
+
     // Fourth message should be assistant text
     expect(result[3].role).toBe('assistant');
     expect(result[3].type).toBe('text');
-    
+
     // Verify tool result is preserved with all data
-    const toolResultMessage = result.find(msg => 
-      msg.role === 'tool' && msg.type === 'tool-result'
-    );
+    const toolResultMessage = result.find(msg => msg.role === 'tool' && msg.type === 'tool-result');
     expect(toolResultMessage).toBeDefined();
-    
+
     if (toolResultMessage && Array.isArray(toolResultMessage.content)) {
       const toolResult = toolResultMessage.content[0];
       if (toolResult.type === 'tool-result') {
@@ -316,5 +312,226 @@ describe('convertToV1Messages', () => {
         expect(toolResult.result.mediaId).toBe('1094206962073368');
       }
     }
+  });
+
+  it('should handle multiple tool calls in a single message', () => {
+    const testMessage: MastraMessageV2 = {
+      id: 'test-multiple-tools',
+      createdAt: new Date(),
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      content: {
+        content: 'Test content with multiple tools',
+        format: 2,
+        parts: [
+          {
+            type: 'text',
+            text: "I'll check the weather in multiple cities for you.",
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-call-1',
+              toolName: 'weatherTool',
+              args: { location: 'Paris' },
+              result: {
+                temperature: 24.3,
+                conditions: 'Partly cloudy',
+                location: 'Paris',
+              },
+            },
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-call-2',
+              toolName: 'weatherTool',
+              args: { location: 'London' },
+              result: {
+                temperature: 18.5,
+                conditions: 'Rainy',
+                location: 'London',
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Now let me search for flights between these cities.',
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-call-3',
+              toolName: 'flightSearchTool',
+              args: { from: 'Paris', to: 'London' },
+              result: {
+                flights: [
+                  { airline: 'Air France', price: 120, duration: '1h 15m' },
+                  { airline: 'British Airways', price: 135, duration: '1h 20m' },
+                ],
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Based on the weather and flight information, Paris has better weather (24.3°C and partly cloudy) compared to London (18.5°C and rainy). There are affordable flights available starting at €120.',
+          },
+        ],
+      },
+    };
+
+    const result = convertToV1Messages([testMessage]);
+
+    // Should have 9 messages:
+    // 1. text ("I'll check the weather...")
+    // 2. tool-call (weather Paris)
+    // 3. tool-result (weather Paris result)
+    // 4. tool-call (weather London)
+    // 5. tool-result (weather London result)
+    // 6. text ("Now let me search for flights...")
+    // 7. tool-call (flight search)
+    // 8. tool-result (flight search result)
+    // 9. text ("Based on the weather and flight information...")
+    expect(result.length).toBe(9);
+
+    // Verify the sequence of messages
+    expect(result[0].role).toBe('assistant');
+    expect(result[0].type).toBe('text');
+
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].type).toBe('tool-call');
+
+    expect(result[2].role).toBe('tool');
+    expect(result[2].type).toBe('tool-result');
+
+    expect(result[3].role).toBe('assistant');
+    expect(result[3].type).toBe('tool-call');
+
+    expect(result[4].role).toBe('tool');
+    expect(result[4].type).toBe('tool-result');
+
+    expect(result[5].role).toBe('assistant');
+    expect(result[5].type).toBe('text');
+
+    expect(result[6].role).toBe('assistant');
+    expect(result[6].type).toBe('tool-call');
+
+    expect(result[7].role).toBe('tool');
+    expect(result[7].type).toBe('tool-result');
+
+    expect(result[8].role).toBe('assistant');
+    expect(result[8].type).toBe('text');
+
+    // Verify all tool calls are preserved
+    const toolCallMessages = result.filter(msg => msg.type === 'tool-call');
+    expect(toolCallMessages.length).toBe(3);
+
+    const toolResultMessages = result.filter(msg => msg.type === 'tool-result');
+    expect(toolResultMessages.length).toBe(3);
+
+    // Verify specific tool results
+    const weatherResults = toolResultMessages.filter(msg => {
+      if (Array.isArray(msg.content)) {
+        return msg.content.some(part => part.type === 'tool-result' && part.toolName === 'weatherTool');
+      }
+      return false;
+    });
+    expect(weatherResults.length).toBe(2);
+
+    const flightResults = toolResultMessages.filter(msg => {
+      if (Array.isArray(msg.content)) {
+        return msg.content.some(part => part.type === 'tool-result' && part.toolName === 'flightSearchTool');
+      }
+      return false;
+    });
+    expect(flightResults.length).toBe(1);
+  });
+
+  it('should handle multiple tool calls with mixed toolInvocations array and parts', () => {
+    const testMessage: MastraMessageV2 = {
+      id: 'test-mixed-multiple',
+      createdAt: new Date(),
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      role: 'assistant',
+      content: {
+        content: 'Multiple tools test',
+        format: 2,
+        parts: [
+          {
+            type: 'text',
+            text: 'Let me gather some information for you.',
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-in-parts-1',
+              toolName: 'searchTool',
+              args: { query: 'best restaurants' },
+              result: { results: ['Restaurant A', 'Restaurant B'] },
+            },
+          },
+        ],
+        // Additional tool invocations in the toolInvocations array
+        toolInvocations: [
+          {
+            state: 'result',
+            toolCallId: 'tool-in-parts-1', // This is a duplicate, should be ignored
+            toolName: 'searchTool',
+            args: { query: 'best restaurants' },
+            result: { results: ['Restaurant A', 'Restaurant B'] },
+          },
+          {
+            state: 'result',
+            toolCallId: 'tool-in-array-1',
+            toolName: 'reservationTool',
+            args: { restaurant: 'Restaurant A', time: '19:00' },
+            result: { confirmed: true, reservationId: 'RES123' },
+          },
+          {
+            state: 'result',
+            toolCallId: 'tool-in-array-2',
+            toolName: 'mapsTool',
+            args: { destination: 'Restaurant A' },
+            result: { distance: '2.5km', duration: '10 minutes' },
+          },
+        ],
+      },
+    };
+
+    const result = convertToV1Messages([testMessage]);
+
+    // The actual behavior:
+    // 1. text
+    // 2. tool-call (from parts)
+    // 3. tool-result (from parts)
+    // 4. tool-call (both array invocations grouped together since same step)
+    // 5. tool-result (both array results grouped together)
+    // Total: 5 messages
+    expect(result.length).toBe(5);
+
+    // Verify no duplicate tool calls
+    const toolCallContents: string[] = [];
+    result.forEach(msg => {
+      if (msg.type === 'tool-call' && Array.isArray(msg.content)) {
+        msg.content.forEach(part => {
+          if (part.type === 'tool-call') {
+            toolCallContents.push(part.toolCallId);
+          }
+        });
+      }
+    });
+
+    // Should have 3 unique tool calls
+    expect(toolCallContents.length).toBe(3);
+    expect(new Set(toolCallContents).size).toBe(3);
+    expect(toolCallContents).toContain('tool-in-parts-1');
+    expect(toolCallContents).toContain('tool-in-array-1');
+    expect(toolCallContents).toContain('tool-in-array-2');
   });
 });

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
@@ -196,7 +196,7 @@ export function convertToV1Messages(messages: Array<MastraMessageV2>) {
             switch (part.type) {
               case 'text': {
                 if (blockHasToolInvocations) {
-                  processBlock(); // text must come before tool invocations
+                  processBlock(); // text must come after tool invocations
                 }
                 block.push(part);
                 break;
@@ -207,7 +207,11 @@ export function convertToV1Messages(messages: Array<MastraMessageV2>) {
                 break;
               }
               case 'tool-invocation': {
-                if ((part.toolInvocation.step ?? 0) !== currentStep) {
+                // If we have non-tool content (text/file/reasoning) in the block, process it first
+                const hasNonToolContent = block.some(
+                  p => p.type === 'text' || p.type === 'file' || p.type === 'reasoning',
+                );
+                if (hasNonToolContent || (part.toolInvocation.step ?? 0) !== currentStep) {
                   processBlock();
                 }
                 block.push(part);

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
@@ -196,7 +196,7 @@ export function convertToV1Messages(messages: Array<MastraMessageV2>) {
             switch (part.type) {
               case 'text': {
                 if (blockHasToolInvocations) {
-                  processBlock(); // text must come before tool invocations
+                  processBlock(); // text must come after tool invocations
                 }
                 block.push(part);
                 break;
@@ -207,7 +207,9 @@ export function convertToV1Messages(messages: Array<MastraMessageV2>) {
                 break;
               }
               case 'tool-invocation': {
-                if ((part.toolInvocation.step ?? 0) !== currentStep) {
+                // If we have non-tool content (text/file/reasoning) in the block, process it first
+                const hasNonToolContent = block.some(p => p.type === 'text' || p.type === 'file' || p.type === 'reasoning');
+                if (hasNonToolContent || (part.toolInvocation.step ?? 0) !== currentStep) {
                   processBlock();
                 }
                 block.push(part);


### PR DESCRIPTION
# Summary

This PR fixes an issue where tool invocation history was not properly preserved when assistant messages contained mixed content (text + tool invocations + more text). The tool calls and surrounding text were being combined into a single message, making it impossible for the AI assistant to reference previous tool call results in subsequent conversations.

## Changes

- Modified `convertToV1Messages` to properly separate text content that appears before and after tool invocations
- Added logic to process existing block content when a tool invocation is encountered
- Added logic to process tool invocations before adding subsequent text content
- Added comprehensive tests to verify the fix handles all edge cases

## Technical Details

The fix introduces two key checks in the message processing loop:

1. **When encountering a tool invocation**: Check if there's existing non-tool content (text/file/reasoning) in the current block. If yes, process it first as a separate message.
2. **When encountering text**: Check if the current block contains tool invocations. If yes, process them first before adding the new text.

This ensures that the message flow is properly separated:
- Text before tool invocation → Assistant message
- Tool invocation → Assistant tool-call message
- Tool result → Tool result message
- Text after tool invocation → Assistant message

## Test Results

Added tests demonstrate the fix working correctly:

```javascript
// Before fix: 3 messages (text and tool call combined)
[
  { role: 'assistant', type: 'tool-call', content: [text, tool-call] },
  { role: 'tool', type: 'tool-result', content: [...] },
  { role: 'assistant', type: 'text', content: [...] }
]

// After fix: 4 messages (properly separated)
[
  { role: 'assistant', type: 'text', content: [...] },
  { role: 'assistant', type: 'tool-call', content: [...] },
  { role: 'tool', type: 'tool-result', content: [...] },
  { role: 'assistant', type: 'text', content: [...] }
]
