### PR TITLE
fix(docs): Prevent submission during text composition (2)

### DIFF
--- a/docs/src/chatbot/components/chat-widget.tsx
+++ b/docs/src/chatbot/components/chat-widget.tsx
@@ -227,6 +227,9 @@ export function CustomChatInterface({
               onKeyDown={(e) => {
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault();
+                  if (e.nativeEvent.isComposing) {
+                    return;
+                  }
                   if (inputValue.trim() === "" || isLoading) return;
                   // Track the question
 


### PR DESCRIPTION
## Description

Fixed a bug in Docs where search keywords (e.g. in Japanese) were submitted immediately after text conversion/IME confirmation.

This is a missed fix from https://github.com/mastra-ai/mastra/pull/7373

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
