### PR TITLE
fix agent scorers display

### DIFF
--- a/.changeset/wild-mugs-wash.md
+++ b/.changeset/wild-mugs-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix agent scorers page by correctly passing in agent name

--- a/packages/server/src/server/handlers/scores.ts
+++ b/packages/server/src/server/handlers/scores.ts
@@ -15,7 +15,7 @@ async function getScorersFromSystem({
 
   const scorersMap = new Map<string, MastraScorerEntry & { agentIds: string[]; workflowIds: string[] }>();
 
-  for (const [agentId, agent] of Object.entries(agents)) {
+  for (const [_agentId, agent] of Object.entries(agents)) {
     const scorers =
       (await agent.getScorers({
         runtimeContext,

--- a/packages/server/src/server/handlers/scores.ts
+++ b/packages/server/src/server/handlers/scores.ts
@@ -24,12 +24,12 @@ async function getScorersFromSystem({
     if (Object.keys(scorers).length > 0) {
       for (const [scorerId, scorer] of Object.entries(scorers)) {
         if (scorersMap.has(scorerId)) {
-          scorersMap.get(scorerId)?.agentIds.push(agentId);
+          scorersMap.get(scorerId)?.agentIds.push(agent.name);
         } else {
           scorersMap.set(scorerId, {
             workflowIds: [],
             ...scorer,
-            agentIds: [agentId],
+            agentIds: [agent.name],
           });
         }
       }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

The frontend is expecting the agent's name however we were passing the key of the agent.

for instance 

```
const randomAgent = new Agent({
  name: 'Random Agent'
  ...
})

export const mastra = new Mastra({
  agents: { randomAgent },
});
```

we were passing `randomAgent` instead of `Random Agent`

before:
<img width="942" height="578" alt="image" src="https://github.com/user-attachments/assets/e13f60dc-f43f-4862-b002-cea1b4b1d94a" />

after:
<img width="879" height="603" alt="image" src="https://github.com/user-attachments/assets/c21b73f2-df81-4f11-a785-0d524d829bfd" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
