### PR TITLE
stopped creating event spans for llm_chunks in ai-observability

### DIFF
--- a/.changeset/brown-eggs-retire.md
+++ b/.changeset/brown-eggs-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+stopped recording event spans for llm_chunks in ai-observability

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV1FinishReason } from '@ai-sdk/provider';
+import type { LanguageModelV1FinishReason, LanguageModelV1StreamPart } from '@ai-sdk/provider';
 import {
   AnthropicSchemaCompatLayer,
   applyCompatLayer,
@@ -192,30 +192,21 @@ export class MastraLLMV1 extends MastraBase {
         const originalStream = result.stream;
         let finishReason: LanguageModelV1FinishReason;
         let finalUsage: any = null;
+        let textOutput: string = '';
 
         const wrappedStream = originalStream.pipeThrough(
           new TransformStream({
             // this gets called on each chunk output
-            transform(chunk, controller) {
-              // Create event spans for text chunks
-              if (chunk.type === 'text-delta') {
-                llmSpan?.createEventSpan({
-                  type: AISpanType.LLM_CHUNK,
-                  name: `llm chunk: ${chunk.type}`,
-                  output: chunk.textDelta,
-                  attributes: {
-                    chunkType: chunk.type,
-                  },
-                });
-              }
-
-              //TODO: Figure out how to get the final usage
-              // if (chunk.type === 'response-metadata' && chunk.usage) {
-              //   finalUsage = chunk.usage;
-              // }
-              if (chunk.type === 'finish') {
-                finishReason = chunk.finishReason;
-                finalUsage = chunk.usage;
+            transform(chunk: LanguageModelV1StreamPart, controller) {
+              //TODO: for tracing, do we want to do anything with the other chunk types?
+              switch (chunk.type) {
+                case 'text-delta':
+                  textOutput += chunk.textDelta;
+                  break;
+                case 'finish':
+                  finishReason = chunk.finishReason;
+                  finalUsage = chunk.usage;
+                  break;
               }
               controller.enqueue(chunk);
             },
@@ -223,6 +214,7 @@ export class MastraLLMV1 extends MastraBase {
             flush() {
               llmSpan?.end({
                 attributes: {
+                  output: textOutput,
                   usage: finalUsage
                     ? {
                         promptTokens: finalUsage.promptTokens,

--- a/packages/core/src/loop/workflow/stream.ts
+++ b/packages/core/src/loop/workflow/stream.ts
@@ -27,18 +27,6 @@ export function workflowLoopStream<
     start: async controller => {
       const writer = new WritableStream<ChunkType>({
         write: chunk => {
-          // Create event spans for streaming chunks on the LLM span (not agent span)
-          if (llmAISpan && chunk.type === 'text-delta') {
-            llmAISpan.createEventSpan({
-              type: AISpanType.LLM_CHUNK,
-              name: `llm chunk: ${chunk.type}`,
-              output: chunk.payload.text,
-              attributes: {
-                chunkType: chunk.type,
-              },
-            });
-          }
-
           controller.enqueue(chunk);
         },
       });

--- a/packages/core/src/loop/workflow/stream.ts
+++ b/packages/core/src/loop/workflow/stream.ts
@@ -1,7 +1,6 @@
 import { ReadableStream } from 'stream/web';
 import type { ToolSet } from 'ai-v5';
 import z from 'zod';
-import { AISpanType } from '../../ai-tracing';
 import type { OutputSchema } from '../../stream/base/schema';
 import type { ChunkType } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';


### PR DESCRIPTION
## Description
 
It turns out that a single chunk from an LLM streaming response is generally a single word.  Creating a LLM_Chunk event span for each returned word is too verbose.

This PR removes our creation of LLM_Chunks spans for streaming Agents in legacy & vnext streaming.

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
