### PR TITLE
fix(core): response messageId consistency

### DIFF
--- a/.changeset/yummy-hats-relax.md
+++ b/.changeset/yummy-hats-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix issue with response message id consistency between stream/generate response and the message ids saveed in the DB. Also fixed the custom generatorId implementation to work with this.

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -6119,6 +6119,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           },
         },
       ];
+
       if (version === 'v1') {
         await agent.generate(messagesWithMetadata, {
           memory: {
@@ -7168,6 +7169,7 @@ describe('Stream ID Consistency', () => {
       name: 'test-agent',
       instructions: 'You are a helpful assistant.',
       model,
+      // model: openai('gpt-4o'),
       memory,
     });
 
@@ -7182,6 +7184,9 @@ describe('Stream ID Consistency', () => {
     });
 
     let streamResponseId: string | undefined;
+    for await (const _chunk of streamResult.fullStream) {
+      console.log('DEBUG chunk', _chunk);
+    }
     await streamResult.consumeStream();
 
     const finishedResult = streamResult;
@@ -7189,6 +7194,7 @@ describe('Stream ID Consistency', () => {
 
     streamResponseId = response?.messages?.[0]?.id;
 
+    console.log('DEBUG streamResponseId', streamResponseId);
     expect(streamResponseId).toBeDefined();
 
     const savedMessages = await memory.getMessages({ threadId });

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -7129,3 +7129,268 @@ describe('Agent Tests', () => {
 //     });
 
 // });
+
+describe('Stream ID Consistency', () => {
+  /**
+   * Test to verify that stream response IDs match database-saved message IDs
+   */
+
+  let memory: MockMemory;
+  let mastra: Mastra;
+
+  beforeEach(() => {
+    memory = new MockMemory();
+    mastra = new Mastra();
+  });
+
+  it('should return stream response IDs that can fetch saved messages from database', async () => {
+    const model = new MockLanguageModelV1({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          initialDelayInMs: 0,
+          chunkDelayInMs: 1,
+          chunks: [
+            { type: 'text-delta', textDelta: 'Hello! ' },
+            { type: 'text-delta', textDelta: 'I am ' },
+            { type: 'text-delta', textDelta: 'a helpful assistant.' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { promptTokens: 10, completionTokens: 20 },
+            },
+          ],
+        }),
+        rawCall: { rawPrompt: [], rawSettings: {} },
+      }),
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model,
+      memory,
+    });
+
+    agent.__registerMastra(mastra);
+
+    const threadId = randomUUID();
+    const resourceId = 'test-resource';
+
+    const streamResult = await agent.stream('Hello!', {
+      threadId,
+      resourceId,
+    });
+
+    let streamResponseId: string | undefined;
+    await streamResult.consumeStream();
+
+    const finishedResult = streamResult;
+    const response = await finishedResult.response;
+
+    streamResponseId = response?.messages?.[0]?.id;
+
+    expect(streamResponseId).toBeDefined();
+
+    const savedMessages = await memory.getMessages({ threadId });
+
+    const messageById = savedMessages.find(m => m.id === streamResponseId);
+
+    expect(messageById).toBeDefined();
+    expect(messageById!.id).toBe(streamResponseId);
+  });
+
+  it('should use custom ID generator for streaming and keep stream response IDs consistent with database', async () => {
+    let customIdCounter = 0;
+    const customIdGenerator = vi.fn(() => `custom-id-${++customIdCounter}`);
+
+    const model = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { promptTokens: 10, completionTokens: 20 },
+        text: 'Hello! I am a helpful assistant.',
+      }),
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          initialDelayInMs: 0,
+          chunkDelayInMs: 1,
+          chunks: [
+            { type: 'text-delta', textDelta: 'Hello! ' },
+            { type: 'text-delta', textDelta: 'I am ' },
+            { type: 'text-delta', textDelta: 'a helpful assistant.' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { promptTokens: 10, completionTokens: 20 },
+            },
+          ],
+        }),
+        rawCall: { rawPrompt: [], rawSettings: {} },
+      }),
+    });
+
+    const mastraWithCustomId = new Mastra({
+      idGenerator: customIdGenerator,
+      logger: false,
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model,
+      memory,
+    });
+
+    agent.__registerMastra(mastraWithCustomId);
+
+    const threadId = randomUUID();
+    const resourceId = 'test-resource';
+
+    const stream = await agent.stream('Hello!', { threadId, resourceId });
+
+    await stream.consumeStream();
+    const res = await stream.response;
+    const messageId = res.messages[0].id;
+
+    const savedMessages = await memory.getMessages({ threadId, selectBy: { include: [{ id: messageId }] } });
+
+    expect(savedMessages).toHaveLength(1);
+    expect(savedMessages[0].id).toBe(messageId);
+    expect(customIdGenerator).toHaveBeenCalled();
+  });
+
+  it('should return streamVNext response IDs that can fetch saved messages from database', async () => {
+    const model = new MockLanguageModelV2({
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          {
+            type: 'stream-start',
+            warnings: [],
+          },
+          {
+            type: 'response-metadata',
+            id: 'v2-msg-xyz123',
+            modelId: 'mock-model-id',
+            timestamp: new Date(0),
+          },
+          { type: 'text-start', id: '1' },
+          { type: 'text-delta', id: '1', delta: 'Hello! ' },
+          { type: 'text-delta', id: '1', delta: 'I am a ' },
+          { type: 'text-delta', id: '1', delta: 'helpful assistant.' },
+          { type: 'text-end', id: '1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      }),
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model,
+      memory,
+    });
+
+    agent.__registerMastra(mastra);
+
+    const threadId = randomUUID();
+    const resourceId = 'test-resource';
+
+    const streamResult = await agent.streamVNext('Hello!', {
+      threadId,
+      resourceId,
+    });
+
+    await streamResult.consumeStream();
+
+    let streamResponseId: string | undefined;
+    const res = await streamResult.response;
+    streamResponseId = res.uiMessages[0].id;
+
+    expect(streamResponseId).toBeDefined();
+
+    const savedMessages = await memory.getMessages({ threadId, selectBy: { include: [{ id: streamResponseId! }] } });
+    const messageById = savedMessages.find(m => m.id === streamResponseId);
+
+    expect(messageById).toBeDefined();
+    expect(messageById!.id).toBe(streamResponseId);
+  });
+
+  it('should use custom ID generator for streamVNext and keep stream response IDs consistent with database', async () => {
+    let customIdCounter = 0;
+    const customIdGenerator = vi.fn(() => `custom-v2-id-${++customIdCounter}`);
+
+    const model = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [
+          {
+            type: 'text',
+            text: 'Hello! I am a helpful assistant.',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          {
+            type: 'stream-start',
+            warnings: [],
+          },
+          {
+            type: 'response-metadata',
+            id: 'custom-v2-msg-xyz123',
+            modelId: 'mock-model-id',
+            timestamp: new Date(0),
+          },
+          { type: 'text-start', id: '1' },
+          { type: 'text-delta', id: '1', delta: 'Hello! ' },
+          { type: 'text-delta', id: '1', delta: 'I am a ' },
+          { type: 'text-delta', id: '1', delta: 'helpful assistant.' },
+          { type: 'text-end', id: '1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      }),
+    });
+
+    const mastraWithCustomId = new Mastra({
+      idGenerator: customIdGenerator,
+      logger: false,
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model,
+      memory,
+    });
+
+    agent.__registerMastra(mastraWithCustomId);
+
+    const threadId = randomUUID();
+    const resourceId = 'test-resource';
+
+    const stream = await agent.streamVNext('Hello!', { threadId, resourceId });
+
+    await stream.consumeStream();
+    const res = await stream.response;
+    const messageId = res.uiMessages[0].id;
+    const savedMessages = await memory.getMessages({ threadId, selectBy: { include: [{ id: messageId }] } });
+    expect(savedMessages).toHaveLength(1);
+    expect(savedMessages[0].id).toBe(messageId);
+    expect(customIdGenerator).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2989,6 +2989,9 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           outputProcessors,
           returnScorerData: options.returnScorerData,
           tracingContext,
+          _internal: {
+            generateId: inputData.experimental_generateMessageId || this.#mastra?.generateId?.bind(this.#mastra),
+          },
         });
 
         if (format === 'aisdk') {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -816,10 +816,7 @@ export class Agent<
         messageList,
       });
 
-      console.log('DEBUG result', JSON.stringify(result, null, 2));
-
       text = await result.text;
-      console.log('DEBUG text', text);
     } else {
       const result = await (llm as MastraLLMV1).__text({
         runtimeContext,
@@ -859,7 +856,6 @@ export class Agent<
     try {
       if (userMessage) {
         const normMessage = new MessageList().add(userMessage, 'user').get.all.ui().at(-1);
-        console.log('DEBUG normMessage', normMessage);
         if (normMessage) {
           return await this.generateTitleFromUserMessage({
             message: normMessage,

--- a/packages/core/src/agent/test-utils.ts
+++ b/packages/core/src/agent/test-utils.ts
@@ -49,10 +49,12 @@ export class MockMemory extends MastraMemory {
     threadId,
     resourceId,
     format = 'v1',
+    selectBy,
   }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
     let results = Array.from(this.messages.values());
     if (threadId) results = results.filter(m => m.threadId === threadId);
     if (resourceId) results = results.filter(m => m.resourceId === resourceId);
+    if (selectBy) results = results.filter(m => selectBy.include?.some(i => i.id === m.id));
     if (format === 'v2') return results as MastraMessageV2[];
     return results as MastraMessageV1[];
   }
@@ -176,6 +178,10 @@ export class MockMemory extends MastraMemory {
   }) {
     // Mock implementation for abstract method
     return { success: true, reason: 'Mock implementation' };
+  }
+
+  async updateMessages({ messages }: { messages: MastraMessageV2[] }) {
+    return this.saveMessages({ messages, format: 'v2' });
   }
 }
 

--- a/packages/core/src/agent/test-utils.ts
+++ b/packages/core/src/agent/test-utils.ts
@@ -54,7 +54,14 @@ export class MockMemory extends MastraMemory {
     let results = Array.from(this.messages.values());
     if (threadId) results = results.filter(m => m.threadId === threadId);
     if (resourceId) results = results.filter(m => m.resourceId === resourceId);
-    if (selectBy) results = results.filter(m => selectBy.include?.some(i => i.id === m.id));
+    if (selectBy) {
+      if (selectBy.include) {
+        results = results.filter(m => selectBy.include?.some(i => i.id === m.id));
+      }
+      if (selectBy.last) {
+        results = results.slice(-selectBy.last);
+      }
+    }
     if (format === 'v2') return results as MastraMessageV2[];
     return results as MastraMessageV1[];
   }

--- a/packages/core/src/llm/model/model.loop.test.ts
+++ b/packages/core/src/llm/model/model.loop.test.ts
@@ -1,6 +1,7 @@
 import { openai } from '@ai-sdk/openai-v5';
 import { describe, it } from 'vitest';
 import z from 'zod';
+import { MessageList } from '../../agent/message-list';
 import { RuntimeContext } from '../../runtime-context';
 import { MastraLLMVNext } from './model.loop';
 
@@ -11,13 +12,17 @@ const model = new MastraLLMVNext({
 describe('MastraLLMVNext', () => {
   it('should generate text - mastra', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you?',
-        },
-      ],
       runtimeContext: new RuntimeContext(),
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you?',
+          },
+        ],
+        'input',
+      ),
+      tracingContext: {},
     });
 
     console.log(await result.getFullOutput());
@@ -25,13 +30,17 @@ describe('MastraLLMVNext', () => {
 
   it('should generate text - aisdk', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you?',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you?',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     console.log(await result.aisdk.v5.getFullOutput());
@@ -39,13 +48,17 @@ describe('MastraLLMVNext', () => {
 
   it('should stream text - mastra', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you?',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you?',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     for await (const chunk of result.fullStream) {
@@ -58,13 +71,17 @@ describe('MastraLLMVNext', () => {
 
   it('should stream text - aisdk', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you?',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you?',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
     });
 
     for await (const chunk of result.aisdk.v5.fullStream) {
@@ -74,13 +91,17 @@ describe('MastraLLMVNext', () => {
 
   it('should stream object - mastra/aisdk', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
       output: z.object({
         name: z.string(),
         age: z.number(),
@@ -96,13 +117,17 @@ describe('MastraLLMVNext', () => {
 
   it('should generate object - mastra', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
       output: z.object({
         name: z.string(),
         age: z.number(),
@@ -116,13 +141,17 @@ describe('MastraLLMVNext', () => {
 
   it('should generate object - aisdk', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
       output: z.object({
         name: z.string(),
         age: z.number(),
@@ -136,13 +165,17 @@ describe('MastraLLMVNext', () => {
 
   it('full stream object - mastra', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
       output: z.object({
         name: z.string(),
         age: z.number(),
@@ -160,13 +193,17 @@ describe('MastraLLMVNext', () => {
 
   it('full stream object - aisdk', async () => {
     const result = model.stream({
-      messages: [
-        {
-          role: 'user',
-          content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
-        },
-      ],
+      messageList: new MessageList().add(
+        [
+          {
+            role: 'user',
+            content: 'Hello, how are you? My name is John Doe and I am 30 years old.',
+          },
+        ],
+        'input',
+      ),
       runtimeContext: new RuntimeContext(),
+      tracingContext: {},
       output: z.object({
         name: z.string(),
         age: z.number(),

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -14,7 +14,6 @@ import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
 
 import type { MastraPrimitives } from '../../action';
-import { MessageList } from '../../agent';
 import { AISpanType } from '../../ai-tracing';
 import { MastraBase } from '../../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -136,6 +136,7 @@ export class MastraLLMVNext extends MastraBase {
     providerOptions,
     tracingContext,
     messageList,
+    _internal,
     // ...rest
   }: ModelLoopStreamArgs<Tools, OUTPUT>): MastraModelOutput<OUTPUT | undefined> {
     let stopWhenToUse;
@@ -183,6 +184,7 @@ export class MastraLLMVNext extends MastraBase {
           ...this.experimental_telemetry,
           ...telemetry_settings,
         },
+        _internal,
         output,
         outputProcessors,
         returnScorerData,

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -136,6 +136,7 @@ export class MastraLLMVNext extends MastraBase {
     returnScorerData,
     providerOptions,
     tracingContext,
+    messageList,
     // ...rest
   }: ModelLoopStreamArgs<Tools, OUTPUT>): MastraModelOutput<OUTPUT | undefined> {
     let stopWhenToUse;
@@ -171,12 +172,6 @@ export class MastraLLMVNext extends MastraBase {
     });
 
     try {
-      const messageList = new MessageList({
-        threadId,
-        resourceId,
-      });
-      messageList.add(messages, 'input');
-
       const loopOptions: LoopOptions<Tools, OUTPUT> = {
         messageList,
         model: this.#model,

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -119,7 +119,6 @@ export class MastraLLMVNext extends MastraBase {
   }
 
   stream<Tools extends ToolSet, OUTPUT extends OutputSchema | undefined = undefined>({
-    messages,
     stopWhen = stepCountIs(5),
     maxSteps,
     tools = {} as Tools,
@@ -146,6 +145,8 @@ export class MastraLLMVNext extends MastraBase {
     } else {
       stopWhenToUse = stopWhen;
     }
+
+    const messages = messageList.get.all.aiV5.model();
 
     const model = this.#model;
     this.logger.debug(`[LLM] - Streaming text`, {

--- a/packages/core/src/llm/model/model.loop.types.ts
+++ b/packages/core/src/llm/model/model.loop.types.ts
@@ -1,11 +1,11 @@
 import type {
-  ModelMessage,
-  UIMessage,
   ToolSet,
   DeepPartial,
   streamText,
   StreamTextOnFinishCallback as OriginalStreamTextOnFinishCallback,
   StreamTextOnStepFinishCallback as OriginalStreamTextOnStepFinishCallback,
+  ModelMessage,
+  UIMessage,
 } from 'ai-v5';
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema } from 'zod';
@@ -39,7 +39,7 @@ export type ModelLoopStreamArgs<
   OUTPUT extends OutputSchema | undefined = undefined,
   STRUCTURED_OUTPUT extends ZodSchema | JSONSchema7 | undefined = undefined,
 > = {
-  messages: UIMessage[] | ModelMessage[];
+  messages?: UIMessage[] | ModelMessage[];
   structuredOutput?: STRUCTURED_OUTPUT extends z.ZodTypeAny ? StructuredOutputOptions<STRUCTURED_OUTPUT> : never;
   outputProcessors?: OutputProcessor[];
   runtimeContext: RuntimeContext;

--- a/packages/core/src/llm/model/model.loop.types.ts
+++ b/packages/core/src/llm/model/model.loop.types.ts
@@ -9,6 +9,7 @@ import type {
 } from 'ai-v5';
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema } from 'zod';
+import type { MessageList } from '../../agent';
 import type { TracingContext } from '../../ai-tracing';
 import type { LoopOptions } from '../../loop/types';
 import type { StructuredOutputOptions, OutputProcessor } from '../../processors';
@@ -46,4 +47,5 @@ export type ModelLoopStreamArgs<
   resourceId?: string;
   threadId?: string;
   returnScorerData?: boolean;
+  messageList: MessageList;
 } & Omit<LoopOptions<TOOLS, OUTPUT>, 'model' | 'messageList'>;

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -719,6 +719,22 @@ exports[`Loop Tests > AISDK v5 > generateText > result.response > should contain
   ],
   "modelId": "test-response-model-id",
   "timestamp": 1970-01-01T00:00:10.000Z,
+  "uiMessages": [
+    {
+      "id": "GhOQiW2oZck1AgkJ",
+      "metadata": {
+        "__originalContent": "Hello, world!",
+        "createdAt": 2025-09-09T17:52:08.767Z,
+      },
+      "parts": [
+        {
+          "text": "Hello, world!",
+          "type": "text",
+        },
+      ],
+      "role": "assistant",
+    },
+  ],
 }
 `;
 

--- a/packages/core/src/loop/loop.test.ts
+++ b/packages/core/src/loop/loop.test.ts
@@ -13,14 +13,14 @@ import { mockDate } from './test-utils/utils';
 
 describe('Loop Tests', () => {
   describe('AISDK v5', () => {
-    // beforeEach(() => {
-    //   vi.useFakeTimers();
-    //   vi.setSystemTime(mockDate);
-    // });
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(mockDate);
+    });
 
-    // afterEach(() => {
-    //   vi.useRealTimers();
-    // });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
 
     textStreamTests({ loopFn: loop, runId: 'test-run-id' });
     fullStreamTests({ loopFn: loop, runId: 'test-run-id' });

--- a/packages/core/src/loop/loop.test.ts
+++ b/packages/core/src/loop/loop.test.ts
@@ -1,4 +1,4 @@
-import { describe } from 'vitest';
+import { beforeEach, afterEach, describe, vi } from 'vitest';
 import { loop } from './loop';
 import { fullStreamTests } from './test-utils/fullStream';
 import { generateTextTestsV5 } from './test-utils/generateText';
@@ -9,9 +9,19 @@ import { telemetryTests } from './test-utils/telemetry';
 import { textStreamTests } from './test-utils/textStream';
 import { toolsTests } from './test-utils/tools';
 import { toUIMessageStreamTests } from './test-utils/toUIMessageStream';
+import { mockDate } from './test-utils/utils';
 
 describe('Loop Tests', () => {
   describe('AISDK v5', () => {
+    // beforeEach(() => {
+    //   vi.useFakeTimers();
+    //   vi.setSystemTime(mockDate);
+    // });
+
+    // afterEach(() => {
+    //   vi.useRealTimers();
+    // });
+
     textStreamTests({ loopFn: loop, runId: 'test-run-id' });
     fullStreamTests({ loopFn: loop, runId: 'test-run-id' });
     toUIMessageStreamTests({ loopFn: loop, runId: 'test-run-id' });

--- a/packages/core/src/loop/test-utils/fullStream.ts
+++ b/packages/core/src/loop/test-utils/fullStream.ts
@@ -2,13 +2,14 @@ import { delay } from '@ai-sdk/provider-utils';
 import { convertAsyncIterableToArray } from '@ai-sdk/provider-utils/test';
 import { tool } from 'ai-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2, mockValues } from 'ai-v5/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import z from 'zod';
 import { MessageList } from '../../agent/message-list';
 import type { loop } from '../loop';
 import {
   createTestModel,
   defaultSettings,
+  mockDate,
   modelWithFiles,
   modelWithReasoning,
   modelWithSources,
@@ -1127,6 +1128,7 @@ export function fullStreamTests({ loopFn, runId }: { loopFn: typeof loop; runId:
     });
 
     it('should send delayed asynchronous tool results', async () => {
+      vi.useRealTimers();
       const messageList = new MessageList();
       messageList.add(
         {
@@ -1174,6 +1176,8 @@ export function fullStreamTests({ loopFn, runId }: { loopFn: typeof loop; runId:
       const fullStream = await convertAsyncIterableToArray(result.aisdk.v5.fullStream);
 
       expect(fullStream).toMatchSnapshot();
+      vi.useFakeTimers();
+      vi.setSystemTime(mockDate);
     });
 
     it('should filter out empty text deltas', async () => {

--- a/packages/core/src/loop/test-utils/generateText.ts
+++ b/packages/core/src/loop/test-utils/generateText.ts
@@ -690,11 +690,70 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
               },
             }),
           }),
+          _internal: { generateId: () => '1234', currentDate: () => new Date(0), now: () => 0 },
           messageList: new MessageList(),
         });
 
-        expect(result.steps?.[0]?.response).toMatchSnapshot();
-        expect(await result.response).toMatchSnapshot();
+        expect(result.steps?.[0]?.response).toMatchInlineSnapshot(`
+          {
+            "body": "test body",
+            "headers": {
+              "custom-response-header": "response-header-value",
+            },
+            "id": "test-id-from-model",
+            "messages": [
+              {
+                "content": [
+                  {
+                    "text": "Hello, world!",
+                    "type": "text",
+                  },
+                ],
+                "role": "assistant",
+              },
+            ],
+            "modelId": "test-response-model-id",
+            "timestamp": 1970-01-01T00:00:10.000Z,
+          }
+        `);
+        expect(await result.response).toMatchInlineSnapshot(`
+          {
+            "body": "test body",
+            "headers": {
+              "custom-response-header": "response-header-value",
+            },
+            "id": "test-id-from-model",
+            "messages": [
+              {
+                "content": [
+                  {
+                    "text": "Hello, world!",
+                    "type": "text",
+                  },
+                ],
+                "role": "assistant",
+              },
+            ],
+            "modelId": "test-response-model-id",
+            "timestamp": 1970-01-01T00:00:10.000Z,
+            "uiMessages": [
+              {
+                "id": "1234",
+                "metadata": {
+                  "__originalContent": "Hello, world!",
+                  "createdAt": 2024-01-01T00:00:00.000Z,
+                },
+                "parts": [
+                  {
+                    "text": "Hello, world!",
+                    "type": "text",
+                  },
+                ],
+                "role": "assistant",
+              },
+            ],
+          }
+        `);
       });
     });
 

--- a/packages/core/src/loop/test-utils/resultObject.ts
+++ b/packages/core/src/loop/test-utils/resultObject.ts
@@ -7,6 +7,7 @@ import type { loop } from '../loop';
 import {
   createTestModel,
   defaultSettings,
+  mockDate,
   modelWithFiles,
   modelWithReasoning,
   modelWithSources,
@@ -305,26 +306,42 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
       await result.aisdk.v5.consumeStream();
 
       expect(await result.aisdk.v5.response).toMatchInlineSnapshot(`
+        {
+          "headers": {
+            "call": "2",
+          },
+          "id": "id-0",
+          "messages": [
             {
-              "headers": {
-                "call": "2",
-              },
-              "id": "id-0",
-              "messages": [
+              "content": [
                 {
-                  "content": [
-                    {
-                      "text": "Hello",
-                      "type": "text",
-                    },
-                  ],
-                  "role": "assistant",
+                  "text": "Hello",
+                  "type": "text",
                 },
               ],
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
-            }
-          `);
+              "role": "assistant",
+            },
+          ],
+          "modelId": "mock-model-id",
+          "timestamp": 1970-01-01T00:00:00.000Z,
+          "uiMessages": [
+            {
+              "id": "msg-0",
+              "metadata": {
+                "__originalContent": "Hello",
+                "createdAt": ${mockDate.toISOString()},
+              },
+              "parts": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+        }
+      `);
     });
   });
 

--- a/packages/core/src/loop/test-utils/utils.ts
+++ b/packages/core/src/loop/test-utils/utils.ts
@@ -6,6 +6,8 @@ import type {
 } from '@ai-sdk/provider-v5';
 import { MockLanguageModelV2, convertArrayToReadableStream, mockId } from 'ai-v5/test';
 
+export const mockDate = new Date('2024-01-01T00:00:00Z');
+
 export const defaultSettings = () =>
   ({
     prompt: 'prompt',

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -789,8 +789,6 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
       ...(scoringData ? { scoringData } : {}),
     };
 
-    fullOutput.response.messages = this.messageList.get.response.aiV5.model();
-
     return fullOutput;
   }
 

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -299,6 +299,7 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
                 response = {
                   ...otherMetadata,
                   messages: messageList.get.response.aiV5.model(),
+                  uiMessages: messageList.get.response.aiV5.ui(),
                 };
               }
 
@@ -338,6 +339,7 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
                     response = {
                       ...otherMetadata,
                       messages: messageList.get.response.aiV5.model(),
+                      uiMessages: messageList.get.response.aiV5.ui(),
                     };
                   }
                 } else {

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1434,7 +1434,7 @@ describe('Workflow', () => {
       });
     });
 
-    it.only('should be able to use an agent as a step', async () => {
+    it('should be able to use an agent as a step', async () => {
       const workflow = createWorkflow({
         id: 'test-workflow',
         inputSchema: z.object({

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1434,7 +1434,7 @@ describe('Workflow', () => {
       });
     });
 
-    it('should be able to use an agent as a step', async () => {
+    it.only('should be able to use an agent as a step', async () => {
       const workflow = createWorkflow({
         id: 'test-workflow',
         inputSchema: z.object({
@@ -1696,7 +1696,7 @@ describe('Workflow', () => {
           payload: {
             stepName: 'mapping_mock-uuid-2',
             id: 'mapping_mock-uuid-2',
-            stepCallId: 'mock-uuid-26',
+            stepCallId: 'mock-uuid-27',
             payload: {},
             startedAt: expect.any(Number),
             status: 'running',
@@ -1709,7 +1709,7 @@ describe('Workflow', () => {
           payload: {
             stepName: 'mapping_mock-uuid-2',
             id: 'mapping_mock-uuid-2',
-            stepCallId: 'mock-uuid-26',
+            stepCallId: 'mock-uuid-27',
             status: 'success',
             output: {
               prompt: 'Capital of UK, just the name',
@@ -1724,7 +1724,7 @@ describe('Workflow', () => {
           payload: {
             stepName: 'test-agent-2',
             id: 'test-agent-2',
-            stepCallId: 'mock-uuid-27',
+            stepCallId: 'mock-uuid-28',
             payload: {
               prompt: 'Capital of UK, just the name',
             },


### PR DESCRIPTION
## Description

Fixes https://github.com/mastra-ai/mastra/issues/7593 and https://github.com/mastra-ai/mastra/issues/7222

Ensures single MessageList gets instantiated per call inside of stream/generate VNext and legacy. Issues with id generation happened because we were instantiating multiple messageLists and the messageList would generate a new id for each of the messages each time. This made it so that the messages returned in the response and the messages saved in the DB had different id's. Making it difficult to update or manage messages that were returned in the response.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
