### PR TITLE
Set custom metadata for traces when starting agents or workflows

### DIFF
--- a/.changeset/soft-geckos-jam.md
+++ b/.changeset/soft-geckos-jam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Custom metadata for traces can now be set when starting agents or workflows

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -4,7 +4,7 @@ import type { ModelMessage, ToolChoice } from 'ai-v5';
 import type { z } from 'zod';
 import type { ZodSchema as ZodSchemaV3 } from 'zod/v3';
 import type { ZodAny } from 'zod/v4';
-import type { TracingContext } from '../ai-tracing';
+import type { TracingContext, TracingOptions } from '../ai-tracing';
 import type { StreamTextOnFinishCallback, StreamTextOnStepFinishCallback } from '../llm/model/base.types';
 import type { LoopConfig, LoopOptions, PrepareStepFunction } from '../loop/types';
 import type { InputProcessor, OutputProcessor } from '../processors';
@@ -103,6 +103,8 @@ export type AgentExecutionOptions<
   returnScorerData?: boolean;
   /** AI tracing context for span hierarchy and metadata */
   tracingContext?: TracingContext;
+  /** AI tracing options for starting new traces */
+  tracingOptions?: TracingOptions;
 
   /** Callback function called before each step of multi-step execution */
   prepareStep?: PrepareStepFunction<any>;

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import type { ZodSchema } from 'zod';
 import type { MastraPrimitives, MastraUnion } from '../action';
 import { AISpanType, getOrCreateSpan, getValidTraceId } from '../ai-tracing';
-import type { AISpan, TracingContext, TracingProperties } from '../ai-tracing';
+import type { AISpan, TracingContext, TracingOptions, TracingProperties } from '../ai-tracing';
 import { MastraBase } from '../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { Metric } from '../eval';
@@ -1668,6 +1668,7 @@ export class Agent<
     writableStream,
     methodType,
     tracingContext,
+    tracingOptions,
   }: {
     instructions: string;
     toolsets?: ToolsetsInput;
@@ -1683,6 +1684,7 @@ export class Agent<
     writableStream?: WritableStream<ChunkType>;
     methodType: 'generate' | 'stream';
     tracingContext?: TracingContext;
+    tracingOptions?: TracingOptions;
   }) {
     return {
       before: async () => {
@@ -1710,6 +1712,7 @@ export class Agent<
             threadId: thread ? thread.id : undefined,
           },
           tracingContext,
+          tracingOptions,
           runtimeContext,
         });
 
@@ -2450,6 +2453,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       toolChoice = 'auto',
       runtimeContext = new RuntimeContext(),
       tracingContext,
+      tracingOptions,
       savePerStep,
       writableStream,
       ...args
@@ -2517,6 +2521,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
       writableStream,
       methodType,
       tracingContext,
+      tracingOptions,
     });
 
     let messageList: MessageList;
@@ -2681,6 +2686,7 @@ Message ${msg.threadId && msg.threadId !== threadObject.id ? 'from previous conv
         threadId: threadFromArgs ? threadFromArgs.id : undefined,
       },
       tracingContext: options.tracingContext,
+      tracingOptions: options.tracingOptions,
       runtimeContext,
     });
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,7 +1,7 @@
 import type { GenerateTextOnStepFinishCallback, TelemetrySettings } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema, ZodTypeAny } from 'zod';
