### PR TITLE
temp disable agent-builder workflows import

### DIFF
--- a/.changeset/wise-tigers-switch.md
+++ b/.changeset/wise-tigers-switch.md
@@ -1,0 +1,6 @@
+---
+"@mastra/deployer": patch
+"@mastra/server": patch
+---
+
+temp disable agent-builder workflows import

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -20,7 +20,7 @@ import { authenticationMiddleware, authorizationMiddleware } from './handlers/au
 import { handleClientsRefresh, handleTriggerClientsRefresh } from './handlers/client';
 import { errorHandler } from './handlers/error';
 import { rootHandler } from './handlers/root';
-import { agentBuilderRouter } from './handlers/routes/agent-builder/router';
+// import { agentBuilderRouter } from './handlers/routes/agent-builder/router';
 import { getModelProvidersHandler } from './handlers/routes/agents/handlers';
 import { agentsRouterDev, agentsRouter } from './handlers/routes/agents/router';
 import { logsRouter } from './handlers/routes/logs/router';

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -418,7 +418,7 @@ export async function createHonoServer(
   // Scores routes
   app.route('/api/scores', scoresRouter(bodyLimitOptions));
   // Agent builder routes
-  app.route('/api/agent-builder', agentBuilderRouter(bodyLimitOptions));
+  // app.route('/api/agent-builder', agentBuilderRouter(bodyLimitOptions));
   // Tool routes
   app.route('/api/tools', toolsRouter(bodyLimitOptions, options.tools));
   // Vector routes

--- a/packages/server/src/server/handlers/agent-builder.ts
+++ b/packages/server/src/server/handlers/agent-builder.ts
@@ -1,4 +1,4 @@
-import { agentBuilderWorkflows } from '@mastra/agent-builder';
+// import { agentBuilderWorkflows } from '@mastra/agent-builder';
 import type { WorkflowInfo } from '@mastra/core/workflows';
 import { HTTPException } from '../http-exception';
 import type { Context } from '../types';
@@ -25,14 +25,14 @@ function createAgentBuilderWorkflowHandler<TWorkflowArgs, TResult>(
     const logger = mastra.getLogger();
 
     try {
-      WorkflowRegistry.registerTemporaryWorkflows(agentBuilderWorkflows);
+      WorkflowRegistry.registerTemporaryWorkflows({});
 
       // Validate actionId if it's provided
-      if (actionId && !WorkflowRegistry.isAgentBuilderWorkflow(actionId)) {
-        throw new HTTPException(400, {
-          message: `Invalid agent-builder action: ${actionId}. Valid actions are: ${Object.keys(agentBuilderWorkflows).join(', ')}`,
-        });
-      }
+      // if (actionId && !WorkflowRegistry.isAgentBuilderWorkflow(actionId)) {
+      //   throw new HTTPException(400, {
+      //     message: `Invalid agent-builder action: ${actionId}. Valid actions are: ${Object.keys({}).join(', ')}`,
+      //   });
+      // }
 
       logger.info(logMessage, { actionId, ...actionArgs });
 

--- a/packages/server/src/server/handlers/agent-builder.ts
+++ b/packages/server/src/server/handlers/agent-builder.ts
@@ -1,6 +1,6 @@
 // import { agentBuilderWorkflows } from '@mastra/agent-builder';
 import type { WorkflowInfo } from '@mastra/core/workflows';
-import { HTTPException } from '../http-exception';
+// import { HTTPException } from '../http-exception';
 import type { Context } from '../types';
 import { getWorkflowInfo, WorkflowRegistry } from '../utils';
 import { handleError } from './error';

--- a/packages/server/src/server/handlers/agent-builder.ts
+++ b/packages/server/src/server/handlers/agent-builder.ts
@@ -25,12 +25,12 @@ function createAgentBuilderWorkflowHandler<TWorkflowArgs, TResult>(
     const logger = mastra.getLogger();
 
     try {
-      WorkflowRegistry.registerTemporaryWorkflows({});
+      // WorkflowRegistry.registerTemporaryWorkflows(agentBuilderWorkflows);
 
       // Validate actionId if it's provided
       // if (actionId && !WorkflowRegistry.isAgentBuilderWorkflow(actionId)) {
       //   throw new HTTPException(400, {
-      //     message: `Invalid agent-builder action: ${actionId}. Valid actions are: ${Object.keys({}).join(', ')}`,
+      //     message: `Invalid agent-builder action: ${actionId}. Valid actions are: ${Object.keys(agentBuilderWorkflows).join(', ')}`,
       //   });
       // }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Disables import of agent-builder workflows and agent-builder routes. This is due to slowdown issues with importing agent-builder workflows which will be looked at later to determine proper solution.
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
