### PR TITLE
Made tracing context optional on tool execute()

### DIFF
--- a/.changeset/bumpy-tables-lose.md
+++ b/.changeset/bumpy-tables-lose.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Made tracing context optional on tool execute()

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -2908,9 +2908,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      await expect(
-        userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} }),
-      ).rejects.toThrow(/same name/i);
+      await expect(userAgent['convertTools']({ runtimeContext: new RuntimeContext() })).rejects.toThrow(/same name/i);
     });
 
     it('should sanitize tool names with invalid characters', async () => {
@@ -2982,7 +2980,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} });
+      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext() });
       expect(Object.keys(tools)).toContain('bad___tool_name');
       expect(Object.keys(tools)).not.toContain(badName);
     });
@@ -3056,7 +3054,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} });
+      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext() });
       expect(Object.keys(tools)).toContain('_1tool');
       expect(Object.keys(tools)).not.toContain(badStart);
     });
@@ -3130,7 +3128,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       });
-      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext(), tracingContext: {} });
+      const tools = await userAgent['convertTools']({ runtimeContext: new RuntimeContext() });
       expect(Object.keys(tools).some(k => k.length === 63)).toBe(true);
       expect(Object.keys(tools)).not.toContain(longName);
     });

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -977,7 +977,7 @@ export class Agent<
     resourceId?: string;
     threadId?: string;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
+    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
   }) {
     let convertedMemoryTools: Record<string, CoreTool> = {};
@@ -1193,7 +1193,7 @@ export class Agent<
     resourceId?: string;
     threadId?: string;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
+    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
     writableStream?: WritableStream<ChunkType>;
   }) {
@@ -1258,7 +1258,7 @@ export class Agent<
     resourceId?: string;
     toolsets: ToolsetsInput;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
+    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
   }) {
     let toolsForRequest: Record<string, CoreTool> = {};
@@ -1308,7 +1308,7 @@ export class Agent<
     threadId?: string;
     resourceId?: string;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
+    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
     clientTools?: ToolsInput;
   }) {
@@ -1348,17 +1348,17 @@ export class Agent<
     threadId,
     resourceId,
     runtimeContext,
-    methodType,
     tracingContext,
+    methodType,
     format,
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     runtimeContext: RuntimeContext;
+    tracingContext?: TracingContext;
     methodType: 'generate' | 'stream' | 'streamVNext' | 'generateVNext';
     format?: 'mastra' | 'aisdk';
-    tracingContext: TracingContext;
   }) {
     const convertedWorkflowTools: Record<string, CoreTool> = {};
     const workflows = await this.getWorkflows({ runtimeContext });
@@ -1486,7 +1486,7 @@ export class Agent<
     resourceId?: string;
     runId?: string;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
+    tracingContext?: TracingContext;
     writableStream?: WritableStream<ChunkType>;
     methodType: 'generate' | 'stream' | 'streamVNext' | 'generateVNext';
     format?: 'mastra' | 'aisdk';

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -122,7 +122,7 @@ export class CoreToolBuilder extends MastraBase {
 
     const execFunction = async (args: unknown, execOptions: ToolExecutionOptions | ToolCallOptions) => {
       // Create tool span if we have an current span available
-      const toolSpan = options.tracingContext.currentSpan?.createChildSpan({
+      const toolSpan = options.tracingContext?.currentSpan?.createChildSpan({
         type: AISpanType.TOOL_CALL,
         name: `tool: ${options.name}`,
         input: args,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -55,7 +55,7 @@ export interface ToolExecutionContext<TSchemaIn extends z.ZodSchema | undefined 
   mastra?: MastraUnion;
   runtimeContext: RuntimeContext;
   writer?: ToolStream<any>;
-  tracingContext: TracingContext;
+  tracingContext?: TracingContext;
 }
 
 export interface ToolAction<

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -224,7 +224,7 @@ export interface ToolOptions {
   description?: string;
   mastra?: (Mastra & MastraPrimitives) | MastraPrimitives;
   runtimeContext: RuntimeContext;
-  tracingContext: TracingContext;
+  tracingContext?: TracingContext;
   memory?: MastraMemory;
   agentName?: string;
   model?: MastraLanguageModel;


### PR DESCRIPTION
## Description

`TracingContext` was recently added to `tool.execute()` as a required param. 

This makes it an optional param instead, allowing users to call `tool.execute()` in their workflow steps manually.


## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
