### PR TITLE
fix(server): Correct `agentIds` for scorers endpoint

### DIFF
--- a/.changeset/seven-pants-swim.md
+++ b/.changeset/seven-pants-swim.md
@@ -1,0 +1,5 @@
+---
+"@mastra/server": patch
+---
+
+Return correct `agentIds` for `/api/scores/scorers` and `/api/scores/scorers/${scorerId}` endpoints

--- a/packages/cli/src/playground/src/pages/scorers/index.tsx
+++ b/packages/cli/src/playground/src/pages/scorers/index.tsx
@@ -20,14 +20,7 @@ export default function Scorers() {
         {isLoading ? (
           <div className="text-center text-icon3 m-[2rem]">Loading...</div>
         ) : (
-          <DataTable
-            columns={scorersTableColumns}
-            data={scorerListData || []}
-            isLoading={isLoading}
-            onClick={props => {
-              console.log(props);
-            }}
-          />
+          <DataTable columns={scorersTableColumns} data={scorerListData || []} isLoading={isLoading} />
         )}
       </div>
     </MainContentLayout>

--- a/packages/cli/src/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/cli/src/playground/src/pages/scorers/scorer/index.tsx
@@ -441,8 +441,6 @@ function ScoreDetails({
     generateReasonPrompt: score?.generateReasonPrompt,
   };
 
-  console.log('Score details:', JSON.stringify(score, null, 2));
-
   return (
     <Dialog.Root open={isOpen} onOpenChange={onClose}>
       <Dialog.Portal>

--- a/packages/server/src/server/handlers/scores.test.ts
+++ b/packages/server/src/server/handlers/scores.test.ts
@@ -249,7 +249,7 @@ describe('Scores Handlers', () => {
 
   describe('saveScoreHandler', () => {
     it('should save score successfully', async () => {
-      const score = createSampleScore({ id: 'new-score-1' });
+      const score = createSampleScore({ scorerId: 'new-score-1' });
       const savedScore = { score };
 
       const result = await saveScoreHandler({
@@ -261,7 +261,7 @@ describe('Scores Handlers', () => {
     });
 
     it('should return empty array when storage method is not available', async () => {
-      const score = createSampleScore({ id: 'new-score-1' });
+      const score = createSampleScore({ scorerId: 'new-score-1' });
 
       // Create mastra instance without storage
       const mastraWithoutStorage = new Mastra({
@@ -277,7 +277,7 @@ describe('Scores Handlers', () => {
     });
 
     it('should handle storage errors gracefully', async () => {
-      const score = createSampleScore({ id: 'new-score-1' });
+      const score = createSampleScore({ scorerId: 'new-score-1' });
       const error = new Error('Storage error');
 
       mockStorage.saveScore = vi.fn().mockRejectedValue(error);

--- a/packages/server/src/server/handlers/scores.ts
+++ b/packages/server/src/server/handlers/scores.ts
@@ -29,7 +29,7 @@ async function getScorersFromSystem({
           scorersMap.set(scorerId, {
             workflowIds: [],
             ...scorer,
-            agentIds: [agent.name],
+            agentIds: [agentId],
           });
         }
       }


### PR DESCRIPTION
## Description

Currently the `/api/scores/scorers` and `/api/scores/scorers/${scorerId}` return an incorrect object where the `agentIds` contains the name, not the id. This PR fixes this small typo.

While debugging this issue I found two instances of stray `console.log()` calls and typos in the test for the scores handler which I fixed.

I'd like to add tests for this fix but I'm not sure how to properly mock the `runtimeContext`

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/6652

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
