### PR TITLE
Updated SensitiveDataFilter to be less greedy in its redacting

### DIFF
--- a/.changeset/better-ducks-win.md
+++ b/.changeset/better-ducks-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Updated SensitiveDataFilter to be less greedy in its redacting

--- a/packages/core/src/ai-tracing/span_processors/sensitive-data-filter.ts
+++ b/packages/core/src/ai-tracing/span_processors/sensitive-data-filter.ts
@@ -142,10 +142,19 @@ export class SensitiveDataFilter implements AISpanProcessor {
   }
 
   /**
-   * Check whether a normalized key matches any sensitive field substring.
+   * Check whether a normalized key exactly matches any sensitive field.
+   * Both key and sensitive fields are normalized by removing all non-alphanumeric
+   * characters and converting to lowercase before comparison.
+   *
+   * Examples:
+   * - "api_key", "api-key", "ApiKey" all normalize to "apikey" → MATCHES "apikey"
+   * - "promptTokens", "prompt_tokens" normalize to "prompttokens" → DOES NOT MATCH "token"
    */
   private isSensitive(normalizedKey: string): boolean {
-    return this.sensitiveFields.some(f => normalizedKey.includes(f));
+    return this.sensitiveFields.some(sensitiveField => {
+      // Simple case-insensitive match after normalization
+      return normalizedKey === sensitiveField;
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes issue found by @greglobinski 

Problem

The SensitiveDataFilter was incorrectly redacting fields like promptTokens and
totalTokens because it used includes() for matching, causing "token" to match any field
containing that substring.

Solution

Simplified the isSensitive method to use exact matching after normalization:
- Both keys and sensitive fields are normalized by removing all non-alphanumeric
characters and converting to lowercase
- Then performs an exact match comparison

Impact

- ✅ api_key, api-key, ApiKey → normalize to apikey → REDACTED
- ✅ promptTokens, prompt_tokens → normalize to prompttokens → NOT REDACTED
- ✅ totalTokens, total_tokens → normalize to totaltokens → NOT REDACTED

This ensures important telemetry data like token counts is preserved while still
protecting sensitive authentication information.

## Related Issue(s)

#6773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
