### PR TITLE
docs: Add Arize AX and Arize Phoenix to the observability providers

### DIFF
--- a/docs/src/content/en/reference/observability/providers/_meta.ts
+++ b/docs/src/content/en/reference/observability/providers/_meta.ts
@@ -1,5 +1,7 @@
 const meta = {
   index: "Overview",
+  "arize-ax": "Arize AX",
+  "arize-phoenix": "Arize Phoenix",
   dash0: "Dash0",
   signoz: "SigNoz",
   braintrust: "Braintrust",

--- a/docs/src/content/en/reference/observability/providers/arize-ax.mdx
+++ b/docs/src/content/en/reference/observability/providers/arize-ax.mdx
@@ -7,8 +7,6 @@ description: Documentation for integrating Arize AX with Mastra, a comprehensive
 
 Arize AX is a comprehensive AI observability platform designed specifically for monitoring, evaluating, and improving LLM applications in production.
 
-> **Note**: Currently, only AI-related calls will contain detailed telemetry data. Other operations will create traces but with limited information.
-
 ## Configuration
 
 To use Arize AX with Mastra, you can configure it using either environment variables or directly in your Mastra configuration.

--- a/docs/src/content/en/reference/observability/providers/arize-ax.mdx
+++ b/docs/src/content/en/reference/observability/providers/arize-ax.mdx
@@ -1,0 +1,83 @@
+---
+title: "Reference: Arize AX Integration | Mastra Observability Docs"
+description: Documentation for integrating Arize AX with Mastra, a comprehensive AI observability platform for monitoring and evaluating LLM applications.
+---
+
+# Arize AX
+
+Arize AX is a comprehensive AI observability platform designed specifically for monitoring, evaluating, and improving LLM applications in production.
+
+> **Note**: Currently, only AI-related calls will contain detailed telemetry data. Other operations will create traces but with limited information.
+
+## Configuration
+
+To use Arize AX with Mastra, you can configure it using either environment variables or directly in your Mastra configuration.
+
+### Using Environment Variables
+
+Set the following environment variables:
+
+```env
+ARIZE_SPACE_ID="your-space-id"
+ARIZE_API_KEY="your-api-key"
+```
+
+### Getting Your Credentials
+
+1. Sign up for an Arize AX account at [app.arize.com](https://app.arize.com)
+2. Navigate to your space settings to find your Space ID and API Key
+
+## Installation
+
+First, install the OpenInference instrumentation package for Mastra:
+
+```bash
+npm install @arizeai/openinference-mastra
+```
+
+## Implementation
+
+Here's how to configure Mastra to use Arize AX with OpenTelemetry:
+
+```typescript
+import { Mastra } from "@mastra/core";
+import {
+  isOpenInferenceSpan,
+  OpenInferenceOTLPTraceExporter,
+} from "@arizeai/openinference-mastra";
+
+export const mastra = new Mastra({
+  // ... other config
+  telemetry: {
+    serviceName: "your-mastra-app",
+    enabled: true,
+    export: {
+      type: "custom",
+      exporter: new OpenInferenceOTLPTraceExporter({
+        url: "https://otlp.arize.com/v1/traces",
+        headers: {
+          "space_id": process.env.ARIZE_SPACE_ID!,
+          "api_key": process.env.ARIZE_API_KEY!,
+        },
+        spanFilter: isOpenInferenceSpan,
+      }),
+    },
+  },
+});
+```
+
+## What Gets Automatically Traced
+
+Mastra's comprehensive tracing captures:
+
+- **Agent Operations**: All agent generation, streaming, and interaction calls
+- **LLM Interactions**: Complete model calls with input/output messages and metadata
+- **Tool Executions**: Function calls made by agents with parameters and results
+- **Workflow Runs**: Step-by-step workflow execution with timing and dependencies
+- **Memory Operations**: Agent memory queries, updates, and retrieval operations
+
+All traces follow OpenTelemetry standards and include relevant metadata such as model parameters, token usage, execution timing, and error details.
+
+## Dashboard
+
+Once configured, you can view your traces and analytics in the Arize AX dashboard at [app.arize.com](https://app.arize.com)

--- a/docs/src/content/en/reference/observability/providers/arize-phoenix.mdx
+++ b/docs/src/content/en/reference/observability/providers/arize-phoenix.mdx
@@ -1,0 +1,123 @@
+---
+title: "Reference: Arize Phoenix Integration | Mastra Observability Docs"
+description: Documentation for integrating Arize Phoenix with Mastra, an open-source AI observability platform for monitoring and evaluating LLM applications.
+---
+
+# Arize Phoenix
+
+Arize Phoenix is an open-source AI observability platform designed for monitoring, evaluating, and improving LLM applications. It can be self-hosted or used via Phoenix Cloud.
+
+> **Note**: Currently, only AI-related calls will contain detailed telemetry data. Other operations will create traces but with limited information.
+
+## Configuration
+
+### Phoenix Cloud
+
+If you're using Phoenix Cloud, configure these environment variables:
+
+```env
+PHOENIX_API_KEY="your-phoenix-api-key"
+PHOENIX_COLLECTOR_ENDPOINT="your-phoenix-hostname"
+```
+
+#### Getting Your Credentials
+
+1. Sign up for an Arize Phoenix account at [app.phoenix.arize.com](https://app.phoenix.arize.com/login)
+2. Grab your API key from the Keys option on the left bar
+3. Note your Phoenix hostname for the collector endpoint
+
+### Self-Hosted Phoenix
+
+If you're running a self-hosted Phoenix instance, configure:
+
+```env
+PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
+# Optional: If authentication enabled
+PHOENIX_API_KEY="your-api-key"
+```
+
+## Installation
+
+Install the necessary packages:
+
+```bash
+npm install @arizeai/openinference-mastra@^2.2.0
+```
+
+## Implementation
+
+Here's how to configure Mastra to use Phoenix with OpenTelemetry:
+
+### Phoenix Cloud Configuration
+
+```typescript
+import { Mastra } from "@mastra/core";
+import {
+  OpenInferenceOTLPTraceExporter,
+  isOpenInferenceSpan,
+} from "@arizeai/openinference-mastra";
+
+export const mastra = new Mastra({
+  // ... other config
+  telemetry: {
+    serviceName: "my-mastra-app",
+    enabled: true,
+    export: {
+      type: "custom",
+      exporter: new OpenInferenceOTLPTraceExporter({
+        url: process.env.PHOENIX_COLLECTOR_ENDPOINT!,
+        headers: {
+          Authorization: `Bearer ${process.env.PHOENIX_API_KEY}`,
+        },
+        spanFilter: isOpenInferenceSpan,
+      }),
+    },
+  },
+});
+```
+
+### Self-Hosted Phoenix Configuration
+
+```typescript
+import { Mastra } from "@mastra/core";
+import {
+  OpenInferenceOTLPTraceExporter,
+  isOpenInferenceSpan,
+} from "@arizeai/openinference-mastra";
+
+export const mastra = new Mastra({
+  // ... other config
+  telemetry: {
+    serviceName: "my-mastra-app",
+    enabled: true,
+    export: {
+      type: "custom",
+      exporter: new OpenInferenceOTLPTraceExporter({
+        url: process.env.PHOENIX_COLLECTOR_ENDPOINT!,
+        // Remove headers if authentication is not enabled
+        spanFilter: isOpenInferenceSpan,
+      }),
+    },
+  },
+});
+```
+
+## What Gets Automatically Traced
+
+Mastra's comprehensive tracing captures:
+
+- **Agent Operations**: All agent generation, streaming, and interaction calls
+- **LLM Interactions**: Complete model calls with input/output messages and metadata
+- **Tool Executions**: Function calls made by agents with parameters and results
+- **Workflow Runs**: Step-by-step workflow execution with timing and dependencies
+- **Memory Operations**: Agent memory queries, updates, and retrieval operations
+
+All traces follow OpenTelemetry standards and include relevant metadata such as model parameters, token usage, execution timing, and error details.
+
+## Dashboard
+
+Once configured, you can view your traces and analytics in Phoenix:
+- **Phoenix Cloud**: [app.phoenix.arize.com](https://app.phoenix.arize.com)
+- **Self-hosted**: Your Phoenix instance URL (e.g., `http://localhost:6006`)
+
+For self-hosting options, see the [Phoenix self-hosting documentation](https://arize.com/docs/phoenix/self-hosting).

--- a/docs/src/content/en/reference/observability/providers/arize-phoenix.mdx
+++ b/docs/src/content/en/reference/observability/providers/arize-phoenix.mdx
@@ -7,8 +7,6 @@ description: Documentation for integrating Arize Phoenix with Mastra, an open-so
 
 Arize Phoenix is an open-source AI observability platform designed for monitoring, evaluating, and improving LLM applications. It can be self-hosted or used via Phoenix Cloud.
 
-> **Note**: Currently, only AI-related calls will contain detailed telemetry data. Other operations will create traces but with limited information.
-
 ## Configuration
 
 ### Phoenix Cloud
@@ -94,7 +92,6 @@ export const mastra = new Mastra({
       type: "custom",
       exporter: new OpenInferenceOTLPTraceExporter({
         url: process.env.PHOENIX_COLLECTOR_ENDPOINT!,
-        // Remove headers if authentication is not enabled
         spanFilter: isOpenInferenceSpan,
       }),
     },

--- a/docs/src/content/en/reference/observability/providers/index.mdx
+++ b/docs/src/content/en/reference/observability/providers/index.mdx
@@ -1,12 +1,14 @@
 ---
 title: "Reference: Provider List | Observability | Mastra Docs"
-description: Overview of observability providers supported by Mastra, including Dash0, SigNoz, Braintrust, Langfuse, and more.
+description: Overview of observability providers supported by Mastra, including Arize AX, Arize Phoenix, Dash0, SigNoz, Braintrust, Langfuse, and more.
 ---
 
 # Observability Providers
 
 Observability providers include:
 
+- [Arize AX](./providers/arize-ax.mdx)
+- [Arize Phoenix](./providers/arize-phoenix.mdx)
 - [Braintrust](./providers/braintrust.mdx)
 - [Dash0](./providers/dash0.mdx)
 - [Laminar](./providers/laminar.mdx)


### PR DESCRIPTION
## Description
Add documentation pages for Arize AX and Arize Phoenix observability providers in the docs.

## Related Issue(s)
N/A

## Type of Change
Documentation update

Phoenix docs: https://arize.com/docs/phoenix/integrations/mastra/mastra-tracing
AX docs: https://arize.com/docs/ax/integrations/frameworks-and-platforms/mastra/mastra-tracing

Working example: https://github.com/Dylancouzon/orchestrator-agents/tree/main/mastra_orchestrator