### PR TITLE
Remove HTTP instrumentation spans and promote their direct child

### DIFF
--- a/.changeset/kind-colts-sin.md
+++ b/.changeset/kind-colts-sin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Correct set the root span for telemetry traces


### PR DESCRIPTION
## Description

We are moving to how we fetch traces from fetching ALL spans to first fetch the root spans followed by fetching all spans for a single trace.

When quering for a trace we filter for a property to distinguish which entity the trace belongs too. However the root level span is `opentelemetry/instrumentation-http` which does not contain this information.

This PR we find all the root level spans then promote their child spans to be the root. This is a pattern we are doing in cloud so we should also be doing the same here.

Photo to verify the trace is still able to display properly:
<img width="924" height="698" alt="image" src="https://github.com/user-attachments/assets/02b29e41-04a3-45cc-8c76-7cd90407b05d" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
