### PR TITLE
Updated Langfuse exporter to handle Event spans

### DIFF
--- a/.changeset/mighty-walls-invent.md
+++ b/.changeset/mighty-walls-invent.md
@@ -1,0 +1,6 @@
+---
+'@mastra/langfuse': patch
+'@mastra/core': patch
+---
+
+"Updated langfuse exporter to handle Event spans"

--- a/observability/langfuse/package.json
+++ b/observability/langfuse/package.json
@@ -41,6 +41,6 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.13.0-0 <0.16.0-0"
+    "@mastra/core": ">=0.15.3-0 <0.16.0-0"
   }
 }

--- a/observability/langfuse/src/ai-tracing.test.ts
+++ b/observability/langfuse/src/ai-tracing.test.ts
@@ -35,20 +35,21 @@ describe('LangfuseExporter', () => {
     // Set up mocks
     mockGeneration = {
       update: vi.fn(),
-      end: vi.fn(),
+      event: vi.fn(),
     };
 
     mockSpan = {
       update: vi.fn(),
-      end: vi.fn(),
       generation: vi.fn().mockReturnValue(mockGeneration),
       span: vi.fn(),
+      event: vi.fn(),
     };
 
     mockTrace = {
       generation: vi.fn().mockReturnValue(mockGeneration),
       span: vi.fn().mockReturnValue(mockSpan),
       update: vi.fn(),
+      event: vi.fn(),
     };
 
     // Set up circular reference
@@ -456,7 +457,7 @@ describe('LangfuseExporter', () => {
   });
 
   describe('Span Ending', () => {
-    it('should end span with success status', async () => {
+    it('should update span with endTime on span end', async () => {
       const span = createMockSpan({
         id: 'test-span',
         name: 'test',
@@ -477,10 +478,7 @@ describe('LangfuseExporter', () => {
         span,
       });
 
-      console.log('BOOP');
-      console.log(span.metadata);
-
-      expect(mockSpan.end).toHaveBeenCalledWith({
+      expect(mockSpan.update).toHaveBeenCalledWith({
         endTime: span.endTime,
         metadata: expect.objectContaining({
           spanType: 'generic',
@@ -488,7 +486,7 @@ describe('LangfuseExporter', () => {
       });
     });
 
-    it('should end span with error status', async () => {
+    it('should update span with error information on span end', async () => {
       const errorSpan = createMockSpan({
         id: 'error-span',
         name: 'failing-operation',
@@ -516,7 +514,7 @@ describe('LangfuseExporter', () => {
         span: errorSpan,
       });
 
-      expect(mockSpan.end).toHaveBeenCalledWith({
+      expect(mockSpan.update).toHaveBeenCalledWith({
         endTime: errorSpan.endTime,
         metadata: expect.objectContaining({
           spanType: 'tool_call',
@@ -525,6 +523,40 @@ describe('LangfuseExporter', () => {
         level: 'ERROR',
         statusMessage: 'Tool execution failed',
       });
+    });
+
+    it('should update root trace and delete from traceMap when root span ends', async () => {
+      const rootSpan = createMockSpan({
+        id: 'root-span-id',
+        name: 'root-span',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      rootSpan.output = { result: 'success' };
+      rootSpan.endTime = new Date();
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        span: rootSpan,
+      });
+
+      // Verify trace was created
+      expect((exporter as any).traceMap.has('root-span-id')).toBe(true);
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        span: rootSpan,
+      });
+
+      // Should update trace with output
+      expect(mockTrace.update).toHaveBeenCalledWith({
+        output: { result: 'success' },
+      });
+
+      // Should remove trace from traceMap
+      expect((exporter as any).traceMap.has('root-span-id')).toBe(false);
     });
   });
 
@@ -575,6 +607,138 @@ describe('LangfuseExporter', () => {
           span,
         }),
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe('Event Span Handling', () => {
+    let mockEvent: any;
+
+    beforeEach(() => {
+      mockEvent = {
+        update: vi.fn(),
+      };
+      mockTrace.event.mockReturnValue(mockEvent);
+      mockSpan.event.mockReturnValue(mockEvent);
+      mockGeneration.event.mockReturnValue(mockEvent);
+    });
+
+    it('should create Langfuse event for root event spans', async () => {
+      const eventSpan = createMockSpan({
+        id: 'event-span-id',
+        name: 'user-feedback',
+        type: AISpanType.GENERIC,
+        isRoot: true,
+        attributes: {
+          eventType: 'user_feedback',
+          rating: 5,
+        },
+        input: { message: 'Great response!' },
+      });
+      eventSpan.isEvent = true;
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        span: eventSpan,
+      });
+
+      // Should create trace for root event span
+      expect(mockLangfuseClient.trace).toHaveBeenCalledWith({
+        id: 'event-span-id',
+        name: 'user-feedback',
+        input: { message: 'Great response!' },
+        metadata: {
+          spanType: 'generic',
+          eventType: 'user_feedback',
+          rating: 5,
+        },
+      });
+
+      // Should create Langfuse event
+      expect(mockTrace.event).toHaveBeenCalledWith({
+        id: 'event-span-id',
+        name: 'user-feedback',
+        startTime: eventSpan.startTime,
+        input: { message: 'Great response!' },
+        metadata: {
+          spanType: 'generic',
+          eventType: 'user_feedback',
+          rating: 5,
+        },
+      });
+    });
+
+    it('should create Langfuse event for child event spans', async () => {
+      // First create a root span
+      const rootSpan = createMockSpan({
+        id: 'root-span-id',
+        name: 'root-agent',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        span: rootSpan,
+      });
+
+      // Then create a child event span
+      const childEventSpan = createMockSpan({
+        id: 'child-event-id',
+        name: 'tool-result',
+        type: AISpanType.GENERIC,
+        isRoot: false,
+        attributes: {
+          toolName: 'calculator',
+          success: true,
+        },
+        output: { result: 42 },
+      });
+      childEventSpan.isEvent = true;
+      childEventSpan.traceId = 'root-span-id';
+      childEventSpan.parent = { id: 'root-span-id' };
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        span: childEventSpan,
+      });
+
+      // Should create event under the parent span
+      expect(mockSpan.event).toHaveBeenCalledWith({
+        id: 'child-event-id',
+        name: 'tool-result',
+        startTime: childEventSpan.startTime,
+        output: { result: 42 },
+        metadata: {
+          spanType: 'generic',
+          toolName: 'calculator',
+          success: true,
+        },
+      });
+    });
+
+    it('should handle event spans with missing parent gracefully', async () => {
+      const orphanEventSpan = createMockSpan({
+        id: 'orphan-event-id',
+        name: 'orphan-event',
+        type: AISpanType.GENERIC,
+        isRoot: false,
+        attributes: {},
+      });
+      orphanEventSpan.isEvent = true;
+      orphanEventSpan.traceId = 'missing-trace-id';
+
+      // Should not throw
+      await expect(
+        exporter.exportEvent({
+          type: AITracingEventType.SPAN_STARTED,
+          span: orphanEventSpan,
+        }),
+      ).resolves.not.toThrow();
+
+      // Should not create any Langfuse objects
+      expect(mockTrace.event).not.toHaveBeenCalled();
+      expect(mockSpan.event).not.toHaveBeenCalled();
     });
   });
 
@@ -657,6 +821,8 @@ function createMockSpan({
     error: vi.fn(),
     update: vi.fn(),
     createChildSpan: vi.fn(),
+    createEventSpan: vi.fn(),
+    isEvent: false,
   } as AnyAISpan;
 
   return mockSpan;

--- a/observability/langfuse/src/ai-tracing.ts
+++ b/observability/langfuse/src/ai-tracing.ts
@@ -7,9 +7,10 @@
  */
 
 import type { AITracingExporter, AITracingEvent, AnyAISpan, LLMGenerationAttributes } from '@mastra/core/ai-tracing';
-import { AISpanType, sanitizeMetadata, omitKeys } from '@mastra/core/ai-tracing';
+import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
+import { ConsoleLogger } from '@mastra/core/logger';
 import { Langfuse } from 'langfuse';
-import type { LangfuseTraceClient, LangfuseSpanClient, LangfuseGenerationClient } from 'langfuse';
+import type { LangfuseTraceClient, LangfuseSpanClient, LangfuseGenerationClient, LangfuseEventClient } from 'langfuse';
 
 export interface LangfuseExporterConfig {
   /** Langfuse API key */
@@ -20,6 +21,8 @@ export interface LangfuseExporterConfig {
   baseUrl: string;
   /** Enable realtime mode - flushes after each event for immediate visibility */
   realtime?: boolean;
+  /** Logger level for diagnostic messages (default: 'warn') */
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
   /** Additional options to pass to the Langfuse client */
   options?: any;
 }
@@ -27,18 +30,21 @@ export interface LangfuseExporterConfig {
 type TraceData = {
   trace: LangfuseTraceClient; // Langfuse trace object
   spans: Map<string, LangfuseSpanClient | LangfuseGenerationClient>; // Maps span.id to Langfuse span/generation
+  events: Map<string, LangfuseEventClient>; // Maps span.id to Langfuse event
 };
 
-type LangfuseSpan = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient;
+type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient | LangfuseEventClient;
 
 export class LangfuseExporter implements AITracingExporter {
   name = 'langfuse';
   private client: Langfuse;
   private realtime: boolean;
   private traceMap = new Map<string, TraceData>();
+  private logger: ConsoleLogger;
 
   constructor(config: LangfuseExporterConfig) {
     this.realtime = config.realtime ?? false;
+    this.logger = new ConsoleLogger({ level: config.logLevel ?? 'warn' });
     this.client = new Langfuse({
       publicKey: config.publicKey,
       secretKey: config.secretKey,
@@ -48,15 +54,20 @@ export class LangfuseExporter implements AITracingExporter {
   }
 
   async exportEvent(event: AITracingEvent): Promise<void> {
+    if (event.span.isEvent) {
+      await this.handleEventSpan(event.span);
+      return;
+    }
+
     switch (event.type) {
       case 'span_started':
         await this.handleSpanStarted(event.span);
         break;
       case 'span_updated':
-        await this.handleSpanUpdateOrEnd(event.span, true);
+        await this.handleSpanUpdateOrEnd(event.span, false);
         break;
       case 'span_ended':
-        await this.handleSpanUpdateOrEnd(event.span, false);
+        await this.handleSpanUpdateOrEnd(event.span, true);
         break;
     }
 
@@ -68,21 +79,19 @@ export class LangfuseExporter implements AITracingExporter {
 
   private async handleSpanStarted(span: AnyAISpan): Promise<void> {
     if (span.isRootSpan) {
-      const trace = this.client.trace(this.buildTracePayload(span));
-      this.traceMap.set(span.trace.id, { trace, spans: new Map() });
+      this.initTrace(span);
     }
+    const method = 'handleSpanStarted';
 
-    const traceData = this.traceMap.get(span.trace.id);
+    const traceData = this.getTraceData({ span, method });
     if (!traceData) {
-      console.log('NO TRACE');
-      // TODO: log warning
       return;
     }
 
-    const langfuseParent =
-      span.parent && traceData.spans.has(span.parent.id)
-        ? (traceData.spans.get(span.parent.id) as LangfuseSpan)
-        : traceData.trace;
+    const langfuseParent = this.getLangfuseParent({ traceData, span, method });
+    if (!langfuseParent) {
+      return;
+    }
 
     const payload = this.buildSpanPayload(span, true);
 
@@ -92,36 +101,120 @@ export class LangfuseExporter implements AITracingExporter {
     traceData.spans.set(span.id, langfuseSpan);
   }
 
-  private async handleSpanUpdateOrEnd(span: AnyAISpan, isUpdate: boolean): Promise<void> {
-    const traceData = this.traceMap.get(span.trace.id);
+  private async handleSpanUpdateOrEnd(span: AnyAISpan, isEnd: boolean): Promise<void> {
+    const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
+
+    const traceData = this.getTraceData({ span, method });
     if (!traceData) {
-      console.log('NO TRACE');
-      // TODO: log warning
       return;
     }
 
     const langfuseSpan = traceData.spans.get(span.id);
     if (!langfuseSpan) {
-      console.log('NO SPAN');
-      // TODO: log warning
+      this.logger.warn('Langfuse exporter: No Langfuse span found for span update/end', {
+        traceId: span.traceId,
+        spanId: span.id,
+        spanName: span.name,
+        spanType: span.type,
+        isRootSpan: span.isRootSpan,
+        parentSpanId: span.parent?.id,
+        availableSpanIds: Array.from(traceData.spans.keys()),
+        method,
+      });
       return;
     }
 
-    if (isUpdate) {
-      langfuseSpan.update(this.buildSpanPayload(span, false));
-    } else {
-      langfuseSpan.end(this.buildSpanPayload(span, false));
+    // use update for both update & end, so that we can use the
+    // end time we set when ending the span.
+    langfuseSpan.update(this.buildSpanPayload(span, false));
 
-      if (span.isRootSpan) {
-        traceData.trace.update({ output: span.output });
-        this.traceMap.delete(span.trace.id);
-      }
+    if (isEnd && span.isRootSpan) {
+      traceData.trace.update({ output: span.output });
+      this.traceMap.delete(span.traceId);
     }
+  }
+
+  private async handleEventSpan(span: AnyAISpan): Promise<void> {
+    if (span.isRootSpan) {
+      this.logger.debug('Langfuse exporter: Creating trace', {
+        traceId: span.traceId,
+        spanId: span.id,
+        spanName: span.name,
+        method: 'handleEventSpan',
+      });
+      this.initTrace(span);
+    }
+    const method = 'handleEventSpan';
+
+    const traceData = this.getTraceData({ span, method });
+    if (!traceData) {
+      return;
+    }
+
+    const langfuseParent = this.getLangfuseParent({ traceData, span, method });
+    if (!langfuseParent) {
+      return;
+    }
+
+    const payload = this.buildSpanPayload(span, true);
+
+    const langfuseEvent = langfuseParent.event(payload);
+
+    traceData.events.set(span.id, langfuseEvent);
+  }
+
+  private initTrace(span: AnyAISpan): void {
+    const trace = this.client.trace(this.buildTracePayload(span));
+    this.traceMap.set(span.traceId, { trace, spans: new Map(), events: new Map() });
+  }
+
+  private getTraceData(options: { span: AnyAISpan; method: string }): TraceData | undefined {
+    const { span, method } = options;
+    if (this.traceMap.has(span.traceId)) {
+      return this.traceMap.get(span.traceId);
+    }
+    this.logger.warn('Langfuse exporter: No trace data found for span', {
+      traceId: span.traceId,
+      spanId: span.id,
+      spanName: span.name,
+      spanType: span.type,
+      isRootSpan: span.isRootSpan,
+      parentSpanId: span.parent?.id,
+      method,
+    });
+  }
+
+  private getLangfuseParent(options: {
+    traceData: TraceData;
+    span: AnyAISpan;
+    method: string;
+  }): LangfuseParent | undefined {
+    const { traceData, span, method } = options;
+
+    const parentId = span.parent?.id;
+    if (!parentId) {
+      return traceData.trace;
+    }
+    if (traceData.spans.has(parentId)) {
+      return traceData.spans.get(parentId);
+    }
+    if (traceData.events.has(parentId)) {
+      return traceData.events.get(parentId);
+    }
+    this.logger.warn('Langfuse exporter: No parent data found for span', {
+      traceId: span.traceId,
+      spanId: span.id,
+      spanName: span.name,
+      spanType: span.type,
+      isRootSpan: span.isRootSpan,
+      parentSpanId: span.parent?.id,
+      method,
+    });
   }
 
   private buildTracePayload(span: AnyAISpan): Record<string, any> {
     const payload: Record<string, any> = {
-      id: span.trace.id,
+      id: span.traceId,
       name: span.name,
     };
 
@@ -133,8 +226,8 @@ export class LangfuseExporter implements AITracingExporter {
 
     payload.metadata = {
       spanType: span.type,
-      ...sanitizeMetadata(span.attributes),
-      ...sanitizeMetadata(remainingMetadata),
+      ...span.attributes,
+      ...remainingMetadata,
     };
 
     return payload;
@@ -179,8 +272,8 @@ export class LangfuseExporter implements AITracingExporter {
 
     payload.metadata = {
       spanType: span.type,
-      ...sanitizeMetadata(omitKeys(attributes, attributesToOmit)),
-      ...sanitizeMetadata(span.metadata),
+      ...omitKeys(attributes, attributesToOmit),
+      ...span.metadata,
     };
 
     if (span.errorInfo) {

--- a/packages/core/src/ai-tracing/ai-tracing.test.ts
+++ b/packages/core/src/ai-tracing/ai-tracing.test.ts
@@ -144,7 +144,6 @@ describe('AI Tracing', () => {
       expect(agentSpan.attributes?.agentId).toBe('agent-123');
       expect(agentSpan.startTime).toBeInstanceOf(Date);
       expect(agentSpan.endTime).toBeUndefined();
-      expect(agentSpan.trace).toBe(agentSpan); // Root span is its own trace
       expect(agentSpan.traceId).toBeValidTraceId();
     });
 
@@ -174,7 +173,6 @@ describe('AI Tracing', () => {
       expect(toolSpan.id).toBeValidSpanId();
       expect(toolSpan.type).toBe(AISpanType.TOOL_CALL);
       expect(toolSpan.attributes?.toolId).toBe('tool-456');
-      expect(toolSpan.trace).toBe(agentSpan); // Child inherits trace from parent
       expect(toolSpan.traceId).toBe(agentSpan.traceId); // Child spans inherit trace ID
     });
 
@@ -822,7 +820,6 @@ describe('AI Tracing', () => {
             type: options.type,
             attributes: options.attributes,
             parent: options.parent,
-            trace: options.parent?.trace || ({} as any),
             traceId: 'custom-trace-id',
             startTime: new Date(),
             aiTracing: this,
@@ -1360,7 +1357,6 @@ describe('AI Tracing', () => {
 
       // Event span should be properly linked to parent
       expect(eventSpan.parent).toBe(rootSpan);
-      expect(eventSpan.trace).toBe(rootSpan);
       expect(eventSpan.traceId).toBe(rootSpan.traceId);
 
       rootSpan.end();
@@ -1550,10 +1546,6 @@ describe('AI Tracing', () => {
       // Event spans should have llmSpan as parent
       expect(eventSpan1.parent).toBe(llmSpan);
       expect(eventSpan2.parent).toBe(llmSpan);
-
-      // Event spans should have rootSpan as trace
-      expect(eventSpan1.trace).toBe(rootSpan);
-      expect(eventSpan2.trace).toBe(rootSpan);
 
       // All spans should share the same traceId
       expect(eventSpan1.traceId).toBe(rootSpan.traceId);

--- a/packages/core/src/ai-tracing/default.ts
+++ b/packages/core/src/ai-tracing/default.ts
@@ -17,6 +17,7 @@ import type {
   AnyAISpan,
 } from './types';
 import { SamplingStrategyType } from './types';
+import { shallowClean } from './utils';
 
 // ============================================================================
 // Default AISpan Implementation
@@ -62,7 +63,6 @@ class DefaultAISpan<TType extends AISpanType> implements AISpan<TType> {
   public type: TType;
   public attributes: AISpanTypeMap[TType];
   public parent?: AnyAISpan;
-  public trace: AnyAISpan;
   public traceId: string;
   public startTime: Date;
   public endTime?: Date;
@@ -84,13 +84,12 @@ class DefaultAISpan<TType extends AISpanType> implements AISpan<TType> {
     this.id = generateSpanId();
     this.name = options.name;
     this.type = options.type;
-    this.attributes = options.attributes || ({} as AISpanTypeMap[TType]);
-    this.metadata = options.metadata;
+    this.attributes = shallowClean(options.attributes) || ({} as AISpanTypeMap[TType]);
+    this.metadata = shallowClean(options.metadata);
     this.parent = options.parent;
-    this.trace = options.parent ? options.parent.trace : (this as any);
     this.startTime = new Date();
     this.aiTracing = aiTracing;
-    this.input = options.input;
+    this.input = shallowClean(options.input);
     this.isEvent = options.isEvent;
     this.logger = new ConsoleLogger({
       name: 'default-ai-span',
@@ -103,13 +102,13 @@ class DefaultAISpan<TType extends AISpanType> implements AISpan<TType> {
       this.traceId = generateTraceId();
     } else {
       // Child span inherits trace ID from root span
-      this.traceId = options.parent.trace.traceId;
+      this.traceId = options.parent.traceId;
     }
 
     if (this.isEvent) {
       // Event spans don't have endTime or input.
       // Event spans are immediately emitted by the base class via the end() event.
-      this.output = options.output;
+      this.output = shallowClean(options.output);
     }
   }
 
@@ -120,13 +119,13 @@ class DefaultAISpan<TType extends AISpanType> implements AISpan<TType> {
     }
     this.endTime = new Date();
     if (options?.output !== undefined) {
-      this.output = options.output;
+      this.output = shallowClean(options.output);
     }
     if (options?.attributes) {
-      this.attributes = { ...this.attributes, ...options.attributes };
+      this.attributes = { ...this.attributes, ...shallowClean(options.attributes) };
     }
     if (options?.metadata) {
-      this.metadata = { ...this.metadata, ...options.metadata };
+      this.metadata = { ...this.metadata, ...shallowClean(options.metadata) };
     }
     // Tracing events automatically handled by base class
   }
@@ -159,10 +158,10 @@ class DefaultAISpan<TType extends AISpanType> implements AISpan<TType> {
 
     // Update attributes if provided
     if (attributes) {
-      this.attributes = { ...this.attributes, ...attributes };
+      this.attributes = { ...this.attributes, ...shallowClean(attributes) };
     }
     if (metadata) {
-      this.metadata = { ...this.metadata, ...metadata };
+      this.metadata = { ...this.metadata, ...shallowClean(metadata) };
     }
 
     if (endSpan) {
@@ -214,16 +213,16 @@ class DefaultAISpan<TType extends AISpanType> implements AISpan<TType> {
     }
 
     if (options?.input !== undefined) {
-      this.input = options.input;
+      this.input = shallowClean(options.input);
     }
     if (options?.output !== undefined) {
-      this.output = options.output;
+      this.output = shallowClean(options.output);
     }
     if (options?.attributes) {
-      this.attributes = { ...this.attributes, ...options.attributes };
+      this.attributes = { ...this.attributes, ...shallowClean(options.attributes) };
     }
     if (options?.metadata) {
-      this.metadata = { ...this.metadata, ...options.metadata };
+      this.metadata = { ...this.metadata, ...shallowClean(options.metadata) };
     }
     // Tracing events automatically handled by base class
   }

--- a/packages/core/src/ai-tracing/no-op.ts
+++ b/packages/core/src/ai-tracing/no-op.ts
@@ -11,7 +11,6 @@ export class NoOpAISpan<TType extends AISpanType = any> implements AISpan<TType>
   public type: TType;
   public attributes: AISpanTypeMap[TType];
   public parent?: AnyAISpan;
-  public trace: AnyAISpan;
   public traceId: string;
   public startTime: Date;
   public endTime?: Date;
@@ -35,7 +34,6 @@ export class NoOpAISpan<TType extends AISpanType = any> implements AISpan<TType>
     this.attributes = options.attributes || ({} as AISpanTypeMap[TType]);
     this.metadata = options.metadata;
     this.parent = options.parent;
-    this.trace = options.parent ? options.parent.trace : (this as any);
     this.traceId = 'no-op-trace';
     this.startTime = new Date();
     this.aiTracing = aiTracing;

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -278,8 +278,6 @@ export interface AISpan<TType extends AISpanType> {
   attributes?: AISpanTypeMap[TType];
   /** Parent span reference (undefined for root spans) */
   parent?: AnyAISpan;
-  /** The top-level span - can be any type */
-  trace: AnyAISpan;
   /** OpenTelemetry-compatible trace ID (32 hex chars) - present on all spans */
   traceId: string;
   /** Pointer to the AITracing instance */
@@ -331,7 +329,7 @@ export interface AISpan<TType extends AISpanType> {
     metadata?: Record<string, any>;
   }): AISpan<TChildType>;
 
-  /** Create event span - can be any span type independent of parent
+  /** Create event span - can be any span type independent of parent 
       Event spans have no input, and no endTime.
   */
   createEventSpan<TChildType extends AISpanType>(options: {

--- a/packages/core/src/ai-tracing/utils.ts
+++ b/packages/core/src/ai-tracing/utils.ts
@@ -133,7 +133,10 @@ function getNestedValue(obj: any, path: string): any {
  */
 function setNestedValue(obj: any, path: string, value: any): void {
   const keys = path.split('.');
-  const lastKey = keys.pop()!;
+  const lastKey = keys.pop();
+  if (!lastKey) {
+    return;
+  }
 
   const target = keys.reduce((current, key) => {
     if (!current[key] || typeof current[key] !== 'object') {

--- a/packages/core/src/ai-tracing/utils.ts
+++ b/packages/core/src/ai-tracing/utils.ts
@@ -3,33 +3,79 @@
  * used in AI tracing and observability.
  */
 
+import type { RuntimeContext } from '../di';
+import { getSelectedAITracing } from './registry';
+import type { AISpan, AISpanType, AISpanTypeMap, TracingContext } from './types';
+
 /**
- * Removes non-serializable values from a metadata object.
- * @param metadata - An object with arbitrary values
- * @returns A new object with only serializable entries
+ * Cleans an object by testing each key-value pair for circular references.
+ * Problematic values are replaced with error messages for debugging.
+ * @param obj - Object to clean
+ * @returns Cleaned object with circular references marked
  */
-export function sanitizeMetadata(metadata: Record<string, any> | undefined): Record<string, any> {
-  if (!metadata) return {};
-  const sanitized: Record<string, any> = {};
-  for (const [key, value] of Object.entries(metadata)) {
-    if (isSerializable(value)) {
-      sanitized[key] = value;
+export function shallowCleanObject(obj: Record<string, any>): Record<string, any> {
+  const cleaned: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    try {
+      JSON.stringify(value);
+      cleaned[key] = value;
+    } catch (error) {
+      // Use the actual error message for debugging
+      cleaned[key] = `[${error instanceof Error ? error.message : String(error)}]`;
     }
   }
-  return sanitized;
+
+  return cleaned;
 }
 
 /**
- * Checks if a value can be safely JSON-stringified.
- * @param value - Any value
- * @returns true if serializable, false otherwise
+ * Cleans an array by applying object cleaning to each item.
+ * @param arr - Array to clean
+ * @returns Cleaned array with problematic items marked
  */
-export function isSerializable(value: any): boolean {
+export function shallowCleanArray(arr: any[]): any[] {
+  return arr.map(item => {
+    if (item && typeof item === 'object' && !Array.isArray(item)) {
+      // Apply object cleaning to each array item
+      return shallowCleanObject(item);
+    }
+
+    // For primitives, nested arrays, etc. - test directly
+    try {
+      JSON.stringify(item);
+      return item;
+    } catch (error) {
+      return `[${error instanceof Error ? error.message : String(error)}]`;
+    }
+  });
+}
+
+/**
+ * Safely cleans any value by removing circular references and marking problematic data.
+ * Provides detailed error information to help identify issues in source code.
+ * @param value - Value to clean (object, array, primitive, etc.)
+ * @returns Cleaned value with circular references marked
+ */
+export function shallowClean(value: any): any {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return shallowCleanArray(value);
+  }
+
+  if (typeof value === 'object') {
+    return shallowCleanObject(value);
+  }
+
+  // Primitives, functions, etc. - test directly
   try {
     JSON.stringify(value);
-    return true;
-  } catch {
-    return false;
+    return value;
+  } catch (error) {
+    return `[${error instanceof Error ? error.message : String(error)}]`;
   }
 }
 
@@ -41,4 +87,104 @@ export function isSerializable(value: any): boolean {
  */
 export function omitKeys<T extends Record<string, any>>(obj: T, keysToOmit: string[]): Partial<T> {
   return Object.fromEntries(Object.entries(obj).filter(([key]) => !keysToOmit.includes(key))) as Partial<T>;
+}
+
+/**
+ * Selectively extracts specific fields from an object using dot notation.
+ * Does not error if fields don't exist - simply omits them from the result.
+ * @param obj - The source object to extract fields from
+ * @param fields - Array of field paths (supports dot notation like 'output.text')
+ * @returns New object containing only the specified fields
+ */
+export function selectFields(obj: any, fields: string[]): any {
+  if (!obj || typeof obj !== 'object') {
+    return obj;
+  }
+
+  const result: any = {};
+
+  for (const field of fields) {
+    const value = getNestedValue(obj, field);
+    if (value !== undefined) {
+      setNestedValue(result, field, value);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Gets a nested value from an object using dot notation
+ * @param obj - Source object
+ * @param path - Dot notation path (e.g., 'output.text')
+ * @returns The value at the path, or undefined if not found
+ */
+function getNestedValue(obj: any, path: string): any {
+  return path.split('.').reduce((current, key) => {
+    return current && typeof current === 'object' ? current[key] : undefined;
+  }, obj);
+}
+
+/**
+ * Sets a nested value in an object using dot notation
+ * @param obj - Target object
+ * @param path - Dot notation path (e.g., 'output.text')
+ * @param value - Value to set
+ */
+function setNestedValue(obj: any, path: string, value: any): void {
+  const keys = path.split('.');
+  const lastKey = keys.pop()!;
+
+  const target = keys.reduce((current, key) => {
+    if (!current[key] || typeof current[key] !== 'object') {
+      current[key] = {};
+    }
+    return current[key];
+  }, obj);
+
+  target[lastKey] = value;
+}
+
+/**
+ * Creates or gets a child span from existing tracing context or starts a new trace.
+ * This helper consolidates the common pattern of creating spans that can either be:
+ * 1. Children of an existing span (when tracingContext.currentSpan exists)
+ * 2. New root spans (when no current span exists)
+ *
+ * @param options - Configuration object for span creation
+ * @returns The created AI span or undefined if tracing is disabled
+ */
+export function getOrCreateSpan<T extends AISpanType>(options: {
+  type: T;
+  name: string;
+  input?: any;
+  attributes?: AISpanTypeMap[T];
+  metadata?: Record<string, any>;
+  tracingContext?: TracingContext;
+  runtimeContext?: RuntimeContext;
+}): AISpan<T> | undefined {
+  const { type, attributes, tracingContext, runtimeContext, ...rest } = options;
+
+  // If we have a current span, create a child span
+  if (tracingContext?.currentSpan) {
+    return tracingContext.currentSpan.createChildSpan({
+      type,
+      attributes,
+      ...rest,
+    });
+  }
+
+  // Otherwise, try to create a new root span
+  const aiTracing = getSelectedAITracing({
+    runtimeContext: runtimeContext,
+  });
+
+  return aiTracing?.startSpan({
+    type,
+    attributes,
+    startOptions: {
+      runtimeContext,
+    },
+    ...rest,
+  });
 }


### PR DESCRIPTION
## Description

This PR addresses JSON serialization issues and improves the Langfuse and Storage exporters implementations with the following key changes:

AI Tracing Layer Protection:
  - Added circular reference protection with shallowClean functions in `ai-tracing/utils.ts`
  - Implemented selectFields utility for filtering large objects before passing to spans
  - Applied cleaning to all span data (input, output, metadata, attributes) to prevent database
  storage failures

Langfuse Exporter Improvements:
  - Unified span lifecycle management - now uses .update() for both span updates and endings
  - Added comprehensive event span handling with new handleEventSpan method
  - Improved trace cleanup logic for better resource management
  - Updated tests to reflect the new unified approach

Key Benefits:
  - Eliminates circular reference JSON serialization errors that were causing database failures
  - Provides better observability with event span support in Langfuse
  - Improves performance with shallow cleaning strategy and selective field extraction

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works

Docs will be updated separately.
