### PR TITLE
fix(core): fix structuredOutput over clientjs

### DIFF
--- a/.changeset/neat-days-clap.md
+++ b/.changeset/neat-days-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix using structuredOutput through client-js

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -5,6 +5,7 @@ import type {
 } from '@ai-sdk/provider-v5';
 import { asSchema, tool as toolFn } from 'ai-v5';
 import type { Tool, ToolChoice } from 'ai-v5';
+import { isJsonSchema } from '../../../base/schema';
 
 export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
   tools,
@@ -59,7 +60,9 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
                 type: 'function' as const,
                 name,
                 description: sdkTool.description,
-                inputSchema: asSchema(sdkTool.inputSchema).jsonSchema,
+                inputSchema: isJsonSchema(sdkTool.inputSchema)
+                  ? sdkTool.inputSchema
+                  : asSchema(sdkTool.inputSchema).jsonSchema,
                 providerOptions: sdkTool.providerOptions,
               };
             case 'provider-defined':

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -4,7 +4,7 @@ import type { Schema } from 'ai-v5';
 import { safeValidateTypes } from '../aisdk/v5/compat';
 import { ChunkFrom } from '../types';
 import type { ChunkType } from '../types';
-import { getTransformedSchema, getResponseFormat } from './schema';
+import { getTransformedSchema, getResponseFormat, isJsonSchema } from './schema';
 import type { InferSchemaOutput, OutputSchema, PartialSchemaOutput, ZodLikePartialSchema } from './schema';
 
 interface ProcessPartialChunkParams {
@@ -68,7 +68,7 @@ abstract class BaseFormatHandler<OUTPUT extends OutputSchema = undefined> {
     if (!schema) {
       this.schema = undefined;
     } else {
-      this.schema = asSchema(schema);
+      this.schema = isJsonSchema(schema) ? (schema as Schema<InferSchemaOutput<OUTPUT>>) : asSchema(schema);
     }
     if (options.validatePartialChunks) {
       if (schema !== undefined && 'partial' in schema && typeof schema.partial === 'function') {

--- a/packages/core/src/stream/base/schema.ts
+++ b/packages/core/src/stream/base/schema.ts
@@ -30,8 +30,13 @@ export type ZodLikePartialSchema<T = any> = (
   safeParse(value: unknown): { success: boolean; data?: Partial<T>; error?: any };
 };
 
+export function isJsonSchema(schema?: unknown): schema is JSONSchema7 {
+  return !!(schema && typeof schema === 'object' && '$schema' in schema);
+}
+
 export function getTransformedSchema<OUTPUT extends OutputSchema = undefined>(schema?: OUTPUT) {
-  const jsonSchema = schema ? asSchema(schema).jsonSchema : undefined;
+  const jsonSchema = isJsonSchema(schema) ? schema : schema ? asSchema(schema).jsonSchema : undefined;
+
   if (!jsonSchema) {
     return undefined;
   }


### PR DESCRIPTION
## Description

When `structuredOutput` gets sent over the wire through client-js, it becomes jsonSchema, but the backend code incorrectly assumes it will be of type Schema instead of JSONSchema
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
