### PR TITLE
fix(cli): properly set base url in playground

### DIFF
--- a/.changeset/shy-maps-serve.md
+++ b/.changeset/shy-maps-serve.md
@@ -1,0 +1,8 @@
+---
+'@mastra/deployer': patch
+'mastra': patch
+'create-mastra': patch
+'@mastra/playground-ui': patch
+---
+
+Properly set baseUrl in playground when user sets the host or port in Mastra instance.

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -199,10 +199,6 @@ export async function dev({
     );
   }
 
-  // Set environment variables for playground development
-  process.env.MASTRA_DEV_PORT = portToUse.toString();
-  process.env.MASTRA_DEV_HOST = serverOptions?.host ?? 'localhost';
-
   await bundler.prepare(dotMastraPath);
 
   const watcher = await bundler.watch(entryFile, dotMastraPath, discoveredTools);

--- a/packages/cli/src/playground/index.html
+++ b/packages/cli/src/playground/index.html
@@ -32,6 +32,7 @@
   <body>
     <script>
       window.MASTRA_TELEMETRY_DISABLED = '%%MASTRA_TELEMETRY_DISABLED%%';
+      window.MASTRA_SERVER_URL = '%%MASTRA_SERVER_URL%%';
     </script>
     <div id="root" class="dark"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/packages/cli/src/playground/src/lib/client.ts
+++ b/packages/cli/src/playground/src/lib/client.ts
@@ -1,7 +1,30 @@
 import { MastraClient } from '@mastra/client-js';
 
+// Extend the window object to include our injected configuration
+declare global {
+  interface Window {
+    MASTRA_TELEMETRY_DISABLED?: string;
+    MASTRA_SERVER_URL?: string;
+  }
+}
+
+// Get the server URL from the injected configuration, fallback to empty string for relative URLs
+// Also check if the placeholder wasn't replaced (indicates an issue with the server-side replacement)
+const getBaseUrl = () => {
+  if (typeof window === 'undefined') return '';
+
+  const serverUrl = window.MASTRA_SERVER_URL;
+
+  // If the placeholder wasn't replaced, fall back to relative URLs
+  if (!serverUrl || serverUrl.includes('%%MASTRA_SERVER_URL%%')) {
+    return '';
+  }
+
+  return serverUrl;
+};
+
 export const client = new MastraClient({
-  baseUrl: '',
+  baseUrl: getBaseUrl(),
   headers: {
     'x-mastra-dev-playground': 'true',
   },

--- a/packages/cli/src/playground/vite.config.ts
+++ b/packages/cli/src/playground/vite.config.ts
@@ -28,8 +28,8 @@ export default defineConfig(({ mode }) => {
 
   if (mode === 'development') {
     // Use environment variable for the target port, fallback to 4111
-    const targetPort = process.env.MASTRA_DEV_PORT || '4111';
-    const targetHost = process.env.MASTRA_DEV_HOST || 'localhost';
+    const targetPort = process.env.PORT || '4111';
+    const targetHost = process.env.HOST || 'localhost';
 
     return {
       ...commonConfig,

--- a/packages/cli/src/playground/vite.config.ts
+++ b/packages/cli/src/playground/vite.config.ts
@@ -27,13 +27,17 @@ export default defineConfig(({ mode }) => {
   };
 
   if (mode === 'development') {
+    // Use environment variable for the target port, fallback to 4111
+    const targetPort = process.env.MASTRA_DEV_PORT || '4111';
+    const targetHost = process.env.MASTRA_DEV_HOST || 'localhost';
+
     return {
       ...commonConfig,
       server: {
         ...commonConfig.server,
         proxy: {
           '/api': {
-            target: 'http://localhost:4111',
+            target: `http://${targetHost}:${targetPort}`,
             changeOrigin: true,
           },
         },


### PR DESCRIPTION
## Description

We weren't handling the case in the playground where a user sets a host or a port. We'd always default the default port and host.

Also fixes https://github.com/mastra-ai/mastra/issues/6623
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
