### PR TITLE
[fix] updated the instructions for setting up the Github MCP client in the MCP course.

### DIFF
--- a/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
+++ b/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
@@ -1,16 +1,36 @@
-# Getting a Composio GitHub MCP URL
+# Getting a Smithery GitHub MCP URL
 
-First, you'll need to get a Composio GitHub MCP URL. This typically requires:
+First, you'll need to get a Smithery GitHub MCP URL. This typically requires:
 
-1. Setting up the Composio GitHub integration
-2. Authenticating with your GitHub account
-3. Getting your unique MCP URL
+1. Setting up a Smithery account
+2. Creating a personal access token with your GitHub account
+3. Getting your unique MCP URL via the Smithery packages
 
-For this example, we'll use an environment variable to store the URL:
+For this example, we'll use an environment variable to store the Smithery API key and profile name which can be found in the Smithery interface.
 
 ```bash
 # Add this to your .env file
-COMPOSIO_MCP_GITHUB=https://your-composio-github-mcp-url.com
+SMITHERY_API_KEY=your_smithery_api_key
+SMITHERY_PROFILE=your_smithery_profile_name
 ```
 
-Using an environment variable keeps your configuration secure and flexible. This approach allows you to easily switch between different GitHub accounts or environments without modifying your code. It also prevents sensitive information from being committed to your repository.
+Using an environment variable keeps your configuration secure and flexible. It also prevents sensitive information from being committed to your repository.
+
+We will use the Smithery packages to authenticate and create a streamable HTTP URL for the MCP server configuration
+
+```bash
+pnpm install @smithery/sdk
+```
+
+```ts
+import { createSmitheryUrl } from "@smithery/sdk";
+
+const smitheryGithubMCPServerUrl = createSmitheryUrl(
+  "https://server.smithery.ai/@smithery-ai/github",
+  {
+    apiKey: process.env.SMITHERY_API_KEY,
+    profile: process.env.SMITHERY_PROFILE,
+  }
+);
+```
+

--- a/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
+++ b/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
@@ -9,7 +9,7 @@ const mcp = new MCPClient({
       url: new URL(process.env.ZAPIER_MCP_URL || ""),
     },
     github: {
-      url: new URL(process.env.COMPOSIO_MCP_GITHUB || ""),
+      url: smitheryGithubMCPServerUrl,
     },
   },
 });


### PR DESCRIPTION
## Description

Updates the instructions for the Github MCP setup section of the MCP course. 

Note that I handle the setup with both the new Composio method and Smithery, and settled on suggesting using Smithery instead. The new Composio method is a bit verbose for the course tutorial, so I opted to use Smithery's GitHub MCP, as it still exposes the simple, streamable HTTP URL.

## Related Issue(s)

Here is the [related issue](https://github.com/mastra-ai/mastra/issues/6473).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
