### PR TITLE
Fix Cannot find package '@babel/preset-typescript'

### DIFF
--- a/.changeset/moody-heads-report.md
+++ b/.changeset/moody-heads-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix babel-preset-typescript import

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -461,7 +461,7 @@ export async function analyzeBundle(
 
   await babel.transformAsync(mastraConfig, {
     filename: mastraEntry,
-    presets: ['@babel/preset-typescript'],
+    presets: [import.meta.resolve('@babel/preset-typescript')],
     plugins: [checkConfigExport(mastraConfigResult)],
   });
 


### PR DESCRIPTION
Fix Cannot find package '@babel/preset-typescript'
