### PR TITLE
return traceId from workflow & agent executions

### DIFF
--- a/.changeset/sweet-toys-build.md
+++ b/.changeset/sweet-toys-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Workflow & Agent executions now return traceId.

--- a/packages/core/src/ai-tracing/context.ts
+++ b/packages/core/src/ai-tracing/context.ts
@@ -24,7 +24,7 @@ const WORKFLOW_METHODS_TO_WRAP = ['execute', 'createRun', 'createRunAsync'];
 function isNoOpSpan(span: AnyAISpan): boolean {
   // Check if this is a NoOp span implementation
   return (
-    span.constructor.name === 'NoOpAISpan' || (span as any).__isNoOp === true || !span.aiTracing // NoOp spans might not have aiTracing reference
+    span.constructor.name === 'NoOpAISpan' || (span as any).__isNoOp === true
   );
 }
 

--- a/packages/core/src/ai-tracing/context.ts
+++ b/packages/core/src/ai-tracing/context.ts
@@ -23,9 +23,7 @@ const WORKFLOW_METHODS_TO_WRAP = ['execute', 'createRun', 'createRunAsync'];
  */
 function isNoOpSpan(span: AnyAISpan): boolean {
   // Check if this is a NoOp span implementation
-  return (
-    span.constructor.name === 'NoOpAISpan' || (span as any).__isNoOp === true
-  );
+  return span.constructor.name === 'NoOpAISpan' || (span as any).__isNoOp === true;
 }
 
 /**

--- a/packages/core/src/ai-tracing/default.ts
+++ b/packages/core/src/ai-tracing/default.ts
@@ -220,6 +220,10 @@ class DefaultAISpan<TType extends AISpanType> implements AISpan<TType> {
     return !this.parent;
   }
 
+  get isValid(): boolean {
+    return true;
+  }
+
   async export(): Promise<string> {
     return JSON.stringify({
       id: this.id,

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -645,7 +645,7 @@ const agentMethods = [
     name: 'generateLegacy',
     method: async (agent: Agent, prompt: string, options?: any) => {
       const result = await agent.generateLegacy(prompt, options);
-      return { text: result.text, object: result.object };
+      return { text: result.text, object: result.object, traceId: result.traceId };
     },
     model: mockModelV1,
     expectedText: 'Mock response',
@@ -654,7 +654,7 @@ const agentMethods = [
     name: 'generateVNext',
     method: async (agent: Agent, prompt: string, options?: any) => {
       const result = await agent.generateVNext(prompt, options);
-      return { text: result.text, object: result.object };
+      return { text: result.text, object: result.object, traceId: result.traceId };
     },
     model: mockModelV2,
     expectedText: 'Mock V2 streaming response',
@@ -667,7 +667,7 @@ const agentMethods = [
       for await (const chunk of result.textStream) {
         fullText += chunk;
       }
-      return { text: fullText, object: result.object };
+      return { text: fullText, object: result.object, traceId: result.traceId };
     },
     model: mockModelV1,
     expectedText: 'Mock streaming response',
@@ -680,7 +680,7 @@ const agentMethods = [
       for await (const chunk of result.textStream) {
         fullText += chunk;
       }
-      return { text: fullText, object: result.object };
+      return { text: fullText, object: result.object, traceId: result.traceId };
     },
     model: mockModelV2,
     expectedText: 'Mock V2 streaming response',
@@ -755,11 +755,13 @@ describe('AI Tracing Integration Tests', () => {
     const run = await workflow.createRunAsync();
     const result = await run.start({ inputData: { value: 15 } });
     expect(result.status).toBe('success');
+    expect(result.traceId).toBeDefined();
 
     const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
     const conditionalSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_CONDITIONAL);
-
+    expect(workflowRunSpans[0].traceId).toBe(result.traceId);
+    
     expect(workflowRunSpans.length).toBe(1); // One workflow run
     expect(workflowStepSpans.length).toBe(2); // checkCondition + processHigh (value=15 > 10)
     expect(conditionalSpans.length).toBe(1); // One branch evaluation
@@ -806,9 +808,11 @@ describe('AI Tracing Integration Tests', () => {
       inputData: { input: 'test unregistered workflow as step' },
     });
     expect(result.status).toBe('success');
+    expect(result.traceId).toBeDefined();
 
     const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
+    expect(workflowRunSpans[0].traceId).toBe(result.traceId);
 
     expect(workflowRunSpans.length).toBe(2); // Main + unregistered workflow
     expect(workflowStepSpans.length).toBe(3); // doWhile step + unregistered step + map step
@@ -853,9 +857,11 @@ describe('AI Tracing Integration Tests', () => {
     const run = await workflow.createRunAsync();
     const result = await run.start({ inputData: { input: 'nested test' } });
     expect(result.status).toBe('success');
+    expect(result.traceId).toBeDefined();
 
     const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
+    expect(workflowRunSpans[0].traceId).toBe(result.traceId);
 
     expect(workflowRunSpans.length).toBe(2); // Parent workflow + child workflow
     expect(workflowStepSpans.length).toBe(2); // nested-workflow-step + simple-step
@@ -886,11 +892,12 @@ describe('AI Tracing Integration Tests', () => {
       inputData: { a: 5, b: 3, operation: 'add' },
     });
     expect(result.status).toBe('success');
+    expect(result.traceId).toBeDefined();
 
-    // Validate span types
     const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
     // const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
+    expect(workflowRunSpans[0].traceId).toBe(result.traceId);
 
     expect(workflowRunSpans.length).toBe(1); // One workflow run
     expect(workflowStepSpans.length).toBe(1); // One step: tool-executor
@@ -938,14 +945,17 @@ describe('AI Tracing Integration Tests', () => {
     const run = await workflow.createRunAsync();
     const result = await run.start({ inputData: { value: 'tacos' } });
     expect(result.status).toBe('success');
+    expect(result.traceId).toBeDefined();
 
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
+    
     expect(workflowStepSpans.length).toBe(1);
-
     const stepSpan = workflowStepSpans[0];
+
     expect(stepSpan.metadata?.customValue).toBe('tacos');
     expect(stepSpan.metadata?.stepType).toBe('metadata-test');
     expect(stepSpan.metadata?.executionTime).toBeDefined();
+    expect(stepSpan.traceId).toBe(result.traceId);
 
     testExporter.finalExpectations();
   });
@@ -999,8 +1009,8 @@ describe('AI Tracing Integration Tests', () => {
     });
 
     expect(result.status).toBe('success');
+    expect(result.traceId).toBeDefined();
 
-    // Look for the parent step span and child span
     const allSpans = testExporter.getAllSpans();
     const childSpans = allSpans.filter(span => span.name === 'custom-child-operation');
     const stepSpans = allSpans.filter(
@@ -1009,17 +1019,14 @@ describe('AI Tracing Integration Tests', () => {
 
     expect(childSpans.length).toBe(1);
     expect(stepSpans.length).toBe(1);
+    const childSpan = childSpans[0];
+    const stepSpan = stepSpans[0];
 
-    // Validate parent-child relationship
-    if (childSpans.length > 0 && stepSpans.length > 0) {
-      const childSpan = childSpans[0];
-      const stepSpan = stepSpans[0];
-
-      expect(childSpan.traceId).toBe(stepSpan.traceId);
-      expect(childSpan.metadata?.childOperation).toBe('processing');
-      expect(childSpan.metadata?.inputValue).toBe('child-span-test');
-      expect(childSpan.metadata?.endValue).toBe('pizza');
-    }
+    expect(childSpan.traceId).toBe(stepSpan.traceId);
+    expect(childSpan.metadata?.childOperation).toBe('processing');
+    expect(childSpan.metadata?.inputValue).toBe('child-span-test');
+    expect(childSpan.metadata?.endValue).toBe('pizza');
+    expect(childSpan.traceId).toBe(result.traceId);
 
     testExporter.finalExpectations();
   });
@@ -1045,8 +1052,8 @@ describe('AI Tracing Integration Tests', () => {
       const agent = mastra.getAgent('testAgent');
       const result = await method(agent, 'Calculate 5 + 3');
       expect(result.text).toBeDefined();
+      expect(result.traceId).toBeDefined();
 
-      // Validate span types
       const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
       const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
@@ -1133,6 +1140,7 @@ describe('AI Tracing Integration Tests', () => {
       const run = await workflow.createRunAsync();
       const result = await run.start({ inputData: { prompt: 'Hello from workflow' } });
       expect(result.status).toBe('success');
+      expect(result.traceId).toBeDefined();
 
       const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
       const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
@@ -1141,6 +1149,7 @@ describe('AI Tracing Integration Tests', () => {
 
       // TODO: revert these expectations to assert equal to just 1 after we can hide
       // internal spans.
+      expect(workflowRunSpans[0].traceId).toBe(result.traceId);
       expect(workflowRunSpans.length).toBeGreaterThanOrEqual(1); // One workflow run (plus internal spans in vNext)
       expect(workflowStepSpans.length).toBeGreaterThanOrEqual(1); // One step: agent-executor (plus internal spans in vNext)
       expect(agentRunSpans.length).toBe(1); // One agent run within the step
@@ -1170,8 +1179,8 @@ describe('AI Tracing Integration Tests', () => {
       const agent = mastra.getAgent('workflowAgent');
       const result = await method(agent, 'Execute the simpleWorkflow with test input');
       expect(result.text).toBeDefined();
+      expect(result.traceId).toBeDefined();
 
-      // Validate spans were created for agent, tool call, and workflow execution
       const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
       const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
@@ -1180,6 +1189,7 @@ describe('AI Tracing Integration Tests', () => {
 
       expect(agentRunSpans.length).toBe(1); // One agent run
       expect(llmGenerationSpans.length).toBe(1); // one llmGeneration per agent run
+      expect(agentRunSpans[0].traceId).toBe(result.traceId);
       expect(toolCallSpans.length).toBe(1); // tool call
 
       // TODO: revert these expectations to assert equal to just 1 after we can hide
@@ -1214,8 +1224,8 @@ describe('AI Tracing Integration Tests', () => {
       const agent = mastra.getAgent('workflowAgent');
       const result = await method(agent, 'Execute the simpleWorkflow with test input');
       expect(result.text).toBeDefined();
+      expect(result.traceId).toBeDefined();
 
-      // Validate spans were created for agent, tool call, and workflow execution
       const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
       const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
@@ -1224,6 +1234,7 @@ describe('AI Tracing Integration Tests', () => {
 
       expect(agentRunSpans.length).toBe(1); // One agent run
       expect(llmGenerationSpans.length).toBe(1); // one llm_generation span per agent run
+      expect(agentRunSpans[0].traceId).toBe(result.traceId);
       expect(toolCallSpans.length).toBe(1); // tool call (workflow is converted into a tool dynamically)
 
       // TODO: revert these expectations to assert equal to just 1 after we can hide
@@ -1275,10 +1286,12 @@ describe('AI Tracing Integration Tests', () => {
       const agent = mastra.getAgent('testAgent');
       const result = await method(agent, 'Use metadata tool to process some data');
       expect(result.text).toBeDefined();
+      expect(result.traceId).toBeDefined();
 
-      // Validate spans were created
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
+      
       expect(toolCallSpans.length).toBeGreaterThanOrEqual(1);
+      expect(toolCallSpans[0].traceId).toBe(result.traceId);
 
       // Find the metadata tool span and validate custom metadata
       const metadataToolSpan = toolCallSpans.find(span => span.name?.includes('metadataTool'));
@@ -1346,13 +1359,14 @@ describe('AI Tracing Integration Tests', () => {
       const agent = mastra.getAgent('testAgent');
       const result = await method(agent, 'Use child span tool to process test-data');
       expect(result.text).toBeDefined();
+      expect(result.traceId).toBeDefined();
 
-      // Validate spans were created
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
       const genericSpans = testExporter.getSpansByType(AISpanType.GENERIC);
 
       expect(toolCallSpans.length).toBeGreaterThanOrEqual(1);
       expect(genericSpans.length).toBeGreaterThanOrEqual(1);
+      expect(toolCallSpans[0].traceId).toBe(result.traceId);
 
       // Find the child span and validate metadata
       const childSpan = genericSpans.find(span => span.name === 'tool-child-operation');
@@ -1409,13 +1423,14 @@ describe('AI Tracing Integration Tests', () => {
 
     // For structured output, result has object property instead of text
     expect(result.object || result).toBeTruthy();
+    expect(result.traceId).toBeDefined();
 
-    // Validate span types
     const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
     const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
 
     expect(agentRunSpans.length).toBe(1); // One agent run
     expect(llmGenerationSpans.length).toBe(1); // One LLM generation
+    expect(agentRunSpans[0].traceId).toBe(result.traceId);
 
     testExporter.finalExpectations();
   });

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -761,7 +761,7 @@ describe('AI Tracing Integration Tests', () => {
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
     const conditionalSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_CONDITIONAL);
     expect(workflowRunSpans[0].traceId).toBe(result.traceId);
-    
+
     expect(workflowRunSpans.length).toBe(1); // One workflow run
     expect(workflowStepSpans.length).toBe(2); // checkCondition + processHigh (value=15 > 10)
     expect(conditionalSpans.length).toBe(1); // One branch evaluation
@@ -948,7 +948,7 @@ describe('AI Tracing Integration Tests', () => {
     expect(result.traceId).toBeDefined();
 
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
-    
+
     expect(workflowStepSpans.length).toBe(1);
     const stepSpan = workflowStepSpans[0];
 
@@ -1289,7 +1289,7 @@ describe('AI Tracing Integration Tests', () => {
       expect(result.traceId).toBeDefined();
 
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
-      
+
       expect(toolCallSpans.length).toBeGreaterThanOrEqual(1);
       expect(toolCallSpans[0].traceId).toBe(result.traceId);
 

--- a/packages/core/src/ai-tracing/no-op.ts
+++ b/packages/core/src/ai-tracing/no-op.ts
@@ -81,4 +81,8 @@ export class NoOpAISpan<TType extends AISpanType = any> implements AISpan<TType>
   get isRootSpan(): boolean {
     return !this.parent;
   }
+
+  get isValid(): boolean {
+    return false;
+  }
 }

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -347,6 +347,9 @@ export interface AISpan<TType extends AISpanType> {
 
   /** Returns `TRUE` if the span is the root span of a trace */
   get isRootSpan(): boolean;
