### PR TITLE
Various improvements to input & output data on AI spans

### DIFF
--- a/.changeset/cute-hotels-make.md
+++ b/.changeset/cute-hotels-make.md
@@ -1,0 +1,6 @@
+---
+'@mastra/inngest': patch
+'@mastra/core': patch
+---
+
+various improvements to input & output data on ai spans

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1693,7 +1693,9 @@ export class Agent<
         const agentAISpan = getOrCreateSpan({
           type: AISpanType.AGENT_RUN,
           name: `agent run: '${this.id}'`,
-          input: messages,
+          input: {
+            messages,
+          },
           attributes: {
             agentId: this.id,
             instructions,
@@ -2166,13 +2168,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
 
         agentAISpan?.end({
           output: {
-            text: result?.text,
-            object: result?.object,
-          },
-          metadata: {
-            usage: result?.usage,
-            toolResults: result?.toolResults,
-            toolCalls: result?.toolCalls,
+            status: 'success',
           },
         });
 
@@ -3226,7 +3222,11 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
     const run = await executionWorkflow.createRunAsync();
     const result = await run.start({ tracingContext: { currentSpan: agentAISpan } });
 
-    agentAISpan?.end({ output: result });
+    agentAISpan?.end({
+      output: {
+        status: result.status,
+      },
+    });
 
     return result;
   }

--- a/packages/core/src/ai-tracing/base.ts
+++ b/packages/core/src/ai-tracing/base.ts
@@ -197,6 +197,10 @@ export abstract class MastraAITracing extends MastraBase {
       attributes?: Partial<AISpanTypeMap[TType]>;
       metadata?: Record<string, any>;
     }) => {
+      if (span.isEvent) {
+        this.logger.warn(`End event is not available on event spans`);
+        return;
+      }
       originalEnd(options);
       this.emitSpanEnded(span);
     };
@@ -207,6 +211,10 @@ export abstract class MastraAITracing extends MastraBase {
       attributes?: Partial<AISpanTypeMap[TType]>;
       metadata?: Record<string, any>;
     }) => {
+      if (span.isEvent) {
+        this.logger.warn(`Update() is not available on event spans`);
+        return;
+      }
       originalUpdate(options);
       this.emitSpanUpdated(span);
     };

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -90,12 +90,17 @@ export interface LLMGenerationAttributes extends AIBaseAttributes {
   };
   /** Model parameters */
   parameters?: {
+    maxOutputTokens?: number;
     temperature?: number;
-    maxTokens?: number;
     topP?: number;
-    frequencyPenalty?: number;
+    topK?: number;
     presencePenalty?: number;
-    stop?: string[];
+    frequencyPenalty?: number;
+    stopSequences?: string[];
+    seed?: number;
+    maxRetries?: number;
+    abortSignal?: any;
+    headers?: Record<string, string | undefined>;
   };
   /** Whether this was a streaming response */
   streaming?: boolean;

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -24,7 +24,6 @@ import type { OutputSchema } from '../../stream/base/schema';
 import { delay } from '../../utils';
 
 import type { ModelLoopStreamArgs } from './model.loop.types';
