### PR TITLE
fix(mastra): Use `-D` alias for create command

### DIFF
--- a/.changeset/khaki-tips-refuse.md
+++ b/.changeset/khaki-tips-refuse.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix issue when using `yarn dlx create-mastra`

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -50,7 +50,11 @@ async function installMastraDependency(
   let installCommand = getPackageManagerAddCommand(pm);
 
   if (isDev) {
-    installCommand = `${installCommand} --save-dev`;
+    /**
+     * All our package managers support -D for devDependencies. We can't use --save-dev across the board because yarn and bun don't alias it.
+     * npm: -D, --save-dev. pnpm: -D, --save-dev. yarn: -D, --dev. bun: -D, --dev
+     */
+    installCommand = `${installCommand} -D`;
   }
 
   try {


### PR DESCRIPTION
## Description

When I tried out `yarn dlx create-mastra` it errored with:

```bash
Project creation failed: Failed to install Mastra CLI: Failed to install mastra (tried @alpha and @latest): Command failed: yarn add --save-dev mastra@latest
error Missing list of packages to add to your project.
```

I checked https://classic.yarnpkg.com/en/docs/cli/add and https://yarnpkg.com/cli/add, yarn doesn't have `--save-dev`. But we can use `-D` across all package managers.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
