### PR TITLE
Pass options to stream and flatten LoopConfig in execution options

### DIFF
--- a/.changeset/spicy-carpets-tap.md
+++ b/.changeset/spicy-carpets-tap.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Pass loop options to streamVnext stream

--- a/.changeset/spicy-carpets-tap.md
+++ b/.changeset/spicy-carpets-tap.md
@@ -1,5 +1,6 @@
 ---
 "@mastra/core": patch
+"@mastra/server": patch
 ---
 
-Pass loop options to streamVnext stream
+Flatten loop config in stream options and pass to loop options

--- a/docs/src/content/en/reference/agents/streamVNext.mdx
+++ b/docs/src/content/en/reference/agents/streamVNext.mdx
@@ -113,60 +113,34 @@ const aiSdkStream = await agent.streamVNext("message for agent", {
       description: "Whether to return detailed scoring data in the response.",
     },
     {
-      name: "options",
-      type: "Omit<LoopConfig, 'onStepFinish' | 'onFinish'>",
+      name: "onChunk",
+      type: "(chunk: ChunkType) => Promise<void> | void",
       isOptional: true,
-      description: "Advanced loop configuration options.",
-      properties: [
-        {
-          parameters: [{
-            name: "onChunk",
-            type: "(chunk: ChunkType) => Promise<void> | void",
-            isOptional: true,
-            description: "Callback function called for each chunk during streaming."
-          }]
-        },
-        {
-          parameters: [{
-            name: "onError",
-            type: "({ error }: { error: Error | string }) => Promise<void> | void",
-            isOptional: true,
-            description: "Callback function called when an error occurs during streaming."
-          }]
-        },
-        {
-          parameters: [{
-            name: "onAbort",
-            type: "(event: any) => Promise<void> | void",
-            isOptional: true,
-            description: "Callback function called when the stream is aborted."
-          }]
-        },
-        {
-          parameters: [{
-            name: "abortSignal",
-            type: "AbortSignal",
-            isOptional: true,
-            description: "Signal object that allows you to abort the agent's execution. When the signal is aborted, all ongoing operations will be terminated."
-          }]
-        },
-        {
-          parameters: [{
-            name: "activeTools",
-            type: "Array<keyof ToolSet> | undefined",
-            isOptional: true,
-            description: "Array of active tool names that can be used during execution."
-          }]
-        },
-        {
-          parameters: [{
-            name: "returnScorerData",
-            type: "boolean",
-            isOptional: true,
-            description: "Whether to return detailed scoring data in the response."
-          }]
-        }
-      ]
+      description: "Callback function called for each chunk during streaming."
+    },
+    {
+      name: "onError",
+      type: "({ error }: { error: Error | string }) => Promise<void> | void",
+      isOptional: true,
+      description: "Callback function called when an error occurs during streaming."
+    },
+    {
+      name: "onAbort",
+      type: "(event: any) => Promise<void> | void",
+      isOptional: true,
+      description: "Callback function called when the stream is aborted."
+    },
+    {
+      name: "abortSignal",
+      type: "AbortSignal",
+      isOptional: true,
+      description: "Signal object that allows you to abort the agent's execution. When the signal is aborted, all ongoing operations will be terminated."
+    },
+    {
+      name: "activeTools",
+      type: "Array<keyof ToolSet> | undefined",
+      isOptional: true,
+      description: "Array of active tool names that can be used during execution."
     },
     {
       name: "context",
@@ -611,7 +585,9 @@ for await (const part of stream.fullStream) {
 return stream.toUIMessageStreamResponse();
 ```
 
-### Using Callbacks with Options
+### Using Callbacks
+
+All callback functions are now available as top-level properties for a cleaner API experience.
 
 ```typescript showLineNumbers copy
 const stream = await agent.streamVNext("Tell me a story", {
@@ -621,17 +597,15 @@ const stream = await agent.streamVNext("Tell me a story", {
   onStepFinish: (step) => {
     console.log('Step completed:', step);
   },
-  options: {
-    onChunk: (chunk) => {
-      console.log('Received chunk:', chunk);
-    },
-    onError: ({ error }) => {
-      console.error('Streaming error:', error);
-    },
-    onAbort: (event) => {
-      console.log('Stream aborted:', event);
-    },
-  }
+  onChunk: (chunk) => {
+    console.log('Received chunk:', chunk);
+  },
+  onError: ({ error }) => {
+    console.error('Streaming error:', error);
+  },
+  onAbort: (event) => {
+    console.log('Stream aborted:', event);
+  },
 });
 
 // Process the stream

--- a/docs/src/content/en/reference/agents/streamVNext.mdx
+++ b/docs/src/content/en/reference/agents/streamVNext.mdx
@@ -611,6 +611,35 @@ for await (const part of stream.fullStream) {
 return stream.toUIMessageStreamResponse();
 ```
 
+### Using Callbacks with Options
+
+```typescript showLineNumbers copy
+const stream = await agent.streamVNext("Tell me a story", {
+  onFinish: (result) => {
+    console.log('Streaming finished:', result);
+  },
+  onStepFinish: (step) => {
+    console.log('Step completed:', step);
+  },
+  options: {
+    onChunk: (chunk) => {
+      console.log('Received chunk:', chunk);
+    },
+    onError: ({ error }) => {
+      console.error('Streaming error:', error);
+    },
+    onAbort: (event) => {
+      console.log('Stream aborted:', event);
+    },
+  }
+});
+
+// Process the stream
+for await (const chunk of stream.textStream) {
+  console.log(chunk);
+}
+```
+
 ### Advanced Example with Options
 
 ```typescript showLineNumbers copy

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -5206,6 +5206,138 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
     });
   });
 
+  if (version === 'v2') {
+    describe.only('streamVNext options', () => {
+      it('should call options.onError when stream error occurs in streamVNext', async () => {
+        const errorModel = new MockLanguageModelV2({
+          doStream: async () => {
+            throw new Error('Simulated stream error');
+          },
+        });
+
+        const agent = new Agent({
+          id: 'test-options-onerror',
+          name: 'Test Options OnError',
+          model: errorModel,
+          instructions: 'You are a helpful assistant.',
+        });
+
+        let errorCaught = false;
+        let caughtError: any = null;
+
+        const stream = await agent.streamVNext('Hello', {
+          options: {
+            onError: ({ error }) => {
+              errorCaught = true;
+              caughtError = error;
+            },
+          },
+        });
+
+        // Consume the stream to trigger the error
+        try {
+          await stream.consumeStream();
+        } catch (err) {
+          // Stream consumption might throw, but onError should still be called
+        }
+
+        expect(errorCaught).toBe(true);
+        expect(caughtError).toBeDefined();
+        expect(caughtError.message).toMatch(/Simulated stream error/);
+      });
+
+      it('should call options.onChunk when streaming in streamVNext', async () => {
+        const agent = new Agent({
+          id: 'test-options-onchunk',
+          name: 'Test Options OnChunk',
+          model: dummyModel,
+          instructions: 'You are a helpful assistant.',
+        });
+
+        const chunks: any[] = [];
+
+        const stream = await agent.streamVNext('Hello', {
+          options: {
+            onChunk: (event: any) => {
+              chunks.push(event.chunk);
+            },
+          },
+        });
+
+        // Consume the stream to trigger chunks
+        await stream.consumeStream();
+
+        expect(chunks.length).toBeGreaterThan(0);
+        expect(chunks[0]).toHaveProperty('type');
+      });
+
+      it('should call options.onAbort when stream is aborted in streamVNext', async () => {
+        const abortController = new AbortController();
+        let pullCalls = 0;
+
+        const abortModel = new MockLanguageModelV2({
+          doStream: async () => ({
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: new ReadableStream({
+              pull(controller) {
+                switch (pullCalls++) {
+                  case 0:
+                    controller.enqueue({
+                      type: 'stream-start',
+                      warnings: [],
+                    });
+                    break;
+                  case 1:
+                    controller.enqueue({
+                      type: 'text-start',
+                      id: '1',
+                    });
+                    break;
+                  case 2:
+                    // Abort during streaming
+                    abortController.abort();
+                    controller.error(new DOMException('The user aborted a request.', 'AbortError'));
+                    break;
+                }
+              },
+            }),
+          }),
+        });
+
+        const agent = new Agent({
+          id: 'test-options-onabort',
+          name: 'Test Options OnAbort',
+          model: abortModel,
+          instructions: 'You are a helpful assistant.',
+        });
+
+        let abortCalled = false;
+        let abortEvent: any = null;
+
+        const stream = await agent.streamVNext('Hello', {
+          options: {
+            onAbort: event => {
+              abortCalled = true;
+              abortEvent = event;
+            },
+            abortSignal: abortController.signal,
+          },
+        });
+
+        // Consume the stream to trigger the abort
+        try {
+          await stream.consumeStream();
+        } catch (err) {
+          // Expected to throw due to abort
+        }
+
+        expect(abortCalled).toBe(true);
+        expect(abortEvent).toBeDefined();
+      });
+    });
+  }
+
   describe(`${version} - dynamic memory configuration`, () => {
     let dummyModel: MockLanguageModelV1 | MockLanguageModelV2;
     if (version === 'v1') {

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -5207,7 +5207,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
   });
 
   if (version === 'v2') {
-    describe.only('streamVNext options', () => {
+    describe('streamVNext options', () => {
       it('should call options.onError when stream error occurs in streamVNext', async () => {
         const errorModel = new MockLanguageModelV2({
           doStream: async () => {
@@ -5237,9 +5237,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         // Consume the stream to trigger the error
         try {
           await stream.consumeStream();
-        } catch (err) {
-          // Stream consumption might throw, but onError should still be called
-        }
+        } catch {}
 
         expect(errorCaught).toBe(true);
         expect(caughtError).toBeDefined();
@@ -5328,9 +5326,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         // Consume the stream to trigger the abort
         try {
           await stream.consumeStream();
-        } catch (err) {
-          // Expected to throw due to abort
-        }
+        } catch {}
 
         expect(abortCalled).toBe(true);
         expect(abortEvent).toBeDefined();

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -5226,11 +5226,9 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         let caughtError: any = null;
 
         const stream = await agent.streamVNext('Hello', {
-          options: {
-            onError: ({ error }) => {
-              errorCaught = true;
-              caughtError = error;
-            },
+          onError: ({ error }) => {
+            errorCaught = true;
+            caughtError = error;
           },
         });
 
@@ -5255,10 +5253,8 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         const chunks: any[] = [];
 
         const stream = await agent.streamVNext('Hello', {
-          options: {
-            onChunk: (event: any) => {
-              chunks.push(event.chunk);
-            },
+          onChunk: (event: any) => {
+            chunks.push(event.chunk);
           },
         });
 
@@ -5314,13 +5310,11 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         let abortEvent: any = null;
 
         const stream = await agent.streamVNext('Hello', {
-          options: {
-            onAbort: event => {
-              abortCalled = true;
-              abortEvent = event;
-            },
-            abortSignal: abortController.signal,
+          onAbort: event => {
+            abortCalled = true;
+            abortEvent = event;
           },
+          abortSignal: abortController.signal,
         });
 
         // Consume the stream to trigger the abort

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -64,13 +64,21 @@ export type AgentExecutionOptions<
   /** Provider-specific options passed to the language model */
   providerOptions?: LoopOptions['providerOptions'];
 
-  /** Advanced loop configuration options */
-  options?: Omit<LoopConfig, 'onStepFinish' | 'onFinish'>;
-
   /** Callback fired after each execution step. Type varies by format */
   onStepFinish?: FORMAT extends 'aisdk' ? StreamTextOnStepFinishCallback<any> : LoopConfig['onStepFinish'];
   /** Callback fired when execution completes. Type varies by format */
   onFinish?: FORMAT extends 'aisdk' ? StreamTextOnFinishCallback<any> : LoopConfig['onFinish'];
+
+  /** Callback fired for each streaming chunk received */
+  onChunk?: LoopConfig['onChunk'];
+  /** Callback fired when an error occurs during streaming */
+  onError?: LoopConfig['onError'];
+  /** Callback fired when streaming is aborted */
+  onAbort?: LoopConfig['onAbort'];
+  /** Tools that are active for this execution */
+  activeTools?: LoopConfig['activeTools'];
+  /** Signal to abort the streaming operation */
+  abortSignal?: LoopConfig['abortSignal'];
 
   /** Input processors to use for this execution (overrides agent's default) */
   inputProcessors?: InputProcessor[];

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2989,21 +2989,11 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
               : this.#outputProcessors
             : []);
 
-        // Create loop options from flattened properties
-        const loopOptions = {
-          onChunk: options.onChunk,
-          onError: options.onError,
-          onAbort: options.onAbort,
-          activeTools: options.activeTools,
-          abortSignal: options.abortSignal,
-        };
-
         const streamResult = llm.stream({
           ...inputData,
           outputProcessors,
           returnScorerData: options.returnScorerData,
           tracingContext,
-          options: loopOptions,
         });
 
         if (format === 'aisdk') {
@@ -3201,6 +3191,11 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
               });
             },
             onStepFinish: result.onStepFinish,
+            onChunk: options.onChunk,
+            onError: options.onError,
+            onAbort: options.onAbort,
+            activeTools: options.activeTools,
+            abortSignal: options.abortSignal,
           },
           output: options.output,
           outputProcessors: effectiveOutputProcessors,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2989,12 +2989,21 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
               : this.#outputProcessors
             : []);
 
+        // Create loop options from flattened properties
+        const loopOptions = {
+          onChunk: options.onChunk,
+          onError: options.onError,
+          onAbort: options.onAbort,
+          activeTools: options.activeTools,
+          abortSignal: options.abortSignal,
+        };
+
         const streamResult = llm.stream({
           ...inputData,
           outputProcessors,
           returnScorerData: options.returnScorerData,
           tracingContext,
-          options: options.options,
+          options: loopOptions,
         });
 
         if (format === 'aisdk') {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2994,6 +2994,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
           outputProcessors,
           returnScorerData: options.returnScorerData,
           tracingContext,
+          options: options.options,
         });
 
         if (format === 'aisdk') {

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -23,7 +23,6 @@ export type LoopConfig = {
   onAbort?: (event: any) => Promise<void> | void;
   activeTools?: Array<keyof ToolSet> | undefined;
   abortSignal?: AbortSignal;
-  returnScorerData?: boolean;
 };
 
 export type LoopOptions<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchema | undefined = undefined> = {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,7 +63,7 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@mastra/core": ">=0.16.0-0 <0.17.0-0",
+    "@mastra/core": ">=0.16.1-0 <0.17.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -361,10 +361,7 @@ export async function generateVNextHandler({
       ...rest,
       runtimeContext: finalRuntimeContext,
       format: rest.format || 'mastra',
-      options: {
-        ...(rest?.options ?? {}),
-        abortSignal,
-      },
+      abortSignal,
     });
 
     return result;
@@ -495,10 +492,7 @@ export function streamVNextGenerateHandler({
     const streamResult = agent.streamVNext(messages, {
       ...rest,
       runtimeContext: finalRuntimeContext,
-      options: {
-        ...(rest?.options ?? {}),
-        abortSignal,
-      },
+      abortSignal,
       format: body.format ?? 'mastra',
     });
 
@@ -544,10 +538,7 @@ export async function streamVNextUIMessageHandler({
     const streamResult = await agent.streamVNext(messages, {
       ...rest,
       runtimeContext: finalRuntimeContext,
-      options: {
-        ...(rest?.options ?? {}),
-        abortSignal,
-      },
+      abortSignal,
       format: 'aisdk',
     });
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes options not being properly passed to streamVNext stream, as well as adds tests and updates docs. It also flattens loopconfig callbacks into execution options.
## Related Issue(s)
#7627 
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