-import { symbol } from 'zod/v4';
 
 export class MastraLLMVNext extends MastraBase {
   #model: LanguageModelV2;

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -12,7 +12,6 @@ import { stepCountIs } from 'ai-v5';
 import type { Schema, ModelMessage, ToolSet } from 'ai-v5';
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
-
 import type { MastraPrimitives } from '../../action';
 import { AISpanType } from '../../ai-tracing';
 import { MastraBase } from '../../base';
@@ -146,7 +145,7 @@ export class MastraLLMVNext extends MastraBase {
       stopWhenToUse = stopWhen;
     }
 
-    const messages = messageList.get.all.aiV5.model();
+    const messages = messageList.get.all.aiV5.prompt();
 
     const model = this.#model;
     this.logger.debug(`[LLM] - Streaming text`, {
@@ -158,15 +157,19 @@ export class MastraLLMVNext extends MastraBase {
     });
 
     const llmAISpan = tracingContext?.currentSpan?.createChildSpan({
-      name: `llm stream: '${model.modelId}'`,
+      name: `llm: '${model.modelId}'`,
       type: AISpanType.LLM_GENERATION,
-      input: messages,
+      input: {
+        messages,
+      },
       attributes: {
         model: model.modelId,
         provider: model.provider,
         streaming: true,
+        parameters: modelSettings,
       },
       metadata: {
+        runId,
         threadId,
         resourceId,
       },
@@ -215,6 +218,7 @@ export class MastraLLMVNext extends MastraBase {
                 },
                 e,
               );
+              llmAISpan?.error({ error: mastraError });
               this.logger.trackException(mastraError);
               throw mastraError;
             }
@@ -240,6 +244,24 @@ export class MastraLLMVNext extends MastraBase {
           onFinish: async props => {
             try {
               await options?.onFinish?.({ ...props, runId: runId! });
+              llmAISpan?.end({
+                output: {
+                  text: props?.text,
+                  reasoning: props?.reasoning,
+                  reasoningText: props?.reasoningText,
+                  files: props?.files,
+                  sources: props?.sources,
+                  warnings: props?.warnings,
+                },
+                attributes: {
+                  finishReason: props?.finishReason,
+                  usage: {
+                    promptTokens: props?.totalUsage?.inputTokens,
+                    completionTokens: props?.totalUsage?.outputTokens,
+                    totalTokens: props?.totalUsage?.totalTokens,
+                  },
+                },
+              });
             } catch (e: unknown) {
               const mastraError = new MastraError(
                 {
@@ -260,6 +282,7 @@ export class MastraLLMVNext extends MastraBase {
                 },
                 e,
               );
+              llmAISpan?.error({ error: mastraError });
               this.logger.trackException(mastraError);
               throw mastraError;
             }
@@ -278,9 +301,7 @@ export class MastraLLMVNext extends MastraBase {
         },
       };
 
-      const result = loop(loopOptions);
-      llmAISpan?.end({ output: result });
-      return result;
+      return loop(loopOptions);
     } catch (e: unknown) {
       const mastraError = new MastraError(
         {

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -1,4 +1,3 @@
-import type { LanguageModelV1FinishReason, LanguageModelV1StreamPart } from '@ai-sdk/provider';
 import {
   AnthropicSchemaCompatLayer,
   applyCompatLayer,
@@ -16,7 +15,6 @@ import type { ZodSchema } from 'zod';
 import { z } from 'zod';
 import type { MastraPrimitives } from '../../action';
 import { AISpanType } from '../../ai-tracing';
-import type { AnyAISpan, TracingContext } from '../../ai-tracing';
 import { MastraBase } from '../../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { Mastra } from '../../mastra';
@@ -112,144 +110,6 @@ export class MastraLLMV1 extends MastraBase {
     });
   }
 
-  private _startAISpan(params: {
-    model: LanguageModel;
-    tracingContext: TracingContext;
-    name: string;
-    streaming: boolean;
-    options: any;
-  }): AnyAISpan | undefined {
-    const { model, tracingContext, name, streaming, options } = params;
-    return tracingContext.currentSpan?.createChildSpan({
-      name,
-      type: AISpanType.LLM_GENERATION,
-      input: options.prompt,
-      attributes: {
-        model: model.modelId,
-        provider: model.provider,
-        parameters: {
-          temperature: options.temperature,
-          maxTokens: options.maxTokens,
-          topP: options.topP,
-          frequencyPenalty: options.frequencyPenalty,
-          presencePenalty: options.presencePenalty,
-          stop: options.stop,
-        },
-        streaming,
-      },
-    });
-  }
-
-  private _wrapModel(model: LanguageModel, tracingContext: TracingContext): LanguageModel {
-    if (!tracingContext.currentSpan) {
-      return model;
-    }
-
-    const wrappedDoGenerate = async (options: any) => {
-      const llmSpan = this._startAISpan({
-        model,
-        tracingContext,
-        name: `llm generate: '${model.modelId}'`,
-        streaming: false,
-        options,
-      });
-
-      try {
-        const result = await model.doGenerate(options);
-
-        llmSpan?.end({
-          output: result.text,
-          attributes: {
-            usage: result.usage
-              ? {
-                  promptTokens: result.usage.promptTokens,
-                  completionTokens: result.usage.completionTokens,
-                }
-              : undefined,
-          },
-        });
-        return result;
-      } catch (error) {
-        llmSpan?.error({ error: error as Error });
-        throw error;
-      }
-    };
-
-    const wrappedDoStream = async (options: any) => {
-      const llmSpan = this._startAISpan({
-        model,
-        tracingContext,
-        name: `llm stream: '${model.modelId}'`,
-        streaming: true,
-        options,
-      });
-
-      try {
-        const result = await model.doStream(options);
-
-        // Create a wrapped stream that tracks the final result
-        const originalStream = result.stream;
-        let finishReason: LanguageModelV1FinishReason;
-        let finalUsage: any = null;
-        let textOutput: string = '';
-
-        const wrappedStream = originalStream.pipeThrough(
-          new TransformStream({
-            // this gets called on each chunk output
-            transform(chunk: LanguageModelV1StreamPart, controller) {
-              //TODO: for tracing, do we want to do anything with the other chunk types?
-              switch (chunk.type) {
-                case 'text-delta':
-                  textOutput += chunk.textDelta;
-                  break;
-                case 'finish':
-                  finishReason = chunk.finishReason;
-                  finalUsage = chunk.usage;
-                  break;
-              }
-              controller.enqueue(chunk);
-            },
-            // this gets called at the end of the stream
-            flush() {
-              llmSpan?.end({
-                attributes: {
-                  output: textOutput,
-                  usage: finalUsage
-                    ? {
-                        promptTokens: finalUsage.promptTokens,
-                        completionTokens: finalUsage.completionTokens,
-                        totalTokens: finalUsage.totalTokens,
-                      }
-                    : undefined,
-                },
-                metadata: {
-                  finishReason,
-                },
-              });
-            },
-          }),
-        );
-
-        return {
-          ...result,
-          stream: wrappedStream,
-        };
-      } catch (error) {
-        llmSpan?.error({ error: error as Error });
-        throw error;
-      }
-    };
-
-    // Create a proper proxy to preserve all model properties including getters/setters
-    return new Proxy(model, {
-      get(target, prop) {
-        if (prop === 'doGenerate') return wrappedDoGenerate;
-        if (prop === 'doStream') return wrappedDoStream;
-        return target[prop as keyof typeof target];
-      },
-    });
-  }
-
   async __text<Tools extends ToolSet, Z extends ZodSchema | JSONSchema7 | undefined>({
     runId,
     messages,
@@ -299,10 +159,36 @@ export class MastraLLMV1 extends MastraBase {
       }
     }
 
+    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+      name: `llm: '${model.modelId}'`,
+      type: AISpanType.LLM_GENERATION,
+      input: {
+        messages,
+        schema,
+      },
+      attributes: {
+        model: model.modelId,
+        provider: model.provider,
+        parameters: {
+          temperature,
+          maxOutputTokens: rest.maxTokens,
+          topP: rest.topP,
+          frequencyPenalty: rest.frequencyPenalty,
+          presencePenalty: rest.presencePenalty,
+        },
+        streaming: false,
+      },
+      metadata: {
+        runId,
+        threadId,
+        resourceId,
+      },
+    });
+
     const argsForExecute: OriginalGenerateTextOptions<Tools, Z> = {
       ...rest,
       messages,
-      model: this._wrapModel(model, tracingContext),
+      model,
       temperature,
       tools: {
         ...(tools as Tools),
@@ -369,6 +255,21 @@ export class MastraLLMV1 extends MastraBase {
       if (schema && result.finishReason === 'stop') {
         result.object = (result as any).experimental_output;
       }
+      llmSpan?.end({
+        output: {
+          text: result.text,
+          object: result.object,
+          reasoning: result.reasoningDetails,
+          reasoningText: result.reasoning,
+          files: result.files,
+          sources: result.sources,
+          warnings: result.warnings,
+        },
+        attributes: {
+          finishReason: result.finishReason,
+          usage: result.usage,
+        },
+      });
 
       return result;
     } catch (e: unknown) {
@@ -387,6 +288,7 @@ export class MastraLLMV1 extends MastraBase {
         },
         e,
       );
+      llmSpan?.error({ error: mastraError });
       throw mastraError;
     }
   }
@@ -406,6 +308,31 @@ export class MastraLLMV1 extends MastraBase {
 
     this.logger.debug(`[LLM] - Generating a text object`, { runId });
 
+    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+      name: `llm: '${model.modelId}'`,
+      type: AISpanType.LLM_GENERATION,
+      input: {
+        messages,
+      },
+      attributes: {
+        model: model.modelId,
+        provider: model.provider,
+        parameters: {
+          temperature: rest.temperature,
+          maxOutputTokens: rest.maxTokens,
+          topP: rest.topP,
+          frequencyPenalty: rest.frequencyPenalty,
+          presencePenalty: rest.presencePenalty,
+        },
+        streaming: false,
+      },
+      metadata: {
+        runId,
+        threadId,
+        resourceId,
+      },
+    });
+
     try {
       let output: 'object' | 'array' = 'object';
       if (structuredOutput instanceof z.ZodArray) {
@@ -414,11 +341,17 @@ export class MastraLLMV1 extends MastraBase {
       }
 
       const processedSchema = this._applySchemaCompat(structuredOutput!);
+      llmSpan?.update({
+        input: {
+          messages,
+          schema: processedSchema,
+        },
+      });
 
       const argsForExecute: OriginalGenerateObjectOptions<Z> = {
         ...rest,
         messages,
-        model: this._wrapModel(model, tracingContext),
+        model,
         // @ts-expect-error - output in our implementation can only be object or array
         output,
         schema: processedSchema as Schema<Z>,
@@ -430,7 +363,21 @@ export class MastraLLMV1 extends MastraBase {
 
       try {
         // @ts-expect-error - output in our implementation can only be object or array
-        return await generateObject(argsForExecute);
+        const result = await generateObject(argsForExecute);
+
+        llmSpan?.end({
+          output: {
+            object: result.object,
+            warnings: result.warnings,
+          },
+          attributes: {
+            finishReason: result.finishReason,
+            usage: result.usage,
+          },
+        });
+
+        // @ts-expect-error - output in our implementation can only be object or array
+        return result;
       } catch (e: unknown) {
         const mastraError = new MastraError(
           {
@@ -447,6 +394,7 @@ export class MastraLLMV1 extends MastraBase {
           },
           e,
         );
+        llmSpan?.error({ error: mastraError });
         throw mastraError;
       }
     } catch (e: unknown) {
@@ -469,6 +417,7 @@ export class MastraLLMV1 extends MastraBase {
         },
         e,
       );
+      llmSpan?.error({ error: mastraError });
       throw mastraError;
     }
   }
@@ -515,8 +464,33 @@ export class MastraLLMV1 extends MastraBase {
       }
     }
 
+    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+      name: `llm: '${model.modelId}'`,
+      type: AISpanType.LLM_GENERATION,
+      input: {
+        messages,
+      },
+      attributes: {
+        model: model.modelId,
+        provider: model.provider,
+        parameters: {
+          temperature,
+          maxOutputTokens: rest.maxTokens,
+          topP: rest.topP,
+          frequencyPenalty: rest.frequencyPenalty,
+          presencePenalty: rest.presencePenalty,
+        },
+        streaming: true,
+      },
+      metadata: {
+        runId,
+        threadId,
+        resourceId,
+      },
+    });
+
     const argsForExecute: OriginalStreamTextOptions<Tools, Z> = {
-      model: this._wrapModel(model, tracingContext),
+      model,
       temperature,
       tools: {
         ...(tools as Tools),
@@ -547,6 +521,7 @@ export class MastraLLMV1 extends MastraBase {
             e,
           );
           this.logger.trackException(mastraError);
+          llmSpan?.error({ error: mastraError });
           throw mastraError;
         }
 
@@ -570,6 +545,20 @@ export class MastraLLMV1 extends MastraBase {
       onFinish: async props => {
         try {
           await onFinish?.({ ...props, runId: runId! });
+          llmSpan?.end({
+            output: {
+              text: props?.text,
+              reasoning: props?.reasoningDetails,
+              reasoningText: props?.reasoning,
+              files: props?.files,
+              sources: props?.sources,
+              warnings: props?.warnings,
+            },
+            attributes: {
+              finishReason: props?.finishReason,
+              usage: props?.usage,
+            },
+          });
         } catch (e: unknown) {
           const mastraError = new MastraError(
             {
@@ -590,6 +579,7 @@ export class MastraLLMV1 extends MastraBase {
             },
             e,
           );
+          llmSpan?.error({ error: mastraError });
           this.logger.trackException(mastraError);
           throw mastraError;
         }
@@ -636,6 +626,7 @@ export class MastraLLMV1 extends MastraBase {
         },
         e,
       );
+      llmSpan?.error({ error: mastraError });
       throw mastraError;
     }
   }
@@ -658,6 +649,31 @@ export class MastraLLMV1 extends MastraBase {
       messages,
     });
 
+    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+      name: `llm: '${model.modelId}'`,
+      type: AISpanType.LLM_GENERATION,
+      input: {
+        messages,
+      },
+      attributes: {
+        model: model.modelId,
+        provider: model.provider,
+        parameters: {
+          temperature: rest.temperature,
+          maxOutputTokens: rest.maxTokens,
+          topP: rest.topP,
+          frequencyPenalty: rest.frequencyPenalty,
+          presencePenalty: rest.presencePenalty,
+        },
+        streaming: true,
+      },
+      metadata: {
+        runId,
+        threadId,
+        resourceId,
+      },
+    });
+
     try {
       let output: 'object' | 'array' = 'object';
       if (structuredOutput instanceof z.ZodArray) {
@@ -666,13 +682,34 @@ export class MastraLLMV1 extends MastraBase {
       }
 
       const processedSchema = this._applySchemaCompat(structuredOutput!);
+      llmSpan?.update({
+        input: {
+          messages,
+          schema: processedSchema,
+        },
+      });
 
       const argsForExecute: OriginalStreamObjectOptions<T> = {
         ...rest,
-        model: this._wrapModel(model, tracingContext),
+        model,
         onFinish: async (props: any) => {
           try {
             await onFinish?.({ ...props, runId: runId! });
+            llmSpan?.end({
+              output: {
+                text: props?.text,
+                object: props?.object,
+                reasoning: props?.reasoningDetails,
+                reasoningText: props?.reasoning,
+                files: props?.files,
+                sources: props?.sources,
+                warnings: props?.warnings,
+              },
+              attributes: {
+                finishReason: props?.finishReason,
+                usage: props?.usage,
+              },
+            });
           } catch (e: unknown) {
             const mastraError = new MastraError(
               {
@@ -694,6 +731,7 @@ export class MastraLLMV1 extends MastraBase {
               e,
             );
             this.logger.trackException(mastraError);
+            llmSpan?.error({ error: mastraError });
             throw mastraError;
           }
 
@@ -732,10 +770,12 @@ export class MastraLLMV1 extends MastraBase {
           },
           e,
         );
+        llmSpan?.error({ error: mastraError });
         throw mastraError;
       }
     } catch (e: unknown) {
       if (e instanceof MastraError) {
+        llmSpan?.error({ error: e });
         throw e;
       }
 
@@ -754,6 +794,7 @@ export class MastraLLMV1 extends MastraBase {
         },
         e,
       );
+      llmSpan?.error({ error: mastraError });
       throw mastraError;
     }
   }

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -634,7 +634,7 @@ describe('Tool Tracing Context Injection', () => {
     // Verify tool span was created
     expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith({
       type: AISpanType.TOOL_CALL,
-      name: 'tool: tracing-test-tool',
+      name: "tool: 'tracing-test-tool'",
       input: { message: 'test' },
       attributes: {
         toolId: 'tracing-test-tool',
@@ -734,7 +734,7 @@ describe('Tool Tracing Context Injection', () => {
     // Verify tool span was created for Vercel tool
     expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith({
       type: AISpanType.TOOL_CALL,
-      name: 'tool: vercel-tool',
+      name: "tool: 'vercel-tool'",
       input: { input: 'test' },
       attributes: {
         toolId: 'vercel-tool',
@@ -847,7 +847,7 @@ describe('Tool Tracing Context Injection', () => {
     // Verify tool span was created with correct toolType attribute
     expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith({
       type: AISpanType.TOOL_CALL,
-      name: 'tool: toolset-tool',
+      name: "tool: 'toolset-tool'",
       input: { message: 'test' },
       attributes: {
         toolId: 'toolset-tool',

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -124,7 +124,7 @@ export class CoreToolBuilder extends MastraBase {
       // Create tool span if we have an current span available
       const toolSpan = options.tracingContext?.currentSpan?.createChildSpan({
         type: AISpanType.TOOL_CALL,
-        name: `tool: ${options.name}`,
+        name: `tool: '${options.name}'`,
         input: args,
         attributes: {
           toolId: options.name,

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -749,7 +749,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     const stepAISpan = tracingContext.currentSpan?.createChildSpan({
       name: `workflow step: '${step.id}'`,
       type: AISpanType.WORKFLOW_STEP,
-      //input: prevOutput,
+      input: prevOutput,
       attributes: {
         stepId: step.id,
       },
@@ -1121,7 +1121,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
   }): Promise<StepResult<any, any, any, any>> {
     const parallelSpan = tracingContext.currentSpan?.createChildSpan({
       type: AISpanType.WORKFLOW_PARALLEL,
-      name: `parallel: ${entry.steps.length} branches`,
+      name: `parallel: '${entry.steps.length} branches'`,
       input: this.getStepOutput(stepResults, prevStep),
       attributes: {
         branchCount: entry.steps.length,
@@ -1240,7 +1240,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
   }): Promise<StepResult<any, any, any, any>> {
     const conditionalSpan = tracingContext.currentSpan?.createChildSpan({
       type: AISpanType.WORKFLOW_CONDITIONAL,
-      name: `conditional: ${entry.conditions.length} conditions`,
+      name: `conditional: '${entry.conditions.length} conditions'`,
       input: prevOutput,
       attributes: {
         conditionCount: entry.conditions.length,
@@ -1253,7 +1253,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
         entry.conditions.map(async (cond, index) => {
           const evalSpan = conditionalSpan?.createChildSpan({
             type: AISpanType.WORKFLOW_CONDITIONAL_EVAL,
-            name: `condition ${index}`,
+            name: `condition '${index}'`,
             input: prevOutput,
             attributes: {
               conditionIndex: index,
@@ -1494,7 +1494,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
 
     const loopSpan = tracingContext.currentSpan?.createChildSpan({
       type: AISpanType.WORKFLOW_LOOP,
-      name: `loop: ${entry.loopType}`,
+      name: `loop: '${entry.loopType}'`,
       input: prevOutput,
       attributes: {
         loopType: entry.loopType,
@@ -1544,7 +1544,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
 
       const evalSpan = loopSpan?.createChildSpan({
         type: AISpanType.WORKFLOW_CONDITIONAL_EVAL,
-        name: `condition: ${entry.loopType}`,
+        name: `condition: '${entry.loopType}'`,
         input: selectFields(result.output, ['stepResult', 'output.text', 'output.object', 'messages']),
         attributes: {
           conditionIndex: iteration,
@@ -1664,7 +1664,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
 
     const loopSpan = tracingContext.currentSpan?.createChildSpan({
       type: AISpanType.WORKFLOW_LOOP,
-      name: `loop: foreach`,
+      name: `loop: 'foreach'`,
       input: prevOutput,
       attributes: {
         loopType: 'foreach',
@@ -1716,7 +1716,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
             executionContext,
             resume,
             prevOutput: item,
-            tracingContext,
+            tracingContext: { currentSpan: loopSpan },
             emitter,
             abortController,
             runtimeContext,
@@ -1783,12 +1783,6 @@ export class DefaultExecutionEngine extends ExecutionEngine {
               },
             });
           }
-          if (execResults.error) {
-            loopSpan?.error({ error: execResults.error });
-          } else {
-            loopSpan?.end({ output: result });
-          }
-
           return result;
         }
 

--- a/workflows/inngest/package.json
+++ b/workflows/inngest/package.json
@@ -54,7 +54,7 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.16.0-0 <0.17.0-0",
+    "@mastra/core": ">=0.16.3-0 <0.17.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -1783,7 +1783,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
   }): Promise<StepResult<any, any, any, any>> {
     const conditionalSpan = tracingContext?.currentSpan?.createChildSpan({
       type: AISpanType.WORKFLOW_CONDITIONAL,
-      name: `conditional: ${entry.conditions.length} conditions`,
+      name: `conditional: '${entry.conditions.length} conditions'`,
       input: prevOutput,
       attributes: {
         conditionCount: entry.conditions.length,
@@ -1797,7 +1797,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           this.inngestStep.run(`workflow.${workflowId}.conditional.${index}`, async () => {
             const evalSpan = conditionalSpan?.createChildSpan({
               type: AISpanType.WORKFLOW_CONDITIONAL_EVAL,
-              name: `condition ${index}`,
+              name: `condition: '${index}'`,
               input: prevOutput,
               attributes: {
                 conditionIndex: index,


### PR DESCRIPTION
## Description

This PR makes several fixes to AI Observability Spans:
* fixes span naming throughout
* fixes input/output/usage on LLM_GENERATION spans, including for VNext
* fixes AGENT_RUN spans to have a single LLM_GENERATION in legacy
* fixes input/output on AGENT_RUN spans
* fixes nesting on various branching spans


Also:
* fixes a MAJOR circular reference bug crashing the server when trying to write to storage or langfuse.
* removes each AISpan from having it's own logger instance.
* continues to improve on our integration tests of ai tracing.

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
