### PR TITLE
fix this when workflow is a step

### DIFF
--- a/.changeset/cold-jokes-wish.md
+++ b/.changeset/cold-jokes-wish.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix this to be not set when workflow is a step

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -267,7 +267,7 @@ export function createStep<
     suspendSchema: params.suspendSchema,
     scorers: params.scorers,
     retries: params.retries,
-    execute: params.execute,
+    execute: params.execute.bind(params),
   };
 }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fixes
```
Error executing step create-github-issue: TypeError: this.__registerMastra is not a function
```

this was not set as a workflow so it couldn't find the __registerMastra

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
