### PR TITLE
fix(core): tool validation when schema uses context or inputData

### DIFF
--- a/.changeset/green-dragons-train.md
+++ b/.changeset/green-dragons-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool validation when schema uses context or inputData reserved keys

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -24,39 +24,98 @@ export function validateToolInput<T = any>(
 
   // Extract the actual input data from various context formats
   let actualInput = input;
+  let validationResult;
+  let returnStructure: 'direct' | 'context' | 'inputData' = 'direct';
+
+  // Try validating the input directly first
+  const directValidation = schema.safeParse(input);
+  if (directValidation.success) {
+    return { data: input };
+  }
 
   // Handle ToolExecutionContext format { context: data, ... }
   if (input && typeof input === 'object' && 'context' in input) {
     actualInput = (input as any).context;
+
+    // Try validating the unwrapped context
+    const contextValidation = schema.safeParse(actualInput);
+    if (contextValidation.success) {
+      validationResult = contextValidation;
+      returnStructure = 'context';
+    }
   }
 
   // Handle StepExecutionContext format { context: { inputData: data, ... }, ... }
-  if (actualInput && typeof actualInput === 'object' && 'inputData' in actualInput) {
-    actualInput = (actualInput as any).inputData;
+  if (!validationResult && actualInput && typeof actualInput === 'object' && 'inputData' in actualInput) {
+    const inputDataValue = (actualInput as any).inputData;
+
+    // Try validating the unwrapped inputData
+    const inputDataValidation = schema.safeParse(inputDataValue);
+    if (inputDataValidation.success) {
+      validationResult = inputDataValidation;
+      returnStructure = 'inputData';
+    }
   }
 
-  const validation = schema.safeParse(actualInput);
-  if (!validation.success) {
-    const errorMessages = validation.error.issues
+  // If one of the unwrapping attempts worked, return the appropriate structure
+  if (validationResult) {
+    if (returnStructure === 'context') {
+      return { data: { ...(input as object), context: validationResult.data } };
+    } else if (returnStructure === 'inputData') {
+      // For inputData unwrapping, preserve the structure if the original context had additional properties
+      // but return just the validated data if it was a pure inputData wrapper
+      if (input && typeof input === 'object' && 'context' in input) {
+        const originalContext = (input as any).context;
+        const contextKeys = Object.keys(originalContext);
+
+        // If context only has inputData, return the full structure with the validated data
+        // Otherwise, return just the validated inputData
+        if (contextKeys.length === 1 && contextKeys[0] === 'inputData') {
+          return { data: { ...(input as object), context: { inputData: validationResult.data } } };
+        } else {
+          // Multiple keys in context, return just the validated data
+          return { data: validationResult.data };
+        }
+      }
+      return { data: validationResult.data };
+    }
+  }
+
+  // If none of the unwrapping attempts work, use the best validation error
+  // Try to provide the most specific error message possible
+  let bestValidation = directValidation;
+
+  if (input && typeof input === 'object' && 'context' in input) {
+    const contextValidation = schema.safeParse((input as any).context);
+    if (contextValidation.error && contextValidation.error.issues.length > 0) {
+      bestValidation = contextValidation;
+      actualInput = (input as any).context;
+    }
+
+    // Try the nested inputData path
+    if (actualInput && typeof actualInput === 'object' && 'inputData' in actualInput) {
+      const inputDataValidation = schema.safeParse((actualInput as any).inputData);
+      if (inputDataValidation.error && inputDataValidation.error.issues.length > 0) {
+        bestValidation = inputDataValidation;
+        actualInput = (actualInput as any).inputData;
+      }
+    }
+  }
+
+  if (!bestValidation.success) {
+    const errorMessages = bestValidation.error.issues
       .map((e: z.ZodIssue) => `- ${e.path?.join('.') || 'root'}: ${e.message}`)
       .join('\n');
 
     const error: ValidationError<T> = {
       error: true,
       message: `Tool validation failed${toolId ? ` for ${toolId}` : ''}. Please fix the following errors and try again:\n${errorMessages}\n\nProvided arguments: ${JSON.stringify(actualInput, null, 2)}`,
-      validationErrors: validation.error.format(),
+      validationErrors: bestValidation.error.format(),
     };
 
     return { data: input, error };
   }
 
-  // Return the original input structure with validated data in the right place
-  if (input && typeof input === 'object' && 'context' in input) {
-    if ((input as any).context && typeof (input as any).context === 'object' && 'inputData' in (input as any).context) {
-      return { data: { ...input, context: { ...(input as any).context, inputData: validation.data } } };
-    }
-    return { data: { ...input, context: validation.data } };
-  }
-
-  return { data: validation.data };
+  // This should not happen since we handle all valid cases above
+  return { data: input };
 }


### PR DESCRIPTION
## Description

There are three different types of tool input data formats. One is just the input data as is, one is nested under a `context` key and one is nested under an `inputData` key. Tool validation would fall apart if the user used one of these two keys that we expect only exist created internally. Validation would fail if a user used these protected keys and it wasn't clear why the failure. We now handle these keys so that it is invisible to the user.

Fixes https://github.com/mastra-ai/mastra/issues/7179

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
