### PR TITLE
docs: update streamVNext documentation for AI SDK v5 support

### DIFF
--- a/docs/src/content/en/docs/agents/streaming.mdx
+++ b/docs/src/content/en/docs/agents/streaming.mdx
@@ -10,7 +10,7 @@ import { Callout } from "nextra/components";
 Agents in Mastra support streaming responses for real-time interaction with clients. This enables progressive rendering of responses and better user experience.
 
 <Callout type="info">
-  **Experimental API**: The `streamVNext` method shown in this guide is an experimental feature with enhanced streaming format support. It will replace the current `stream()` method after additional testing and refinement. For production use, consider using the stable [`stream()` method](/docs/agents/overview#2-generating-and-streaming-text) until `streamVNext` is finalized.
+  **Experimental API**: The `streamVNext` method shown in this guide is an experimental feature with enhanced streaming format support. It will replace the current `stream()` method after additional testing and refinement. For production use, consider using the stable [`stream()` method](/docs/agents/overview#streaming-responses) until `streamVNext` is finalized.
 </Callout>
 
 ## Usage

--- a/docs/src/content/en/docs/agents/streaming.mdx
+++ b/docs/src/content/en/docs/agents/streaming.mdx
@@ -5,46 +5,76 @@ description: Documentation on how to stream agents
 
 import { Callout } from "nextra/components";
 
-# Agent Streaming
+# Agent Streaming (VNext)
 
 Agents in Mastra support streaming responses for real-time interaction with clients. This enables progressive rendering of responses and better user experience.
 
 <Callout type="info">
-  **Experimental API**: The `streamVNext` method shown in this guide is an experimental feature that will replace the current `stream()` method after additional testing and refinement. For production use, consider using the stable [`stream()` method](/docs/agents/overview#2-generating-and-streaming-text) until `streamVNext` is finalized.
+  **Experimental API**: The `streamVNext` method shown in this guide is an experimental feature with enhanced streaming format support. It will replace the current `stream()` method after additional testing and refinement. For production use, consider using the stable [`stream()` method](/docs/agents/overview#2-generating-and-streaming-text) until `streamVNext` is finalized.
 </Callout>
 
 ## Usage
 
-The experimental streaming protocol uses the `streamVNext` method on an agent. This method returns a custom MastraAgentStream that extends ReadableStream with additional utilities.
+The experimental streaming protocol uses the `streamVNext` method on an agent. This method now supports multiple output stream formats, for Mastra (default) and AI SDK v5.
+
+
+## Format Parameter
+
+The `format` parameter determines the output stream type:
+
+- **`'mastra'` (default)**: Returns `MastraModelOutput` - Mastra's native streaming format
+- **`'aisdk'`**: Returns `AISDKV5OutputStream` - Compatible with AI SDK v5 interfaces like useChat.
 
 ```typescript
-const stream = await agent.streamVNext({ role: "user", content: "Tell me a story." });
+// Mastra format (default)
+const mastraStream = await agent.streamVNext("Hello");
 
-for await (const chunk of stream) {
+// AI SDK v5 format
+const aiSdkStream = await agent.streamVNext("Hello", { 
+  format: 'aisdk' 
+});
+```
+
+### Default Mastra Format
+
+By default, `streamVNext` returns a `MastraModelOutput` stream:
+
+```typescript
+const stream = await agent.streamVNext("Tell me a story.");
+
+// Access the text stream
+for await (const chunk of stream.textStream) {
+  console.log(chunk);
+}
+
+// Or get the full text after streaming
+const fullText = await stream.text;
+```
+
+### AI SDK v5 Compatibility
+
+For integration with AI SDK v5, use the `format: 'aisdk'` parameter to get an `AISDKV5OutputStream`:
+
+```typescript
+const stream = await agent.streamVNext("Tell me a story.", {
+  format: 'aisdk'
+});
+
+// The stream is now compatible with AI SDK v5 interfaces
+for await (const chunk of stream.fullStream) {
+  // Process AI SDK v5 formatted chunks
   console.log(chunk);
 }
 ```
 
-Each chunk is a JSON object with the following properties:
+## Stream Properties
 
-```json
-{
-  type: string;
-  runId: string;
-  from: string;
-  payload: Record<string, any>;
-}
-```
+Both stream formats provide access to various response properties:
 
-The stream provides several utility functions for working with streaming responses:
-
-- `stream.finishReason` - The reason the agent stopped streaming.
-- `stream.toolCalls` - The tool calls made by the agent.
-- `stream.toolResults` - The tool results returned by the agent.
-- `stream.usage` - The total token usage of the agent, including agents/workflows as a tool.
-- `stream.text` - The full text of the agent's response.
-- `stream.object` - The object of the agent's response, if you use output or experimental output.
-- `stream.textStream` - A readable stream that will emit the text of the agent's response.
+- `stream.textStream` - A readable stream that emits text chunks
+- `stream.text` - Promise that resolves to the full text response
+- `stream.finishReason` - The reason the agent stopped streaming
+- `stream.usage` - Token usage information
 
 ### How to use the stream in a tool
 

--- a/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
@@ -9,9 +9,9 @@ import { Callout, Tabs } from "nextra/components";
 
 Mastra integrates with [Vercel's AI SDK](https://sdk.vercel.ai) to support model routing, React Hooks, and data streaming methods.
 
-## AI SDK v5 (beta)
+## AI SDK v5
 
-Mastra also supports AI SDK v5 (beta) see the following section for v5 specific methods: [Vercel AI SDK v5](/docs/frameworks/agentic-uis/ai-sdk#vercel-ai-sdk-v5)
+Mastra also supports AI SDK v5 see the following section for v5 specific methods: [Vercel AI SDK v5](/docs/frameworks/agentic-uis/ai-sdk#vercel-ai-sdk-v5)
 
 <Callout type="warning">
   The code examples contained with this page assume you're using the Next.js App Router at the root of your
@@ -380,7 +380,7 @@ export async function POST(req: Request) {
 
 ## Vercel AI SDK v5
 
-This guide covers Mastra-specific considerations when migrating from AI SDK v4 to v5 beta.
+This guide covers Mastra-specific considerations when migrating from AI SDK v4 to v5.
 
 > Please add any feedback or bug reports to the [AI SDK v5 mega issue in Github.](https://github.com/mastra-ai/mastra/issues/5470)
 
@@ -404,59 +404,12 @@ Follow the official [AI SDK v5 Migration Guide](https://v5.ai-sdk.dev/docs/migra
 
 This guide covers only the Mastra-specific aspects of the migration.
 
-- **Data compatibility**: New data stored in v5 format will no longer work if you downgrade from the beta
-- **Backup recommendation**: Keep DB backups from before you upgrade to v5 beta
-- **Production use**: Wait for the AI SDK v5 stable release before using in production applications
-- **Prerelease status**: The Mastra `ai-v5` tag is a prerelease version and may have bugs
+- **Data compatibility**: New data stored in v5 format will no longer work if you downgrade from v5 to v4
+- **Backup recommendation**: Keep DB backups from before you upgrade to v5
 
 ### Memory and Storage
 
 Mastra automatically handles AI SDK v4 data using its internal `MessageList` class, which manages format conversion—including v4 to v5. No database migrations are required; your existing messages are translated on the fly and continue working after you upgrade.
-
-### Migration strategy
-
-Migrating to AI SDK v5 with Mastra involves updating both your **backend** (Mastra server) and **frontend**.
-We provide a compatibility mode to handle stream format conversion during the transition.
-
-### Upgrade dependencies
-
-Install the `@ai-v5` prerelease version of all Mastra packages:
-
-<Tabs items={["npm", "yarn", "pnpm", "bun"]}>
-  <Tabs.Tab>
-    ```bash copy
-    npm install mastra@ai-v5 @mastra/core@ai-v5 @mastra/memory@ai-v5
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```bash copy
-    yarn add mastra@ai-v5 @mastra/core@ai-v5 @mastra/memory@ai-v5
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```bash copy
-    pnpm add mastra@ai-v5 @mastra/core@ai-v5 @mastra/memory@ai-v5
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```bash copy
-    bun add mastra@ai-v5 @mastra/core@ai-v5 @mastra/memory@ai-v5
-    ```
-  </Tabs.Tab>
-</Tabs>
-
-Configure your Mastra instance with `v4` compatibility so your frontend, and the Mastra Playground will continue to work:
-
-```typescript {7} filename="mastra/index.ts" showLineNumbers copy
-import { Mastra } from "@mastra/core/mastra";
-
-import { weatherAgent } from "./agents/weather-agent";
-
-export const mastra = new Mastra({
-  agents: { weatherAgent },
-  aiSdkCompat: 'v4',
-});
-```
 
 ### Enabling stream compatibility
 
@@ -481,13 +434,3 @@ export async function POST(req: Request) {
 <Callout type="info">
   **Note**: The `streamVNext` method with format support is experimental and may change as we refine the feature based on feedback. See the [Agent Streaming documentation](/docs/agents/streaming) for more details about streamVNext.
 </Callout>
-
-### Frontend upgrade
-
-When you're ready, remove the compatibility flag and upgrade your frontend:
-
-1. Remove `aiSdkCompat: 'v4'` from your Mastra configuration
-2. Follow the AI SDK guide on upgrading your frontend dependencies
-3. Update your frontend code for v5 breaking changes
-
-

--- a/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
@@ -384,6 +384,20 @@ This guide covers Mastra-specific considerations when migrating from AI SDK v4 t
 
 > Please add any feedback or bug reports to the [AI SDK v5 mega issue in Github.](https://github.com/mastra-ai/mastra/issues/5470)
 
+### Experimental streamVNext Support
+
+Mastra's experimental `streamVNext` method now includes native AI SDK v5 support through the `format` parameter. This provides seamless integration with AI SDK v5's streaming interfaces without requiring compatibility wrappers.
+
+```typescript
+// Use streamVNext with AI SDK v5 format
+const stream = await agent.streamVNext(messages, {
+  format: 'aisdk'  // Enable AI SDK v5 compatibility
+});
+
+// The stream is now compatible with AI SDK v5 interfaces
+return stream.toUIMessageStreamResponse();
+```
+
 ### Official migration guide
 
 Follow the official [AI SDK v5 Migration Guide](https://v5.ai-sdk.dev/docs/migration-guides/migration-guide-5-0) for all AI SDK core breaking changes, package updates, and API changes.
@@ -446,21 +460,27 @@ export const mastra = new Mastra({
 
 ### Enabling stream compatibility
 
-If your frontend calls a Mastra agent using a custom API route, wrap the `toUIMessageStreamResponse()` result with `createV4CompatibleResponse` to maintain AI SDK `v4` compatibility.
-
+To enable AI SDK v5 compatibility, use the experimental `streamVNext` method with the `format` parameter:
 
 ```typescript filename="app/api/chat/route.ts" showLineNumbers copy
 import { mastra } from "../../../mastra";
-import { createV4CompatibleResponse } from "@mastra/core/agent";
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
   const myAgent = mastra.getAgent("weatherAgent");
-  const stream = await myAgent.stream(messages);
+  
+  // Use streamVNext with AI SDK v5 format (experimental)
+  const stream = await myAgent.streamVNext(messages, {
+    format: 'aisdk'
+  });
 
-  return createV4CompatibleResponse(stream.toUIMessageStreamResponse().body!);
+  return stream.toUIMessageStreamResponse();
 }
 ```
+
+<Callout type="info">
+  **Note**: The `streamVNext` method with format support is experimental and may change as we refine the feature based on feedback. See the [Agent Streaming documentation](/docs/agents/streaming) for more details about streamVNext.
+</Callout>
 
 ### Frontend upgrade
 

--- a/docs/src/content/en/examples/agents/ai-sdk-v5-integration.mdx
+++ b/docs/src/content/en/examples/agents/ai-sdk-v5-integration.mdx
@@ -3,11 +3,12 @@ title: "Example: AI SDK v5 Integration | Agents | Mastra Docs"
 description: Example of integrating Mastra agents with AI SDK v5 for streaming chat interfaces with memory and tool integration.
 ---
 
+import { Callout } from "nextra/components";
 import { GithubLink } from "@/components/github-link";
 
 # Example: AI SDK v5 Integration
 
-This example demonstrates how to integrate Mastra agents with [AI SDK v5](https://sdk.vercel.ai/) to build modern streaming chat interfaces. It showcases a complete Next.js application with real-time conversation capabilities, persistent memory, and tool integration.
+This example demonstrates how to integrate Mastra agents with [AI SDK v5](https://sdk.vercel.ai/) to build modern streaming chat interfaces. It showcases a complete Next.js application with real-time conversation capabilities, persistent memory, and tool integration using the experimental `streamVNext` method with AI SDK v5 format support.
 
 ## Key Features
 
@@ -134,24 +135,27 @@ const getWeather = async (location: string) => {
 
 ### Streaming Chat Endpoint
 
-Create an API route that streams responses from your Mastra agent:
+Create an API route that streams responses from your Mastra agent using the experimental `streamVNext` with AI SDK v5 format:
 
 ```typescript showLineNumbers copy filename="app/api/chat/route.ts"
 import { mastra } from "@/src/mastra";
-import { createV4CompatibleResponse } from "@mastra/core/agent";
 
 const myAgent = mastra.getAgent("weatherAgent");
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  const stream = await myAgent.stream(messages, {
-    threadId: "user-session", // Use actual user/session ID
-    resourceId: "weather-chat",
+  // Use streamVNext with AI SDK v5 format (experimental)
+  const stream = await myAgent.streamVNext(messages, {
+    format: 'aisdk',  // Enable AI SDK v5 compatibility
+    memory: {
+      thread: "user-session", // Use actual user/session ID
+      resource: "weather-chat",
+    },
   });
 
-  // Convert Mastra stream to AI SDK v5 compatible format
-  return createV4CompatibleResponse(stream.toUIMessageStreamResponse().body!);
+  // Stream is already in AI SDK v5 format
+  return stream.toUIMessageStreamResponse();
 }
 ```
 
@@ -256,14 +260,23 @@ NOTE: ai-sdk v5 is still in beta, while it is in beta you'll have to install the
 
 ## Key Integration Points
 
-### Compatibility Layer
+### Experimental streamVNext Format Support
 
-The `createV4CompatibleResponse` function bridges Mastra's streaming format with AI SDK v5:
+The experimental `streamVNext` method with `format: 'aisdk'` provides native AI SDK v5 compatibility:
 
 ```typescript
-// Converts Mastra stream to AI SDK v5 compatible format
-return createV4CompatibleResponse(stream.toUIMessageStreamResponse().body!);
+// Use streamVNext with AI SDK v5 format
+const stream = await agent.streamVNext(messages, {
+  format: 'aisdk'  // Returns AISDKV5OutputStream
+});
+
+// Direct compatibility with AI SDK v5 interfaces
+return stream.toUIMessageStreamResponse();
 ```
+
+<Callout type="info">
+  **Note**: The `streamVNext` method with format support is experimental and may change as we refine the feature based on feedback. See the [Agent Streaming documentation](/docs/agents/streaming) for more details.
+</Callout>
 
 ### Memory Persistence
 

--- a/docs/src/content/en/reference/agents/streamVNext.mdx
+++ b/docs/src/content/en/reference/agents/streamVNext.mdx
@@ -536,9 +536,13 @@ await agent.streamVNext("message for agent", {
   stopWhen: stepCountIs(3), // Stop after 3 steps
   modelSettings: {
     temperature: 0.7,
+  modelSettings: {
+    temperature: 0.7,
+  },
   memory: {
     thread: "user-123",
     resource: "test-app"
+  },
   },
   toolChoice: "auto",
   // Structured output with better DX

--- a/docs/src/content/en/reference/agents/streamVNext.mdx
+++ b/docs/src/content/en/reference/agents/streamVNext.mdx
@@ -8,15 +8,21 @@ import { Callout } from "nextra/components";
 # Agent.streamVNext() (Experimental)
 
 <Callout type="warning">
-  **Experimental Feature**: This is a new streaming implementation that will replace the existing `stream()` method once battle-tested. The API may change as we refine the feature based on feedback.
+  **Experimental Feature**: This is a new streaming implementation with support for multiple output formats, including AI SDK v5 compatibility. It will replace the existing `stream()` method once battle-tested. The API may change as we refine the feature based on feedback.
 </Callout>
 
-The `.streamVNext()` method enables real-time streaming of responses from an agent with enhanced capabilities. This method accepts messages and optional streaming options, providing a next-generation streaming experience that will eventually replace the current `stream()` method.
+The `.streamVNext()` method enables real-time streaming of responses from an agent with enhanced capabilities and format flexibility. This method accepts messages and optional streaming options, providing a next-generation streaming experience with support for both Mastra's native format and AI SDK v5 compatibility.
 
 ## Usage example
 
 ```typescript copy
-await agent.streamVNext("message for agent");
+// Default Mastra format
+const mastraStream = await agent.streamVNext("message for agent");
+
+// AI SDK v5 compatible format
+const aiSdkStream = await agent.streamVNext("message for agent", {
+  format: 'aisdk'
+});
 ```
 
 ## Parameters
@@ -30,7 +36,7 @@ await agent.streamVNext("message for agent");
     },
     {
       name: "options",
-      type: "AgentExecutionOptions<Output, StructuredOutput>",
+      type: "AgentExecutionOptions<Output, StructuredOutput, Format>",
       isOptional: true,
       description: "Optional configuration for the streaming process.",
     },
@@ -41,6 +47,13 @@ await agent.streamVNext("message for agent");
 
 <PropertiesTable
   content={[
+    {
+      name: "format",
+      type: "'mastra' | 'aisdk'",
+      isOptional: true,
+      defaultValue: "'mastra'",
+      description: "Determines the output stream format. Use 'mastra' for Mastra's native format (default) or 'aisdk' for AI SDK v5 compatibility.",
+    },
     {
       name: "abortSignal",
       type: "AbortSignal",
@@ -168,13 +181,6 @@ await agent.streamVNext("message for agent");
       ]
     },
     {
-      name: "maxSteps",
-      type: "number",
-      isOptional: true,
-      defaultValue: "5",
-      description: "Maximum number of execution steps allowed.",
-    },
-    {
       name: "maxRetries",
       type: "number",
       isOptional: true,
@@ -251,11 +257,77 @@ await agent.streamVNext("message for agent");
       ]
     },
     {
-      name: "temperature",
-      type: "number",
+      name: "modelSettings",
+      type: "CallSettings",
       isOptional: true,
       description:
-        "Controls randomness in the model's output. Higher values (e.g., 0.8) make the output more random, lower values (e.g., 0.2) make it more focused and deterministic.",
+        "Model-specific settings like temperature, maxTokens, topP, etc. These are passed to the underlying language model.",
+      properties: [
+        {
+          parameters: [{
+            name: "temperature",
+            type: "number",
+            isOptional: true,
+            description: "Controls randomness in the model's output. Higher values (e.g., 0.8) make the output more random, lower values (e.g., 0.2) make it more focused and deterministic."
+          }]
+        },
+        {
+          parameters: [{
+            name: "maxTokens",
+            type: "number",
+            isOptional: true,
+            description: "Maximum number of tokens to generate."
+          }]
+        },
+        {
+          parameters: [{
+            name: "topP",
+            type: "number",
+            isOptional: true,
+            description: "Nucleus sampling. This is a number between 0 and 1. It is recommended to set either temperature or topP, but not both."
+          }]
+        },
+        {
+          parameters: [{
+            name: "topK",
+            type: "number",
+            isOptional: true,
+            description: "Only sample from the top K options for each subsequent token. Used to remove 'long tail' low probability responses."
+          }]
+        },
+        {
+          parameters: [{
+            name: "presencePenalty",
+            type: "number",
+            isOptional: true,
+            description: "Presence penalty setting. It affects the likelihood of the model to repeat information that is already in the prompt. A number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition)."
+          }]
+        },
+        {
+          parameters: [{
+            name: "frequencyPenalty",
+            type: "number",
+            isOptional: true,
+            description: "Frequency penalty setting. It affects the likelihood of the model to repeatedly use the same words or phrases. A number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition)."
+          }]
+        },
+        {
+          parameters: [{
+            name: "stopSequences",
+            type: "string[]",
+            isOptional: true,
+            description: "Stop sequences. If set, the model will stop generating text when one of the stop sequences is generated."
+          }]
+        },
+        {
+          parameters: [{
+            name: "seed",
+            type: "number",
+            isOptional: true,
+            description: "The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results."
+          }]
+        }
+      ]
     },
     {
       name: "threadId",
@@ -380,64 +452,16 @@ await agent.streamVNext("message for agent");
       description: "Generate a unique ID for each message.",
     },
     {
-      name: "maxTokens",
-      type: "number",
+      name: "stopWhen",
+      type: "StopCondition | StopCondition[]",
       isOptional: true,
-      description: "Maximum number of tokens to generate.",
-    },
-    {
-      name: "topP",
-      type: "number",
-      isOptional: true,
-      description: "Nucleus sampling. This is a number between 0 and 1. It is recommended to set either `temperature` or `topP`, but not both.",
-    },
-    {
-      name: "topK",
-      type: "number",
-      isOptional: true,
-      description: "Only sample from the top K options for each subsequent token. Used to remove 'long tail' low probability responses.",
-    },
-    {
-      name: "presencePenalty",
-      type: "number",
-      isOptional: true,
-      description: "Presence penalty setting. It affects the likelihood of the model to repeat information that is already in the prompt. A number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).",
-    },
-    {
-      name: "frequencyPenalty",
-      type: "number",
-      isOptional: true,
-      description: "Frequency penalty setting. It affects the likelihood of the model to repeatedly use the same words or phrases. A number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).",
-    },
-    {
-      name: "stopSequences",
-      type: "string[]",
-      isOptional: true,
-      description: "Stop sequences. If set, the model will stop generating text when one of the stop sequences is generated.",
-    },
-    {
-      name: "seed",
-      type: "number",
-      isOptional: true,
-      description: "The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.",
+      description: "Condition(s) that determine when to stop the agent's execution. Can be a single condition or array of conditions.",
     },
     {
       name: "headers",
       type: "Record<string, string | undefined>",
       isOptional: true,
       description: "Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.",
-    },
-    {
-      name: "system",
-      type: "string",
-      isOptional: true,
-      description: "System message to include in the prompt. Can be used with `prompt` or `messages`.",
-    },
-    {
-      name: "prompt",
-      type: "string",
-      isOptional: true,
-      description: "A simple text prompt. You can either use `prompt` or `messages` but not both.",
     }
   ]}
 />
@@ -448,21 +472,70 @@ await agent.streamVNext("message for agent");
   content={[
     {
       name: "stream",
-      type: "MastraAgentStream<Output extends ZodSchema ? z.infer<Output> : StructuredOutput extends ZodSchema ? z.infer<StructuredOutput> : unknown>",
-      description: "A streaming interface that provides enhanced streaming capabilities for text and structured output.",
+      type: "MastraModelOutput<Output> | AISDKV5OutputStream<Output>",
+      description: "Returns a streaming interface based on the format parameter. When format is 'mastra' (default), returns MastraModelOutput. When format is 'aisdk', returns AISDKV5OutputStream for AI SDK v5 compatibility.",
     },
   ]}
 />
 
 ## Extended usage example
 
+### Mastra Format (Default)
+
+```typescript showLineNumbers copy
+import { stepCountIs } from 'ai-v5';
+
+const stream = await agent.streamVNext("Tell me a story", {
+  stopWhen: stepCountIs(3), // Stop after 3 steps
+  modelSettings: {
+    temperature: 0.7,
+  },
+});
+
+// Access text stream
+for await (const chunk of stream.textStream) {
+  console.log(chunk);
+}
+
+// Get full text after streaming
+const fullText = await stream.text;
+```
+
+### AI SDK v5 Format
+
+```typescript showLineNumbers copy
+import { stepCountIs } from 'ai-v5';
+
+const stream = await agent.streamVNext("Tell me a story", {
+  format: 'aisdk',
+  stopWhen: stepCountIs(3), // Stop after 3 steps
+  modelSettings: {
+    temperature: 0.7,
+  },
+});
+
+// Use with AI SDK v5 compatible interfaces
+for await (const part of stream.fullStream) {
+  if (part.type === 'text-delta') {
+    console.log(part.text);
+  }
+}
+
+// In an API route for frontend integration
+return stream.toUIMessageStreamResponse();
+```
+
+### Advanced Example with Options
+
 ```typescript showLineNumbers copy
 import { z } from "zod";
-import { ModerationProcessor, BatchPartsProcessor } from "@mastra/core/processors";
+import { stepCountIs } from 'ai-v5';
 
 await agent.streamVNext("message for agent", {
-  temperature: 0.7,
-  maxSteps: 3,
+  format: 'aisdk', // Enable AI SDK v5 compatibility
+  stopWhen: stepCountIs(3), // Stop after 3 steps
+  modelSettings: {
+    temperature: 0.7,
   memory: {
     thread: "user-123",
     resource: "test-app"


### PR DESCRIPTION
Claude says:

Updated the experimental streamVNext documentation to reflect the new multi-format support that was recently merged.

The main change is that streamVNext now supports a format parameter to choose between Mastra's native format and AI SDK v5 compatibility:

```typescript
// Default Mastra format
const stream = await agent.streamVNext("Hello");

// AI SDK v5 compatible format
const stream = await agent.streamVNext("Hello", { 
  format: 'aisdk' 
});
```

Also corrected the parameter structure - model settings like temperature now go under modelSettings, and v2 models use stopWhen instead of maxSteps:

```typescript
const stream = await agent.streamVNext("Tell me a story", {
  format: 'aisdk',
  stopWhen: stepCountIs(3),
  modelSettings: {
    temperature: 0.7,
  },
});
```

Removed references to the deprecated createV4CompatibleResponse function since it no longer exists, and updated all related examples to use the new format parameter approach.