### PR TITLE
fix(workflow):  lazy initialize Run's `AbortController`

### DIFF
--- a/.changeset/many-parts-design.md
+++ b/.changeset/many-parts-design.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+lazy initialize Run's `AbortController`

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1210,7 +1210,7 @@ export class Workflow<
     const nestedAbortCb = () => {
       abort();
     };
-    run.abortController?.signal.addEventListener('abort', nestedAbortCb);
+    run.abortController.signal.addEventListener('abort', nestedAbortCb);
     abortSignal.addEventListener('abort', async () => {
       run.abortController.signal.removeEventListener('abort', nestedAbortCb);
       await run.cancel();
@@ -1337,7 +1337,7 @@ export class Run<
   TInput extends z.ZodType<any> = z.ZodType<any>,
   TOutput extends z.ZodType<any> = z.ZodType<any>,
 > {
-  public abortController: AbortController;
+  #abortController?: AbortController;
   protected emitter: EventEmitter;
   /**
    * Unique identifier for this workflow
@@ -1406,7 +1406,14 @@ export class Run<
     this.emitter = new EventEmitter();
     this.retryConfig = params.retryConfig;
     this.cleanup = params.cleanup;
-    this.abortController = new AbortController();
+  }
+
+  public get abortController(): AbortController {
+    if (!this.#abortController) {
+      this.#abortController = new AbortController();
+    }
+
+    return this.#abortController;
   }
 
   /**


### PR DESCRIPTION
## Description

There is an issue when using `AbortControllers` in Cloudflare workers see https://github.com/cloudflare/workerd/issues/3657
To allow for deploying a Mastra project to Cloudflare workers I made the following changes:
- Changed `abortController` to a private optional field `#abortController`
- Added getter to lazily initialize the `AbortController` when accessed

To test these changes, you can use the `Steps To Reproduce` instructions from https://github.com/mastra-ai/mastra/issues/6337 and you will not get any error anymore. (The error was `Error: Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler. This is a limitation of Cloudflare Workers which allows us to improve overall performance. (I/O type: RefcountedCanceler)`)

## Related Issue(s)

fixed #6337

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
