### PR TITLE
Bug fix: MCP server sending keep-alive message before endpoint messages

### DIFF
--- a/.changeset/happy-books-travel.md
+++ b/.changeset/happy-books-travel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed an issue where keep-alive messages were interfering with endpoint messages on initial SSE connection

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1197,10 +1197,10 @@ export class MCPServer extends MCPServerBase {
       while (true) {
         // This will keep the connection alive
         // You can also await for a promise that never resolves
+        await stream.sleep(60_000);
         const sessionIds = Array.from(this.sseHonoTransports.keys() || []);
         this.logger.debug('Active Hono SSE sessions:', { sessionIds });
         await stream.write(':keep-alive\n\n');
-        await stream.sleep(60_000);
       }
     } catch (e) {
       const mastraError = new MastraError(


### PR DESCRIPTION
## Description
Fixed an issue where the MCP Hono server was sending keep-alive messages before endpoint messages upon connection.

## Related Issue(s)

Fixes #6340 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
