### PR TITLE
[core] Fix scorers have resourceId and threadId

### DIFF
--- a/.changeset/cruel-ghosts-see.md
+++ b/.changeset/cruel-ghosts-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+fix: add threadId and resourceId to scorers

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2077,6 +2077,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           runtimeContext,
           structuredOutput,
           overrideScorers,
+          threadId,
+          resourceId,
         });
 
         const scoringData: {
@@ -2107,6 +2109,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     runtimeContext,
     structuredOutput,
     overrideScorers,
+    threadId,
+    resourceId,
   }: {
     messageList: MessageList;
     runId: string;
@@ -2115,6 +2119,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     runtimeContext: RuntimeContext;
     structuredOutput?: boolean;
     overrideScorers?: MastraScorers;
+    threadId?: string;
+    resourceId?: string;
   }) {
     const agentName = this.name;
     const userInputMessages = messageList.get.all.ui().filter(m => m.role === 'user');
@@ -2163,6 +2169,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           source: 'LIVE',
           entityType: 'AGENT',
           structuredOutput: !!structuredOutput,
+          threadId,
+          resourceId,
         });
       }
     }

--- a/packages/core/src/scores/hooks.ts
+++ b/packages/core/src/scores/hooks.ts
@@ -13,6 +13,8 @@ export function runScorer({
   structuredOutput,
   source,
   entityType,
+  threadId,
+  resourceId,
 }: {
   scorerId: string;
   scorerObject: MastraScorerEntry;
@@ -24,6 +26,8 @@ export function runScorer({
   structuredOutput: boolean;
   source: ScoringSource;
   entityType: ScoringEntityType;
+  threadId?: string;
+  resourceId?: string;
 }) {
   let shouldExecute = false;
 
@@ -59,6 +63,8 @@ export function runScorer({
     entity,
     structuredOutput,
     entityType,
+    threadId,
+    resourceId,
   };
 
   executeHook(AvailableHooks.ON_SCORER_RUN, payload);


### PR DESCRIPTION
## Description

Added threadId and resourceId to scorers as they were not included.
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
