### PR TITLE
chore(mcp): bump mcp sdk vers

### DIFF
--- a/.changeset/big-foxes-double.md
+++ b/.changeset/big-foxes-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Update the MCP SDK version and update elicitation to match new spec (reject becomes decline)

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -342,7 +342,7 @@ The handler function receives a request object with:
 - `requestedSchema`: A JSON schema defining the structure of the expected response
 
 The handler must return an `ElicitResult` with:
-- `action`: One of `'accept'`, `'reject'`, or `'cancel'`
+- `action`: One of `'accept'`, `'decline'`, or `'cancel'`
 - `content`: The user's data (only when action is `'accept'`)
 
 **Example:**
@@ -363,8 +363,8 @@ mcpClient.elicitation.onRequest('serverName', async (request) => {
     };
   }
   
-  // Simulate user rejecting the request
-  return { action: 'reject' };
+  // Simulate user declining the request
+  return { action: 'decline' };
 });
 ```
 
@@ -423,7 +423,7 @@ await mcpClient.elicitation.onRequest('interactiveServer', async (request) => {
     // Validate required fields
     if (answer === '' && isRequired) {
       console.log(`❌ ${fieldName} is required`);
-      return { action: 'reject' };
+      return { action: 'decline' };
     }
     
     if (answer !== '') {
@@ -442,7 +442,7 @@ await mcpClient.elicitation.onRequest('interactiveServer', async (request) => {
   } else if (confirm.toLowerCase() === 'cancel') {
     return { action: 'cancel' };
   } else {
-    return { action: 'reject' };
+    return { action: 'decline' };
   }
 });
 ```
@@ -521,7 +521,7 @@ Elicitation is a feature that allows MCP servers to request structured informati
 1. **Server Request**: An MCP server tool calls `server.elicitation.sendRequest()` with a message and schema
 2. **Client Handler**: Your elicitation handler function is called with the request
 3. **User Interaction**: Your handler collects user input (via UI, CLI, etc.)
-4. **Response**: Your handler returns the user's response (accept/reject/cancel)
+4. **Response**: Your handler returns the user's response (accept/decline/cancel)
 5. **Tool Continuation**: The server tool receives the response and continues execution
 
 ### Setting Up Elicitation
@@ -566,9 +566,9 @@ Your elicitation handler must return one of three response types:
   };
   ```
 
-- **Reject**: User explicitly declined to provide the information
+- **Decline**: User explicitly declined to provide the information
   ```typescript
