### PR TITLE
[Fix] Apply number constraints to NumberField

### DIFF
--- a/packages/playground-ui/src/components/ui/autoform/zodProvider/index.tsx
+++ b/packages/playground-ui/src/components/ui/autoform/zodProvider/index.tsx
@@ -3,11 +3,50 @@ import { getDefaultValueInZodStack, getFieldConfigInZodStack, ZodObjectOrWrapped
 import { z } from 'zod';
 import { inferFieldType } from './field-type-inference';
 
+// Extract number constraints from Zod schema
+function extractNumberConstraints(schema: z.ZodTypeAny): { min?: number; max?: number; step?: number } {
+  const constraints: { min?: number; max?: number; step?: number } = {};
+
+  // Get the base schema
+  let baseSchema = schema;
+  while (baseSchema._def && (baseSchema._def.effect || baseSchema._def.innerType)) {
+    baseSchema = baseSchema._def.effect?.schema || baseSchema._def.innerType || baseSchema;
+  }
+
+  // Extract min, max and step
+  if (baseSchema._def && baseSchema._def.checks) {
+    for (const check of baseSchema._def.checks) {
+      if (check.kind === 'min' && check.inclusive) {
+        constraints.min = check.value;
+      } else if (check.kind === 'max' && check.inclusive) {
+        constraints.max = check.value;
+      } else if (check.kind === 'multipleOf') {
+        constraints.step = check.value;
+      }
+    }
+  }
+
+  return constraints;
+}
+
 function parseField(key: string, schema: z.ZodTypeAny): ParsedField {
   const baseSchema = getBaseSchema(schema);
-  const fieldConfig = getFieldConfigInZodStack(schema);
+  let fieldConfig = getFieldConfigInZodStack(schema);
   const type = inferFieldType(baseSchema, fieldConfig);
   const defaultValue = getDefaultValueInZodStack(schema);
+
+  // Extract number constraints for number fields
+  if (type === 'number' && baseSchema instanceof z.ZodNumber) {
+    const constraints = extractNumberConstraints(schema);
+    if (Object.keys(constraints).length > 0) {
+      if (!fieldConfig) {
+        fieldConfig = {};
+      }
+      if (typeof fieldConfig === 'object') {
+        fieldConfig.inputProps = { ...fieldConfig?.inputProps, ...constraints };
+      }
+    }
+  }
 
   // Enums
   const options = baseSchema._def?.values;

--- a/packages/playground-ui/src/components/ui/autoform/zodProvider/index.tsx
+++ b/packages/playground-ui/src/components/ui/autoform/zodProvider/index.tsx
@@ -8,10 +8,7 @@ function extractNumberConstraints(schema: z.ZodTypeAny): { min?: number; max?: n
   const constraints: { min?: number; max?: number; step?: number } = {};
 
   // Get the base schema
-  let baseSchema = schema;
-  while (baseSchema._def && (baseSchema._def.effect || baseSchema._def.innerType)) {
-    baseSchema = baseSchema._def.effect?.schema || baseSchema._def.innerType || baseSchema;
-  }
+  let baseSchema = getBaseSchema(schema);
 
   // Extract min, max and step
   if (baseSchema._def && baseSchema._def.checks) {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Apply `min`, `max` and `step` to NumberField if defined in schema



```
    volume: z.number().min(0).max(1).multipleOf(0.1),
```



https://github.com/user-attachments/assets/6657279a-6b1c-40c3-ba33-f942513d147e

<img width="1401" height="618" alt="CleanShot 2025-08-14 at 10 23 54" src="https://github.com/user-attachments/assets/3b61d6be-4b4c-424a-aa4e-883faf58bc7f" />



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

https://github.com/mastra-ai/mastra/issues/6716

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
