### PR TITLE
fix: create unique IDs when splitting v2 message parts to separate v1 messages

### DIFF
--- a/.changeset/old-jars-add.md
+++ b/.changeset/old-jars-add.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool call history not being accessible in agent conversations
+
+When converting v2 messages (with combined tool calls and text) to v1 format for memory storage, split messages were all keeping the same ID. This caused later messages to replace earlier ones when added back to MessageList, losing tool history.
+
+The fix adds ID deduplication by appending `__split-N` suffixes to split messages and prevents double-suffixing when messages are re-converted between formats.

--- a/packages/core/src/agent/message-list/message-list.test.ts
+++ b/packages/core/src/agent/message-list/message-list.test.ts
@@ -2868,7 +2868,6 @@ describe('MessageList', () => {
 
       // Step 3: Get remembered messages as v1 (like agent does for processing)
       const rememberedV1 = messageList.get.remembered.v1();
-      console.log('Remembered V1 messages:', JSON.stringify(rememberedV1, null, 2));
 
       // Step 4: Simulate memory.processMessages (which just returns them if no processors)
       const processedMemoryMessages = rememberedV1;
@@ -2895,11 +2894,8 @@ describe('MessageList', () => {
       // Step 6: Get prompt messages (what's sent to LLM)
       const promptMessages = returnList.get.all.prompt();
 
-      console.log('Final prompt messages (sent to LLM):', JSON.stringify(promptMessages, null, 2));
-
       // Verify the tool history is preserved
       const assistantMessages = promptMessages.filter(m => m.role === 'assistant');
-      console.log('Assistant messages count:', assistantMessages.length);
 
       // Check if tool calls are present
       const hasToolCall = promptMessages.some(
@@ -2909,9 +2905,6 @@ describe('MessageList', () => {
       const hasToolResult = promptMessages.some(
         m => m.role === 'tool' && Array.isArray(m.content) && m.content.some(c => c.type === 'tool-result'),
       );
-
-      console.log('Has tool call:', hasToolCall);
-      console.log('Has tool result:', hasToolResult);
 
       // These should be true if tool history is preserved
       expect(hasToolCall).toBe(true);

--- a/packages/core/src/agent/message-list/message-list.test.ts
+++ b/packages/core/src/agent/message-list/message-list.test.ts
@@ -2895,8 +2895,6 @@ describe('MessageList', () => {
       const promptMessages = returnList.get.all.prompt();
 
       // Verify the tool history is preserved
-      const assistantMessages = promptMessages.filter(m => m.role === 'assistant');
-
       // Check if tool calls are present
       const hasToolCall = promptMessages.some(
         m => m.role === 'assistant' && Array.isArray(m.content) && m.content.some(c => c.type === 'tool-call'),

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
@@ -519,10 +519,10 @@ describe('convertToV1Messages', () => {
     expect(result[0].id).toBe(testMessage.id);
 
     // Split messages should have suffixes
-    expect(result[1].id).toBe(`${testMessage.id}-1`);
-    expect(result[2].id).toBe(`${testMessage.id}-2`);
-    expect(result[3].id).toBe(`${testMessage.id}-3`);
-    expect(result[4].id).toBe(`${testMessage.id}-4`);
+    expect(result[1].id).toBe(`${testMessage.id}__split-1`);
+    expect(result[2].id).toBe(`${testMessage.id}__split-2`);
+    expect(result[3].id).toBe(`${testMessage.id}__split-3`);
+    expect(result[4].id).toBe(`${testMessage.id}__split-4`);
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -1563,9 +1563,9 @@ describe('convertToV1Messages', () => {
             }),
           ]),
         }),
-        // 3. Tool returns result (with ${id}-1 suffix due to message splitting)
+        // 3. Tool returns result (with ${id}__split-1 suffix due to message splitting)
         expect.objectContaining({
-          id: '17949558-8a2b-4841-990d-ce05d29a8afb-1',
+          id: '17949558-8a2b-4841-990d-ce05d29a8afb__split-1',
           role: 'tool',
           type: 'tool-result',
           content: expect.arrayContaining([
@@ -1581,9 +1581,9 @@ describe('convertToV1Messages', () => {
             }),
           ]),
         }),
-        // 4. Assistant provides text response (SEPARATE from tool call/result, with ${id}-2 suffix due to message splitting)
+        // 4. Assistant provides text response (SEPARATE from tool call/result, with ${id}__split-2 suffix due to message splitting)
         expect.objectContaining({
-          id: '17949558-8a2b-4841-990d-ce05d29a8afb-2',
+          id: '17949558-8a2b-4841-990d-ce05d29a8afb__split-2',
           role: 'assistant',
           type: 'text',
           content: expect.arrayContaining([

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import type { MastraMessageV1 } from '../../../memory/types';
 import type { MastraMessageV2 } from '../../message-list';
 import { MessageList } from '../../message-list';
-import type { MastraMessageV1 } from '../../../memory/types';
 import { convertToV1Messages } from './convert-to-mastra-v1';
 
 describe('convertToV1Messages', () => {
@@ -1751,9 +1751,6 @@ describe('convertToV1Messages', () => {
     ];
 
     messageList.add(v2Messages, 'memory');
-
-    // Get the UI messages
-    const uiMessages = messageList.get.all.ui();
 
     // Get the core messages (what would be sent to LLM)
     const coreMessages = messageList.get.all.core();

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.test.ts
@@ -501,7 +501,6 @@ describe('convertToV1Messages', () => {
     const result = convertToV1Messages([testMessage]);
 
     const sharedFields = {
-      id: testMessage.id,
       createdAt: testMessage.createdAt,
       resourceId: testMessage.resourceId,
       threadId: testMessage.threadId,
@@ -515,9 +514,20 @@ describe('convertToV1Messages', () => {
     // 5. tool-result (both array results grouped together)
     // Total: 5 messages
     expect(result.length).toBe(5);
+
+    // First message should keep original ID
+    expect(result[0].id).toBe(testMessage.id);
+
+    // Split messages should have suffixes
+    expect(result[1].id).toBe(`${testMessage.id}-1`);
+    expect(result[2].id).toBe(`${testMessage.id}-2`);
+    expect(result[3].id).toBe(`${testMessage.id}-3`);
+    expect(result[4].id).toBe(`${testMessage.id}-4`);
+
     expect(result).toEqual([
       expect.objectContaining({
         ...sharedFields,
+        id: testMessage.id,
         role: 'assistant',
         type: 'text',
         content: 'Multiple tools test',
@@ -1889,136 +1899,5 @@ describe('convertToV1Messages', () => {
     expect(messagesByRole.user).toBe(2);
     expect(messagesByRole.assistant).toBeGreaterThanOrEqual(2);
     expect(messagesByRole.tool).toBe(1);
-  });
-
-  it('should handle memory processor flow like agent does (BUG: v1 messages with same ID replace each other)', () => {
-    // This test reproduces the bug where v1 messages with the same ID replace each other
-    // when added back to a MessageList, causing tool history to be lost
-
-    // Step 1: Create message list with thread info
-    const messageList = new MessageList({
-      threadId: 'ff1fa961-7925-44b7-909a-a4c9fba60b4e',
-      resourceId: 'weatherAgent',
-    });
-
-    // Step 2: Add memory messages (from rememberMessages)
-    const memoryMessagesV2: MastraMessageV2[] = [
-      {
-        id: 'fbd2f506-90e6-4f52-8ba4-633abe9e8442',
-        role: 'user',
-        createdAt: new Date('2025-08-05T22:58:18.403Z'),
-        threadId: 'ff1fa961-7925-44b7-909a-a4c9fba60b4e',
-        resourceId: 'weatherAgent',
-        content: {
-          format: 2,
-          parts: [{ type: 'text', text: 'LA weather' }],
-          content: 'LA weather',
-        },
-      },
-      {
-        id: '17949558-8a2b-4841-990d-ce05d29a8afb',
-        role: 'assistant',
-        createdAt: new Date('2025-08-05T22:58:22.151Z'),
-        threadId: 'ff1fa961-7925-44b7-909a-a4c9fba60b4e',
-        resourceId: 'weatherAgent',
-        content: {
-          format: 2,
-          parts: [
-            {
-              type: 'tool-invocation',
-              toolInvocation: {
-                state: 'result',
-                toolCallId: 'call_WLUBDGduzBI0KBmGZVXA8lMM',
-                toolName: 'weatherTool',
-                args: { location: 'Los Angeles' },
-                result: {
-                  temperature: 29.4,
-                  feelsLike: 30.5,
-                  humidity: 48,
-                  windSpeed: 16,
-                  windGust: 18.7,
-                  conditions: 'Clear sky',
-                  location: 'Los Angeles',
-                },
-              },
-            },
-            {
-              type: 'text',
-              text: 'The current weather in Los Angeles is as follows:\n\n- **Temperature:** 29.4°C (Feels like 30.5°C)\n- **Humidity:** 48%\n- **Wind Speed:** 16 km/h\n- **Wind Gusts:** 18.7 km/h\n- **Conditions:** Clear sky\n\nIf you need any specific activities or further information, let me know!',
-            },
-          ],
-          toolInvocations: [
-            {
-              state: 'result',
-              toolCallId: 'call_WLUBDGduzBI0KBmGZVXA8lMM',
-              toolName: 'weatherTool',
-              args: { location: 'Los Angeles' },
-              result: {
-                temperature: 29.4,
-                feelsLike: 30.5,
-                humidity: 48,
-                windSpeed: 16,
-                windGust: 18.7,
-                conditions: 'Clear sky',
-                location: 'Los Angeles',
-              },
-            },
-          ],
-        },
-      },
-    ];
-
-    messageList.add(memoryMessagesV2, 'memory');
-
-    // Step 3: Get remembered messages as v1 (like agent does for processing)
-    const rememberedV1 = messageList.get.remembered.v1();
-    console.log('Remembered V1 messages:', JSON.stringify(rememberedV1, null, 2));
-
-    // Step 4: Simulate memory.processMessages (which just returns them if no processors)
-    const processedMemoryMessages = rememberedV1;
-
-    // Step 5: Create return list like agent does
-    const returnList = new MessageList().add(processedMemoryMessages as any, 'memory').add(
-      [
-        {
-          id: 'd936d31b-0ad5-43a8-89ed-c5cc24c60895',
-          role: 'user',
-          createdAt: new Date('2025-08-05T22:58:38.656Z'),
-          threadId: 'ff1fa961-7925-44b7-909a-a4c9fba60b4e',
-          resourceId: 'weatherAgent',
-          content: {
-            format: 2,
-            parts: [{ type: 'text', text: 'what was the result when you called the tool?' }],
-            content: 'what was the result when you called the tool?',
-          },
-        },
-      ],
-      'user',
-    );
-
-    // Step 6: Get prompt messages (what's sent to LLM)
-    const promptMessages = returnList.get.all.prompt();
-
-    console.log('Final prompt messages (sent to LLM):', JSON.stringify(promptMessages, null, 2));
-
-    // Verify the tool history is preserved
-    const assistantMessages = promptMessages.filter(m => m.role === 'assistant');
-    console.log('Assistant messages count:', assistantMessages.length);
-
-    // Check if tool calls are present
-    const hasToolCall = promptMessages.some(
-      m => m.role === 'assistant' && Array.isArray(m.content) && m.content.some(c => c.type === 'tool-call'),
-    );
-
-    const hasToolResult = promptMessages.some(
-      m => m.role === 'tool' && Array.isArray(m.content) && m.content.some(c => c.type === 'tool-result'),
-    );
-
-    console.log('Has tool call:', hasToolCall);
-    console.log('Has tool result:', hasToolResult);
-
-    // These should be true if tool history is preserved
-    expect(hasToolCall).toBe(true);
-    expect(hasToolResult).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #6087 where tool call history wasn't accessible in later conversation turns
- The bug occurred when v2 messages with both tool calls and text were split into multiple v1 messages - they all kept the same ID
- When these v1 messages were added back to MessageList, the `shouldReplaceMessage` logic caused later messages to replace earlier ones, losing the tool history

## Solution
Modified the `makePushOrCombine` function in `convertToV1Messages` to:
- Track ID usage with a `Map<string, number>()` 
- Append suffixes (__split-1, __split-2, etc.) when the same ID is used multiple times for split messages
- Only modify IDs when actually pushing new messages, not when combining

This ensures tool history is preserved throughout the conversation flow and the AI can access previous tool calls.

## Test plan
- [x] Added test case reproducing the bug in message-list.test.ts
- [x] Updated expectations in convert-to-mastra-v1.test.ts to reflect the new ID deduplication behavior
- [x] All tests pass