### PR TITLE
fix(core): Improve workflow `then` type

### DIFF
--- a/.changeset/fuzzy-stars-make.md
+++ b/.changeset/fuzzy-stars-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved typing for `workflow.then` to allow the provided steps `inputSchema` to be a subset of the previous steps `outputSchema`. Also errors if the provided steps `inputSchema` is a superset of the previous steps outputSchema.

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -9443,7 +9443,7 @@ describe('Workflow', () => {
         inputSchema: prevStep.outputSchema.extend({ c: z.string() }),
         ...sharedStepAttrs,
       });
-      // @ts-expect-error -- superset step should not be allowed
+      // @ts-expect-error -- extra-required-key-step should not be allowed
       workflow.then(prevStep).then(extraRequiredKeyStep);
 
       const distinctTypeStep = createStep({
@@ -9451,7 +9451,7 @@ describe('Workflow', () => {
         inputSchema: z.string(),
         ...sharedStepAttrs,
       });
-      // @ts-expect-error -- distinct step should not be allowed
+      // @ts-expect-error -- distinct-type-step should not be allowed
       workflow.then(prevStep).then(distinctTypeStep);
     });
   });

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1155,7 +1155,7 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        inputSchema: z.object({}),
+        inputSchema: z.object({ value: z.string() }),
         outputSchema: z.object({
           result: z.string(),
         }),
@@ -2943,7 +2943,7 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        inputSchema: z.object({}),
+        inputSchema: z.object({ value: z.string() }),
         outputSchema: z.object({
           result: z.string(),
         }),
@@ -2993,7 +2993,7 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        inputSchema: z.object({}),
+        inputSchema: z.object({ value: z.string() }),
         outputSchema: z.object({
           result: z.string(),
         }),
@@ -3056,7 +3056,7 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        inputSchema: z.object({}),
+        inputSchema: z.object({ value: z.string() }),
         outputSchema: z.object({
           result: z.string(),
         }),
@@ -7000,7 +7000,7 @@ describe('Workflow', () => {
       });
       const finalStep = createStep({
         id: 'final',
-        inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+        inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
         outputSchema: z.object({ success: z.boolean() }),
         execute: final,
       });
@@ -7237,7 +7237,7 @@ describe('Workflow', () => {
       });
       const finalStep = createStep({
         id: 'final',
-        inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+        inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
         outputSchema: z.object({ finalValue: z.number() }),
         execute: final,
       });
@@ -7368,7 +7368,7 @@ describe('Workflow', () => {
         });
         const finalStep = createStep({
           id: 'final',
-          inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+          inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
           outputSchema: z.object({ finalValue: z.number() }),
           execute: final,
         });
@@ -7503,7 +7503,7 @@ describe('Workflow', () => {
         });
         const finalStep = createStep({
           id: 'final',
-          inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+          inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
           outputSchema: z.object({ finalValue: z.number() }),
           execute: final,
         });
@@ -7639,7 +7639,7 @@ describe('Workflow', () => {
         });
         const finalStep = createStep({
           id: 'final',
-          inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+          inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
           outputSchema: z.object({ finalValue: z.number() }),
           execute: final,
         });
