### PR TITLE
feat(mcp): add createMCPTool helper for proper execute types

### DIFF
--- a/.changeset/dry-ideas-talk.md
+++ b/.changeset/dry-ideas-talk.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/mcp': patch
+---
+
+New createMCPTool helper for correct types for MCP Server tools

--- a/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
@@ -341,22 +341,23 @@ When a tool includes an `outputSchema`, its `execute` function **must** return a
 Here's an example of a tool with an `outputSchema`:
 
 ```typescript filename="src/tools/structured-tool.ts"
-import { createTool } from '@mastra/core/tools';
+import { createMCPTool } from '@mastra/mcp';
 import { z } from 'zod';
 
-export const structuredTool = createTool({
+export const structuredTool = createMCPTool({
+  id: 'structuredTool',
   description: 'A test tool that returns structured data.',
-  parameters: z.object({
+  inputSchema: z.object({
     input: z.string().describe('Some input string.'),
   }),
   outputSchema: z.object({
     processedInput: z.string().describe('The processed input string.'),
     timestamp: z.string().describe('An ISO timestamp.'),
   }),
-  execute: async ({ input }) => {
+  execute: async (params, { elicitation, extra }) => {
     // When outputSchema is defined, you must return an object
     return {
-      processedInput: `processed: ${input}`,
+      processedInput: `processed: ${params.input}`,
       timestamp: new Date().toISOString(),
     };
   },

--- a/docs/src/content/en/guides/guide/notes-mcp-server.mdx
+++ b/docs/src/content/en/guides/guide/notes-mcp-server.mdx
@@ -220,7 +220,7 @@ Tools are the actions your server can perform. Let's create a `write` tool.
 First, define the tool in `src/mastra/tools/write-note.ts`:
 
 ```typescript copy filename="src/mastra/tools/write-note.ts"
-import { createTool } from "@mastra/core/tools";
+import { createMCPTool } from "@mastra/mcp";
 import { z } from "zod";
 import { fileURLToPath } from "url";
 import path from "node:path";
@@ -230,7 +230,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const NOTES_DIR = path.resolve(__dirname, "../../../notes");
 
