### PR TITLE
fix export map and workspace

### DIFF
--- a/.changeset/ten-adults-push.md
+++ b/.changeset/ten-adults-push.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+ Optimize workspace dependency detection in bundler
+
+  - Check workspace map directly before resolving package.json path

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -330,13 +330,14 @@ export abstract class Bundler extends MastraBundler {
     const workspaceDependencies = new Set<string>();
     for (const dep of analyzedBundleInfo.externalDependencies) {
       try {
-        const pkgPath = resolveFrom(mastraEntryFile, `${dep}/package.json`);
-        const pkg = await readJSON(pkgPath);
-
-        if (workspaceMap.has(pkg.name)) {
-          workspaceDependencies.add(pkg.name);
+        if (workspaceMap.has(dep)) {
+          workspaceDependencies.add(dep);
           continue;
         }
+
+        // fix with better pkg root resolving
+        const pkgPath = resolveFrom(mastraEntryFile, `${dep}/package.json`);
+        const pkg = await readJSON(pkgPath);
 
         dependenciesToInstall.set(dep, pkg.version);
       } catch {


### PR DESCRIPTION
Optimize workspace dependency detection in bundler

  - Check workspace map directly before resolving package.json path