### PR TITLE
fixed private member access on wrapped workflow and agent

### DIFF
--- a/.changeset/tiny-monkeys-lay.md
+++ b/.changeset/tiny-monkeys-lay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed wrapped mastra class inside workflow steps.

--- a/packages/core/src/ai-tracing/context.ts
+++ b/packages/core/src/ai-tracing/context.ts
@@ -56,11 +56,13 @@ export function wrapMastra<T extends Mastra>(mastra: T, tracingContext: TracingC
             };
           }
 
-          // Pass through all other methods unchanged
-          return (target as any)[prop];
+          // Pass through all other methods unchanged - bind functions to preserve 'this' context
+          const value = (target as any)[prop];
+          return typeof value === 'function' ? value.bind(target) : value;
         } catch (error) {
           console.warn('AI Tracing: Failed to wrap method, falling back to original', error);
-          return (target as any)[prop];
+          const value = (target as any)[prop];
+          return typeof value === 'function' ? value.bind(target) : value;
         }
       },
     });
@@ -93,10 +95,13 @@ export function wrapAgent<T extends Agent>(agent: T, tracingContext: TracingCont
             };
           }
 
-          return (target as any)[prop];
+          // Bind functions to preserve 'this' context for private member access
+          const value = (target as any)[prop];
+          return typeof value === 'function' ? value.bind(target) : value;
         } catch (error) {
           console.warn('AI Tracing: Failed to wrap agent method, falling back to original', error);
-          return (target as any)[prop];
+          const value = (target as any)[prop];
+          return typeof value === 'function' ? value.bind(target) : value;
         }
       },
     });
@@ -130,10 +135,13 @@ export function wrapWorkflow<T extends Workflow>(workflow: T, tracingContext: Tr
             };
           }
 
-          return (target as any)[prop];
+          // Bind functions to preserve 'this' context for private member access
+          const value = (target as any)[prop];
+          return typeof value === 'function' ? value.bind(target) : value;
         } catch (error) {
           console.warn('AI Tracing: Failed to wrap workflow method, falling back to original', error);
-          return (target as any)[prop];
+          const value = (target as any)[prop];
+          return typeof value === 'function' ? value.bind(target) : value;
         }
       },
     });


### PR DESCRIPTION
## Description

  Fixed `Cannot read private member #mastra` error when calling agent.getLLM() from
  workflow steps.

  Root cause: AI tracing proxies (wrapAgent, wrapWorkflow, wrapMastra) weren't binding
  methods, causing this context loss when accessing private fields.

  Solution: Added .bind(target) to all proxy functions, matching the existing
  `createMastraProxy` pattern used for tools.

  What the fix does:
  - Before: return (target as any)[prop] - unbound function, wrong this context
  - After: return value.bind(target) - bound function, correct this context

  What it doesn't do:
  - Doesn't expose new properties or methods
  - Doesn't bypass private field access controls
  - Doesn't change the proxy's access control logic

  The binding just ensures that when users call legitimate public methods (like
  getLLM()), those methods can access their own private fields.

## Related Issue(s)

#6773 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
