### PR TITLE
fix(core, client-js): add structuredOutput to client js

### DIFF
--- a/.changeset/proud-crabs-find.md
+++ b/.changeset/proud-crabs-find.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': patch
+'@mastra/core': patch
+---
+
+Allow streamVNext and generateVNext to use structuredOutputs from the MastraClient

--- a/client-sdks/client-js/src/resources/agent.vnext.test.ts
+++ b/client-sdks/client-js/src/resources/agent.vnext.test.ts
@@ -133,4 +133,119 @@ describe('Agent vNext', () => {
       }),
     );
   });
+
+  it('streamVNext: supports structuredOutput without explicit model', async () => {
+    // Mock response with structured output
+    const sseChunks = [
+      { type: 'step-start', payload: { messageId: 'm1' } },
+      { type: 'text-delta', payload: { text: '{"name": "John", "age": 30}' } },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'stop' }, usage: { totalTokens: 1 } } },
+    ];
+
+    (global.fetch as any).mockResolvedValueOnce(sseResponse(sseChunks));
+
+    // Define a schema for structured output
+    const personSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const resp = await agent.streamVNext({
+      messages: 'Create a person object',
+      structuredOutput: {
+        schema: personSchema,
+        // Note: No model provided - should fallback to agent's model
+      },
+    });
+
+    // Verify stream works correctly
+    let receivedChunks = 0;
+    await resp.processDataStream({
+      onChunk: async _chunk => {
+        receivedChunks++;
+      },
+    });
+    expect(receivedChunks).toBe(4);
+
+    // Verify request contains structuredOutput in the body
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4111/api/agents/agent-1/stream/vnext',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringMatching(/structuredOutput/),
+      }),
+    );
+
+    // Parse the request body to verify structuredOutput is properly sent
+    const requestBody = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(requestBody).toHaveProperty('structuredOutput');
+    expect(requestBody.structuredOutput).toHaveProperty('schema');
+    expect(requestBody.structuredOutput.schema).toEqual(
+      expect.objectContaining({
+        type: 'object',
+        properties: expect.objectContaining({
+          name: { type: 'string' },
+          age: { type: 'number' },
+        }),
+      }),
+    );
+    // Verify no model is included in structuredOutput (should fallback to agent's model)
+    expect(requestBody.structuredOutput).not.toHaveProperty('model');
+  });
+
+  it('generateVNext: supports structuredOutput without explicit model', async () => {
+    const mockJson = {
+      id: 'gen-1',
+      object: { name: 'Jane', age: 25 },
+      finishReason: 'stop',
+      usage: { totalTokens: 10 },
+    };
+
+    (global.fetch as any).mockResolvedValueOnce(
+      new Response(JSON.stringify(mockJson), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const personSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = await agent.generateVNext({
+      messages: 'Create a person object',
+      structuredOutput: {
+        schema: personSchema,
+        instructions: 'Generate a person with realistic data',
+        // Note: No model provided - should fallback to agent's model
+      },
+    });
+
+    expect(result).toEqual(mockJson);
+
+    // Verify request contains structuredOutput in the body
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4111/api/agents/agent-1/generate/vnext',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringMatching(/structuredOutput/),
+      }),
+    );
+
+    // Parse the request body to verify structuredOutput is properly sent
+    const requestBody = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(requestBody).toHaveProperty('structuredOutput');
+    expect(requestBody.structuredOutput).toHaveProperty('schema');
+    expect(requestBody.structuredOutput).toHaveProperty('instructions', 'Generate a person with realistic data');
+    expect(requestBody.structuredOutput.schema).toEqual(
+      expect.objectContaining({
+        type: 'object',
+        properties: expect.objectContaining({
+          name: { type: 'string' },
+          age: { type: 'number' },
+        }),
+      }),
+    );
+    // Verify no model is included in structuredOutput (should fallback to agent's model)
+    expect(requestBody.structuredOutput).not.toHaveProperty('model');
+  });
 });

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2,6 +2,7 @@ import type {
   AgentExecutionOptions,
   AgentGenerateOptions,
   AgentStreamOptions,
+  StructuredOutputOptions,
   ToolsInput,
   UIMessageWithMetadata,
 } from '@mastra/core/agent';
@@ -100,12 +101,21 @@ export type StreamParams<T extends JSONSchema7 | ZodSchema | undefined = undefin
   Omit<AgentStreamOptions<T>, 'output' | 'experimental_output' | 'runtimeContext' | 'clientTools' | 'abortSignal'>
 >;
 
