### PR TITLE
Update trace UI

### DIFF
--- a/packages/playground-ui/src/domains/traces/components/traces-table.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-table.tsx
@@ -1,9 +1,7 @@
-import { Skeleton } from '@/components/ui/skeleton';
 import { Table, Tbody, Th, Row, Cell, DateTimeCell, UnitCell, TxtCell } from '@/ds/components/Table';
 import { Thead } from '@/ds/components/Table';
 import type { RefinedTrace } from '@/domains/traces/types';
 import { Badge } from '@/ds/components/Badge';
-import { TraceIcon } from '@/ds/icons/TraceIcon';
 import { useOpenTrace } from '../hooks/use-open-trace';
 import { Txt } from '@/ds/components/Txt';
 import { useContext } from 'react';
@@ -45,15 +43,10 @@ const TraceRow = ({ trace, index, isActive }: { trace: RefinedTrace; index: numb
   const hasFailure = trace.trace.some(span => span.status.code === 2);
 
   return (
-    <Row className={isActive ? 'bg-surface4' : ''} onClick={() => openTrace(trace.trace, index)}>
+    <Row className={isActive ? 'bg-surface4' : ''} onClick={() => openTrace(trace.traceId, index, trace.trace[0])}>
       <DateTimeCell dateTime={new Date(trace.started / 1000)} />
       <TxtCell title={trace.traceId}>{trace.traceId.substring(0, 7)}...</TxtCell>
       <UnitCell unit="ms">{toSigFigs(trace.duration / 1000, 3)}</UnitCell>
-      <Cell>
-        <button onClick={() => openTrace(trace.trace, index)}>
-          <Badge icon={<TraceIcon />}>{trace.trace.length}</Badge>
-        </button>
-      </Cell>
       <Cell>
         {hasFailure ? (
           <Badge variant="error" icon={<X />}>
@@ -80,7 +73,6 @@ export const TracesTable = ({ traces, error }: TracesTableProps) => {
         <Th width={120}>Time</Th>
         <Th width="auto">Trace Id</Th>
         <Th width={120}>Duration</Th>
-        <Th width={120}>Spans</Th>
         <Th width={120}>Status</Th>
       </Thead>
       {error ? (

--- a/packages/playground-ui/src/domains/traces/components/traces-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-view.tsx
@@ -14,6 +14,7 @@ export interface TracesViewProps {
   stepName?: string;
   className?: string;
   setEndOfListElement: (element: HTMLDivElement | null) => void;
+  TraceLoader?: React.ComponentType;
 }
 
 export function TracesView({
@@ -24,6 +25,7 @@ export function TracesView({
   stepName,
   className,
   setEndOfListElement,
+  TraceLoader,
 }: TracesViewProps) {
   if (isLoading) {
     return <TracesViewSkeleton />;
@@ -38,6 +40,7 @@ export function TracesView({
         stepName={stepName}
         className={className}
         setEndOfListElement={setEndOfListElement}
+        TraceLoader={TraceLoader}
       />
     </TraceProvider>
   );
@@ -50,9 +53,18 @@ interface TracesViewInnerProps {
   stepName?: string;
   className?: string;
   setEndOfListElement: (element: HTMLDivElement | null) => void;
+  TraceLoader?: React.ComponentType;
 }
 
-function TracesViewInner({ traces, error, runId, stepName, className, setEndOfListElement }: TracesViewInnerProps) {
+function TracesViewInner({
+  traces,
+  error,
+  runId,
+  stepName,
+  className,
+  setEndOfListElement,
+  TraceLoader,
+}: TracesViewInnerProps) {
   // This is a hack. To fix, The provider should not resolve the data like this.
   // We should resolve the data first and pass them to the provider instead of having the proving setState on the result.
   const hasRunRef = useRef(false);
@@ -83,7 +95,7 @@ function TracesViewInner({ traces, error, runId, stepName, className, setEndOfLi
         <div aria-hidden ref={setEndOfListElement} />
       </div>
 
-      {open && <TracesSidebar width={sidebarWidth} onResize={setSidebarWidth} />}
+      {open && <TracesSidebar width={sidebarWidth} onResize={setSidebarWidth} TraceLoader={TraceLoader} />}
     </div>
   );
 }

--- a/packages/playground-ui/src/domains/traces/hooks/use-open-trace.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-open-trace.ts
@@ -10,14 +10,24 @@ export const useOpenTrace = () => {
     trace: currentTrace,
     setSpan,
     setCurrentTraceIndex,
+    setTraceId,
+    setIsLoadingTrace,
   } = useContext(TraceContext);
 
-  const openTrace = (trace: Span[], traceIndex: number) => {
-    setTrace(trace);
-    const parentSpan = trace.find(span => span.parentSpanId === null) || trace[0];
-    setSpan(parentSpan);
+  const openTrace = (traceId: string, traceIndex: number, rootSpan?: Span) => {
+    // Set loading state
+    setIsLoadingTrace(true);
     setCurrentTraceIndex(traceIndex);
-    if (open && currentTrace?.[0]?.id !== trace[0].id) return;
+    setTraceId(traceId);
+
+    // If we have a root span, show it immediately while loading
+    if (rootSpan) {
+      setTrace([rootSpan]);
+      setSpan(rootSpan);
+    }
+
+    // Toggle sidebar
+    if (open && currentTrace?.[0]?.traceId !== traceId) return;
     setOpen(prev => !prev);
   };
 

--- a/packages/playground-ui/src/domains/traces/index.ts
+++ b/packages/playground-ui/src/domains/traces/index.ts
@@ -1,2 +1,5 @@
 export * from './components/traces-view';
 export * from './utils';
+export { TraceContext, TraceProvider } from './context/trace-context';
+export type { TraceContextType } from './context/trace-context';
+export * from './types';

--- a/packages/playground-ui/src/domains/traces/trace-details.tsx
+++ b/packages/playground-ui/src/domains/traces/trace-details.tsx
@@ -6,13 +6,18 @@ import { Button } from '@/ds/components/Button';
 import { TraceContext } from './context/trace-context';
 import SpanView from './trace-span-view';
 import { Txt } from '@/ds/components/Txt';
+// TraceLoader will be imported from the playground package when used
 
 import { Icon } from '@/ds/icons';
 import { Header } from '@/ds/components/Header';
 import { Badge } from '@/ds/components/Badge';
 
-export function TraceDetails() {
-  const { trace, currentTraceIndex, prevTrace, nextTrace, traces } = useContext(TraceContext);
+interface TraceDetailsProps {
+  TraceLoader?: React.ComponentType;
+}
+
+export function TraceDetails({ TraceLoader }: TraceDetailsProps = {}) {
+  const { trace, currentTraceIndex, prevTrace, nextTrace, traces, isLoadingTrace } = useContext(TraceContext);
 
   const actualTrace = traces[currentTraceIndex];
 
@@ -23,6 +28,7 @@ export function TraceDetails() {
 
   return (
     <aside>
+      {TraceLoader && <TraceLoader />}
       <Header>
         <div className="flex items-center gap-1">
           <Button className="bg-transparent border-none" onClick={prevTrace} disabled={currentTraceIndex === 0}>
@@ -54,7 +60,15 @@ export function TraceDetails() {
       </Header>
 
       <div className="p-5">
-        <SpanView trace={trace} />
+        {isLoadingTrace ? (
+          <div className="flex items-center justify-center p-4">
+            <Txt variant="ui-md" className="text-icon3">
+              Loading trace details...
+            </Txt>
+          </div>
+        ) : (
+          <SpanView trace={trace} />
+        )}
       </div>
     </aside>
   );

--- a/packages/playground-ui/src/domains/traces/traces-sidebar.tsx
+++ b/packages/playground-ui/src/domains/traces/traces-sidebar.tsx
@@ -6,9 +6,10 @@ export interface TracesSidebarProps {
   className?: string;
   onResize?: (width: number) => void;
   width: number;
+  TraceLoader?: React.ComponentType;
 }
 
-export const TracesSidebar = ({ onResize }: TracesSidebarProps) => {
+export const TracesSidebar = ({ onResize, TraceLoader }: TracesSidebarProps) => {
   return (
     <MastraResizablePanel
       className="h-full absolute right-0 inset-y-0 bg-surface2"
@@ -19,7 +20,7 @@ export const TracesSidebar = ({ onResize }: TracesSidebarProps) => {
     >
       <div className="h-full grid grid-cols-2">
         <div className="overflow-x-scroll w-full h-[calc(100%-40px)]">
-          <TraceDetails />
+          <TraceDetails TraceLoader={TraceLoader} />
         </div>
 
         <div className="h-[calc(100%-40px)] overflow-x-scroll w-full border-l border-border1">

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -7,7 +7,7 @@ export * from './domains/scores/index';
 export * from './domains/tools/index';
 export * from './domains/workflows/index';
 export * from './domains/templates/index';
-export * from './domains/traces/index';
+
 export * from './domains/observability/index';
 export * from './domains/resizable-panel';
 export * from './components/dynamic-form/index';
@@ -36,7 +36,8 @@ export * from './components/ui/entry';
 export * from './hooks';
 export * from './lib/tanstack-query';
 
-export type { TraceContextType } from './domains/traces/context/trace-context';
+export { TracesView, TraceContext, TraceProvider } from './domains/traces/index';
+export type { TracesViewProps, TraceContextType } from './domains/traces/index';
 
 export * from './store/playground-store';
 export * from './lib/framework';

--- a/packages/playground/src/domains/traces/components/trace-loader.tsx
+++ b/packages/playground/src/domains/traces/components/trace-loader.tsx
@@ -1,0 +1,35 @@
+import { useContext, useEffect } from 'react';
+import { TraceContext, TraceContextType } from '@mastra/playground-ui';
+import { useTrace } from '../hooks/use-trace';
+import { refineTraces } from '../utils/refine-traces';
+
+export function TraceLoader() {
+  const { traceId, setTrace, setIsLoadingTrace, isLoadingTrace } = useContext<TraceContextType>(TraceContext);
+
+  const {
+    data: traceData,
+    isLoading,
+    isError,
+  } = useTrace(traceId, {
+    enabled: !!traceId && isLoadingTrace,
+  });
+
+  useEffect(() => {
+    if (traceData?.trace?.spans && !isLoading) {
+      // Process the full trace data
+      const refinedTraces = refineTraces(traceData.trace?.spans);
+      if (refinedTraces.length > 0) {
+        setTrace(refinedTraces[0].trace);
+      }
+      setIsLoadingTrace(false);
+    }
+  }, [traceData, isLoading, setTrace, setIsLoadingTrace]);
+
+  useEffect(() => {
+    if (isError) {
+      setIsLoadingTrace(false);
+    }
+  }, [isError, setIsLoadingTrace]);
+
+  return null; // This component doesn't render anything
+}

--- a/packages/playground/src/domains/traces/hooks/use-trace.tsx
+++ b/packages/playground/src/domains/traces/hooks/use-trace.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from '@mastra/playground-ui';
+import { client } from '@/lib/client';
+
+export const useTrace = (traceId: string | null | undefined, options?: { enabled?: boolean }) => {
+  const query = useQuery({
+    queryKey: ['trace', traceId],
+    queryFn: async () => {
+      if (!traceId) {
+        throw new Error('Trace ID is required');
+      }
+
+      const res = await client.getTrace(traceId);
+      return res;
+    },
+    enabled: options?.enabled !== undefined ? options.enabled : !!traceId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+    ...options,
+  });
+
+  return query;
+};

--- a/packages/playground/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground/src/domains/traces/hooks/use-traces.tsx
@@ -1,7 +1,7 @@
 import { client } from '@/lib/client';
-import { refineTraces } from '../utils/refine-traces';
 import { useInView, useInfiniteQuery } from '@mastra/playground-ui';
 import { useEffect } from 'react';
+import { refineRootTraces } from '../utils/refine-traces';
 
 const fetchFn = async ({ componentName, page, perPage }: { componentName: string; page: number; perPage: number }) => {
   try {
@@ -34,7 +34,7 @@ export const useTraces = (componentName: string, isWorkflow: boolean = false) =>
       }
       return lastPageParam + 1;
     },
-    select: data => refineTraces(data.pages.flat() || [], isWorkflow),
+    select: data => refineRootTraces(data.pages.flat() || [], isWorkflow),
     staleTime: 0,
     gcTime: 0,
   });

--- a/packages/playground/src/domains/traces/utils/refine-traces.ts
+++ b/packages/playground/src/domains/traces/utils/refine-traces.ts
@@ -1,5 +1,35 @@
 import { Span, RefinedTrace } from '@mastra/playground-ui';
 
+export const refineRootTraces = (rootSpans: Span[], isWorkflow: boolean = false): RefinedTrace[] => {
+  const newName = (name: string) => {
+    if (name?.startsWith('workflow.') && isWorkflow) {
+      return name?.split('.')?.slice(2)?.join('.');
+    }
+    if (name?.startsWith('agent.') && !isWorkflow) {
+      return name?.split('.')?.slice(1)?.join('.');
+    }
+    return name;
+  };
+
+  return rootSpans.map(span => {
+    const processedSpan = {
+      ...span,
+      name: newName(span.name),
+      duration: span.endTime - span.startTime,
+    };
+
+    return {
+      traceId: span.traceId,
+      serviceName: processedSpan.name,
+      duration: processedSpan.duration,
+      status: span.status,
+      started: span.startTime,
+      trace: [processedSpan], // Only root span initially
+      runId: span.attributes?.runId ? String(span.attributes.runId) : undefined,
+    };
+  });
+};
+
 export const refineTraces = (traces: Span[], isWorkflow: boolean = false): RefinedTrace[] => {
   const listOfSpanIds = new Set<string>();
 

--- a/packages/playground/src/pages/agents/agent/traces.tsx
+++ b/packages/playground/src/pages/agents/agent/traces.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 
 import { useAgent } from '@/hooks/use-agents';
 import { useTraces } from '@/domains/traces/hooks/use-traces';
+import { TraceLoader } from '@/domains/traces/components/trace-loader';
 
 function AgentTracesPage() {
   const { agentId } = useParams();
@@ -16,6 +17,7 @@ function AgentTracesPage() {
       isLoading={isAgentLoading || isTracesLoading}
       error={error}
       setEndOfListElement={setEndOfListElement}
+      TraceLoader={TraceLoader}
     />
   );
 }

--- a/packages/playground/src/pages/workflows/workflow/traces.tsx
+++ b/packages/playground/src/pages/workflows/workflow/traces.tsx
@@ -3,6 +3,7 @@ import { TracesView } from '@mastra/playground-ui';
 
 import { useWorkflow } from '@/hooks/use-workflows';
 import { useTraces } from '@/domains/traces/hooks/use-traces';
+import { TraceLoader } from '@/domains/traces/components/trace-loader';
 
 function WorkflowTracesPage() {
   const { workflowId } = useParams();
@@ -25,6 +26,7 @@ function WorkflowTracesPage() {
       setEndOfListElement={setEndOfListElement}
       runId={runId || undefined}
       stepName={stepName || undefined}
+      TraceLoader={TraceLoader}
     />
   );
 }


### PR DESCRIPTION
## Description

This PR uses the new api when viewing the traces page. We will first fetch root spans then when a user clicks on a trace we will fetch all child spans.

This PR also removes the span count from the root trace page because we can no longer calculate the number of child spans.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
