### PR TITLE
fix(server): Add helpful error message to index entrypoint

### DIFF
--- a/.changeset/cold-experts-slide.md
+++ b/.changeset/cold-experts-slide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Add helpful error message when trying to import from top-level import

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,0 +1,3 @@
+throw new Error(`No exports are available from the top-level "@mastra/server" package.
+
+Use specific subpath imports instead, e.g. "@mastra/server/handlers" or "@mastra/server/handlers/tools".`);


### PR DESCRIPTION
## Description

Our `@mastra/server` package doesn't "barrel export" it's contents from the root index entrypoint (on purpose). But when someone imports from there and nothing happens, we should point them towards the subpath imports.

So I added an error message to just do that.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
