### PR TITLE
chore(ai-tracing): moved console exporter

### DIFF
--- a/packages/core/src/ai-tracing/ai-tracing.test.ts
+++ b/packages/core/src/ai-tracing/ai-tracing.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MastraError } from '../error';
 import { MastraAITracing } from './base';
-import { DefaultAITracing, DefaultConsoleExporter, SensitiveDataFilter, aiTracingDefaultConfig } from './default';
+import { DefaultAITracing, SensitiveDataFilter, aiTracingDefaultConfig } from './default';
+import { ConsoleExporter } from './exporters';
 import {
   clearAITracingRegistry,
   getAITracing,
@@ -548,7 +549,7 @@ describe('AI Tracing', () => {
       const tracing = new DefaultAITracing();
 
       expect(tracing.getExporters()).toHaveLength(1);
-      expect(tracing.getExporters()[0]).toBeInstanceOf(DefaultConsoleExporter);
+      expect(tracing.getExporters()[0]).toBeInstanceOf(ConsoleExporter);
     });
 
     it('should shutdown all components', async () => {
@@ -1053,65 +1054,6 @@ describe('AI Tracing', () => {
       });
 
       expect(toolSpan.attributes?.toolId).toBe('calculator');
-    });
-  });
-
-  describe('DefaultConsoleExporter', () => {
-    it('should log span events with proper formatting', async () => {
-      const logger = {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        debug: vi.fn(),
-      };
-
-      const exporter = new DefaultConsoleExporter(logger as any);
-
-      const mockSpan = {
-        id: 'test-span-1',
-        name: 'test-span',
-        type: AISpanType.AGENT_RUN,
-        startTime: new Date(),
-        endTime: new Date(),
-        traceId: 'trace-123',
-        trace: { traceId: 'trace-123' },
-        attributes: { agentId: 'agent-123', normalField: 'visible-data' },
-      };
-
-      await exporter.exportEvent({
-        type: AITracingEventType.SPAN_STARTED,
-        span: mockSpan as any,
-      });
-
-      // Should log with proper formatting (no filtering happens in exporter anymore)
-      expect(logger.info).toHaveBeenCalledWith('🚀 SPAN_STARTED');
-      expect(logger.info).toHaveBeenCalledWith('   Type: agent_run');
-      expect(logger.info).toHaveBeenCalledWith('   Name: test-span');
-      expect(logger.info).toHaveBeenCalledWith('   ID: test-span-1');
-      expect(logger.info).toHaveBeenCalledWith('   Trace ID: trace-123');
-
-      // Check that attributes are logged (filtering happens at processor level now)
-      const attributesCall = logger.info.mock.calls.find(call => call[0].includes('Attributes:'));
-      expect(attributesCall).toBeDefined();
-      expect(attributesCall![0]).toContain('visible-data');
-    });
-
-    it('should throw error for unknown events', async () => {
-      const logger = {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        debug: vi.fn(),
-      };
-
-      const exporter = new DefaultConsoleExporter(logger as any);
-
-      await expect(
-        exporter.exportEvent({
-          type: 'unknown_event' as any,
-          span: {} as any,
-        }),
-      ).rejects.toThrow('Tracing event type not implemented: unknown_event');
     });
   });
 

--- a/packages/core/src/ai-tracing/exporters/console.test.ts
+++ b/packages/core/src/ai-tracing/exporters/console.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AISpanType, AITracingEventType } from '../types';
+import { ConsoleExporter } from './console';
+
+describe('DefaultConsoleExporter', () => {
+  it('should log span events with proper formatting', async () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    const exporter = new ConsoleExporter(logger as any);
+
+    const mockSpan = {
+      id: 'test-span-1',
+      name: 'test-span',
+      type: AISpanType.AGENT_RUN,
+      startTime: new Date(),
+      endTime: new Date(),
+      traceId: 'trace-123',
+      trace: { traceId: 'trace-123' },
+      attributes: { agentId: 'agent-123', normalField: 'visible-data' },
+    };
+
+    await exporter.exportEvent({
+      type: AITracingEventType.SPAN_STARTED,
+      span: mockSpan as any,
+    });
+
+    // Should log with proper formatting (no filtering happens in exporter anymore)
+    expect(logger.info).toHaveBeenCalledWith('🚀 SPAN_STARTED');
+    expect(logger.info).toHaveBeenCalledWith('   Type: agent_run');
+    expect(logger.info).toHaveBeenCalledWith('   Name: test-span');
+    expect(logger.info).toHaveBeenCalledWith('   ID: test-span-1');
+    expect(logger.info).toHaveBeenCalledWith('   Trace ID: trace-123');
+
+    // Check that attributes are logged (filtering happens at processor level now)
+    const attributesCall = logger.info.mock.calls.find(call => call[0].includes('Attributes:'));
+    expect(attributesCall).toBeDefined();
+    expect(attributesCall![0]).toContain('visible-data');
+  });
+
+  it('should throw error for unknown events', async () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    const exporter = new ConsoleExporter(logger as any);
+
+    await expect(
+      exporter.exportEvent({
+        type: 'unknown_event' as any,
+        span: {} as any,
+      }),
+    ).rejects.toThrow('Tracing event type not implemented: unknown_event');
+  });
+});

