### PR TITLE
fix(deployer): Improve default `/api` route

### DIFF
--- a/.changeset/eager-pears-wash.md
+++ b/.changeset/eager-pears-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Improve default /api route by giving helpful information

--- a/packages/deployer/src/server/handlers/root.ts
+++ b/packages/deployer/src/server/handlers/root.ts
@@ -7,22 +7,116 @@ export async function rootHandler(c: Context) {
   return c.html(
     /* html */
     `
-      <html>
-        <head>
-          <meta charset="utf-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <title>Mastra API</title>
-          <style>body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }</style>
-        </head>
-        <body>
-          <h1>Welcome to the Mastra API!</h1>
-          <p>
-            You can discover all available endpoints on the 
-            <a href="${baseUrl}/swagger-ui" target="_blank">Swagger UI</a> page.
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Mastra API</title>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/inter-ui/3.19.3/inter.min.css" />
+        <style>
+          body {
+            margin: 0;
+            padding: 0;
+            background-color: #0d0d0d;
+            color: #ffffff;
+            font-family:
+              'Inter',
+              -apple-system,
+              BlinkMacSystemFont,
+              system-ui,
+              sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+          }
+
+          main {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+            text-align: center;
+          }
+
+          h1 {
+            font-size: 4rem;
+            font-weight: 600;
+            margin: 0 0 1rem 0;
+            background: linear-gradient(to right, #fff, #ccc);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            line-height: 1.2;
+          }
+
+          .subtitle {
+            color: #9ca3af;
+            font-size: 1.25rem;
+            max-width: 600px;
+            margin: 0 auto 3rem auto;
+            line-height: 1.6;
+          }
+
+          .link {
+            color: #ffffff;
+          }
+
+          .link:hover {
+            text-decoration: none;
+          }
+
+          .docs-link {
+            background-color: #1a1a1a;
+            padding: 1rem 2rem;
+            border-radius: 0.5rem;
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            font-family: monospace;
+            font-size: 1rem;
+            color: #ffffff;
+            text-decoration: none;
+            transition: background-color 0.2s;
+          }
+
+          .docs-link:hover {
+            background-color: #252525;
+          }
+
+          .arrow-icon {
+            transition: transform 0.2s;
+          }
+
+          .docs-link:hover .arrow-icon {
+            transform: translateX(4px);
+          }
+        </style>
+      </head>
+      <body>
+        <main>
+          <h1>Welcome to the Mastra API</h1>
+          <p class="subtitle">
+            Discover all available endpoints through Swagger UI. You can also define your own <a href="https://mastra.ai/en/docs/server-db/custom-api-routes" target="_blank" class="link">API routes</a>.
           </p>
-          <p>By default Mastra automatically exposes registered agents and workflows via the server. For additional behavior you can define your own <a href="https://mastra.ai/en/docs/server-db/custom-api-routes" target="_blank">HTTP routes</a>.</p>
-        </body>
-      </html>
+          <a href="${baseUrl}/swagger-ui" target="_blank" class="docs-link">
+            Browse Swagger UI
+            <svg
+              class="arrow-icon"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M5 12h14M12 5l7 7-7 7" />
+            </svg>
+          </a>
+        </main>
+      </body>
+    </html>
     `,
   );
 }

--- a/packages/deployer/src/server/handlers/root.ts
+++ b/packages/deployer/src/server/handlers/root.ts
@@ -98,7 +98,7 @@ export async function rootHandler(c: Context) {
         <main>
           <h1>Welcome to the Mastra API</h1>
           <p class="subtitle">
-            Discover all available endpoints through Swagger UI. You can also define your own <a href="https://mastra.ai/en/docs/server-db/custom-api-routes" target="_blank" class="link">API routes</a>.
+            Discover all available endpoints through Swagger UI. You can also define your own <a href="https://mastra.ai/docs/server-db/custom-api-routes" target="_blank" class="link">API routes</a>.
           </p>
           <a href="${baseUrl}/swagger-ui" target="_blank" class="docs-link">
             Browse Swagger UI

--- a/packages/deployer/src/server/handlers/root.ts
+++ b/packages/deployer/src/server/handlers/root.ts
@@ -2,5 +2,27 @@ import type { Context } from 'hono';
 
 // Root handler
 export async function rootHandler(c: Context) {
-  return c.text('Hello to the Mastra API!');
+  const baseUrl = new URL(c.req.url).origin;
+
+  return c.html(
+    /* html */
+    `
+      <html>
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>Mastra API</title>
+          <style>body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }</style>
+        </head>
+        <body>
+          <h1>Welcome to the Mastra API!</h1>
+          <p>
+            You can discover all available endpoints on the 
+            <a href="${baseUrl}/swagger-ui" target="_blank">Swagger UI</a> page.
+          </p>
+          <p>By default Mastra automatically exposes registered agents and workflows via the server. For additional behavior you can define your own <a href="https://mastra.ai/en/docs/server-db/custom-api-routes" target="_blank">HTTP routes</a>.</p>
+        </body>
+      </html>
+    `,
+  );
 }


### PR DESCRIPTION
## Description

While using Mastra I noticed that the `/api` page linked in the terminal is pretty barebones. I've added a link to the generated Swagger UI overview and the docs on custom API routes.

<img width="2643" height="1535" alt="CleanShot 2025-09-15 at 12 51 56" src="https://github.com/user-attachments/assets/b448fe43-5e81-4717-a387-25f7d7036298" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
