### PR TITLE
fix(core,memory): fix schema issues with certain model providers

### DIFF
--- a/.changeset/pink-apes-turn.md
+++ b/.changeset/pink-apes-turn.md
@@ -1,0 +1,7 @@
+---
+'@mastra/schema-compat': patch
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fix vnext working memory tool schema when model is incompatible with schema

--- a/packages/core/src/action/index.ts
+++ b/packages/core/src/action/index.ts
@@ -28,6 +28,7 @@ export interface IExecutionContext<TSchemaIn extends z.ZodSchema | undefined = u
   runId?: string;
   threadId?: string;
   resourceId?: string;
+  memory?: MastraMemory;
 }
 
 export interface IAction<

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -6,7 +6,7 @@ import { MastraBase } from '../base';
 import type { Mastra } from '../mastra';
 import type { MastraStorage, PaginationInfo, StorageGetMessagesArg, ThreadSortOptions } from '../storage';
 import { augmentWithInit } from '../storage/storageWithInit';
-import type { CoreTool } from '../tools';
+import type { ToolAction } from '../tools';
 import { deepMerge } from '../utils';
 import type { MastraVector } from '../vector';
 
@@ -155,7 +155,7 @@ export abstract class MastraMemory extends MastraBase {
    * This will be called when converting tools for the agent.
    * Implementations can override this to provide additional tools.
    */
-  public getTools(_config?: MemoryConfig): Record<string, CoreTool> {
+  public getTools(_config?: MemoryConfig): Record<string, ToolAction<any, any, any>> {
     return {};
   }
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,5 +1,5 @@
 import { generateEmptyFromSchema } from '@mastra/core';
-import type { CoreTool, MastraMessageV1 } from '@mastra/core';
+import type { MastraMessageV1, ToolAction } from '@mastra/core';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageV2, UIMessageWithMetadata } from '@mastra/core/agent';
 import { MastraMemory } from '@mastra/core/memory';
@@ -948,7 +948,7 @@ ${
     return Boolean(isMDWorkingMemory && isMDWorkingMemory.version === `vnext`);
   }
 
-  public getTools(config?: MemoryConfig): Record<string, CoreTool> {
+  public getTools(config?: MemoryConfig): Record<string, ToolAction<any, any, any>> {
     const mergedConfig = this.getMergedThreadConfig(config);
     if (mergedConfig.workingMemory?.enabled) {
       return {

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -1,130 +1,139 @@
-import type { CoreTool, MemoryConfig } from '@mastra/core';
+import type { MemoryConfig, StorageThreadType } from '@mastra/core';
+import { createTool } from '@mastra/core';
 import { z } from 'zod';
 
-export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig): CoreTool => ({
-  description:
-    'Update the working memory with new information. Always pass data as string to the memory field. Never pass an object.',
-  parameters: z.object({
-    memory: z
-      .string()
-      .describe(
-        `The ${!!memoryConfig?.workingMemory?.schema ? 'JSON' : 'Markdown'} formatted working memory content to store. This MUST be a string. Never pass an object.`,
-      ),
-  }),
-  execute: async (params: any) => {
-    const { context, threadId, memory, resourceId } = params;
-    if (!threadId || !memory) {
-      throw new Error('Thread ID and Memory instance are required for working memory updates');
-    }
+export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig) => {
+  return createTool({
+    id: 'update-working-memory',
+    description:
+      'Update the working memory with new information. Always pass data as string to the memory field. Never pass an object.',
+    inputSchema: z.object({
+      memory: z
+        .string()
+        .describe(
+          `The ${!!memoryConfig?.workingMemory?.schema ? 'JSON' : 'Markdown'} formatted working memory content to store. This MUST be a string. Never pass an object.`,
+        ),
+    }),
+    execute: async params => {
+      const { context, threadId, memory, resourceId } = params;
+      if (!threadId || !memory) {
+        throw new Error('Thread ID and Memory instance are required for working memory updates');
+      }
 
-    let thread = await memory.getThreadById({ threadId });
+      let thread = await memory.getThreadById({ threadId });
 
-    if (!thread) {
-      thread = await memory.createThread({
+      if (!thread) {
+        thread = await memory.createThread({
+          threadId,
+          resourceId: resourceId || thread?.resourceId,
+          memoryConfig,
+        });
+      }
+
+      if (thread.resourceId && thread.resourceId !== resourceId) {
+        throw new Error(`Thread with id ${threadId} resourceId does not match the current resourceId ${resourceId}`);
+      }
+
+      const workingMemory = context.memory;
+
+      // Use the new updateWorkingMemory method which handles both thread and resource scope
+      await memory.updateWorkingMemory({
         threadId,
-        resourceId: resourceId || thread.resourceId,
+        resourceId: resourceId || thread?.resourceId,
+        workingMemory: workingMemory,
         memoryConfig,
       });
-    }
 
-    if (thread.resourceId && thread.resourceId !== resourceId) {
-      throw new Error(`Thread with id ${threadId} resourceId does not match the current resourceId ${resourceId}`);
-    }
+      return { success: true };
+    },
+  });
+};
 
-    const workingMemory = context.memory;
+export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig) => {
+  return createTool({
+    id: 'update-working-memory',
+    description: 'Update the working memory with new information.',
+    inputSchema: z.object({
+      newMemory: z
+        .string()
+        .optional()
+        .describe(
+          `The ${config.workingMemory?.schema ? 'JSON' : 'Markdown'} formatted working memory content to store`,
+        ),
+      searchString: z
+        .string()
+        .optional()
+        .describe(
+          "The working memory string to find. Will be replaced with the newMemory string. If this is omitted or doesn't exist, the newMemory string will be appended to the end of your working memory. Replacing single lines at a time is encouraged for greater accuracy. If updateReason is not 'append-new-memory', this search string must be provided or the tool call will be rejected.",
+        ),
+      updateReason: z
+        .enum(['append-new-memory', 'clarify-existing-memory', 'replace-irrelevant-memory'])
+        .optional()
+        .describe(
+          "The reason you're updating working memory. Passing any value other than 'append-new-memory' requires a searchString to be provided. Defaults to append-new-memory",
+        ),
+    }),
+    execute: async params => {
+      const { context, threadId, memory, resourceId } = params;
+      if (!threadId || !memory) {
+        throw new Error('Thread ID and Memory instance are required for working memory updates');
+      }
 
-    // Use the new updateWorkingMemory method which handles both thread and resource scope
-    await memory.updateWorkingMemory({
-      threadId,
-      resourceId: resourceId || thread.resourceId,
-      workingMemory: workingMemory,
-      memoryConfig,
-    });
+      let thread = await memory.getThreadById({ threadId });
 
-    return { success: true };
-  },
-});
+      if (!thread) {
+        thread = await memory.createThread({
+          threadId,
+          resourceId: resourceId || (thread as unknown as StorageThreadType)?.resourceId,
+          memoryConfig: config,
+        });
+      }
 
-export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig): CoreTool => ({
-  description: 'Update the working memory with new information.',
-  parameters: z.object({
-    newMemory: z
-      .string()
-      .optional()
-      .describe(`The ${config.workingMemory?.schema ? 'JSON' : 'Markdown'} formatted working memory content to store`),
-    searchString: z
-      .string()
-      .optional()
-      .describe(
-        "The working memory string to find. Will be replaced with the newMemory string. If this is omitted or doesn't exist, the newMemory string will be appended to the end of your working memory. Replacing single lines at a time is encouraged for greater accuracy. If updateReason is not 'append-new-memory', this search string must be provided or the tool call will be rejected.",
-      ),
-    updateReason: z
-      .enum(['append-new-memory', 'clarify-existing-memory', 'replace-irrelevant-memory'])
-      .optional()
-      .describe(
-        "The reason you're updating working memory. Passing any value other than 'append-new-memory' requires a searchString to be provided. Defaults to append-new-memory",
-      ),
-  }),
-  execute: async (params: any) => {
-    const { context, threadId, memory, resourceId } = params;
-    if (!threadId || !memory) {
-      throw new Error('Thread ID and Memory instance are required for working memory updates');
-    }
+      if (thread.resourceId && thread.resourceId !== resourceId) {
+        throw new Error(`Thread with id ${threadId} resourceId does not match the current resourceId ${resourceId}`);
+      }
 
-    let thread = await memory.getThreadById({ threadId });
+      const workingMemory = context.newMemory || '';
+      if (!context.updateReason) context.updateReason = `append-new-memory`;
 
-    if (!thread) {
-      thread = await memory.createThread({
+      if (
+        context.searchString &&
+        config.workingMemory?.scope === `resource` &&
+        context.updateReason === `replace-irrelevant-memory`
+      ) {
+        // don't allow replacements due to something not being relevant to the current conversation
+        // if there's no searchString, then we will append.
+        context.searchString = undefined;
+      }
+
+      if (context.updateReason === `append-new-memory` && context.searchString) {
+        // do not find/replace when append-new-memory is selected
+        // some models get confused and pass a search string even when they don't want to replace it.
+        // TODO: maybe they're trying to add new info after the search string?
+        context.searchString = undefined;
+      }
+
+      if (context.updateReason !== `append-new-memory` && !context.searchString) {
+        return {
+          success: false,
+          reason: `updateReason was ${context.updateReason} but no searchString was provided. Unable to replace undefined with "${context.newMemory}"`,
+        };
+      }
+
+      // Use the new updateWorkingMemory method which handles both thread and resource scope
+      const result = await memory.__experimental_updateWorkingMemoryVNext({
         threadId,
-        resourceId: resourceId || thread.resourceId,
-        config,
+        resourceId: resourceId || thread?.resourceId,
+        workingMemory: workingMemory,
+        searchString: context.searchString,
+        memoryConfig: config,
       });
-    }
 
-    if (thread.resourceId && thread.resourceId !== resourceId) {
-      throw new Error(`Thread with id ${threadId} resourceId does not match the current resourceId ${resourceId}`);
-    }
+      if (result) {
+        return result;
+      }
 
-    const workingMemory = context.newMemory || '';
-    if (!context.updateReason) context.updateReason = `append-new-memory`;
-
-    if (
-      context.searchString &&
-      config.workingMemory?.scope === `resource` &&
-      context.updateReason === `replace-irrelevant-memory`
-    ) {
-      // don't allow replacements due to something not being relevant to the current conversation
-      // if there's no searchString, then we will append.
-      context.searchString = undefined;
-    }
-
-    if (context.updateReason === `append-new-memory` && context.searchString) {
-      // do not find/replace when append-new-memory is selected
-      // some models get confused and pass a search string even when they don't want to replace it.
-      // TODO: maybe they're trying to add new info after the search string?
-      context.searchString = undefined;
-    }
-
-    if (context.updateReason !== `append-new-memory` && !context.searchString) {
-      return {
-        success: false,
-        reason: `updateReason was ${context.updateReason} but no searchString was provided. Unable to replace undefined with "${context.newMemory}"`,
-      };
-    }
-
-    // Use the new updateWorkingMemory method which handles both thread and resource scope
-    const result = await memory.__experimental_updateWorkingMemoryVNext({
-      threadId,
-      resourceId: resourceId || thread.resourceId,
-      workingMemory: workingMemory,
-      searchString: context.searchString,
-      memoryConfig: config,
-    });
-
-    if (result) {
-      return result;
-    }
-
-    return { success: true };
-  },
-});
+      return { success: true };
+    },
+  });
+};

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -1,4 +1,4 @@
-import type { MemoryConfig, StorageThreadType } from '@mastra/core';
+import type { MemoryConfig } from '@mastra/core';
 import { createTool } from '@mastra/core';
 import { z } from 'zod';
 
@@ -84,7 +84,7 @@ export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig
       if (!thread) {
         thread = await memory.createThread({
           threadId,
-          resourceId: resourceId || (thread as unknown as StorageThreadType)?.resourceId,
+          resourceId: resourceId || thread!.resourceId,
           memoryConfig: config,
         });
       }

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -25,7 +25,7 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig) => {
       if (!thread) {
         thread = await memory.createThread({
           threadId,
-          resourceId: resourceId || thread?.resourceId,
+          resourceId: resourceId || thread!.resourceId,
           memoryConfig,
         });
       }

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -51,19 +51,16 @@ export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig
     newMemory: z
       .string()
       .optional()
-      .nullable()
       .describe(`The ${config.workingMemory?.schema ? 'JSON' : 'Markdown'} formatted working memory content to store`),
     searchString: z
       .string()
       .optional()
-      .nullable()
       .describe(
         "The working memory string to find. Will be replaced with the newMemory string. If this is omitted or doesn't exist, the newMemory string will be appended to the end of your working memory. Replacing single lines at a time is encouraged for greater accuracy. If updateReason is not 'append-new-memory', this search string must be provided or the tool call will be rejected.",
       ),
     updateReason: z
       .enum(['append-new-memory', 'clarify-existing-memory', 'replace-irrelevant-memory'])
       .optional()
-      .nullable()
       .describe(
         "The reason you're updating working memory. Passing any value other than 'append-new-memory' requires a searchString to be provided. Defaults to append-new-memory",
       ),

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -16,8 +16,8 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig) => {
     }),
     execute: async params => {
       const { context, threadId, memory, resourceId } = params;
-      if (!threadId || !memory) {
-        throw new Error('Thread ID and Memory instance are required for working memory updates');
+      if (!threadId || !memory || !resourceId) {
+        throw new Error('Thread ID, Memory instance, and resourceId are required for working memory updates');
       }
 
       let thread = await memory.getThreadById({ threadId });
@@ -25,7 +25,7 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig) => {
       if (!thread) {
         thread = await memory.createThread({
           threadId,
-          resourceId: resourceId || thread!.resourceId,
+          resourceId,
           memoryConfig,
         });
       }
@@ -39,7 +39,7 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfig) => {
       // Use the new updateWorkingMemory method which handles both thread and resource scope
       await memory.updateWorkingMemory({
         threadId,
-        resourceId: resourceId || thread?.resourceId,
+        resourceId,
         workingMemory: workingMemory,
         memoryConfig,
       });
@@ -75,8 +75,8 @@ export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig
     }),
     execute: async params => {
       const { context, threadId, memory, resourceId } = params;
-      if (!threadId || !memory) {
-        throw new Error('Thread ID and Memory instance are required for working memory updates');
+      if (!threadId || !memory || !resourceId) {
+        throw new Error('Thread ID, Memory instance, and resourceId are required for working memory updates');
       }
 
       let thread = await memory.getThreadById({ threadId });
@@ -84,7 +84,7 @@ export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig
       if (!thread) {
         thread = await memory.createThread({
           threadId,
-          resourceId: resourceId || thread!.resourceId,
+          resourceId,
           memoryConfig: config,
         });
       }
@@ -123,7 +123,7 @@ export const __experimental_updateWorkingMemoryToolVNext = (config: MemoryConfig
       // Use the new updateWorkingMemory method which handles both thread and resource scope
       const result = await memory.__experimental_updateWorkingMemoryVNext({
         threadId,
-        resourceId: resourceId || thread?.resourceId,
+        resourceId,
         workingMemory: workingMemory,
         searchString: context.searchString,
         memoryConfig: config,

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.ts
@@ -26,7 +26,11 @@ export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
   isReasoningModel(): boolean {
     // there isn't a good way to automatically detect reasoning models besides doing this.
     // in the future when o5 is released this compat wont apply and we'll want to come back and update this class + our tests
-    return this.getModel().modelId.includes(`o3`) || this.getModel().modelId.includes(`o4`);
+    return (
+      this.getModel().modelId.includes(`o3`) ||
+      this.getModel().modelId.includes(`o4`) ||
+      this.getModel().modelId.includes(`o1`)
+    );
   }
 
   shouldApply(): boolean {


### PR DESCRIPTION
## Description

openai reasoning models would not handle the new working memory tool schema properly and would throw an error. I discovered that the memory tools were not being run through the schema-compat, this is because we weren't using `makeCoreTool` on the memory tools. Adding this fixed the issue.

This fixes https://github.com/mastra-ai/mastra/issues/6548
<!-- Provide a brief description of the changes in this PR -->
