### PR TITLE
Fix: Template slug when getting template environment variables

### DIFF
--- a/.changeset/weak-terms-push.md
+++ b/.changeset/weak-terms-push.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+'create-mastra': patch
+'@mastra/playground-ui': patch
+---
+
+Fix template slug when getting template environment variables

--- a/packages/playground/src/pages/templates/template/index.tsx
+++ b/packages/playground/src/pages/templates/template/index.tsx
@@ -46,7 +46,7 @@ export default function Template() {
   });
 
   const { data: templateEnvVars, isLoading: isLoadingEnvVars } = useTemplateRepoEnvVars({
-    repo: `template-${templateSlug}`,
+    repo: template?.githubUrl ? new URL(template.githubUrl).pathname.split('/')[2] : `template-${templateSlug}`,
     owner: 'mastra-ai',
     branch: selectedProvider,
   });


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes an issue where the wrong repo slug is used when trying to get the template env vars, resulting in a 404. This happens when the template slug stored in templates.json is different than the github slug in the url. This fix checks the URL first to ensure that the proper slug is used if present.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
