### PR TITLE
fix: improve V5 message list formatting and streaming output

### DIFF
--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -372,9 +372,6 @@ export class MessageList {
           return [{ type: 'text', text: latest.content }];
         }
         return latest.content.map(c => {
-          if (c.type === `text`) return c;
-          if (c.type === `reasoning`) return c;
-          if (c.type === `tool-call`) return c;
           if (c.type === `tool-result`)
             return {
               type: 'tool-result',
@@ -396,7 +393,21 @@ export class MessageList {
                 mediaType: c.mediaType,
               }),
             } satisfies Extract<AIV5Type.StepResult<any>['content'][number], { type: 'file' }>;
-          throw new Error();
+          if (c.type === `image`) {
+            return {
+              type: 'file',
+              file: new DefaultGeneratedFileWithType({
+                data:
+                  typeof c.image === `string`
+                    ? c.image
+                    : c.image instanceof URL
+                      ? c.image.toString()
+                      : convertDataContentToBase64String(c.image),
+                mediaType: c.mediaType || 'unknown',
+              }),
+            };
+          }
+          return c;
         });
       },
     },

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -359,8 +359,8 @@ export class MessageList {
     aiV5: {
       ui: (): AIV5Type.UIMessage[] => this.response.v3().map(MessageList.mastraMessageV3ToAIV5UIMessage),
       model: (): AIV5ResponseMessage[] =>
-        MessageList.mastraMessagesV2ToAIV5ResponseMessages(
-          this.aiV5UIMessagesToAIV5ModelMessages(this.response.aiV5.ui()),
+        this.aiV5UIMessagesToAIV5ModelMessages(this.response.aiV5.ui()).filter(
+          m => m.role === `tool` || m.role === `assistant`,
         ),
       modelContent: (): AIV5Type.StepResult<any>['content'] => {
         return this.response.aiV5.model().map(this.response.aiV5.stepContent).flat();
@@ -2433,9 +2433,5 @@ export class MessageList {
       }
     }
     return key;
-  }
-
-  private static mastraMessagesV2ToAIV5ResponseMessages(messages: AIV5.ModelMessage[]): AIV5ResponseMessage[] {
-    return messages.filter(m => m.role === `tool` || m.role === `assistant`);
   }
 }

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -678,20 +678,18 @@ exports[`Loop Tests > AISDK v5 > generateText > options.stopWhen > 2 steps: init
 
 exports[`Loop Tests > AISDK v5 > generateText > result.files > should contain files 1`] = `
 [
-  DefaultGeneratedFileWithType {
-    "base64Data": undefined,
-    "mimeType": "image/png",
-    "type": "file",
+  DefaultGeneratedFile {
+    "base64Data": "AQID",
+    "mediaType": "image/png",
     "uint8ArrayData": Uint8Array [
       1,
       2,
       3,
     ],
   },
-  DefaultGeneratedFileWithType {
+  DefaultGeneratedFile {
     "base64Data": "QkFVRw==",
-    "mimeType": "image/jpeg",
-    "type": "file",
+    "mediaType": "image/jpeg",
     "uint8ArrayData": undefined,
   },
 ]

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -856,25 +856,33 @@ exports[`Loop Tests > AISDK v5 > generateText > result.sources > should contain 
 
 exports[`Loop Tests > AISDK v5 > generateText > result.steps > should add the reasoning from the model response to the step result 1`] = `
 [
-  {
-    "experimental_providerMetadata": undefined,
-    "files": [],
-    "finishReason": "stop",
-    "isContinued": false,
-    "logprobs": undefined,
-    "providerMetadata": undefined,
-    "reasoning": "I will open the conversation with witty banter.",
-    "reasoningDetails": [
+  DefaultStepResult {
+    "content": [
       {
-        "signature": "signature",
+        "providerMetadata": {
+          "testProvider": {
+            "signature": "signature",
+          },
+        },
         "text": "I will open the conversation with witty banter.",
+        "type": "reasoning",
+      },
+      {
+        "providerMetadata": {
+          "testProvider": {
+            "redactedData": "redacted-reasoning-data",
+          },
+        },
+        "text": "",
+        "type": "reasoning",
+      },
+      {
+        "text": "Hello, world!",
         "type": "text",
       },
-      {
-        "data": "redacted-reasoning-data",
-        "type": "redacted",
-      },
     ],
+    "finishReason": "stop",
+    "providerMetadata": undefined,
     "request": {},
     "response": {
       "headers": undefined,
@@ -883,37 +891,43 @@ exports[`Loop Tests > AISDK v5 > generateText > result.steps > should add the re
         {
           "content": [
             {
-              "signature": "signature",
+              "providerOptions": {
+                "testProvider": {
+                  "signature": "signature",
+                },
+              },
               "text": "I will open the conversation with witty banter.",
               "type": "reasoning",
             },
             {
-              "data": "redacted-reasoning-data",
-              "type": "redacted-reasoning",
+              "providerOptions": {
+                "testProvider": {
+                  "redactedData": "redacted-reasoning-data",
+                },
+              },
+              "text": "",
+              "type": "reasoning",
             },
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },
           ],
-          "id": "msg-0",
           "role": "assistant",
         },
       ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "stepType": "initial",
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
-      "completionTokens": 20,
-      "promptTokens": 10,
-      "totalTokens": 30,
+      "cachedInputTokens": undefined,
+      "inputTokens": 3,
+      "outputTokens": 10,
+      "reasoningTokens": undefined,
+      "totalTokens": 13,
     },
-    "warnings": undefined,
+    "warnings": [],
   },
 ]
 `;

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -1006,35 +1006,12 @@ exports[`Loop Tests > AISDK v5 > generateText > result.steps > should contain fi
 
 exports[`Loop Tests > AISDK v5 > generateText > result.steps > should contain sources 1`] = `
 [
-  {
-    "experimental_providerMetadata": undefined,
-    "files": [],
-    "finishReason": "stop",
-    "isContinued": false,
-    "logprobs": undefined,
-    "providerMetadata": undefined,
-    "reasoning": undefined,
-    "reasoningDetails": [],
-    "request": {},
-    "response": {
-      "headers": undefined,
-      "id": "id-0",
-      "messages": [
-        {
-          "content": [
-            {
-              "text": "Hello, world!",
-              "type": "text",
-            },
-          ],
-          "id": "msg-0",
-          "role": "assistant",
-        },
-      ],
-      "modelId": "mock-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
-    },
-    "sources": [
+  DefaultStepResult {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
       {
         "id": "123",
         "providerMetadata": {
@@ -1044,6 +1021,7 @@ exports[`Loop Tests > AISDK v5 > generateText > result.steps > should contain so
         },
         "sourceType": "url",
         "title": "Example",
+        "type": "source",
         "url": "https://example.com",
       },
       {
@@ -1055,19 +1033,40 @@ exports[`Loop Tests > AISDK v5 > generateText > result.steps > should contain so
         },
         "sourceType": "url",
         "title": "Example 2",
+        "type": "source",
         "url": "https://example.com/2",
       },
     ],
-    "stepType": "initial",
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
-    "usage": {
-      "completionTokens": 20,
-      "promptTokens": 10,
-      "totalTokens": 30,
+    "finishReason": "stop",
+    "providerMetadata": undefined,
+    "request": {},
+    "response": {
+      "body": undefined,
+      "headers": undefined,
+      "id": "id-0",
+      "messages": [
+        {
+          "content": [
+            {
+              "providerOptions": undefined,
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "warnings": undefined,
+    "usage": {
+      "cachedInputTokens": undefined,
+      "inputTokens": 3,
+      "outputTokens": 10,
+      "reasoningTokens": undefined,
+      "totalTokens": 13,
+    },
+    "warnings": [],
   },
 ]
 `;

--- a/packages/core/src/loop/loop.test.ts
+++ b/packages/core/src/loop/loop.test.ts
@@ -5,7 +5,7 @@ import { generateTextTestsV5 } from './test-utils/generateText';
 import { optionsTests } from './test-utils/options';
 import { resultObjectTests } from './test-utils/resultObject';
 import { streamObjectTests } from './test-utils/streamObject';
-// import { telemetryTests } from './test-utils/telemetry';
+import { telemetryTests } from './test-utils/telemetry';
 import { textStreamTests } from './test-utils/textStream';
 import { toolsTests } from './test-utils/tools';
 import { toUIMessageStreamTests } from './test-utils/toUIMessageStream';
@@ -17,7 +17,7 @@ describe('Loop Tests', () => {
     toUIMessageStreamTests({ loopFn: loop, runId: 'test-run-id' });
     resultObjectTests({ loopFn: loop, runId: 'test-run-id' });
     optionsTests({ loopFn: loop, runId: 'test-run-id' });
-    // telemetryTests({ loopFn: loop, runId: 'test-run-id' });
+    telemetryTests({ loopFn: loop, runId: 'test-run-id' });
     generateTextTestsV5({ loopFn: loop, runId: 'test-run-id' });
     toolsTests({ loopFn: loop, runId: 'test-run-id' });
 

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -46,6 +46,7 @@ export function loop<Tools extends ToolSet = ToolSet>({
       provider: model.provider,
     },
     modelSettings,
+    headers: modelSettings?.headers ?? rest.headers,
     telemetry_settings,
   });
 
@@ -57,6 +58,17 @@ export function loop<Tools extends ToolSet = ToolSet>({
       : {}),
   });
 
+  const { rootSpan: modelStreamSpan } = getRootSpan({
+    operationId: `mastra.stream.aisdk.doStream`,
+    model: {
+      modelId: model.modelId,
+      provider: model.provider,
+    },
+    modelSettings,
+    headers: modelSettings?.headers ?? rest.headers,
+    telemetry_settings,
+  });
+
   const workflowLoopProps: LoopRun<Tools> = {
     model,
     runId: runIdToUse,
@@ -66,7 +78,8 @@ export function loop<Tools extends ToolSet = ToolSet>({
     includeRawChunks: !!includeRawChunks,
     _internal: internalToUse,
     tools,
-    modelStreamSpan: rootSpan,
+    modelStreamSpan,
+    telemetry_settings,
     ...rest,
   };
 

--- a/packages/core/src/loop/test-utils/generateText.ts
+++ b/packages/core/src/loop/test-utils/generateText.ts
@@ -5,7 +5,7 @@ import z from 'zod';
 import { MessageList } from '../../agent/message-list';
 import type { loop } from '../loop';
 import type { LoopOptions } from '../types';
-import { createTestModel, modelWithReasoning, modelWithSources, testUsage } from './utils';
+import { createTestModel, modelWithFiles, modelWithReasoning, modelWithSources, testUsage } from './utils';
 import type { LanguageModelV2StreamPart } from '@ai-sdk/provider-v5';
 
 export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; runId: string }) {
@@ -194,19 +194,16 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
       });
     });
 
-    // describe('result.files', () => {
-    //   // TODO: text data is being added as base64Data
-    //   // generateText uses a defaurt StepResult class than streaming does
-    //   // https://github.com/vercel/ai/blob/53569b8e0e5c958db0186009b83ce941a5bc91c1/packages/ai/src/generate-text/generate-text.ts#L540
-    //   it.todo('should contain files', async () => {
-    //     const result = await generateText({
-    //       model: modelWithFiles,
-    //       prompt: 'prompt',
-    //     });
+    describe('result.files', () => {
+      it.todo('should contain files', async () => {
+        const result = await generateText({
+          model: modelWithFiles,
+          messageList: new MessageList(),
+        });
 
-    //     expect(result.files).toMatchSnapshot();
-    //   });
-    // });
+        expect(result.files).toMatchSnapshot();
+      });
+    });
 
     // describe('result.steps', () => {
     //   // TODO: include `reasoning` and `reasoningDetails` in step result

--- a/packages/core/src/loop/test-utils/generateText.ts
+++ b/packages/core/src/loop/test-utils/generateText.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV2StreamPart, SharedV2ProviderMetadata } from '@ai-sdk/provider-v5';
 import type { generateText as generateText5 } from 'ai-v5';
 import { convertArrayToReadableStream, mockId, MockLanguageModelV2 } from 'ai-v5/test';
 import { assertType, describe, expect, it } from 'vitest';
@@ -6,7 +7,6 @@ import { MessageList } from '../../agent/message-list';
 import type { loop } from '../loop';
 import type { LoopOptions } from '../types';
 import { createTestModel, modelWithFiles, modelWithReasoning, modelWithSources, testUsage } from './utils';
-import type { LanguageModelV2StreamPart, SharedV2ProviderMetadata } from '@ai-sdk/provider-v5';
 
 export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; runId: string }) {
   const generateText = async (args: Omit<LoopOptions, 'runId'>): ReturnType<typeof generateText5> => {

--- a/packages/core/src/loop/test-utils/generateText.ts
+++ b/packages/core/src/loop/test-utils/generateText.ts
@@ -256,9 +256,6 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
         }),
       });
 
-      // TODO: include `reasoning` and `reasoningDetails` in step result
-      // generateText uses a defaurt StepResult class than streaming does
-      // https://github.com/vercel/ai/blob/53569b8e0e5c958db0186009b83ce941a5bc91c1/packages/ai/src/generate-text/generate-text.ts#L540
       it.todo('should add the reasoning from the model response to the step result', async () => {
         const result = await generateText({
           model: modelWithReasoning,

--- a/packages/core/src/loop/test-utils/generateText.ts
+++ b/packages/core/src/loop/test-utils/generateText.ts
@@ -256,6 +256,37 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
         }),
       });
 
+      const modelWithSources = new MockLanguageModelV2({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream<LanguageModelV2StreamPart>([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Hello, world!' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'source',
+              sourceType: 'url',
+              id: '123',
+              url: 'https://example.com',
+              title: 'Example',
+              providerMetadata: { provider: { custom: 'value' } },
+            },
+            {
+              type: 'source',
+              sourceType: 'url',
+              id: '456',
+              url: 'https://example.com/2',
+              title: 'Example 2',
+              providerMetadata: { provider: { custom: 'value2' } },
+            },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: testUsage,
+            },
+          ]),
+        }),
+      });
+
       it.todo('should add the reasoning from the model response to the step result', async () => {
         const result = await generateText({
           model: modelWithReasoning,
@@ -269,9 +300,6 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
         expect(result.steps).toMatchSnapshot();
       });
 
-      // TODO: include `sources` in step result
-      // generateText uses a defaurt StepResult class than streaming does
-      // https://github.com/vercel/ai/blob/53569b8e0e5c958db0186009b83ce941a5bc91c1/packages/ai/src/generate-text/generate-text.ts#L540
       it.todo('should contain sources', async () => {
         const result = await generateText({
           model: modelWithSources,

--- a/packages/core/src/loop/test-utils/resultObject.ts
+++ b/packages/core/src/loop/test-utils/resultObject.ts
@@ -678,7 +678,6 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         {
                           "data": "Hello World",
                           "mediaType": "text/plain",
-                          "providerOptions": undefined,
                           "type": "file",
                         },
                         {
@@ -688,7 +687,6 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         {
                           "data": "QkFVRw==",
                           "mediaType": "image/jpeg",
-                          "providerOptions": undefined,
                           "type": "file",
                         },
                       ],

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -56,7 +56,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
   describe('streamObject', () => {
     describe('output = "object"', () => {
       describe('result.objectStream', () => {
-        it.todo('should send object deltas', async () => {
+        it('should send object deltas', async () => {
           const mockModel = createTestModel();
 
           const messageList = new MessageList();
@@ -256,7 +256,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
           });
         });
 
-        it.todo('should reject object promise when the streamed object does not match the schema', async () => {
+        it('should reject object promise when the streamed object does not match the schema', async () => {
           const result = loopFn({
             runId,
             model: new MockLanguageModelV2({

--- a/packages/core/src/loop/test-utils/telemetry.ts
+++ b/packages/core/src/loop/test-utils/telemetry.ts
@@ -38,7 +38,7 @@ export function telemetryTests({ loopFn, runId }: { loopFn: typeof loop; runId: 
       expect(tracer.jsonSpans).toMatchSnapshot();
     });
 
-    it.only('should record telemetry data when enabled', async () => {
+    it('should record telemetry data when enabled', async () => {
       const messageList = new MessageList();
       messageList.add(
         {

--- a/packages/core/src/loop/workflow/llm-execution.ts
+++ b/packages/core/src/loop/workflow/llm-execution.ts
@@ -4,7 +4,7 @@ import type { LanguageModelV2, LanguageModelV2Usage } from '@ai-sdk/provider-v5'
 import type { ToolSet } from 'ai-v5';
 import type { MessageList } from '../../agent/message-list';
 import { execute } from '../../stream/aisdk/v5/execute';
-import { DefaultStepResult, transformResponse } from '../../stream/aisdk/v5/output-helpers';
+import { DefaultStepResult } from '../../stream/aisdk/v5/output-helpers';
 import { convertMastraChunkToAISDKv5 } from '../../stream/aisdk/v5/transform';
 import { MastraModelOutput } from '../../stream/base/output';
 import type { ChunkType } from '../../stream/types';
@@ -537,32 +537,23 @@ export function createLLMExecutionStep<Tools extends ToolSet = ToolSet>({
 
       const steps = inputData.output?.steps || [];
 
-      const v5NonUserMessages = messageList.get.response.aiV5.ui();
-
       steps.push(
         new DefaultStepResult({
           warnings: outputStream.warnings,
           providerMetadata: providerOptions,
           finishReason: runState.state.stepResult?.reason,
-          content: transformResponse({
-            response: { ...responseMetadata, messages: v5NonUserMessages },
-            isMessages: false,
-            runId,
-          }),
-          response: transformResponse({
-            response: { ...responseMetadata, messages: v5NonUserMessages },
-            isMessages: true,
-            runId,
-          }),
+          content: messageList.get.response.aiV5.modelContent(),
+          // @ts-ignore this is how it worked internally for transformResponse which was removed TODO: how should this actually work?
+          response: { ...responseMetadata, messages: messageList.get.response.aiV5.model() },
           request: request,
           usage: outputStream.usage as LanguageModelV2Usage,
         }),
       );
 
       const messages = {
-        all: messageList.get.all.v3(),
-        user: messageList.get.input.v3(),
-        nonUser: messageList.get.response.v3(),
+        all: messageList.get.all.aiV5.model(),
+        user: messageList.get.input.aiV5.model(),
+        nonUser: messageList.get.response.aiV5.model(),
       };
 
       return {

--- a/packages/core/src/loop/workflow/llm-execution.ts
+++ b/packages/core/src/loop/workflow/llm-execution.ts
@@ -47,7 +47,7 @@ async function processOutputStream({
     }
 
     if (chunk.type == 'object') {
-      controller.enqueue(chunk);
+      // controller.enqueue(chunk);
       continue;
     }
 

--- a/packages/core/src/loop/workflow/outer-llm-step.ts
+++ b/packages/core/src/loop/workflow/outer-llm-step.ts
@@ -18,6 +18,7 @@ export function createOuterLLMWorkflow<Tools extends ToolSet = ToolSet>({
     model,
     _internal,
     modelStreamSpan,
+    telemetry_settings,
     ...rest,
   });
 
@@ -150,7 +151,18 @@ export function createOuterLLMWorkflow<Tools extends ToolSet = ToolSet>({
     .then(llmExecutionStep)
     .map(({ inputData }) => {
       if (modelStreamSpan && telemetry_settings?.recordOutputs !== false && inputData.output.toolCalls?.length) {
-        modelStreamSpan.setAttribute('stream.response.toolCalls', JSON.stringify(inputData.output.toolCalls));
+        modelStreamSpan.setAttribute(
+          'stream.response.toolCalls',
+          JSON.stringify(
+            inputData.output.toolCalls?.map((toolCall: any) => {
+              return {
+                toolCallId: toolCall.toolCallId,
+                args: toolCall.args,
+                toolName: toolCall.toolName,
+              };
+            }),
+          ),
+        );
       }
       return inputData.output.toolCalls || [];
     })

--- a/packages/core/src/loop/workflow/stream.ts
+++ b/packages/core/src/loop/workflow/stream.ts
@@ -21,13 +21,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet>({
     start: async controller => {
       const messageId = rest.experimental_generateMessageId?.() || _internal?.generateId?.();
 
-      const { rootSpan } = getRootSpan({
-        operationId: `mastra.stream.model.aisdk`,
-        model,
-        telemetry_settings,
-      });
-
-      rootSpan.setAttributes({
+      modelStreamSpan.setAttributes({
         ...(telemetry_settings?.recordInputs !== false
           ? {
               'stream.prompt.toolChoice': toolChoice ? JSON.stringify(toolChoice) : 'auto',
@@ -80,7 +74,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet>({
             });
           }
 
-          rootSpan.setAttributes({
+          modelStreamSpan.setAttributes({
             'stream.response.id': inputData.metadata.id,
             'stream.response.model': model.modelId,
             ...(inputData.metadata.providerMetadata
@@ -98,7 +92,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet>({
               : {}),
           });
 
-          rootSpan.end();
+          modelStreamSpan.end();
 
           const reason = inputData.stepResult.reason;
 
@@ -118,11 +112,11 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet>({
 
       const msToFirstChunk = _internal?.now?.()! - rest.startTimestamp!;
 
-      rootSpan.addEvent('ai.stream.firstChunk', {
+      modelStreamSpan.addEvent('ai.stream.firstChunk', {
         'ai.response.msToFirstChunk': msToFirstChunk,
       });
 
-      rootSpan.setAttributes({
+      modelStreamSpan.setAttributes({
         'stream.response.timestamp': new Date(rest.startTimestamp).toISOString(),
         'stream.response.msToFirstChunk': msToFirstChunk,
       });
@@ -168,8 +162,8 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet>({
       });
 
       const msToFinish = (_internal?.now?.() ?? Date.now()) - rest.startTimestamp;
-      rootSpan.addEvent('ai.stream.finish');
-      rootSpan.setAttributes({
+      modelStreamSpan.addEvent('ai.stream.finish');
+      modelStreamSpan.setAttributes({
         'stream.response.msToFinish': msToFinish,
         'stream.response.avgOutputTokensPerSecond':
           (1000 * (executionResult?.result?.output?.usage?.outputTokens ?? 0)) / msToFinish,

--- a/packages/core/src/loop/workflow/stream.ts
+++ b/packages/core/src/loop/workflow/stream.ts
@@ -3,7 +3,6 @@ import type { ToolSet } from 'ai-v5';
 import z from 'zod';
 import type { ChunkType } from '../../stream/types';
 import { createWorkflow } from '../../workflows';
-import { getRootSpan } from '../telemetry';
 import type { LoopRun } from '../types';
 import { createOuterLLMWorkflow } from './outer-llm-step';
 import { llmIterationOutputSchema } from './schema';

--- a/packages/core/src/loop/workflow/tool-call-step.ts
+++ b/packages/core/src/loop/workflow/tool-call-step.ts
@@ -1,6 +1,6 @@
 import type { ToolSet } from 'ai-v5';
 import { createStep } from '../../workflows';
-import { getRootSpan } from '../telemetry';
+import { assembleOperationName, getRootSpan, getTracer } from '../telemetry';
 import type { OuterLLMRun } from '../types';
 import { toolCallInputSchema, toolCallOutputSchema } from './schema';
 
@@ -41,16 +41,16 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet>({
         return inputData;
       }
 
-      const { rootSpan } = getRootSpan({
-        operationId: 'mastra.stream.toolCall',
-        model: {
-          modelId: model.modelId,
-          provider: model.provider,
-        },
-        telemetry_settings: telemetry_settings,
+      const tracer = getTracer({
+        isEnabled: telemetry_settings?.isEnabled,
+        tracer: telemetry_settings?.tracer,
       });
 
-      const span = rootSpan.setAttributes({
+      const span = tracer.startSpan('mastra.stream.toolCall').setAttributes({
+        ...assembleOperationName({
+          operationId: 'mastra.stream.toolCall',
+          telemetry: telemetry_settings,
+        }),
         'stream.toolCall.toolName': inputData.toolName,
         'stream.toolCall.toolCallId': inputData.toolCallId,
         'stream.toolCall.args': JSON.stringify(inputData.args),

--- a/packages/core/src/loop/workflow/tool-call-step.ts
+++ b/packages/core/src/loop/workflow/tool-call-step.ts
@@ -1,12 +1,11 @@
 import type { ToolSet } from 'ai-v5';
 import { createStep } from '../../workflows';
-import { assembleOperationName, getRootSpan, getTracer } from '../telemetry';
+import { assembleOperationName, getTracer } from '../telemetry';
 import type { OuterLLMRun } from '../types';
 import { toolCallInputSchema, toolCallOutputSchema } from './schema';
 
 export function createToolCallStep<Tools extends ToolSet = ToolSet>({
   tools,
-  model,
   messageList,
   options,
   telemetry_settings,

--- a/packages/core/src/stream/aisdk/v5/object/stream-object.ts
+++ b/packages/core/src/stream/aisdk/v5/object/stream-object.ts
@@ -86,7 +86,11 @@ export function createObjectStreamTransformer({
           textAccumulatedText += chunk.payload.text;
           const { value: currentObjectJson } = await parsePartialJson(textAccumulatedText);
 
-          if (currentObjectJson !== undefined && !isDeepEqualData(textPreviousObject, currentObjectJson)) {
+          if (
+            currentObjectJson !== undefined &&
+            typeof currentObjectJson === 'object' &&
+            !isDeepEqualData(textPreviousObject, currentObjectJson)
+          ) {
             textPreviousObject = currentObjectJson;
             controller.enqueue({
               type: 'object',

--- a/packages/core/src/stream/aisdk/v5/output.ts
+++ b/packages/core/src/stream/aisdk/v5/output.ts
@@ -173,6 +173,22 @@ export class AISDKV5OutputStream {
       .filter(Boolean);
   }
 
+  get generateTextFiles() {
+    return this.#modelOutput.files
+      .map(file => {
+        if (file.type === 'file') {
+          return (
+            convertMastraChunkToAISDKv5({
+              chunk: file,
+              mode: 'generate',
+            }) as any
+          )?.file;
+        }
+        return;
+      })
+      .filter(Boolean);
+  }
+
   get toolCalls() {
     return this.#modelOutput.toolCalls.map(toolCall => {
       return convertMastraChunkToAISDKv5({
@@ -274,7 +290,7 @@ export class AISDKV5OutputStream {
       toolCalls: this.toolCalls,
       toolResults: this.toolResults,
       sources: this.sources,
-      files: this.files,
+      files: this.generateTextFiles,
       response: this.response,
       content: this.content,
       totalUsage: this.#modelOutput.totalUsage,

--- a/packages/core/src/stream/aisdk/v5/output.ts
+++ b/packages/core/src/stream/aisdk/v5/output.ts
@@ -1,7 +1,7 @@
 import { TransformStream } from 'stream/web';
 import { getErrorMessage } from '@ai-sdk/provider-v5';
 import { consumeStream, createTextStreamResponse, createUIMessageStream, createUIMessageStreamResponse } from 'ai-v5';
-import type { StepResult, TextStreamPart, ToolSet, UIMessage, UIMessageStreamOptions } from 'ai-v5';
+import type { TextStreamPart, ToolSet, UIMessage, UIMessageStreamOptions } from 'ai-v5';
 import type { MessageList } from '../../../agent/message-list';
 import type { ObjectOptions } from '../../../loop/types';
 import type { MastraModelOutput } from '../../base/output';

--- a/packages/core/src/stream/aisdk/v5/output.ts
+++ b/packages/core/src/stream/aisdk/v5/output.ts
@@ -1,7 +1,7 @@
 import { TransformStream } from 'stream/web';
 import { getErrorMessage } from '@ai-sdk/provider-v5';
 import { consumeStream, createTextStreamResponse, createUIMessageStream, createUIMessageStreamResponse } from 'ai-v5';
-import type { TextStreamPart, ToolSet, UIMessage, UIMessageStreamOptions } from 'ai-v5';
+import type { StepResult, TextStreamPart, ToolSet, UIMessage, UIMessageStreamOptions } from 'ai-v5';
 import type { MessageList } from '../../../agent/message-list';
 import type { ObjectOptions } from '../../../loop/types';
 import type { MastraModelOutput } from '../../base/output';
@@ -223,6 +223,10 @@ export class AISDKV5OutputStream {
     return transformSteps({ steps: this.#modelOutput.steps });
   }
 
+  get generateTextSteps() {
+    return transformSteps({ steps: this.#modelOutput.steps });
+  }
+
   get content() {
     return this.#messageList.get.response.aiV5.modelContent();
   }
@@ -280,7 +284,7 @@ export class AISDKV5OutputStream {
     return {
       text: this.#modelOutput.text,
       usage: this.#modelOutput.usage,
-      steps: this.steps,
+      steps: this.generateTextSteps,
       finishReason: this.#modelOutput.finishReason,
       warnings: this.#modelOutput.warnings,
       providerMetadata: this.#modelOutput.providerMetadata,

--- a/packages/core/src/stream/aisdk/v5/output.ts
+++ b/packages/core/src/stream/aisdk/v5/output.ts
@@ -8,7 +8,7 @@ import type { MastraModelOutput } from '../../base/output';
 import type { ChunkType } from '../../types';
 import type { ConsumeStreamOptions } from './compat';
 import { getResponseUIMessageId, convertFullStreamChunkToUIMessageStream } from './compat';
-import { transformResponse, transformSteps } from './output-helpers';
+import { transformSteps } from './output-helpers';
 import { convertMastraChunkToAISDKv5 } from './transform';
 import type { OutputChunkType } from './transform';
 
@@ -198,33 +198,18 @@ export class AISDKV5OutputStream {
   }
 
   get response() {
-    const response = transformResponse({
-      response: this.#modelOutput.response,
-      isMessages: true,
-      runId: this.#modelOutput.runId,
-    });
-    const newResponse = {
-      ...response,
-      messages: response.messages?.map((message: any) => ({
-        role: message.role,
-        content: message.content?.parts,
-      })),
+    return {
+      ...this.#modelOutput.response,
     };
-
-    return newResponse;
   }
 
   get steps() {
-    return transformSteps({ steps: this.#modelOutput.steps, runId: this.#modelOutput.runId });
+    return transformSteps({ steps: this.#modelOutput.steps });
   }
 
   get content() {
     const content =
-      transformResponse({
-        response: this.#modelOutput.response,
-        isMessages: false,
-        runId: this.#modelOutput.runId,
-      }).messages?.flatMap((message: any) => {
+      this.#modelOutput.response.messages?.flatMap((message: any) => {
         return message.content?.parts;
       }) ?? [];
 

--- a/packages/core/src/stream/aisdk/v5/output.ts
+++ b/packages/core/src/stream/aisdk/v5/output.ts
@@ -208,12 +208,7 @@ export class AISDKV5OutputStream {
   }
 
   get content() {
-    const content =
-      this.#modelOutput.response.messages?.flatMap((message: any) => {
-        return message.content?.parts;
-      }) ?? [];
-
-    return content;
+    return this.#messageList.get.response.aiV5.modelContent();
   }
 
   get fullStream() {

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -6,7 +6,7 @@ import type {
 } from '@ai-sdk/provider-v5';
 import type { ObjectStreamPart, TextStreamPart, ToolSet } from 'ai-v5';
 import type { ChunkType } from '../../types';
-import { DefaultGeneratedFileWithType } from './file';
+import { DefaultGeneratedFile, DefaultGeneratedFileWithType } from './file';
 
 type StreamPart =
   | Exclude<LanguageModelV2StreamPart, { type: 'finish' }>
@@ -312,7 +312,13 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
 
 export type OutputChunkType = TextStreamPart<ToolSet> | ObjectStreamPart<any> | undefined;
 
-export function convertMastraChunkToAISDKv5({ chunk }: { chunk: ChunkType }): OutputChunkType {
+export function convertMastraChunkToAISDKv5({
+  chunk,
+  mode = 'stream',
+}: {
+  chunk: ChunkType;
+  mode?: 'generate' | 'stream';
+}): OutputChunkType {
   switch (chunk.type) {
     case 'start':
       return {
@@ -383,6 +389,16 @@ export function convertMastraChunkToAISDKv5({ chunk }: { chunk: ChunkType }): Ou
         providerMetadata: chunk.payload.providerMetadata,
       };
     case 'file':
+      if (mode === 'generate') {
+        return {
+          type: 'file',
+          file: new DefaultGeneratedFile({
+            data: chunk.payload.data,
+            mediaType: chunk.payload.mimeType,
+          }),
+        };
+      }
+
       return {
         type: 'file',
         file: new DefaultGeneratedFileWithType({

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -315,8 +315,10 @@ export class MastraModelOutput extends MastraBase {
                         'stream.response.toolCalls': JSON.stringify(
                           baseFinishStep?.toolCalls?.map(chunk => {
                             return {
-                              type: chunk.type,
-                              ...chunk.payload,
+                              type: 'tool-call',
+                              toolCallId: chunk.payload.toolCallId,
+                              args: chunk.payload.args,
+                              toolName: chunk.payload.toolName,
                             };
                           }),
                         ),

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV1StreamPart } from 'ai';
+import type { StepResult } from 'ai-v5';
 
 export type ChunkType = {
   type: string;
@@ -39,6 +40,7 @@ export interface StepBufferItem {
   response?: any;
   request?: any;
   usage?: any;
+  content: StepResult<any>['content'];
 }
 
 export interface BufferedByStep {


### PR DESCRIPTION
Claude says: 
This PR fixes issues with V5 message formatting in the streaming output by improving how messages are converted and handled.

The main issue was that the message list wasn't properly formatting V5 response messages and the streaming output had redundant transformation logic that was causing type issues.

Now the MessageList class properly converts messages to V5 response format and provides clean methods for extracting step content. The streaming output helpers have been simplified to work directly with the step buffer items instead of doing redundant transformations.

This should resolve any formatting inconsistencies when using V5 streaming responses.