### PR TITLE
Fix safelyParseJson for string values and update tests

### DIFF
--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -4,26 +4,3 @@ export * from './workflows';
 export * from './traces';
 export * from './memory';
 export * from './legacy-evals';
-
-export function safelyParseJSON(jsonParam: any): any {
-  // If already an object (and not null), return as-is
-  if (jsonParam && typeof jsonParam === 'object') {
-    return jsonParam;
-  }
-  // If null or undefined, return empty object
-  if (jsonParam == null) {
-    return {};
-  }
-  // If it's a string, try to parse
-  if (typeof jsonParam === 'string') {
-    try {
-      return JSON.parse(jsonParam);
-    } catch {
-      console.error('Failed to parse JSON string');
-      console.error(jsonParam);
-      return {};
-    }
-  }
-  // For anything else (number, boolean, etc.), return empty object
-  return {};
-}

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -3,3 +3,4 @@ export * from './types';
 export * from './constants';
 export * from './mock';
 export * from './domains';
+export * from './utils';

--- a/packages/core/src/storage/utils.test.ts
+++ b/packages/core/src/storage/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { safelyParseJSON } from '.';
+import { safelyParseJSON } from './utils';
 
 describe('safelyParseJSON', () => {
   const sampleObject = {
@@ -51,5 +51,23 @@ describe('safelyParseJSON', () => {
 
     // Assert: Verify different object instances
     expect(numberResult).not.toBe(booleanResult);
+  });
+  it('should return raw string when provided a non-JSON string', () => {
+    const raw = 'hello world'; // not valid JSON
+    expect(safelyParseJSON(raw)).toBe(raw);
+  });
+
+  it('should still parse valid JSON strings', () => {
+    const json = '{"a":1,"b":"two"}';
+    expect(safelyParseJSON(json)).toEqual({ a: 1, b: 'two' });
+  });
+  it('parses JSON numbers/booleans/arrays', () => {
+    expect(safelyParseJSON('123')).toBe(123);
+    expect(safelyParseJSON('true')).toBe(true);
+    expect(safelyParseJSON('[1,2]')).toEqual([1, 2]);
+  });
+
+  it('trims whitespace around JSON strings', () => {
+    expect(safelyParseJSON(' { "x": 1 } ')).toEqual({ x: 1 });
   });
 });

--- a/packages/core/src/storage/utils.ts
+++ b/packages/core/src/storage/utils.ts
@@ -1,0 +1,15 @@
+export function safelyParseJSON(input: any): any {
+  // If already an object (and not null), return as-is
+  if (input && typeof input === 'object') return input;
+  if (input == null) return {};
+  // If it's a string, try to parse
+  if (typeof input === 'string') {
+    try {
+      return JSON.parse(input);
+    } catch {
+      return input;
+    }
+  }
+  // For anything else (number, boolean, etc.), return empty object
+  return {};
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Updates location of safelyParseJSON and fix parsing for string values to not return an empty object. Also adds tests
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#6694 
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
