### PR TITLE
Call getMemoryMessages even during first turn in a thread

### DIFF
--- a/.changeset/fair-walls-collect.md
+++ b/.changeset/fair-walls-collect.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+"@mastra/memory": patch
+---
+
+Call getMemoryMessages even during first turn in a thread

--- a/.changeset/fair-walls-collect.md
+++ b/.changeset/fair-walls-collect.md
@@ -3,4 +3,4 @@
 "@mastra/memory": patch
 ---
 
-Call getMemoryMessages even during first turn in a thread
+Call getMemoryMessages even during first turn in a thread when semantic recall scope is resource

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1812,8 +1812,11 @@ export class Agent<
           });
         }
 
+        const config = memory.getMergedThreadConfig(memoryConfig || {});
+        const hasResourceScopeSemanticRecall =
+          typeof config?.semanticRecall === 'object' && config?.semanticRecall?.scope === 'resource';
         let [memoryMessages, memorySystemMessage] = await Promise.all([
-          existingThread
+          existingThread || hasResourceScopeSemanticRecall
             ? this.getMemoryMessages({
                 resourceId,
                 threadId: threadObject.id,
@@ -2847,8 +2850,11 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           });
         }
 
+        const config = memory.getMergedThreadConfig(memoryConfig || {});
+        const hasResourceScopeSemanticRecall =
+          typeof config?.semanticRecall === 'object' && config?.semanticRecall?.scope === 'resource';
         let [memoryMessages, memorySystemMessage] = await Promise.all([
-          existingThread
+          existingThread || hasResourceScopeSemanticRecall
             ? this.getMemoryMessages({
                 resourceId,
                 threadId: threadObject.id,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -53,10 +53,8 @@ export class Memory extends MastraMemory {
     this.threadConfig = mergedConfig;
   }
 
-  protected async validateThreadIsOwnedByResource(threadId: string, resourceId: string, config?: MemoryConfig) {
-    const mergedConfig = config ? this.getMergedThreadConfig(config) : undefined;
-    const resourceScope =
-      typeof mergedConfig?.semanticRecall === 'object' && mergedConfig?.semanticRecall?.scope === 'resource';
+  protected async validateThreadIsOwnedByResource(threadId: string, resourceId: string, config: MemoryConfig) {
+    const resourceScope = typeof config?.semanticRecall === 'object' && config?.semanticRecall?.scope === 'resource';
 
     const thread = await this.storage.getThreadById({ threadId });
 
@@ -265,8 +263,8 @@ export class Memory extends MastraMemory {
     vectorMessageSearch?: string;
     config?: MemoryConfig;
   }): Promise<{ messages: MastraMessageV1[]; messagesV2: MastraMessageV2[] }> {
-    if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, config);
     const threadConfig = this.getMergedThreadConfig(config || {});
+    if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, threadConfig);
 
     if (!threadConfig.lastMessages && !threadConfig.semanticRecall) {
       return {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes an issue where getMemoryMessages does not get called for the first turn in a thread even when semanticMemory scoped to resource.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#7367 
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