-import type { TracingContext } from '../ai-tracing';
+import type { TracingContext, TracingOptions } from '../ai-tracing';
 import type { Metric } from '../eval';
 import type {
   CoreMessage,
@@ -142,6 +142,8 @@ export type AgentGenerateOptions<
   outputProcessors?: OutputProcessor[];
   /** AI tracing context for span hierarchy and metadata */
   tracingContext?: TracingContext;
+  /** AI tracing options for starting new traces */
+  tracingOptions?: TracingOptions;
 } & (
   | {
       /**
@@ -217,6 +219,8 @@ export type AgentStreamOptions<
   inputProcessors?: InputProcessor[];
   /** AI tracing context for span hierarchy and metadata */
   tracingContext?: TracingContext;
+  /** AI tracing options for starting new traces */
+  tracingOptions?: TracingOptions;
   /** Scorers to use for this generation */
   scorers?: MastraScorers | Record<string, { scorer: MastraScorer['name']; sampling?: ScoringSamplingConfig }>;
 } & (

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -379,6 +379,26 @@ export interface AISpanOptions<TType extends AISpanType> {
   isEvent: boolean;
 }
 
+// ============================================================================
+// Lifecycle Types
+// ============================================================================
+
+/**
+ * Options passed when starting a new agent or workflow execution
+ */
+export interface TracingOptions {
+  /** Metadata to add to the root trace span */
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Context for AI tracing that flows through workflow and agent execution
+ */
+export interface TracingContext {
+  /** Current AI span for creating child spans and adding metadata */
+  currentSpan?: AnyAISpan;
+}
+
 /**
  * Properties returned to the user for working with traces externally.
  */
@@ -520,11 +540,3 @@ export type TracingSelector = (
   context: AITracingSelectorContext,
   availableTracers: ReadonlyMap<string, MastraAITracing>,
 ) => string | undefined;
-
-/**
- * Context for AI tracing that flows through workflow and agent execution
- */
-export interface TracingContext {
-  /** Current AI span for creating child spans and adding metadata */
-  currentSpan?: AnyAISpan;
-}

--- a/packages/core/src/ai-tracing/utils.ts
+++ b/packages/core/src/ai-tracing/utils.ts
@@ -5,7 +5,7 @@
 
 import type { RuntimeContext } from '../di';
 import { getSelectedAITracing } from './registry';
-import type { AISpan, AISpanType, AISpanTypeMap, AnyAISpan, TracingContext } from './types';
+import type { AISpan, AISpanType, AISpanTypeMap, AnyAISpan, TracingContext, TracingOptions } from './types';
 
 const DEFAULT_KEYS_TO_STRIP = new Set(['logger', 'providerMetadata', 'steps', 'tracingContext']);
 export interface DeepCleanOptions {
@@ -157,9 +157,15 @@ export function getOrCreateSpan<T extends AISpanType>(options: {
   attributes?: AISpanTypeMap[T];
   metadata?: Record<string, any>;
   tracingContext?: TracingContext;
+  tracingOptions?: TracingOptions;
   runtimeContext?: RuntimeContext;
 }): AISpan<T> | undefined {
-  const { type, attributes, tracingContext, runtimeContext, ...rest } = options;
+  const { type, attributes, tracingContext, tracingOptions, runtimeContext, ...rest } = options;
+
+  const metadata = {
+    ...(rest.metadata ?? {}),
+    ...(tracingOptions?.metadata ?? {}),
+  };
 
   // If we have a current span, create a child span
   if (tracingContext?.currentSpan) {
@@ -167,6 +173,7 @@ export function getOrCreateSpan<T extends AISpanType>(options: {
       type,
       attributes,
       ...rest,
+      metadata,
     });
   }
 
@@ -182,6 +189,7 @@ export function getOrCreateSpan<T extends AISpanType>(options: {
       runtimeContext,
     },
     ...rest,
+    metadata,
   });
 }
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -7,7 +7,7 @@ import type { Mastra, WorkflowRun } from '..';
 import type { MastraPrimitives } from '../action';
 import { Agent } from '../agent';
 import { AISpanType, getOrCreateSpan, getValidTraceId } from '../ai-tracing';
-import type { TracingContext } from '../ai-tracing';
+import type { TracingContext, TracingOptions } from '../ai-tracing';
 import { MastraBase } from '../base';
 import { RuntimeContext } from '../di';
 import { RegisteredLogger } from '../logger';
@@ -1316,12 +1316,14 @@ export class Run<
     runtimeContext,
     writableStream,
     tracingContext,
+    tracingOptions,
     format,
   }: {
     inputData?: z.infer<TInput>;
     runtimeContext?: RuntimeContext;
     writableStream?: WritableStream<ChunkType>;
     tracingContext?: TracingContext;
+    tracingOptions?: TracingOptions;
     format?: 'aisdk' | 'mastra' | undefined;
   }): Promise<WorkflowResult<TOutput, TSteps>> {
     // note: this span is ended inside this.executionEngine.execute()
@@ -1333,6 +1335,7 @@ export class Run<
         workflowId: this.workflowId,
       },
       tracingContext,
+      tracingOptions,
       runtimeContext,
     });
 
@@ -1385,17 +1388,20 @@ export class Run<
     runtimeContext,
     writableStream,
     tracingContext,
+    tracingOptions,
   }: {
     inputData?: z.infer<TInput>;
     runtimeContext?: RuntimeContext;
     writableStream?: WritableStream<ChunkType>;
     tracingContext?: TracingContext;
+    tracingOptions?: TracingOptions;
   }): Promise<WorkflowResult<TOutput, TSteps>> {
     return this._start({
       inputData,
       runtimeContext,
       writableStream,
       tracingContext,
+      tracingOptions,
       format: 'aisdk',
     });
   }
@@ -1683,6 +1689,7 @@ export class Run<
     runtimeContext?: RuntimeContext;
     runCount?: number;
     tracingContext?: TracingContext;
+    tracingOptions?: TracingOptions;
   }): Promise<WorkflowResult<TOutput, TSteps>> {
     const snapshot = await this.#mastra?.getStorage()?.loadWorkflowSnapshot({
       workflowName: this.workflowId,
@@ -1778,6 +1785,7 @@ export class Run<
         workflowId: this.workflowId,
       },
       tracingContext: params.tracingContext,
+      tracingOptions: params.tracingOptions,
       runtimeContext: runtimeContextToUse,
     });
 


### PR DESCRIPTION
## Description

Another user request. When starting agents or workflows, the user wants to be able to set custom metadata that will be included in the trace for filtering purposes later.

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
