### PR TITLE
do not pass tracing context to scorer run

### DIFF
--- a/.changeset/chatty-cycles-sing.md
+++ b/.changeset/chatty-cycles-sing.md
@@ -1,0 +1,6 @@
+---
+'@mastra/inngest': patch
+'@mastra/core': patch
+---
+
+fix: do not pass tracing context to score run

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -6588,7 +6588,6 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         input: expect.any(Object),
         output: expect.any(Object),
         runtimeContext: expect.any(Object),
-        tracingContext: expect.any(Object),
         entity: expect.objectContaining({
           id: 'Test Agent',
           name: 'Test Agent',

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2136,7 +2136,6 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           outputText,
           instructions,
           runtimeContext,
-          tracingContext: { currentSpan: agentAISpan },
           structuredOutput,
           overrideScorers,
           threadId,
@@ -2181,7 +2180,6 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     outputText,
     instructions,
     runtimeContext,
-    tracingContext,
     structuredOutput,
     overrideScorers,
     threadId,
@@ -2192,7 +2190,6 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     outputText: string;
     instructions: string;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
     structuredOutput?: boolean;
     overrideScorers?:
       | MastraScorers
@@ -2248,7 +2245,6 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           input: scorerInput,
           output: scorerOutput,
           runtimeContext,
-          tracingContext,
           entity: {
             id: this.id,
             name: this.name,
@@ -3405,7 +3401,6 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       outputText,
       instructions,
       runtimeContext,
-      tracingContext,
       structuredOutput,
       overrideScorers,
     });

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -899,7 +899,6 @@ export class DefaultExecutionEngine extends ExecutionEngine {
             workflowId,
             stepId: step.id,
             runtimeContext,
-            tracingContext: innerTracingContext,
             disableScorers,
           });
         }
@@ -1016,7 +1015,6 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     workflowId,
     stepId,
     runtimeContext,
-    tracingContext,
     disableScorers,
   }: {
     scorers: DynamicArgument<MastraScorers>;
@@ -1024,7 +1022,6 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     input: any;
     output: any;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
     workflowId: string;
     stepId: string;
     disableScorers?: boolean;
@@ -1062,7 +1059,6 @@ export class DefaultExecutionEngine extends ExecutionEngine {
           input: [input],
           output: output,
           runtimeContext,
-          tracingContext,
           entity: {
             id: workflowId,
             stepId: stepId,

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -1673,7 +1673,6 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
             workflowId: executionContext.workflowId,
             stepId: step.id,
             runtimeContext,
-            tracingContext: { currentSpan: stepAISpan },
             disableScorers,
           });
         }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->


## Related Issue(s)

Fixes the related error:
```
ERROR [2025-09-03 16:40:17.428 -0700] (Mastra): {"message":"SQLITE_ERROR: table mastra_scorers has no column named tracingContext","details":{"message":"SQLITE_ERROR: table mastra_scorers has no column named tracingContext","domain":"SCORER","category":"USER","details":{"scorerId":"scorer1","entityId":"Ghibli Films Buddy","entityType":"AGENT"}},"code":"MASTRA_SCORER_FAILED_TO_RUN_HOOK"}
^C
```

Will follow up by re adding the tracing context and updating storage adapters to run a  migration the add new column

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