--- a/packages/core/src/ai-tracing/exporters/console.ts
+++ b/packages/core/src/ai-tracing/exporters/console.ts
@@ -1,0 +1,101 @@
+import { ConsoleLogger, LogLevel } from '../../logger';
+import type { IMastraLogger } from '../../logger';
+import { AITracingEventType } from '../types';
+import type { AITracingEvent, AITracingExporter } from '../types';
+
+export class ConsoleExporter implements AITracingExporter {
+  name = 'tracing-console-exporter';
+  private logger: IMastraLogger;
+
+  constructor(logger?: IMastraLogger) {
+    if (logger) {
+      this.logger = logger;
+    } else {
+      // Fallback: create a direct ConsoleLogger instance if none provided
+      this.logger = new ConsoleLogger({ level: LogLevel.INFO });
+    }
+  }
+
+  async exportEvent(event: AITracingEvent): Promise<void> {
+    const span = event.span;
+
+    // Helper to safely stringify attributes (filtering already done by processor)
+    const formatAttributes = (attributes: any) => {
+      try {
+        return JSON.stringify(attributes, null, 2);
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : 'Unknown formatting error';
+        return `[Unable to serialize attributes: ${errMsg}]`;
+      }
+    };
+
+    // Helper to format duration
+    const formatDuration = (startTime: Date, endTime?: Date) => {
+      if (!endTime) return 'N/A';
+      const duration = endTime.getTime() - startTime.getTime();
+      return `${duration}ms`;
+    };
+
+    switch (event.type) {
+      case AITracingEventType.SPAN_STARTED:
+        this.logger.info(`🚀 SPAN_STARTED`);
+        this.logger.info(`   Type: ${span.type}`);
+        this.logger.info(`   Name: ${span.name}`);
+        this.logger.info(`   ID: ${span.id}`);
+        this.logger.info(`   Trace ID: ${span.traceId}`);
+        if (span.input !== undefined) {
+          this.logger.info(`   Input: ${formatAttributes(span.input)}`);
+        }
+        this.logger.info(`   Attributes: ${formatAttributes(span.attributes)}`);
+        this.logger.info('─'.repeat(80));
+        break;
+
+      case AITracingEventType.SPAN_ENDED:
+        const duration = formatDuration(span.startTime, span.endTime);
+        this.logger.info(`✅ SPAN_ENDED`);
+        this.logger.info(`   Type: ${span.type}`);
+        this.logger.info(`   Name: ${span.name}`);
+        this.logger.info(`   ID: ${span.id}`);
+        this.logger.info(`   Duration: ${duration}`);
+        this.logger.info(`   Trace ID: ${span.traceId}`);
+        if (span.input !== undefined) {
+          this.logger.info(`   Input: ${formatAttributes(span.input)}`);
+        }
+        if (span.output !== undefined) {
+          this.logger.info(`   Output: ${formatAttributes(span.output)}`);
+        }
+        if (span.errorInfo) {
+          this.logger.info(`   Error: ${formatAttributes(span.errorInfo)}`);
+        }
+        this.logger.info(`   Attributes: ${formatAttributes(span.attributes)}`);
+        this.logger.info('─'.repeat(80));
+        break;
+
+      case AITracingEventType.SPAN_UPDATED:
+        this.logger.info(`📝 SPAN_UPDATED`);
+        this.logger.info(`   Type: ${span.type}`);
+        this.logger.info(`   Name: ${span.name}`);
+        this.logger.info(`   ID: ${span.id}`);
+        this.logger.info(`   Trace ID: ${span.traceId}`);
+        if (span.input !== undefined) {
+          this.logger.info(`   Input: ${formatAttributes(span.input)}`);
+        }
+        if (span.output !== undefined) {
+          this.logger.info(`   Output: ${formatAttributes(span.output)}`);
+        }
+        if (span.errorInfo) {
+          this.logger.info(`   Error: ${formatAttributes(span.errorInfo)}`);
+        }
+        this.logger.info(`   Updated Attributes: ${formatAttributes(span.attributes)}`);
+        this.logger.info('─'.repeat(80));
+        break;
+
+      default:
+        this.logger.warn(`Tracing event type not implemented: ${(event as any).type}`);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.logger.info('ConsoleExporter shutdown');
+  }
+}

--- a/packages/core/src/ai-tracing/exporters/index.ts
+++ b/packages/core/src/ai-tracing/exporters/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Mastra AI Tracing Exporters
+ */
+
+// Core types and interfaces
+export * from './console';


### PR DESCRIPTION
## Description

Moved the AI tracing console exporter into its own file.

This is in preparation for making a new DefaultExporter for AI tracing that will write to mastra storage.

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
