### PR TITLE
fix: handle Zod v4 default values in OpenAI reasoning schema compat

### DIFF
--- a/packages/schema-compat/src/provider-compats-v4.test.ts
+++ b/packages/schema-compat/src/provider-compats-v4.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { OpenAIReasoningSchemaCompatLayer } from './provider-compats/openai-reasoning';
+import type { ModelInformation } from './types';
+
+// Mock the regular 'zod' import to use zod v4
+vi.mock('zod', () => ({
+  z,
+}));
+
+describe('OpenAIReasoningSchemaCompatLayer with Zod v4', () => {
+  // Test for issue #7791: TypeError: defaultDef.defaultValue is not a function
+  it('should handle schemas with default values correctly', () => {
+    const modelInfo: ModelInformation = {
+      modelId: 'openai/o3-mini',
+      supportsStructuredOutputs: false,
+      provider: 'openai',
+    };
+
+    const compat = new OpenAIReasoningSchemaCompatLayer(modelInfo);
+
+    // This schema reproduces the exact issue from the bug report
+    const schema = z.object({
+      force_new_login: z.boolean().default(false).describe('Force a new login'),
+      optional_text: z.string().default('default text').describe('Optional text with default'),
+      number_with_default: z.number().default(42).describe('Number with default value'),
+    });
+
+    // This should not throw "TypeError: defaultDef.defaultValue is not a function"
+    const processedSchema = compat.processToAISDKSchema(schema);
+
+    expect(processedSchema).toHaveProperty('jsonSchema');
+    expect(processedSchema).toHaveProperty('validate');
+
+    // Test validation with custom data
+    const validData = {
+      force_new_login: true,
+      optional_text: 'custom text',
+      number_with_default: 100,
+    };
+
+    const validationResult = processedSchema.validate!(validData);
+    expect(validationResult).toHaveProperty('success');
+    expect(validationResult.success).toBe(true);
+
+    // Test with default values (empty object should use defaults)
+    const defaultData = {};
+    const defaultValidation = processedSchema.validate!(defaultData);
+    expect(defaultValidation).toHaveProperty('success');
+    expect(defaultValidation.success).toBe(true);
+
+    // The validated value should include the defaults
+    if (defaultValidation.success) {
+      expect(defaultValidation.value).toEqual({
+        force_new_login: false,
+        optional_text: 'default text',
+        number_with_default: 42,
+      });
+    }
+  });
+
+  it('should handle nested schemas with default values', () => {
+    const modelInfo: ModelInformation = {
+      modelId: 'openai/o3-mini',
+      supportsStructuredOutputs: false,
+      provider: 'openai',
+    };
+
+    const compat = new OpenAIReasoningSchemaCompatLayer(modelInfo);
+
+    const schema = z.object({
+      user: z.object({
+        name: z.string().default('Anonymous'),
+        age: z.number().default(18),
+      }),
+      settings: z.object({
+        notifications: z.boolean().default(true),
+      }),
+    });
+
+    // This should not throw an error
+    const processedSchema = compat.processToAISDKSchema(schema);
+
+    expect(processedSchema).toHaveProperty('jsonSchema');
+    expect(processedSchema).toHaveProperty('validate');
+  });
+});

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.ts
@@ -51,7 +51,9 @@ export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
     } else if (isDefault(z)(value)) {
       const defaultDef = value._def;
       const innerType = defaultDef.innerType;
-      const defaultValue = defaultDef.defaultValue();
+      // Handle both Zod v3 (function) and v4 (direct value)
+      const defaultValue =
+        typeof defaultDef.defaultValue === 'function' ? defaultDef.defaultValue() : defaultDef.defaultValue;
       const constraints: { defaultValue?: unknown } = {};
       if (defaultValue !== undefined) {
         constraints.defaultValue = defaultValue;


### PR DESCRIPTION
Fixes #7791 

The OpenAI reasoning schema compatibility layer was calling `defaultValue()` as a function, which works in Zod v3 but fails in Zod v4 where `defaultValue` is stored directly as a value.

This caused the error: `TypeError: defaultDef.defaultValue is not a function`

The fix checks if `defaultValue` is a function before calling it:

```typescript
// Before - only worked with Zod v3
const defaultValue = defaultDef.defaultValue();

// After - works with both v3 and v4
const defaultValue = typeof defaultDef.defaultValue === 'function' 
  ? defaultDef.defaultValue() 
  : defaultDef.defaultValue;
```

Added tests that specifically use Zod v4 to verify the fix works and that default values are properly extracted and added to schema descriptions.