### PR TITLE
fix(deployer): Add missing rollup json() plugin

### DIFF
--- a/.changeset/cuddly-badgers-watch.md
+++ b/.changeset/cuddly-badgers-watch.md
@@ -1,0 +1,5 @@
+---
+"@mastra/deployer": patch
+---
+
+Fix issue where `.json` files couldn't be imported and used with deployers

--- a/packages/deployer/src/build/__snapshots__/deployer.test.ts.snap
+++ b/packages/deployer/src/build/__snapshots__/deployer.test.ts.snap
@@ -56,3 +56,16 @@ const deployer = getDeployer();
 export { deployer };
 "
 `;
+
+exports[`getDeployer > should support json imports 1`] = `
+"import { TestDeployer } from '@mastra/deployer/test';
+
+var name = "example-json-name";
+
+const deployer = new TestDeployer({
+  name
+});
+
+export { deployer };
+"
+`;

--- a/packages/deployer/src/build/bundlerOptions.ts
+++ b/packages/deployer/src/build/bundlerOptions.ts
@@ -2,6 +2,7 @@ import * as babel from '@babel/core';
 import { rollup } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
 import { tsConfigPaths } from './plugins/tsconfig-paths';
 import { removeAllOptionsExceptBundler } from './babel/remove-all-options-bundler';
 import { recursiveRemoveNonReferencedNodes } from './plugins/remove-unused-references';
@@ -35,6 +36,7 @@ export function getBundlerOptionsBundler(
         transformMixedEsModules: true,
         ignoreTryCatch: false,
       }),
+      json(),
       {
         name: 'get-bundler-config',
         transform(code, id) {

--- a/packages/deployer/src/build/deployer.test.ts
+++ b/packages/deployer/src/build/deployer.test.ts
@@ -22,4 +22,16 @@ describe('getDeployer', () => {
 
     expect(result?.output[0].code).toMatchSnapshot();
   });
+
+  it('should support json imports', async () => {
+    const bundle = await getDeployerBundler(join(_dirname, './plugins/__fixtures__/basic-with-json.js'), {
+      isDeployerRemoved: false,
+    });
+
+    const result = await bundle.generate({
+      format: 'esm',
+    });
+
+    expect(result?.output[0].code).toMatchSnapshot();
+  });
 });

--- a/packages/deployer/src/build/deployer.ts
+++ b/packages/deployer/src/build/deployer.ts
@@ -5,6 +5,7 @@ import esbuild from 'rollup-plugin-esbuild';
 
 import { removeAllExceptDeployer } from './babel/get-deployer';
 import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
 import { recursiveRemoveNonReferencedNodes } from './plugins/remove-unused-references';
 
 export function getDeployerBundler(entryFile: string, result: { isDeployerRemoved: boolean }) {
@@ -80,6 +81,7 @@ export function getDeployerBundler(entryFile: string, result: { isDeployerRemove
         platform: 'node',
         minify: false,
       }),
+      json(),
     ],
   });
 }

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-json.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-json.js
@@ -1,0 +1,14 @@
+import { Mastra } from '@mastra/core/mastra';
+import { createLogger } from '@mastra/core/logger';
+import { TestDeployer } from '@mastra/deployer/test';
+import { name } from './example.json';
+
+export const mastra = new Mastra({
+  logger: createLogger({
+    name: name,
+    level: 'info',
+  }),
+  deployer: new TestDeployer({
+    name: name,
+  }),
+});

--- a/packages/deployer/src/build/plugins/__fixtures__/example.json
+++ b/packages/deployer/src/build/plugins/__fixtures__/example.json
@@ -1,0 +1,3 @@
+{
+  "name": "example-json-name"
+}


### PR DESCRIPTION
## Description

Throughout our rollup configs we often already use the `json()` plugin to allow for imports from json files. In the linked issue (https://github.com/mastra-ai/mastra/issues/6728) the user added the Cloudflare deployer and used the name from the JSON file for that deployer.

We were missing the `json()` plugin in two rollup configs that were called for this codepath. A JSON import used outside of the deployer currently already works.

The added test failed before my change.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/6728

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
