### PR TITLE
added ability to hide internal ai tracing spans

### DIFF
--- a/.changeset/curly-years-scream.md
+++ b/.changeset/curly-years-scream.md
@@ -1,0 +1,6 @@
+---
+'@mastra/inngest': patch
+'@mastra/core': patch
+---
+
+Added the ability to hide internal ai tracing spans (enabled by default)

--- a/.changeset/lovely-webs-pick.md
+++ b/.changeset/lovely-webs-pick.md
@@ -1,0 +1,6 @@
+---
+'@mastra/braintrust': patch
+'@mastra/langfuse': patch
+---
+
+updated exporter to use a lightweight span for exporting

--- a/observability/braintrust/package.json
+++ b/observability/braintrust/package.json
@@ -45,7 +45,7 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.15.3-0 <0.17.0-0"
+    "@mastra/core": ">=0.16.4-0 <0.17.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/observability/braintrust/src/ai-tracing.ts
+++ b/observability/braintrust/src/ai-tracing.ts
@@ -6,7 +6,12 @@
  * Events are handled as zero-duration spans with matching start/end times.
  */
 
-import type { AITracingExporter, AITracingEvent, AnyAISpan, LLMGenerationAttributes } from '@mastra/core/ai-tracing';
+import type {
+  AITracingExporter,
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+} from '@mastra/core/ai-tracing';
 import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
 import { ConsoleLogger } from '@mastra/core/logger';
 import { initLogger } from 'braintrust';
@@ -74,25 +79,25 @@ export class BraintrustExporter implements AITracingExporter {
       return;
     }
 
-    if (event.span.isEvent) {
-      await this.handleEventSpan(event.span);
+    if (event.exportedSpan.isEvent) {
+      await this.handleEventSpan(event.exportedSpan);
       return;
     }
 
     switch (event.type) {
       case 'span_started':
-        await this.handleSpanStarted(event.span);
+        await this.handleSpanStarted(event.exportedSpan);
         break;
       case 'span_updated':
-        await this.handleSpanUpdateOrEnd(event.span, false);
+        await this.handleSpanUpdateOrEnd(event.exportedSpan, false);
         break;
       case 'span_ended':
-        await this.handleSpanUpdateOrEnd(event.span, true);
+        await this.handleSpanUpdateOrEnd(event.exportedSpan, true);
         break;
     }
   }
 
