### PR TITLE
added output to agent spans in ai-tracing

### DIFF
--- a/.changeset/plenty-actors-clean.md
+++ b/.changeset/plenty-actors-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+"added output to agent spans in ai-tracing"

--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -95,6 +95,7 @@ describe('create mastra', () => {
         await expect(response.json()).resolves.toMatchInlineSnapshot(`
           {
             "weatherAgent": {
+              "agents": {},
               "defaultGenerateOptions": {},
               "defaultStreamOptions": {},
               "instructions": "
@@ -124,7 +125,6 @@ describe('create mastra', () => {
                 },
               },
               "workflows": {},
-              "agents": {},
             },
           }
         `);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2199,7 +2199,9 @@ export class Agent<
 
         agentAISpan?.end({
           output: {
-            status: 'success',
+            text: result?.text,
+            object: result?.object,
+            files: result?.files,
           },
         });
 
@@ -2700,6 +2702,7 @@ export class Agent<
     const instructions = options.instructions || (await this.getInstructions({ runtimeContext }));
 
     // Set AI Tracing context
+    // Note this span is ended at the end of #executeOnFinish
     const agentAISpan = getOrCreateSpan({
       type: AISpanType.AGENT_RUN,
       name: `agent run: '${this.id}'`,
@@ -2711,7 +2714,7 @@ export class Agent<
       metadata: {
         runId,
         resourceId,
-        threadId: threadFromArgs ? threadFromArgs.id : undefined,
+        threadId: threadFromArgs?.id,
       },
       tracingContext: options.tracingContext,
       tracingOptions: options.tracingOptions,
@@ -3056,7 +3059,7 @@ export class Agent<
       steps: [prepareToolsStep, prepareMemory],
     })
       .parallel([prepareToolsStep, prepareMemory])
-      .map(async ({ inputData, bail, tracingContext }) => {
+      .map(async ({ inputData, bail }) => {
         const result = {
           ...options,
           tools: inputData['prepare-tools-step'].convertedTools as Record<string, Tool>,
@@ -3209,7 +3212,7 @@ export class Agent<
                   resourceId,
                   memoryConfig,
                   runtimeContext,
-                  tracingContext,
+                  agentAISpan: agentAISpan,
                   runId,
                   messageList,
                   threadExists: inputData['prepare-memory-step'].threadExists,
@@ -3256,12 +3259,6 @@ export class Agent<
     const run = await executionWorkflow.createRunAsync();
     const result = await run.start({ tracingContext: { currentSpan: agentAISpan } });
 
-    agentAISpan?.end({
-      output: {
-        status: result.status,
-      },
-    });
-
     return result;
   }
 
@@ -3274,7 +3271,7 @@ export class Agent<
     memoryConfig,
     outputText,
     runtimeContext,
-    tracingContext,
+    agentAISpan,
     runId,
     messageList,
     threadExists,
@@ -3289,7 +3286,7 @@ export class Agent<
     threadId?: string;
     resourceId?: string;
     runtimeContext: RuntimeContext;
-    tracingContext: TracingContext;
+    agentAISpan?: AISpan<AISpanType.AGENT_RUN>;
     memoryConfig: MemoryConfig | undefined;
     outputText: string;
     messageList: MessageList;
@@ -3383,7 +3380,7 @@ export class Agent<
 
           if (shouldGenerate && userMessage) {
             promises.push(
-              this.genTitle(userMessage, runtimeContext, tracingContext, titleModel, titleInstructions).then(title => {
+              this.genTitle(userMessage, runtimeContext, { currentSpan: agentAISpan }, titleModel, titleInstructions).then(title => {
                 if (title) {
                   return memory.createThread({
                     threadId: thread.id,
@@ -3450,7 +3447,15 @@ export class Agent<
       runtimeContext,
       structuredOutput,
       overrideScorers,
-      tracingContext,
+      tracingContext: { currentSpan: agentAISpan },
+    });
+
+    agentAISpan?.end({
+      output: {
+        text: result?.text,
+        object: result?.object,
+        files: result?.files,
+      },
     });
   }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3380,7 +3380,13 @@ export class Agent<
 
           if (shouldGenerate && userMessage) {
             promises.push(
-              this.genTitle(userMessage, runtimeContext, { currentSpan: agentAISpan }, titleModel, titleInstructions).then(title => {
+              this.genTitle(
+                userMessage,
+                runtimeContext,
+                { currentSpan: agentAISpan },
+                titleModel,
+                titleInstructions,
+              ).then(title => {
                 if (title) {
                   return memory.createThread({
                     threadId: thread.id,

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -1097,17 +1097,19 @@ describe('AI Tracing Integration Tests', () => {
       switch (name) {
         case 'generateLegacy':
           expect(llmGenerationSpan.output.text).toBe('Mock response');
+          expect(agentRunSpan.output.text).toBe('Mock response');
           break;
         case 'streamLegacy':
           expect(llmGenerationSpan.output.text).toBe('Mock streaming response');
+          expect(agentRunSpan.output.text).toBe('Mock streaming response');
           break;
         default: // VNext generate & stream
           expect(llmGenerationSpan.output.text).toBe('Mock V2 streaming response');
+          expect(agentRunSpan.output.text).toBe('Mock V2 streaming response');
           break;
       }
       expect(llmGenerationSpan.attributes?.usage?.totalTokens).toBeGreaterThan(1);
 
-      expect(agentRunSpan.output?.status).toBe('success');
       testExporter.finalExpectations();
     });
   });

--- a/packages/core/src/ai-tracing/utils.ts
+++ b/packages/core/src/ai-tracing/utils.ts
@@ -7,7 +7,7 @@ import type { RuntimeContext } from '../di';
 import { getSelectedAITracing } from './registry';
 import type { AISpan, AISpanType, AISpanTypeMap, AnyAISpan, TracingContext, TracingOptions } from './types';
 
-const DEFAULT_KEYS_TO_STRIP = new Set(['logger', 'providerMetadata', 'steps', 'tracingContext']);
+const DEFAULT_KEYS_TO_STRIP = new Set(['logger','experimental_providerMetadata', 'providerMetadata', 'steps', 'tracingContext']);
 export interface DeepCleanOptions {
   keysToStrip?: Set<string>;
   maxDepth?: number;

--- a/packages/core/src/ai-tracing/utils.ts
+++ b/packages/core/src/ai-tracing/utils.ts
@@ -7,7 +7,13 @@ import type { RuntimeContext } from '../di';
 import { getSelectedAITracing } from './registry';
 import type { AISpan, AISpanType, AISpanTypeMap, AnyAISpan, TracingContext, TracingOptions } from './types';
 
-const DEFAULT_KEYS_TO_STRIP = new Set(['logger','experimental_providerMetadata', 'providerMetadata', 'steps', 'tracingContext']);
+const DEFAULT_KEYS_TO_STRIP = new Set([
+  'logger',
+  'experimental_providerMetadata',
+  'providerMetadata',
+  'steps',
+  'tracingContext',
+]);
 export interface DeepCleanOptions {
   keysToStrip?: Set<string>;
   maxDepth?: number;


### PR DESCRIPTION
## Description

@YujohnNattrass noticed that agent spans current only show `status: success` for output info. while this is technically true, it would probably be better to show the text/object/file output instead. 

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
