### PR TITLE
fix(@mastra/core): include assistant messages in onFinish callback for aisdk format

### DIFF
--- a/.changeset/cute-papers-end.md
+++ b/.changeset/cute-papers-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixes #7254 where the onFinish callback wasn't returning assistant messages when using format: 'aisdk' in streamVNext. The messageList was being updated with response messages but these weren't being passed to the user's onFinish callback.

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -4996,8 +4996,9 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         expect(messagesInOnFinish).toBeDefined();
         expect(messagesInOnFinish).toBeInstanceOf(Array);
 
-        // Verify that we have user and assistant messages
-        expect(hasUserMessage).toBe(true);
+        // response messages should not be user messages
+        expect(hasUserMessage).toBe(false);
+        // Verify that we have assistant messages
         expect(hasAssistantMessage).toBe(true);
 
         // Verify the assistant message content

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -4940,6 +4940,77 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
 
         expect(secondResponse.response.messages).toEqual([expect.objectContaining({ role: 'assistant' })]);
       }, 30_000);
+
+      it('should include assistant messages in onFinish callback with aisdk format', async () => {
+        const mockModel = new MockLanguageModelV2({
+          doStream: async () => ({
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            stream: convertArrayToReadableStream([
+              { type: 'text-delta', id: '1', delta: 'Hello! ' },
+              { type: 'text-delta', id: '2', delta: 'Nice to meet you!' },
+              {
+                type: 'finish',
+                id: '3',
+                finishReason: 'stop',
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              },
+            ]),
+            warnings: [],
+          }),
+        });
+
+        const agent = new Agent({
+          id: 'test-aisdk-onfinish',
+          name: 'Test AISDK onFinish',
+          model: mockModel,
+          instructions: 'You are a helpful assistant.',
+        });
+
+        let messagesInOnFinish: any[] | undefined;
+        let hasUserMessage = false;
+        let hasAssistantMessage = false;
+
+        const result = await agent.streamVNext('Hello, please respond with a greeting.', {
+          format: 'aisdk',
+          onFinish: props => {
+            // Store the messages from onFinish
+            messagesInOnFinish = props.messages;
+
+            if (props.messages) {
+              props.messages.forEach((msg: any) => {
+                if (msg.role === 'user') hasUserMessage = true;
+                if (msg.role === 'assistant') hasAssistantMessage = true;
+              });
+            }
+          },
+        });
+
+        // Consume the stream
+        await result.consumeStream();
+
+        // Verify that messages were provided in onFinish
+        expect(messagesInOnFinish).toBeDefined();
+        expect(messagesInOnFinish).toBeInstanceOf(Array);
+
+        // Verify that we have user and assistant messages
+        expect(hasUserMessage).toBe(true);
+        expect(hasAssistantMessage).toBe(true);
+
+        // Verify the assistant message content
+        const assistantMessage = messagesInOnFinish?.find((m: any) => m.role === 'assistant');
+        expect(assistantMessage).toBeDefined();
+        expect(assistantMessage?.content).toBeDefined();
+
+        // For the v2 model, the assistant message should contain the streamed text
+        if (typeof assistantMessage?.content === 'string') {
+          expect(assistantMessage.content).toContain('Hello!');
+        } else if (Array.isArray(assistantMessage?.content)) {
+          const textContent = assistantMessage.content.find((c: any) => c.type === 'text');
+          expect(textContent?.text).toContain('Hello!');
+        }
+      });
     });
   });
 

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -3049,13 +3049,11 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
                   runId,
                 });
               }
-              // For aisdk format, include all messages including the assistant's response
-              const finalMessages = options.format === 'aisdk' ? messageList.get.all.ui() : undefined;
 
               await options?.onFinish?.({
                 ...result,
                 runId,
-                ...(finalMessages ? { messages: finalMessages } : {}),
+                messages: messageList.get.response.aiV5.model(),
               } as any);
             },
             onStepFinish: result.onStepFinish,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -3049,7 +3049,14 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
                   runId,
                 });
               }
-              await options?.onFinish?.({ ...result, runId } as any);
+              // For aisdk format, include all messages including the assistant's response
+              const finalMessages = options.format === 'aisdk' ? messageList.get.all.ui() : undefined;
+
+              await options?.onFinish?.({
+                ...result,
+                runId,
+                ...(finalMessages ? { messages: finalMessages } : {}),
+              } as any);
             },
             onStepFinish: result.onStepFinish,
           },


### PR DESCRIPTION
Fixes #7254 where the onFinish callback wasn't returning assistant messages when using format: 'aisdk' in streamVNext.

The issue was that while the messageList was being updated with response messages, these weren't being passed to the user's onFinish callback.

Before the fix, when using streamVNext with format: 'aisdk', the onFinish callback would wouldn't receive all response messages

```typescript
await agent.streamVNext('Hello', {
  format: 'aisdk',
  onFinish: (props) => {
    console.log(props.messages); // Missing assistant messages
  }
});
```

After the fix, the onFinish callback now receives all response messages