### PR TITLE
fix(core): deprecate output property in favor of structuredOutput

### DIFF
--- a/.changeset/whole-pumas-pump.md
+++ b/.changeset/whole-pumas-pump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Deprecate "output" in generate and stream VNext in favour of structuredOutput. When structuredOutput is used in tandem with maxSteps = 1, the structuredOutput processor won't run, it'll generate the output using the main agent, similar to how "output" used to work.

--- a/docs/src/content/en/reference/agents/generateVNext.mdx
+++ b/docs/src/content/en/reference/agents/generateVNext.mdx
@@ -224,7 +224,8 @@ const aiSdkResult = await agent.generateVNext("message for agent", {
       name: "output",
       type: "Zod schema | JsonSchema7",
       isOptional: true,
-      description: "Schema for structured output generation (Zod schema or JSON Schema).",
+      description: 
+        "**Deprecated.** Use structuredOutput with maxSteps:1 to achieve the same thing. Defines the expected structure of the output. Can be a JSON Schema object or a Zod schema.",
     },
     {
       name: "memory",

--- a/docs/src/content/en/reference/agents/streamVNext.mdx
+++ b/docs/src/content/en/reference/agents/streamVNext.mdx
@@ -226,7 +226,7 @@ const aiSdkStream = await agent.streamVNext("message for agent", {
       type: "Zod schema | JsonSchema7",
       isOptional: true,
       description:
-        "Defines the expected structure of the output. Can be a JSON Schema object or a Zod schema.",
+        "**Deprecated.** Use structuredOutput with maxSteps:1 to achieve the same thing. Defines the expected structure of the output. Can be a JSON Schema object or a Zod schema.",
     },
     {
       name: "memory",

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -8196,7 +8196,7 @@ describe('Stream ID Consistency', () => {
   }, 10000); // Increase timeout to 10 seconds
 });
 
-describe.only('Agent structuredOutput to output deprecation mapping', () => {
+describe('Agent structuredOutput to output deprecation mapping', () => {
   it('should map structuredOutput to output when maxSteps is 1', async () => {
     let structuredOutputProcessorGotCalled = false;
     const mockModel = new MockLanguageModelV2({

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -8195,3 +8195,280 @@ describe('Stream ID Consistency', () => {
     expect(onFinishResult.object).toEqual({ name: 'John', age: 30 });
   }, 10000); // Increase timeout to 10 seconds
 });
+
+describe.only('Agent structuredOutput to output deprecation mapping', () => {
+  it('should map structuredOutput to output when maxSteps is 1', async () => {
+    let structuredOutputProcessorGotCalled = false;
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: '{"name": "John", "age": 30}',
+            },
+          ],
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          warnings: [],
+        };
+      },
+      doStream: async _options => {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: '{"name": "John", "age": 30}' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      name: 'test-structured-deprecation',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+    });
+
+    const outputSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = await agent.streamVNext(
+      [
+        {
+          role: 'user',
+          content: 'Generate a person',
+        },
+      ],
+      {
+        structuredOutput: {
+          schema: outputSchema,
+        },
+        maxSteps: 1,
+      },
+    );
+
+    expect(structuredOutputProcessorGotCalled).toBe(false);
+    expect(await result.object).toEqual({ name: 'John', age: 30 });
+  });
+
+  it('should NOT map structuredOutput to output when maxSteps is not 1', async () => {
+    let structuredOutputProcessorGotCalled = false;
+
+    const structuringModel = new MockLanguageModelV2({
+      doGenerate: async options => {
+        if (
+          options.prompt.some(
+            p =>
+              Array.isArray(p.content) &&
+              p.content.some(c => c.type === 'text' && c.text.includes('Extract and structure the key information')),
+          )
+        ) {
+          structuredOutputProcessorGotCalled = true;
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: '{"name": "John", "age": 30}',
+            },
+          ],
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          warnings: [],
+        };
+      },
+      doStream: async options => {
+        if (
+          options.prompt.some(
+            p =>
+              Array.isArray(p.content) &&
+              p.content.some(c => c.type === 'text' && c.text.includes('Extract and structure the key information')),
+          )
+        ) {
+          structuredOutputProcessorGotCalled = true;
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: '{"name": "John", "age": 30}' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Response text',
+            },
+          ],
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Response text' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      name: 'test-structured-no-deprecation',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+    });
+
+    const outputSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = await agent.streamVNext(
+      [
+        {
+          role: 'user',
+          content: 'Generate a person',
+        },
+      ],
+      {
+        structuredOutput: {
+          schema: outputSchema,
+          model: structuringModel,
+        },
+        maxSteps: 2,
+      },
+    );
+
+    await result.consumeStream();
+
+    expect(structuredOutputProcessorGotCalled).toBe(true);
+    expect(await result.object).toEqual({ name: 'John', age: 30 });
+  });
+
+  it('should use model override from structuredOutput when maxSteps is 1', async () => {
+    let defaultModelGotCalled = false;
+    let overrideModelGotCalled = false;
+    const defaultModel = new MockLanguageModelV2({
+      modelId: 'default-model',
+      doGenerate: async () => ({
+        content: [
+          {
+            type: 'text',
+            text: 'Default model response',
+          },
+        ],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        warnings: [],
+      }),
+
+      doStream: async options => {
+        console.log(`defaultModel.doStream:`, JSON.stringify(options, null, 2));
+        defaultModelGotCalled = true;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: '{"name": "Default", "age": 1}' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const overrideModel = new MockLanguageModelV2({
+      modelId: 'override-model',
+      doGenerate: async () => ({
+        content: [
+          {
+            type: 'text',
+            text: 'Override model response',
+          },
+        ],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        warnings: [],
+      }),
+      doStream: async () => {
+        overrideModelGotCalled = true;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: '{"name": "Override", "age": 99}' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      name: 'test-model-override',
+      instructions: 'You are a helpful assistant.',
+      model: defaultModel,
+    });
+
+    const outputSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = await agent.streamVNext(
+      [
+        {
+          role: 'user',
+          content: 'Generate a person',
+        },
+      ],
+      {
+        structuredOutput: {
+          schema: outputSchema,
+          model: overrideModel,
+        },
+        maxSteps: 1,
+      },
+    );
+
+    await result.consumeStream();
+
+    expect(defaultModelGotCalled).toBe(false);
+    expect(overrideModelGotCalled).toBe(true);
+    expect(await result.object).toEqual({ name: 'Override', age: 99 });
+  });
+});

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -8197,6 +8197,8 @@ describe('Stream ID Consistency', () => {
 });
 
 describe('Agent structuredOutput to output deprecation mapping', () => {
+  const structuredOutputPrompt = 'Extract and structure the key information';
+
   it('should map structuredOutput to output when maxSteps is 1', async () => {
     let structuredOutputProcessorGotCalled = false;
     const mockModel = new MockLanguageModelV2({
@@ -8213,7 +8215,16 @@ describe('Agent structuredOutput to output deprecation mapping', () => {
           warnings: [],
         };
       },
-      doStream: async _options => {
+      doStream: async options => {
+        if (
+          options.prompt.some(
+            p =>
+              Array.isArray(p.content) &&
+              p.content.some(c => c.type === 'text' && c.text.includes(structuredOutputPrompt)),
+          )
+        ) {
+          structuredOutputProcessorGotCalled = true;
+        }
         return {
           stream: convertArrayToReadableStream([
             { type: 'text-start', id: '1' },
@@ -8268,7 +8279,7 @@ describe('Agent structuredOutput to output deprecation mapping', () => {
           options.prompt.some(
             p =>
               Array.isArray(p.content) &&
-              p.content.some(c => c.type === 'text' && c.text.includes('Extract and structure the key information')),
+              p.content.some(c => c.type === 'text' && c.text.includes(structuredOutputPrompt)),
           )
         ) {
           structuredOutputProcessorGotCalled = true;
@@ -8290,7 +8301,7 @@ describe('Agent structuredOutput to output deprecation mapping', () => {
           options.prompt.some(
             p =>
               Array.isArray(p.content) &&
-              p.content.some(c => c.type === 'text' && c.text.includes('Extract and structure the key information')),
+              p.content.some(c => c.type === 'text' && c.text.includes(structuredOutputPrompt)),
           )
         ) {
           structuredOutputProcessorGotCalled = true;
@@ -8390,8 +8401,7 @@ describe('Agent structuredOutput to output deprecation mapping', () => {
         warnings: [],
       }),
 
-      doStream: async options => {
-        console.log(`defaultModel.doStream:`, JSON.stringify(options, null, 2));
+      doStream: async () => {
         defaultModelGotCalled = true;
         return {
           stream: convertArrayToReadableStream([

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2697,7 +2697,7 @@ export class Agent<
       );
     }
 
-    const llm = (await this.getLLM({ runtimeContext, model: options._modelOverride })) as MastraLLMVNext;
+    const llm = (await this.getLLM({ runtimeContext, model: options.model })) as MastraLLMVNext;
 
     const runId = options.runId || this.#mastra?.generateId() || randomUUID();
     const instructions = options.instructions || (await this.getInstructions({ runtimeContext }));

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3576,7 +3576,7 @@ export class Agent<
       ...mergedStreamOptions,
       messages,
       methodType: 'streamVNext',
-      _modelOverride: modelOverride,
+      model: modelOverride,
     });
 
     if (result.status !== 'success') {

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -6,6 +6,7 @@ import type { ZodSchema as ZodSchemaV3 } from 'zod/v3';
 import type { ZodAny } from 'zod/v4';
 import type { TracingContext, TracingOptions } from '../ai-tracing';
 import type { StreamTextOnFinishCallback, StreamTextOnStepFinishCallback } from '../llm/model/base.types';
+import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { LoopConfig, LoopOptions, PrepareStepFunction } from '../loop/types';
 import type { InputProcessor, OutputProcessor } from '../processors';
 import type { RuntimeContext } from '../runtime-context';
@@ -65,7 +66,10 @@ export type AgentExecutionOptions<
   /** Runtime context containing dynamic configuration and state */
   runtimeContext?: RuntimeContext;
 
-  /** Schema for structured output generation (Zod schema or JSON Schema) @experimental */
+  /**
+   * Schema for structured output generation (Zod schema or JSON Schema)
+   * @deprecated Use `structuredOutput` instead. The `output` property will be removed in a future version.
+   */
   output?: OUTPUT;
 
   /** @deprecated Use memory.resource instead. Identifier for the resource/user */
@@ -138,4 +142,6 @@ export type InnerAgentExecutionOptions<
   writableStream?: WritableStream<ChunkType>;
   messages: MessageListInput;
   methodType: 'generate' | 'stream' | 'streamVNext';
+  /** Internal: Model override for when structuredOutput.model is used with maxSteps=1 */
+  _modelOverride?: MastraLanguageModel;
 };

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -143,5 +143,5 @@ export type InnerAgentExecutionOptions<
   messages: MessageListInput;
   methodType: 'generate' | 'stream' | 'streamVNext';
   /** Internal: Model override for when structuredOutput.model is used with maxSteps=1 */
-  _modelOverride?: MastraLanguageModel;
+  model?: MastraLanguageModel;
 };

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -431,6 +431,7 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
 
                   if (
                     messagesWithStructuredData[0] &&
+                    // this is to make typescript happy
                     messagesWithStructuredData[0].content.metadata?.structuredOutput
                   ) {
                     const structuredOutput = messagesWithStructuredData[0].content.metadata.structuredOutput;


### PR DESCRIPTION
This PR deprecates the `output` property in `generateVNext` and `streamVNext` methods in favor of using the `structuredOutput` property.

When `maxSteps` is set to 1, the system now internally maps `structuredOutput.schema` to `output` and handles the model override from `structuredOutput.model`. This maintains backward compatibility while encouraging users to adopt the new API.

Before:
```typescript
agent.streamVNext(messages, {
  output: schema,
  maxSteps: 1
})
```

After:
```typescript
agent.streamVNext(messages, {
  structuredOutput: {
    schema: schema,
    model: customModel // optional
  },
  maxSteps: 1
})
```

The old `output` property still works but is marked as deprecated and will be removed in a future version.