### PR TITLE
fix(core): pipe providerOptions in streamVNext, fix reasoning-delta

### DIFF
--- a/.changeset/mean-bats-sing.md
+++ b/.changeset/mean-bats-sing.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix passing providerOptions through in streamVNext, enabling reasoning-delta chunks to be receiving.

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -3007,6 +3007,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           structuredOutput: result.structuredOutput,
           stopWhen: result.stopWhen,
           maxSteps: result.maxSteps,
+          providerOptions: result.providerOptions,
           options: {
             onFinish: async (payload: any) => {
               if (payload.finishReason === 'error') {


### PR DESCRIPTION
## Description

ProviderOptions were not being passed through, so reasoning-delta chunks were never able to be received in the stream. Fixes https://github.com/mastra-ai/mastra/issues/7319
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
