### PR TITLE
Add default width  for AI span element

### DIFF
--- a/.changeset/old-birds-follow.md
+++ b/.changeset/old-birds-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Add default width to AI span timeline presentation

--- a/packages/playground-ui/src/domains/observability/components/trace-timeline-span.tsx
+++ b/packages/playground-ui/src/domains/observability/components/trace-timeline-span.tsx
@@ -118,7 +118,7 @@ export function TraceTimelineSpan({
             <div
               className={cn('bg-icon1 h-full absolute rounded-full')}
               style={{
-                width: `${percentageSpanLatency}%`,
+                width: percentageSpanLatency ? `${percentageSpanLatency}%` : '2px',
                 left: `${percentageSpanStartTime}%`,
                 backgroundColor: spanUI?.color,
               }}

--- a/packages/playground-ui/src/domains/observability/components/trace-timeline-span.tsx
+++ b/packages/playground-ui/src/domains/observability/components/trace-timeline-span.tsx
@@ -110,7 +110,7 @@ export function TraceTimelineSpan({
                       : 'none',
                 }}
               >
-                {(span.latency / 1000).toFixed(2)}&nbsp;s
+                {(span.latency / 1000).toFixed(3)}&nbsp;s
               </span>
             </span>
           </div>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

<img width="1151" height="681" alt="CleanShot 2025-09-15 at 16 01 36" src="https://github.com/user-attachments/assets/5674216f-1c37-405a-9b0b-59f6c56dc243" />

- add a default width for AI span element to render it even when the span has no end date so also the duration, just for visiblity in such cases we render `2px` wide tiny but visible element 
- increase decimal places to show miliseconds

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