+
+  /** Returns `TRUE` if the span is a valid span (not a NO-OP Span) */
+  get isValid(): boolean;
 }
 
 /**
@@ -375,6 +378,14 @@ export interface AISpanOptions<TType extends AISpanType> {
   /** Is an event span? */
   isEvent: boolean;
 }
+
+/**
+ * Properties returned to the user for working with traces externally.
+ */
+export type TracingProperties = {
+  /** Trace ID used on the execution (if the execution was traced). */
+  traceId?: string;
+};
 
 // ============================================================================
 // Configuration Types

--- a/packages/core/src/ai-tracing/utils.ts
+++ b/packages/core/src/ai-tracing/utils.ts
@@ -5,7 +5,7 @@
 
 import type { RuntimeContext } from '../di';
 import { getSelectedAITracing } from './registry';
-import type { AISpan, AISpanType, AISpanTypeMap, TracingContext } from './types';
+import type { AISpan, AISpanType, AISpanTypeMap, AnyAISpan, TracingContext } from './types';
 
 const DEFAULT_KEYS_TO_STRIP = new Set(['logger', 'providerMetadata', 'steps', 'tracingContext']);
 export interface DeepCleanOptions {
@@ -183,4 +183,19 @@ export function getOrCreateSpan<T extends AISpanType>(options: {
     },
     ...rest,
   });
