### PR TITLE
fix(@mastra/core): preserve provider metadata during V5 message conversions

### DIFF
--- a/.changeset/empty-ears-relate.md
+++ b/.changeset/empty-ears-relate.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix provider metadata preservation during V5 message conversions
+
+Provider metadata (providerMetadata and callProviderMetadata) is now properly preserved when converting messages between AI SDK V5 and internal V2 formats. This ensures provider-specific information isn't lost during message transformations.

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -2124,24 +2124,6 @@ export class MessageList {
       content.metadata = { ...message.metadata } as Record<string, unknown>;
     }
 
-    if (`experimental_attachments` in message && (message as any).experimental_attachments !== undefined) {
-      const attachments = (message as any).experimental_attachments as AIV4Type.UIMessage['experimental_attachments'];
-      // Preserve experimental_attachments in metadata for round-trip (even if empty array)
-      content.metadata = {
-        ...(content.metadata || {}),
-        __originalExperimentalAttachments: attachments,
-      };
-      if (attachments?.length) {
-        for (const attachment of attachments) {
-          content.parts.push({
-            type: 'file',
-            url: attachment.url,
-            mediaType: attachment.contentType || 'unknown',
-          } as any);
-        }
-      }
-    }
-
     return {
       id: message.id || this.newMessageId(),
       role: MessageList.getRole(message),

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -23,8 +23,7 @@ type MastraMessageShared = {
 
 export type MastraMessageContentV2 = {
   format: 2; // format 2 === UIMessage in AI SDK v4
-  parts: (AIV4Type.UIMessage['parts'][number] & // add optional prov meta for AIV5 - v4 doesn't track this, and we're storing mmv2 in the db, so we need to extend
-  { providerMetadata?: AIV5Type.ProviderMetadata })[];
+  parts: (AIV4Type.UIMessage['parts'][number] & { providerMetadata?: AIV5Type.ProviderMetadata })[]; // add optional prov meta for AIV5 - v4 doesn't track this, and we're storing mmv2 in the db, so we need to extend
   experimental_attachments?: AIV4Type.UIMessage['experimental_attachments'];
   content?: AIV4Type.UIMessage['content'];
   toolInvocations?: AIV4Type.UIMessage['toolInvocations'];

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -23,7 +23,8 @@ type MastraMessageShared = {
 
 export type MastraMessageContentV2 = {
   format: 2; // format 2 === UIMessage in AI SDK v4
-  parts: AIV4Type.UIMessage['parts'];
+  parts: (AIV4Type.UIMessage['parts'][number] & // add optional prov meta for AIV5 - v4 doesn't track this, and we're storing mmv2 in the db, so we need to extend
+  { providerMetadata?: AIV5Type.ProviderMetadata })[];
   experimental_attachments?: AIV4Type.UIMessage['experimental_attachments'];
   content?: AIV4Type.UIMessage['content'];
   toolInvocations?: AIV4Type.UIMessage['toolInvocations'];
@@ -1776,34 +1777,32 @@ export class MessageList {
       content: {
         format: 2,
         parts: v3Msg.content.parts
-          .map((p): any => {
-            if (AIV5.isToolUIPart(p) || (p as any).type === 'dynamic-tool') {
-              const toolName = getToolName(p as any);
+          .map((p): null | MastraMessageContentV2['parts'][number] => {
+            if (AIV5.isToolUIPart(p) || p.type === 'dynamic-tool') {
+              const toolName = getToolName(p);
               const shared = {
-                state: (p as any).state,
-                args: (p as any).input,
-                toolCallId: (p as any).toolCallId,
+                state: p.state,
+                args: p.input,
+                toolCallId: p.toolCallId,
                 toolName,
               };
 
-              if ((p as any).state === `output-available`) {
+              if (p.state === `output-available`) {
                 return {
                   type: 'tool-invocation',
                   toolInvocation: {
                     ...shared,
                     state: 'result',
-                    result:
-                      typeof (p as any).output === 'object' && (p as any).output && 'value' in (p as any).output
-                        ? (p as any).output.value
-                        : (p as any).output,
+                    result: typeof p.output === 'object' && p.output && 'value' in p.output ? p.output.value : p.output,
                   },
+                  providerMetadata: p.callProviderMetadata,
                 };
               }
               return {
                 type: 'tool-invocation',
                 toolInvocation: {
                   ...shared,
-                  state: (p as any).state === `input-available` ? `call` : `partial-call`,
+                  state: p.state === `input-available` ? `call` : `partial-call`,
                 },
               };
             }
@@ -1813,36 +1812,40 @@ export class MessageList {
               case 'file':
                 // Skip file parts that came from experimental_attachments
                 // They will be restored separately from __originalExperimentalAttachments
-                if (attachmentUrls.has((p as any).url)) {
+                if (attachmentUrls.has(p.url)) {
                   return null;
                 }
                 return {
                   type: 'file',
-                  mimeType: (p as any).mediaType,
-                  data: (p as any).url,
+                  mimeType: p.mediaType,
+                  data: p.url,
+                  providerMetadata: p.providerMetadata,
                 };
               case 'reasoning':
-                if ((p as any).text === '') return null;
+                if (p.text === '') return null;
                 return {
                   type: 'reasoning',
-                  reasoning: '',
-                  details: [{ type: 'text', text: (p as any).text }],
+                  reasoning: p.text,
+                  details: [{ type: 'text', text: p.text }],
+                  providerMetadata: p.providerMetadata,
                 };
+
               case 'source-url':
                 return {
                   type: 'source',
                   source: {
-                    url: (p as any).url,
-                    id: (p as any).sourceId,
+                    url: p.url,
+                    id: p.sourceId,
                     sourceType: 'url',
                   },
+                  providerMetadata: p.providerMetadata,
                 };
               case 'step-start':
                 return p;
             }
             return null;
           })
-          .filter((p): p is any => Boolean(p)),
+          .filter((p): p is MastraMessageContentV2['parts'][number] => Boolean(p)),
       },
     };
 
@@ -1941,6 +1944,7 @@ export class MessageList {
               state: 'output-available',
               input: part.toolInvocation.args,
               output: part.toolInvocation.result,
+              callProviderMetadata: part.providerMetadata,
             } satisfies AIV5Type.UIMessagePart<any, any>);
           } else {
             parts.push({
@@ -1958,8 +1962,8 @@ export class MessageList {
             sourceId: part.source.id,
             url: part.source.url,
             title: part.source.title,
-            providerMetadata: part.source.providerMetadata,
-          } as any);
+            providerMetadata: part.source.providerMetadata || part.providerMetadata,
+          });
           break;
 
         case 'reasoning':
@@ -1975,7 +1979,8 @@ export class MessageList {
               type: 'reasoning',
               text: text || '',
               state: 'done',
-            } as any);
+              providerMetadata: part.providerMetadata,
+            });
           }
           break;
 
@@ -1984,7 +1989,8 @@ export class MessageList {
             type: 'file',
             url: part.data,
             mediaType: part.mimeType,
-          } as any);
+            providerMetadata: part.providerMetadata,
+          });
           fileUrls.add(part.data);
           break;
       }
