### PR TITLE
adds support for event-type spans to the default ai observability exporter

### DIFF
--- a/.changeset/silly-impalas-speak.md
+++ b/.changeset/silly-impalas-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Adds handling for event-type spans to the default ai observability exporter

--- a/packages/core/src/ai-tracing/exporters/default.test.ts
+++ b/packages/core/src/ai-tracing/exporters/default.test.ts
@@ -365,6 +365,41 @@ describe('DefaultExporter', () => {
           }),
         );
       });
+
+      it('should handle event-type spans that only emit SPAN_ENDED', async () => {
+        const exporter = new DefaultExporter(
+          {
+            strategy: 'batch-with-updates',
+            maxBatchSize: 1, // Set to 1 to trigger immediate flush
+          },
+          mockLogger,
+        );
+        exporter.__registerMastra(mockMastra);
+        exporter.init();
+
+        // Event-type spans only emit SPAN_ENDED (no SPAN_STARTED)
+        const eventSpan = createMockEvent(AITracingEventType.SPAN_ENDED, 'trace-1', 'event-1', true);
+        await exporter.exportEvent(eventSpan);
+
+        // Wait for async flush to complete
+        await new Promise(resolve => setImmediate(resolve));
+
+        // Should create the span record (not treat as out-of-order)
+        expect(mockStorage.batchCreateAISpans).toHaveBeenCalledWith({
+          records: expect.arrayContaining([
+            expect.objectContaining({
+              spanId: 'event-1',
+              traceId: 'trace-1',
+            }),
+          ]),
+        });
+
+        // Should not log out-of-order warning
+        expect(mockLogger.warn).not.toHaveBeenCalledWith(
+          'Out-of-order span update detected - skipping event',
+          expect.anything(),
+        );
+      });
     });
 
     describe('Insert-only strategy', () => {

--- a/packages/core/src/ai-tracing/exporters/default.ts
+++ b/packages/core/src/ai-tracing/exporters/default.ts
@@ -241,6 +241,17 @@ export class DefaultExporter implements AITracingExporter {
               },
               sequenceNumber: this.getNextSequence(spanKey),
             });
+          } else if (event.span.isEvent) {
+            // Event-type spans only emit SPAN_ENDED (no prior SPAN_STARTED)
+            const createRecord = {
+              traceId: event.span.traceId,
+              spanId: event.span.id,
+              ...this.buildCreateRecord(event.span),
+              createdAt: new Date(),
+              updatedAt: null,
+            };
+            this.buffer.creates.push(createRecord);
+            this.buffer.seenSpans.add(spanKey);
           } else {
             // Out-of-order case: log and skip
             this.handleOutOfOrderUpdate(event);


### PR DESCRIPTION
## Description

When testing on alpha, I saw a bunch of errors like these:
```
Out-of-order span update detected - skipping event {
  spanId: 'bb99c6936bd17a40',
  traceId: 'b45537a80aff11f762d316a32e2123b5',
  eventType: 'span_ended'
}
```
And realized I never setup the default exporter to accept the new event-type spans that only have an `end` event.  This fixes that issue.

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
