### PR TITLE
fix(docs): Prevent submission during text composition

### DIFF
--- a/docs/src/components/custom-search.tsx
+++ b/docs/src/components/custom-search.tsx
@@ -181,6 +181,9 @@ export const CustomSearch: FC<SearchProps> = ({
         break;
       case "Enter":
         event.preventDefault();
+        if (event.nativeEvent.isComposing) {
+          return;
+        }
         if (selectedIndex === 0) {
           handleSelect({ url: "use-ai" });
         } else if (selectedIndex > 0) {


### PR DESCRIPTION
## Description
Fixed a bug in Docs where search keywords (e.g. in Japanese) were submitted immediately after text conversion/IME confirmation

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ]  Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x]  Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
