### PR TITLE
added providerOptions to createVectorQueryTool and createGraphRAGTool

### DIFF
--- a/.changeset/metal-melons-whisper.md
+++ b/.changeset/metal-melons-whisper.md
@@ -1,0 +1,5 @@
+---
+"@mastra/rag": patch
+---
+
+added providerOptions to createVectorQueryTool and createGraphRAGTool

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -98,6 +98,13 @@ const graphTool = createGraphRAGTool({
       isOptional: true,
       defaultValue: "Default graph options",
     },
+    {
+      name: "providerOptions",
+      type: "Record<string, Record<string, any>>",
+      description:
+        "Provider-specific options for the embedding model (e.g., outputDimensionality). **Important**: Only works with AI SDK EmbeddingModelV2 models. For V1 models, configure options when creating the model itself.",
+      isOptional: true,
+    },
   ]}
 />
 

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -108,6 +108,13 @@ const queryTool = createVectorQueryTool({
         "Database-specific configuration options for optimizing queries. (Can be set at creation or overridden at runtime.)",
       isOptional: true,
     },
+    {
+      name: "providerOptions",
+      type: "Record<string, Record<string, any>>",
+      description:
+        "Provider-specific options for the embedding model (e.g., outputDimensionality). **Important**: Only works with AI SDK EmbeddingModelV2 models. For V1 models, configure options when creating the model itself.",
+      isOptional: true,
+    },
   ]}
 />
 

--- a/packages/rag/src/tools/graph-rag.ts
+++ b/packages/rag/src/tools/graph-rag.ts
@@ -39,6 +39,8 @@ export const createGraphRAGTool = (options: GraphRagToolOptions) => {
       const topK: number = runtimeContext.get('topK') ?? context.topK ?? 10;
       const filter: Record<string, any> = runtimeContext.get('filter') ?? context.filter;
       const queryText = context.queryText;
+      const providerOptions: Record<string, Record<string, any>> | undefined =
+        runtimeContext.get('providerOptions') ?? options.providerOptions;
 
       const enableFilter = !!runtimeContext.get('filter') || (options.enableFilter ?? false);
 
@@ -92,6 +94,7 @@ export const createGraphRAGTool = (options: GraphRagToolOptions) => {
           queryFilter: Object.keys(queryFilter || {}).length > 0 ? queryFilter : undefined,
           topK: topKValue,
           includeVectors: true,
+          providerOptions,
         });
         if (logger) {
           logger.debug('vectorQuerySearch returned results', { count: results.length });

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -64,6 +64,8 @@ export type VectorQueryToolOptions = {
   reranker?: RerankConfig;
   /** Database-specific configuration options */
   databaseConfig?: DatabaseConfig;
+  /** Provider-specific options for the embedding model (e.g., Google's outputDimensionality) */
+  providerOptions?: Record<string, Record<string, any>>;
 } & (
   | {
       vectorStoreName: string;
@@ -88,6 +90,8 @@ export type GraphRagToolOptions = {
     restartProb?: number;
     threshold?: number;
   };
+  /** Provider-specific options for the embedding model (e.g., Google's outputDimensionality) */
+  providerOptions?: Record<string, Record<string, any>>;
 };
 
 /**

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -64,17 +64,16 @@ export type VectorQueryToolOptions = {
   reranker?: RerankConfig;
   /** Database-specific configuration options */
   databaseConfig?: DatabaseConfig;
-  /** Provider-specific options for the embedding model (e.g., Google's outputDimensionality) */
-  providerOptions?: Record<string, Record<string, any>>;
-} & (
-  | {
-      vectorStoreName: string;
-    }
-  | {
-      vectorStoreName?: string;
-      vectorStore: MastraVector;
-    }
-);
+} & ProviderOptions &
+  (
+    | {
+        vectorStoreName: string;
+      }
+    | {
+        vectorStoreName?: string;
+        vectorStore: MastraVector;
+      }
+  );
 
 export type GraphRagToolOptions = {
   id?: string;
@@ -90,7 +89,20 @@ export type GraphRagToolOptions = {
     restartProb?: number;
     threshold?: number;
   };
-  /** Provider-specific options for the embedding model (e.g., Google's outputDimensionality) */
+} & ProviderOptions;
+
+export type ProviderOptions = {
+  /**
+   * Provider-specific options for the embedding model (e.g., outputDimensionality).
+   *
+   * ⚠️  **IMPORTANT**: `providerOptions` only work with AI SDK v2 models.
+   *
+   * **For v1 models**: Configure options when creating the model:
+   * ✅ const model = openai.embedding('text-embedding-3-small', { dimensions: 512 });
+   *
+   * **For v2 models**: Use providerOptions:
+   * ✅ providerOptions: { openai: { dimensions: 512 } }
+   */
   providerOptions?: Record<string, Record<string, any>>;
 };
 

--- a/packages/rag/src/tools/vector-query.test.ts
+++ b/packages/rag/src/tools/vector-query.test.ts
@@ -415,4 +415,63 @@ describe('createVectorQueryTool', () => {
       expect(result.relevantContext[0]).toEqual({ text: 'bar' });
     });
   });
