### PR TITLE
chore(storage): replace console.log with logger.debug in inmemory operations

### DIFF
--- a/.changeset/blue-dolls-create.md
+++ b/.changeset/blue-dolls-create.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+replace console.log with logger.debug in inmemory operations

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -24,7 +24,7 @@ export class StoreOperationsInMemory extends StoreOperations {
   }
 
   async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
-    console.log(`[insert] tableName: ${tableName}, record:`, record);
+    this.logger.debug(`[insert] tableName: ${tableName}, record:`, record);
     const table = this.data[tableName];
     let key = record.id;
     if ([TABLE_WORKFLOW_SNAPSHOT, TABLE_EVALS].includes(tableName) && !record.id && record.run_id) {
@@ -34,12 +34,12 @@ export class StoreOperationsInMemory extends StoreOperations {
       key = `auto-${Date.now()}-${Math.random()}`;
       record.id = key;
     }
-    console.log(`[insert] Using key: ${key}`);
+    this.logger.debug(`[insert] Using key: ${key}`);
     table.set(key, record);
   }
 
   async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
-    console.log(`[batchInsert] tableName: ${tableName}, records:`, records);
+    this.logger.debug(`[batchInsert] tableName: ${tableName}, records:`, records);
     const table = this.data[tableName];
     for (const record of records) {
       let key = record.id;
@@ -50,7 +50,7 @@ export class StoreOperationsInMemory extends StoreOperations {
         key = `auto-${Date.now()}-${Math.random()}`;
         record.id = key;
       }
-      console.log(`[batchInsert] Using key: ${key}`);
+      this.logger.debug(`[batchInsert] Using key: ${key}`);
       table.set(key, record);
     }
   }

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -33,8 +33,8 @@ export class WorkflowsInMemory extends WorkflowsStorage {
       updatedAt: new Date(),
     };
 
-    console.log('[persistWorkflowSnapshot] args:', { workflowName, runId, snapshot });
-    console.log('[persistWorkflowSnapshot] data:', data);
+    this.logger.debug('[persistWorkflowSnapshot] args:', { workflowName, runId, snapshot });
+    this.logger.debug('[persistWorkflowSnapshot] data:', data);
     await this.operations.insert({
       tableName: TABLE_WORKFLOW_SNAPSHOT,
       record: data,
@@ -73,9 +73,9 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    console.log(`[getWorkflowRuns] called with`, { workflowName, fromDate, toDate, limit, offset, resourceId });
+    this.logger.debug(`[getWorkflowRuns] called with`, { workflowName, fromDate, toDate, limit, offset, resourceId });
     let runs = Array.from(this.collection.values());
-    console.log(`[getWorkflowRuns] initial runs:`, runs);
+    this.logger.debug(`[getWorkflowRuns] initial runs:`, runs);
 
     if (workflowName) runs = runs.filter((run: any) => run.workflow_name === workflowName);
     if (fromDate && toDate) {
@@ -91,7 +91,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     }
     if (resourceId) runs = runs.filter((run: any) => run.resourceId === resourceId);
 
-    console.log(`[getWorkflowRuns] after filtering:`, runs);
+    this.logger.debug(`[getWorkflowRuns] after filtering:`, runs);
     const total = runs.length;
 
     // Sort by createdAt
@@ -114,7 +114,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
       workflowName: run.workflow_name,
     }));
 
-    console.log(`[getWorkflowRuns] parsedRuns:`, parsedRuns);
+    this.logger.debug(`[getWorkflowRuns] parsedRuns:`, parsedRuns);
     return { runs: parsedRuns as WorkflowRun[], total };
   }
 
@@ -125,7 +125,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     runId: string;
     workflowName?: string;
   }): Promise<WorkflowRun | null> {
-    console.log(`[getWorkflowRunById] called for runId ${runId}, workflowName ${workflowName}`);
+    this.logger.debug(`[getWorkflowRunById] called for runId ${runId}, workflowName ${workflowName}`);
     let run = Array.from(this.collection.values()).find((r: any) => r.run_id === runId);
 
     if (run && workflowName && run.workflow_name !== workflowName) {
@@ -144,7 +144,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
       workflowName: run.workflow_name,
     };
 
-    console.log(`[getWorkflowRunById] parsedRun:`, parsedRun);
+    this.logger.debug(`[getWorkflowRunById] parsedRun:`, parsedRun);
     return parsedRun as WorkflowRun;
   }
 }


### PR DESCRIPTION
## Description

This PR replaces `console.log` with `logger.debug` in inmemory operations.

Please let me know if these should be completely removed instead ;)

## Related Issue(s)

Fixes https://discord.com/channels/1309558646228779139/1407383480341368842/1407383480341368842

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