-  private async handleSpanStarted(span: AnyAISpan): Promise<void> {
+  private async handleSpanStarted(span: AnyExportedAISpan): Promise<void> {
     if (span.isRootSpan) {
       await this.initLogger(span);
     }
@@ -119,7 +124,7 @@ export class BraintrustExporter implements AITracingExporter {
     spanData.spans.set(span.id, braintrustSpan);
   }
 
-  private async handleSpanUpdateOrEnd(span: AnyAISpan, isEnd: boolean): Promise<void> {
+  private async handleSpanUpdateOrEnd(span: AnyExportedAISpan, isEnd: boolean): Promise<void> {
     const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
 
     const spanData = this.getSpanData({ span, method });
@@ -135,7 +140,7 @@ export class BraintrustExporter implements AITracingExporter {
         spanName: span.name,
         spanType: span.type,
         isRootSpan: span.isRootSpan,
-        parentSpanId: span.parent?.id,
+        parentSpanId: span.parentSpanId,
         method,
       });
       return;
@@ -157,7 +162,7 @@ export class BraintrustExporter implements AITracingExporter {
     }
   }
 
-  private async handleEventSpan(span: AnyAISpan): Promise<void> {
+  private async handleEventSpan(span: AnyExportedAISpan): Promise<void> {
     if (span.isRootSpan) {
       this.logger.debug('Braintrust exporter: Creating logger for event', {
         traceId: span.traceId,
@@ -193,7 +198,7 @@ export class BraintrustExporter implements AITracingExporter {
     spanData.spans.set(span.id, braintrustSpan);
   }
 
-  private async initLogger(span: AnyAISpan): Promise<void> {
+  private async initLogger(span: AnyExportedAISpan): Promise<void> {
     const logger = await initLogger({
       projectName: this.config.projectName ?? 'mastra-tracing',
       apiKey: this.config.apiKey,
@@ -204,7 +209,7 @@ export class BraintrustExporter implements AITracingExporter {
     this.traceMap.set(span.traceId, { logger, spans: new Map() });
   }
 
-  private getSpanData(options: { span: AnyAISpan; method: string }): SpanData | undefined {
+  private getSpanData(options: { span: AnyExportedAISpan; method: string }): SpanData | undefined {
     const { span, method } = options;
     if (this.traceMap.has(span.traceId)) {
       return this.traceMap.get(span.traceId);
@@ -216,19 +221,19 @@ export class BraintrustExporter implements AITracingExporter {
       spanName: span.name,
       spanType: span.type,
       isRootSpan: span.isRootSpan,
-      parentSpanId: span.parent?.id,
+      parentSpanId: span.parentSpanId,
       method,
     });
   }
 
   private getBraintrustParent(options: {
     spanData: SpanData;
-    span: AnyAISpan;
+    span: AnyExportedAISpan;
     method: string;
   }): Logger<true> | Span | undefined {
     const { spanData, span, method } = options;
 
-    const parentId = span.parent?.id;
+    const parentId = span.parentSpanId;
     if (!parentId) {
       return spanData.logger;
     }
@@ -243,12 +248,12 @@ export class BraintrustExporter implements AITracingExporter {
       spanName: span.name,
       spanType: span.type,
       isRootSpan: span.isRootSpan,
-      parentSpanId: span.parent?.id,
+      parentSpanId: span.parentSpanId,
       method,
     });
   }
 
-  private buildSpanPayload(span: AnyAISpan): Record<string, any> {
+  private buildSpanPayload(span: AnyExportedAISpan): Record<string, any> {
     const payload: Record<string, any> = {};
 
     // Core span data

--- a/observability/langfuse/package.json
+++ b/observability/langfuse/package.json
@@ -45,7 +45,7 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.15.3-0 <0.17.0-0"
+    "@mastra/core": ">=0.16.4-0 <0.17.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/observability/langfuse/src/ai-tracing.ts
+++ b/observability/langfuse/src/ai-tracing.ts
@@ -6,7 +6,12 @@
  * LLM_GENERATION spans become Langfuse generations, all others become spans.
  */
 
-import type { AITracingExporter, AITracingEvent, AnyAISpan, LLMGenerationAttributes } from '@mastra/core/ai-tracing';
+import type {
+  AITracingExporter,
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+} from '@mastra/core/ai-tracing';
 import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
 import { ConsoleLogger } from '@mastra/core/logger';
 import { Langfuse } from 'langfuse';
@@ -70,20 +75,20 @@ export class LangfuseExporter implements AITracingExporter {
       return;
     }
 
-    if (event.span.isEvent) {
-      await this.handleEventSpan(event.span);
+    if (event.exportedSpan.isEvent) {
+      await this.handleEventSpan(event.exportedSpan);
       return;
     }
 
     switch (event.type) {
       case 'span_started':
-        await this.handleSpanStarted(event.span);
+        await this.handleSpanStarted(event.exportedSpan);
         break;
       case 'span_updated':
-        await this.handleSpanUpdateOrEnd(event.span, false);
+        await this.handleSpanUpdateOrEnd(event.exportedSpan, false);
         break;
       case 'span_ended':
-        await this.handleSpanUpdateOrEnd(event.span, true);
+        await this.handleSpanUpdateOrEnd(event.exportedSpan, true);
         break;
     }
 
@@ -93,7 +98,7 @@ export class LangfuseExporter implements AITracingExporter {
     }
   }
 
-  private async handleSpanStarted(span: AnyAISpan): Promise<void> {
+  private async handleSpanStarted(span: AnyExportedAISpan): Promise<void> {
     if (span.isRootSpan) {
       this.initTrace(span);
     }
@@ -117,7 +122,7 @@ export class LangfuseExporter implements AITracingExporter {
     traceData.spans.set(span.id, langfuseSpan);
   }
 
-  private async handleSpanUpdateOrEnd(span: AnyAISpan, isEnd: boolean): Promise<void> {
+  private async handleSpanUpdateOrEnd(span: AnyExportedAISpan, isEnd: boolean): Promise<void> {
     const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
 
     const traceData = this.getTraceData({ span, method });
@@ -133,7 +138,7 @@ export class LangfuseExporter implements AITracingExporter {
         spanName: span.name,
         spanType: span.type,
         isRootSpan: span.isRootSpan,
-        parentSpanId: span.parent?.id,
+        parentSpanId: span.parentSpanId,
         method,
       });
       return;
@@ -149,7 +154,7 @@ export class LangfuseExporter implements AITracingExporter {
     }
   }
 
-  private async handleEventSpan(span: AnyAISpan): Promise<void> {
+  private async handleEventSpan(span: AnyExportedAISpan): Promise<void> {
     if (span.isRootSpan) {
       this.logger.debug('Langfuse exporter: Creating trace', {
         traceId: span.traceId,
@@ -178,12 +183,12 @@ export class LangfuseExporter implements AITracingExporter {
     traceData.events.set(span.id, langfuseEvent);
   }
 
-  private initTrace(span: AnyAISpan): void {
+  private initTrace(span: AnyExportedAISpan): void {
     const trace = this.client.trace(this.buildTracePayload(span));
     this.traceMap.set(span.traceId, { trace, spans: new Map(), events: new Map() });
   }
 
-  private getTraceData(options: { span: AnyAISpan; method: string }): TraceData | undefined {
+  private getTraceData(options: { span: AnyExportedAISpan; method: string }): TraceData | undefined {
     const { span, method } = options;
     if (this.traceMap.has(span.traceId)) {
       return this.traceMap.get(span.traceId);
@@ -194,19 +199,19 @@ export class LangfuseExporter implements AITracingExporter {
       spanName: span.name,
       spanType: span.type,
       isRootSpan: span.isRootSpan,
-      parentSpanId: span.parent?.id,
+      parentSpanId: span.parentSpanId,
       method,
     });
   }
 
   private getLangfuseParent(options: {
     traceData: TraceData;
-    span: AnyAISpan;
+    span: AnyExportedAISpan;
     method: string;
   }): LangfuseParent | undefined {
     const { traceData, span, method } = options;
 
-    const parentId = span.parent?.id;
+    const parentId = span.parentSpanId;
     if (!parentId) {
       return traceData.trace;
     }
@@ -222,12 +227,12 @@ export class LangfuseExporter implements AITracingExporter {
       spanName: span.name,
       spanType: span.type,
       isRootSpan: span.isRootSpan,
-      parentSpanId: span.parent?.id,
+      parentSpanId: span.parentSpanId,
       method,
     });
   }
 
-  private buildTracePayload(span: AnyAISpan): Record<string, any> {
+  private buildTracePayload(span: AnyExportedAISpan): Record<string, any> {
     const payload: Record<string, any> = {
       id: span.traceId,
       name: span.name,
@@ -248,7 +253,7 @@ export class LangfuseExporter implements AITracingExporter {
     return payload;
   }
 
-  private buildSpanPayload(span: AnyAISpan, isCreate: boolean): Record<string, any> {
+  private buildSpanPayload(span: AnyExportedAISpan, isCreate: boolean): Record<string, any> {
     const payload: Record<string, any> = {};
 
     if (isCreate) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2182,7 +2182,7 @@ export class Agent<
           overrideScorers,
           threadId,
           resourceId,
-          tracingContext: { currentSpan: agentAISpan },
+          tracingContext: { currentSpan: agentAISpan, isInternal: true },
         });
 
         const scoringData: {
@@ -3260,7 +3260,7 @@ export class Agent<
       .commit();
 
     const run = await executionWorkflow.createRunAsync();
-    const result = await run.start({ tracingContext: { currentSpan: agentAISpan } });
+    const result = await run.start({ tracingContext: { currentSpan: agentAISpan, isInternal: true } });
 
     return result;
   }
@@ -3458,7 +3458,7 @@ export class Agent<
       runtimeContext,
       structuredOutput,
       overrideScorers,
-      tracingContext: { currentSpan: agentAISpan },
+      tracingContext: { currentSpan: agentAISpan, isInternal: true },
     });
 
     agentAISpan?.end({

--- a/packages/core/src/ai-tracing/ai-tracing.test.ts
+++ b/packages/core/src/ai-tracing/ai-tracing.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MastraError } from '../error';
 import { clearAITracingRegistry } from './registry';
 import { DefaultAITracing } from './tracers';
-import type { AITracingEvent, AITracingExporter, LLMGenerationAttributes, AISpan, AITracing } from './types';
+import type { AITracingEvent, AITracingExporter, LLMGenerationAttributes, AITracing, ExportedAISpan } from './types';
 import { AISpanType, SamplingStrategyType, AITracingEventType } from './types';
 
 // Custom matchers for OpenTelemetry ID validation
@@ -263,7 +263,7 @@ describe('AI Tracing', () => {
       // Should emit span_started
       expect(testExporter.events).toHaveLength(1);
       expect(testExporter.events[0].type).toBe(AITracingEventType.SPAN_STARTED);
-      expect(testExporter.events[0].span.id).toBe(span.id);
+      expect(testExporter.events[0].exportedSpan.id).toBe(span.id);
 
       // Update span - cast to LLM attributes type for usage field
       span.update({ attributes: { usage: { totalTokens: 100 } } });
@@ -271,7 +271,7 @@ describe('AI Tracing', () => {
       // Should emit span_updated
       expect(testExporter.events).toHaveLength(2);
       expect(testExporter.events[1].type).toBe(AITracingEventType.SPAN_UPDATED);
-      expect((testExporter.events[1].span.attributes as LLMGenerationAttributes).usage?.totalTokens).toBe(100);
+      expect((testExporter.events[1].exportedSpan.attributes as LLMGenerationAttributes).usage?.totalTokens).toBe(100);
 
       // End span
       span.end({ attributes: { usage: { totalTokens: 150 } } });
@@ -279,8 +279,8 @@ describe('AI Tracing', () => {
       // Should emit span_ended
       expect(testExporter.events).toHaveLength(3);
       expect(testExporter.events[2].type).toBe(AITracingEventType.SPAN_ENDED);
-      expect(testExporter.events[2].span.endTime).toBeInstanceOf(Date);
-      expect((testExporter.events[2].span.attributes as LLMGenerationAttributes).usage?.totalTokens).toBe(150);
+      expect(testExporter.events[2].exportedSpan.endTime).toBeInstanceOf(Date);
+      expect((testExporter.events[2].exportedSpan.attributes as LLMGenerationAttributes).usage?.totalTokens).toBe(150);
     });
 
     it('should handle errors with default endSpan=true', () => {
@@ -664,7 +664,7 @@ describe('AI Tracing', () => {
       // Should have emitted exactly one event: span_ended
       expect(testExporter.events).toHaveLength(1);
       expect(testExporter.events[0].type).toBe(AITracingEventType.SPAN_ENDED);
-      expect(testExporter.events[0].span).toBe(eventSpan);
+      expect(testExporter.events[0].exportedSpan).toStrictEqual(eventSpan.exportSpan());
 
       rootSpan.end();
     });
@@ -904,7 +904,7 @@ describe('AI Tracing', () => {
       // Should have exported the event span
       expect(testExporter.events).toHaveLength(1);
       const exportedEvent = testExporter.events[0];
-      const exportedSpan = exportedEvent.span as AISpan<AISpanType.LLM_CHUNK>;
+      const exportedSpan = exportedEvent.exportedSpan as ExportedAISpan<AISpanType.LLM_CHUNK>;
 
       // Verify exported span properties
       expect(exportedSpan.isEvent).toBe(true);

--- a/packages/core/src/ai-tracing/exporters/cloud.test.ts
+++ b/packages/core/src/ai-tracing/exporters/cloud.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { AITracingEvent, AnyAISpan, CreateSpanOptions } from '..';
+import type { AITracingEvent, AnyExportedAISpan, CreateSpanOptions } from '..';
 import { AISpanType, AITracingEventType } from '..';
 
 import { fetchWithRetry } from '../../utils';
@@ -24,21 +24,14 @@ function createTestJWT(payload: { teamId: string; projectId: string }): string {
 
 function getMockSpan<TType extends AISpanType>(
   options: CreateSpanOptions<TType> & { id: string; traceId: string },
-): AnyAISpan {
+): AnyExportedAISpan {
   return {
     ...options,
     startTime: new Date(),
     endTime: new Date(),
     isEvent: options.isEvent ?? false,
-    isValid: true,
     isRootSpan: true,
-    parent: undefined,
-    aiTracing: {} as any,
-    end: vi.fn(),
-    error: vi.fn(),
-    update: vi.fn(),
-    createChildSpan: vi.fn(),
-    createEventSpan: vi.fn(),
+    parentSpanId: undefined,
   };
 }
 
@@ -72,7 +65,7 @@ describe('CloudExporter', () => {
     it('should process SPAN_ENDED events', async () => {
       const spanEndedEvent: AITracingEvent = {
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       };
 
       // Mock the internal buffer to verify span was added
@@ -86,7 +79,7 @@ describe('CloudExporter', () => {
     it('should ignore SPAN_STARTED events', async () => {
       const spanStartedEvent: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       };
 
       const addToBufferSpy = vi.spyOn(exporter as any, 'addToBuffer');
@@ -99,7 +92,7 @@ describe('CloudExporter', () => {
     it('should ignore SPAN_UPDATED events', async () => {
       const spanUpdatedEvent: AITracingEvent = {
         type: AITracingEventType.SPAN_UPDATED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       };
 
       const addToBufferSpy = vi.spyOn(exporter as any, 'addToBuffer');
@@ -111,9 +104,9 @@ describe('CloudExporter', () => {
 
     it('should only increment buffer size for SPAN_ENDED events', async () => {
       const events: AITracingEvent[] = [
-        { type: AITracingEventType.SPAN_STARTED, span: mockSpan },
-        { type: AITracingEventType.SPAN_UPDATED, span: mockSpan },
-        { type: AITracingEventType.SPAN_ENDED, span: mockSpan },
+        { type: AITracingEventType.SPAN_STARTED, exportedSpan: mockSpan },
+        { type: AITracingEventType.SPAN_UPDATED, exportedSpan: mockSpan },
+        { type: AITracingEventType.SPAN_ENDED, exportedSpan: mockSpan },
       ];
 
       for (const event of events) {
@@ -151,7 +144,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       const buffer = (exporter as any).buffer;
@@ -166,7 +159,7 @@ describe('CloudExporter', () => {
       // Add first span
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       const buffer = (exporter as any).buffer;
@@ -179,7 +172,7 @@ describe('CloudExporter', () => {
       const secondSpan = { ...mockSpan, id: 'span-456' };
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: secondSpan,
+        exportedSpan: secondSpan,
       });
 
       // firstEventTime should not have changed
@@ -194,14 +187,14 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
       expect(buffer.totalSize).toBe(1);
 
       const secondSpan = { ...mockSpan, id: 'span-456' };
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: secondSpan,
+        exportedSpan: secondSpan,
       });
       expect(buffer.totalSize).toBe(2);
     });
@@ -209,7 +202,7 @@ describe('CloudExporter', () => {
     it('should add spans with correct structure to buffer', async () => {
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       const buffer = (exporter as any).buffer;
@@ -250,20 +243,20 @@ describe('CloudExporter', () => {
     });
 
     it('should handle parent span references', async () => {
-      const parentSpan: AnyAISpan = {
+      const parentSpan: AnyExportedAISpan = {
         ...mockSpan,
         id: 'parent-span',
       };
 
-      const childSpan: AnyAISpan = {
+      const childSpan: AnyExportedAISpan = {
         ...mockSpan,
         id: 'child-span',
-        parent: parentSpan,
+        parentSpanId: parentSpan.id,
       };
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: childSpan,
+        exportedSpan: childSpan,
       });
 
       const buffer = (exporter as any).buffer;
@@ -297,7 +290,7 @@ describe('CloudExporter', () => {
       // Add first span - should not flush
       await smallBatchExporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       expect(shouldFlushSpy).toHaveReturnedWith(false);
@@ -307,7 +300,7 @@ describe('CloudExporter', () => {
       const secondSpan = { ...mockSpan, id: 'span-456' };
       await smallBatchExporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: secondSpan,
+        exportedSpan: secondSpan,
       });
 
       expect(shouldFlushSpy).toHaveReturnedWith(true);
@@ -319,7 +312,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       expect(scheduleFlushSpy).toHaveBeenCalledOnce();
@@ -331,7 +324,7 @@ describe('CloudExporter', () => {
       // Add first span
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       expect(scheduleFlushSpy).toHaveBeenCalledTimes(1);
@@ -340,7 +333,7 @@ describe('CloudExporter', () => {
       const secondSpan = { ...mockSpan, id: 'span-456' };
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: secondSpan,
+        exportedSpan: secondSpan,
       });
 
       expect(scheduleFlushSpy).toHaveBeenCalledTimes(1); // Still only called once
@@ -403,7 +396,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(
@@ -431,7 +424,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Fast-forward timer
@@ -445,7 +438,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Trigger flush
@@ -463,7 +456,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Fast-forward timer to trigger flush
@@ -480,7 +473,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Verify timer is set
@@ -500,7 +493,7 @@ describe('CloudExporter', () => {
       // Add event to buffer
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Manually clear the timer that was set
@@ -562,7 +555,7 @@ describe('CloudExporter', () => {
     it('should call cloud API with correct URL and headers', async () => {
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Trigger immediate flush
@@ -585,7 +578,7 @@ describe('CloudExporter', () => {
     it('should send spans in correct format', async () => {
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       await (exporter as any).flush();
@@ -621,7 +614,7 @@ describe('CloudExporter', () => {
 
       await authExporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       await (authExporter as any).flush();
@@ -634,16 +627,16 @@ describe('CloudExporter', () => {
     });
 
     it('should handle multiple spans in batch', async () => {
-      const spans = [
+      const exportedSpans = [
         { ...mockSpan, id: 'span-1' },
         { ...mockSpan, id: 'span-2' },
         { ...mockSpan, id: 'span-3' },
       ];
 
-      for (const span of spans) {
+      for (const exportedSpan of exportedSpans) {
         await exporter.exportEvent({
           type: AITracingEventType.SPAN_ENDED,
-          span,
+          exportedSpan,
         });
       }
 
@@ -664,7 +657,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       await (exporter as any).flush();
@@ -714,7 +707,7 @@ describe('CloudExporter', () => {
 
       await retryExporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       await (retryExporter as any).flush();
@@ -738,7 +731,7 @@ describe('CloudExporter', () => {
 
       await customRetryExporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       await (customRetryExporter as any).flush();
@@ -764,7 +757,7 @@ describe('CloudExporter', () => {
 
       await retryExporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Flush should not throw - errors are caught and logged
@@ -784,7 +777,7 @@ describe('CloudExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       // Fast-forward to trigger scheduled flush - errors should be caught
@@ -827,7 +820,7 @@ describe('CloudExporter', () => {
       // Set up a timer by adding an event
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       const timer = (exporter as any).flushTimer;
@@ -847,12 +840,12 @@ describe('CloudExporter', () => {
       // Add events to buffer
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: { ...mockSpan, id: 'span-456' },
+        exportedSpan: { ...mockSpan, id: 'span-456' },
       });
 
       const buffer = (exporter as any).buffer;
@@ -890,7 +883,7 @@ describe('CloudExporter', () => {
       // Add event to buffer
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: mockSpan,
+        exportedSpan: mockSpan,
       });
 
       await exporter.shutdown();

--- a/packages/core/src/ai-tracing/exporters/cloud.ts
+++ b/packages/core/src/ai-tracing/exporters/cloud.ts
@@ -3,7 +3,7 @@ import { ConsoleLogger, LogLevel } from '../../logger';
 import type { IMastraLogger } from '../../logger';
 import { fetchWithRetry } from '../../utils';
 import { AITracingEventType } from '../types';
-import type { AITracingEvent, AITracingExporter, AnyAISpan } from '../types';
+import type { AITracingEvent, AITracingExporter, AnyExportedAISpan } from '../types';
 
 export interface CloudExporterConfig {
   maxBatchSize?: number; // Default: 1000 spans
@@ -109,17 +109,17 @@ export class CloudExporter implements AITracingExporter {
       this.buffer.firstEventTime = new Date();
     }
 
-    const spanRecord = this.formatSpan(event.span);
+    const spanRecord = this.formatSpan(event.exportedSpan);
 
     this.buffer.spans.push(spanRecord);
     this.buffer.totalSize++;
   }
 
-  private formatSpan(span: AnyAISpan): MastraCloudSpanRecord {
+  private formatSpan(span: AnyExportedAISpan): MastraCloudSpanRecord {
     const spanRecord: MastraCloudSpanRecord = {
       traceId: span.traceId,
       spanId: span.id,
-      parentSpanId: span.parent?.id ?? null,
+      parentSpanId: span.parentSpanId ?? null,
       name: span.name,
       spanType: span.type,
       attributes: span.attributes ?? null,

--- a/packages/core/src/ai-tracing/exporters/console.test.ts
+++ b/packages/core/src/ai-tracing/exporters/console.test.ts
@@ -22,11 +22,13 @@ describe('DefaultConsoleExporter', () => {
       traceId: 'trace-123',
       trace: { traceId: 'trace-123' },
       attributes: { agentId: 'agent-123', normalField: 'visible-data' },
+      isRootSpan: false,
+      isEvent: false,
     };
 
     await exporter.exportEvent({
       type: AITracingEventType.SPAN_STARTED,
-      span: mockSpan as any,
+      exportedSpan: mockSpan,
     });
 
     // Should log with proper formatting (no filtering happens in exporter anymore)
@@ -54,7 +56,7 @@ describe('DefaultConsoleExporter', () => {
 
     await exporter.exportEvent({
       type: 'unknown_event' as any,
-      span: {} as any,
+      exportedSpan: {} as any,
     });
 
     expect(logger.warn).toHaveBeenCalledWith('Tracing event type not implemented: unknown_event');

--- a/packages/core/src/ai-tracing/exporters/console.ts
+++ b/packages/core/src/ai-tracing/exporters/console.ts
@@ -17,7 +17,7 @@ export class ConsoleExporter implements AITracingExporter {
   }
 
   async exportEvent(event: AITracingEvent): Promise<void> {
-    const span = event.span;
+    const span = event.exportedSpan;
 
     // Helper to safely stringify attributes (filtering already done by processor)
     const formatAttributes = (attributes: any) => {

--- a/packages/core/src/ai-tracing/exporters/default.test.ts
+++ b/packages/core/src/ai-tracing/exporters/default.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AISpanType, AITracingEventType } from '../types';
-import type { LLMGenerationAttributes, WorkflowStepAttributes, AITracingEvent, AnyAISpan } from '../types';
+import type { LLMGenerationAttributes, WorkflowStepAttributes, AITracingEvent, AnyExportedAISpan } from '../types';
 import { DefaultExporter } from './default';
 
 // Mock Mastra and logger
@@ -607,7 +607,7 @@ describe('DefaultExporter', () => {
     ): AITracingEvent {
       return {
         type,
-        span: {
+        exportedSpan: {
           id: spanId,
           traceId,
           type: AISpanType.GENERIC,
@@ -619,7 +619,7 @@ describe('DefaultExporter', () => {
           metadata: undefined,
           input: 'test input',
           output: type === AITracingEventType.SPAN_ENDED ? 'test output' : undefined,
-        } as any as AnyAISpan,
+        } as any as AnyExportedAISpan,
       };
     }
   });

--- a/packages/core/src/ai-tracing/exporters/default.ts
+++ b/packages/core/src/ai-tracing/exporters/default.ts
@@ -4,7 +4,7 @@ import type { Mastra } from '../../mastra';
 import type { MastraStorage } from '../../storage/base';
 import type { AISpanRecord } from '../../storage/types';
 import { AITracingEventType } from '../types';
-import type { AITracingEvent, AITracingExporter, AnyAISpan, TracingStrategy } from '../types';
+import type { AITracingEvent, AITracingExporter, AnyExportedAISpan, TracingStrategy } from '../types';
 
 type InternalAISpanRecord = Omit<AISpanRecord, 'spanId' | 'traceId' | 'createdAt' | 'updatedAt'>;
 
@@ -174,8 +174,8 @@ export class DefaultExporter implements AITracingExporter {
    */
   private handleOutOfOrderUpdate(event: AITracingEvent): void {
     this.logger.warn('Out-of-order span update detected - skipping event', {
-      spanId: event.span.id,
-      traceId: event.span.traceId,
+      spanId: event.exportedSpan.id,
+      traceId: event.exportedSpan.traceId,
       eventType: event.type,
     });
   }
@@ -184,7 +184,7 @@ export class DefaultExporter implements AITracingExporter {
    * Adds an event to the appropriate buffer based on strategy
    */
   private addToBuffer(event: AITracingEvent): void {
-    const spanKey = this.buildSpanKey(event.span.traceId, event.span.id);
+    const spanKey = this.buildSpanKey(event.exportedSpan.traceId, event.exportedSpan.id);
 
     // Set first event time if buffer is empty
     if (this.buffer.totalSize === 0) {
@@ -195,9 +195,9 @@ export class DefaultExporter implements AITracingExporter {
       case AITracingEventType.SPAN_STARTED:
         if (this.resolvedStrategy === 'batch-with-updates') {
           const createRecord = {
-            traceId: event.span.traceId,
-            spanId: event.span.id,
-            ...this.buildCreateRecord(event.span),
+            traceId: event.exportedSpan.traceId,
+            spanId: event.exportedSpan.id,
+            ...this.buildCreateRecord(event.exportedSpan),
             createdAt: new Date(),
             updatedAt: null,
           };
@@ -212,10 +212,10 @@ export class DefaultExporter implements AITracingExporter {
           if (this.buffer.seenSpans.has(spanKey)) {
             // Normal case: create already in buffer
             this.buffer.updates.push({
-              traceId: event.span.traceId,
-              spanId: event.span.id,
+              traceId: event.exportedSpan.traceId,
+              spanId: event.exportedSpan.id,
               updates: {
-                ...this.buildUpdateRecord(event.span),
+                ...this.buildUpdateRecord(event.exportedSpan),
                 updatedAt: new Date(),
               },
               sequenceNumber: this.getNextSequence(spanKey),
@@ -234,20 +234,20 @@ export class DefaultExporter implements AITracingExporter {
           if (this.buffer.seenSpans.has(spanKey)) {
             // Normal case: create already in buffer
             this.buffer.updates.push({
-              traceId: event.span.traceId,
-              spanId: event.span.id,
+              traceId: event.exportedSpan.traceId,
+              spanId: event.exportedSpan.id,
               updates: {
-                ...this.buildUpdateRecord(event.span),
+                ...this.buildUpdateRecord(event.exportedSpan),
                 updatedAt: new Date(),
               },
               sequenceNumber: this.getNextSequence(spanKey),
             });
-          } else if (event.span.isEvent) {
+          } else if (event.exportedSpan.isEvent) {
             // Event-type spans only emit SPAN_ENDED (no prior SPAN_STARTED)
             const createRecord = {
-              traceId: event.span.traceId,
-              spanId: event.span.id,
-              ...this.buildCreateRecord(event.span),
+              traceId: event.exportedSpan.traceId,
+              spanId: event.exportedSpan.id,
+              ...this.buildCreateRecord(event.exportedSpan),
               createdAt: new Date(),
               updatedAt: null,
             };
@@ -261,9 +261,9 @@ export class DefaultExporter implements AITracingExporter {
         } else if (this.resolvedStrategy === 'insert-only') {
           // Only process SPAN_ENDED for insert-only strategy
           const createRecord = {
-            traceId: event.span.traceId,
-            spanId: event.span.id,
-            ...this.buildCreateRecord(event.span),
+            traceId: event.exportedSpan.traceId,
+            spanId: event.exportedSpan.id,
+            ...this.buildCreateRecord(event.exportedSpan),
             createdAt: new Date(),
             updatedAt: null,
           };
@@ -335,7 +335,7 @@ export class DefaultExporter implements AITracingExporter {
    * Serializes span attributes to storage record format
    * Handles all AI span types and their specific attributes
    */
-  private serializeAttributes(span: AnyAISpan): Record<string, any> | null {
+  private serializeAttributes(span: AnyExportedAISpan): Record<string, any> | null {
     if (!span.attributes) {
       return null;
     }
@@ -368,9 +368,9 @@ export class DefaultExporter implements AITracingExporter {
     }
   }
 
-  private buildCreateRecord(span: AnyAISpan): InternalAISpanRecord {
+  private buildCreateRecord(span: AnyExportedAISpan): InternalAISpanRecord {
     return {
-      parentSpanId: span.parent?.id ?? null,
+      parentSpanId: span.parentSpanId ?? null,
       name: span.name,
       scope: null,
       spanType: span.type,
@@ -386,7 +386,7 @@ export class DefaultExporter implements AITracingExporter {
     };
   }
 
-  private buildUpdateRecord(span: AnyAISpan): Partial<InternalAISpanRecord> {
+  private buildUpdateRecord(span: AnyExportedAISpan): Partial<InternalAISpanRecord> {
     return {
       name: span.name,
       scope: null,
@@ -404,7 +404,7 @@ export class DefaultExporter implements AITracingExporter {
    * Handles realtime strategy - processes each event immediately
    */
   private async handleRealtimeEvent(event: AITracingEvent, storage: MastraStorage): Promise<void> {
-    const span = event.span;
+    const span = event.exportedSpan;
 
     // Event spans only have an end event
     if (span.isEvent) {

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -14,7 +14,7 @@ import { createWorkflow, createStep } from '../workflows';
 // AI Tracing imports
 import { clearAITracingRegistry, shutdownAITracingRegistry } from './registry';
 import { AISpanType, AITracingEventType } from './types';
-import type { AITracingExporter, AITracingEvent, AnyAISpan, AISpan } from './types';
+import type { AITracingExporter, AITracingEvent, AISpan, ExportedAISpan, AnyExportedAISpan } from './types';
 
 /**
  * Test exporter for AI tracing events with real-time span lifecycle validation.
@@ -48,7 +48,7 @@ class TestExporter implements AITracingExporter {
   private logs: string[] = [];
 
   async exportEvent(event: AITracingEvent) {
-    const logMessage = `[TestExporter] ${event.type}: ${event.span.type} "${event.span.name}" (trace: ${event.span.traceId.slice(-8)}, span: ${event.span.id.slice(-8)})`;
+    const logMessage = `[TestExporter] ${event.type}: ${event.exportedSpan.type} "${event.exportedSpan.name}" (trace: ${event.exportedSpan.traceId.slice(-8)}, span: ${event.exportedSpan.id.slice(-8)})`;
 
     // Store log for potential test failure reporting
     this.logs.push(logMessage);
@@ -59,7 +59,7 @@ class TestExporter implements AITracingExporter {
     }
     // Otherwise, logs will only appear on test failures
 
-    const spanId = event.span.id;
+    const spanId = event.exportedSpan.id;
     const state = this.spanStates.get(spanId) || {
       hasStart: false,
       hasEnd: false,
@@ -69,27 +69,30 @@ class TestExporter implements AITracingExporter {
 
     // Real-time validation as events arrive using Vitest expect
     if (event.type === AITracingEventType.SPAN_STARTED) {
-      expect(state.hasStart, `Span ${spanId} (${event.span.type} "${event.span.name}") started twice`).toBe(false);
+      expect(
+        state.hasStart,
+        `Span ${spanId} (${event.exportedSpan.type} "${event.exportedSpan.name}") started twice`,
+      ).toBe(false);
       state.hasStart = true;
     } else if (event.type === AITracingEventType.SPAN_ENDED) {
       // Detect event spans (zero duration) - only check this in SPAN_ENDED where we have final timestamps
-      const isEventSpan = event.span.startTime === event.span.endTime;
+      const isEventSpan = event.exportedSpan.startTime === event.exportedSpan.endTime;
       if (isEventSpan) {
         // Event spans should only emit SPAN_ENDED, no SPAN_STARTED or SPAN_UPDATED
         expect(
           state.hasStart,
-          `Event span ${spanId} (${event.span.type} "${event.span.name}") incorrectly received SPAN_STARTED. Event spans should only emit SPAN_ENDED.`,
+          `Event span ${spanId} (${event.exportedSpan.type} "${event.exportedSpan.name}") incorrectly received SPAN_STARTED. Event spans should only emit SPAN_ENDED.`,
         ).toBe(false);
         expect(
           state.hasUpdate,
-          `Event span ${spanId} (${event.span.type} "${event.span.name}") incorrectly received SPAN_UPDATED. Event spans should only emit SPAN_ENDED.`,
+          `Event span ${spanId} (${event.exportedSpan.type} "${event.exportedSpan.name}") incorrectly received SPAN_UPDATED. Event spans should only emit SPAN_ENDED.`,
         ).toBe(false);
         state.isEventSpan = true;
       } else {
         // Normal span should have started
         expect(
           state.hasStart,
-          `Normal span ${spanId} (${event.span.type} "${event.span.name}") ended without starting`,
+          `Normal span ${spanId} (${event.exportedSpan.type} "${event.exportedSpan.name}") ended without starting`,
         ).toBe(true);
       }
       state.hasEnd = true;
@@ -112,29 +115,29 @@ class TestExporter implements AITracingExporter {
   }
 
   // Helper method to get final spans by type for test assertions
-  getSpansByType<T extends AISpanType>(type: T): AISpan<T>[] {
+  getSpansByType<T extends AISpanType>(type: T): ExportedAISpan<T>[] {
     return Array.from(this.spanStates.values())
       .filter(state => {
         // Only return completed spans of the requested type
         // Check the final span's type, not the first event
         const finalEvent =
           state.events.find(e => e.type === AITracingEventType.SPAN_ENDED) || state.events[state.events.length - 1];
-        return state.hasEnd && finalEvent.span.type === type;
+        return state.hasEnd && finalEvent.exportedSpan.type === type;
       })
       .map(state => {
         // Return the final span from SPAN_ENDED event
         const endEvent = state.events.find(e => e.type === AITracingEventType.SPAN_ENDED);
-        return endEvent!.span;
+        return endEvent!.exportedSpan;
       }) as AISpan<T>[];
   }
 
   // Helper to get all incomplete spans (spans that started but never ended)
-  getIncompleteSpans(): Array<{ spanId: string; span: AnyAISpan; state: any }> {
+  getIncompleteSpans(): Array<{ spanId: string; span: AnyExportedAISpan; state: any }> {
     return Array.from(this.spanStates.entries())
       .filter(([_, state]) => !state.hasEnd)
       .map(([spanId, state]) => ({
         spanId,
-        span: state.events[0].span,
+        span: state.events[0].exportedSpan,
         state: { hasStart: state.hasStart, hasUpdate: state.hasUpdate, hasEnd: state.hasEnd },
       }));
   }
@@ -146,11 +149,11 @@ class TestExporter implements AITracingExporter {
    *
    * Note: For specific span types, prefer using getSpansByType() for more precise filtering
    */
-  getAllSpans(): AnyAISpan[] {
+  getAllSpans(): AnyExportedAISpan[] {
     return Array.from(this.spanStates.values()).map(state => {
       // Return the final span from SPAN_ENDED event, or latest event if not ended
       const endEvent = state.events.find(e => e.type === AITracingEventType.SPAN_ENDED);
-      return endEvent ? endEvent.span : state.events[state.events.length - 1].span;
+      return endEvent ? endEvent.exportedSpan : state.events[state.events.length - 1].exportedSpan;
     });
   }
 
@@ -624,13 +627,14 @@ const mockModelV2 = new MockLanguageModelV2({
  * - AI tracing with TestExporter for span validation
  * - Integration tests configuration
  */
-function getBaseMastraConfig(testExporter: TestExporter) {
+function getBaseMastraConfig(testExporter: TestExporter, options = {}) {
   return {
     telemetry: { enabled: false },
     storage: new MockStore(),
     observability: {
       configs: {
         test: {
+          ...options,
           serviceName: 'integration-tests',
           exporters: [testExporter],
         },
@@ -1042,77 +1046,148 @@ describe('AI Tracing Integration Tests', () => {
     testExporter.finalExpectations();
   });
 
-  describe.each(agentMethods)('should trace agent with multiple tools using $name', ({ name, method, model }) => {
-    it(`should trace spans correctly`, async () => {
-      const testAgent = new Agent({
-        name: 'Test Agent',
-        instructions: 'You are a test agent',
-        model,
-        tools: {
-          calculator: calculatorTool,
-          apiCall: apiTool,
-          workflowExecutor: workflowExecutorTool,
-        },
+  describe.each(agentMethods)(
+    'should trace agent with multiple tools HIDING internal spans using $name',
+    ({ name, method, model }) => {
+      it(`should trace spans correctly`, async () => {
+        const testAgent = new Agent({
+          name: 'Test Agent',
+          instructions: 'You are a test agent',
+          model,
+          tools: {
+            calculator: calculatorTool,
+            apiCall: apiTool,
+            workflowExecutor: workflowExecutorTool,
+          },
+        });
+
+        const mastra = new Mastra({
+          ...getBaseMastraConfig(testExporter),
+          agents: { testAgent },
+        });
+
+        const agent = mastra.getAgent('testAgent');
+        const result = await method(agent, 'Calculate 5 + 3');
+        expect(result.text).toBeDefined();
+        expect(result.traceId).toBeDefined();
+
+        const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
+        const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
+        const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
+        const workflowSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
+        const workflowSteps = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
+
+        expect(agentRunSpans.length).toBe(1); // one agent run
+        expect(llmGenerationSpans.length).toBe(1); // tool call
+        expect(toolCallSpans.length).toBe(1); // one tool call (calculator)
+        expect(workflowSpans.length).toBe(0); // no workflows
+        expect(workflowSteps.length).toBe(0); // no workflows
+
+        const agentRunSpan = agentRunSpans[0];
+        const llmGenerationSpan = llmGenerationSpans[0];
+        const toolCallSpan = toolCallSpans[0];
+
+        // verify span nesting
+        expect(llmGenerationSpan.parentSpanId).toEqual(agentRunSpan.id);
+        expect(toolCallSpan.parentSpanId).toEqual(agentRunSpan.id);
+
+        expect(llmGenerationSpan.name).toBe("llm: 'mock-model-id'");
+        expect(llmGenerationSpan.input.messages).toHaveLength(2);
+        switch (name) {
+          case 'generateLegacy':
+            expect(llmGenerationSpan.output.text).toBe('Mock response');
+            expect(agentRunSpan.output.text).toBe('Mock response');
+            break;
+          case 'streamLegacy':
+            expect(llmGenerationSpan.output.text).toBe('Mock streaming response');
+            expect(agentRunSpan.output.text).toBe('Mock streaming response');
+            break;
+          default: // VNext generate & stream
+            expect(llmGenerationSpan.output.text).toBe('Mock V2 streaming response');
+            expect(agentRunSpan.output.text).toBe('Mock V2 streaming response');
+            break;
+        }
+        expect(llmGenerationSpan.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+
+        testExporter.finalExpectations();
       });
+    },
+  );
 
-      const mastra = new Mastra({
-        ...getBaseMastraConfig(testExporter),
-        agents: { testAgent },
+  describe.each(agentMethods)(
+    'should trace agent with multiple tools SHOWING internal spans using $name',
+    ({ name, method, model }) => {
+      it(`should trace spans correctly`, async () => {
+        const testAgent = new Agent({
+          name: 'Test Agent',
+          instructions: 'You are a test agent',
+          model,
+          tools: {
+            calculator: calculatorTool,
+            apiCall: apiTool,
+            workflowExecutor: workflowExecutorTool,
+          },
+        });
+
+        const mastra = new Mastra({
+          ...getBaseMastraConfig(testExporter, { includeInternalSpans: true }),
+          agents: { testAgent },
+        });
+
+        const agent = mastra.getAgent('testAgent');
+        const result = await method(agent, 'Calculate 5 + 3');
+        expect(result.text).toBeDefined();
+        expect(result.traceId).toBeDefined();
+
+        const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
+        const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
+        const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
+        const workflowSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
+        const workflowSteps = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
+
+        expect(agentRunSpans.length).toBe(1); // one agent run
+        expect(llmGenerationSpans.length).toBe(1); // tool call
+        expect(toolCallSpans.length).toBe(1); // one tool call (calculator)
+
+        const agentRunSpan = agentRunSpans[0];
+        const llmGenerationSpan = llmGenerationSpans[0];
+        const toolCallSpan = toolCallSpans[0];
+
+        // verify span nesting
+        if (name.includes('Legacy')) {
+          expect(llmGenerationSpan.parentSpanId).toEqual(agentRunSpan.id);
+          expect(toolCallSpan.parentSpanId).toEqual(agentRunSpan.id);
+        } else {
+          // VNext
+          const executionWorkflowSpan = workflowSpans.filter(span => span.name?.includes('execution-workflow'))[0];
+          const agenticLoopWorkflowSpan = workflowSpans.filter(span => span.name?.includes('agentic-loop'))[0];
+          const streamTextStepSpan = workflowSteps.filter(span => span.name?.includes('stream-text-step'))[0];
+          expect(streamTextStepSpan.parentSpanId).toEqual(executionWorkflowSpan.id);
+          expect(agenticLoopWorkflowSpan.parentSpanId).toEqual(llmGenerationSpan.id);
+        }
+
+        expect(llmGenerationSpan.name).toBe("llm: 'mock-model-id'");
+        expect(llmGenerationSpan.input.messages).toHaveLength(2);
+        switch (name) {
+          case 'generateLegacy':
+            expect(llmGenerationSpan.output.text).toBe('Mock response');
+            expect(agentRunSpan.output.text).toBe('Mock response');
+            break;
+          case 'streamLegacy':
+            expect(llmGenerationSpan.output.text).toBe('Mock streaming response');
+            expect(agentRunSpan.output.text).toBe('Mock streaming response');
+            break;
+          default: // VNext generate & stream
+            expect(llmGenerationSpan.output.text).toBe('Mock V2 streaming response');
+            expect(agentRunSpan.output.text).toBe('Mock V2 streaming response');
+            break;
+        }
+        expect(llmGenerationSpan.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+
+        testExporter.finalExpectations();
       });
-
-      const agent = mastra.getAgent('testAgent');
-      const result = await method(agent, 'Calculate 5 + 3');
-      expect(result.text).toBeDefined();
-      expect(result.traceId).toBeDefined();
-
-      const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
-      const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
-      const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
-      const workflowSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
-      const workflowSteps = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
-
-      expect(agentRunSpans.length).toBe(1); // one agent run
-      expect(llmGenerationSpans.length).toBe(1); // tool call
-      expect(toolCallSpans.length).toBe(1); // one tool call (calculator)
-
-      const agentRunSpan = agentRunSpans[0];
-      const llmGenerationSpan = llmGenerationSpans[0];
-      const toolCallSpan = toolCallSpans[0];
-
-      // verify span nesting
-      if (name.includes('Legacy')) {
-        expect(llmGenerationSpan.parent?.id).toEqual(agentRunSpan.id);
-        expect(toolCallSpan.parent?.id).toEqual(agentRunSpan.id);
-      } else {
-        // VNext
-        const executionWorkflowSpan = workflowSpans.filter(span => span.name?.includes('execution-workflow'))[0];
-        const agenticLoopWorkflowSpan = workflowSpans.filter(span => span.name?.includes('agentic-loop'))[0];
-        const streamTextStepSpan = workflowSteps.filter(span => span.name?.includes('stream-text-step'))[0];
-        expect(streamTextStepSpan.parent?.id).toEqual(executionWorkflowSpan.id);
-        expect(agenticLoopWorkflowSpan.parent?.id).toEqual(llmGenerationSpan.id);
-      }
-
-      expect(llmGenerationSpan.name).toBe("llm: 'mock-model-id'");
-      expect(llmGenerationSpan.input.messages).toHaveLength(2);
-      switch (name) {
-        case 'generateLegacy':
-          expect(llmGenerationSpan.output.text).toBe('Mock response');
-          expect(agentRunSpan.output.text).toBe('Mock response');
-          break;
-        case 'streamLegacy':
-          expect(llmGenerationSpan.output.text).toBe('Mock streaming response');
-          expect(agentRunSpan.output.text).toBe('Mock streaming response');
-          break;
-        default: // VNext generate & stream
-          expect(llmGenerationSpan.output.text).toBe('Mock V2 streaming response');
-          expect(agentRunSpan.output.text).toBe('Mock V2 streaming response');
-          break;
-      }
-      expect(llmGenerationSpan.attributes?.usage?.totalTokens).toBeGreaterThan(1);
-
-      testExporter.finalExpectations();
-    });
-  });
+    },
+  );
 
   describe.each(agentMethods)('agent launched inside workflow step using $name', ({ method, model }) => {
     it(`should trace spans correctly`, async () => {
@@ -1160,11 +1235,9 @@ describe('AI Tracing Integration Tests', () => {
       const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
       const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
 
-      // TODO: revert these expectations to assert equal to just 1 after we can hide
-      // internal spans.
+      expect(workflowRunSpans.length).toBe(1); // One workflow run
       expect(workflowRunSpans[0].traceId).toBe(result.traceId);
-      expect(workflowRunSpans.length).toBeGreaterThanOrEqual(1); // One workflow run (plus internal spans in vNext)
-      expect(workflowStepSpans.length).toBeGreaterThanOrEqual(1); // One step: agent-executor (plus internal spans in vNext)
+      expect(workflowStepSpans.length).toBe(1); // One step: agent-executor
       expect(agentRunSpans.length).toBe(1); // One agent run within the step
       expect(llmGenerationSpans.length).toBe(1); // 1 llm span inside agent
 
@@ -1218,10 +1291,8 @@ describe('AI Tracing Integration Tests', () => {
       expect(llmGenerationSpans.length).toBe(1); // one llmGeneration per agent run
       expect(toolCallSpans.length).toBe(1); // tool call
 
-      // TODO: revert these expectations to assert equal to just 1 after we can hide
-      // internal spans.
-      expect(workflowRunSpans.length).toBeGreaterThanOrEqual(1); // One workflow run (simpleWorkflow) + internal vnext agent workflows
-      expect(workflowStepSpans.length).toBeGreaterThanOrEqual(1); // One step (simple-step) + internal vnext agent spans
+      expect(workflowRunSpans.length).toBe(1); // One workflow run (simpleWorkflow)
+      expect(workflowStepSpans.length).toBe(1); // One step (simple-step)
 
       testExporter.finalExpectations();
     });
@@ -1263,10 +1334,8 @@ describe('AI Tracing Integration Tests', () => {
       expect(agentRunSpans[0].traceId).toBe(result.traceId);
       expect(toolCallSpans.length).toBe(1); // tool call (workflow is converted into a tool dynamically)
 
-      // TODO: revert these expectations to assert equal to just 1 after we can hide
-      // internal spans.
-      expect(workflowRunSpans.length).toBeGreaterThanOrEqual(1); // One workflow run (simpleWorkflow) + internal vnext agent workflows
-      expect(workflowStepSpans.length).toBeGreaterThanOrEqual(1); // One step (simple-step) + internal vnext agent spans
+      expect(workflowRunSpans.length).toBe(1); // One workflow run (simpleWorkflow)
+      expect(workflowStepSpans.length).toBe(1); // One step (simple-step)
 
       testExporter.finalExpectations();
     });
@@ -1390,8 +1459,8 @@ describe('AI Tracing Integration Tests', () => {
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
       const genericSpans = testExporter.getSpansByType(AISpanType.GENERIC);
 
-      expect(toolCallSpans.length).toBeGreaterThanOrEqual(1);
-      expect(genericSpans.length).toBeGreaterThanOrEqual(1);
+      expect(toolCallSpans.length).toBe(1);
+      expect(genericSpans.length).toBe(1);
       expect(toolCallSpans[0].traceId).toBe(result.traceId);
 
       // Find the child span and validate metadata

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -14,7 +14,7 @@ import { createWorkflow, createStep } from '../workflows';
 // AI Tracing imports
 import { clearAITracingRegistry, shutdownAITracingRegistry } from './registry';
 import { AISpanType, AITracingEventType } from './types';
-import type { AITracingExporter, AITracingEvent, AISpan, ExportedAISpan, AnyExportedAISpan } from './types';
+import type { AITracingExporter, AITracingEvent, ExportedAISpan, AnyExportedAISpan } from './types';
 
 /**
  * Test exporter for AI tracing events with real-time span lifecycle validation.
@@ -128,7 +128,7 @@ class TestExporter implements AITracingExporter {
         // Return the final span from SPAN_ENDED event
         const endEvent = state.events.find(e => e.type === AITracingEventType.SPAN_ENDED);
         return endEvent!.exportedSpan;
-      }) as AISpan<T>[];
+      }) as ExportedAISpan<T>[];
   }
 
   // Helper to get all incomplete spans (spans that started but never ended)

--- a/packages/core/src/ai-tracing/span_processors/sensitive-data-filter.ts
+++ b/packages/core/src/ai-tracing/span_processors/sensitive-data-filter.ts
@@ -1,79 +1,171 @@
 import type { AISpanProcessor, AnyAISpan } from '../types';
 
+export type RedactionStyle = 'full' | 'partial';
+
+/**
+ * Options for configuring the SensitiveDataFilter.
+ */
+export interface SensitiveDataFilterOptions {
+  /**
+   * List of sensitive field names to redact.
+   * Matching is case-insensitive and normalizes separators (`api-key`, `api_key`, `Api Key` → `apikey`).
+   *
+   * Defaults include: password, token, secret, key, apikey, auth, authorization,
+   * bearer, bearertoken, jwt, credential, clientsecret, privatekey, refresh, ssn.
+   */
+  sensitiveFields?: string[];
+
+  /**
+   * The token used for full redaction.
+   * Default: "[REDACTED]"
+   */
+  redactionToken?: string;
+
+  /**
+   * Style of redaction to use:
+   * - "full": always replace with redactionToken.
+   * - "partial": show 3 characters from the start and end, redact the middle.
+   *
+   * Default: "full"
+   */
+  redactionStyle?: RedactionStyle;
+}
+
+/**
+ * SensitiveDataFilter
+ *
+ * An AISpanProcessor that redacts sensitive information from span fields.
+ *
+ * - Sensitive keys are matched case-insensitively, normalized to remove separators.
+ * - Sensitive values are redacted using either full or partial redaction.
+ * - Partial redaction always keeps 3 chars at the start and end.
+ * - If filtering a field fails, the field is replaced with:
+ *   `{ error: { processor: "sensitive-data-filter" } }`
+ */
 export class SensitiveDataFilter implements AISpanProcessor {
   name = 'sensitive-data-filter';
   private sensitiveFields: string[];
+  private redactionToken: string;
+  private redactionStyle: RedactionStyle;
 
-  constructor(sensitiveFields?: string[]) {
-    // Default sensitive fields with case-insensitive matching
+  constructor(options: SensitiveDataFilterOptions = {}) {
     this.sensitiveFields = (
-      sensitiveFields || [
+      options.sensitiveFields || [
         'password',
         'token',
         'secret',
         'key',
-        'apiKey',
+        'apikey',
         'auth',
         'authorization',
         'bearer',
+        'bearertoken',
         'jwt',
         'credential',
-        'sessionId',
+        'clientsecret',
+        'privatekey',
+        'refresh',
+        'ssn',
       ]
-    ).map(field => field.toLowerCase());
+    ).map(f => this.normalizeKey(f));
+
+    this.redactionToken = options.redactionToken ?? '[REDACTED]';
+    this.redactionStyle = options.redactionStyle ?? 'full';
   }
 
-  process(span: AnyAISpan): AnyAISpan | null {
-    // Deep filter function to recursively handle nested objects
-    const deepFilter = (obj: any, seen = new WeakSet()): any => {
-      if (obj === null || typeof obj !== 'object') {
-        return obj;
-      }
+  /**
+   * Process a span by filtering sensitive data across its key fields.
+   * Fields processed: attributes, metadata, input, output, errorInfo.
+   *
+   * @param span - The input span to filter
+   * @returns A new span with sensitive values redacted
+   */
+  process(span: AnyAISpan): AnyAISpan {
+    span.attributes = this.tryFilter(span.attributes);
+    span.metadata = this.tryFilter(span.metadata);
+    span.input = this.tryFilter(span.input);
+    span.output = this.tryFilter(span.output);
+    span.errorInfo = this.tryFilter(span.errorInfo);
+    return span;
+  }
 
-      // Handle circular references
-      if (seen.has(obj)) {
-        return '[Circular Reference]';
-      }
-      seen.add(obj);
-
-      if (Array.isArray(obj)) {
-        return obj.map(item => deepFilter(item, seen));
-      }
-
-      const filtered: any = {};
-      Object.keys(obj).forEach(key => {
-        if (this.sensitiveFields.includes(key.toLowerCase())) {
-          // Only redact primitive values, recurse into objects/arrays
-          if (obj[key] && typeof obj[key] === 'object') {
-            filtered[key] = deepFilter(obj[key], seen);
-          } else {
-            filtered[key] = '[REDACTED]';
-          }
-        } else {
-          filtered[key] = deepFilter(obj[key], seen);
-        }
-      });
-
-      return filtered;
-    };
-
-    try {
-      // Create a copy of the span with filtered attributes
-      const filteredSpan = { ...span };
-      filteredSpan.attributes = deepFilter(span.attributes);
-      filteredSpan.metadata = deepFilter(span.metadata);
-      filteredSpan.input = deepFilter(span.input);
-      filteredSpan.output = deepFilter(span.output);
-      filteredSpan.errorInfo = deepFilter(span.errorInfo);
-      return filteredSpan;
-    } catch {
-      // If filtering fails, return heavily redacted span for security
-      const safeSpan = { ...span };
-      safeSpan.attributes = {
-        '[FILTERING_ERROR]': 'Attributes were completely redacted due to filtering error',
-      } as any;
-      return safeSpan;
+  /**
+   * Recursively filter objects/arrays for sensitive keys.
+   * Handles circular references by replacing with a marker.
+   */
+  private deepFilter(obj: any, seen = new WeakSet()): any {
+    if (obj === null || typeof obj !== 'object') {
+      return obj;
     }
+
+    if (seen.has(obj)) {
+      return '[Circular Reference]';
+    }
+    seen.add(obj);
+
+    if (Array.isArray(obj)) {
+      return obj.map(item => this.deepFilter(item, seen));
+    }
+
+    const filtered: any = {};
+    for (const key of Object.keys(obj)) {
+      const normKey = this.normalizeKey(key);
+
+      if (this.isSensitive(normKey)) {
+        if (obj[key] && typeof obj[key] === 'object') {
+          filtered[key] = this.deepFilter(obj[key], seen);
+        } else {
+          filtered[key] = this.redactValue(obj[key]);
+        }
+      } else {
+        filtered[key] = this.deepFilter(obj[key], seen);
+      }
+    }
+
+    return filtered;
+  }
+
+  private tryFilter(value: any): any {
+    try {
+      return this.deepFilter(value);
+    } catch {
+      return { error: { processor: this.name } };
+    }
+  }
+
+  /**
+   * Normalize keys by lowercasing and stripping non-alphanumeric characters.
+   * Ensures consistent matching for variants like "api-key", "api_key", "Api Key".
+   */
+  private normalizeKey(key: string): string {
+    return key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  }
+
+  /**
+   * Check whether a normalized key matches any sensitive field substring.
+   */
+  private isSensitive(normalizedKey: string): boolean {
+    return this.sensitiveFields.some(f => normalizedKey.includes(f));
+  }
+
+  /**
+   * Redact a sensitive value.
+   * - Full style: replaces with a fixed token.
+   * - Partial style: shows 3 chars at start and end, hides the middle.
+   *
+   * Non-string values are converted to strings before partial redaction.
+   */
+  private redactValue(value: any): string {
+    if (this.redactionStyle === 'full') {
+      return this.redactionToken;
+    }
+
+    const str = String(value);
+    const len = str.length;
+    if (len <= 6) {
+      return this.redactionToken; // too short, redact fully
+    }
+    return str.slice(0, 3) + '…' + str.slice(len - 3);
   }
 
   async shutdown(): Promise<void> {

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -629,7 +629,7 @@ export interface AISpanProcessor {
   /** Processor name */
   name: string;
   /** Process span before export */
-  process(span: AnyAISpan): AnyAISpan | undefined;
+  process(span?: AnyAISpan): AnyAISpan | undefined;
   /** Shutdown processor */
   shutdown(): Promise<void>;
 }

--- a/packages/core/src/ai-tracing/utils.ts
+++ b/packages/core/src/ai-tracing/utils.ts
@@ -124,6 +124,7 @@ export function getOrCreateSpan<T extends AISpanType>(options: {
       attributes,
       ...rest,
       metadata,
+      isInternal: tracingContext?.isInternal,
     });
   }
 

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -173,6 +173,7 @@ export class MastraLLMVNext extends MastraBase {
         threadId,
         resourceId,
       },
+      isInternal: false,
     });
 
     try {

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -183,6 +183,7 @@ export class MastraLLMV1 extends MastraBase {
         threadId,
         resourceId,
       },
+      isInternal: false,
     });
 
     const argsForExecute: OriginalGenerateTextOptions<Tools, Z> = {
@@ -331,6 +332,7 @@ export class MastraLLMV1 extends MastraBase {
         threadId,
         resourceId,
       },
+      isInternal: false,
     });
 
     try {
@@ -487,6 +489,7 @@ export class MastraLLMV1 extends MastraBase {
         threadId,
         resourceId,
       },
+      isInternal: false,
     });
 
     const argsForExecute: OriginalStreamTextOptions<Tools, Z> = {
@@ -672,6 +675,7 @@ export class MastraLLMV1 extends MastraBase {
         threadId,
         resourceId,
       },
+      isInternal: false,
     });
 
     try {

--- a/packages/core/src/loop/workflow/stream.ts
+++ b/packages/core/src/loop/workflow/stream.ts
@@ -155,7 +155,7 @@ export function workflowLoopStream<
             nonUser: [],
           },
         },
-        tracingContext: { currentSpan: llmAISpan },
+        tracingContext: { currentSpan: llmAISpan, isInternal: true },
       });
 
       if (executionResult.status !== 'success') {

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -131,6 +131,7 @@ export class CoreToolBuilder extends MastraBase {
           toolDescription: options.description,
           toolType: logType || 'tool',
         },
+        isInternal: options.tracingContext?.isInternal,
       });
 
       try {

--- a/workflows/inngest/package.json
+++ b/workflows/inngest/package.json
@@ -54,7 +54,7 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.16.3-0 <0.17.0-0",
+    "@mastra/core": ">=0.16.4-0 <0.17.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -1045,6 +1045,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
         durationMs: duration,
         sleepType: fn ? 'dynamic' : 'fixed',
       },
+      isInternal: tracingContext?.isInternal,
     });
 
     if (fn) {
@@ -1059,6 +1060,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           runCount: -1,
           tracingContext: {
             currentSpan: sleepSpan,
+            isInternal: sleepSpan?.isInternal,
           },
           getInitData: () => stepResults?.input as any,
           getStepResult: (step: any) => {
@@ -1162,6 +1164,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
         durationMs: date ? Math.max(0, date.getTime() - Date.now()) : undefined,
         sleepType: fn ? 'dynamic' : 'fixed',
       },
+      isInternal: tracingContext?.isInternal,
     });
 
     if (fn) {
@@ -1176,6 +1179,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           runCount: -1,
           tracingContext: {
             currentSpan: sleepUntilSpan,
+            isInternal: sleepUntilSpan?.isInternal,
           },
           getInitData: () => stepResults?.input as any,
           getStepResult: (step: any) => {
@@ -1285,6 +1289,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
       attributes: {
         stepId: step.id,
       },
+      isInternal: tracingContext?.isInternal,
     });
 
     const startedAt = await this.inngestStep.run(
@@ -1545,6 +1550,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           resumeData: resume?.steps[0] === step.id ? resume?.resumePayload : undefined,
           tracingContext: {
             currentSpan: stepAISpan,
+            isInternal: stepAISpan?.isInternal,
           },
           getInitData: () => stepResults?.input as any,
           getStepResult: (step: any) => {
@@ -1679,7 +1685,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
             stepId: step.id,
             runtimeContext,
             disableScorers,
-            tracingContext: { currentSpan: stepAISpan },
+            tracingContext: { currentSpan: stepAISpan, isInternal: true },
           });
         }
       });
@@ -1788,6 +1794,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
       attributes: {
         conditionCount: entry.conditions.length,
       },
+      isInternal: tracingContext?.isInternal,
     });
 
     let execResults: any;
@@ -1802,6 +1809,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
               attributes: {
                 conditionIndex: index,
               },
+              isInternal: tracingContext?.isInternal,
             });
 
             try {
@@ -1814,6 +1822,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
                 inputData: prevOutput,
                 tracingContext: {
                   currentSpan: evalSpan,
+                  isInternal: evalSpan?.isInternal,
                 },
                 getInitData: () => stepResults?.input as any,
                 getStepResult: (step: any) => {
@@ -1910,6 +1919,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           disableScorers,
           tracingContext: {
             currentSpan: conditionalSpan,
+            isInternal: conditionalSpan?.isInternal,
           },
         }),
       ),


### PR DESCRIPTION
## Description

In VNext endpoints in Agents, many of the spans shown in ai tracing are related to the inner workings of our system. This PR introduces a feature to hide these internal spans. This allows the user to focus on the parts of the system that they control.

Internal spans are now hidden by default, but they can be shown via configuration.

This PR also introduces a new concept: `ExportedAISpan`.  This is a lightweight version of the internal `AISpan` for use in exporters.  When firing tracing events, we now convert spans to this lightweight type before sending the data onto the TracingExporters. Spans marked as internal are no longer exported.

When converting an `AISpan` to an `ExportedAISpan` we figure out the correct parentId by recursively moving up in the parent tree until we find a span that is not marked as "internal". This becomes the span's proper parentId. 

This allows us to maintain the full span tree inside mastra, but collapse it to just the external spans at export time. 

Also significantly improved the functionality of the SensitveDataFilter. The previous implementation was "not great".

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
