### PR TITLE
[FEATURE] Improve create-mastra init command - ask questions at the s…

### DIFF
--- a/.changeset/brave-times-wash.md
+++ b/.changeset/brave-times-wash.md
@@ -1,0 +1,5 @@
+---
+'create-mastra': patch
+---
+
+on mastra create ask all interactive questions to the user before proceeding with setup and init activities

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -7,7 +7,6 @@ import { cloneTemplate, installDependencies } from '../../utils/clone-template';
 import { loadTemplates, selectTemplate, findTemplateByName, getDefaultProjectName } from '../../utils/template-utils';
 import type { Template } from '../../utils/template-utils';
 import { init } from '../init/init';
-import { interactivePrompt } from '../init/utils';
 import type { LLMProvider } from '../init/utils';
 import { getPackageManager } from '../utils.js';
 
@@ -31,7 +30,7 @@ export const create = async (args: {
     return;
   }
 
-  const { projectName } = await createMastraProject({
+  const { projectName, result } = await createMastraProject({
     projectName: args?.projectName,
     createVersionTag: args?.createVersionTag,
     timeout: args?.timeout,
@@ -43,7 +42,7 @@ export const create = async (args: {
   // to false (in this case, no example code) and we need to distinguish
   // between those and the case where the args were not passed at all.
   if (args.components === undefined || args.llmProvider === undefined || args.addExample === undefined) {
-    const result = await interactivePrompt();
+    // const result = await interactivePrompt(); //Just avoid asking questions here to the user, all questions are asked in createMastraProject
 
     // Track model provider selection from interactive prompt
     const analytics = getAnalytics();

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -94,13 +94,12 @@ export const createMastraProject = async ({
       defaultValue: 'my-mastra-app',
     }));
 
-  const result = await interactivePrompt();
-
   if (p.isCancel(projectName)) {
     p.cancel('Operation cancelled');
     process.exit(0);
   }
 
+  const result = await interactivePrompt();
   const s = p.spinner();
 
   try {

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -3,11 +3,11 @@ import child_process from 'node:child_process';
 import util from 'node:util';
 import * as p from '@clack/prompts';
 import color from 'picocolors';
-
 import { DepsService } from '../../services/service.deps.js';
 import { getPackageManagerAddCommand } from '../../utils/package-manager.js';
 import type { PackageManager } from '../../utils/package-manager.js';
 import { getPackageManager } from '../utils.js';
+import { interactivePrompt } from '../init/utils';
 
 const exec = util.promisify(child_process.exec);
 
@@ -93,6 +93,8 @@ export const createMastraProject = async ({
       placeholder: 'my-mastra-app',
       defaultValue: 'my-mastra-app',
     }));
+
+  const result = await interactivePrompt();
 
   if (p.isCancel(projectName)) {
     p.cancel('Operation cancelled');
@@ -206,7 +208,7 @@ export const createMastraProject = async ({
     p.outro('Project created successfully');
     console.log('');
 
-    return { projectName };
+    return { projectName, result };
   } catch (error) {
     s.stop();
 


### PR DESCRIPTION

## Description

At present during "create mastra" command the project name is asked and then during init some more details are asked for the user to enter llm, api key etc. This fix is to enhance the user experience while installing the package by asking all relevant questions at the beginning only and then followed with non interactive setup and init activities.

## Related Issue(s)

This is related to [FEATURE] Improve create-mastra/init command - ask questions at the start #7573

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ X] I have added tests that prove my fix is effective or that my feature works
[mastra_create_test_fix_7573.docx](https://github.com/user-attachments/files/22243524/mastra_create_test_fix_7573.docx)
