### PR TITLE
Do not export otel scoped traces

### DIFF
--- a/.changeset/spotty-houses-eat.md
+++ b/.changeset/spotty-houses-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Do not export otel scoped traces

--- a/packages/deployer/public/templates/instrumentation-template.js
+++ b/packages/deployer/public/templates/instrumentation-template.js
@@ -27,7 +27,7 @@ class CompositeExporter {
         return httpTarget === "/api/telemetry";
       }).map((span) => span.spanContext().traceId)
     );
-    const filteredSpans = spans.filter((span) => !telemetryTraceIds.has(span.spanContext().traceId));
+    const filteredSpans = spans.filter((span) => !telemetryTraceIds.has(span.spanContext().traceId) && !span.instrumentationScope?.name?.startsWith('@opentelemetry'));
     if (filteredSpans.length === 0) {
       resultCallback({ code: ExportResultCode.SUCCESS });
       return;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

OpenTelemetry auto-instrumentation generates excessive low-level spans that cause database storage issues and aren't displayed in the UI. In a 5-minute test, 31,000 trace records were created with only 1,000 relevant to actual agent operations.

opentelemetry automatically create spans for every database connection, SQL query, and HTTP request, currently we have no way to display these spans and users are running into issues inserting these spans into their db.

This PR filters out those spans.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
