### PR TITLE
fix: handle tool-output stream chunk to ui message

### DIFF
--- a/.changeset/metal-bugs-laugh.md
+++ b/.changeset/metal-bugs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Handle ui message conversion of tool-output streaming chunks for nested tool events.

--- a/packages/core/src/stream/aisdk/v5/compat.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat.test.ts
@@ -67,7 +67,7 @@ describe('convertFullStreamChunkToUIMessageStream', () => {
     });
   });
 
-  it('should not convert typed tool-output part into UI message if type does no begin with tool-', () => {
+  it('should not convert typed tool-output part into UI message if type does not begin with tool-', () => {
     // Arrange: Create a tool-output part with sample data
     const toolOutput = {
       type: 'tool-output',

--- a/packages/core/src/stream/aisdk/v5/compat/ui-message.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/ui-message.ts
@@ -32,7 +32,7 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
   sendFinish,
   responseMessageId,
 }: {
-  part: TextStreamPart<ToolSet> | { type: 'tool-output'; toolCallId: string; output: any };
+  part: TextStreamPart<ToolSet> | { type: 'tool-output'; toolCallId: string; toolName: string; output: any };
   messageMetadataValue?: any;
   sendReasoning?: boolean;
   sendSources?: boolean;
@@ -170,6 +170,25 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
     }
 
     case 'tool-output': {
+      if ('type' in part.output) {
+        if (!part.output.type.includes('tool-')) return
+
+        return convertFullStreamChunkToUIMessageStream({
+          part: {
+            toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            ...part.output
+          },
+          onError,
+          messageMetadataValue,
+          responseMessageId,
+          sendFinish,
+          sendReasoning,
+          sendSources,
+          sendStart,
+        });
+      }
+
       return {
         id: part.toolCallId,
         ...part.output,

--- a/packages/core/src/stream/aisdk/v5/compat/ui-message.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/ui-message.ts
@@ -171,7 +171,7 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
 
     case 'tool-output': {
       if ('type' in part.output) {
-        if (!part.output.type.includes('tool-')) return
+        if (!part.output.type.startsWith('tool-')) return
 
         return convertFullStreamChunkToUIMessageStream({
           part: {


### PR DESCRIPTION
## Description

Handle conversion of `tool-output` streaming chunks to ui message. This allows display of chained tool calls via `assistant-ui` and the `/stream/vnext/ui` endpoint.

Example:
User Input -> Agent -> Tool A -> Tool B -> Tool C

UI:
User Input
Tool A
Tool B
Tool C
Agent Output

## Related Issue(s)

https://discord.com/channels/1309558646228779139/1412610154649751653

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
