### PR TITLE
fix(deployer): transpilePackages with relative sibling files

### DIFF
--- a/.changeset/dark-steaks-share.md
+++ b/.changeset/dark-steaks-share.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix a bug for transpilePackages usage where sibling files inside transpiled packages didn't resolve correctly

--- a/e2e-tests/monorepo/template/packages/hello-world/src/constants.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/constants.ts
@@ -1,0 +1,1 @@
+export const HELLO_WORLD = 'Hello, World!';

--- a/e2e-tests/monorepo/template/packages/hello-world/src/tool.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/tool.ts
@@ -1,7 +1,8 @@
 import { createTool } from '@mastra/core/tools';
+import { HELLO_WORLD } from './constants';
 
 export const helloWorldTool = createTool({
   id: 'hello-world',
   description: 'A tool that returns hello world',
-  execute: async () => 'Hello, world!',
+  execute: async () => HELLO_WORLD,
 });

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -272,7 +272,9 @@ export async function bundleExternals(
             name: 'external-resolver',
             resolveId(id: string, importer: string | undefined) {
               const pathsToTranspile = [...transpilePackagesMap.values()];
-              if (importer && pathsToTranspile.some(p => importer?.startsWith(p))) {
+              const notRelative = !id.startsWith('.');
+              console.log({ id, importer, pathsToTranspile });
+              if (importer && pathsToTranspile.some(p => importer?.startsWith(p)) && notRelative) {
                 return {
                   id: resolveFrom(importer, id),
                   external: true,

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -64,6 +64,13 @@ function findExternalImporter(module: OutputChunk, external: string, allOutputs:
 }
 
 /**
+ * Check if a path is relative without relying on `isAbsolute()` as we want to allow package names (e.g. `@pkg/name`)
+ */
+function isRelativePath(id: string): boolean {
+  return id === '.' || id === '..' || id.startsWith('./') || id.startsWith('../');
+}
+
+/**
  * Analyzes the entry file to identify dependencies that need optimization.
  * This is the first step of the bundle analysis process.
  *
@@ -273,7 +280,7 @@ export async function bundleExternals(
             name: 'external-resolver',
             resolveId(id: string, importer: string | undefined) {
               const pathsToTranspile = [...transpilePackagesMap.values()];
-              if (importer && pathsToTranspile.some(p => importer?.startsWith(p)) && isAbsolute(id)) {
+              if (importer && pathsToTranspile.some(p => importer?.startsWith(p)) && !isRelativePath(id)) {
                 return {
                   id: resolveFrom(importer, id),
                   external: true,

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -7,6 +7,7 @@ import virtual from '@rollup/plugin-virtual';
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import { isAbsolute } from 'node:path';
 import { rollup, type OutputAsset, type OutputChunk, type Plugin } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 import { isNodeBuiltin } from './isNodeBuiltin';
@@ -272,9 +273,7 @@ export async function bundleExternals(
             name: 'external-resolver',
             resolveId(id: string, importer: string | undefined) {
               const pathsToTranspile = [...transpilePackagesMap.values()];
-              const notRelative = !id.startsWith('.');
-              console.log({ id, importer, pathsToTranspile });
-              if (importer && pathsToTranspile.some(p => importer?.startsWith(p)) && notRelative) {
+              if (importer && pathsToTranspile.some(p => importer?.startsWith(p)) && isAbsolute(id)) {
                 return {
                   id: resolveFrom(importer, id),
                   external: true,


### PR DESCRIPTION
## Description

This is a small fix for files that are imported relatively inside packages that are transpiled. Before you'd get an error stack from `resolve-from` like:

```bash
ERROR [2025-08-19 10:42:26.644 +0200] (Mastra CLI): Cannot find module './runtime'
Require stack:
- /.../packages/api-client/src/index.ts/noop.js
```

We check now if the `id` is absolute before marking a file as external. E2E test added to verify it.

## Related Issue(s)

It's related to https://github.com/mastra-ai/mastra/issues/1996 but most probably only fixes a small portion of the issues.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
