### PR TITLE
docs: add warning about Upstash pay-as-you-go pricing

### DIFF
--- a/docs/src/content/en/reference/storage/upstash.mdx
+++ b/docs/src/content/en/reference/storage/upstash.mdx
@@ -7,6 +7,10 @@ description: Documentation for the Upstash storage implementation in Mastra.
 
 The Upstash storage implementation provides a serverless-friendly storage solution using Upstash's Redis-compatible key-value store.
 
+<Callout type="warning">
+  **Important:** When using Mastra with Upstash, the pay-as-you-go model can result in unexpectedly high costs due to the high volume of Redis commands generated during agent conversations. We strongly recommend using a **fixed pricing plan** for predictable costs. See [Upstash pricing](https://upstash.com/pricing/redis) for details and [GitHub issue #5850](https://github.com/mastra-ai/mastra/issues/5850) for context.
+</Callout>
+
 ## Installation
 
 ```bash copy


### PR DESCRIPTION
Adds a warning to the Upstash storage documentation about potential high costs when using pay-as-you-go pricing. Users have reported unexpected charges of $80-100+ during development due to the high volume of Redis commands generated by agent conversations.

The warning recommends using Upstash's fixed pricing plans for predictable costs and includes links to both the Upstash pricing page and the GitHub issue for context.

Fixes #5850