### PR TITLE
Fix typos in comment

### DIFF
--- a/integrations/github/src/client/types.gen.ts
+++ b/integrations/github/src/client/types.gen.ts
@@ -1736,7 +1736,7 @@ export type codespace = {
    */
   idle_timeout_minutes: number | null;
   /**
-   * Text to show user when codespace idle timeout minutes has been overriden by an organization policy
+   * Text to show user when codespace idle timeout minutes has been overridden by an organization policy
    */
   idle_timeout_notice?: string | null;
   /**
@@ -1986,7 +1986,7 @@ export type codespace_with_full_repository = {
    */
   idle_timeout_minutes: number | null;
   /**
-   * Text to show user when codespace idle timeout minutes has been overriden by an organization policy
+   * Text to show user when codespace idle timeout minutes has been overridden by an organization policy
    */
   idle_timeout_notice?: string | null;
   /**
@@ -2721,7 +2721,7 @@ export type dependabot_alert_security_advisory = {
      */
     readonly type: 'CVE' | 'GHSA';
     /**
-     * The value of the advisory identifer.
+     * The value of the advisory identifier.
      */
     readonly value: string;
   }>;


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `overriden` → `overridden`
  - `identifer` → `identifier`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.