### PR TITLE
updated observability config and moved cloudExporter to core

### DIFF
--- a/.changeset/floppy-moons-agree.md
+++ b/.changeset/floppy-moons-agree.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloud': patch
+---
+
+Updated observability config, including adding a default section. Added CloudExporter for ai observability.

--- a/.changeset/fresh-papers-help.md
+++ b/.changeset/fresh-papers-help.md
@@ -1,0 +1,6 @@
+---
+'@mastra/braintrust': patch
+'@mastra/langfuse': patch
+---
+
+"updated observability config"

--- a/.changeset/seven-oranges-matter.md
+++ b/.changeset/seven-oranges-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloud': patch
+---
+
+Removed the MastraCloudAITracingExporter from the package. Use the CloudExport in @mastra/core instead.

--- a/docs/src/content/en/docs/observability/ai-tracing.mdx
+++ b/docs/src/content/en/docs/observability/ai-tracing.mdx
@@ -59,18 +59,33 @@ import { LangfuseExporter } from '@mastra/langfuse';
 export const mastra = new Mastra({
   // ... other config
   observability: {
-    instances: {
-      langfuse: {
-        serviceName: 'my-service',
-        exporters: [
-          new LangfuseExporter({
-            publicKey: process.env.LANGFUSE_PUBLIC_KEY,
-            secretKey: process.env.LANGFUSE_SECRET_KEY,
-            baseUrl: process.env.LANGFUSE_BASE_URL, // Optional - defaults to Langfuse cloud
-            realtime: true,
-          }),
-        ],
+    aiTracing: {
+      configs: {
+        langfuse: {
+          serviceName: 'my-service',
+          exporters: [
+            new LangfuseExporter({
+              publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+              secretKey: process.env.LANGFUSE_SECRET_KEY,
+              baseUrl: process.env.LANGFUSE_BASE_URL, // Optional - defaults to Langfuse cloud
+              realtime: true,
+            }),
+          ],
+        },
       },
+    },
+  },
+});
+```
+
+For the quickest setup with built-in exporters:
+
+```ts filename="src/mastra/index.ts" showLineNumbers copy
+export const mastra = new Mastra({
+  // ... other config
+  observability: {
+    aiTracing: {
+      default: { enabled: true }, // Enables DefaultExporter and CloudExporter
     },
   },
 });
@@ -82,11 +97,16 @@ The AI tracing config accepts these properties:
 
 ```ts
 type AITracingConfig = {
+  // Enable default configuration with built-in exporters
+  default?: {
+    enabled?: boolean;
+  };
+
   // Map of tracing instance names to their configurations
-  instances: Record<string, AITracingInstanceConfig | MastraAITracing>;
+  configs: Record<string, AITracingInstanceConfig | MastraAITracing>;
 
   // Optional function to select which tracing instance to use
-  selector?: TracingSelector;
+  configSelector?: TracingSelector;
 };
 
 type AITracingInstanceConfig = {
@@ -108,6 +128,35 @@ type AITracingInstanceConfig = {
 };
 ```
 
+### Default Configuration
+
+When `default.enabled` is set to `true`, Mastra automatically configures AI tracing with sensible defaults:
+
+```ts filename="src/mastra/index.ts" showLineNumbers copy
+export const mastra = new Mastra({
+  observability: {
+    aiTracing: {
+      default: { enabled: true },
+      configs: {
+        // Your custom configs can coexist with the default
+      }
+    }
+  }
+});
+```
+
+The default configuration includes:
+- **Service Name**: `"mastra"`
+- **Sampling**: Always sample (100% of traces)
+- **Exporters**: 
+  - `DefaultExporter` - Persists traces to your configured storage
+  - `CloudExporter` - Sends traces to Mastra Cloud (requires `MASTRA_CLOUD_ACCESS_TOKEN`)
+- **Processors**: `SensitiveDataFilter` - Automatically redacts sensitive fields
+
+<Callout type="info">
+  **Note**: You cannot name a custom config `"default"` when the default configuration is enabled. This will throw an error to prevent naming conflicts.
+</Callout>
+
 ### Sampling Configuration
 
 Control which traces are collected and exported:
@@ -115,35 +164,37 @@ Control which traces are collected and exported:
 ```ts filename="src/mastra/index.ts" showLineNumbers copy
 export const mastra = new Mastra({
   observability: {
-    instances: {
-      langfuse: {
-        serviceName: 'my-service',
-        // Sample all traces (default)
-        sampling: { type: 'always' },
-        exporters: [langfuseExporter],
-      },
-
-      development: {
-        serviceName: 'dev-service',
-        // Sample 10% of traces
-        sampling: {
-          type: 'ratio',
-          probability: 0.1
+    aiTracing: {
+      configs: {
+        langfuse: {
+          serviceName: 'my-service',
+          // Sample all traces (default)
+          sampling: { type: 'always' },
+          exporters: [langfuseExporter],
         },
-        exporters: [langfuseExporter],
-      },
 
-      custom: {
-        serviceName: 'custom-service',
-        // Custom sampling logic
-        sampling: {
-          type: 'custom',
-          sampler: (context) => {
-            // Only trace requests from specific users
-            return context.metadata?.userId === 'debug-user';
-          }
+        development: {
+          serviceName: 'dev-service',
+          // Sample 10% of traces
+          sampling: {
+            type: 'ratio',
+            probability: 0.1
+          },
+          exporters: [langfuseExporter],
         },
-        exporters: [langfuseExporter],
+
+        custom: {
+          serviceName: 'custom-service',
+          // Custom sampling logic
+          sampling: {
+            type: 'custom',
+            sampler: (context) => {
+              // Only trace requests from specific users
+              return context.metadata?.userId === 'debug-user';
+            }
+          },
+          exporters: [langfuseExporter],
+        },
       },
     },
   },
@@ -151,6 +202,66 @@ export const mastra = new Mastra({
 ```
 
 ## Exporters
+
+### Built-in Exporters
+
+Mastra includes two built-in exporters that are automatically configured when using the default configuration:
+
+#### DefaultExporter
+
+The `DefaultExporter` persists traces to your configured Mastra storage backend. It handles batching and retry logic automatically.
+
+**Features:**
+- Automatic batching with configurable batch size
+- Retry logic for failed exports
+- Strategy selection based on storage capabilities
+- No external dependencies required
+
+**Configuration:**
+```ts
+import { DefaultExporter } from '@mastra/core';
+
+new DefaultExporter({
+  maxBatchSize: 1000,    // Maximum spans per batch
+  maxBatchWaitMs: 5000,  // Maximum wait time before flushing
+  maxRetries: 4,         // Number of retry attempts
+  strategy: 'auto',      // 'auto' | 'realtime' | 'batch-with-updates' | 'insert-only'
+});
+```
+
+<Callout type="info">
+  If storage is not configured, the DefaultExporter will log a warning and operate as a no-op, allowing your application to continue without errors.
+</Callout>
+
+#### CloudExporter
+
+The `CloudExporter` sends traces to Mastra Cloud for online visualization and analysis.
+
+**Features:**
+- Real-time trace visualization in Mastra Cloud dashboard
+- Automatic batching and compression
+- Secure token-based authentication
+- Graceful fallback when token is not configured
+
+**Configuration:**
+```ts
+import { CloudExporter } from '@mastra/core';
+
+new CloudExporter({
+  accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN, // Required
+  endpoint: 'https://api.mastra.ai/ai/spans/publish', // Optional custom endpoint
+  maxBatchSize: 1000,    // Maximum spans per batch
+  maxBatchWaitMs: 5000,  // Maximum wait time before flushing
+});
+```
+
+**Environment Variables:**
+- `MASTRA_CLOUD_ACCESS_TOKEN` - Your Mastra Cloud access token
+- `MASTRA_CLOUD_AI_TRACES_ENDPOINT` - Optional custom endpoint URL
+
+<Callout type="warning">
+  If `MASTRA_CLOUD_ACCESS_TOKEN` is not set, the CloudExporter will log a message directing you to sign up at [mastra.ai](https://mastra.ai) and operate as a no-op.
+</Callout>
 
 ### Langfuse Exporter
 
@@ -284,24 +395,51 @@ You can configure multiple tracing instances and use a selector to choose which 
 ```ts filename="mastra.config.ts" showLineNumbers copy
 export const mastra = new Mastra({
   observability: {
-    instances: {
-      production: {
-        serviceName: 'prod-service',
-        sampling: { type: 'ratio', probability: 0.1 },
-        exporters: [prodLangfuseExporter],
+    aiTracing: {
+      configs: {
+        production: {
+          serviceName: 'prod-service',
+          sampling: { type: 'ratio', probability: 0.1 },
+          exporters: [prodLangfuseExporter],
+        },
+        development: {
+          serviceName: 'dev-service',
+          sampling: { type: 'always' },
+          exporters: [devLangfuseExporter],
+        },
       },
-      development: {
-        serviceName: 'dev-service',
-        sampling: { type: 'always' },
-        exporters: [devLangfuseExporter],
+      configSelector: (context, availableTracers) => {
+        // Use development tracer for debug sessions
+        if (context.runtimeContext?.get('debug') === 'true') {
+          return 'development';
+        }
+        return 'production';
       },
     },
-    selector: (context, availableTracers) => {
-      // Use development tracer for debug sessions
-      if (context.runtimeContext?.get('debug') === 'true') {
-        return 'development';
-      }
-      return 'production';
+  },
+});
+```
+
+You can also combine the default configuration with custom configs:
+
+```ts filename="mastra.config.ts" showLineNumbers copy
+export const mastra = new Mastra({
+  observability: {
+    aiTracing: {
+      default: { enabled: true }, // Provides 'default' instance
+      configs: {
+        langfuse: {
+          serviceName: 'langfuse-service',
+          exporters: [langfuseExporter],
+        },
+      },
+      configSelector: (context, availableTracers) => {
+        // Route specific requests to langfuse, others to default
+        if (context.runtimeContext?.get('useExternalTracing')) {
+          return 'langfuse';
+        }
+        return 'default';
+      },
     },
   },
 });

--- a/observability/braintrust/README.md
+++ b/observability/braintrust/README.md
@@ -17,7 +17,7 @@ import { BraintrustExporter } from '@mastra/braintrust';
 const mastra = new Mastra({
   ...,
   observability: {
-    instances: {
+    configs: {
       braintrust: {
         serviceName: 'service',
         exporters: [

--- a/observability/langfuse/README.md
+++ b/observability/langfuse/README.md
@@ -17,7 +17,7 @@ import { LangfuseExporter } from '@mastra/langfuse';
 const mastra = new Mastra({
   ...,
   observability: {
-    instances: {
+    configs: {
       langfuse: {
         serviceName: 'service',
         exporters: [

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -14,42 +14,6 @@ pnpm add @mastra/cloud
 
 ## Features
 
-### AI Tracing
-
-Track and monitor AI operations and spans with the `MastraCloudAITracingExporter`:
-
-```typescript
-import { MastraCloudAITracingExporter } from '@mastra/cloud';
-
-// Initialize the AI tracing exporter
-const cloudAITracingExporter = new MastraCloudAITracingExporter({
-  accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN, // Your Mastra Cloud access token
-  endpoint: 'https://api.mastra.ai/ai/spans/publish', // Optional: custom endpoint
-  logger: yourLoggerInstance, // Optional logger
-});
-
-// Use with Mastra instance
-export const mastra = new Mastra({
-  agents: { agent },
-  logger: new PinoLogger({
-    name: 'Mastra',
-    level: 'info',
-  }),
-  observability: {
-    instances: {
-      cloud: {
-        serviceName: 'service',
-        exporters: [cloudAITracingExporter],
-      },
-    },
-  },
-});
-```
-
-**Required Environment Variable:**
-
-- `MASTRA_CLOUD_ACCESS_TOKEN`: Your Mastra Cloud access token (generated from your Mastra Cloud project)
-
 #### API Reference
 
 ##### `MastraCloudAITracingExporter`

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -1,4 +1,2 @@
 export { MastraCloudExporter } from './telemetry';
-export { MastraCloudAITracingExporter } from './ai-tracing';
-export type { MastraCloudAITracingExporterConfig } from './ai-tracing';
 export type { MastraCloudExporterOptions } from './telemetry';

--- a/packages/core/src/ai-tracing/ai-tracing.test.ts
+++ b/packages/core/src/ai-tracing/ai-tracing.test.ts
@@ -1,32 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MastraError } from '../error';
-import { MastraAITracing } from './base';
-import { DefaultAITracing, SensitiveDataFilter, aiTracingDefaultConfig } from './default';
+import type { MastraAITracing } from './base';
+import { DefaultAITracing, SensitiveDataFilter } from './default';
 import { ConsoleExporter } from './exporters';
-import {
-  clearAITracingRegistry,
-  getAITracing,
-  registerAITracing,
-  unregisterAITracing,
-  hasAITracing,
-  getDefaultAITracing,
-  setAITracingSelector,
-  getSelectedAITracing,
-  setupAITracing,
-  shutdownAITracingRegistry,
-} from './registry';
-import type {
-  AITracingEvent,
-  AITracingExporter,
-  TraceContext,
-  LLMGenerationAttributes,
-  AITracingInstanceConfig,
-  AISpanOptions,
-  AISpan,
-  TracingSelector,
-  AITracingSelectorContext,
-} from './types';
+import { clearAITracingRegistry } from './registry';
+import type { AITracingEvent, AITracingExporter, TraceContext, LLMGenerationAttributes, AISpan } from './types';
 import { AISpanType, SamplingStrategyType, AITracingEventType } from './types';
 
 // Custom matchers for OpenTelemetry ID validation
@@ -122,7 +101,7 @@ describe('AI Tracing', () => {
     it('should create and start spans with type safety', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -150,7 +129,7 @@ describe('AI Tracing', () => {
     it('should create child spans with different types', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -179,7 +158,7 @@ describe('AI Tracing', () => {
     it('should correctly set parent relationships and isRootSpan property', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -226,7 +205,7 @@ describe('AI Tracing', () => {
     it('should maintain consistent traceId across span hierarchy', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -271,7 +250,7 @@ describe('AI Tracing', () => {
     it('should emit events throughout span lifecycle', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -308,7 +287,7 @@ describe('AI Tracing', () => {
     it('should handle errors with default endSpan=true', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -343,7 +322,7 @@ describe('AI Tracing', () => {
     it('should handle errors with explicit endSpan=false', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -372,7 +351,7 @@ describe('AI Tracing', () => {
     it('should always sample with ALWAYS strategy', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -390,7 +369,7 @@ describe('AI Tracing', () => {
     it('should never sample with NEVER strategy', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.NEVER },
         exporters: [testExporter],
       });
@@ -412,7 +391,7 @@ describe('AI Tracing', () => {
       // Test probability = 0.5
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.RATIO, probability: 0.5 },
         exporters: [testExporter],
       });
@@ -445,7 +424,7 @@ describe('AI Tracing', () => {
 
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.CUSTOM, sampler: shouldSample },
         exporters: [testExporter],
       });
@@ -462,7 +441,7 @@ describe('AI Tracing', () => {
     it('should handle invalid ratio probability', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.RATIO, probability: 1.5 }, // Invalid > 1
         exporters: [testExporter],
       });
@@ -480,7 +459,7 @@ describe('AI Tracing', () => {
     it('should handle parent relationships correctly in NoOp spans', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.NEVER }, // Force NoOp spans
         exporters: [testExporter],
       });
@@ -524,7 +503,7 @@ describe('AI Tracing', () => {
 
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [failingExporter, testExporter], // One fails, one succeeds
       });
@@ -544,7 +523,11 @@ describe('AI Tracing', () => {
     });
 
     it('should use default console exporter when none provided', () => {
-      const tracing = new DefaultAITracing();
+      const tracing = new DefaultAITracing({
+        serviceName: 'test-service',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
 
       expect(tracing.getExporters()).toHaveLength(1);
       expect(tracing.getExporters()[0]).toBeInstanceOf(ConsoleExporter);
@@ -559,7 +542,7 @@ describe('AI Tracing', () => {
 
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [mockExporter],
       });
@@ -570,445 +553,11 @@ describe('AI Tracing', () => {
     });
   });
 
-  describe('Registry', () => {
-    it('should register and retrieve tracing instances', () => {
-      const tracing = new DefaultAITracing({
-        serviceName: 'registry-test',
-        instanceName: 'registry-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      registerAITracing('my-tracing', tracing);
-
-      expect(getAITracing('my-tracing')).toBe(tracing);
-    });
-
-    it('should clear registry', () => {
-      const tracing = new DefaultAITracing({
-        serviceName: 'registry-test',
-        instanceName: 'registry-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-      registerAITracing('test', tracing);
-
-      clearAITracingRegistry();
-
-      expect(getAITracing('test')).toBeUndefined();
-    });
-
-    it('should handle multiple instances', () => {
-      const tracing1 = new DefaultAITracing({
-        serviceName: 'test-1',
-        instanceName: 'instance-1',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-      const tracing2 = new DefaultAITracing({
-        serviceName: 'test-2',
-        instanceName: 'instance-2',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      registerAITracing('first', tracing1);
-      registerAITracing('second', tracing2);
-
-      expect(getAITracing('first')).toBe(tracing1);
-      expect(getAITracing('second')).toBe(tracing2);
-    });
-
-    it('should prevent duplicate registration', () => {
-      const tracing1 = new DefaultAITracing({
-        serviceName: 'test-1',
-        instanceName: 'instance-1',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-      const tracing2 = new DefaultAITracing({
-        serviceName: 'test-2',
-        instanceName: 'instance-2',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      registerAITracing('duplicate', tracing1);
-
-      expect(() => {
-        registerAITracing('duplicate', tracing2);
-      }).toThrow("AI Tracing instance 'duplicate' already registered");
-    });
-
-    it('should unregister instances correctly', () => {
-      const tracing = new DefaultAITracing({
-        serviceName: 'test-1',
-        instanceName: 'instance-1',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      registerAITracing('test', tracing);
-      expect(getAITracing('test')).toBe(tracing);
-
-      expect(unregisterAITracing('test')).toBe(true);
-      expect(getAITracing('test')).toBeUndefined();
-    });
-
-    it('should return false when unregistering non-existent instance', () => {
-      expect(unregisterAITracing('non-existent')).toBe(false);
-    });
-
-    it('should handle hasAITracing checks correctly', () => {
-      const enabledTracing = new DefaultAITracing({
-        serviceName: 'enabled-test',
-        instanceName: 'enabled-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-      const disabledTracing = new DefaultAITracing({
-        serviceName: 'disabled-test',
-        instanceName: 'disabled-instance',
-        sampling: { type: SamplingStrategyType.NEVER },
-      });
-
-      registerAITracing('enabled', enabledTracing);
-      registerAITracing('disabled', disabledTracing);
-
-      expect(hasAITracing('enabled')).toBe(true);
-      expect(hasAITracing('disabled')).toBe(false);
-      expect(hasAITracing('non-existent')).toBe(false);
-    });
-
-    it('should access tracing config through registry', () => {
-      const tracing = new DefaultAITracing({
-        serviceName: 'config-test',
-        instanceName: 'config-instance',
-        sampling: { type: SamplingStrategyType.RATIO, probability: 0.5 },
-      });
-
-      registerAITracing('config-test', tracing);
-      const retrieved = getAITracing('config-test');
-
-      expect(retrieved).toBeDefined();
-      expect(retrieved!.getConfig().serviceName).toBe('config-test');
-      expect(retrieved!.getConfig().sampling.type).toBe(SamplingStrategyType.RATIO);
-    });
-
-    it('should use selector function when provided', () => {
-      const tracing1 = new DefaultAITracing({
-        serviceName: 'console-tracing',
-        instanceName: 'console-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-      const tracing2 = new DefaultAITracing({
-        serviceName: 'langfuse-tracing',
-        instanceName: 'langfuse-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      registerAITracing('console', tracing1);
-      registerAITracing('langfuse', tracing2);
-
-      const selector: TracingSelector = (context, _availableTracers) => {
-        // For testing, we'll simulate routing based on runtime context
-        if (context.runtimeContext?.['environment'] === 'production') return 'langfuse';
-        if (context.runtimeContext?.['environment'] === 'development') return 'console';
-        return undefined; // Fall back to default
-      };
-
-      setAITracingSelector(selector);
-
-      const prodContext: AITracingSelectorContext = {
-        runtimeContext: { environment: 'production' } as any,
-      };
-
-      const devContext: AITracingSelectorContext = {
-        runtimeContext: { environment: 'development' } as any,
-      };
-
-      expect(getSelectedAITracing(prodContext)).toBe(tracing2); // langfuse
-      expect(getSelectedAITracing(devContext)).toBe(tracing1); // console
-    });
-
-    it('should fall back to default when selector returns invalid name', () => {
-      const tracing1 = new DefaultAITracing({
-        serviceName: 'default-tracing',
-        instanceName: 'default-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      registerAITracing('default', tracing1, true); // Explicitly set as default
-
-      const selector: TracingSelector = (_context, _availableTracers) => 'non-existent';
-      setAITracingSelector(selector);
-
-      const context: AITracingSelectorContext = {
-        runtimeContext: undefined,
-      };
-
-      expect(getSelectedAITracing(context)).toBe(tracing1); // Falls back to default
-    });
-
-    it('should handle default tracing behavior', () => {
-      const tracing1 = new DefaultAITracing({
-        serviceName: 'first-tracing',
-        instanceName: 'first-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-      const tracing2 = new DefaultAITracing({
-        serviceName: 'second-tracing',
-        instanceName: 'second-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      // First registered becomes default automatically
-      registerAITracing('first', tracing1);
-      registerAITracing('second', tracing2);
-
-      expect(getDefaultAITracing()).toBe(tracing1);
-
-      // Explicitly set second as default
-      registerAITracing('third', tracing2, true);
-      expect(getDefaultAITracing()).toBe(tracing2);
-    });
-  });
-
-  describe('Mastra Integration', () => {
-    it('should configure AI tracing with simple config', async () => {
-      const instanceConfig: AITracingInstanceConfig = {
-        serviceName: 'test-service',
-        instanceName: 'test-instance',
-        exporters: [],
-      };
-
-      setupAITracing({
-        instances: {
-          test: instanceConfig,
-        },
-      });
-
-      // Verify AI tracing was registered and set as default
-      const tracing = getAITracing('test');
-      expect(tracing).toBeDefined();
-      expect(tracing?.getConfig().serviceName).toBe('test-service');
-      expect(tracing?.getConfig().sampling?.type).toBe(SamplingStrategyType.ALWAYS); // Should default to ALWAYS
-      expect(getDefaultAITracing()).toBe(tracing); // First one becomes default
-
-      // Cleanup
-      await shutdownAITracingRegistry();
-    });
-
-    it('should use ALWAYS sampling by default when sampling is not specified', async () => {
-      const instanceConfig: AITracingInstanceConfig = {
-        serviceName: 'default-sampling-test',
-        instanceName: 'default-sampling-instance',
-      };
-
-      setupAITracing({
-        instances: {
-          test: instanceConfig,
-        },
-      });
-
-      const tracing = getAITracing('test');
-      expect(tracing?.getConfig().sampling?.type).toBe(SamplingStrategyType.ALWAYS);
-
-      // Cleanup
-      await shutdownAITracingRegistry();
-    });
-
-    it('should configure AI tracing with custom implementation', async () => {
-      class CustomAITracing extends MastraAITracing {
-        protected createSpan<TType extends AISpanType>(options: AISpanOptions<TType>): AISpan<TType> {
-          // Custom implementation - just return a mock span for testing
-          return {
-            id: 'custom-span-id',
-            name: options.name,
-            type: options.type,
-            attributes: options.attributes,
-            parent: options.parent,
-            traceId: 'custom-trace-id',
-            startTime: new Date(),
-            aiTracing: this,
-            isEvent: false,
-            end: () => {},
-            error: () => {},
-            update: () => {},
-            createChildSpan: () => ({}) as any,
-            createEventSpan: () => ({}) as any,
-            get isRootSpan() {
-              return !options.parent;
-            },
-          } as AISpan<TType>;
-        }
-      }
-
-      const customInstance = new CustomAITracing({
-        serviceName: 'custom-service',
-        instanceName: 'custom-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      setupAITracing({
-        instances: {
-          custom: customInstance,
-        },
-      });
-
-      // Verify custom implementation was registered
-      const tracing = getAITracing('custom');
-      expect(tracing).toBeDefined();
-      expect(tracing).toBe(customInstance);
-      expect(tracing?.getConfig().serviceName).toBe('custom-service');
-
-      // Cleanup
-      await shutdownAITracingRegistry();
-    });
-
-    it('should support mixed configuration (config + instance)', async () => {
-      class CustomAITracing extends MastraAITracing {
-        protected createSpan<TType extends AISpanType>(_options: AISpanOptions<TType>): AISpan<TType> {
-          return {} as AISpan<TType>; // Mock implementation
-        }
-      }
-
-      const customInstance = new CustomAITracing({
-        serviceName: 'custom-service',
-        instanceName: 'custom-instance',
-        sampling: { type: SamplingStrategyType.NEVER },
-      });
-
-      setupAITracing({
-        instances: {
-          standard: {
-            serviceName: 'standard-service',
-            exporters: [],
-          },
-          custom: customInstance,
-        },
-      });
-
-      // Verify both instances were registered
-      const standardTracing = getAITracing('standard');
-      const customTracing = getAITracing('custom');
-
-      expect(standardTracing).toBeDefined();
-      expect(standardTracing).toBeInstanceOf(DefaultAITracing);
-      expect(standardTracing?.getConfig().serviceName).toBe('standard-service');
-
-      expect(customTracing).toBeDefined();
-      expect(customTracing).toBe(customInstance);
-      expect(customTracing?.getConfig().serviceName).toBe('custom-service');
-
-      // Cleanup
-      await shutdownAITracingRegistry();
-    });
-
-    it('should handle registry shutdown during Mastra shutdown', async () => {
-      let shutdownCalled = false;
-
-      class TestAITracing extends MastraAITracing {
-        protected createSpan<TType extends AISpanType>(_options: AISpanOptions<TType>): AISpan<TType> {
-          return {} as AISpan<TType>;
-        }
-
-        async shutdown(): Promise<void> {
-          shutdownCalled = true;
-          await super.shutdown();
-        }
-      }
-
-      const testInstance = new TestAITracing({
-        serviceName: 'test-service',
-        instanceName: 'test-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      });
-
-      setupAITracing({
-        instances: {
-          test: testInstance,
-        },
-      });
-
-      // Verify instance is registered
-      expect(getAITracing('test')).toBe(testInstance);
-
-      // Shutdown should call instance shutdown and clear registry
-      await shutdownAITracingRegistry();
-
-      expect(shutdownCalled).toBe(true);
-      expect(getAITracing('test')).toBeUndefined();
-    });
-
-    it('should prevent duplicate registration across multiple Mastra instances', () => {
-      const config: AITracingInstanceConfig = {
-        serviceName: 'test-service',
-        instanceName: 'test-instance',
-        sampling: { type: SamplingStrategyType.ALWAYS },
-      };
-
-      setupAITracing({
-        instances: {
-          duplicate: config,
-        },
-      });
-
-      // Attempting to register the same name should throw
-      expect(() => {
-        setupAITracing({
-          instances: {
-            duplicate: config,
-          },
-        });
-      }).toThrow("AI Tracing instance 'duplicate' already registered");
-    });
-
-    it('should support selector function configuration', async () => {
-      const selector: TracingSelector = (context, _availableTracers) => {
-        if (context.runtimeContext?.['service'] === 'agent') return 'langfuse';
-        if (context.runtimeContext?.['service'] === 'workflow') return 'datadog';
-        return undefined; // Use default
-      };
-
-      setupAITracing({
-        instances: {
-          console: {
-            serviceName: 'console-service',
-            exporters: [],
-          },
-          langfuse: {
-            serviceName: 'langfuse-service',
-            exporters: [],
-          },
-          datadog: {
-            serviceName: 'datadog-service',
-            exporters: [],
-          },
-        },
-        selector: selector,
-      });
-
-      // Test selector functionality
-      const agentContext: AITracingSelectorContext = {
-        runtimeContext: { service: 'agent' } as any,
-      };
-
-      const workflowContext: AITracingSelectorContext = {
-        runtimeContext: { service: 'workflow' } as any,
-      };
-
-      const genericContext: AITracingSelectorContext = {
-        runtimeContext: undefined,
-      };
-
-      // Verify selector routes correctly
-      expect(getSelectedAITracing(agentContext)).toBe(getAITracing('langfuse'));
-      expect(getSelectedAITracing(workflowContext)).toBe(getAITracing('datadog'));
-      expect(getSelectedAITracing(genericContext)).toBe(getDefaultAITracing()); // Falls back to default (console)
-
-      // Cleanup
-      await shutdownAITracingRegistry();
-    });
-  });
-
   describe('Type Safety', () => {
     it('should enforce correct attribute types for different span types', () => {
       const tracing = new DefaultAITracing({
         serviceName: 'test-tracing',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });
@@ -1278,10 +827,11 @@ describe('AI Tracing', () => {
     describe('as part of the default config', () => {
       it('should automatically filter sensitive data in default tracing', () => {
         const tracing = new DefaultAITracing({
-          ...aiTracingDefaultConfig,
           serviceName: 'test-tracing',
-          instanceName: 'test-instance',
+          name: 'test-instance',
+          sampling: { type: SamplingStrategyType.ALWAYS },
           exporters: [testExporter],
+          processors: [new SensitiveDataFilter()],
         });
 
         const span = tracing.startSpan({
@@ -1321,7 +871,7 @@ describe('AI Tracing', () => {
       testExporter = new TestExporter();
       aiTracing = new DefaultAITracing({
         serviceName: 'test-event-spans',
-        instanceName: 'test-instance',
+        name: 'test-instance',
         sampling: { type: SamplingStrategyType.ALWAYS },
         exporters: [testExporter],
       });

--- a/packages/core/src/ai-tracing/base.ts
+++ b/packages/core/src/ai-tracing/base.ts
@@ -38,7 +38,7 @@ export abstract class MastraAITracing extends MastraBase {
     // Apply defaults for optional fields
     this.config = {
       serviceName: config.serviceName,
-      instanceName: config.instanceName,
+      name: config.name,
       sampling: config.sampling ?? { type: SamplingStrategyType.ALWAYS },
       exporters: config.exporters ?? [],
       processors: config.processors ?? [],
@@ -52,7 +52,7 @@ export abstract class MastraAITracing extends MastraBase {
     super.__setLogger(logger);
     // Log AI tracing initialization details after logger is properly set
     this.logger.debug(
-      `[AI Tracing] Initialized [service=${this.config.serviceName}] [instance=${this.config.instanceName}] [sampling=${this.config.sampling.type}]`,
+      `[AI Tracing] Initialized [service=${this.config.serviceName}] [instance=${this.config.name}] [sampling=${this.config.sampling.type}]`,
     );
   }
 

--- a/packages/core/src/ai-tracing/default.ts
+++ b/packages/core/src/ai-tracing/default.ts
@@ -16,7 +16,6 @@ import type {
   AISpanProcessor,
   AnyAISpan,
 } from './types';
-import { SamplingStrategyType } from './types';
 import { shallowClean } from './utils';
 
 // ============================================================================
@@ -330,24 +329,17 @@ export class SensitiveDataFilter implements AISpanProcessor {
 }
 
 // ============================================================================
-// Default Configuration (defined after classes to avoid circular dependencies)
-// ============================================================================
-
-export const aiTracingDefaultConfig: AITracingInstanceConfig = {
-  serviceName: 'mastra-ai-service',
-  instanceName: 'default',
-  sampling: { type: SamplingStrategyType.ALWAYS },
-  exporters: [new ConsoleExporter()],
-  processors: [new SensitiveDataFilter()],
-};
-
-// ============================================================================
 // Default AI Tracing Implementation
 // ============================================================================
 
 export class DefaultAITracing extends MastraAITracing {
-  constructor(config: AITracingInstanceConfig = aiTracingDefaultConfig) {
-    super(config);
+  constructor(config: AITracingInstanceConfig) {
+    // If no exporters provided, add ConsoleExporter as default
+    const configWithDefaults = {
+      ...config,
+      exporters: config.exporters?.length ? config.exporters : [new ConsoleExporter()],
+    };
+    super(configWithDefaults);
   }
 
   // ============================================================================

--- a/packages/core/src/ai-tracing/exporters/cloud.md
+++ b/packages/core/src/ai-tracing/exporters/cloud.md
@@ -1,0 +1,35 @@
+### AI Tracing
+
+Track and monitor AI operations and spans with the `CloudExporter`:
+
+```typescript
+import { CloudExporter } from '@mastra/core';
+
+// Initialize the AI tracing exporter
+const cloudExporter = new CloudExporter({
+  accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN, // Your Mastra Cloud access token
+  endpoint: 'https://api.mastra.ai/ai/spans/publish', // Optional: custom endpoint
+  logger: yourLoggerInstance, // Optional logger
+});
+
+// Use with Mastra instance
+export const mastra = new Mastra({
+  agents: { agent },
+  logger: new PinoLogger({
+    name: 'Mastra',
+    level: 'info',
+  }),
+  observability: {
+    configs: {
+      cloud: {
+        serviceName: 'service',
+        exporters: [cloudExporter],
+      },
+    },
+  },
+});
+```
+
+**Required Environment Variable:**
+
+- `MASTRA_CLOUD_ACCESS_TOKEN`: Your Mastra Cloud access token (generated from your Mastra Cloud project)

--- a/packages/core/src/ai-tracing/exporters/cloud.test.ts
+++ b/packages/core/src/ai-tracing/exporters/cloud.test.ts
@@ -1,8 +1,9 @@
-import { AISpanType, AITracingEvent, AITracingEventType, AnyAISpan } from '..';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AITracingEvent, AnyAISpan } from '..';
+import { AISpanType, AITracingEventType } from '..';
 
-import { CloudExporter } from './cloud';
 import { fetchWithRetry } from '../../utils';
+import { CloudExporter } from './cloud';
 
 // Mock fetchWithRetry
 vi.mock('../../utils', () => ({

--- a/packages/core/src/ai-tracing/exporters/cloud.ts
+++ b/packages/core/src/ai-tracing/exporters/cloud.ts
@@ -1,6 +1,7 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import { ConsoleLogger, LogLevel } from '../../logger';
 import type { IMastraLogger } from '../../logger';
+import { fetchWithRetry } from '../../utils';
 import { AITracingEventType } from '../types';
 import type { AITracingEvent, AITracingExporter, AnyAISpan } from '../types';
 
@@ -55,7 +56,7 @@ export class CloudExporter implements AITracingExporter {
     if (!accessToken) {
       this.logger.warn(
         'CloudExporter disabled: MASTRA_CLOUD_ACCESS_TOKEN environment variable not set. ' +
-          '🚀 Sign up for Mastra Cloud at https://mastra.ai to see your AI traces online and obtain your access token.',
+          '🚀 Sign up for Mastra Cloud at https://cloud.mastra.ai to see your AI traces online and obtain your access token.',
       );
       this.isDisabled = true;
     }
@@ -284,45 +285,4 @@ export class CloudExporter implements AITracingExporter {
 
     this.logger.info('CloudExporter shutdown complete');
   }
-}
-
-/**
- * Performs a fetch request with automatic retries using exponential backoff
- * @param url The URL to fetch from
- * @param options Standard fetch options
- * @param maxRetries Maximum number of retry attempts
- * @param validateResponse Optional function to validate the response beyond HTTP status
- * @returns The fetch Response if successful
- */
-export async function fetchWithRetry(
-  url: string,
-  options: RequestInit = {},
-  maxRetries: number = 3,
-): Promise<Response> {
-  let retryCount = 0;
-  let lastError: Error | null = null;
-
-  while (retryCount < maxRetries) {
-    try {
-      const response = await fetch(url, options);
-
-      if (!response.ok) {
-        throw new Error(`Request failed with status: ${response.status} ${response.statusText}`);
-      }
-
-      return response;
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      retryCount++;
-
-      if (retryCount >= maxRetries) {
-        break;
-      }
-
-      const delay = Math.min(1000 * Math.pow(2, retryCount) * 1000, 10000);
-      await new Promise(resolve => setTimeout(resolve, delay));
-    }
-  }
-
-  throw lastError || new Error('Request failed after multiple retry attempts');
 }

--- a/packages/core/src/ai-tracing/exporters/cloud.ts
+++ b/packages/core/src/ai-tracing/exporters/cloud.ts
@@ -1,12 +1,10 @@
-import type { AITracingEvent, AITracingExporter, AnyAISpan } from '@mastra/core/ai-tracing';
-import { AITracingEventType } from '@mastra/core/ai-tracing';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import type { IMastraLogger } from '@mastra/core/logger';
-import { ConsoleLogger, LogLevel } from '@mastra/core/logger';
+import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
+import { ConsoleLogger, LogLevel } from '../../logger';
+import type { IMastraLogger } from '../../logger';
+import { AITracingEventType } from '../types';
+import type { AITracingEvent, AITracingExporter, AnyAISpan } from '../types';
 
-import { fetchWithRetry } from '../utils/fetchWithRetry';
-
-export interface MastraCloudAITracingExporterConfig {
+export interface CloudExporterConfig {
   maxBatchSize?: number; // Default: 1000 spans
   maxBatchWaitMs?: number; // Default: 5000ms
   maxRetries?: number; // Default: 3
@@ -41,22 +39,25 @@ interface MastraCloudSpanRecord {
   updatedAt: Date | null;
 }
 
-export class MastraCloudAITracingExporter implements AITracingExporter {
+export class CloudExporter implements AITracingExporter {
   name = 'mastra-cloud-ai-tracing-exporter';
 
-  private config: Required<MastraCloudAITracingExporterConfig>;
+  private config: Required<CloudExporterConfig>;
   private buffer: MastraCloudBuffer;
   private flushTimer: NodeJS.Timeout | null = null;
   private logger: IMastraLogger;
+  private isDisabled: boolean = false;
 
-  constructor(config: MastraCloudAITracingExporterConfig = {}) {
+  constructor(config: CloudExporterConfig = {}) {
+    this.logger = config.logger ?? new ConsoleLogger({ level: LogLevel.INFO });
+
     const accessToken = config.accessToken ?? process.env.MASTRA_CLOUD_ACCESS_TOKEN;
     if (!accessToken) {
-      throw new MastraError({
-        id: `CLOUD_AI_TRACING_EXPORTER_ACCESS_TOKEN_REQUIRED`,
-        domain: ErrorDomain.MASTRA_OBSERVABILITY,
-        category: ErrorCategory.USER,
-      });
+      this.logger.warn(
+        'CloudExporter disabled: MASTRA_CLOUD_ACCESS_TOKEN environment variable not set. ' +
+          '🚀 Sign up for Mastra Cloud at https://mastra.ai to see your AI traces online and obtain your access token.',
+      );
+      this.isDisabled = true;
     }
 
     const endpoint =
@@ -66,12 +67,10 @@ export class MastraCloudAITracingExporter implements AITracingExporter {
       maxBatchSize: config.maxBatchSize ?? 1000,
       maxBatchWaitMs: config.maxBatchWaitMs ?? 5000,
       maxRetries: config.maxRetries ?? 3,
-      accessToken: accessToken,
+      accessToken: accessToken || '', // Empty string if no token
       endpoint,
-      logger: config.logger ?? new ConsoleLogger({ level: LogLevel.INFO }),
+      logger: this.logger,
     };
-
-    this.logger = this.config.logger;
 
     this.buffer = {
       spans: [],
@@ -80,6 +79,11 @@ export class MastraCloudAITracingExporter implements AITracingExporter {
   }
 
   async exportEvent(event: AITracingEvent): Promise<void> {
+    // Skip if disabled due to missing token
+    if (this.isDisabled) {
+      return;
+    }
+
     // Cloud AI Observability only process SPAN_ENDED events
     if (event.type !== AITracingEventType.SPAN_ENDED) {
       return;
@@ -242,6 +246,11 @@ export class MastraCloudAITracingExporter implements AITracingExporter {
   }
 
   async shutdown(): Promise<void> {
+    // Skip if disabled
+    if (this.isDisabled) {
+      return;
+    }
+
     // Clear any pending timer
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
@@ -273,6 +282,47 @@ export class MastraCloudAITracingExporter implements AITracingExporter {
       }
     }
 
-    this.logger.info('CloudAITracingExporter shutdown complete');
+    this.logger.info('CloudExporter shutdown complete');
   }
+}
+
+/**
+ * Performs a fetch request with automatic retries using exponential backoff
+ * @param url The URL to fetch from
+ * @param options Standard fetch options
+ * @param maxRetries Maximum number of retry attempts
+ * @param validateResponse Optional function to validate the response beyond HTTP status
+ * @returns The fetch Response if successful
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  maxRetries: number = 3,
+): Promise<Response> {
+  let retryCount = 0;
+  let lastError: Error | null = null;
+
+  while (retryCount < maxRetries) {
+    try {
+      const response = await fetch(url, options);
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status: ${response.status} ${response.statusText}`);
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      retryCount++;
+
+      if (retryCount >= maxRetries) {
+        break;
+      }
+
+      const delay = Math.min(1000 * Math.pow(2, retryCount) * 1000, 10000);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError || new Error('Request failed after multiple retry attempts');
 }

--- a/packages/core/src/ai-tracing/exporters/default.test.ts
+++ b/packages/core/src/ai-tracing/exporters/default.test.ts
@@ -251,7 +251,7 @@ describe('DefaultExporter', () => {
         // Should not throw, but log error instead
         expect(() => exporter.init()).not.toThrow();
 
-        expect(mockLogger.error).toHaveBeenCalledWith(
+        expect(mockLogger.warn).toHaveBeenCalledWith(
           'DefaultExporter disabled: Storage not available. Traces will not be persisted.',
         );
       });

--- a/packages/core/src/ai-tracing/exporters/default.test.ts
+++ b/packages/core/src/ai-tracing/exporters/default.test.ts
@@ -240,7 +240,7 @@ describe('DefaultExporter', () => {
         expect(() => exporter.init()).toThrow('DefaultExporter: init() called before __registerMastra()');
       });
 
-      it('should throw error if storage not available during init()', () => {
+      it('should log error if storage not available during init()', () => {
         const mockMastraWithoutStorage = {
           getStorage: vi.fn().mockReturnValue(null),
         } as any;
@@ -248,7 +248,12 @@ describe('DefaultExporter', () => {
         const exporter = new DefaultExporter({}, mockLogger);
         exporter.__registerMastra(mockMastraWithoutStorage);
 
-        expect(() => exporter.init()).toThrow('DefaultExporter: Storage not available during initialization');
+        // Should not throw, but log error instead
+        expect(() => exporter.init()).not.toThrow();
+
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          'DefaultExporter disabled: Storage not available. Traces will not be persisted.',
+        );
       });
     });
 

--- a/packages/core/src/ai-tracing/exporters/default.ts
+++ b/packages/core/src/ai-tracing/exporters/default.ts
@@ -127,7 +127,8 @@ export class DefaultExporter implements AITracingExporter {
 
     const storage = this.mastra.getStorage();
     if (!storage) {
-      throw new Error('DefaultExporter: Storage not available during initialization');
+      this.logger.warn('DefaultExporter disabled: Storage not available. Traces will not be persisted.');
+      return;
     }
 
     this.initializeStrategy(storage);
@@ -500,13 +501,13 @@ export class DefaultExporter implements AITracingExporter {
    */
   private async flush(): Promise<void> {
     if (!this.mastra) {
-      this.logger.warn('Cannot flush traces. Mastra instance not registered yet.');
+      this.logger.debug('Cannot flush traces. Mastra instance not registered yet.');
       return;
     }
 
     const storage = this.mastra.getStorage();
     if (!storage) {
-      this.logger.warn('Cannot flush traces. Mastra storage is not initialized');
+      this.logger.debug('Cannot flush traces. Mastra storage is not initialized');
       return;
     }
 
@@ -610,13 +611,13 @@ export class DefaultExporter implements AITracingExporter {
 
   async exportEvent(event: AITracingEvent): Promise<void> {
     if (!this.mastra) {
-      this.logger.warn('Cannot export AI tracing event. Mastra instance not registered yet.');
+      this.logger.debug('Cannot export AI tracing event. Mastra instance not registered yet.');
       return;
     }
 
     const storage = this.mastra.getStorage();
     if (!storage) {
-      this.logger.warn('Cannot store traces. Mastra storage is not initialized');
+      this.logger.debug('Cannot store traces. Mastra storage is not initialized');
       return;
     }
 

--- a/packages/core/src/ai-tracing/exporters/index.ts
+++ b/packages/core/src/ai-tracing/exporters/index.ts
@@ -3,5 +3,7 @@
  */
 
 // Core types and interfaces
+export { CloudExporter } from './cloud';
+export type { CloudExporterConfig } from './cloud';
 export * from './console';
 export * from './default';

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -629,7 +629,7 @@ function getBaseMastraConfig(testExporter: TestExporter) {
     telemetry: { enabled: false },
     storage: new MockStore(),
     observability: {
-      instances: {
+      configs: {
         test: {
           serviceName: 'integration-tests',
           exporters: [testExporter],

--- a/packages/core/src/ai-tracing/registry.test.ts
+++ b/packages/core/src/ai-tracing/registry.test.ts
@@ -634,7 +634,9 @@ describe('AI Tracing Registry', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('CloudExporter disabled: MASTRA_CLOUD_ACCESS_TOKEN environment variable not set'),
       );
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Sign up for Mastra Cloud at https://mastra.ai'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Sign up for Mastra Cloud at https://cloud.mastra.ai'),
+      );
 
       // Verify exporter is disabled but doesn't throw
       const event = {

--- a/packages/core/src/ai-tracing/registry.test.ts
+++ b/packages/core/src/ai-tracing/registry.test.ts
@@ -31,6 +31,10 @@ describe('AI Tracing Registry', () => {
     clearAITracingRegistry();
   });
 
+  afterEach(async () => {
+    await shutdownAITracingRegistry();
+  });
+
   describe('Registry', () => {
     it('should register and retrieve tracing instances', () => {
       const tracing = new DefaultAITracing({
@@ -247,9 +251,6 @@ describe('AI Tracing Registry', () => {
       expect(tracing?.getConfig().serviceName).toBe('test-service');
       expect(tracing?.getConfig().sampling?.type).toBe(SamplingStrategyType.ALWAYS); // Should default to ALWAYS
       expect(getDefaultAITracing()).toBe(tracing); // First one becomes default
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should use ALWAYS sampling by default when sampling is not specified', async () => {
@@ -266,9 +267,6 @@ describe('AI Tracing Registry', () => {
 
       const tracing = getAITracing('test');
       expect(tracing?.getConfig().sampling?.type).toBe(SamplingStrategyType.ALWAYS);
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should configure AI tracing with custom implementation', async () => {
@@ -314,9 +312,6 @@ describe('AI Tracing Registry', () => {
       expect(tracing).toBeDefined();
       expect(tracing).toBe(customInstance);
       expect(tracing?.getConfig().serviceName).toBe('custom-service');
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should support mixed configuration (config + instance)', async () => {
@@ -353,9 +348,6 @@ describe('AI Tracing Registry', () => {
       expect(customTracing).toBeDefined();
       expect(customTracing).toBe(customInstance);
       expect(customTracing?.getConfig().serviceName).toBe('custom-service');
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should handle registry shutdown during Mastra shutdown', async () => {
@@ -459,9 +451,6 @@ describe('AI Tracing Registry', () => {
       expect(getSelectedAITracing(agentContext)).toBe(getAITracing('langfuse'));
       expect(getSelectedAITracing(workflowContext)).toBe(getAITracing('datadog'));
       expect(getSelectedAITracing(genericContext)).toBe(getDefaultAITracing()); // Falls back to default (console)
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
   });
 
@@ -499,9 +488,6 @@ describe('AI Tracing Registry', () => {
       const processors = defaultInstance?.getProcessors();
       expect(processors).toHaveLength(1);
       expect(processors?.[0]).toBeInstanceOf(SensitiveDataFilter);
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should not create default config when disabled', async () => {
@@ -521,9 +507,6 @@ describe('AI Tracing Registry', () => {
       // Custom config should be the default
       const customInstance = getAITracing('custom');
       expect(getDefaultAITracing()).toBe(customInstance);
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should not create default config when default property is not provided', async () => {
@@ -538,9 +521,6 @@ describe('AI Tracing Registry', () => {
 
       const defaultInstance = getAITracing('default');
       expect(defaultInstance).toBeUndefined();
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should throw error when custom config named "default" conflicts with default config', () => {
@@ -571,9 +551,6 @@ describe('AI Tracing Registry', () => {
       const defaultInstance = getAITracing('default');
       expect(defaultInstance).toBeDefined();
       expect(defaultInstance?.getConfig().serviceName).toBe('my-custom-default');
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should work with both default and custom configs', async () => {
@@ -607,9 +584,6 @@ describe('AI Tracing Registry', () => {
       const custom2 = getAITracing('custom2');
       expect(custom2).toBeDefined();
       expect(custom2?.getConfig().serviceName).toBe('custom-service-2');
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should work with selector when default config is enabled', async () => {
@@ -642,9 +616,6 @@ describe('AI Tracing Registry', () => {
 
       // Should route to custom config
       expect(getSelectedAITracing(customContext)).toBe(getAITracing('custom'));
-
-      // Cleanup
-      await shutdownAITracingRegistry();
     });
 
     it('should handle CloudExporter gracefully when token is missing', async () => {

--- a/packages/core/src/ai-tracing/registry.test.ts
+++ b/packages/core/src/ai-tracing/registry.test.ts
@@ -1,0 +1,694 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MastraAITracing } from './base';
+import { DefaultAITracing, SensitiveDataFilter } from './default';
+import { CloudExporter, DefaultExporter } from './exporters';
+import {
+  clearAITracingRegistry,
+  getAITracing,
+  registerAITracing,
+  unregisterAITracing,
+  hasAITracing,
+  getDefaultAITracing,
+  setAITracingSelector,
+  getSelectedAITracing,
+  setupAITracing,
+  shutdownAITracingRegistry,
+} from './registry';
+import type {
+  AITracingInstanceConfig,
+  AISpanOptions,
+  AISpan,
+  TracingSelector,
+  AITracingSelectorContext,
+} from './types';
+import { AISpanType, SamplingStrategyType, AITracingEventType } from './types';
+
+describe('AI Tracing Registry', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Clear registry
+    clearAITracingRegistry();
+  });
+
+  describe('Registry', () => {
+    it('should register and retrieve tracing instances', () => {
+      const tracing = new DefaultAITracing({
+        serviceName: 'registry-test',
+        name: 'registry-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      registerAITracing('my-tracing', tracing);
+
+      expect(getAITracing('my-tracing')).toBe(tracing);
+    });
+
+    it('should clear registry', () => {
+      const tracing = new DefaultAITracing({
+        serviceName: 'registry-test',
+        name: 'registry-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+      registerAITracing('test', tracing);
+
+      clearAITracingRegistry();
+
+      expect(getAITracing('test')).toBeUndefined();
+    });
+
+    it('should handle multiple instances', () => {
+      const tracing1 = new DefaultAITracing({
+        serviceName: 'test-1',
+        name: 'instance-1',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+      const tracing2 = new DefaultAITracing({
+        serviceName: 'test-2',
+        name: 'instance-2',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      registerAITracing('first', tracing1);
+      registerAITracing('second', tracing2);
+
+      expect(getAITracing('first')).toBe(tracing1);
+      expect(getAITracing('second')).toBe(tracing2);
+    });
+
+    it('should prevent duplicate registration', () => {
+      const tracing1 = new DefaultAITracing({
+        serviceName: 'test-1',
+        name: 'instance-1',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+      const tracing2 = new DefaultAITracing({
+        serviceName: 'test-2',
+        name: 'instance-2',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      registerAITracing('duplicate', tracing1);
+
+      expect(() => {
+        registerAITracing('duplicate', tracing2);
+      }).toThrow("AI Tracing instance 'duplicate' already registered");
+    });
+
+    it('should unregister instances correctly', () => {
+      const tracing = new DefaultAITracing({
+        serviceName: 'test-1',
+        name: 'instance-1',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      registerAITracing('test', tracing);
+      expect(getAITracing('test')).toBe(tracing);
+
+      expect(unregisterAITracing('test')).toBe(true);
+      expect(getAITracing('test')).toBeUndefined();
+    });
+
+    it('should return false when unregistering non-existent instance', () => {
+      expect(unregisterAITracing('non-existent')).toBe(false);
+    });
+
+    it('should handle hasAITracing checks correctly', () => {
+      const enabledTracing = new DefaultAITracing({
+        serviceName: 'enabled-test',
+        name: 'enabled-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+      const disabledTracing = new DefaultAITracing({
+        serviceName: 'disabled-test',
+        name: 'disabled-instance',
+        sampling: { type: SamplingStrategyType.NEVER },
+      });
+
+      registerAITracing('enabled', enabledTracing);
+      registerAITracing('disabled', disabledTracing);
+
+      expect(hasAITracing('enabled')).toBe(true);
+      expect(hasAITracing('disabled')).toBe(false);
+      expect(hasAITracing('non-existent')).toBe(false);
+    });
+
+    it('should access tracing config through registry', () => {
+      const tracing = new DefaultAITracing({
+        serviceName: 'config-test',
+        name: 'config-instance',
+        sampling: { type: SamplingStrategyType.RATIO, probability: 0.5 },
+      });
+
+      registerAITracing('config-test', tracing);
+      const retrieved = getAITracing('config-test');
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.getConfig().serviceName).toBe('config-test');
+      expect(retrieved!.getConfig().sampling.type).toBe(SamplingStrategyType.RATIO);
+    });
+
+    it('should use selector function when provided', () => {
+      const tracing1 = new DefaultAITracing({
+        serviceName: 'console-tracing',
+        name: 'console-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+      const tracing2 = new DefaultAITracing({
+        serviceName: 'langfuse-tracing',
+        name: 'langfuse-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      registerAITracing('console', tracing1);
+      registerAITracing('langfuse', tracing2);
+
+      const selector: TracingSelector = (context, _availableTracers) => {
+        // For testing, we'll simulate routing based on runtime context
+        if (context.runtimeContext?.['environment'] === 'production') return 'langfuse';
+        if (context.runtimeContext?.['environment'] === 'development') return 'console';
+        return undefined; // Fall back to default
+      };
+
+      setAITracingSelector(selector);
+
+      const prodContext: AITracingSelectorContext = {
+        runtimeContext: { environment: 'production' } as any,
+      };
+
+      const devContext: AITracingSelectorContext = {
+        runtimeContext: { environment: 'development' } as any,
+      };
+
+      expect(getSelectedAITracing(prodContext)).toBe(tracing2); // langfuse
+      expect(getSelectedAITracing(devContext)).toBe(tracing1); // console
+    });
+
+    it('should fall back to default when selector returns invalid name', () => {
+      const tracing1 = new DefaultAITracing({
+        serviceName: 'default-tracing',
+        name: 'default-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      registerAITracing('default', tracing1, true); // Explicitly set as default
+
+      const selector: TracingSelector = (_context, _availableTracers) => 'non-existent';
+      setAITracingSelector(selector);
+
+      const context: AITracingSelectorContext = {
+        runtimeContext: undefined,
+      };
+
+      expect(getSelectedAITracing(context)).toBe(tracing1); // Falls back to default
+    });
+
+    it('should handle default tracing behavior', () => {
+      const tracing1 = new DefaultAITracing({
+        serviceName: 'first-tracing',
+        name: 'first-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+      const tracing2 = new DefaultAITracing({
+        serviceName: 'second-tracing',
+        name: 'second-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      // First registered becomes default automatically
+      registerAITracing('first', tracing1);
+      registerAITracing('second', tracing2);
+
+      expect(getDefaultAITracing()).toBe(tracing1);
+
+      // Explicitly set second as default
+      registerAITracing('third', tracing2, true);
+      expect(getDefaultAITracing()).toBe(tracing2);
+    });
+  });
+
+  describe('Mastra Integration', () => {
+    it('should configure AI tracing with simple config', async () => {
+      const instanceConfig: AITracingInstanceConfig = {
+        serviceName: 'test-service',
+        name: 'test-instance',
+        exporters: [],
+      };
+
+      setupAITracing({
+        configs: {
+          test: instanceConfig,
+        },
+      });
+
+      // Verify AI tracing was registered and set as default
+      const tracing = getAITracing('test');
+      expect(tracing).toBeDefined();
+      expect(tracing?.getConfig().serviceName).toBe('test-service');
+      expect(tracing?.getConfig().sampling?.type).toBe(SamplingStrategyType.ALWAYS); // Should default to ALWAYS
+      expect(getDefaultAITracing()).toBe(tracing); // First one becomes default
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should use ALWAYS sampling by default when sampling is not specified', async () => {
+      const instanceConfig: AITracingInstanceConfig = {
+        serviceName: 'default-sampling-test',
+        name: 'default-sampling-instance',
+      };
+
+      setupAITracing({
+        configs: {
+          test: instanceConfig,
+        },
+      });
+
+      const tracing = getAITracing('test');
+      expect(tracing?.getConfig().sampling?.type).toBe(SamplingStrategyType.ALWAYS);
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should configure AI tracing with custom implementation', async () => {
+      class CustomAITracing extends MastraAITracing {
+        protected createSpan<TType extends AISpanType>(options: AISpanOptions<TType>): AISpan<TType> {
+          // Custom implementation - just return a mock span for testing
+          return {
+            id: 'custom-span-id',
+            name: options.name,
+            type: options.type,
+            attributes: options.attributes,
+            parent: options.parent,
+            traceId: 'custom-trace-id',
+            startTime: new Date(),
+            aiTracing: this,
+            isEvent: false,
+            end: () => {},
+            error: () => {},
+            update: () => {},
+            createChildSpan: () => ({}) as any,
+            createEventSpan: () => ({}) as any,
+            get isRootSpan() {
+              return !options.parent;
+            },
+          } as AISpan<TType>;
+        }
+      }
+
+      const customInstance = new CustomAITracing({
+        serviceName: 'custom-service',
+        name: 'custom-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      setupAITracing({
+        configs: {
+          custom: customInstance,
+        },
+      });
+
+      // Verify custom implementation was registered
+      const tracing = getAITracing('custom');
+      expect(tracing).toBeDefined();
+      expect(tracing).toBe(customInstance);
+      expect(tracing?.getConfig().serviceName).toBe('custom-service');
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should support mixed configuration (config + instance)', async () => {
+      class CustomAITracing extends MastraAITracing {
+        protected createSpan<TType extends AISpanType>(_options: AISpanOptions<TType>): AISpan<TType> {
+          return {} as AISpan<TType>; // Mock implementation
+        }
+      }
+
+      const customInstance = new CustomAITracing({
+        serviceName: 'custom-service',
+        name: 'custom-instance',
+        sampling: { type: SamplingStrategyType.NEVER },
+      });
+
+      setupAITracing({
+        configs: {
+          standard: {
+            serviceName: 'standard-service',
+            exporters: [],
+          },
+          custom: customInstance,
+        },
+      });
+
+      // Verify both instances were registered
+      const standardTracing = getAITracing('standard');
+      const customTracing = getAITracing('custom');
+
+      expect(standardTracing).toBeDefined();
+      expect(standardTracing).toBeInstanceOf(DefaultAITracing);
+      expect(standardTracing?.getConfig().serviceName).toBe('standard-service');
+
+      expect(customTracing).toBeDefined();
+      expect(customTracing).toBe(customInstance);
+      expect(customTracing?.getConfig().serviceName).toBe('custom-service');
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should handle registry shutdown during Mastra shutdown', async () => {
+      let shutdownCalled = false;
+
+      class TestAITracing extends MastraAITracing {
+        protected createSpan<TType extends AISpanType>(_options: AISpanOptions<TType>): AISpan<TType> {
+          return {} as AISpan<TType>;
+        }
+
+        async shutdown(): Promise<void> {
+          shutdownCalled = true;
+          await super.shutdown();
+        }
+      }
+
+      const testInstance = new TestAITracing({
+        serviceName: 'test-service',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      });
+
+      setupAITracing({
+        configs: {
+          test: testInstance,
+        },
+      });
+
+      // Verify instance is registered
+      expect(getAITracing('test')).toBe(testInstance);
+
+      // Shutdown should call instance shutdown and clear registry
+      await shutdownAITracingRegistry();
+
+      expect(shutdownCalled).toBe(true);
+      expect(getAITracing('test')).toBeUndefined();
+    });
+
+    it('should prevent duplicate registration across multiple Mastra instances', () => {
+      const config: AITracingInstanceConfig = {
+        serviceName: 'test-service',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+      };
+
+      setupAITracing({
+        configs: {
+          duplicate: config,
+        },
+      });
+
+      // Attempting to register the same name should throw
+      expect(() => {
+        setupAITracing({
+          configs: {
+            duplicate: config,
+          },
+        });
+      }).toThrow("AI Tracing instance 'duplicate' already registered");
+    });
+
+    it('should support selector function configuration', async () => {
+      const selector: TracingSelector = (context, _availableTracers) => {
+        if (context.runtimeContext?.['service'] === 'agent') return 'langfuse';
+        if (context.runtimeContext?.['service'] === 'workflow') return 'datadog';
+        return undefined; // Use default
+      };
+
+      setupAITracing({
+        configs: {
+          console: {
+            serviceName: 'console-service',
+            exporters: [],
+          },
+          langfuse: {
+            serviceName: 'langfuse-service',
+            exporters: [],
+          },
+          datadog: {
+            serviceName: 'datadog-service',
+            exporters: [],
+          },
+        },
+        configSelector: selector,
+      });
+
+      // Test selector functionality
+      const agentContext: AITracingSelectorContext = {
+        runtimeContext: { service: 'agent' } as any,
+      };
+
+      const workflowContext: AITracingSelectorContext = {
+        runtimeContext: { service: 'workflow' } as any,
+      };
+
+      const genericContext: AITracingSelectorContext = {
+        runtimeContext: undefined,
+      };
+
+      // Verify selector routes correctly
+      expect(getSelectedAITracing(agentContext)).toBe(getAITracing('langfuse'));
+      expect(getSelectedAITracing(workflowContext)).toBe(getAITracing('datadog'));
+      expect(getSelectedAITracing(genericContext)).toBe(getDefaultAITracing()); // Falls back to default (console)
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+  });
+
+  describe('Default Config', () => {
+    beforeEach(() => {
+      // Mock environment variable for CloudExporter
+      vi.stubEnv('MASTRA_CLOUD_ACCESS_TOKEN', 'test-token-123');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should create default config when enabled', async () => {
+      setupAITracing({
+        default: { enabled: true },
+        configs: {},
+      });
+
+      const defaultInstance = getAITracing('default');
+      expect(defaultInstance).toBeDefined();
+      expect(defaultInstance?.getConfig().serviceName).toBe('mastra');
+      expect(defaultInstance?.getConfig().sampling.type).toBe(SamplingStrategyType.ALWAYS);
+
+      // Verify it's set as the default
+      expect(getDefaultAITracing()).toBe(defaultInstance);
+
+      // Verify exporters
+      const exporters = defaultInstance?.getExporters();
+      expect(exporters).toHaveLength(2);
+      expect(exporters?.[0]).toBeInstanceOf(DefaultExporter);
+      expect(exporters?.[1]).toBeInstanceOf(CloudExporter);
+
+      // Verify processors
+      const processors = defaultInstance?.getProcessors();
+      expect(processors).toHaveLength(1);
+      expect(processors?.[0]).toBeInstanceOf(SensitiveDataFilter);
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should not create default config when disabled', async () => {
+      setupAITracing({
+        default: { enabled: false },
+        configs: {
+          custom: {
+            serviceName: 'custom-service',
+            exporters: [],
+          },
+        },
+      });
+
+      const defaultInstance = getAITracing('default');
+      expect(defaultInstance).toBeUndefined();
+
+      // Custom config should be the default
+      const customInstance = getAITracing('custom');
+      expect(getDefaultAITracing()).toBe(customInstance);
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should not create default config when default property is not provided', async () => {
+      setupAITracing({
+        configs: {
+          custom: {
+            serviceName: 'custom-service',
+            exporters: [],
+          },
+        },
+      });
+
+      const defaultInstance = getAITracing('default');
+      expect(defaultInstance).toBeUndefined();
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should throw error when custom config named "default" conflicts with default config', () => {
+      expect(() => {
+        setupAITracing({
+          default: { enabled: true },
+          configs: {
+            default: {
+              serviceName: 'my-custom-default',
+              exporters: [],
+            },
+          },
+        });
+      }).toThrow("Cannot use 'default' as a custom config name when default tracing is enabled");
+    });
+
+    it('should allow custom config named "default" when default config is disabled', async () => {
+      setupAITracing({
+        default: { enabled: false },
+        configs: {
+          default: {
+            serviceName: 'my-custom-default',
+            exporters: [],
+          },
+        },
+      });
+
+      const defaultInstance = getAITracing('default');
+      expect(defaultInstance).toBeDefined();
+      expect(defaultInstance?.getConfig().serviceName).toBe('my-custom-default');
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should work with both default and custom configs', async () => {
+      setupAITracing({
+        default: { enabled: true },
+        configs: {
+          custom1: {
+            serviceName: 'custom-service-1',
+            exporters: [],
+          },
+          custom2: {
+            serviceName: 'custom-service-2',
+            exporters: [],
+          },
+        },
+      });
+
+      // Default config should exist
+      const defaultInstance = getAITracing('default');
+      expect(defaultInstance).toBeDefined();
+      expect(defaultInstance?.getConfig().serviceName).toBe('mastra');
+
+      // Default should be the default instance
+      expect(getDefaultAITracing()).toBe(defaultInstance);
+
+      // Custom configs should also exist
+      const custom1 = getAITracing('custom1');
+      expect(custom1).toBeDefined();
+      expect(custom1?.getConfig().serviceName).toBe('custom-service-1');
+
+      const custom2 = getAITracing('custom2');
+      expect(custom2).toBeDefined();
+      expect(custom2?.getConfig().serviceName).toBe('custom-service-2');
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should work with selector when default config is enabled', async () => {
+      const selector: TracingSelector = (context, _availableTracers) => {
+        if (context.runtimeContext?.['useDefault'] === true) return 'default';
+        return 'custom';
+      };
+
+      setupAITracing({
+        default: { enabled: true },
+        configs: {
+          custom: {
+            serviceName: 'custom-service',
+            exporters: [],
+          },
+        },
+        configSelector: selector,
+      });
+
+      const defaultContext: AITracingSelectorContext = {
+        runtimeContext: { useDefault: true } as any,
+      };
+
+      const customContext: AITracingSelectorContext = {
+        runtimeContext: { useDefault: false } as any,
+      };
+
+      // Should route to default config
+      expect(getSelectedAITracing(defaultContext)).toBe(getAITracing('default'));
+
+      // Should route to custom config
+      expect(getSelectedAITracing(customContext)).toBe(getAITracing('custom'));
+
+      // Cleanup
+      await shutdownAITracingRegistry();
+    });
+
+    it('should handle CloudExporter gracefully when token is missing', async () => {
+      // Clear the token environment variable
+      const originalToken = process.env.MASTRA_CLOUD_ACCESS_TOKEN;
+      delete process.env.MASTRA_CLOUD_ACCESS_TOKEN;
+      vi.unstubAllEnvs(); // Make sure mock is cleared
+
+      // Spy on console to check for combined warning message
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // CloudExporter should not throw, but log warning instead
+      const exporter = new CloudExporter();
+
+      // Verify combined warning message was logged
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('CloudExporter disabled: MASTRA_CLOUD_ACCESS_TOKEN environment variable not set'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Sign up for Mastra Cloud at https://mastra.ai'));
+
+      // Verify exporter is disabled but doesn't throw
+      const event = {
+        type: AITracingEventType.SPAN_ENDED,
+        span: {
+          id: 'test-span',
+          traceId: 'test-trace',
+          name: 'test',
+          type: AISpanType.GENERIC,
+          startTime: new Date(),
+          endTime: new Date(),
+        } as any,
+        serviceName: 'test',
+        instanceName: 'test',
+        timestamp: new Date(),
+      };
+
+      // Should not throw when exporting
+      await expect(exporter.exportEvent(event)).resolves.not.toThrow();
+
+      // Restore mocks
+      warnSpy.mockRestore();
+      if (originalToken) {
+        process.env.MASTRA_CLOUD_ACCESS_TOKEN = originalToken;
+      }
+    });
+  });
+});

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -408,7 +408,7 @@ export type TracingStrategy = 'realtime' | 'batch-with-updates' | 'insert-only';
  * Configuration for a single AI tracing instance
  */
 export interface AITracingInstanceConfig {
-  /** name from the registry */
+  /** Unique identifier for this config in the ai tracing registry */
   name: string;
   /** Service name for tracing */
   serviceName: string;

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -329,7 +329,7 @@ export interface AISpan<TType extends AISpanType> {
     metadata?: Record<string, any>;
   }): AISpan<TChildType>;
 
-  /** Create event span - can be any span type independent of parent 
+  /** Create event span - can be any span type independent of parent
       Event spans have no input, and no endTime.
   */
   createEventSpan<TChildType extends AISpanType>(options: {
@@ -408,10 +408,10 @@ export type TracingStrategy = 'realtime' | 'batch-with-updates' | 'insert-only';
  * Configuration for a single AI tracing instance
  */
 export interface AITracingInstanceConfig {
+  /** name from the registry */
+  name: string;
   /** Service name for tracing */
   serviceName: string;
-  /** Instance name from the registry */
-  instanceName: string;
   /** Sampling strategy - controls whether tracing is collected (defaults to ALWAYS) */
   sampling?: SamplingStrategy;
   /** Custom exporters */
@@ -424,10 +424,14 @@ export interface AITracingInstanceConfig {
  * Complete AI Tracing configuration
  */
 export interface AITracingConfig {
+  /** Enables default exporters, with sampling: always, and sensitive data filtering */
+  default?: {
+    enabled?: boolean;
+  };
   /** Map of tracing instance names to their configurations or pre-instantiated instances */
-  instances: Record<string, Omit<AITracingInstanceConfig, 'instanceName'> | MastraAITracing>;
+  configs: Record<string, Omit<AITracingInstanceConfig, 'name'> | MastraAITracing>;
   /** Optional selector function to choose which tracing instance to use */
-  selector?: TracingSelector;
+  configSelector?: TracingSelector;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

Enhanced AI tracing system with default configuration support and graceful error handling.

Key Features Added

1. Default AI Tracing Configuration
  - Added default.enabled property to AITracingConfig
  - When enabled, automatically creates a 'default' AI tracing instance with:
      - Service name: 'mastra'
    - Sampling: ALWAYS
    - Exporters: DefaultExporter + CloudExporter
    - Processors: SensitiveDataFilter
  - Prevents naming conflicts when custom configs use 'default' name
2. Graceful Error Handling
  - DefaultExporter: Logs warnings instead of throwing when storage is missing
  - CloudExporter: Shows marketing message when MASTRA_CLOUD_ACCESS_TOKEN is missing, continues operating in disabled
mode
  - Both exporters fail silently to prevent blocking application startup
    
Moved CloudExporter from `@mastra/cloud` package to `@mastra/core` to avoid circular dependencies.

Updated Observability config shape as requested.

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
