### PR TITLE
Handle zod intersections in dynamic form

### DIFF
--- a/.changeset/puny-socks-do.md
+++ b/.changeset/puny-socks-do.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Handle zod intersections in dynamic form

--- a/packages/playground-ui/src/components/dynamic-form/index.tsx
+++ b/packages/playground-ui/src/components/dynamic-form/index.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../ds/components/Button';
 import { ScrollArea } from '../ui/scroll-area';
 import { AutoForm } from '@/components/ui/autoform';
 import type { ExtendableAutoFormProps } from '@autoform/react';
-import z, { ZodObject } from 'zod';
+import z, { ZodObject, ZodIntersection } from 'zod';
 import { Label } from '../ui/label';
 import { Icon } from '@/ds/icons';
 import { ZodProvider, fieldConfig } from '@autoform/zod/v4';
@@ -25,6 +25,11 @@ function isEmptyZodObject(schema: unknown): boolean {
   if (schema instanceof ZodObject) {
     return Object.keys(schema.shape).length === 0;
   }
+
+  if (schema instanceof ZodIntersection) {
+    return isEmptyZodObject(schema._def.left) || isEmptyZodObject(schema._def.right);
+  }
+
   return false;
 }
 

--- a/packages/playground-ui/src/components/ui/autoform/zodProvider/field-type-inference.ts
+++ b/packages/playground-ui/src/components/ui/autoform/zodProvider/field-type-inference.ts
@@ -8,6 +8,7 @@ export function inferFieldType(schema: z.ZodTypeAny, fieldConfig?: FieldConfig):
   }
 
   if (schema instanceof z.ZodObject) return 'object';
+  if (schema instanceof z.ZodIntersection) return 'object';
   if (schema instanceof z.ZodNumber) return 'number';
   if (schema instanceof z.ZodBoolean) return 'boolean';
   if (schema instanceof z.ZodString) {

--- a/packages/playground-ui/src/components/ui/autoform/zodProvider/index.ts
+++ b/packages/playground-ui/src/components/ui/autoform/zodProvider/index.ts
@@ -27,6 +27,15 @@ function parseField(key: string, schema: z.ZodTypeAny): ParsedField {
   if (baseSchema instanceof zV3.ZodObject || baseSchema instanceof z.ZodObject) {
     subSchema = Object.entries(baseSchema.shape).map(([key, field]) => parseField(key, field as z.ZodTypeAny));
   }
+  if (baseSchema instanceof zV3.ZodIntersection || baseSchema instanceof z.ZodIntersection) {
+    const subSchemaLeft = Object.entries(baseSchema._def.left.shape).map(([key, field]) =>
+      parseField(key, field as z.ZodTypeAny),
+    );
+    const subSchemaRight = Object.entries(baseSchema._def.right.shape).map(([key, field]) =>
+      parseField(key, field as z.ZodTypeAny),
+    );
+    subSchema = [...subSchemaLeft, ...subSchemaRight];
+  }
   if (baseSchema instanceof zV3.ZodArray || baseSchema instanceof z.ZodArray) {
     // @ts-expect-error - property element exists in zod v4 Arrays
     subSchema = [parseField('0', baseSchema._zod.def.element)];


### PR DESCRIPTION
## Description

Handle zod intersections in dynamic form. So for schemas like

```
const type1 = z.object({
  type: z.string().describe('the type'),
});
const workflowInput = z.intersection(
  type1,
  z.object({
    prop: z.string().describe('the prop'),
  }),
);
```

it'll render the right inputs

<img width="542" height="846" alt="Screenshot 2025-09-12 at 12 21 24 PM" src="https://github.com/user-attachments/assets/dcd32406-3f76-45cb-bf92-f079b07dad5c" />


## Related Issue(s)

#7672 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
