### PR TITLE
feat(@mastra/core): add InferUITools type helpers for AI SDK v5 compatibility

### DIFF
--- a/.changeset/ui-types-helpers.md
+++ b/.changeset/ui-types-helpers.md
@@ -1,0 +1,11 @@
+---
+"@mastra/core": patch
+---
+
+Add InferUITools and related type helpers for AI SDK compatibility
+
+Adds new type utility functions to help with type inference when using Mastra tools with the AI SDK's UI components:
+- `InferUITools` - Infers input/output types for a collection of tools
+- `InferUITool` - Infers input/output types for a single tool
+
+These type helpers allow developers to easily integrate Mastra tools with AI SDK UI components like `useChat` by providing proper type inference for tool inputs and outputs.

--- a/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
@@ -483,3 +483,82 @@ const { error, status, sendMessage, messages, regenerate, stop } =
 <Callout type="info">
   **Note**: The `streamVNext` method with format support is experimental and may change as we refine the feature based on feedback. See the [Agent Streaming documentation](/docs/agents/streaming) for more details about streamVNext.
 </Callout>
+
+### Type Inference for Tools
+
+When using tools with TypeScript in AI SDK v5, Mastra provides type inference helpers to ensure type safety for your tool inputs and outputs.
+
+#### InferUITool
+
+The `InferUITool` type helper infers the input and output types of a single Mastra tool:
+
+```typescript filename="app/types.ts" showLineNumbers copy
+import { InferUITool, createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+const weatherTool = createTool({
+  id: "get-weather",
+  description: "Get the current weather",
+  inputSchema: z.object({
+    location: z.string().describe("The city and state"),
+  }),
+  outputSchema: z.object({
+    temperature: z.number(),
+    conditions: z.string(),
+  }),
+  execute: async ({ context }) => {
+    return {
+      temperature: 72,
+      conditions: "sunny",
+    };
+  },
+});
+
+// Infer the types from the tool
+type WeatherUITool = InferUITool<typeof weatherTool>;
+// This creates:
+// {
+//   input: { location: string };
+//   output: { temperature: number; conditions: string };
+// }
+```
+
+#### InferUITools
+
+The `InferUITools` type helper infers the input and output types of multiple tools:
+
+```typescript filename="app/mastra/tools.ts" showLineNumbers copy
+import { InferUITools, createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+// Using weatherTool from the previous example
+const tools = {
+  weather: weatherTool,
+  calculator: createTool({
+    id: "calculator",
+    description: "Perform basic arithmetic",
+    inputSchema: z.object({
+      operation: z.enum(["add", "subtract", "multiply", "divide"]),
+      a: z.number(),
+      b: z.number(),
+    }),
+    outputSchema: z.object({
+      result: z.number(),
+    }),
+    execute: async ({ context }) => {
+      // implementation...
+      return { result: 0 };
+    },
+  }),
+};
+
+// Infer types from the tool set
+export type MyUITools = InferUITools<typeof tools>;
+// This creates:
+// {
+//   weather: { input: { location: string }; output: { temperature: number; conditions: string } };
+//   calculator: { input: { operation: "add" | "subtract" | "multiply" | "divide"; a: number; b: number }; output: { result: number } };
+// }
+```
+
+These type helpers provide full TypeScript support when using Mastra tools with AI SDK v5 UI components, ensuring type safety across your application.

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,4 +1,5 @@
 export * from './tool';
 export * from './types';
+export * from './ui-types';
 export { isVercelTool } from './toolchecks';
 export { ToolStream } from './stream';

--- a/packages/core/src/tools/ui-types.ts
+++ b/packages/core/src/tools/ui-types.ts
@@ -32,7 +32,7 @@ export type InferUITool<TOOL> = {
 /**
  * A set of tools (object with tool instances)
  */
-export type ToolSet = Record<string, any>;
+export type ToolSet = Record<string, Tool<any, any, any>>;
 
 /**
  * Infer the input and output types of a tool set so it can be used as a UI tool set.

--- a/packages/core/src/tools/ui-types.ts
+++ b/packages/core/src/tools/ui-types.ts
@@ -1,0 +1,47 @@
+import type { z } from 'zod';
+import type { Tool } from './tool';
+
+/**
+ * UI tool type for use with AI SDK frontend components
+ */
+export type UITool = {
+  input: unknown;
+  output: unknown | undefined;
+};
+
+/**
+ * Infer the input type of a Mastra tool
+ */
+export type InferToolInput<T> =
+  T extends Tool<infer I, any, any> ? (I extends z.ZodSchema ? z.infer<I> : never) : never;
+
+/**
+ * Infer the output type of a Mastra tool
+ */
+export type InferToolOutput<T> =
+  T extends Tool<any, infer O, any> ? (O extends z.ZodSchema ? z.infer<O> : never) : never;
+
+/**
+ * Infer the input and output types of a tool so it can be used as a UI tool.
+ */
+export type InferUITool<TOOL> = {
+  input: InferToolInput<TOOL>;
+  output: InferToolOutput<TOOL>;
+};
+
+/**
+ * A set of tools (object with tool instances)
+ */
+export type ToolSet = Record<string, any>;
+
+/**
+ * Infer the input and output types of a tool set so it can be used as a UI tool set.
+ */
+export type InferUITools<TOOLS extends ToolSet> = {
+  [NAME in keyof TOOLS & string]: InferUITool<TOOLS[NAME]>;
+};
+
+/**
+ * UI tools type for frontend components
+ */
+export type UITools = Record<string, UITool>;


### PR DESCRIPTION
This PR adds type inference helpers to make Mastra tools work seamlessly with AI SDK v5's type system.

The issue was that when using Mastra tools with AI SDK v5's InferUITools, TypeScript would throw compatibility errors. This happened because Mastra's Tool type structure didn't match what the AI SDK expected.

Now you can get proper type inference for your tools:

```typescript
import { InferUITools, createTool } from '@mastra/core/tools';

const weatherTool = createTool({
  id: 'get-weather',
  inputSchema: z.object({ location: z.string() }),
  outputSchema: z.object({ temperature: z.number() }),
  execute: async ({ context }) => ({ temperature: 72 })
});

const tools = { weather: weatherTool };

// Type-safe tool inference for AI SDK UI components
type MyUITools = InferUITools<typeof tools>;
// Results in: { weather: { input: { location: string }, output: { temperature: number } } }
```

The new helpers (InferUITool and InferUITools) extract the input and output types from Mastra tools, making them compatible with AI SDK v5 UI components like useChat.

Fixes #7184

<img width="776" height="1043" alt="Screenshot 2025-09-04 at 11 40 40 AM" src="https://github.com/user-attachments/assets/f34263fe-3237-4628-8121-b015637230f1" />