### PR TITLE
feat(api): add missing endpoint to get agent tool by ID

### DIFF
--- a/.changeset/seven-cougars-smell.md
+++ b/.changeset/seven-cougars-smell.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/server': patch
+---
+
+add missing endpoint to get agent tool by ID

--- a/packages/deployer/src/server/handlers/routes/agents/router.ts
+++ b/packages/deployer/src/server/handlers/routes/agents/router.ts
@@ -3,7 +3,7 @@ import { bodyLimit } from 'hono/body-limit';
 import { describeRoute } from 'hono-openapi';
 import type { BodyLimitOptions } from '../../../types';
 import { generateSystemPromptHandler } from '../../prompt';
-import { executeAgentToolHandler } from '../tools/handlers';
+import { executeAgentToolHandler, getAgentToolHandler } from '../tools/handlers';
 import {
   generateHandler,
   generateVNextHandler,
@@ -868,6 +868,37 @@ export function agentsRouter(bodyLimitOptions: BodyLimitOptions) {
       },
     }),
     listenHandler,
+  );
+
+  router.get(
+    '/:agentId/tools/:toolId',
+    describeRoute({
+      description: 'Get agent tool by ID',
+      tags: ['agents'],
+      parameters: [
+        {
+          name: 'agentId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+        {
+          name: 'toolId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      responses: {
+        200: {
+          description: 'Tool details',
+        },
+        404: {
+          description: 'Tool or agent not found',
+        },
+      },
+    }),
+    getAgentToolHandler,
   );
 
   router.post(

--- a/packages/deployer/src/server/handlers/routes/tools/handlers.ts
+++ b/packages/deployer/src/server/handlers/routes/tools/handlers.ts
@@ -4,6 +4,7 @@ import {
   getToolByIdHandler as getOriginalToolByIdHandler,
   executeToolHandler as getOriginalExecuteToolHandler,
   executeAgentToolHandler as getOriginalExecuteAgentToolHandler,
+  getAgentToolHandler as getOriginalAgentToolHandler,
 } from '@mastra/server/handlers/tools';
 import type { Context } from 'hono';
 
@@ -62,6 +63,26 @@ export function executeToolHandler(tools: Record<string, any>) {
       return handleError(error, 'Error executing tool');
     }
   };
+}
+
+export async function getAgentToolHandler(c: Context) {
+  try {
+    const mastra: Mastra = c.get('mastra');
+    const runtimeContext = c.get('runtimeContext');
+    const agentId = c.req.param('agentId');
+    const toolId = c.req.param('toolId');
+
+    const result = await getOriginalAgentToolHandler({
+      mastra,
+      agentId,
+      toolId,
+      runtimeContext,
+    });
+
+    return c.json(result);
+  } catch (error) {
+    return handleError(error, 'Error getting agent tool');
+  }
 }
 
 export async function executeAgentToolHandler(c: Context) {


### PR DESCRIPTION
## Description

Using the client sdk, the following code fails because the endpoint `/api/agents/:agentId/tools/:toolId` does not exist:

```ts
const mastraClient = new MastraClient({
  baseUrl: "http://localhost:4111/",
});
const agent = mastraClient.getAgent("weatherAgent");
const tool = await agent.getTool("get-weather");
```

## Related Issue(s)

Fixes https://discord.com/channels/1309558646228779139/1412091272453161082/1412091272453161082

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
