### PR TITLE
fix(deployer): Correct `yarn pack` flags

### DIFF
--- a/.changeset/horse-battery-staple.md
+++ b/.changeset/horse-battery-staple.md
@@ -2,6 +2,4 @@
 "@mastra/deployer": patch
 ---
 
-Fix native dependencies in yarn monorepos
-
-Resolve issue #7525 where @mastra/deployer attempted to call a non-existant flag on `yarn pack`.
+Fix bug for Yarn users where a non-existent `yarn pack` flag was called

--- a/.changeset/horse-battery-staple.md
+++ b/.changeset/horse-battery-staple.md
@@ -1,0 +1,7 @@
+---
+"@mastra/deployer": patch
+---
+
+Fix native dependencies in yarn monorepos
+
+Resolve issue #7525 where @mastra/deployer attempted to call a non-existant flag on `yarn pack`.

--- a/packages/deployer/src/bundler/workspaceDependencies.ts
+++ b/packages/deployer/src/bundler/workspaceDependencies.ts
@@ -131,9 +131,10 @@ export const packWorkspaceDependencies = async ({
       await Promise.all(
         batch.map(async pkgName => {
           const dep = workspaceMap.get(pkgName);
+          const sanitizedName = slugify(pkgName);
           if (!dep) return;
 
-          await depsService.pack({ dir: dep.location, destination: workspaceDirPath });
+          await depsService.pack({ dir: dep.location, destination: workspaceDirPath, sanitizedName: sanitizedName });
         }),
       );
     }

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -7,7 +7,6 @@ import { readJSON, writeJSON, ensureFile } from 'fs-extra/esm';
 import type { PackageJson } from 'type-fest';
 
 import { createChildProcessLogger } from '../deploy/log.js';
-import { de } from 'zod/v4/locales';
 
 type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -70,6 +70,8 @@ export class Deps extends MastraBase {
 
     let destinationFlag = `--pack-destination ${destination}`;
     if (this.packageManager === 'yarn') {
+      // %s includes an '@' at the start of packages names with an '@'
+      // so we need to use our sanitizedName instead.
       destinationFlag = `--out ${destination}/${sanitizedName}-%v.tgz`;
     }
 

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -7,6 +7,7 @@ import { readJSON, writeJSON, ensureFile } from 'fs-extra/esm';
 import type { PackageJson } from 'type-fest';
 
 import { createChildProcessLogger } from '../deploy/log.js';
+import { de } from 'zod/v4/locales';
 
 type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
@@ -61,14 +62,19 @@ export class Deps extends MastraBase {
     return `file:./workspace-module/${pkgName}-${version}.tgz`;
   }
 
-  public async pack({ dir, destination }: { dir: string; destination: string }) {
+  public async pack({ dir, destination, sanitizedName }: { dir: string; destination: string; sanitizedName: string }) {
     const cpLogger = createChildProcessLogger({
       logger: this.logger,
       root: dir,
     });
 
+    let destinationFlag = `--pack-destination ${destination}`;
+    if (this.packageManager === 'yarn') {
+      destinationFlag = `--out ${destination}/${sanitizedName}-%v.tgz`;
+    }
+
     return cpLogger({
-      cmd: `${this.packageManager} pack --pack-destination ${destination}`,
+      cmd: `${this.packageManager} pack ${destinationFlag}`,
       args: [],
       env: {
         PATH: process.env.PATH!,


### PR DESCRIPTION
## Description

Fix native dependencies in yarn monorepos

Fix bug where @mastra/deployer attempted to call a non-existant flag on `yarn pack`.

## Related Issue(s)

Fixes #7525

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

* Not added - see discussion here: https://github.com/mastra-ai/mastra/issues/7525#issuecomment-3264936765

I have confirmed no new test breakages. 
I'm seeing:
> Error: Snapshot `getDeployer > should be able to extract the deployer from ./plugins/__fixtures__/empty-mastra.js 1` mismatched`

At HEAD, but I've not attempted to fix this in the current PR.
