### PR TITLE
Allow both workflow stream message formats for now

### DIFF
--- a/.changeset/mean-yaks-clean.md
+++ b/.changeset/mean-yaks-clean.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Allow both workflow stream message formats for now

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -117,7 +117,26 @@ export type VariableReference<
     }
   | { value: any; schema: z.ZodTypeAny };
 
-export type StreamEvent = TextStreamPart<any> | WorkflowStreamEvent;
+export type StreamEvent =
+  // old events
+  | TextStreamPart<any>
+  | {
+      type: 'step-suspended';
+      payload: any;
+      id: string;
+    }
+  | {
+      type: 'step-waiting';
+      payload: any;
+      id: string;
+    }
+  | {
+      type: 'step-result';
+      payload: any;
+      id: string;
+    }
+  // vnext events
+  | WorkflowStreamEvent;
 export type WorkflowStreamEvent =
   | {
       type: 'workflow-start';

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -137,6 +137,7 @@ export type StreamEvent =
     }
   // vnext events
   | WorkflowStreamEvent;
+
 export type WorkflowStreamEvent =
   | {
       type: 'workflow-start';


### PR DESCRIPTION
Allows both vNext streaming events, and `.stream()` event types.