+}
+
+/**
+ * Extracts the trace ID from a span if it is valid.
+ *
+ * This helper is typically used to safely retrieve the `traceId` from a span object,
+ * while gracefully handling invalid spans — such as no-op spans — by returning `undefined`.
+ *
+ * A span is considered valid if `span.isValid` is `true`.
+ *
+ * @param span - The span object to extract the trace ID from. May be `undefined`.
+ * @returns The `traceId` if the span is valid, otherwise `undefined`.
+ */
+export function getValidTraceId(span?: AnyAISpan): string | undefined {
+  return span?.isValid ? span.traceId : undefined;
 }

--- a/packages/core/src/llm/model/base.types.ts
+++ b/packages/core/src/llm/model/base.types.ts
@@ -21,7 +21,7 @@ import type {
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
 import type { MessageList } from '../../agent/types';
-import type { TracingContext } from '../../ai-tracing';
+import type { TracingContext, TracingProperties } from '../../ai-tracing';
 import type { OutputProcessor } from '../../processors';
 import type { RuntimeContext } from '../../runtime-context';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '../../scores';
@@ -95,8 +95,7 @@ export type GenerateTextResult<
 > = Omit<OriginalGenerateTextResult<Tools, inferOutput<Output>>, 'experimental_output'> & {
   object?: Output extends undefined ? never : inferOutput<Output>;
   messageList?: MessageList;
-} & TripwireProperties &
-  ScoringProperties;
+} & TripwireProperties & ScoringProperties & TracingProperties;
 
 export type OriginalGenerateObjectOptions<Output extends ZodSchema | JSONSchema7 | undefined = undefined> =
   | Parameters<typeof generateObject<inferOutput<Output>>>[0]
