### PR TITLE
remove duplication of tagged system messages

### DIFF
--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -585,7 +585,7 @@ export class MessageList {
     if (tag && !this.isDuplicateSystem(coreMessage, tag)) {
       this.taggedSystemMessages[tag] ||= [];
       this.taggedSystemMessages[tag].push(coreMessage);
-    } else if (!this.isDuplicateSystem(coreMessage)) {
+    } else if (!tag && !this.isDuplicateSystem(coreMessage)) {
       this.systemMessages.push(coreMessage);
     }
   }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
When a tagged system message is added, and found to be a duplicate, it gets added to the regular system messages. This causes tagged messages and regular system messages to contain the same message, which seems like a bug. This PR checks to ensure that if a tagged message is a duplicate, it is ignored and not added to system messages.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
