### PR TITLE
docs(deployment): add reverse proxy configuration guide

### DIFF
--- a/docs/src/content/en/docs/deployment/_meta.ts
+++ b/docs/src/content/en/docs/deployment/_meta.ts
@@ -4,6 +4,7 @@ const meta = {
   "web-framework": "With a Web Framework",
   "serverless-platforms": "Serverless Platforms",
   "cloud-providers": "Cloud Providers",
+  "behind-reverse-proxy": "Behind a Reverse Proxy",
 };
 
 export default meta;

--- a/docs/src/content/en/docs/deployment/behind-reverse-proxy.mdx
+++ b/docs/src/content/en/docs/deployment/behind-reverse-proxy.mdx
@@ -1,0 +1,39 @@
+---
+title: "Behind a Reverse Proxy"
+description: "Deploy a Mastra server behind a Reverse Proxy"
+---
+
+# Deploy a Mastra Server behind a Reverse Proxy
+
+When streaming responses (e.g., SSE, chunked HTTP) from Mastra Server fail or hang behind a reverse proxy, it’s often due to proxy buffering or timeouts. 
+Reverse proxies like `Nginx` and `Caddy` buffer responses by default, which can break streaming protocols.
+
+It is recommended to disable buffering and increase read timeouts.
+
+## Nginx Configuration
+```nginx filename="nginx.conf" showLineNumbers
+location / {
+    proxy_pass http://localhost:4111;
+
+    # Disable buffering for streaming responses
+    proxy_buffering off;
+
+    # increase read timeout for longer streaming sessions
+    proxy_read_timeout 300s; # Wait up to 5 minutes for upstream response
+}
+```
+
+## Caddy Configuration
+```nginx filename="Caddyfile" showLineNumbers
+reverse_proxy localhost:4111 {
+    # Disable buffering for streaming responses
+    flush_interval -1  # Caddy v2.4+ syntax
+    # flush_interval 0  # Legacy syntax
+
+    # increase read timeout for longer streaming sessions
+    read_timeout 300s  # Wait up to 5 minutes for upstream response
+}
+```
+
+## Others
+For other proxies (Cloudflare, HAProxy, etc.), refer to their documentation for equivalent "response buffering" settings.


### PR DESCRIPTION
## Description
It is a follow up from an issue that was raised on [Discord](https://discord.com/channels/1309558646228779139/1310121281177387109/1405431464467894342) where `watching` a workflow was not working as expected. After some investigation, I found that the issue is most likely due to the Mastra server being hosted behind a reverse proxy as I was able to reproduce the issue locally when running Mastra behind Nginx.

This PR adds documentation for deploying Mastra server behind reverse proxies including Nginx and Caddy.

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
