### PR TITLE
fix(mastra): Improve init command

### DIFF
--- a/.changeset/fine-cows-love.md
+++ b/.changeset/fine-cows-love.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+---
+
+Improve the `mastra init` CLI.
+
+Previously, when you ran `mastra init` in a directory without a `package.json` file you'd receive no output. Now the CLI shows an error with next steps. Additionally, `mastra init` now also installs `zod` if not present already.

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -1,7 +1,7 @@
 import { analytics } from '../..';
 import type { CLI_ORIGIN } from '../../analytics';
 import { init } from '../init/init';
-import { checkAndInstallCoreDeps, checkPkgJson, interactivePrompt } from '../init/utils';
+import { checkAndInstallCoreDeps, checkForPkgJson, interactivePrompt } from '../init/utils';
 
 const origin = process.env.MASTRA_ANALYTICS_ORIGIN as CLI_ORIGIN;
 
@@ -10,7 +10,7 @@ export const initProject = async (args: any) => {
     command: 'init',
     args,
     execution: async () => {
-      await checkPkgJson();
+      await checkForPkgJson();
       await checkAndInstallCoreDeps(args?.example || args?.default);
 
       if (!Object.keys(args).length) {

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -11,7 +11,6 @@ import yoctoSpinner from 'yocto-spinner';
 
 import { DepsService } from '../../services/service.deps';
 import { FileService } from '../../services/service.file';
-import { logger } from '../../utils/logger';
 import {
   cursorGlobalMCPConfigPath,
   globalMCPIsAlreadyInstalled,
@@ -654,23 +653,22 @@ export const interactivePrompt = async () => {
   return mastraProject;
 };
 
-export const checkPkgJson = async () => {
+/**
+ * Check if the current directory has a package.json file. If not, we should alert the user to create one or run "mastra create" to create a new project. The package.json file is required to install dependencies in the next steps.
+ */
+export const checkForPkgJson = async () => {
   const cwd = process.cwd();
   const pkgJsonPath = path.join(cwd, 'package.json');
 
-  let isPkgJsonPresent = false;
-
   try {
-    await fsExtra.readJSON(pkgJsonPath);
-    isPkgJsonPresent = true;
+    await fs.access(pkgJsonPath);
+
+    // Do nothing
   } catch {
-    isPkgJsonPresent = false;
-  }
+    p.log.error(
+      'No package.json file found in the current directory. Please run "npm init -y" to create one, or run "npx create-mastra@latest" to create a new Mastra project.',
+    );
 
-  if (isPkgJsonPresent) {
-    return;
+    process.exit(1);
   }
-
-  logger.debug('package.json not found, create one or run "mastra create" to create a new project');
-  process.exit(0);
 };


### PR DESCRIPTION
## Description

Improve the `mastra init` CLI.

When run in a directory without a package.json, we now show an error:

<img width="1775" height="1082" alt="CleanShot 2025-09-15 at 12 15 31" src="https://github.com/user-attachments/assets/b41c0305-31c2-41e0-9504-6d5b6f5f369d" />

When run in a project that hasn't got the `zod` dependency installed already, we install it now.

Before:

<img width="1775" height="1342" alt="CleanShot 2025-09-15 at 12 16 23" src="https://github.com/user-attachments/assets/687c4cb9-53e2-4ec6-aa1b-7c56cc084e62" />

After:

<img width="1775" height="1362" alt="CleanShot 2025-09-15 at 12 23 07" src="https://github.com/user-attachments/assets/1f0b7ca5-3702-404a-8f71-4ef0d3f8c933" />


## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/7729

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
