### PR TITLE
ci: propagate TypeScript build errors with correct exit code

### DIFF
--- a/packages/_types-builder/src/index.js
+++ b/packages/_types-builder/src/index.js
@@ -52,8 +52,8 @@ export async function generateTypes(rootDir) {
       await fs.writeFile(fullPath, code);
     }
   } catch (err) {
-    console.log(err);
-    // debug here?
-    throw err;
+    // TypeScript errors are already printed to console via stdio: 'inherit'
+    // Just exit with the same code as tsc
+    process.exit(err.code || 1);
   }
 }


### PR DESCRIPTION
TypeScript errors weren't causing the build to fail properly. The types-builder was catching errors but not exiting with the error code.

The fix adds `process.exit(err.code || 1)` to propagate tsc's exit code when compilation fails.

Before:
```javascript
} catch (err) {
  console.log(err);
  // debug here?
  throw err;
}
```

After:
```javascript
} catch (err) {
  // TypeScript errors are already printed to console via stdio: 'inherit'
  // Just exit with the same code as tsc
  process.exit(err.code || 1);
}
```

Now when there are TypeScript errors, the build correctly fails with exit code 2.