### PR TITLE
Persist to snapshot when step starts

### DIFF
--- a/.changeset/true-monkeys-camp.md
+++ b/.changeset/true-monkeys-camp.md
@@ -1,0 +1,6 @@
+---
+'@mastra/inngest': patch
+'@mastra/core': patch
+---
+
+Persist to snapshot when step starts

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -2914,6 +2914,7 @@ describe('Workflow', () => {
           setTimeout(async () => {
             const currentExecResult = await incrementWorkflow.getWorkflowRunExecutionResult(run.runId);
             expect(currentExecResult?.status).toBe('running');
+            expect(currentExecResult?.steps['final']?.status).toBe('running');
           }, 500);
         }
       }

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -971,6 +971,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
     abortController,
     runtimeContext,
     writableStream,
+    serializedStepGraph,
   }: {
     workflowId: string;
     runId: string;
@@ -986,6 +987,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
     abortController: AbortController;
     runtimeContext: RuntimeContext;
     writableStream?: WritableStream<ChunkType>;
+    serializedStepGraph: SerializedStepFlowEntry[];
   }): Promise<StepResult<any, any, any, any>> {
     return super.executeStep({
       workflowId,
@@ -999,6 +1001,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
       abortController,
       runtimeContext,
       writableStream,
+      serializedStepGraph,
     });
   }
 
@@ -1738,10 +1741,10 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           workflowId,
           runId,
           entry: step,
+          serializedStepGraph,
           prevStep,
           stepResults,
           resume,
-          serializedStepGraph,
           executionContext: {
             workflowId,
             runId,


### PR DESCRIPTION
## Description

This PR adds changing the status of workflow run to `running` in storage and persisting the step information as the step run begins.

## Related Issue(s)

It addresses this issue - #6936 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
