### PR TITLE
Add default cloud endpoint for ai exporter and update naming

### DIFF
--- a/.changeset/huge-ends-stick.md
+++ b/.changeset/huge-ends-stick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloud': patch
+---
+
+Rename cloud exporter to MastraCloudAITracingExporter and provide default value for trace endpoint

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -14,6 +14,57 @@ pnpm add @mastra/cloud
 
 ## Features
 
+### AI Tracing
+
+Track and monitor AI operations and spans with the `MastraCloudAITracingExporter`:
+
+```typescript
+import { MastraCloudAITracingExporter } from '@mastra/cloud';
+
+// Initialize the AI tracing exporter
+const cloudAITracingExporter = new MastraCloudAITracingExporter({
+  accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN, // Your Mastra Cloud access token
+  endpoint: 'https://api.mastra.ai/ai/spans/publish', // Optional: custom endpoint
+  logger: yourLoggerInstance, // Optional logger
+});
+
+// Use with Mastra instance
+export const mastra = new Mastra({
+  agents: { agent },
+  logger: new PinoLogger({
+    name: 'Mastra',
+    level: 'info',
+  }),
+  observability: {
+    instances: {
+      cloud: {
+        serviceName: 'service',
+        exporters: [cloudAITracingExporter],
+      },
+    },
+  },
+});
+```
+
+**Required Environment Variable:**
+
+- `MASTRA_CLOUD_ACCESS_TOKEN`: Your Mastra Cloud access token (generated from your Mastra Cloud project)
+
+#### API Reference
+
+##### `MastraCloudAITracingExporter`
+
+A custom AI tracing exporter that sends AI span data to Mastra Cloud for observability and monitoring.
+
+###### Constructor Options
+
+- `accessToken` (required): Your Mastra Cloud access token
+- `endpoint` (optional): Custom endpoint URL for sending AI tracing data (defaults to `https://api.mastra.ai/ai/spans/publish`)
+- `maxBatchSize` (optional): Maximum number of spans to batch before sending (default: 1000)
+- `maxBatchWaitMs` (optional): Maximum time to wait before sending a batch in milliseconds (default: 5000)
+- `maxRetries` (optional): Maximum number of retry attempts for failed requests (default: 3)
+- `logger` (optional): Logger instance compatible with the Mastra Logger interface
+
 ### Telemetry
 
 The package currently provides OpenTelemetry integration with Mastra Cloud for instrumenting and collecting telemetry data from your applications.
@@ -52,13 +103,13 @@ export const mastra = new Mastra({
 });
 ```
 
-## API Reference
+#### API Reference
 
-### `MastraCloudExporter`
+##### `MastraCloudExporter`
 
 A custom OpenTelemetry exporter that sends telemetry data to Mastra Cloud.
 
-#### Constructor Options
+###### Constructor Options
 
 - `accessToken` (required): Your Mastra Cloud access token
 - `endpoint` (optional): Custom endpoint URL for sending telemetry data

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -1,4 +1,4 @@
 export { MastraCloudExporter } from './telemetry';
-export { CloudAITracingExporter } from './ai-tracing';
-export type { CloudAITracingExporterConfig } from './ai-tracing';
+export { MastraCloudAITracingExporter } from './ai-tracing';
+export type { MastraCloudAITracingExporterConfig } from './ai-tracing';
 export type { MastraCloudExporterOptions } from './telemetry';


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

This PR has the following changes:
- updated the env var for the mastra endpoint to MASTRA_CLOUD_AI_TRACES_ENDPOINT to clarify this is only for AI traces
- Adds a default value for the endpoint to `https://api.mastra.ai/ai/spans/publish`
- renames the exporter to `MastraCloudAITracingExporter` to be consistent with our other exporter
- updates the README

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