-export const writeNoteTool = createTool({
+export const writeNoteTool = createMCPTool({
   id: "write",
   description: "Write a new note or overwrite an existing one.",
   inputSchema: z.object({
@@ -244,9 +244,9 @@ export const writeNoteTool = createTool({
       .describe("The markdown content of the note."),
   }),
   outputSchema: z.string().nonempty(),
-  execute: async ({ context }) => {
+  execute: async (params, { elicitation, extra }) => {
     try {
-      const { title, content } = context;
+      const { title, content } = params;
       const filePath = path.join(NOTES_DIR, `${title}.md`);
       await fs.mkdir(NOTES_DIR, { recursive: true });
       await fs.writeFile(filePath, content, "utf-8");

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -18,8 +18,7 @@ To create a new `MCPServer`, you need to provide some basic information about yo
 ```typescript
 import { openai } from "@ai-sdk/openai";
 import { Agent } from "@mastra/core/agent";
-import { createTool } from "@mastra/core/tools";
-import { MCPServer } from "@mastra/mcp";
+import { MCPServer, createMCPTool } from "@mastra/mcp";
 import { z } from "zod";
 import { dataProcessingWorkflow } from "../workflows/dataProcessingWorkflow";
 
@@ -30,7 +29,7 @@ const myAgent = new Agent({
   model: openai("gpt-4o-mini"),
 });
 
-const weatherTool = createTool({
+const weatherTool = createMCPTool({
   id: "getWeather",
   description: "Gets the current weather for a location.",
   inputSchema: z.object({ location: z.string() }),
@@ -69,10 +68,10 @@ The constructor accepts an `MCPServerConfig` object with the following propertie
     },
     {
       name: "tools",
-      type: "ToolsInput",
+      type: "MCPToolsInput",
       isOptional: false,
       description:
-        "An object where keys are tool names and values are Mastra tool definitions (created with `createTool` or Vercel AI SDK). These tools will be directly exposed.",
+        "An object where keys are tool names and values are tool definitions. Supports Mastra tools (created with `createMCPTool` or `createTool`) or Vercel AI SDK tools. Tools created with `createMCPTool` have access to MCP-specific features like elicitation for user interaction.",
     },
     {
       name: "agents",
@@ -846,17 +845,18 @@ The `MCPServer` class automatically includes elicitation capabilities. Tools rec
 When tools are executed within an MCP server context, they receive an additional `options` parameter:
 
 ```typescript
-execute: async ({ context }, options) => {
-  // context contains the tool's input parameters
-  // options contains server capabilities like elicitation and authentication info
+execute: async (params, { elicitation, extra }) => {
+  // params contains the validated tool input parameters
+  // elicitation provides user interaction capabilities
+  // extra contains MCP-specific context (auth, session, etc.)
   
   // Access authentication information (when available)
-  if (options.extra?.authInfo) {
-    console.log('Authenticated request from:', options.extra.authInfo.clientId);
+  if (extra?.authInfo) {
+    console.log('Authenticated request from:', extra.authInfo.clientId);
   }
   
   // Use elicitation capabilities
-  const result = await options.elicitation.sendRequest({
+  const result = await elicitation.sendRequest({
     message: "Please provide information",
     requestedSchema: { /* schema */ }
   });
@@ -881,29 +881,28 @@ A common use case is during tool execution. When a tool needs user input, it can
 Here's an example of a tool that uses elicitation to collect user contact information:
 
 ```typescript
-import { MCPServer } from "@mastra/mcp";
-import { createTool } from "@mastra/core/tools";
+import { MCPServer, createMCPTool } from "@mastra/mcp";
 import { z } from "zod";
 
 const server = new MCPServer({
   name: "Interactive Server",
   version: "1.0.0",
   tools: {
-    collectContactInfo: createTool({
+    collectContactInfo: createMCPTool({
       id: "collectContactInfo",
       description: "Collects user contact information through elicitation",
       inputSchema: z.object({
         reason: z.string().optional().describe("Reason for collecting contact info"),
       }),
-      execute: async ({ context }, options) => {
-        const { reason } = context;
+      execute: async (params, { context, elicitation, extra }) => {
+        const { reason } = params;
         
         // Log session info if available
-        console.log('Request from session:', options.extra?.sessionId);
+        console.log('Request from session:', extra?.sessionId);
 
         try {
           // Request user input via elicitation
-          const result = await options.elicitation.sendRequest({
+          const result = await elicitation.sendRequest({
             message: reason 
               ? `Please provide your contact information. ${reason}`
               : 'Please provide your contact information',
@@ -1010,17 +1009,17 @@ Tools should handle all three response types appropriately.
 The elicitation functionality is available through the `options` parameter in tool execution:
 
 ```typescript
-// Within a tool's execute function
-execute: async ({ context }, options) => {
+// Within a tool's execute function (using createMCPTool)
+execute: async (params, { elicitation, extra }) => {
   // Use elicitation for user input
-  const result = await options.elicitation.sendRequest({
+  const result = await elicitation.sendRequest({
     message: string,           // Message to display to user
     requestedSchema: object    // JSON schema defining expected response structure
   }): Promise<ElicitResult>
   
   // Access authentication info if needed
-  if (options.extra?.authInfo) {
-    // Use options.extra.authInfo.token, etc.
+  if (extra?.authInfo) {
+    // Use extra.authInfo.token, etc.
   }
 }
 ```
@@ -1041,15 +1040,15 @@ type ElicitResult = {
 Tools can access request metadata via `options.extra` when using HTTP-based transports:
 
 ```typescript
-execute: async ({ context }, options) => {
-  if (!options.extra?.authInfo?.token) {
+execute: async (params, { elicitation, extra }) => {
+  if (!extra?.authInfo?.token) {
     return "Authentication required";
   }
   
   // Use the auth token
   const response = await fetch('/api/data', {
-    headers: { Authorization: `Bearer ${options.extra.authInfo.token}` },
-    signal: options.extra.signal,
+    headers: { Authorization: `Bearer ${extra.authInfo.token}` },
+    signal: extra.signal,
   });
   
   return response.json();

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -2,3 +2,4 @@ export * from './tool';
 export * from './types';
 export { isVercelTool } from './toolchecks';
 export { ToolStream } from './stream';
+export { validateToolInput } from './validation';

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import type * as http from 'node:http';
-import type { ToolsInput, Agent } from '@mastra/core/agent';
+import type { Agent, ToolsInput } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { MCPServerBase } from '@mastra/core/mcp';
 import type {
-  MCPServerConfig,
   ServerInfo,
   ServerDetailInfo,
   ConvertedTool,
@@ -14,7 +13,7 @@ import type {
 } from '@mastra/core/mcp';
 import { RuntimeContext } from '@mastra/core/runtime-context';
 import { createTool } from '@mastra/core/tools';
-import type { InternalCoreTool } from '@mastra/core/tools';
+import type { InternalCoreTool, ToolAction } from '@mastra/core/tools';
 import { makeCoreTool } from '@mastra/core/utils';
 import type { Workflow } from '@mastra/core/workflows';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -50,7 +49,14 @@ import { SSETransport } from 'hono-mcp-server-sse-transport';
 import { z } from 'zod';
 import { ServerPromptActions } from './promptActions';
 import { ServerResourceActions } from './resourceActions';
-import type { MCPServerPrompts, MCPServerResources, ElicitationActions, MCPTool } from './types';
+import type {
+  MCPServerPrompts,
+  MCPServerResources,
+  ElicitationActions,
+  MCPServerConfig,
+  MCPToolsInput,
+  MCPTool,
+} from './types';
 export class MCPServer extends MCPServerBase {
   private server: Server;
   private stdioTransport?: StdioServerTransport;
@@ -103,7 +109,7 @@ export class MCPServer extends MCPServerBase {
    * @param opts - Configuration options for the server, including registry metadata.
    */
   constructor(opts: MCPServerConfig & { resources?: MCPServerResources; prompts?: MCPServerPrompts }) {
-    super(opts);
+    super(opts as any);
     this.resourceOptions = opts.resources;
     this.promptOptions = opts.prompts;
 
@@ -730,13 +736,13 @@ export class MCPServer extends MCPServerBase {
   /**
    * Convert and validate all provided tools, logging registration status.
    * Also converts agents and workflows into tools.
-   * @param tools Tool definitions
+   * @param tools Tool definitions (supports ToolsInput, MCPToolsInput)
    * @param agentsConfig Agent definitions to be converted to tools, expected from MCPServerConfig
    * @param workflowsConfig Workflow definitions to be converted to tools, expected from MCPServerConfig
    * @returns Converted tools registry
    */
   convertTools(
-    tools: ToolsInput,
+    tools: ToolsInput | MCPToolsInput,
     agentsConfig?: Record<string, Agent>,
     workflowsConfig?: Record<string, Workflow>,
   ): Record<string, ConvertedTool> {
@@ -763,7 +769,7 @@ export class MCPServer extends MCPServerBase {
         description: toolInstance?.description,
       };
 
-      const coreTool = makeCoreTool(toolInstance, options) as InternalCoreTool;
+      const coreTool = makeCoreTool(toolInstance as ToolAction<any, any, any>, options) as InternalCoreTool;
 
       definedConvertedTools[toolName] = {
         name: toolName,
@@ -772,7 +778,7 @@ export class MCPServer extends MCPServerBase {
         outputSchema: coreTool.outputSchema,
         execute: coreTool.execute!,
       };
-      this.logger.info(`Registered explicit tool: '${toolName}'`);
+      this.logger.info(`Registered tool: '${toolName}'`);
     }
     this.logger.info(`Total defined tools registered: ${Object.keys(definedConvertedTools).length}`);
 

--- a/packages/mcp/src/server/types.ts
+++ b/packages/mcp/src/server/types.ts
@@ -1,4 +1,6 @@
-import type { InternalCoreTool } from '@mastra/core/tools';
+import type { MCPServerConfig as BaseMCPServerConfig } from '@mastra/core/mcp';
+import type { InternalCoreTool, ToolAction, VercelTool, VercelToolV5 } from '@mastra/core/tools';
+import { validateToolInput } from '@mastra/core/tools';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type {
   ElicitRequest,
@@ -8,6 +10,7 @@ import type {
   Resource,
   ResourceTemplate,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { z } from 'zod';
 
 export type MCPServerResourceContentCallback = ({
   uri,
@@ -55,5 +58,147 @@ export type MCPTool = {
     },
   ) => Promise<any>;
 };
+
+/**
+ * Enhanced execute options for MCP tools that includes elicitation and extra context
+ */
+export interface MCPToolExecuteOptions<TSchemaIn extends z.ZodSchema | undefined = undefined> {
+  context: TSchemaIn extends z.ZodSchema ? z.infer<TSchemaIn> : any;
+  elicitation: ElicitationActions;
+  extra: MCPRequestHandlerExtra;
+}
+
+/**
+ * Action interface for MCP tools
+ */
+export interface MCPToolAction<
+  TSchemaIn extends z.ZodSchema | undefined = undefined,
+  TSchemaOut extends z.ZodSchema | undefined = undefined,
+> {
+  id: string;
+  description: string;
+  inputSchema?: TSchemaIn;
+  outputSchema?: TSchemaOut;
+  execute: (
+    params: TSchemaIn extends z.ZodSchema ? z.infer<TSchemaIn> : any,
+    options: MCPToolExecuteOptions<TSchemaIn>,
+  ) => Promise<TSchemaOut extends z.ZodSchema ? z.infer<TSchemaOut> : any>;
+}
+
+/**
+ * Creates an MCP tool with proper typing for the MCP server environment.
+ * Similar to createTool but specifically designed for MCP tools with elicitation support.
+ *
+ * @param opts Tool action configuration
+ * @returns MCPTool instance
+ *
+ * @example
+ * ```typescript
+ * const mcpTool = createMCPTool({
+ *   id: 'weather',
+ *   description: 'Get weather information',
+ *   inputSchema: z.object({
+ *     city: z.string(),
+ *   }),
+ *   outputSchema: z.object({
+ *     temperature: z.number(),
+ *     condition: z.string(),
+ *   }),
+ *   execute: async (params, { context, elicitation, extra }) => {
+ *     // params contains the validated input: { city: string }
+ *     // context is the same as params for convenience
+ *     // Can use elicitation.sendRequest() for interactive prompts
+ *     // Access extra MCP context via extra parameter
+ *     return { temperature: 72, condition: 'sunny' };
+ *   },
+ * });
+ * ```
+ */
+export function createMCPTool<
+  TSchemaIn extends z.ZodSchema | undefined = undefined,
+  TSchemaOut extends z.ZodSchema | undefined = undefined,
+>(opts: MCPToolAction<TSchemaIn, TSchemaOut>): MCPTool {
+  let parameters: InternalCoreTool['parameters'];
+  let outputSchema: InternalCoreTool['outputSchema'];
+
+  if (opts.inputSchema) {
+    // Create a basic validator-like object for the parameters
+    parameters = {
+      jsonSchema: opts.inputSchema,
+      validate: (value: any) => {
+        try {
+          const result = opts.inputSchema!.safeParse(value);
+          return result.success ? { success: true, value: result.data } : { success: false, error: result.error };
+        } catch (e) {
+          return { success: false, error: e };
+        }
+      },
+    } as any;
+  } else {
+    parameters = undefined as any;
+  }
+
+  if (opts.outputSchema) {
+    // Create a basic validator-like object for the output schema
+    outputSchema = {
+      jsonSchema: opts.outputSchema,
+      validate: (value: any) => {
+        try {
+          const result = opts.outputSchema!.safeParse(value);
+          return result.success ? { success: true, value: result.data } : { success: false, error: result.error };
+        } catch (e) {
+          return { success: false, error: e };
+        }
+      },
+    } as any;
+  }
+
+  return {
+    id: opts.id,
+    description: opts.description,
+    parameters,
+    outputSchema,
+    execute: async (
+      params: any,
+      options: {
+        messages: any[];
+        toolCallId: string;
+        elicitation: ElicitationActions;
+        extra: MCPRequestHandlerExtra;
+      },
+    ) => {
+      // Create enhanced options that include MCP-specific context
+      const mcpOptions: MCPToolExecuteOptions<TSchemaIn> = {
+        context: params,
+        elicitation: options.elicitation,
+        extra: options.extra,
+      };
+
+      const { data, error } = validateToolInput(opts.inputSchema, params, opts.id);
+      if (error) {
+        return error as any;
+      }
+
+      return opts.execute(data as TSchemaIn extends z.ZodSchema ? z.infer<TSchemaIn> : any, mcpOptions);
+    },
+  };
+}
+
+/**
+ * MCP-specific tools input that supports MCPToolAction and MCPTool types in addition to regular tools
+ */
+export type MCPToolsInput = Record<
+  string,
+  ToolAction<any, any, any> | VercelTool | VercelToolV5 | MCPToolAction<any, any> | MCPTool
+>;
+
+/**
+ * Enhanced MCPServerConfig that supports MCP-specific tool types.
+ * This overrides the base MCPServerConfig from @mastra/core/mcp to accept our enhanced tool types.
+ */
+export interface MCPServerConfig extends Omit<BaseMCPServerConfig, 'tools'> {
+  /** The tools that this MCP server will expose. Supports regular tools, MCP tool actions, or MCP tools. */
+  tools: MCPToolsInput;
+}
 
 export type { Resource, ResourceTemplate };


### PR DESCRIPTION
## Description

using `createTool` would give you the wrong types inside of `execute` in the tool for an MCP server. Using `createMCPTool` ensures the types that are available to an MCP Tool are there.
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
