### PR TITLE
Fixed wrapping of models with AI Tracing when used with structured output.

### DIFF
--- a/.changeset/beige-islands-speak.md
+++ b/.changeset/beige-islands-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed wrapping of models with AI Tracing when used with structured output.

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -225,11 +225,14 @@ export class MastraLLMV1 extends MastraBase {
       }
     };
 
-    return {
-      ...model,
-      doGenerate: wrappedDoGenerate,
-      doStream: wrappedDoStream,
-    };
+    // Create a proper proxy to preserve all model properties including getters/setters
+    return new Proxy(model, {
+      get(target, prop) {
+        if (prop === 'doGenerate') return wrappedDoGenerate;
+        if (prop === 'doStream') return wrappedDoStream;
+        return target[prop as keyof typeof target];
+      },
+    });
   }
 
   async __text<Tools extends ToolSet, Z extends ZodSchema | JSONSchema7 | undefined>({


### PR DESCRIPTION
## Description

  - Fix "Model does not have a default object generation mode" error when using AI
  tracing with structured output
  - Replace object spread with Proxy in `_wrapModel()` to preserve all model properties
  including non-enumerable ones

@mcgrawia Thanks for your continued help testing the new AI Tracing feature, and reporting bugs as you find them. 

## Related Issue(s)

#7190

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

Tested locally and confirmed the fix.