-  return { action: 'reject' };
+  return { action: 'decline' };
   ```
 
 - **Cancel**: User dismissed or cancelled the request
@@ -613,7 +613,7 @@ await mcpClient.elicitation.onRequest('interactiveServer', async (request) => {
 
 - **Always handle elicitation**: Set up your handler before calling tools that might use elicitation
 - **Validate input**: Check that required fields are provided
-- **Respect user choice**: Handle reject and cancel responses gracefully
+- **Respect user choice**: Handle decline and cancel responses gracefully
 - **Clear UI**: Make it obvious what information is being requested and why
 - **Security**: Never auto-accept requests for sensitive information
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -872,7 +872,7 @@ A common use case is during tool execution. When a tool needs user input, it can
 1. The tool calls `options.elicitation.sendRequest()` with a message and schema
 2. The request is sent to the connected MCP client
 3. The client presents the request to the user (via UI, command line, etc.)
-4. The user provides input, rejects, or cancels the request
+4. The user provides input, declines, or cancels the request
 5. The client sends the response back to the server
 6. The tool receives the response and continues execution
 
@@ -934,7 +934,7 @@ const server = new MCPServer({
           // Handle the user's response
           if (result.action === 'accept') {
             return `Contact information collected: ${JSON.stringify(result.content, null, 2)}`;
-          } else if (result.action === 'reject') {
+          } else if (result.action === 'decline') {
             return 'Contact information collection was declined by the user.';
           } else {
             return 'Contact information collection was cancelled by the user.';
@@ -990,7 +990,7 @@ Users can respond to elicitation requests in three ways:
 
 1. **Accept** (`action: 'accept'`): User provided data and confirmed submission
    - Contains `content` field with the submitted data
-2. **Reject** (`action: 'reject'`): User explicitly declined to provide information
+2. **Decline** (`action: 'decline'`): User explicitly declined to provide information
    - No content field
 3. **Cancel** (`action: 'cancel'`): User dismissed the request without deciding
    - No content field
@@ -1001,7 +1001,7 @@ Tools should handle all three response types appropriately.
 
 - **Never request sensitive information** like passwords, SSNs, or credit card numbers
 - Validate all user input against the provided schema
-- Handle rejection and cancellation gracefully
+- Handle declining and cancellation gracefully
 - Provide clear reasons for data collection
 - Respect user privacy and preferences
 
@@ -1031,7 +1031,7 @@ The `ElicitResult` type:
 
 ```typescript
 type ElicitResult = {
-  action: 'accept' | 'reject' | 'cancel';
+  action: 'accept' | 'decline' | 'cancel';
   content?: any; // Only present when action is 'accept'
 }
 ```

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^14.1.1",
-    "@modelcontextprotocol/sdk": "^1.13.0",
+    "@modelcontextprotocol/sdk": "^1.17.0",
     "date-fns": "^4.1.0",
     "exit-hook": "^4.0.0",
     "fast-deep-equal": "^3.1.3",

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -356,7 +356,7 @@ describe('MastraMCPClient - Elicitation Tests', () => {
   it('should handle elicitation request with reject response', async () => {
     const mockHandler = vi.fn(async (request) => {
       expect(request.message).toBe('Please provide sensitive information');
-      return { action: 'reject' as const };
+      return { action: 'decline' as const };
     });
 
     client = new InternalMastraMCPClient({
@@ -383,7 +383,7 @@ describe('MastraMCPClient - Elicitation Tests', () => {
     expect(result.content[0].type).toBe('text');
     
     const elicitationResult = JSON.parse(result.content[0].text);
-    expect(elicitationResult.action).toBe('reject');
+    expect(elicitationResult.action).toBe('decline');
   });
 
   it('should handle elicitation request with cancel response', async () => {

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -1564,7 +1564,7 @@ describe('MCPServer - Elicitation', () => {
   it('should handle elicitation request with reject response', async () => {
     const mockElicitationHandler = vi.fn(async request => {
       expect(request.message).toBe('Please provide sensitive data');
-      return { action: 'reject' as const };
+      return { action: 'decline' as const };
     });
 
     elicitationClient = new InternalMastraMCPClient({
@@ -1586,7 +1586,7 @@ describe('MCPServer - Elicitation', () => {
     });
 
     expect(mockElicitationHandler).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(result.content[0].text)).toEqual({ action: 'reject' });
+    expect(JSON.parse(result.content[0].text)).toEqual({ action: 'decline' });
   });
 
   it('should handle elicitation request with cancel response', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,7 +706,7 @@ importers:
     dependencies:
       mem0ai:
         specifier: ^2.1.36
-        version: 2.1.36(@anthropic-ai/sdk@0.27.3(encoding@0.1.13))(@cloudflare/workers-types@4.20250803.0)(@google/genai@1.14.0(@modelcontextprotocol/sdk@1.13.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3))(@langchain/core@0.3.59(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76)))(@mistralai/mistralai@1.7.2(zod@3.25.76))(@qdrant/js-client-rest@1.15.0(typescript@5.8.3))(@supabase/supabase-js@2.50.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(@types/jest@29.5.14)(@types/pg@8.15.5)(@types/sqlite3@3.1.11)(cloudflare@4.5.0(encoding@0.1.13))(encoding@0.1.13)(groq-sdk@0.5.0(encoding@0.1.13))(neo4j-driver@5.28.1)(ollama@0.5.16)(pg@8.16.3)(redis@5.8.0)(sqlite3@5.1.7)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))
+        version: 2.1.36(@anthropic-ai/sdk@0.27.3(encoding@0.1.13))(@cloudflare/workers-types@4.20250803.0)(@google/genai@1.14.0(@modelcontextprotocol/sdk@1.17.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3))(@langchain/core@0.3.59(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76)))(@mistralai/mistralai@1.7.2(zod@3.25.76))(@qdrant/js-client-rest@1.15.0(typescript@5.8.3))(@supabase/supabase-js@2.50.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(@types/jest@29.5.14)(@types/pg@8.15.5)(@types/sqlite3@3.1.11)(cloudflare@4.5.0(encoding@0.1.13))(encoding@0.1.13)(groq-sdk@0.5.0(encoding@0.1.13))(neo4j-driver@5.28.1)(ollama@0.5.16)(pg@8.16.3)(redis@5.8.0)(sqlite3@5.1.7)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -1776,8 +1776,8 @@ importers:
         specifier: ^14.1.1
         version: 14.1.1
       '@modelcontextprotocol/sdk':
-        specifier: ^1.13.0
-        version: 1.13.3
+        specifier: ^1.17.0
+        version: 1.17.3
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1832,7 +1832,7 @@ importers:
         version: 4.8.12
       hono-mcp-server-sse-transport:
         specifier: 0.0.7
-        version: 0.0.7(@modelcontextprotocol/sdk@1.13.3)(hono@4.8.12)
+        version: 0.0.7(@modelcontextprotocol/sdk@1.17.3)(hono@4.8.12)
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(@microsoft/api-extractor@7.52.8(@types/node@20.19.9))(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
@@ -3575,7 +3575,7 @@ importers:
     dependencies:
       '@google/genai':
         specifier: latest
-        version: 1.14.0(@modelcontextprotocol/sdk@1.13.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3)
+        version: 1.14.0(@modelcontextprotocol/sdk@1.17.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3)
       google-auth-library:
         specifier: ^10.2.1
         version: 10.2.1
@@ -6869,6 +6869,10 @@ packages:
 
   '@modelcontextprotocol/sdk@1.13.3':
     resolution: {integrity: sha512-bGwA78F/U5G2jrnsdRkPY3IwIwZeWUEfb5o764b79lb0rJmMT76TLwKhdNZOWakOQtedYefwIR4emisEMvInKA==}
+    engines: {node: '>=18'}
+
+  '@modelcontextprotocol/sdk@1.17.3':
+    resolution: {integrity: sha512-JPwUKWSsbzx+DLFznf/QZ32Qa+ptfbUlHhRLrBQBAFu9iI1iYvizM4p+zhhRDceSsPutXp4z+R/HPVphlIiclg==}
     engines: {node: '>=18'}
 
   '@mongodb-js/saslprep@1.3.0':
@@ -19618,12 +19622,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google/genai@1.14.0(@modelcontextprotocol/sdk@1.13.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3)':
+  '@google/genai@1.14.0(@modelcontextprotocol/sdk@1.17.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3)':
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.13.3
+      '@modelcontextprotocol/sdk': 1.17.3
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -20449,6 +20453,23 @@ snapshots:
   '@mixmark-io/domino@2.2.0': {}
 
   '@modelcontextprotocol/sdk@1.13.3':
+    dependencies:
+      ajv: 6.12.6
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.3
+      express: 5.1.0
+      express-rate-limit: 7.5.0(express@5.1.0)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.17.3':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
@@ -24096,14 +24117,6 @@ snapshots:
     optionalDependencies:
       vite: 5.4.19(@types/node@20.19.9)(terser@5.43.1)
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.5(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
-
   '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -24234,7 +24247,7 @@ snapshots:
   '@wong2/mcp-cli@1.10.0':
     dependencies:
       '@json-schema-tools/traverse': 1.10.4
-      '@modelcontextprotocol/sdk': 1.13.3
+      '@modelcontextprotocol/sdk': 1.17.3
       conf: 13.1.0
       eventsource: 3.0.7
       express: 5.1.0
@@ -27001,9 +27014,9 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
-  hono-mcp-server-sse-transport@0.0.7(@modelcontextprotocol/sdk@1.13.3)(hono@4.8.12):
+  hono-mcp-server-sse-transport@0.0.7(@modelcontextprotocol/sdk@1.17.3)(hono@4.8.12):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.13.3
+      '@modelcontextprotocol/sdk': 1.17.3
       hono: 4.8.12
 
   hono-openapi@0.4.8(hono@4.8.12)(openapi-types@12.1.3)(zod@3.25.76):
@@ -28453,11 +28466,11 @@ snapshots:
 
   media-typer@1.1.0: {}
 
-  mem0ai@2.1.36(@anthropic-ai/sdk@0.27.3(encoding@0.1.13))(@cloudflare/workers-types@4.20250803.0)(@google/genai@1.14.0(@modelcontextprotocol/sdk@1.13.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3))(@langchain/core@0.3.59(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76)))(@mistralai/mistralai@1.7.2(zod@3.25.76))(@qdrant/js-client-rest@1.15.0(typescript@5.8.3))(@supabase/supabase-js@2.50.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(@types/jest@29.5.14)(@types/pg@8.15.5)(@types/sqlite3@3.1.11)(cloudflare@4.5.0(encoding@0.1.13))(encoding@0.1.13)(groq-sdk@0.5.0(encoding@0.1.13))(neo4j-driver@5.28.1)(ollama@0.5.16)(pg@8.16.3)(redis@5.8.0)(sqlite3@5.1.7)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3)):
+  mem0ai@2.1.36(@anthropic-ai/sdk@0.27.3(encoding@0.1.13))(@cloudflare/workers-types@4.20250803.0)(@google/genai@1.14.0(@modelcontextprotocol/sdk@1.17.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3))(@langchain/core@0.3.59(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76)))(@mistralai/mistralai@1.7.2(zod@3.25.76))(@qdrant/js-client-rest@1.15.0(typescript@5.8.3))(@supabase/supabase-js@2.50.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(@types/jest@29.5.14)(@types/pg@8.15.5)(@types/sqlite3@3.1.11)(cloudflare@4.5.0(encoding@0.1.13))(encoding@0.1.13)(groq-sdk@0.5.0(encoding@0.1.13))(neo4j-driver@5.28.1)(ollama@0.5.16)(pg@8.16.3)(redis@5.8.0)(sqlite3@5.1.7)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3)):
     dependencies:
       '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
       '@cloudflare/workers-types': 4.20250803.0
-      '@google/genai': 1.14.0(@modelcontextprotocol/sdk@1.13.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3)
+      '@google/genai': 1.14.0(@modelcontextprotocol/sdk@1.17.3)(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.3)
       '@langchain/core': 0.3.59(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76))
       '@mistralai/mistralai': 1.7.2(zod@3.25.76)
       '@qdrant/js-client-rest': 1.15.0(typescript@5.8.3)
@@ -31964,7 +31977,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## Description

Bumps the MCP SDK to latest version. As a result the enum for elicitation was updated (`reject` has become `decline`).

Addresses https://github.com/mastra-ai/mastra/issues/6796
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
