### PR TITLE
FIX: Make system message always available during agent calls

### DIFF
--- a/.changeset/mighty-dodos-sell.md
+++ b/.changeset/mighty-dodos-sell.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+"@mastra/libsql": patch
+---
+
+make system message always available during agent calls

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1531,18 +1531,18 @@ export class Agent<
           });
         }
 
-        let [memoryMessages, memorySystemMessage] = existingThread
-          ? await Promise.all([
-              this.getMemoryMessages({
+        let [memoryMessages, memorySystemMessage] = await Promise.all([
+          existingThread
+            ? this.getMemoryMessages({
                 resourceId,
                 threadId: threadObject.id,
                 vectorMessageSearch: new MessageList().add(messages, `user`).getLatestUserContent() || '',
                 memoryConfig,
                 runtimeContext,
-              }),
-              memory.getSystemMessage({ threadId: threadObject.id, resourceId, memoryConfig }),
-            ])
-          : [[], null];
+              })
+            : [],
+          memory.getSystemMessage({ threadId: threadObject.id, resourceId, memoryConfig }),
+        ]);
 
         this.logger.debug('Fetched messages from memory', {
           threadId: threadObject.id,

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -553,7 +553,6 @@ export class MemoryLibSQL extends MemoryStorage {
   }
 
   async saveResource({ resource }: { resource: StorageResourceType }): Promise<StorageResourceType> {
-    console.log('resource', resource);
     await this.operations.insert({
       tableName: TABLE_RESOURCES,
       record: {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR makes system memory message always available, even for new threads.
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
