### PR TITLE
fix(core, schema-compat): zod.toJsonSchema compiling error

### DIFF
--- a/.changeset/bright-ducks-mix.md
+++ b/.changeset/bright-ducks-mix.md
@@ -1,0 +1,6 @@
+---
+'@mastra/schema-compat': patch
+'@mastra/core': patch
+---
+
+Fix issue with some compilers and calling zod v4's toJSONSchema function

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -274,8 +274,9 @@ export class MastraLLMV1 extends MastraBase {
 
         let jsonSchemaToUse;
         if ('toJSONSchema' in z) {
+          // Use dynamic property access to avoid import errors in Zod v3
           // @ts-ignore
-          jsonSchemaToUse = z.toJSONSchema(schema) as JSONSchema7;
+          jsonSchemaToUse = (z as any)['toJSONSchema'](schema) as JSONSchema7;
         } else {
           jsonSchemaToUse = zodToJsonSchema(schema, {
             $refStrategy: 'none',

--- a/packages/schema-compat/src/zod-to-json.ts
+++ b/packages/schema-compat/src/zod-to-json.ts
@@ -7,12 +7,13 @@ import zodToJsonSchemaOriginal from 'zod-to-json-schema';
 
 export function zodToJsonSchema(zodSchema: ZodSchemaV3 | ZodSchemaV4, target: Targets = 'jsonSchema7') {
   if ('toJSONSchema' in z) {
-    // @ts-expect-error - type not present main zod v3
-    return z.toJSONSchema(zodSchema, {
+    // Use dynamic property access to avoid import errors in Zod v3
+    return (z as any)['toJSONSchema'](zodSchema, {
       unrepresentable: 'any',
       override: (ctx: any) => {
-        const def = ctx.zodSchema._zod.def;
-        if (def.type === 'date') {
+        // Safe access to handle cases where _zod might be undefined
+        const def = ctx.zodSchema?._zod?.def;
+        if (def && def.type === 'date') {
           ctx.jsonSchema.type = 'string';
           ctx.jsonSchema.format = 'date-time';
         }


### PR DESCRIPTION
## Description

I think some compilers are strict, like in the case of using nextjs, and they will check z.toJSONSchema getting called, but this function only exists in v4 and not v3, so when you're using v3 it will throw a compilation error.

Fixes https://github.com/mastra-ai/mastra/issues/7112
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