@@ -119,8 +118,7 @@ export type GenerateObjectWithMessagesArgs<Output extends ZodSchema | JSONSchema
 export type GenerateObjectResult<Output extends ZodSchema | JSONSchema7 | undefined = undefined> =
   OriginalGenerateObjectResult<inferOutput<Output>> & {
     readonly reasoning?: never;
-  } & TripwireProperties &
-    ScoringProperties;
+  } & TripwireProperties & ScoringProperties & TracingProperties;
 
 export type GenerateReturn<
   Tools extends ToolSet,
@@ -157,7 +155,7 @@ export type StreamTextResult<
   Output extends ZodSchema | JSONSchema7 | undefined = undefined,
 > = Omit<OriginalStreamTextResult<Tools, DeepPartial<inferOutput<Output>>>, 'experimental_output'> & {
   object?: inferOutput<Output>;
-} & TripwireProperties;
+} & TripwireProperties & TracingProperties;
 
 export type OriginalStreamObjectOptions<Output extends ZodSchema | JSONSchema7> =
   | Parameters<typeof streamObject<inferOutput<Output>>>[0]

--- a/packages/core/src/llm/model/base.types.ts
+++ b/packages/core/src/llm/model/base.types.ts
@@ -95,7 +95,9 @@ export type GenerateTextResult<
 > = Omit<OriginalGenerateTextResult<Tools, inferOutput<Output>>, 'experimental_output'> & {
   object?: Output extends undefined ? never : inferOutput<Output>;
   messageList?: MessageList;
-} & TripwireProperties & ScoringProperties & TracingProperties;
+} & TripwireProperties &
+  ScoringProperties &
+  TracingProperties;
 
 export type OriginalGenerateObjectOptions<Output extends ZodSchema | JSONSchema7 | undefined = undefined> =
   | Parameters<typeof generateObject<inferOutput<Output>>>[0]
