### PR TITLE
fix: retry on fetching workflow (for cloud)

### DIFF
--- a/.changeset/hot-bars-tie.md
+++ b/.changeset/hot-bars-tie.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'@mastra/core': patch
+---
+
+avoid refetching on error when resolving a workflow in cloud

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -110,7 +110,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.16.3-0 <0.17.0-0",
+    "@mastra/core": ">=0.16.4-0 <0.17.0-0",
     "lucide-react": "^0.474.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",

--- a/packages/playground-ui/src/hooks/index.ts
+++ b/packages/playground-ui/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-in-view';
+export * from './use-workflows';

--- a/packages/playground-ui/src/hooks/use-workflows.ts
+++ b/packages/playground-ui/src/hooks/use-workflows.ts
@@ -23,7 +23,7 @@ export type ExtendedWorkflowWatchResult = WorkflowWatchResult & {
   } | null;
 };
 
-export const useWorkflow = (workflowId: string) => {
+export const useWorkflow = (workflowId: string, enabled = true) => {
   const client = useMastraClient();
   const { runtimeContext } = usePlaygroundStore();
   return useQuery({
@@ -31,6 +31,8 @@ export const useWorkflow = (workflowId: string) => {
     queryFn: () => client.getWorkflow(workflowId).details(runtimeContext),
     retry: false,
     refetchOnWindowFocus: false,
+    throwOnError: false,
+    enabled,
   });
 };
 

--- a/packages/playground/src/domains/workflows/workflow-information.tsx
+++ b/packages/playground/src/domains/workflows/workflow-information.tsx
@@ -10,12 +10,12 @@ import {
   Tab,
   TabContent,
   EntityHeader,
+  useWorkflow,
 } from '@mastra/playground-ui';
 
 import { WorkflowLogs } from './workflow-logs';
 import {
   useLegacyWorkflow,
-  useWorkflow,
   useExecuteWorkflow,
   useResumeWorkflow,
   useStreamWorkflow,

--- a/packages/playground/src/domains/workflows/workflow-layout.tsx
+++ b/packages/playground/src/domains/workflows/workflow-layout.tsx
@@ -7,11 +7,11 @@ import {
   MainContentLayout,
   MastraResizablePanel,
   MainContentContent,
+  useWorkflow,
 } from '@mastra/playground-ui';
 
 import { Skeleton } from '@/components/ui/skeleton';
 
-import { useWorkflow } from '@/hooks/use-workflows';
 import { cn } from '@/lib/utils';
 
 import { WorkflowHeader } from './workflow-header';

--- a/packages/playground/src/hooks/use-workflows.ts
+++ b/packages/playground/src/hooks/use-workflows.ts
@@ -81,17 +81,6 @@ export const useLegacyWorkflow = (workflowId: string, enabled = true) => {
   });
 };
 
-export const useWorkflow = (workflowId: string, enabled = true) => {
-  const { runtimeContext } = usePlaygroundStore();
-  return useQuery({
-    gcTime: 0,
-    staleTime: 0,
-    queryKey: ['workflow', workflowId],
-    queryFn: () => client.getWorkflow(workflowId).details(runtimeContext),
-    enabled,
-  });
-};
-
 export const useExecuteWorkflow = () => {
   const createLegacyWorkflowRun = useMutation({
     mutationFn: async ({ workflowId, prevRunId }: { workflowId: string; prevRunId?: string }) => {

--- a/packages/playground/src/pages/workflows/workflow/index.tsx
+++ b/packages/playground/src/pages/workflows/workflow/index.tsx
@@ -1,5 +1,5 @@
-import { useSendWorkflowRunEvent, useWorkflow } from '@/hooks/use-workflows';
-import { WorkflowGraph } from '@mastra/playground-ui';
+import { useSendWorkflowRunEvent } from '@/hooks/use-workflows';
+import { WorkflowGraph, useWorkflow } from '@mastra/playground-ui';
 import { useNavigate, useParams } from 'react-router';
 
 export const Workflow = () => {

--- a/packages/playground/src/pages/workflows/workflow/traces.tsx
+++ b/packages/playground/src/pages/workflows/workflow/traces.tsx
@@ -1,7 +1,6 @@
 import { useParams, useSearchParams } from 'react-router';
-import { TracesView } from '@mastra/playground-ui';
+import { TracesView, useWorkflow } from '@mastra/playground-ui';
 
-import { useWorkflow } from '@/hooks/use-workflows';
 import { useTraces } from '@/domains/traces/hooks/use-traces';
 
 function WorkflowTracesPage() {


### PR DESCRIPTION
## Description

When we show a workflow as a tool in the playground, we try to fetch a workflow with the toolname. If it exists, we show info about it, however, when it does not exist, we shouldn't let tanstack query refetch in the background.

This PR is a fix for unifying the way we fetch workflows in the playground (and so, in cloud playground's too)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
