### PR TITLE
docs: update agent memory syntax to new memory object pattern

### DIFF
--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -165,22 +165,26 @@ const response = await agent.generate("Remember my favorite color is blue.", {
 
 ## Using Memory in Agent Calls
 
-To utilize memory during interactions, you **must** provide `resourceId` and `threadId` when calling the agent's `stream()` or `generate()` methods.
+To utilize memory during interactions, you **must** provide a `memory` object with `resource` and `thread` properties when calling the agent's `stream()` or `generate()` methods.
 
-- `resourceId`: Typically identifies the user or entity (e.g., `user_123`).
-- `threadId`: Identifies a specific conversation thread (e.g., `support_chat_456`).
+- `resource`: Typically identifies the user or entity (e.g., `user_123`).
+- `thread`: Identifies a specific conversation thread (e.g., `support_chat_456`).
 
 ```typescript
 // Example agent call using memory
 await agent.stream("Remember my favorite color is blue.", {
-  resourceId: "user_alice",
-  threadId: "preferences_thread",
+  memory: {
+    resource: "user_alice",
+    thread: "preferences_thread",
+  },
 });
 
 // Later in the same thread...
 const response = await agent.stream("What's my favorite color?", {
-  resourceId: "user_alice",
-  threadId: "preferences_thread",
+  memory: {
+    resource: "user_alice",
+    thread: "preferences_thread",
+  },
 });
 // Agent will use memory to recall the favorite color.
 ```

--- a/docs/src/content/en/examples/memory/use-chat.mdx
+++ b/docs/src/content/en/examples/memory/use-chat.mdx
@@ -31,12 +31,12 @@ Benefits:
 
 The default behavior of `useChat` sends the entire chat history with each request. Since Mastra's memory automatically retrieves history based on `threadId`, sending the full history from the client leads to duplicate messages in the context window and storage.
 
-**Solution:** Configure `useChat` to send **only the latest message** along with your `threadId` and `resourceId`.
+**Solution:** Configure `useChat` to send **only the latest message** along with your memory configuration (thread and resource identifiers).
 
 ```typescript filename="components/Chat.tsx" showLineNumbers copy
 import { useChat } from "ai/react";
 
-export function Chat({ threadId, resourceId }) {
+export function Chat({ thread, resource }) {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
     api: "/api/chat", // Your backend endpoint
     // Pass only the latest message and custom IDs
@@ -47,8 +47,10 @@ export function Chat({ threadId, resourceId }) {
       // Return the structured body for your API route
       return {
         message: lastMessage, // Send only the most recent message content/role
-        threadId,
-        resourceId,
+        memory: {
+          thread,
+          resource,
+        },
       };
     },
     // Optional: Initial messages if loading history from backend
@@ -84,7 +86,7 @@ const mastraClient = new MastraClient({
 
 export async function POST(request: Request) {
   // Get data structured by experimental_prepareRequestBody
-  const { message, threadId, resourceId }: { message: CoreMessage | null; threadId: string; resourceId: string } = await request.json();
+  const { message, memory }: { message: CoreMessage | null; memory: { thread: string; resource: string } } = await request.json();
 
   // Handle cases where message might be null (e.g., initial load or error)
   if (!message || !message.content) {
@@ -97,8 +99,7 @@ export async function POST(request: Request) {
   // Stream the response with memory context
   const response = await agent.stream({
     messages: [{ role: message.role || "user", content: message.content }],
-    threadId,
-    resourceId,
+    memory,
   });
 
   // Return the streaming response to the frontend
@@ -113,7 +114,7 @@ If you've deployed your Mastra Server with a custom route handler for chat, you 
 ```typescript filename="components/Chat.tsx" showLineNumbers copy
 import { useChat } from "ai/react";
 
-export function Chat({ threadId, resourceId, agentId = "ChatAgent" }) {
+export function Chat({ thread, resource, agentId = "ChatAgent" }) {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
     // Connect directly to your Mastra Server's stream endpoint
     api: `${process.env.NEXT_PUBLIC_MASTRA_SERVER_URL}/api/agents/${agentId}/stream`,
@@ -122,8 +123,10 @@ export function Chat({ threadId, resourceId, agentId = "ChatAgent" }) {
       // The Mastra Server expects the full messages array, not just a single message
       return {
         messages: lastMessage ? [lastMessage] : [],
-        threadId,
-        resourceId,
+        memory: {
+          thread,
+          resource,
+        },
       };
     },
     headers: {
@@ -206,7 +209,7 @@ function ChatApp() {
       />
       <div style={{ flexGrow: 1 }}>
         {currentThreadId ? (
-          <Chat threadId={currentThreadId} resourceId={userId} agentId="your-agent-id" /> // Your useChat component
+          <Chat thread={currentThreadId} resource={userId} agentId="your-agent-id" /> // Your useChat component
         ) : (
           <div>Select or start a conversation.</div>
         )}
@@ -236,12 +239,12 @@ function ChatApp() {
 1. **Connection refused**: Ensure your Mastra Server is running and accessible
 2. **Authentication errors**: Check your API key configuration
 3. **Message duplication**: Verify you're only sending the latest message
-4. **Missing thread history**: Ensure `threadId` and `resourceId` are passed correctly
+4. **Missing thread history**: Ensure memory configuration with `thread` and `resource` is passed correctly
 5. **CORS errors (direct connection)**: Configure your Mastra Server to allow requests from your frontend origin
 
 ## Related
 
 - **[MastraClient Overview](../../docs/server-db/mastra-client.mdx)**: Learn more about the Mastra Client SDK
 - **[Mastra Server](../../docs/deployment/server-deployment.mdx)**: How to deploy and configure a Mastra Server
-- **[Memory Overview](../../docs/memory/overview.mdx)**: Core concepts of `resourceId` and `threadId`
+- **[Memory Overview](../../docs/memory/overview.mdx)**: Core concepts of memory resources and threads
 - **[AI SDK Integration](../../docs/frameworks/agentic-uis/ai-sdk.mdx#usechat)**: General useChat documentation

--- a/examples/memory-per-resource-example/src/example.ts
+++ b/examples/memory-per-resource-example/src/example.ts
@@ -43,33 +43,33 @@ const userChoice = await new Promise<string>(resolve => {
   });
 });
 
-let resourceId: string;
+let resource: string;
 let userName: string;
 
 switch (userChoice) {
   case '1':
-    resourceId = USERS.alice;
+    resource = USERS.alice;
     userName = 'Alice';
     break;
   case '2':
-    resourceId = USERS.bob;
+    resource = USERS.bob;
     userName = 'Bob';
     break;
   case '3':
-    resourceId = USERS.demo;
+    resource = USERS.demo;
     userName = 'Demo User';
     break;
   default:
-    resourceId = `user-${randomUUID()}`;
+    resource = `user-${randomUUID()}`;
     userName = 'Random User';
 }
 
 // Always generate a new thread ID to demonstrate cross-thread persistence
-const threadId = randomUUID();
+const thread = randomUUID();
 
 console.log(chalk.green(`\n✅ Simulating: ${userName}`));
-console.log(chalk.gray(`📧 Resource ID: ${resourceId}`));
-console.log(chalk.gray(`🧵 Thread ID: ${threadId}`));
+console.log(chalk.gray(`📧 Resource ID: ${resource}`));
+console.log(chalk.gray(`🧵 Thread ID: ${thread}`));
 console.log(chalk.bold.yellow('\n💡 TIP: Run this example multiple times with the same user choice'));
 console.log(chalk.bold.yellow('   to see how working memory persists across conversation threads!\n'));
 
@@ -107,7 +107,7 @@ async function main() {
         If this is a returning user, greet them warmly and reference what you remember!`,
         },
       ],
-      { threadId, resourceId },
+      { memory: { thread, resource } },
     ),
   );
 
@@ -124,7 +124,7 @@ async function main() {
       break;
     }
 
-    await logResponse(await agent.stream(userInput, { threadId, resourceId }));
+    await logResponse(await agent.stream(userInput, { memory: { thread, resource } }));
   }
 
   rl.close();

--- a/examples/memory-with-libsql/src/chat.ts
+++ b/examples/memory-with-libsql/src/chat.ts
@@ -7,12 +7,12 @@ import { mastra } from './mastra';
 
 const agent = mastra.getAgent('memoryAgent');
 
-let threadId = randomUUID();
+let thread = randomUUID();
 // use this to play with a long running conversation. comment it out to get a new thread id every time
-threadId = `f45a59b3-d9da-4a2a-8348-9386e4e621a3`;
-console.log(threadId);
+thread = `f45a59b3-d9da-4a2a-8348-9386e4e621a3`;
+console.log(thread);
 
-const resourceId = 'SOME_USER_ID';
+const resource = 'SOME_USER_ID';
 
 async function logRes(res: Awaited<ReturnType<typeof agent.stream>>) {
   console.log(`\n🤖 Agent:`);
@@ -31,7 +31,7 @@ async function main() {
           content: `Chat with user started now ${new Date().toISOString()}. Don't mention this message. This means some time may have passed between this message and the one before. The user left and came back again. Say something to start the conversation up again. If there are no other messages besides this one then this is a new conversation.`,
         },
       ],
-      { resourceId, threadId },
+      { memory: { resource, thread } },
     ),
   );
 
@@ -49,8 +49,7 @@ async function main() {
 
     await logRes(
       await agent.stream(prompt, {
-        threadId,
-        resourceId,
+        memory: { thread, resource },
       }),
     );
   }

--- a/examples/memory-with-pg/src/chat.ts
+++ b/examples/memory-with-pg/src/chat.ts
@@ -7,13 +7,13 @@ import { mastra } from './mastra';
 
 const agent = mastra.getAgent('memoryAgent');
 
-let threadId = randomUUID();
+let thread = randomUUID();
 // use this to play with a long running conversation. comment it out to get a new thread id every time
-threadId = `39873fbf-84d6-425e-8c1b-8afd798d72a4`;
-// threadId = `12569b14-3e16-4e31-8130-8d9676f1932c`;
-console.log(threadId);
+thread = `39873fbf-84d6-425e-8c1b-8afd798d72a4`;
+// thread = `12569b14-3e16-4e31-8130-8d9676f1932c`;
+console.log(thread);
 
-const resourceId = 'SOME_USER_ID';
+const resource = 'SOME_USER_ID';
 
 async function logRes(res: Awaited<ReturnType<typeof agent.stream>>) {
   console.log(`\n🤖 Agent:`);
@@ -32,7 +32,7 @@ async function main() {
           content: `Chat with user started now ${new Date().toISOString()}. Don't mention this message. This means some time may have passed between this message and the one before. The user left and came back again. Say something to start the conversation up again.`,
         },
       ],
-      { resourceId, threadId },
+      { memory: { resource, thread } },
     ),
   );
 
@@ -50,8 +50,7 @@ async function main() {
 
     await logRes(
       await agent.stream(prompt, {
-        threadId,
-        resourceId,
+        memory: { thread, resource },
       }),
     );
   }


### PR DESCRIPTION
Updates the documentation to use the new memory object syntax instead of the deprecated threadId/resourceId parameters, fixing #5426.

The old syntax:
```typescript
await agent.stream("Hello", {
  threadId: "thread-123",
  resourceId: "user-456"
});
```

Is now:
```typescript
await agent.stream("Hello", {
  memory: {
    thread: "thread-123",
    resource: "user-456"
  }
});
```

Updated the agent memory documentation, useChat example, and several example files to use the cleaner variable names and new syntax pattern.