@@ -118,7 +120,9 @@ export type GenerateObjectWithMessagesArgs<Output extends ZodSchema | JSONSchema
 export type GenerateObjectResult<Output extends ZodSchema | JSONSchema7 | undefined = undefined> =
   OriginalGenerateObjectResult<inferOutput<Output>> & {
     readonly reasoning?: never;
-  } & TripwireProperties & ScoringProperties & TracingProperties;
+  } & TripwireProperties &
+    ScoringProperties &
+    TracingProperties;
 
 export type GenerateReturn<
   Tools extends ToolSet,
@@ -155,7 +159,8 @@ export type StreamTextResult<
   Output extends ZodSchema | JSONSchema7 | undefined = undefined,
 > = Omit<OriginalStreamTextResult<Tools, DeepPartial<inferOutput<Output>>>, 'experimental_output'> & {
   object?: inferOutput<Output>;
-} & TripwireProperties & TracingProperties;
+} & TripwireProperties &
+  TracingProperties;
 
 export type OriginalStreamObjectOptions<Output extends ZodSchema | JSONSchema7> =
   | Parameters<typeof streamObject<inferOutput<Output>>>[0]

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -113,6 +113,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
       outputProcessors,
       outputProcessorRunnerMode: 'result',
       returnScorerData,
+      tracingContext: { currentSpan: llmAISpan },
     },
   });
 }