@@ -7817,7 +7817,7 @@ describe('Workflow', () => {
         });
         const finalStep = createStep({
           id: 'final',
-          inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+          inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
           outputSchema: z.object({
             finalValue: z.number(),
           }),
@@ -8164,7 +8164,7 @@ describe('Workflow', () => {
         });
         const finalStep = createStep({
           id: 'final',
-          inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+          inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
           outputSchema: z.object({
             finalValue: z.number(),
           }),
@@ -8282,7 +8282,7 @@ describe('Workflow', () => {
       });
       const finalStep = createStep({
         id: 'final',
-        inputSchema: z.object({ newValue: z.number(), other: z.number() }),
+        inputSchema: z.object({ newValue: z.number().optional(), other: z.number().optional() }),
         outputSchema: z.object({
           finalValue: z.number(),
         }),
@@ -8724,7 +8724,7 @@ describe('Workflow', () => {
       const step = createStep({
         id: 'step1',
         execute,
-        inputSchema: z.object({ human: z.boolean() }),
+        inputSchema: z.object({ human: z.boolean().optional() }),
         outputSchema: z.object({}),
       });
       const workflow = createWorkflow({
@@ -9389,7 +9389,7 @@ describe('Workflow', () => {
       const prevStep = createStep({
         id: 'prev-step',
         inputSchema: z.object({ value: z.string() }),
-        outputSchema: z.object({ a: z.string(), b: z.string() }),
+        outputSchema: z.object({ a: z.string(), b: z.string().optional() }),
         execute: async () => {
           return { a: 'a', b: 'b' };
         },
@@ -9408,35 +9408,51 @@ describe('Workflow', () => {
 
       const equalStep = createStep({
         id: 'equal-step',
-        inputSchema: z.object({ a: z.string(), b: z.string() }),
+        inputSchema: prevStep.outputSchema,
         ...sharedStepAttrs,
       });
       // this is ok
       workflow.then(prevStep).then(equalStep);
 
-      const subsetStep = createStep({
-        id: 'subset-step',
-        inputSchema: z.object({ a: z.string() }),
+      const missingRequiredKeyStep = createStep({
+        id: 'missing-required-key-step',
+        inputSchema: prevStep.outputSchema.omit({ a: true }),
         ...sharedStepAttrs,
       });
       // this is ok
-      workflow.then(prevStep).then(subsetStep);
+      workflow.then(prevStep).then(missingRequiredKeyStep);
 
-      const supersetStep = createStep({
-        id: 'superset-step',
-        inputSchema: z.object({ a: z.string(), b: z.string(), c: z.string() }),
+      const missingOptionalKeyStep = createStep({
+        id: 'missing-optional-key-step',
+        inputSchema: prevStep.outputSchema.omit({ b: true }),
+        ...sharedStepAttrs,
+      });
+      // this is ok
+      workflow.then(prevStep).then(missingOptionalKeyStep);
+
+      const extraOptionalKeyStep = createStep({
+        id: 'extra-optional-key-step',
+        inputSchema: prevStep.outputSchema.extend({ c: z.string().optional() }),
+        ...sharedStepAttrs,
+      });
+      // this is ok
+      workflow.then(prevStep).then(extraOptionalKeyStep);
+
+      const extraRequiredKeyStep = createStep({
+        id: 'extra-required-key-step',
+        inputSchema: prevStep.outputSchema.extend({ c: z.string() }),
         ...sharedStepAttrs,
       });
       // @ts-expect-error -- superset step should not be allowed
-      workflow.then(prevStep).then(supersetStep);
+      workflow.then(prevStep).then(extraRequiredKeyStep);
 
-      const distinctStep = createStep({
-        id: 'distinct-step',
+      const distinctTypeStep = createStep({
+        id: 'distinct-type-step',
         inputSchema: z.string(),
         ...sharedStepAttrs,
       });
       // @ts-expect-error -- distinct step should not be allowed
-      workflow.then(prevStep).then(distinctStep);
+      workflow.then(prevStep).then(distinctTypeStep);
     });
   });
 });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -421,7 +421,7 @@ export class Workflow<
   then<TStepInputSchema extends z.ZodType<any>, TStepId extends string, TSchemaOut extends z.ZodType<any>>(
     step: Step<
       TStepId,
-      TPrevSchema extends TStepInputSchema ? TStepInputSchema : never,
+      z.TypeOf<TPrevSchema> extends z.TypeOf<TStepInputSchema> ? TStepInputSchema : never,
       TSchemaOut,
       any,
       any,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -418,8 +418,15 @@ export class Workflow<
    * @param step The step to add to the workflow
    * @returns The workflow instance for chaining
    */
-  then<TStepInputSchema extends TPrevSchema, TStepId extends string, TSchemaOut extends z.ZodType<any>>(
-    step: Step<TStepId, TStepInputSchema, TSchemaOut, any, any, TEngineType>,
+  then<TStepInputSchema extends z.ZodType<any>, TStepId extends string, TSchemaOut extends z.ZodType<any>>(
+    step: Step<
+      TStepId,
+      TPrevSchema extends TStepInputSchema ? TStepInputSchema : never,
+      TSchemaOut,
+      any,
+      any,
+      TEngineType
+    >,
   ) {
     this.stepFlow.push({ type: 'step', step: step as any });
     this.serializedStepFlow.push({


### PR DESCRIPTION
## Description

Improved typing for `workflow.then` to allow the provided steps `inputSchema` to be a subset of the previous steps `outputSchema`. Also errors if the provided steps `inputSchema` is a superset of the previous steps outputSchema.

I'm not sure whether you consider this a breaking change. It's a type-level change only, and the only case it will cause an error in existing code is when you have a step that defined an `inputSchema` that is a superset of the previous steps `outputSchema`, which should never succeed anyway.

## Related Issue(s)

Fixes #7122 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type safety for workflow step chaining—input schemas can now be subsets of previous steps' output schemas.

* **Bug Fixes**
  * Added error handling to prevent incompatible schema mappings between workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->