### PR TITLE
fixed id propagation trough tool transformations

### DIFF
--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -274,6 +274,7 @@ export class CoreToolBuilder extends MastraBase {
 
     return {
       ...definition,
+      id: 'id' in this.originalTool ? this.originalTool.id : undefined,
       parameters: processedSchema,
       outputSchema: processedOutputSchema,
     };

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -274,7 +274,7 @@ export class CoreToolBuilder extends MastraBase {
 
     return {
       ...definition,
-      id: this.originalTool.id ?? undefined,
+      id: 'id' in this.originalTool ? this.originalTool.id : undefined,
       parameters: processedSchema,
       outputSchema: processedOutputSchema,
     };

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -274,7 +274,7 @@ export class CoreToolBuilder extends MastraBase {
 
     return {
       ...definition,
-      id: 'id' in this.originalTool ? this.originalTool.id : undefined,
+      id: this.originalTool.id ?? undefined,
       parameters: processedSchema,
       outputSchema: processedOutputSchema,
     };


### PR DESCRIPTION
## Description

This fixes tool `id` propagation through our tool transformations, so that the `id` can be captured in AI tracing and logging.

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