-export type StreamVNextParams<OUTPUT extends OutputSchema | undefined = undefined> = {
+export type StreamVNextParams<
+  OUTPUT extends OutputSchema | undefined = undefined,
+  STRUCTURED_OUTPUT extends ZodSchema | JSONSchema7 | undefined = undefined,
+> = {
   messages: MessageListInput;
   output?: OUTPUT;
   runtimeContext?: RuntimeContext | Record<string, any>;
   clientTools?: ToolsInput;
-} & WithoutMethods<Omit<AgentExecutionOptions<OUTPUT>, 'output' | 'runtimeContext' | 'clientTools' | 'options'>>;
+  structuredOutput?: STRUCTURED_OUTPUT extends ZodSchema ? StructuredOutputOptions<STRUCTURED_OUTPUT> : never;
+} & WithoutMethods<
+  Omit<
+    AgentExecutionOptions<OUTPUT, STRUCTURED_OUTPUT>,
+    'output' | 'runtimeContext' | 'clientTools' | 'options' | 'structuredOutput'
+  >
+>;
 
 export type UpdateModelParams = {
   modelId: string;

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -109,7 +109,10 @@ export type StreamVNextParams<
   output?: OUTPUT;
   runtimeContext?: RuntimeContext | Record<string, any>;
   clientTools?: ToolsInput;
-  structuredOutput?: STRUCTURED_OUTPUT extends ZodSchema ? StructuredOutputOptions<STRUCTURED_OUTPUT> : never;
+  // Can't serialize the model, so we need to omit it, falls back to agent's model
+  structuredOutput?: STRUCTURED_OUTPUT extends ZodSchema
+    ? Omit<StructuredOutputOptions<STRUCTURED_OUTPUT>, 'model'>
+    : never;
 } & WithoutMethods<
   Omit<
     AgentExecutionOptions<OUTPUT, STRUCTURED_OUTPUT>,

--- a/packages/core/src/agent/agent-processor.test.ts
+++ b/packages/core/src/agent/agent-processor.test.ts
@@ -1827,8 +1827,8 @@ describe('v1 model - output processors', () => {
     it('should process structured output through output processors', async () => {
       let processedObject: any = null;
 
-      class StructuredOutputProcessor implements Processor {
-        readonly name = 'structured-output-processor';
+      class TestStructuredOutputProcessor implements Processor {
+        readonly name = 'test-structured-output-processor';
 
         async processOutputResult({ messages }) {
           // Process the final generated text and extract the structured data
@@ -1873,7 +1873,7 @@ describe('v1 model - output processors', () => {
             usage: { completionTokens: 10, promptTokens: 10 },
           }),
         }),
-        outputProcessors: [new StructuredOutputProcessor()],
+        outputProcessors: [new TestStructuredOutputProcessor()],
       });
 
       const result = await agent.generate('Who won the 2012 US presidential election?', {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -3117,7 +3117,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
         // Handle structuredOutput option by creating an StructuredOutputProcessor
         if (options.structuredOutput) {
-          const structuredProcessor = new StructuredOutputProcessor(options.structuredOutput);
+          const agentModel = await this.getModel({ runtimeContext: result.runtimeContext! });
+          const structuredProcessor = new StructuredOutputProcessor(options.structuredOutput, agentModel);
           effectiveOutputProcessors = effectiveOutputProcessors
             ? [...effectiveOutputProcessors, structuredProcessor]
             : [structuredProcessor];
@@ -3619,7 +3620,8 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     // Handle structuredOutput option by creating an StructuredOutputProcessor
     let finalOutputProcessors = mergedGenerateOptions.outputProcessors;
     if (mergedGenerateOptions.structuredOutput) {
-      const structuredProcessor = new StructuredOutputProcessor(mergedGenerateOptions.structuredOutput);
+      const agentModel = await this.getModel({ runtimeContext: mergedGenerateOptions.runtimeContext });
+      const structuredProcessor = new StructuredOutputProcessor(mergedGenerateOptions.structuredOutput, agentModel);
       finalOutputProcessors = finalOutputProcessors
         ? [...finalOutputProcessors, structuredProcessor]
         : [structuredProcessor];

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -44,8 +44,8 @@ export type StructuredOutputOptions<S extends ZodTypeAny = ZodTypeAny> = {
   /** Zod schema to validate the output against */
   schema: S;
 
-  /** Model to use for the internal structuring agent */
-  model: MastraLanguageModel;
+  /** Model to use for the internal structuring agent. If not provided, falls back to the agent's model */
+  model?: MastraLanguageModel;
 
   /**
    * Custom instructions for the structuring agent.


### PR DESCRIPTION
## Description

- add structuredOutput property to client-js, falls back to using agent model
- model is optional now in `structuredOutput`

Fixes https://github.com/mastra-ai/mastra/issues/7302

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
