### PR TITLE
Piped tracingContext through everything

### DIFF
--- a/.changeset/lucky-clowns-tap.md
+++ b/.changeset/lucky-clowns-tap.md
@@ -1,0 +1,6 @@
+---
+'@mastra/inngest': patch
+'@mastra/mcp': patch
+---
+
+"piped tracingContext through inngest and mcp packages"

--- a/.changeset/old-bats-double.md
+++ b/.changeset/old-bats-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+"pipes tracingContext through all ai items: agents, workflows, tools, processors, scorers, etc.."

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -2831,7 +2831,9 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      await expect(userAgent['convertTools']({ runtimeContext: new RuntimeContext() })).rejects.toThrow(/same name/i);
+      await expect(
+        userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} }),
+      ).rejects.toThrow(/same name/i);
     });
 
     it('should sanitize tool names with invalid characters', async () => {
@@ -2903,7 +2905,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext() });
+      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} });
       expect(Object.keys(tools)).toContain('bad___tool_name');
       expect(Object.keys(tools)).not.toContain(badName);
     });
@@ -2977,7 +2979,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext() });
+      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} });
       expect(Object.keys(tools)).toContain('_1tool');
       expect(Object.keys(tools)).not.toContain(badStart);
     });
@@ -3051,7 +3053,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext() });
+      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} });
       expect(Object.keys(tools).some(k => k.length === 63)).toBe(true);
       expect(Object.keys(tools)).not.toContain(longName);
     });
@@ -6327,6 +6329,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         input: expect.any(Object),
         output: expect.any(Object),
         runtimeContext: expect.any(Object),