+
+  describe('providerOptions', () => {
+    it('should pass providerOptions to vectorQuerySearch', async () => {
+      const tool = createVectorQueryTool({
+        indexName: 'testIndex',
+        model: mockModel,
+        vectorStoreName: 'testStore',
+        providerOptions: { google: { outputDimensionality: 1536 } },
+      });
+
+      await tool.execute({
+        context: { queryText: 'foo', topK: 10 },
+        mastra: mockMastra as any,
+        runtimeContext: new RuntimeContext(),
+      });
+
+      expect(vectorQuerySearch).toHaveBeenCalledWith({
+        indexName: 'testIndex',
+        vectorStore: { testStore: {} },
+        queryText: 'foo',
+        model: mockModel,
+        queryFilter: undefined,
+        topK: 10,
+        includeVectors: false,
+        databaseConfig: undefined,
+        providerOptions: { google: { outputDimensionality: 1536 } },
+      });
+    });
+
+    it('should allow providerOptions override via runtimeContext', async () => {
+      const tool = createVectorQueryTool({
+        indexName: 'testIndex',
+        model: mockModel,
+        vectorStoreName: 'testStore',
+        providerOptions: { google: { outputDimensionality: 1536 } },
+      });
+
+      const runtimeContext = new RuntimeContext();
+      runtimeContext.set('providerOptions', { google: { outputDimensionality: 768 } });
+
+      await tool.execute({
+        context: { queryText: 'foo', topK: 10 },
+        mastra: mockMastra as any,
+        runtimeContext,
+      });
+
+      expect(vectorQuerySearch).toHaveBeenCalledWith({
+        indexName: 'testIndex',
+        vectorStore: { testStore: {} },
+        queryText: 'foo',
+        model: mockModel,
+        queryFilter: undefined,
+        topK: 10,
+        includeVectors: false,
+        databaseConfig: undefined,
+        providerOptions: { google: { outputDimensionality: 768 } },
+      });
+    });
+  });
 });

--- a/packages/rag/src/tools/vector-query.ts
+++ b/packages/rag/src/tools/vector-query.ts
@@ -32,6 +32,8 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
       const reranker: RerankConfig = runtimeContext.get('reranker') ?? options.reranker;
       const databaseConfig = runtimeContext.get('databaseConfig') ?? options.databaseConfig;
       const model: EmbeddingModel<string> = runtimeContext.get('model') ?? options.model;
+      const providerOptions: Record<string, Record<string, any>> | undefined =
+        runtimeContext.get('providerOptions') ?? options.providerOptions;
 
       if (!indexName) throw new Error(`indexName is required, got: ${indexName}`);
       if (!vectorStoreName) throw new Error(`vectorStoreName is required, got: ${vectorStoreName}`); // won't fire
@@ -98,6 +100,7 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
           topK: topKValue,
           includeVectors,
           databaseConfig,
+          providerOptions,
         });
         if (logger) {
           logger.debug('vectorQuerySearch returned results', { count: results.length });

--- a/packages/rag/src/utils/vector-search.ts
+++ b/packages/rag/src/utils/vector-search.ts
@@ -1,9 +1,9 @@
 import type { MastraVector, MastraEmbeddingModel, QueryResult, QueryVectorParams } from '@mastra/core/vector';
 import { embedV1, embedV2 } from '@mastra/core/vector';
 import type { VectorFilter } from '@mastra/core/vector/filter';
-import type { DatabaseConfig } from '../tools/types';
+import type { DatabaseConfig, ProviderOptions } from '../tools/types';
 
-interface VectorQuerySearchParams {
+type VectorQuerySearchParams = {
   indexName: string;
   vectorStore: MastraVector;
   queryText: string;
@@ -14,9 +14,7 @@ interface VectorQuerySearchParams {
   maxRetries?: number;
   /** Database-specific configuration options */
   databaseConfig?: DatabaseConfig;
-  /** Provider-specific options for the embedding model (e.g., Google's outputDimensionality) */
-  providerOptions?: Record<string, Record<string, any>>;
-}
+} & ProviderOptions;
 
 interface VectorQuerySearchResult {
   results: QueryResult[];

--- a/packages/rag/src/utils/vector-search.ts
+++ b/packages/rag/src/utils/vector-search.ts
@@ -15,6 +15,8 @@ interface VectorQuerySearchParams {
   maxRetries?: number;
   /** Database-specific configuration options */
   databaseConfig?: DatabaseConfig;
+  /** Provider-specific options for the embedding model (e.g., Google's outputDimensionality) */
+  providerOptions?: Record<string, Record<string, any>>;
 }
 
 interface VectorQuerySearchResult {
@@ -41,11 +43,13 @@ export const vectorQuerySearch = async ({
   includeVectors = false,
   maxRetries = 2,
   databaseConfig = {},
+  providerOptions,
 }: VectorQuerySearchParams): Promise<VectorQuerySearchResult> => {
   const { embedding } = await embed({
     value: queryText,
     model,
     maxRetries,
+    ...(providerOptions && { providerOptions }),
   });
 
   // Build query parameters with database-specific configurations


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Allows providerOptions to be passed in to the createVectorQueryTool and createGraphRAGTool functions, so users can pass their options to the embed functions
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes #7117 
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
