### PR TITLE
fix(@mastra/core): skip system messages from memory to prevent duplication

### DIFF
--- a/.changeset/silver-lions-sit.md
+++ b/.changeset/silver-lions-sit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added a patch to filter out system messages that were stored in the db via an old memory bug that was patched long ago (see issue 6689). Users upgrading from the old version that still had the bug would see errors when the memory messages were retrieved from the db

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -648,9 +648,14 @@ export class MessageList {
       });
     }
 
-    if (message.role === `system` && (MessageList.isAIV4CoreMessage(message) || MessageList.isAIV5CoreMessage(message)))
-      return this.addSystem(message);
     if (message.role === `system`) {
+      // In the past system messages were accidentally stored in the db. these should be ignored because memory is not supposed to store system messages.
+      if (messageSource === `memory`) return null;
+
+      if (MessageList.isAIV4CoreMessage(message) || MessageList.isAIV5CoreMessage(message))
+        return this.addSystem(message);
+
+      // if we didn't add the message and we didn't ignore this intentionally, then it's a problem!
       throw new MastraError({
         id: 'INVALID_SYSTEM_MESSAGE_FORMAT',
         domain: ErrorDomain.AGENT,


### PR DESCRIPTION
Fixes #6689

This resolves the `INVALID_SYSTEM_MESSAGE_FORMAT` error that occurred after upgrading from v0.10.0 when system messages were retrieved from the database.

Previously, system messages were accidentally stored in the database in older versions. When these messages were retrieved and passed to `MessageList.add()` with source `memory`, they would throw an error because they weren't in the expected CoreMessage format.

The fix now silently skips system messages when the source is `memory`, which aligns with the original intent that memory shouldn't store system messages. Regular system messages added programmatically continue to work as expected.

Added tests to verify system messages from memory are properly ignored while other messages continue to work correctly.