### PR TITLE
use dynamic import for p-map

### DIFF
--- a/.changeset/good-fans-guess.md
+++ b/.changeset/good-fans-guess.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix dev server bug related to p-map imports

--- a/packages/core/src/scores/run-experiment.ts
+++ b/packages/core/src/scores/run-experiment.ts
@@ -1,5 +1,4 @@
 import type { CoreMessage } from 'ai';
-import pMap from 'p-map';
 import type { Agent, AiMessageType, UIMessageWithMetadata } from '../agent';
 import { MastraError } from '../error';
 import type { RuntimeContext } from '../runtime-context';
@@ -79,6 +78,8 @@ export const runExperiment = async <const TScorer extends readonly MastraScorer[
       text: 'Failed to run experiment: No target provided',
     });
   }
+
+  const pMap = (await import('p-map')).default;
 
   await pMap(
     data,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

p-map version 7+ is not compatible to node versions 20.0 - 20.18, moving to a dynamic import fixed the issue

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
