### PR TITLE
fix(cloudflare-deployer): Only add postgres-store-instance-checker if pg is used

### DIFF
--- a/.changeset/tangy-dolls-stay.md
+++ b/.changeset/tangy-dolls-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-cloudflare': patch
+---
+
+Fix `postgres-store-instance-checker` babel bug when `@mastra/pg` was not used.

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -169,6 +169,8 @@ export class CloudflareDeployer extends Deployer {
       enableEsmShim: false,
     });
 
+    const hasPostgresStore = (await this.deps.checkDependencies(['@mastra/pg'])) === `ok`;
+
     if (Array.isArray(inputOptions.plugins)) {
       inputOptions.plugins = [
         virtual({
@@ -178,9 +180,12 @@ process.versions.node = '${process.versions.node}';
       `,
         }),
         ...inputOptions.plugins,
-        postgresStoreInstanceChecker(),
         mastraInstanceWrapper(mastraEntryFile),
       ];
+
+      if (hasPostgresStore) {
+        inputOptions.plugins.push(postgresStoreInstanceChecker());
+      }
     }
 
     return inputOptions;
@@ -205,7 +210,7 @@ process.versions.node = '${process.versions.node}';
 
     if (hasLibsql) {
       this.logger.error(
-        'Cloudflare Deployer does not support @libsql/client(which may have been installed by @mastra/libsql) as a dependency. Please use Cloudflare D1 instead @mastra/cloudflare-d1',
+        'Cloudflare Deployer does not support @libsql/client (which may have been installed by @mastra/libsql) as a dependency. Please use Cloudflare D1 instead: @mastra/cloudflare-d1.',
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Description

Only add `postgres-store-instance-checker` babel plugin if `@mastra/pg` is used.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/7811

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
