### PR TITLE
fix(core): model v2 schema compat

### DIFF
--- a/.changeset/stupid-wolves-grab.md
+++ b/.changeset/stupid-wolves-grab.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Don't set supportsStructuredOutputs for every v2 model

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -265,18 +265,15 @@ export class CoreToolBuilder extends MastraBase {
     const schemaCompatLayers = [];
 
     if (model) {
-      let supportsStructuredOutputs = false;
-      if (model.specificationVersion === 'v2') {
-        supportsStructuredOutputs = true;
-      } else {
-        supportsStructuredOutputs = model.supportsStructuredOutputs ?? false;
-      }
+      const supportsStructuredOutputs =
+        model.specificationVersion !== 'v2' ? (model.supportsStructuredOutputs ?? false) : true;
 
       const modelInfo = {
         modelId: model.modelId,
         supportsStructuredOutputs,
         provider: model.provider,
       };
+
       schemaCompatLayers.push(
         new OpenAIReasoningSchemaCompatLayer(modelInfo),
         new OpenAISchemaCompatLayer(modelInfo),

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -266,7 +266,7 @@ export class CoreToolBuilder extends MastraBase {
 
     if (model) {
       const supportsStructuredOutputs =
-        model.specificationVersion !== 'v2' ? (model.supportsStructuredOutputs ?? false) : true;
+        model.specificationVersion !== 'v2' ? (model.supportsStructuredOutputs ?? false) : false;
 
       const modelInfo = {
         modelId: model.modelId,


### PR DESCRIPTION
## Description

- don't set `model.supportsStructuredOutputs` for v2 language models. Fixes https://github.com/mastra-ai/mastra/issues/7110
- It was making the wrong schema compat layer run
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