+        tracingContext: expect.any(Object),
         entity: expect.objectContaining({
           id: 'Test Agent',
           name: 'Test Agent',

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -7,8 +7,8 @@ import type { JSONSchema7 } from 'json-schema';
 import { z } from 'zod';
 import type { ZodSchema } from 'zod';
 import type { MastraPrimitives, MastraUnion } from '../action';
-import { AISpanType, getSelectedAITracing } from '../ai-tracing';
-import type { AISpan, AnyAISpan } from '../ai-tracing';
+import { AISpanType, getOrCreateSpan } from '../ai-tracing';
+import type { AISpan, TracingContext } from '../ai-tracing';
 import { MastraBase } from '../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { Metric } from '../eval';
@@ -74,7 +74,6 @@ import type {
   ToolsetsInput,
   ToolsInput,
   AgentMemoryOption,
-  AgentAISpanProperties,
 } from './types';
 export * from './input-processor';
 export { TripWire };
@@ -750,11 +749,13 @@ export class Agent<
   async generateTitleFromUserMessage({
     message,
     runtimeContext = new RuntimeContext(),
+    tracingContext,
     model,
     instructions,
   }: {
     message: string | MessageInput;
     runtimeContext?: RuntimeContext;
+    tracingContext: TracingContext;
     model?: DynamicArgument<MastraLanguageModel>;
     instructions?: DynamicArgument<string>;
   }) {
@@ -791,6 +792,7 @@ export class Agent<
     if (llm.getModel().specificationVersion === 'v2') {
       const result = (llm as MastraLLMVNext).stream({
         runtimeContext,
+        tracingContext,
         messages: [
           {
             role: 'system',
@@ -807,6 +809,7 @@ export class Agent<
     } else {
       const result = await (llm as MastraLLMV1).__text({
         runtimeContext,
+        tracingContext,
         messages: [
           {
             role: 'system',
@@ -835,6 +838,7 @@ export class Agent<
   async genTitle(
     userMessage: string | MessageInput | undefined,
     runtimeContext: RuntimeContext,
+    tracingContext: TracingContext,
     model?: DynamicArgument<MastraLanguageModel>,
     instructions?: DynamicArgument<string>,
   ) {
@@ -845,6 +849,7 @@ export class Agent<
           return await this.generateTitleFromUserMessage({
             message: normMessage,
             runtimeContext,
+            tracingContext,
             model,
             instructions,
           });
@@ -963,15 +968,15 @@ export class Agent<
     resourceId,
     threadId,
     runtimeContext,
+    tracingContext,
     mastraProxy,
-    agentAISpan,
   }: {
     runId?: string;
     resourceId?: string;
     threadId?: string;
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     mastraProxy?: MastraUnion;
-    agentAISpan?: AnyAISpan;
   }) {
     let convertedMemoryTools: Record<string, CoreTool> = {};
     // Get memory tools if available
@@ -997,8 +1002,8 @@ export class Agent<
           memory,
           agentName: this.name,
           runtimeContext,
+          tracingContext,
           model: typeof this.model === 'function' ? await this.getModel({ runtimeContext }) : this.model,
-          agentAISpan,
         };
         const convertedToCoreTool = makeCoreTool(toolObj, options);
         convertedMemoryTools[toolName] = convertedToCoreTool;
@@ -1009,10 +1014,12 @@ export class Agent<
 
   private async __runInputProcessors({
     runtimeContext,
+    tracingContext,
     messageList,
     inputProcessorOverrides,
   }: {
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     messageList: MessageList;
     inputProcessorOverrides?: InputProcessor[];
   }): Promise<{
@@ -1029,15 +1036,15 @@ export class Agent<
         inputProcessorOverrides,
       });
       // Create traced version of runInputProcessors similar to workflow _runStep pattern
-      const tracedRunInputProcessors = (messageList: MessageList) => {
+      const tracedRunInputProcessors = (messageList: MessageList, tracingContext: TracingContext) => {
         const telemetry = this.#mastra?.getTelemetry();
         if (!telemetry) {
-          return runner.runInputProcessors(messageList, undefined);
+          return runner.runInputProcessors(messageList, tracingContext, undefined);
         }
 
         return telemetry.traceMethod(
           async (data: { messageList: MessageList }) => {
-            return runner.runInputProcessors(data.messageList, telemetry);
+            return runner.runInputProcessors(data.messageList, tracingContext, telemetry);
           },
           {
             spanName: `agent.${this.name}.inputProcessors`,
@@ -1051,7 +1058,7 @@ export class Agent<
       };
 
       try {
-        messageList = await tracedRunInputProcessors(messageList);
+        messageList = await tracedRunInputProcessors(messageList, tracingContext);
       } catch (error) {
         if (error instanceof TripWire) {
           tripwireTriggered = true;
@@ -1079,10 +1086,12 @@ export class Agent<
 
   private async __runOutputProcessors({
     runtimeContext,
+    tracingContext,
     messageList,
     outputProcessorOverrides,
   }: {
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     messageList: MessageList;
     outputProcessorOverrides?: OutputProcessor[];
   }): Promise<{
@@ -1100,15 +1109,15 @@ export class Agent<
       });
 
       // Create traced version of runOutputProcessors similar to workflow _runStep pattern
-      const tracedRunOutputProcessors = (messageList: MessageList) => {
+      const tracedRunOutputProcessors = (messageList: MessageList, tracingContext: TracingContext) => {
         const telemetry = this.#mastra?.getTelemetry();
         if (!telemetry) {
-          return runner.runOutputProcessors(messageList, undefined);
+          return runner.runOutputProcessors(messageList, tracingContext, undefined);
         }
 
         return telemetry.traceMethod(
           async (data: { messageList: MessageList }) => {
-            return runner.runOutputProcessors(data.messageList, telemetry);
+            return runner.runOutputProcessors(data.messageList, tracingContext, telemetry);
           },
           {
             spanName: `agent.${this.name}.outputProcessors`,
@@ -1122,7 +1131,7 @@ export class Agent<
       };
 
       try {
-        messageList = await tracedRunOutputProcessors(messageList);
+        messageList = await tracedRunOutputProcessors(messageList, tracingContext);
       } catch (e) {
         if (e instanceof TripWire) {
           tripwireTriggered = true;
@@ -1170,21 +1179,21 @@ export class Agent<
   }
 
   private async getAssignedTools({
-    runtimeContext,
     runId,
     resourceId,
     threadId,
+    runtimeContext,
+    tracingContext,
     mastraProxy,
     writableStream,
-    agentAISpan,
   }: {
     runId?: string;
     resourceId?: string;
     threadId?: string;
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     mastraProxy?: MastraUnion;
     writableStream?: WritableStream<ChunkType>;
-    agentAISpan?: AnyAISpan;
   }) {
     let toolsForRequest: Record<string, CoreTool> = {};
 
@@ -1214,9 +1223,9 @@ export class Agent<
           memory,
           agentName: this.name,
           runtimeContext,
+          tracingContext,
           model: typeof this.model === 'function' ? await this.getModel({ runtimeContext }) : this.model,
           writableStream,
-          agentAISpan,
         };
         return [k, makeCoreTool(tool, options)];
       }),
@@ -1239,16 +1248,16 @@ export class Agent<
     resourceId,
     toolsets,
     runtimeContext,
+    tracingContext,
     mastraProxy,
-    agentAISpan,
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     toolsets: ToolsetsInput;
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     mastraProxy?: MastraUnion;
-    agentAISpan?: AnyAISpan;
   }) {
     let toolsForRequest: Record<string, CoreTool> = {};
 
@@ -1272,8 +1281,8 @@ export class Agent<
             memory,
             agentName: this.name,
             runtimeContext,
+            tracingContext,
             model: typeof this.model === 'function' ? await this.getModel({ runtimeContext }) : this.model,
-            agentAISpan,
           };
           const convertedToCoreTool = makeCoreTool(toolObj, options, 'toolset');
           toolsForRequest[toolName] = convertedToCoreTool;
@@ -1289,17 +1298,17 @@ export class Agent<
     threadId,
     resourceId,
     runtimeContext,
+    tracingContext,
     mastraProxy,
     clientTools,
-    agentAISpan,
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     mastraProxy?: MastraUnion;
     clientTools?: ToolsInput;
-    agentAISpan?: AnyAISpan;
   }) {
     let toolsForRequest: Record<string, CoreTool> = {};
     const memory = await this.getMemory({ runtimeContext });
@@ -1321,8 +1330,8 @@ export class Agent<
           memory,
           agentName: this.name,
           runtimeContext,
+          tracingContext,
           model: typeof this.model === 'function' ? await this.getModel({ runtimeContext }) : this.model,
-          agentAISpan,
         };
         const convertedToCoreTool = makeCoreTool(rest, options, 'client-tool');
         toolsForRequest[toolName] = convertedToCoreTool;
@@ -1337,13 +1346,13 @@ export class Agent<
     threadId,
     resourceId,
     runtimeContext,
-    agentAISpan,
+    tracingContext,
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     runtimeContext: RuntimeContext;
-    agentAISpan?: AnyAISpan;
+    tracingContext: TracingContext;
   }) {
     let convertedWorkflowTools: Record<string, CoreTool> = {};
     const workflows = await this.getWorkflows({ runtimeContext });
@@ -1356,7 +1365,7 @@ export class Agent<
             // manually wrap workflow tools with ai tracing, so that we can pass the
             // current tool span onto the workflow to maintain continuity of the trace
             execute: async (args: any) => {
-              const toolAISpan = agentAISpan?.createChildSpan({
+              const toolAISpan = tracingContext.currentSpan?.createChildSpan({
                 type: AISpanType.TOOL_CALL,
                 name: `tool: '${workflowName}'`,
                 input: args,
@@ -1381,7 +1390,7 @@ export class Agent<
                 const result = await run.start({
                   inputData: args,
                   runtimeContext,
-                  currentSpan: toolAISpan,
+                  tracingContext: { currentSpan: toolAISpan },
                 });
                 toolAISpan?.end({ output: result });
                 return result;
@@ -1424,8 +1433,8 @@ export class Agent<
     resourceId,
     runId,
     runtimeContext,
+    tracingContext,
     writableStream,
-    agentAISpan,
   }: {
     toolsets?: ToolsetsInput;
     clientTools?: ToolsInput;
@@ -1433,8 +1442,8 @@ export class Agent<
     resourceId?: string;
     runId?: string;
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     writableStream?: WritableStream<ChunkType>;
-    agentAISpan?: AnyAISpan;
   }): Promise<Record<string, CoreTool>> {
     let mastraProxy = undefined;
     const logger = this.logger;
@@ -1448,9 +1457,9 @@ export class Agent<
       resourceId,
       threadId,
       runtimeContext,
+      tracingContext,
       mastraProxy,
       writableStream,
-      agentAISpan,
     });
 
     const memoryTools = await this.getMemoryTools({
@@ -1458,8 +1467,8 @@ export class Agent<
       resourceId,
       threadId,
       runtimeContext,
+      tracingContext,
       mastraProxy,
-      agentAISpan,
     });
 
     const toolsetTools = await this.getToolsets({
@@ -1467,9 +1476,9 @@ export class Agent<
       resourceId,
       threadId,
       runtimeContext,
+      tracingContext,
       mastraProxy,
       toolsets: toolsets!,
-      agentAISpan,
     });
 
     const clientSideTools = await this.getClientTools({
@@ -1477,9 +1486,9 @@ export class Agent<
       resourceId,
       threadId,
       runtimeContext,
+      tracingContext,
       mastraProxy,
       clientTools: clientTools!,
-      agentAISpan,
     });
 
     const workflowTools = await this.getWorkflowTools({
@@ -1487,7 +1496,7 @@ export class Agent<
       resourceId,
       threadId,
       runtimeContext,
-      agentAISpan,
+      tracingContext,
     });
 
     return this.formatTools({
@@ -1587,7 +1596,7 @@ export class Agent<
     runtimeContext,
     saveQueueManager,
     writableStream,
-    currentSpan,
+    tracingContext,
   }: {
     instructions: string;
     toolsets?: ToolsetsInput;
@@ -1601,7 +1610,7 @@ export class Agent<
     runtimeContext: RuntimeContext;
     saveQueueManager: SaveQueueManager;
     writableStream?: WritableStream<ChunkType>;
-    currentSpan?: AnyAISpan;
+    tracingContext?: TracingContext;
   }) {
     return {
       before: async () => {
@@ -1609,8 +1618,10 @@ export class Agent<
           this.logger.debug(`[Agents:${this.name}] - Starting generation`, { runId });
         }
 
-        const spanArgs = {
+        const agentAISpan = getOrCreateSpan({
+          type: AISpanType.AGENT_RUN,
           name: `agent run: '${this.id}'`,
+          input: messages,
           attributes: {
             agentId: this.id,
             instructions,
@@ -1624,27 +1635,11 @@ export class Agent<
             resourceId,
             threadId: thread ? thread.id : undefined,
           },
-        };
+          tracingContext,
+          runtimeContext,
+        });
 
-        // if currentSpan passed, use it to build agentSpan
-        // otherwise, attempt to create new trace
-        let agentAISpan: AISpan<AISpanType.AGENT_RUN> | undefined;
-        if (currentSpan) {
-          agentAISpan = currentSpan.createChildSpan({ type: AISpanType.AGENT_RUN, ...spanArgs });
-        } else {
-          const aiTracing = getSelectedAITracing({
-            runtimeContext: runtimeContext,
-          });
-          if (aiTracing) {
-            agentAISpan = aiTracing.startSpan({
-              type: AISpanType.AGENT_RUN,
-              ...spanArgs,
-              startOptions: {
-                runtimeContext,
-              },
-            });
-          }
-        }
+        const innerTracingContext: TracingContext = { currentSpan: agentAISpan };
 
         const memory = await this.getMemory({ runtimeContext });
 
@@ -1676,8 +1671,8 @@ export class Agent<
           resourceId,
           runId,
           runtimeContext,
+          tracingContext: innerTracingContext,
           writableStream,
-          agentAISpan,
         });
 
         const messageList = new MessageList({
@@ -1697,6 +1692,7 @@ export class Agent<
           messageList.add(messages, 'user');
           const { tripwireTriggered, tripwireReason } = await this.__runInputProcessors({
             runtimeContext,
+            tracingContext: innerTracingContext,
             messageList,
           });
           return {
@@ -1835,6 +1831,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
         const { tripwireTriggered, tripwireReason } = await this.__runInputProcessors({
           runtimeContext,
+          tracingContext: innerTracingContext,
           messageList,
         });
 
@@ -1923,17 +1920,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
             };
           }),
         };
-        agentAISpan?.end({
-          output: {
-            text: result?.text,
-            object: result?.object,
-          },
-          metadata: {
-            usage: result?.usage,
-            toolResults: result?.toolResults,
-            toolCalls: result?.toolCalls,
-          },
-        });
+
         this.logger.debug(`[Agent:${this.name}] - Post processing LLM response`, {
           runId,
           result: resToLog,
@@ -2013,7 +2000,13 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
               if (shouldGenerate && userMessage) {
                 promises.push(
-                  this.genTitle(userMessage, runtimeContext, titleModel, titleInstructions).then(title => {
+                  this.genTitle(
+                    userMessage,
+                    runtimeContext,
+                    { currentSpan: agentAISpan },
+                    titleModel,
+                    titleInstructions,
+                  ).then(title => {
                     if (title) {
                       return memory.createThread({
                         threadId: thread.id,
@@ -2032,6 +2025,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           } catch (e) {
             await saveQueueManager.flushMessages(messageList, threadId, memoryConfig);
             if (e instanceof MastraError) {
+              agentAISpan?.error({ error: e });
               throw e;
             }
             const mastraError = new MastraError(
@@ -2050,6 +2044,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
             );
             this.logger.trackException(mastraError);
             this.logger.error(mastraError.toString());
+            agentAISpan?.error({ error: mastraError });
             throw mastraError;
           }
         } else {
@@ -2078,6 +2073,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           outputText,
           instructions,
           runtimeContext,
+          tracingContext: { currentSpan: agentAISpan },
           structuredOutput,
           overrideScorers,
           threadId,
@@ -2097,6 +2093,18 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           output: messageList.getPersisted.response.ui(),
         };
 
+        agentAISpan?.end({
+          output: {
+            text: result?.text,
+            object: result?.object,
+          },
+          metadata: {
+            usage: result?.usage,
+            toolResults: result?.toolResults,
+            toolCalls: result?.toolCalls,
+          },
+        });
+
         return {
           scoringData,
         };
@@ -2110,6 +2118,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     outputText,
     instructions,
     runtimeContext,
+    tracingContext,
     structuredOutput,
     overrideScorers,
     threadId,
@@ -2120,6 +2129,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     outputText: string;
     instructions: string;
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     structuredOutput?: boolean;
     overrideScorers?:
       | MastraScorers
@@ -2175,6 +2185,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           input: scorerInput,
           output: scorerOutput,
           runtimeContext,
+          tracingContext,
           entity: {
             id: this.id,
             name: this.name,
@@ -2245,8 +2256,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
               experimental_output?: never;
             },
         'runId'
-      > & { runId: string } & TripwireProperties &
-        AgentAISpanProperties
+      > & { runId: string } & TripwireProperties & { agentAISpan?: AISpan<AISpanType.AGENT_RUN> }
     >;
     after: (args: {
       result: GenerateReturn<any, Output, ExperimentalOutput>;
@@ -2281,8 +2291,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
               experimental_output?: never;
             },
         'runId'
-      > & { runId: string } & TripwireProperties &
-        AgentAISpanProperties
+      > & { runId: string } & TripwireProperties & { agentAISpan?: AISpan<AISpanType.AGENT_RUN> }
     >;
     after: (args: {
       result: OriginalStreamTextOnFinishEventArg<any> | OriginalStreamObjectOnFinishEventArg<ExperimentalOutput>;
@@ -2320,8 +2329,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
                   experimental_output?: never;
                 },
             'runId'
-          > & { runId: string } & TripwireProperties &
-            AgentAISpanProperties
+          > & { runId: string } & TripwireProperties & { agentAISpan?: AISpan<AISpanType.AGENT_RUN> }
         >)
       | (() => Promise<
           Omit<
@@ -2332,8 +2340,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
                   experimental_output?: never;
                 },
             'runId'
-          > & { runId: string } & TripwireProperties &
-            AgentAISpanProperties
+          > & { runId: string } & TripwireProperties & { agentAISpan?: AISpan<AISpanType.AGENT_RUN> }
         >);
     after:
       | ((args: {
@@ -2372,6 +2379,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       temperature,
       toolChoice = 'auto',
       runtimeContext = new RuntimeContext(),
+      tracingContext,
       savePerStep,
       writableStream,
       ...args
@@ -2437,7 +2445,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       runtimeContext,
       saveQueueManager,
       writableStream,
-      currentSpan: args.tracingContext?.currentSpan,
+      tracingContext,
     });
 
     let messageList: MessageList;
@@ -2561,6 +2569,24 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     const runId = options.runId || this.#mastra?.generateId() || randomUUID();
     const instructions = options.instructions || (await this.getInstructions({ runtimeContext }));
 
+    // Set AI Tracing context
+    const agentAISpan = getOrCreateSpan({
+      type: AISpanType.AGENT_RUN,
+      name: `agent run: '${this.id}'`,
+      input: options.messages,
+      attributes: {
+        agentId: this.id,
+        instructions,
+      },
+      metadata: {
+        runId,
+        resourceId,
+        threadId: threadFromArgs ? threadFromArgs.id : undefined,
+      },
+      tracingContext: options.tracingContext,
+      runtimeContext,
+    });
+
     // Set Telemetry context
     // Set thread ID and resource ID context for telemetry
     const activeSpan = Telemetry.getActiveSpan();
@@ -2632,6 +2658,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           runId,
           runtimeContext,
           writableStream: options.writableStream,
+          tracingContext: { currentSpan: agentAISpan },
         });
 
         return {
@@ -2651,7 +2678,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
         tripwire: z.boolean().optional(),
         tripwireReason: z.string().optional(),
       }),
-      execute: async () => {
+      execute: async ({ tracingContext }) => {
         const thread = threadFromArgs;
         const messageList = new MessageList({
           threadId: thread?.id,
@@ -2670,6 +2697,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           messageList.add(options.messages, 'user');
           const { tripwireTriggered, tripwireReason } = await this.__runInputProcessors({
             runtimeContext,
+            tracingContext,
             messageList,
           });
           return {
@@ -2783,8 +2811,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
               if (!lastYmd || lastYmd !== ymd) {
                 result += `\nthe following messages are from ${ymd}\n`;
               }
-              result += `
-Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conversation' : ''} at ${timeofday}: ${JSON.stringify(msg)}`;
+              result += `Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conversation' : ''} at ${timeofday}: ${JSON.stringify(msg)}`;
 
               lastYmd = ymd;
             }
@@ -2806,6 +2833,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
         const { tripwireTriggered, tripwireReason } = await this.__runInputProcessors({
           runtimeContext,
+          tracingContext,
           messageList,
         });
 
@@ -2856,7 +2884,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       id: 'stream-text-step',
       inputSchema: z.any(),
       outputSchema: z.any(),
-      execute: async ({ inputData }) => {
+      execute: async ({ inputData, tracingContext }) => {
         this.logger.debug(`Starting agent ${this.name} llm stream call`, {
           runId,
         });
@@ -2874,6 +2902,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
         const streamResult = llm.stream({
           ...inputData,
           outputProcessors,
+          tracingContext,
         });
 
         if (options.format === 'aisdk') {
@@ -2891,7 +2920,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       steps: [prepareToolsStep, prepareMemory],
     })
       .parallel([prepareToolsStep, prepareMemory])
-      .map(async ({ inputData, bail }) => {
+      .map(async ({ inputData, bail, tracingContext }) => {
         const result = {
           ...options,
           messages: inputData['prepare-memory-step'].messageObjects,
@@ -2999,6 +3028,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
         const loopOptions: ModelLoopStreamArgs<any, OUTPUT> = {
           messages: result.messages as ModelMessage[],
           runtimeContext: result.runtimeContext!,
+          tracingContext: { currentSpan: agentAISpan },
           runId,
           toolChoice: result.toolChoice,
           tools: result.tools,
@@ -3037,6 +3067,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
                   resourceId,
                   memoryConfig,
                   runtimeContext,
+                  tracingContext,
                   runId,
                   messageList,
                   threadExists: inputData['prepare-memory-step'].threadExists,
@@ -3068,8 +3099,11 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       .commit();
 
     const run = await executionWorkflow.createRunAsync();
+    const result = await run.start({ tracingContext: { currentSpan: agentAISpan } });
 
-    return await run.start({});
+    agentAISpan?.end({ output: result });
+
+    return result;
   }
 
   async #executeOnFinish({
@@ -3081,6 +3115,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     memoryConfig,
     outputText,
     runtimeContext,
+    tracingContext,
     runId,
     messageList,
     threadExists,
@@ -3095,6 +3130,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     threadId?: string;
     resourceId?: string;
     runtimeContext: RuntimeContext;
+    tracingContext: TracingContext;
     memoryConfig: MemoryConfig | undefined;
     outputText: string;
     messageList: MessageList;
@@ -3195,7 +3231,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
           if (shouldGenerate && userMessage) {
             promises.push(
-              this.genTitle(userMessage, runtimeContext, titleModel, titleInstructions).then(title => {
+              this.genTitle(userMessage, runtimeContext, tracingContext, titleModel, titleInstructions).then(title => {
                 if (title) {
                   return memory.createThread({
                     threadId: thread.id,
@@ -3260,6 +3296,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       outputText,
       instructions,
       runtimeContext,
+      tracingContext,
       structuredOutput,
       overrideScorers,
     });
@@ -3443,6 +3480,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
     const { experimental_output, output, agentAISpan, ...llmOptions } = beforeResult;
 
+    const tracingContext: TracingContext = { currentSpan: agentAISpan };
+
     // Handle structuredOutput option by creating an StructuredOutputProcessor
     let finalOutputProcessors = mergedGenerateOptions.outputProcessors;
     if (mergedGenerateOptions.structuredOutput) {
@@ -3455,12 +3494,13 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     if (!output || experimental_output) {
       const result = await llmToUse.__text<any, EXPERIMENTAL_OUTPUT>({
         ...llmOptions,
-        agentAISpan,
+        tracingContext,
         experimental_output,
       });
 
       const outputProcessorResult = await this.__runOutputProcessors({
         runtimeContext: mergedGenerateOptions.runtimeContext || new RuntimeContext(),
+        tracingContext,
         outputProcessorOverrides: finalOutputProcessors,
         messageList: new MessageList({
           threadId: llmOptions.threadId || '',
@@ -3570,7 +3610,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
     const result = await llmToUse.__textObject<NonNullable<OUTPUT>>({
       ...llmOptions,
-      agentAISpan,
+      tracingContext,
       structuredOutput: output as NonNullable<OUTPUT>,
     });
 
@@ -3578,6 +3618,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
     const outputProcessorResult = await this.__runOutputProcessors({
       runtimeContext: mergedGenerateOptions.runtimeContext || new RuntimeContext(),
+      tracingContext,
       messageList: new MessageList({
         threadId: llmOptions.threadId || '',
         resourceId: llmOptions.resourceId || '',
@@ -3788,6 +3829,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     const { onFinish, runId, output, experimental_output, agentAISpan, ...llmOptions } = beforeResult;
 
     const overrideScorers = mergedStreamOptions.scorers;
+    const tracingContext: TracingContext = { currentSpan: agentAISpan };
+
     if (!output || experimental_output) {
       this.logger.debug(`Starting agent ${this.name} llm stream call`, {
         runId,
@@ -3796,7 +3839,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       const streamResult = llm.__stream({
         ...llmOptions,
         experimental_output,
-        agentAISpan,
+        tracingContext,
         onFinish: async result => {
           try {
             const outputText = result.text;
@@ -3828,7 +3871,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
     return llm.__streamObject({
       ...llmOptions,
-      agentAISpan,
+      tracingContext,
       onFinish: async result => {
         try {
           const outputText = JSON.stringify(result.object);

--- a/packages/core/src/agent/input-processor/processors/language-detector.ts
+++ b/packages/core/src/agent/input-processor/processors/language-detector.ts
@@ -1,4 +1,3 @@
-import type { TracingContext } from '../../../ai-tracing';
 import { LanguageDetector } from '../../../processors/processors/language-detector';
 import type {
   LanguageDetectorOptions,

--- a/packages/core/src/agent/input-processor/processors/language-detector.ts
+++ b/packages/core/src/agent/input-processor/processors/language-detector.ts
@@ -1,3 +1,4 @@
+import type { TracingContext } from '../../../ai-tracing';
 import { LanguageDetector } from '../../../processors/processors/language-detector';
 import type {
   LanguageDetectorOptions,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,7 +1,7 @@
 import type { GenerateTextOnStepFinishCallback, TelemetrySettings } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema, ZodTypeAny } from 'zod';
-import type { AISpan, AISpanType, TracingContext } from '../ai-tracing';
+import type { TracingContext } from '../ai-tracing';
 import type { Metric } from '../eval';
 import type {
   CoreMessage,
@@ -33,10 +33,6 @@ export type { MastraMessageV2, MastraMessageContentV2, UIMessageWithMetadata, Me
 export type { Message as AiMessageType } from 'ai';
 
 export type ToolsInput = Record<string, ToolAction<any, any, any> | VercelTool | VercelToolV5>;
-
-export type AgentAISpanProperties = {
-  agentAISpan?: AISpan<AISpanType.AGENT_RUN>;
-};
 
 export type ToolsetsInput = Record<string, ToolsInput>;
 

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -18,7 +18,7 @@ import type {
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema } from 'zod';
 
-import type { AISpan, AISpanType } from '../ai-tracing';
+import type { TracingContext } from '../ai-tracing';
 import type { Run } from '../run/types';
 import type { RuntimeContext } from '../runtime-context';
 import type { CoreTool } from '../tools/types';
@@ -109,7 +109,7 @@ type MastraCustomLLMOptions<Z extends ZodSchema | JSONSchema7 | undefined = unde
   threadId?: string;
   resourceId?: string;
   runtimeContext: RuntimeContext;
-  agentAISpan?: AISpan<AISpanType.AGENT_RUN>;
+  tracingContext: TracingContext;
 } & Run;
 
 export type LLMTextOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {

--- a/packages/core/src/llm/model/base.types.ts
+++ b/packages/core/src/llm/model/base.types.ts
@@ -21,7 +21,7 @@ import type {
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
 import type { MessageList } from '../../agent/types';
-import type { AISpan, AISpanType } from '../../ai-tracing';
+import type { TracingContext } from '../../ai-tracing';
 import type { RuntimeContext } from '../../runtime-context';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '../../scores';
 import type { inferOutput, ScoringProperties, TripwireProperties } from './shared.types';
@@ -34,8 +34,8 @@ type MastraCustomLLMOptions = {
   threadId?: string;
   resourceId?: string;
   runtimeContext: RuntimeContext;
+  tracingContext: TracingContext;
   runId?: string;
-  agentAISpan?: AISpan<AISpanType.AGENT_RUN>;
 };
 type MastraCustomLLMOptionsKeys = keyof MastraCustomLLMOptions;
 

--- a/packages/core/src/llm/model/model.loop.types.ts
+++ b/packages/core/src/llm/model/model.loop.types.ts
@@ -9,6 +9,7 @@ import type {
 } from 'ai-v5';
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema } from 'zod';
+import type { TracingContext } from '../../ai-tracing';
 import type { LoopOptions } from '../../loop/types';
 import type { StructuredOutputOptions, OutputProcessor } from '../../processors';
 import type { RuntimeContext } from '../../runtime-context';
@@ -41,6 +42,7 @@ export type ModelLoopStreamArgs<
   structuredOutput?: STRUCTURED_OUTPUT extends z.ZodTypeAny ? StructuredOutputOptions<STRUCTURED_OUTPUT> : never;
   outputProcessors?: OutputProcessor[];
   runtimeContext: RuntimeContext;
+  tracingContext: TracingContext;
   resourceId?: string;
   threadId?: string;
 } & Omit<LoopOptions<TOOLS, OUTPUT>, 'model' | 'messageList'>;

--- a/packages/core/src/llm/model/model.test.ts
+++ b/packages/core/src/llm/model/model.test.ts
@@ -17,6 +17,7 @@ describe('MastraLLM', () => {
   };
 
   const runtimeContext = new RuntimeContext();
+  const tracingContext = {};
 
   const mockTools = {
     testTool: makeCoreTool(
@@ -33,6 +34,7 @@ describe('MastraLLM', () => {
         logger: mockMastra.logger,
         mastra: mockMastra as any,
         runtimeContext,
+        tracingContext,
       },
     ),
   };
@@ -85,6 +87,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -103,6 +106,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         output: schema,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -115,6 +119,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -127,6 +132,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -141,6 +147,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -156,6 +163,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -171,6 +179,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -182,6 +191,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -193,6 +203,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -210,6 +221,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -231,6 +243,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -248,6 +261,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -269,6 +283,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -285,6 +300,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -301,6 +317,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -315,6 +332,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -330,6 +348,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -352,6 +371,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -367,6 +387,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -389,6 +410,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -405,6 +427,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -419,6 +442,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -433,6 +457,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -450,6 +475,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -465,6 +491,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -496,6 +523,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -515,6 +543,7 @@ describe('MastraLLM', () => {
         runtimeContext,
         structuredOutput: schema,
         temperature: 0.7,
+        tracingContext,
       });
 
       expect(result?.object?.content).toEqual('Custom object response');
@@ -530,6 +559,7 @@ describe('MastraLLM', () => {
         structuredOutput: arraySchema,
         temperature: 0.7,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -551,6 +581,7 @@ describe('MastraLLM', () => {
         structuredOutput: jsonSchema,
         temperature: 0.7,
         runtimeContext,
+        tracingContext,
       });
 
       expect(generateSpy).toHaveBeenCalled();
@@ -569,6 +600,7 @@ describe('MastraLLM', () => {
         structuredOutput: schema,
         temperature: 0.7,
         runtimeContext,
+        tracingContext,
       });
     });
   });
@@ -587,6 +619,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -602,6 +635,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -623,6 +657,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -644,6 +679,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -663,6 +699,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -681,6 +718,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();
@@ -701,6 +739,7 @@ describe('MastraLLM', () => {
         temperature: 0.7,
         maxSteps: 5,
         runtimeContext,
+        tracingContext,
       });
 
       expect(streamSpy).toHaveBeenCalled();

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { MastraPrimitives } from '../../action';
 import { AISpanType } from '../../ai-tracing';
-import type { AISpan, AnyAISpan } from '../../ai-tracing';
+import type { AnyAISpan, TracingContext } from '../../ai-tracing';
 import { MastraBase } from '../../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { Mastra } from '../../mastra';
@@ -41,6 +41,7 @@ import type {
   StreamReturn,
 } from './base.types';
 import type { inferOutput } from './shared.types';
+import { parallel } from 'radash';
 
 export class MastraLLMV1 extends MastraBase {
   #model: LanguageModel;
@@ -113,14 +114,15 @@ export class MastraLLMV1 extends MastraBase {
     });
   }
 
-  private _startAISpan(
-    model: LanguageModel,
-    agentAISpan: AISpan<AISpanType.AGENT_RUN>,
-    name: string,
-    streaming: boolean,
-    options: any,
-  ): AnyAISpan {
-    return agentAISpan?.createChildSpan({
+  private _startAISpan(parmams: {
+    model: LanguageModel;
+    tracingContext: TracingContext;
+    name: string;
+    streaming: boolean;
+    options: any;
+  }): AnyAISpan | undefined {
+    const { model, tracingContext, name, streaming, options } = parmams;
+    return tracingContext.currentSpan?.createChildSpan({
       name,
       type: AISpanType.LLM_GENERATION,
       input: options.prompt,
@@ -140,18 +142,24 @@ export class MastraLLMV1 extends MastraBase {
     });
   }
 
-  private _wrapModel(model: LanguageModel, agentAISpan?: AISpan<AISpanType.AGENT_RUN>): LanguageModel {
-    if (!agentAISpan) {
+  private _wrapModel(model: LanguageModel, tracingContext: TracingContext): LanguageModel {
+    if (!tracingContext.currentSpan) {
       return model;
     }
 
     const wrappedDoGenerate = async (options: any) => {
-      const llmSpan = this._startAISpan(model, agentAISpan, `llm generate: '${model.modelId}'`, false, options);
+      const llmSpan = this._startAISpan({
+        model,
+        tracingContext,
+        name: `llm generate: '${model.modelId}'`,
+        streaming: false,
+        options,
+      });
 
       try {
         const result = await model.doGenerate(options);
 
-        llmSpan.end({
+        llmSpan?.end({
           output: result.text,
           attributes: {
             usage: result.usage
@@ -164,13 +172,19 @@ export class MastraLLMV1 extends MastraBase {
         });
         return result;
       } catch (error) {
-        llmSpan.error({ error: error as Error });
+        llmSpan?.error({ error: error as Error });
         throw error;
       }
     };
 
     const wrappedDoStream = async (options: any) => {
-      const llmSpan = this._startAISpan(model, agentAISpan, `llm stream: '${model.modelId}'`, true, options);
+      const llmSpan = this._startAISpan({
+        model,
+        tracingContext,
+        name: `llm stream: '${model.modelId}'`,
+        streaming: true,
+        options,
+      });
 
       try {
         const result = await model.doStream(options);
@@ -184,7 +198,18 @@ export class MastraLLMV1 extends MastraBase {
           new TransformStream({
             // this gets called on each chunk output
             transform(chunk, controller) {
-              //TODO: Would be great to export chunks as events on the span
+              // Create event spans for text chunks
+              if (chunk.type === 'text-delta') {
+                llmSpan?.createEventSpan({
+                  type: AISpanType.LLM_CHUNK,
+                  name: `llm chunk: ${chunk.type}`,
+                  output: chunk.textDelta,
+                  attributes: {
+                    chunkType: chunk.type,
+                  },
+                });
+              }
+
               //TODO: Figure out how to get the final usage
               // if (chunk.type === 'response-metadata' && chunk.usage) {
               //   finalUsage = chunk.usage;
@@ -197,7 +222,7 @@ export class MastraLLMV1 extends MastraBase {
             },
             // this gets called at the end of the stream
             flush() {
-              llmSpan.end({
+              llmSpan?.end({
                 attributes: {
                   usage: finalUsage
                     ? {
@@ -220,7 +245,7 @@ export class MastraLLMV1 extends MastraBase {
           stream: wrappedStream,
         };
       } catch (error) {
-        llmSpan.error({ error: error as Error });
+        llmSpan?.error({ error: error as Error });
         throw error;
       }
     };
@@ -248,7 +273,7 @@ export class MastraLLMV1 extends MastraBase {
     threadId,
     resourceId,
     runtimeContext,
-    agentAISpan,
+    tracingContext,
     ...rest
   }: GenerateTextWithMessagesArgs<Tools, Z>): Promise<GenerateTextResult<Tools, Z>> {
     const model = this.#model;
@@ -296,7 +321,7 @@ export class MastraLLMV1 extends MastraBase {
     const argsForExecute: OriginalGenerateTextOptions<Tools, Z> = {
       ...rest,
       messages,
-      model: this._wrapModel(model, agentAISpan),
+      model: this._wrapModel(model, tracingContext),
       temperature,
       tools: {
         ...(tools as Tools),
@@ -393,7 +418,7 @@ export class MastraLLMV1 extends MastraBase {
     threadId,
     resourceId,
     runtimeContext,
-    agentAISpan,
+    tracingContext,
     ...rest
   }: GenerateObjectWithMessagesArgs<Z>): Promise<GenerateObjectResult<Z>> {
     const model = this.#model;
@@ -412,7 +437,7 @@ export class MastraLLMV1 extends MastraBase {
       const argsForExecute: OriginalGenerateObjectOptions<Z> = {
         ...rest,
         messages,
-        model: this._wrapModel(model, agentAISpan),
+        model: this._wrapModel(model, tracingContext),
         // @ts-expect-error - output in our implementation can only be object or array
         output,
         schema: processedSchema as Schema<Z>,
@@ -481,7 +506,7 @@ export class MastraLLMV1 extends MastraBase {
     threadId,
     resourceId,
     runtimeContext,
-    agentAISpan,
+    tracingContext,
     ...rest
   }: StreamTextWithMessagesArgs<Tools, Z>): StreamTextResult<Tools, Z> {
     const model = this.#model;
@@ -510,7 +535,7 @@ export class MastraLLMV1 extends MastraBase {
     }
 
     const argsForExecute: OriginalStreamTextOptions<Tools, Z> = {
-      model: this._wrapModel(model, agentAISpan),
+      model: this._wrapModel(model, tracingContext),
       temperature,
       tools: {
         ...(tools as Tools),
@@ -643,7 +668,7 @@ export class MastraLLMV1 extends MastraBase {
     onFinish,
     structuredOutput,
     telemetry,
-    agentAISpan,
+    tracingContext,
     ...rest
   }: StreamObjectWithMessagesArgs<T>): StreamObjectResult<T> {
     const model = this.#model;
@@ -663,7 +688,7 @@ export class MastraLLMV1 extends MastraBase {
 
       const argsForExecute: OriginalStreamObjectOptions<T> = {
         ...rest,
-        model: this._wrapModel(model, agentAISpan),
+        model: this._wrapModel(model, tracingContext),
         onFinish: async props => {
           try {
             // @ts-expect-error - onFinish is not inferred correctly

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -113,14 +113,14 @@ export class MastraLLMV1 extends MastraBase {
     });
   }
 
-  private _startAISpan(parmams: {
+  private _startAISpan(params: {
     model: LanguageModel;
     tracingContext: TracingContext;
     name: string;
     streaming: boolean;
     options: any;
   }): AnyAISpan | undefined {
-    const { model, tracingContext, name, streaming, options } = parmams;
+    const { model, tracingContext, name, streaming, options } = params;
     return tracingContext.currentSpan?.createChildSpan({
       name,
       type: AISpanType.LLM_GENERATION,

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -41,7 +41,6 @@ import type {
   StreamReturn,
 } from './base.types';
 import type { inferOutput } from './shared.types';
-import { parallel } from 'radash';
 
 export class MastraLLMV1 extends MastraBase {
   #model: LanguageModel;

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -20,6 +20,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
   _internal,
   mode = 'stream',
   outputProcessors,
+  llmAISpan,
   ...rest
 }: LoopOptions<Tools, OUTPUT>) {
   let loggerToUse =
@@ -85,6 +86,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
     telemetry_settings,
     modelSettings,
     outputProcessors,
+    llmAISpan,
     ...rest,
   };
 

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV2, SharedV2ProviderOptions } from '@ai-sdk/provider-
 import type { Span } from '@opentelemetry/api';
 import type { CallSettings, IdGenerator, StopCondition, TelemetrySettings, ToolChoice, ToolSet } from 'ai-v5';
 import type { MessageList } from '../agent/message-list';
+import type { AISpan, AISpanType } from '../ai-tracing';
 import type { IMastraLogger } from '../logger';
 import type { OutputProcessor } from '../processors';
 import type { OutputSchema } from '../stream/base/schema';
@@ -48,6 +49,7 @@ export type LoopOptions<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSc
   output?: OUTPUT;
   downloadRetries?: number;
   downloadConcurrency?: number;
+  llmAISpan?: AISpan<AISpanType.LLM_GENERATION>;
 };
 
 export type LoopRun<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchema | undefined = undefined> = LoopOptions<

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -1,4 +1,5 @@
 import type { MastraMessageV2 } from '../agent/message-list';
+import type { TracingContext } from '../ai-tracing';
 import type { ChunkType } from '../stream';
 
 export interface Processor {
@@ -10,6 +11,7 @@ export interface Processor {
   processInput?(args: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> | MastraMessageV2[];
 
   /**
@@ -22,6 +24,7 @@ export interface Processor {
     streamParts: ChunkType[];
     state: Record<string, any>;
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<ChunkType | null | undefined>;
 
   /**
@@ -30,6 +33,7 @@ export interface Processor {
   processOutputResult?(args: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> | MastraMessageV2[];
 }
 

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -2,10 +2,10 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
-import type { TracingContext } from '../../ai-tracing';
 
 /**
  * Confidence scores for each moderation category (0-1)

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -5,6 +5,7 @@ import { TripWire } from '../../agent/trip-wire';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
+import type { TracingContext } from '../../ai-tracing';
 
 /**
  * Confidence scores for each moderation category (0-1)
@@ -129,9 +130,10 @@ export class ModerationProcessor implements Processor {
   async processInput(args: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> {
     try {
-      const { messages, abort } = args;
+      const { messages, abort, tracingContext } = args;
 
       if (messages.length === 0) {
         return messages;
@@ -149,7 +151,7 @@ export class ModerationProcessor implements Processor {
           continue;
         }
 
-        const moderationResult = await this.moderateContent(textContent);
+        const moderationResult = await this.moderateContent(textContent, false, tracingContext);
         results.push(moderationResult);
 
         if (this.isModerationFlagged(moderationResult)) {
@@ -176,6 +178,7 @@ export class ModerationProcessor implements Processor {
   async processOutputResult(args: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> {
     return this.processInput(args);
   }
@@ -185,9 +188,10 @@ export class ModerationProcessor implements Processor {
     streamParts: ChunkType[];
     state: Record<string, any>;
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<ChunkType | null | undefined> {
     try {
-      const { part, streamParts, abort } = args;
+      const { part, streamParts, abort, tracingContext } = args;
 
       // Only process text-delta chunks for moderation
       if (part.type !== 'text-delta') {
@@ -197,7 +201,7 @@ export class ModerationProcessor implements Processor {
       // Build context from chunks based on chunkWindow (streamParts includes the current part)
       const contentToModerate = this.buildContextFromChunks(streamParts);
 
-      const moderationResult = await this.moderateContent(contentToModerate, true);
+      const moderationResult = await this.moderateContent(contentToModerate, true, tracingContext);
 
       if (this.isModerationFlagged(moderationResult)) {
         this.handleFlaggedContent(moderationResult, this.strategy, abort);
@@ -222,7 +226,11 @@ export class ModerationProcessor implements Processor {
   /**
    * Moderate content using the internal agent
    */
-  private async moderateContent(content: string, isStream = false): Promise<ModerationResult> {
+  private async moderateContent(
+    content: string,
+    isStream = false,
+    tracingContext?: TracingContext,
+  ): Promise<ModerationResult> {
     const prompt = this.createModerationPrompt(content, isStream);
 
     try {
@@ -248,11 +256,13 @@ export class ModerationProcessor implements Processor {
           modelSettings: {
             temperature: 0,
           },
+          tracingContext,
         });
       } else {
         response = await this.moderationAgent.generate(prompt, {
           output: schema,
           temperature: 0,
+          tracingContext,
         });
       }
 

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -6,6 +6,7 @@ import { TripWire } from '../../agent/trip-wire';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
+import type { TracingContext } from '../../ai-tracing';
 
 /**
  * PII categories for detection and redaction
@@ -178,9 +179,10 @@ export class PIIDetector implements Processor {
   async processInput(args: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> {
     try {
-      const { messages, abort } = args;
+      const { messages, abort, tracingContext } = args;
 
       if (messages.length === 0) {
         return messages;
@@ -197,7 +199,7 @@ export class PIIDetector implements Processor {
           continue;
         }
 
-        const detectionResult = await this.detectPII(textContent);
+        const detectionResult = await this.detectPII(textContent, tracingContext);
 
         if (this.isPIIFlagged(detectionResult)) {
           const processedMessage = this.handleDetectedPII(message, detectionResult, this.strategy, abort);
@@ -230,7 +232,7 @@ export class PIIDetector implements Processor {
   /**
    * Detect PII using the internal agent
    */
-  private async detectPII(content: string): Promise<PIIDetectionResult> {
+  private async detectPII(content: string, tracingContext?: TracingContext): Promise<PIIDetectionResult> {
     const prompt = this.createDetectionPrompt(content);
 
     const schema = z.object({
@@ -269,11 +271,13 @@ export class PIIDetector implements Processor {
           modelSettings: {
             temperature: 0,
           },
+          tracingContext,
         });
       } else {
         response = await this.detectionAgent.generate(prompt, {
           output: schema,
           temperature: 0,
+          tracingContext,
         });
       }
 
@@ -528,8 +532,9 @@ IMPORTANT: IF NO PII IS DETECTED, RETURN AN EMPTY OBJECT, DO NOT INCLUDE ANYTHIN
     streamParts: ChunkType[];
     state: Record<string, any>;
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<ChunkType | null> {
-    const { part, abort } = args;
+    const { part, abort, tracingContext } = args;
     try {
       // Only process text-delta chunks
       if (part.type !== 'text-delta') {
@@ -541,7 +546,7 @@ IMPORTANT: IF NO PII IS DETECTED, RETURN AN EMPTY OBJECT, DO NOT INCLUDE ANYTHIN
         return part;
       }
 
-      const detectionResult = await this.detectPII(textContent);
+      const detectionResult = await this.detectPII(textContent, tracingContext);
 
       if (this.isPIIFlagged(detectionResult)) {
         switch (this.strategy) {

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -3,10 +3,10 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
-import type { TracingContext } from '../../ai-tracing';
 
 /**
  * PII categories for detection and redaction

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -4,6 +4,7 @@ import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';
+import type { TracingContext } from '../../ai-tracing';
 
 /**
  * Confidence scores for each detection category (0-1)
@@ -110,9 +111,10 @@ export class PromptInjectionDetector implements Processor {
   async processInput(args: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> {
     try {
-      const { messages, abort } = args;
+      const { messages, abort, tracingContext } = args;
 
       if (messages.length === 0) {
         return messages;
@@ -130,7 +132,7 @@ export class PromptInjectionDetector implements Processor {
           continue;
         }
 
-        const detectionResult = await this.detectPromptInjection(textContent);
+        const detectionResult = await this.detectPromptInjection(textContent, tracingContext);
         results.push(detectionResult);
 
         if (this.isInjectionFlagged(detectionResult)) {
@@ -163,7 +165,10 @@ export class PromptInjectionDetector implements Processor {
   /**
    * Detect prompt injection using the internal agent
    */
-  private async detectPromptInjection(content: string): Promise<PromptInjectionResult> {
+  private async detectPromptInjection(
+    content: string,
+    tracingContext?: TracingContext,
+  ): Promise<PromptInjectionResult> {
     const prompt = this.createDetectionPrompt(content);
     try {
       const model = await this.detectionAgent.getModel();
@@ -191,11 +196,13 @@ export class PromptInjectionDetector implements Processor {
           modelSettings: {
             temperature: 0,
           },
+          tracingContext,
         });
       } else {
         response = await this.detectionAgent.generate(prompt, {
           output: schema,
           temperature: 0,
+          tracingContext,
         });
       }
 

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -2,9 +2,9 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';
-import type { TracingContext } from '../../ai-tracing';
 
 /**
  * Confidence scores for each detection category (0-1)

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
-import type { TracingContext } from '../../ai-tracing';
 
 export interface SystemPromptScrubberOptions {
   /** Strategy to use when system prompts are detected: 'block' | 'warn' | 'filter' | 'redact' */

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -258,7 +258,7 @@ describe('ProcessorRunner', () => {
     describe('telemetry integration', () => {
       it('should use telemetry.traceMethod for individual processors when telemetry is provided', async () => {
         const mockTelemetry = {
-          traceMethod: vi.fn(fn => {
+          traceMethod: vi.fn((fn, _options) => {
             return () => fn({ messageList });
           }),
         };
@@ -281,7 +281,7 @@ describe('ProcessorRunner', () => {
         });
 
         messageList.add([createMessage('original', 'user')], 'user');
-        await runner.runInputProcessors(messageList, mockTelemetry);
+        await runner.runInputProcessors(messageList, undefined, mockTelemetry);
 
         expect(mockTelemetry.traceMethod).toHaveBeenCalledWith(expect.any(Function), {
           spanName: 'agent.inputProcessor.processor1',
@@ -437,7 +437,7 @@ describe('ProcessorRunner', () => {
     describe('telemetry integration', () => {
       it('should use telemetry.traceMethod for individual processors when telemetry is provided', async () => {
         const mockTelemetry = {
-          traceMethod: vi.fn(fn => {
+          traceMethod: vi.fn((fn, _options) => {
             return () => fn({ messageList });
           }),
         };
@@ -460,7 +460,7 @@ describe('ProcessorRunner', () => {
         });
 
         messageList.add([createMessage('original', 'assistant')], 'response');
-        await runner.runOutputProcessors(messageList, mockTelemetry);
+        await runner.runOutputProcessors(messageList, undefined, mockTelemetry);
 
         expect(mockTelemetry.traceMethod).toHaveBeenCalledWith(expect.any(Function), {
           spanName: 'agent.outputProcessor.processor1',

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -1,5 +1,6 @@
 import type { MastraMessageV2, MessageList } from '../agent/message-list';
 import { TripWire } from '../agent/trip-wire';
+import type { TracingContext } from '../ai-tracing';
 import type { IMastraLogger } from '../logger';
 import type { ChunkType } from '../stream';
 import type { MastraModelOutput } from '../stream/base/output';
@@ -48,7 +49,11 @@ export class ProcessorRunner {
     this.agentName = agentName;
   }
 
-  async runOutputProcessors(messageList: MessageList, telemetry?: any): Promise<MessageList> {
+  async runOutputProcessors(
+    messageList: MessageList,
+    tracingContext?: TracingContext,
+    telemetry?: any,
+  ): Promise<MessageList> {
     const responseMessages = messageList.clear.response.v2();
 
     let processableMessages: MastraMessageV2[] = [...responseMessages];
@@ -76,11 +81,15 @@ export class ProcessorRunner {
       }
 
       if (!telemetry) {
-        processableMessages = await processMethod({ messages: processableMessages, abort: ctx.abort });
+        processableMessages = await processMethod({ messages: processableMessages, abort: ctx.abort, tracingContext });
       } else {
         await telemetry.traceMethod(
           async () => {
-            processableMessages = await processMethod({ messages: processableMessages, abort: ctx.abort });
+            processableMessages = await processMethod({
+              messages: processableMessages,
+              abort: ctx.abort,
+              tracingContext,
+            });
             return processableMessages;
           },
           {
@@ -108,6 +117,7 @@ export class ProcessorRunner {
   async processPart(
     part: ChunkType,
     processorStates: Map<string, ProcessorState>,
+    tracingContext?: TracingContext,
   ): Promise<{
     part: ChunkType | null | undefined;
     blocked: boolean;
@@ -140,6 +150,7 @@ export class ProcessorRunner {
               abort: (reason?: string) => {
                 throw new TripWire(reason || `Stream part blocked by ${processor.name}`);
               },
+              tracingContext,
             });
 
             // If result is null, or undefined, don't emit
@@ -161,7 +172,10 @@ export class ProcessorRunner {
     }
   }
 
-  async runOutputProcessorsForStream(streamResult: MastraModelOutput): Promise<ReadableStream<any>> {
+  async runOutputProcessorsForStream(
+    streamResult: MastraModelOutput,
+    tracingContext: TracingContext,
+  ): Promise<ReadableStream<any>> {
     return new ReadableStream({
       start: async controller => {
         const reader = streamResult.fullStream.getReader();
@@ -177,7 +191,11 @@ export class ProcessorRunner {
             }
 
             // Process all stream parts through output processors
-            const { part: processedPart, blocked, reason } = await this.processPart(value, processorStates);
+            const {
+              part: processedPart,
+              blocked,
+              reason,
+            } = await this.processPart(value, processorStates, tracingContext);
 
             if (blocked) {
               // Log that part was blocked
@@ -206,7 +224,11 @@ export class ProcessorRunner {
     });
   }
 
-  async runInputProcessors(messageList: MessageList, telemetry?: any): Promise<MessageList> {
+  async runInputProcessors(
+    messageList: MessageList,
+    tracingContext: TracingContext,
+    telemetry?: any,
+  ): Promise<MessageList> {
     const userMessages = messageList.clear.input.v2();
 
     let processableMessages: MastraMessageV2[] = [...userMessages];
@@ -234,11 +256,15 @@ export class ProcessorRunner {
       }
 
       if (!telemetry) {
-        processableMessages = await processMethod({ messages: processableMessages, abort: ctx.abort });
+        processableMessages = await processMethod({ messages: processableMessages, abort: ctx.abort, tracingContext });
       } else {
         await telemetry.traceMethod(
           async () => {
-            processableMessages = await processMethod({ messages: processableMessages, abort: ctx.abort });
+            processableMessages = await processMethod({
+              messages: processableMessages,
+              abort: ctx.abort,
+              tracingContext,
+            });
             return processableMessages;
           },
           {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -174,7 +174,7 @@ export class ProcessorRunner {
 
   async runOutputProcessorsForStream(
     streamResult: MastraModelOutput,
-    tracingContext: TracingContext,
+    tracingContext?: TracingContext,
   ): Promise<ReadableStream<any>> {
     return new ReadableStream({
       start: async controller => {
@@ -226,7 +226,7 @@ export class ProcessorRunner {
 
   async runInputProcessors(
     messageList: MessageList,
-    tracingContext: TracingContext,
+    tracingContext?: TracingContext,
     telemetry?: any,
   ): Promise<MessageList> {
     const userMessages = messageList.clear.input.v2();

--- a/packages/core/src/scores/hooks.ts
+++ b/packages/core/src/scores/hooks.ts
@@ -1,3 +1,4 @@
+import type { TracingContext } from '../ai-tracing';
 import { AvailableHooks, executeHook } from '../hooks';
 import type { MastraScorerEntry } from './base';
 import type { ScoringEntityType, ScoringHookInput, ScoringSource } from './types';
@@ -9,6 +10,7 @@ export function runScorer({
   input,
   output,
   runtimeContext,
+  tracingContext,
   entity,
   structuredOutput,
   source,
@@ -22,6 +24,7 @@ export function runScorer({
   input: any;
   output: any;
   runtimeContext: Record<string, any>;
+  tracingContext: TracingContext;
   entity: Record<string, any>;
   structuredOutput: boolean;
   source: ScoringSource;
@@ -58,6 +61,7 @@ export function runScorer({
     input,
     output,
     runtimeContext: Object.fromEntries(runtimeContext.entries()),
+    tracingContext,
     runId,
     source,
     entity,

--- a/packages/core/src/scores/hooks.ts
+++ b/packages/core/src/scores/hooks.ts
@@ -24,7 +24,7 @@ export function runScorer({
   input: any;
   output: any;
   runtimeContext: Record<string, any>;
-  tracingContext: TracingContext;
+  tracingContext?: TracingContext;
   entity: Record<string, any>;
   structuredOutput: boolean;
   source: ScoringSource;

--- a/packages/core/src/scores/run-experiment/index.ts
+++ b/packages/core/src/scores/run-experiment/index.ts
@@ -1,5 +1,6 @@
 import type { CoreMessage } from 'ai';
 import type { Agent, AiMessageType, UIMessageWithMetadata } from '../../agent';
+import type { TracingContext } from '../../ai-tracing';
 import { MastraError } from '../../error';
 import type { RuntimeContext } from '../../runtime-context';
 import { Workflow } from '../../workflows';
@@ -15,6 +16,7 @@ type RunExperimentDataItem<TTarget = unknown> = {
       : unknown;
   groundTruth?: any;
   runtimeContext?: RuntimeContext;
+  tracingContext?: TracingContext;
 };
 
 type WorkflowScorerConfig = {
@@ -254,6 +256,7 @@ async function runScorers(
           output: targetResult.scoringData?.output,
           groundTruth: item.groundTruth,
           runtimeContext: item.runtimeContext,
+          tracingContext: item.tracingContext,
         });
 
         scorerResults[scorer.name] = score;
@@ -283,6 +286,7 @@ async function runScorers(
           output: targetResult.scoringData.output,
           groundTruth: item.groundTruth,
           runtimeContext: item.runtimeContext,
+          tracingContext: item.tracingContext,
         });
         workflowScorerResults[scorer.name] = score;
       }
@@ -304,6 +308,7 @@ async function runScorers(
                 output: stepResult.output,
                 groundTruth: item.groundTruth,
                 runtimeContext: item.runtimeContext,
+                tracingContext: item.tracingContext,
               });
               stepResults[scorer.name] = score;
             } catch (error) {

--- a/packages/core/src/scores/types.ts
+++ b/packages/core/src/scores/types.ts
@@ -1,6 +1,7 @@
 import type { CoreMessage, CoreSystemMessage } from 'ai';
 import { z } from 'zod';
 import type { UIMessageWithMetadata } from '../agent';
+import type { TracingContext } from '../ai-tracing';
 
 export type ScoringSamplingConfig = { type: 'none' } | { type: 'ratio'; rate: number };
 
@@ -19,6 +20,7 @@ export type ScoringInput = {
   output: Record<string, any>;
   additionalContext?: Record<string, any>;
   runtimeContext?: Record<string, any>;
+  tracingContext?: TracingContext;
 };
 
 export type ScoringHookInput = {
@@ -32,6 +34,7 @@ export type ScoringHookInput = {
   entity: Record<string, any>;
   entityType: ScoringEntityType;
   runtimeContext?: Record<string, any>;
+  tracingContext?: TracingContext;
   structuredOutput?: boolean;
   traceId?: string;
   resourceId?: string;

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -446,6 +446,7 @@ describe('CoreToolBuilder ID Preservation', () => {
         logger: console as any,
         description: 'A test tool',
         runtimeContext: new RuntimeContext(),
+        tracingContext: {},
       },
     });
 
@@ -469,6 +470,7 @@ describe('CoreToolBuilder ID Preservation', () => {
         logger: console as any,
         description: 'A tool without ID',
         runtimeContext: new RuntimeContext(),
+        tracingContext: {},
       },
     });
 
@@ -493,6 +495,7 @@ describe('CoreToolBuilder ID Preservation', () => {
         logger: console as any,
         description: 'A provider-defined tool',
         runtimeContext: new RuntimeContext(),
+        tracingContext: {},
       },
     });
 
@@ -551,7 +554,7 @@ describe('Tool Tracing Context Injection', () => {
         } as any,
         description: 'Test tool that captures tracing context',
         runtimeContext: new RuntimeContext(),
-        agentAISpan: mockAgentSpan,
+        tracingContext: { currentSpan: mockAgentSpan },
       },
     });
 
@@ -652,7 +655,7 @@ describe('Tool Tracing Context Injection', () => {
         } as any,
         description: 'Vercel tool test',
         runtimeContext: new RuntimeContext(),
-        agentAISpan: mockAgentSpan,
+        tracingContext: { currentSpan: mockAgentSpan },
       },
     });
 
@@ -713,7 +716,7 @@ describe('Tool Tracing Context Injection', () => {
         } as any,
         description: 'Tool that throws an error',
         runtimeContext: new RuntimeContext(),
-        agentAISpan: mockAgentSpan,
+        tracingContext: { currentSpan: mockAgentSpan },
       },
     });
 
@@ -764,7 +767,7 @@ describe('Tool Tracing Context Injection', () => {
         } as any,
         description: 'Tool from a toolset',
         runtimeContext: new RuntimeContext(),
-        agentAISpan: mockAgentSpan,
+        tracingContext: { currentSpan: mockAgentSpan },
       },
       logType: 'toolset', // Specify toolset type
     });
@@ -814,6 +817,7 @@ describe('Tool Input Validation', () => {
         tags: ['developer', 'typescript'],
       },
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     expect(result).toEqual({
@@ -830,6 +834,7 @@ describe('Tool Input Validation', () => {
         age: 25,
       },
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     expect(result).toEqual({
@@ -847,6 +852,7 @@ describe('Tool Input Validation', () => {
         age: 30,
       },
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     expect(result).toHaveProperty('error', true);
@@ -864,6 +870,7 @@ describe('Tool Input Validation', () => {
         age: -5, // Negative age
       },
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     expect(result).toHaveProperty('error', true);
@@ -882,6 +889,7 @@ describe('Tool Input Validation', () => {
         email: 'not-an-email', // Invalid email
       },
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     expect(result).toHaveProperty('error', true);
@@ -918,6 +926,7 @@ describe('Tool Input Validation', () => {
         tags: [], // Empty array when min(1) required
       },
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     expect(result).toHaveProperty('error', true);
@@ -937,6 +946,7 @@ describe('Tool Input Validation', () => {
         tags: [],
       },
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     expect(result).toHaveProperty('error', true);

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -608,8 +608,8 @@ describe('Tool Tracing Context Injection', () => {
         } as any,
         description: 'Test tool without agent span',
         runtimeContext: new RuntimeContext(),
-        // No agentAISpan provided
-      } as any,
+        tracingContext: {},
+      },
     });
 
     const builtTool = builder.build();

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -121,8 +121,8 @@ export class CoreToolBuilder extends MastraBase {
     });
 
     const execFunction = async (args: unknown, execOptions: ToolExecutionOptions | ToolCallOptions) => {
-      // Create tool span if we have an agent span available
-      const toolSpan = options.agentAISpan?.createChildSpan({
+      // Create tool span if we have an current span available
+      const toolSpan = options.tracingContext.currentSpan?.createChildSpan({
         type: AISpanType.TOOL_CALL,
         name: `tool: ${options.name}`,
         input: args,

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -158,6 +158,7 @@ describe('makeCoreTool', () => {
     name: 'testTool',
     description: 'Test tool description',
     runtimeContext: new RuntimeContext(),
+    tracingContext: {},
   };
 
   it('should convert a Vercel tool correctly', async () => {
@@ -301,6 +302,7 @@ it('should log correctly for Vercel tool execution', async () => {
     name: 'testTool',
     agentName: 'testAgent',
     runtimeContext: new RuntimeContext(),
+    tracingContext: {},
   });
 
   await coreTool.execute?.({ name: 'test' }, { toolCallId: 'test-id', messages: [] });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,7 +5,7 @@ import jsonSchemaToZod from 'json-schema-to-zod';
 import { z } from 'zod';
 import type { MastraPrimitives } from './action';
 import type { ToolsInput } from './agent';
-import type { AnyAISpan } from './ai-tracing';
+import type { TracingContext } from './ai-tracing';
 import type { IMastraLogger } from './logger';
 import type { Mastra } from './mastra';
 import type { AiMessageType, MastraLanguageModel, MastraMemory } from './memory';
@@ -224,11 +224,11 @@ export interface ToolOptions {
   description?: string;
   mastra?: (Mastra & MastraPrimitives) | MastraPrimitives;
   runtimeContext: RuntimeContext;
+  tracingContext: TracingContext;
   memory?: MastraMemory;
   agentName?: string;
   model?: MastraLanguageModel;
   writableStream?: WritableStream<ChunkType>;
-  agentAISpan?: AnyAISpan;
 }
 
 /**

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -1,5 +1,5 @@
 import type { Mastra, SerializedStepFlowEntry } from '..';
-import type { AnyAISpan } from '../ai-tracing';
+import type { TracingContext } from '../ai-tracing';
 import { MastraBase } from '../base';
 import type { RuntimeContext } from '../di';
 import { RegisteredLogger } from '../logger';
@@ -51,7 +51,7 @@ export abstract class ExecutionEngine extends MastraBase {
     };
     emitter: Emitter;
     runtimeContext: RuntimeContext;
-    currentSpan?: AnyAISpan;
+    tracingContext?: TracingContext;
     retryConfig?: {
       attempts?: number;
       delay?: number;

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,7 +39,7 @@
     "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.15.2-0 <0.16.0-0",
+    "@mastra/core": ">=0.15.3-0 <0.16.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -609,12 +609,12 @@ export class MCPServer extends MCPServerBase {
         inputSchema: z.object({
           message: z.string().describe('The question or input for the agent.'),
         }),
-        execute: async ({ context, runtimeContext }) => {
+        execute: async ({ context, runtimeContext, tracingContext }) => {
           this.logger.debug(
             `Executing agent tool '${agentToolName}' for agent '${agent.name}' with message: "${context.message}"`,
           );
           try {
-            const response = await agent.generate(context.message, { runtimeContext });
+            const response = await agent.generate(context.message, { runtimeContext, tracingContext });
             return response;
           } catch (error) {
             this.logger.error(`Error executing agent tool '${agentToolName}' for agent '${agent.name}':`, error);
@@ -628,6 +628,7 @@ export class MCPServer extends MCPServerBase {
         logger: this.logger,
         mastra: this.mastra,
         runtimeContext: new RuntimeContext(),
+        tracingContext: {},
         description: agentToolDefinition.description,
       };
       const coreTool = makeCoreTool(agentToolDefinition, options) as InternalCoreTool;
@@ -681,7 +682,7 @@ export class MCPServer extends MCPServerBase {
         id: workflowToolName,
         description: `Run workflow '${workflowKey}'. Workflow description: ${workflowDescription}`,
         inputSchema: workflow.inputSchema,
-        execute: async ({ context, runtimeContext }) => {
+        execute: async ({ context, runtimeContext, tracingContext }) => {
           this.logger.debug(
             `Executing workflow tool '${workflowToolName}' for workflow '${workflow.id}' with input:`,
             context,
@@ -689,7 +690,7 @@ export class MCPServer extends MCPServerBase {
           try {
             const run = workflow.createRun({ runId: runtimeContext?.get('runId') });
 
-            const response = await run.start({ inputData: context, runtimeContext });
+            const response = await run.start({ inputData: context, runtimeContext, tracingContext });
 
             return response;
           } catch (error) {
@@ -707,6 +708,7 @@ export class MCPServer extends MCPServerBase {
         logger: this.logger,
         mastra: this.mastra,
         runtimeContext: new RuntimeContext(),
+        tracingContext: {},
         description: workflowToolDefinition.description,
       };
 
@@ -755,6 +757,7 @@ export class MCPServer extends MCPServerBase {
       const options = {
         name: toolName,
         runtimeContext: new RuntimeContext(),
+        tracingContext: {},
         mastra: this.mastra,
         logger: this.logger,
         description: toolInstance?.description,

--- a/workflows/inngest/package.json
+++ b/workflows/inngest/package.json
@@ -50,7 +50,7 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.14.2-0 <0.16.0-0",
+    "@mastra/core": ">=0.15.3-0 <0.16.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -1265,9 +1265,9 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
     emitter,
     abortController,
     runtimeContext,
+    tracingContext,
     writableStream,
     disableScorers,
-    tracingContext,
   }: {
     step: Step<string, any, any>;
     stepResults: Record<string, StepResult<any, any, any, any>>;
@@ -1281,9 +1281,9 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
     emitter: Emitter;
     abortController: AbortController;
     runtimeContext: RuntimeContext;
+    tracingContext?: TracingContext;
     writableStream?: WritableStream<ChunkType>;
     disableScorers?: boolean;
-    tracingContext?: TracingContext;
   }): Promise<StepResult<any, any, any, any>> {
     const stepAISpan = tracingContext?.currentSpan?.createChildSpan({
       name: `workflow step: '${step.id}'`,
@@ -1685,6 +1685,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
             workflowId: executionContext.workflowId,
             stepId: step.id,
             runtimeContext,
+            tracingContext: { currentSpan: stepAISpan },
             disableScorers,
           });
         }


### PR DESCRIPTION
## Description

This PR pipes `tracingContext` through everything: agents, workflows, processors, scorers, etc...

This ensures that a single trace is generated for a single AI event. Additionally it allows users to create their own spans as needed in their code. (instead of many traces for a single AI event.)

`TracingContext` becomes the new pattern for passing trace context. Similar to `RuntimeContext`. Unlike RuntimeContext which is a single object through all items, TracingContext creates a new nested object as a child of the previous at each branching point.

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

Will make docs updates separately.