@@ -2138,12 +2144,12 @@ export class MessageList {
     coreMessage: AIV5Type.ModelMessage,
     messageSource: MessageSource,
   ): MastraMessageV3 {
-    const id = `id` in coreMessage ? (coreMessage.id as string) : this.newMessageId();
+    const id = `id` in coreMessage && typeof coreMessage.id === `string` ? coreMessage.id : this.newMessageId();
     const parts: AIV5Type.UIMessage['parts'] = [];
 
     // Add step-start for input messages
     if (messageSource === 'input' && coreMessage.role === 'user') {
-      parts.push({ type: 'step-start' } as any);
+      parts.push({ type: 'step-start' });
     }
 
     if (typeof coreMessage.content === 'string') {
@@ -2158,6 +2164,7 @@ export class MessageList {
             parts.push({
               type: 'text',
               text: part.text,
+              providerMetadata: part.providerOptions,
             });
             break;
 
@@ -2182,6 +2189,7 @@ export class MessageList {
                   ? { type: 'text', value: part.output }
                   : (part.output ?? { type: 'text', value: '' }),
               input: {},
+              callProviderMetadata: part.providerOptions,
             });
             break;
 
@@ -2189,10 +2197,16 @@ export class MessageList {
             parts.push({
               type: 'reasoning',
               text: part.text,
+              providerMetadata: part.providerOptions,
             });
             break;
           case 'image':
-            parts.push({ type: 'file', url: part.image.toString(), mediaType: part.mediaType || 'unknown' } as any);
+            parts.push({
+              type: 'file',
+              url: part.image.toString(),
+              mediaType: part.mediaType || 'unknown',
+              providerMetadata: part.providerOptions,
+            });
             break;
           case 'file':
             if (part.data instanceof URL) {
@@ -2200,6 +2214,7 @@ export class MessageList {
                 type: 'file',
                 url: part.data.toString(),
                 mediaType: part.mediaType,
+                providerMetadata: part.providerOptions,
               });
             } else {
               try {
@@ -2207,6 +2222,7 @@ export class MessageList {
                   type: 'file',
                   mediaType: part.mediaType,
                   url: convertDataContentToBase64String(part.data),
+                  providerMetadata: part.providerOptions,
                 });
               } catch (error) {
                 console.error(`Failed to convert binary data to base64 in CoreMessage file part: ${error}`, error);
@@ -2331,17 +2347,17 @@ export class MessageList {
       if (part.type === `text`) {
         key += part.text;
       }
-      if (AIV5.isToolUIPart(part) || (part as any).type === 'dynamic-tool') {
-        key += (part as any).toolCallId;
-        key += (part as any).state;
+      if (AIV5.isToolUIPart(part) || part.type === 'dynamic-tool') {
+        key += part.toolCallId;
+        key += part.state;
       }
       if (part.type === `reasoning`) {
-        key += (part as any).text;
+        key += part.text;
       }
       if (part.type === `file`) {
-        key += (part as any).url.length;
-        key += (part as any).mediaType;
-        key += (part as any).filename || '';
+        key += part.url.length;
+        key += part.mediaType;
+        key += part.filename || '';
       }
     }
     return key;


### PR DESCRIPTION
Fixed an issue where provider metadata was being lost when converting messages between AI SDK V5 and our internal V2 format.

The provider metadata fields (providerMetadata and callProviderMetadata) are now properly preserved during the V5 -> V2 -> V5 roundtrip conversion. This ensures important provider-specific information isn't lost during message transformations.

Before: Provider metadata was dropped during conversion
After: Provider metadata is preserved on all part types (text, file, reasoning, source-url, tool invocations)

Also added comprehensive test coverage to verify the fix works correctly across all message part types.