### PR TITLE
Fixed ai tracing for workflows nested directly in agents

### DIFF
--- a/.changeset/all-guests-act.md
+++ b/.changeset/all-guests-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed ai tracing for workflows nested directly in agents

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1413,6 +1413,7 @@ export class Agent<
                 const streamResult = run.streamVNext({
                   inputData: context,
                   runtimeContext,
+                  tracingContext: innerTracingContext,
                   format,
                 });
 
@@ -2741,10 +2742,10 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           resourceId,
           runId,
           runtimeContext,
+          tracingContext: { currentSpan: agentAISpan },
           writableStream: options.writableStream,
           methodType,
           format,
-          tracingContext: { currentSpan: agentAISpan },
         });
 
         return {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1498,8 +1498,14 @@ export class Run<
   streamVNext({
     inputData,
     runtimeContext,
+    tracingContext,
     format,
-  }: { inputData?: z.infer<TInput>; runtimeContext?: RuntimeContext; format?: 'aisdk' | 'mastra' | undefined } = {}) {
+  }: {
+    inputData?: z.infer<TInput>;
+    runtimeContext?: RuntimeContext;
+    tracingContext?: TracingContext;
+    format?: 'aisdk' | 'mastra' | undefined;
+  } = {}) {
     this.closeStreamAction = async () => {};
 
     return new MastraWorkflowStream({
@@ -1561,15 +1567,19 @@ export class Run<
           }
         };
 
-        const executionResults = this._start({ inputData, runtimeContext, writableStream: writable, format }).then(
-          result => {
-            if (result.status !== 'suspended') {
-              this.closeStreamAction?.().catch(() => {});
-            }
+        const executionResults = this._start({
+          inputData,
+          runtimeContext,
+          tracingContext,
+          writableStream: writable,
+          format,
+        }).then(result => {
+          if (result.status !== 'suspended') {
+            this.closeStreamAction?.().catch(() => {});
+          }
 
-            return result;
-          },
-        );
+          return result;
+        });
         this.executionResults = executionResults;
 
         return readable;


### PR DESCRIPTION
## Description

AI Tracing propegation was broken for workflows run directly inside agents like the following example:

```
const simpleWorkflow = createSimpleWorkflow();

const workflowAgent = new Agent({
  name: 'Workflow Agent',
  instructions: 'You can execute workflows that exist in your config',
  model,
  workflows: {
    simpleWorkflow,
  },
});
```

It is fixed now.

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