--- a/packages/core/src/loop/workflow/llm-execution.ts
+++ b/packages/core/src/loop/workflow/llm-execution.ts
@@ -384,7 +384,7 @@ export function createLLMExecutionStep<
     id: 'llm-execution',
     inputSchema: llmIterationOutputSchema,
     outputSchema: llmIterationOutputSchema,
-    execute: async ({ inputData, bail }) => {
+    execute: async ({ inputData, bail, tracingContext }) => {
       const runState = new AgenticRunState({
         _internal: _internal!,
         model,
@@ -512,6 +512,7 @@ export function createLLMExecutionStep<
           output,
           outputProcessors,
           outputProcessorRunnerMode: 'stream',
+          tracingContext,
         },
       });
 

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -1,5 +1,5 @@
 import type { Mastra, SerializedStepFlowEntry } from '..';
-import type { TracingContext } from '../ai-tracing';
+import type { AISpan, AISpanType } from '../ai-tracing';
 import { MastraBase } from '../base';
 import type { RuntimeContext } from '../di';
 import { RegisteredLogger } from '../logger';
@@ -51,7 +51,7 @@ export abstract class ExecutionEngine extends MastraBase {
     };
     emitter: Emitter;
     runtimeContext: RuntimeContext;
-    tracingContext?: TracingContext;
+    workflowAISpan?: AISpan<AISpanType.WORKFLOW_RUN>;
     retryConfig?: {
       attempts?: number;
       delay?: number;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -1,5 +1,6 @@
 import type { TextStreamPart } from 'ai';
 import type { z } from 'zod';
+import type { TracingProperties } from '../ai-tracing';
 import type { Mastra } from '../mastra';
 import type { ExecutionEngine } from './execution-engine';
 import type { ExecuteFunction, Step } from './step';
@@ -389,7 +390,7 @@ export type StepWithComponent = Step<string, any, any, any, any, any> & {
 };
 
 export type WorkflowResult<TOutput extends z.ZodType<any>, TSteps extends Step<string, any, any>[]> =
-  | {
+  | ({
       status: 'success';
       result: z.infer<TOutput>;
       steps: {
@@ -402,8 +403,8 @@ export type WorkflowResult<TOutput extends z.ZodType<any>, TSteps extends Step<s
               z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
             >;
       };
-    }
-  | {
+    } & TracingProperties)
+  | ({
       status: 'failed';
       steps: {
         [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
@@ -416,8 +417,8 @@ export type WorkflowResult<TOutput extends z.ZodType<any>, TSteps extends Step<s
             >;
       };
       error: Error;
-    }
-  | {
+    } & TracingProperties)
+  | ({
       status: 'suspended';
       steps: {
         [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
@@ -430,7 +431,7 @@ export type WorkflowResult<TOutput extends z.ZodType<any>, TSteps extends Step<s
             >;
       };
       suspended: [string[], ...string[][]];
-    };
+    } & TracingProperties);
 
 export type WorkflowConfig<
   TWorkflowId extends string = string,


### PR DESCRIPTION
## Description

A user has requested that we make `traceId` available on the results of workflow and agent runs, so that they can use the id for adding scores to traces inside of Langfuse.

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
