### PR TITLE
docs(streaming): add warning about awaiting writer.write calls

### DIFF
--- a/docs/src/content/en/docs/streaming/tool-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/tool-streaming.mdx
@@ -3,6 +3,8 @@ title: "Tool Streaming | Streaming | Mastra"
 description: "Learn how to use tool streaming in Mastra, including handling tool calls, tool results, and tool execution events during streaming."
 ---
 
+import { Callout } from "nextra/components";
+
 # Tool streaming
 
 Tool streaming in Mastra enables tools to send incremental results while they run, rather than waiting until execution finishes. This allows you to surface partial progress, intermediate states, or progressive data directly to users or upstream agents and workflows.
@@ -35,6 +37,10 @@ export const testAgent = new Agent({
 ### Using the `writer` argument
 
 The `writer` argument is passed to a tool’s `execute` function and can be used to emit custom events, data, or values into the active stream. This enables tools to provide intermediate results or status updates while execution is still in progress.
+
+<Callout type="warning">
+You must `await` the call to `writer.write(...)` or else you will lock the stream and get a `WritableStream is locked` error.
+</Callout>
 
 ```typescript {5,8,15} showLineNumbers copy
 import { createTool } from "@mastra/core/tools";

--- a/docs/src/content/en/docs/streaming/workflow-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/workflow-streaming.mdx
@@ -3,6 +3,8 @@ title: "Workflow Streaming | Streaming | Mastra"
 description: "Learn how to use workflow streaming in Mastra, including handling workflow execution events, step streaming, and workflow integration with agents and tools."
 ---
 
+import { Callout } from "nextra/components";
+
 # Workflow streaming
 
 Workflow streaming in Mastra enables workflows to send incremental results while they execute, rather than waiting until completion. This allows you to surface partial progress, intermediate states, or progressive data directly to users or upstream agents and workflows.
@@ -17,6 +19,10 @@ By combining writable workflow streams with agent streaming, you gain fine-grain
 ### Using the `writer` argument
 
 The `writer` argument is passed to a workflow step's `execute` function and can be used to emit custom events, data, or values into the active stream. This enables workflow steps to provide intermediate results or status updates while execution is still in progress.
+
+<Callout type="warning">
+You must `await` the call to `writer.write(...)` or else you will lock the stream and get a `WritableStream is locked` error.
+</Callout>
 
 ```typescript {5,8,15} showLineNumbers copy
 import { createStep } from "@mastra/core/workflows";


### PR DESCRIPTION
## Description

Add Callout warnings to both tool-streaming and workflow-streaming documentation emphasizing that writer.write() calls must be awaited to prevent stream locking errors.

## Related Issue(s)

Several issues reported via discord

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
