### PR TITLE
fix issue with libsql missing new schema

### DIFF
--- a/.changeset/nine-comics-guess.md
+++ b/.changeset/nine-comics-guess.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed dependency issue with new AI_SPAN schema

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -41,6 +41,6 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.13.0-0 <0.16.0-0"
+    "@mastra/core": ">=0.15.0-0 <0.16.0-0"
   }
 }


### PR DESCRIPTION
## Description

  - Fix module import error where AI_SPAN_SCHEMA was not available in older
  @mastra/core versions
  - Update libsql store peerDependency from >=0.13.0-0 to >=0.15.0-0 since
  AI_SPAN_SCHEMA was introduced in core v0.15.0
  - Ensures compatibility between libsql observability features and required core
  exports

## Related Issue(s)

Fixes #7192 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
