### PR TITLE
fix: use correct lodash/fp imports

### DIFF
--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -58,7 +58,7 @@ describe.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
       const res = await fetch(`http://localhost:${port}/test`);
       const body = await res.json();
       expect(res.status).toBe(200);
-      expect(body).toEqual({ message: 'Hello, world!' });
+      expect(body).toEqual({ message: 'Hello, world!', a: 'b' });
     });
     it('should resolve api ALL routes', async () => {
       let res = await fetch(`http://localhost:${port}/all`);

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/agents/index.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/agents/index.ts
@@ -8,5 +8,5 @@ export const innerAgent = new Agent({
   name: 'inner-agent',
   instructions: 'You are a helpful assistant.',
   model: openai('gpt-4o'),
-  tools: [helloWorldTool, lodashTool, toolUsingNativeBindings, toolWithNativeBindingPackageDep, calculatorTool],
+  tools: { helloWorldTool, lodashTool, toolUsingNativeBindings, toolWithNativeBindingPackageDep, calculatorTool },
 });

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/api/route/test.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/api/route/test.ts
@@ -1,8 +1,13 @@
 import { registerApiRoute } from '@mastra/core/server';
+import { IgetYouAnything } from '@custom-lodash/index';
 
 export const testRoute = registerApiRoute('/test', {
   method: 'GET',
   handler: async c => {
-    return c.json({ message: 'Hello, world!' });
+    const obj = {
+      a: 'b',
+    };
+
+    return c.json({ message: 'Hello, world!', a: IgetYouAnything(obj, 'a') });
   },
 });

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/index.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/index.ts
@@ -4,7 +4,7 @@ import { testRoute } from '@/api/route/test';
 import { allRoute } from '@/api/route/all';
 
 export const mastra = new Mastra({
-  agents: [innerAgent],
+  agents: { innerAgent },
   server: {
     port: process.env.MASTRA_PORT ? parseInt(process.env.MASTRA_PORT) : 3000,
     apiRoutes: [testRoute, allRoute],

--- a/e2e-tests/monorepo/template/apps/custom/tsconfig.json
+++ b/e2e-tests/monorepo/template/apps/custom/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/mastra/*"]
+      "@/*": ["./src/mastra/*"],
+      "@custom-lodash/*": ["../../packages/lodash-test/src/*"]
     }
   }
 }

--- a/e2e-tests/monorepo/template/packages/lodash-test/package.json
+++ b/e2e-tests/monorepo/template/packages/lodash-test/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@inner/lodash",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "src/index.mjs",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@mastra/core": "monorepo-test",
+    "lodash": "^4.17.21"
+  }
+}

--- a/e2e-tests/monorepo/template/packages/lodash-test/src/index.ts
+++ b/e2e-tests/monorepo/template/packages/lodash-test/src/index.ts
@@ -1,0 +1,5 @@
+import { get } from 'lodash/fp';
+
+export const IgetYouAnything = (obj: any, key: string) => {
+  return get(key, obj);
+};

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -6,7 +6,6 @@ import { fileURLToPath } from 'node:url';
 import { rollup, type InputOptions, type OutputOptions } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
-
 import type { analyzeBundle } from './analyze';
 import { removeDeployer } from './plugins/remove-deployer';
 import { tsConfigPaths } from './plugins/tsconfig-paths';
@@ -94,7 +93,6 @@ export async function getInputOptions(
           { find: /^\#mastra$/, replacement: normalizedEntryFile },
         ],
       }),
-      optimizeLodashImports(),
       {
         name: 'tools-rewriter',
         resolveId(id: string) {
@@ -112,6 +110,7 @@ export async function getInputOptions(
         minify: false,
         define: env,
       }),
+      optimizeLodashImports(),
       commonjs({
         extensions: ['.js', '.ts'],
         transformMixedEsModules: true,

--- a/packages/deployer/src/build/bundlerOptions.ts
+++ b/packages/deployer/src/build/bundlerOptions.ts
@@ -6,6 +6,7 @@ import { tsConfigPaths } from './plugins/tsconfig-paths';
 import { removeAllOptionsExceptBundler } from './babel/remove-all-options-bundler';
 import { recursiveRemoveNonReferencedNodes } from './plugins/remove-unused-references';
 import type { Config } from '@mastra/core';
+import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
 
 export function getBundlerOptionsBundler(
   entryFile: string,
@@ -27,6 +28,7 @@ export function getBundlerOptionsBundler(
         platform: 'node',
         minify: false,
       }),
+      optimizeLodashImports(),
       commonjs({
         extensions: ['.js', '.ts'],
         strictRequires: 'strict',

--- a/packages/deployer/src/build/serverOptions.ts
+++ b/packages/deployer/src/build/serverOptions.ts
@@ -7,6 +7,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import { recursiveRemoveNonReferencedNodes } from './plugins/remove-unused-references';
 import type { Config, Mastra } from '@mastra/core';
 import { tsConfigPaths } from './plugins/tsconfig-paths';
+import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
 
 export function getServerOptionsBundler(
   entryFile: string,
@@ -28,6 +29,7 @@ export function getServerOptionsBundler(
         platform: 'node',
         minify: false,
       }),
+      optimizeLodashImports(),
       commonjs({
         extensions: ['.js', '.ts'],
         strictRequires: 'strict',


### PR DESCRIPTION
## Summary
  - Add lodash import optimization to the Rollup bundler configuration
  - Update test template to validate lodash usage in deployed applications
  - Fix agent and configuration object syntax to use object notation instead of arrays


##  Test Plan
- E2e tests pass with lodash optimization
- Bundle builds successfully with optimized lodash imports
- API routes work correctly with lodash functions