### PR TITLE
chore(repo): Use GitHub changelog for changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.4/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "mastra-ai/mastra" }
+  ],
   "commit": false,
   "fixed": [["@mastra/core", "@mastra/server", "@mastra/deployer"], ["mastra", "create-mastra"]],
   "linked": [],

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -93,6 +93,8 @@ jobs:
           git push
           echo "executed=true" >> "$GITHUB_OUTPUT"
           pnpm install
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Push version changes
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/pr-snapshot.yml
+++ b/.github/workflows/pr-snapshot.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Run Changeset Version Snapshot
         run: pnpm changeset version --snapshot ${{ env.FINAL_TAG }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Publish to npm
         run: pnpm publish -r --no-git-checks --tag ${{ env.FINAL_TAG }} --access public

--- a/e2e-tests/_local-registry-setup/prepare.js
+++ b/e2e-tests/_local-registry-setup/prepare.js
@@ -94,6 +94,15 @@ export async function prepareMonorepo(monorepoDir, glob, tag) {
       }
     })();
 
+    // Because it requires a GITHUB_TOKEN
+    console.log('Updating .changeset/config.json to not use @changesets/changelog-github');
+    await (async function updateChangesetConfig() {
+      const content = readFileSync(join(monorepoDir, '.changeset/config.json'), 'utf8');
+      const parsed = JSON.parse(content);
+      parsed.changelog = '@changesets/cli/changelog';
+      writeFileSync(join(monorepoDir, '.changeset/config.json'), JSON.stringify(parsed, null, 2));
+    })();
+
     console.log('Running pnpm changeset pre exit');
     await retryWithTimeout(
       async () => {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.11",
   "type": "module",
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.6",
     "@types/node": "^20.19.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.1
+        version: 0.5.1(encoding@0.1.13)
       '@changesets/cli':
         specifier: ^2.29.6
         version: 2.29.6(@types/node@20.19.9)
@@ -5349,6 +5352,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.5.1':
+    resolution: {integrity: sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==}
+
   '@changesets/cli@2.29.6':
     resolution: {integrity: sha512-6qCcVsIG1KQLhpQ5zE8N0PckIx4+9QlHK3z6/lwKnw7Tir71Bjw8BeOZaxA/4Jt00pcgCnCSWZnyuZf5Il05QQ==}
     hasBin: true
@@ -5361,6 +5367,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.6.0':
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
 
   '@changesets/get-release-plan@4.0.13':
     resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
@@ -11210,6 +11219,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
@@ -11426,6 +11438,10 @@ packages:
   dotenv@17.0.1:
     resolution: {integrity: sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==}
     engines: {node: '>=12'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   drizzle-kit@0.30.6:
     resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
@@ -19083,6 +19099,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.5.1(encoding@0.1.13)':
+    dependencies:
+      '@changesets/get-github-info': 0.6.0(encoding@0.1.13)
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.29.6(@types/node@20.19.9)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.12
@@ -19136,6 +19160,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.2
+
+  '@changesets/get-github-info@0.6.0(encoding@0.1.13)':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
@@ -25778,6 +25809,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dataloader@1.4.0: {}
+
   date-fns-jalali@4.1.0-0: {}
 
   date-fns@3.6.0: {}
@@ -25932,6 +25965,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.0.1: {}
+
+  dotenv@8.6.0: {}
 
   drizzle-kit@0.30.6:
     dependencies:


### PR DESCRIPTION
## Description

Use https://github.com/changesets/changesets/tree/main/packages/changelog-github to enhance the auto-generated `CHANGELOG.md` files. It'll link to GitHub PRs, authors and commits.

Example: https://github.com/LekoArts/secco/blob/main/CHANGELOG.md
