### PR TITLE
Fix cloud ai-trace build

### DIFF
--- a/packages/cloud/tsup.config.ts
+++ b/packages/cloud/tsup.config.ts
@@ -2,7 +2,7 @@ import { generateTypes } from '@internal/types-builder';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/ai-tracing/index.ts'],
   format: ['esm', 'cjs'],
   clean: true,
   dts: false,


### PR DESCRIPTION
## Description

This will allow us to build packages so we can export directly from: `@mastra/cloud/ai-tracing`

for example: `import { CloudAITracingExporter } from '@mastra/cloud/ai-tracing';`
instead of: `import { CloudAITracingExporter } from '@mastra/cloud';

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
