### PR TITLE
fix: handle MastraError instances with 400 status in voice handler

### DIFF
--- a/.changeset/nasty-schools-return.md
+++ b/.changeset/nasty-schools-return.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Voice errors that are instance of a MastraError should not throw a 500

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream';
 import type { Agent } from '@mastra/core/agent';
+import { MastraError } from '@mastra/core/error';
 import type { RuntimeContext } from '@mastra/core/runtime-context';
 import { HTTPException } from '../http-exception';
 import type { Context } from '../types';
@@ -75,7 +76,13 @@ export async function generateSpeechHandler({
       throw new HTTPException(400, { message: 'Agent does not have voice capabilities' });
     }
 
-    const audioStream = await voice.speak(body!.text!, { speaker: body!.speakerId! });
+    const audioStream = await voice.speak(body!.text!, { speaker: body!.speakerId! }).catch(err => {
+      if (err instanceof MastraError) {
+        throw new HTTPException(400, { message: err.message });
+      }
+
+      throw err;
+    });
 
     if (!audioStream) {
       throw new HTTPException(500, { message: 'Failed to generate speech' });

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -76,13 +76,15 @@ export async function generateSpeechHandler({
       throw new HTTPException(400, { message: 'Agent does not have voice capabilities' });
     }
 
-    const audioStream = await voice.speak(body!.text!, { speaker: body!.speakerId! }).catch(err => {
-      if (err instanceof MastraError) {
-        throw new HTTPException(400, { message: err.message });
-      }
+    const audioStream = await Promise.resolve()
+      .then(() => voice.speak(body!.text!, { speaker: body!.speakerId! }))
+      .catch((err) => {
+        if (err instanceof MastraError) {
+          throw new HTTPException(400, { message: err.message });
+        }
 
-      throw err;
-    });
+        throw err;
+      });
 
     if (!audioStream) {
       throw new HTTPException(500, { message: 'Failed to generate speech' });

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -78,7 +78,7 @@ export async function generateSpeechHandler({
 
     const audioStream = await Promise.resolve()
       .then(() => voice.speak(body!.text!, { speaker: body!.speakerId! }))
-      .catch((err) => {
+      .catch(err => {
         if (err instanceof MastraError) {
           throw new HTTPException(400, { message: err.message });
         }


### PR DESCRIPTION
## Summary
- Handle voice generation errors that are MastraError instances by returning a 400 status code instead of 500
- Provides clearer error messages to clients when voice generation fails due to client errors

## Test plan
- [ ] Test voice generation with valid parameters
- [ ] Test voice generation with invalid speaker ID to trigger MastraError
- [ ] Verify that MastraError instances return 400 status code
- [ ] Verify that non-MastraError exceptions still return 500 status code