### PR TITLE
fix(core): set mastra instance inside of mcp tools

### DIFF
--- a/.changeset/sweet-parrots-relax.md
+++ b/.changeset/sweet-parrots-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Pass mastra instance into MCP Server tools

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -48,13 +48,15 @@ export abstract class MCPServerBase extends MastraBase {
   /** Information about remote access points for this server. */
   public readonly remotes?: RemoteInfo[];
   /** The tools registered with and converted by this MCP server. */
-  public readonly convertedTools: Record<string, ConvertedTool>;
+  public convertedTools: Record<string, ConvertedTool>;
   /** Reference to the Mastra instance if this server is registered with one. */
   public mastra: Mastra | undefined;
   /** Agents to be exposed as tools. */
   protected readonly agents?: MCPServerConfig['agents'];
   /** Workflows to be exposed as tools. */
   protected readonly workflows?: MCPServerConfig['workflows'];
+  /** Original tools configuration for re-conversion when Mastra instance is registered. */
+  protected readonly originalTools: ToolsInput;
 
   /**
    * Public getter for the server's unique ID.
@@ -108,6 +110,8 @@ export abstract class MCPServerBase extends MastraBase {
    */
   __registerMastra(mastra: Mastra): void {
     this.mastra = mastra;
+    // Re-convert tools now that we have the Mastra instance to populate MCP tools execute with mastra instance
+    this.convertedTools = this.convertTools(this.originalTools, this.agents, this.workflows);
   }
 
   /**
@@ -137,6 +141,7 @@ export abstract class MCPServerBase extends MastraBase {
     this.remotes = config.remotes;
     this.agents = config.agents;
     this.workflows = config.workflows;
+    this.originalTools = config.tools;
     this.convertedTools = this.convertTools(config.tools, config.agents, config.workflows);
   }
 

--- a/packages/mcp/integration-tests/src/mastra/mcp/index.ts
+++ b/packages/mcp/integration-tests/src/mastra/mcp/index.ts
@@ -42,5 +42,25 @@ export const myMcpServer = new MCPServer({
         return `The weather in ${city} is ${temp} and sunny.`;
       },
     }),
+    testMastraInstance: createTool({
+      id: 'testMastraInstance',
+      description: 'Test tool to verify mastra instance is available in MCP server tool execution.',
+      inputSchema: z.object({
+        testMessage: z.string().describe('A test message to verify the tool is working.'),
+      }),
+      execute: async ({ context, mastra }) => {
+        return {
+          success: true,
+          testMessage: context.testMessage,
+          mastraAvailable: !!mastra,
+          mastraType: typeof mastra,
+          // Verify that the mastra instance has the expected properties
+          mastraHasAgents: mastra ? 'getAgents' in mastra : false,
+          mastraHasMCPServers: mastra ? 'getMCPServers' in mastra : false,
+          mastraHasLogger: mastra ? 'getLogger' in mastra : false,
+          timestamp: new Date().toISOString(),
+        };
+      },
+    }),
   },
 });


### PR DESCRIPTION
## Description

We were creating the MCP tools before the mastra instance got populated inside of the MCP server. This ensures that when we attach the mcp server to a mastra instance we'll recreate the tools and populate the execute functions with the mastra instance. Fixes https://github.com/mastra-ai/mastra/issues/7478
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
