### PR TITLE
fix(core): handle JSON code blocks in structured output streaming

### DIFF
--- a/.changeset/mighty-shrimps-grab.md
+++ b/.changeset/mighty-shrimps-grab.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+fix(core): handle JSON code blocks in structured output streaming

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -383,7 +383,6 @@ class EnumFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseFor
 
       // Only emit if we have valid partial matches and the result isn't empty
       if (partialResult.length > 0 && bestMatch && bestMatch !== this.textPreviousEnumResult) {
-        console.log('bestMatch', bestMatch);
         this.textPreviousEnumResult = bestMatch;
         return {
           shouldEmit: true,

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -103,6 +103,31 @@ abstract class BaseFormatHandler<OUTPUT extends OutputSchema = undefined> {
    * @returns Promise resolving to validation result
    */
   abstract validateAndTransformFinal(finalValue: string): Promise<ValidateAndTransformFinalResult<OUTPUT>>;
+
+  /**
+   * Preprocesses accumulated text to handle LLMs that wrap JSON in code blocks.
+   * Extracts content from the first complete valid ```json...``` code block or removes opening ```json prefix if no complete code block is found (streaming chunks).
+   * @param accumulatedText - Raw accumulated text from streaming
+   * @returns Processed text ready for JSON parsing
+   */
+  protected preprocessText(accumulatedText: string): string {
+    let processedText = accumulatedText;
+
+    // Some LLMs wrap the JSON response in code blocks.
+    // In that case, first try to extract content from complete code blocks
+    if (processedText.includes('```json')) {
+      const match = processedText.match(/```json\s*\n?([\s\S]*?)\n?\s*```/);
+      if (match && match[1]) {
+        // Complete code block found - use content between tags
+        processedText = match[1].trim();
+      } else {
+        // No complete code block - just remove the opening ```json
+        processedText = processedText.replace(/^```json\s*\n?/, '');
+      }
+    }
+
+    return processedText;
+  }
 }
 
 /**
@@ -116,7 +141,8 @@ class ObjectFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseF
     accumulatedText,
     previousObject,
   }: ProcessPartialChunkParams): Promise<ProcessPartialChunkResult> {
-    const { value: currentObjectJson, state } = await parsePartialJson(accumulatedText);
+    const processedAccumulatedText = this.preprocessText(accumulatedText);
+    const { value: currentObjectJson, state } = await parsePartialJson(processedAccumulatedText);
 
     // TODO: test partial object chunk validation with schema.partial()
     if (this.validatePartialChunks && this.partialSchema) {
@@ -158,20 +184,7 @@ class ObjectFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseF
         error: new Error('No object generated: could not parse the response.'),
       };
     }
-
-    let rawValue = finalRawValue;
-    /**
-     * If the final value is a string and includes ```json,
-     * extract the JSON string from the code block.
-     * This is a workaround for models that dont support structured output natively
-     */
-    if (typeof finalRawValue === 'string' && finalRawValue?.includes?.('```json')) {
-      const match = finalRawValue.match(/```json\s*\n?([\s\S]*?)\n?\s*```/);
-      if (match && match[1]) {
-        // match the first string between (```json) and (```)
-        rawValue = match[1].trim();
-      }
-    }
+    const rawValue = this.preprocessText(finalRawValue);
     const { value } = await parsePartialJson(rawValue);
 
     if (!this.schema) {
@@ -220,7 +233,8 @@ class ArrayFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseFo
     accumulatedText,
     previousObject,
   }: ProcessPartialChunkParams): Promise<ProcessPartialChunkResult> {
-    const { value: currentObjectJson, state: parseState } = await parsePartialJson(accumulatedText);
+    const processedAccumulatedText = this.preprocessText(accumulatedText);
+    const { value: currentObjectJson, state: parseState } = await parsePartialJson(processedAccumulatedText);
     // TODO: parse/validate partial array elements, emit error chunk if validation fails
     // using this.partialSchema / this.validatePartialChunks
     if (currentObjectJson !== undefined && !isDeepEqualData(previousObject, currentObjectJson)) {
@@ -353,7 +367,8 @@ class EnumFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseFor
     accumulatedText,
     previousObject,
   }: ProcessPartialChunkParams): Promise<ProcessPartialChunkResult> {
-    const { value: currentObjectJson } = await parsePartialJson(accumulatedText);
+    const processedAccumulatedText = this.preprocessText(accumulatedText);
+    const { value: currentObjectJson } = await parsePartialJson(processedAccumulatedText);
     if (
       currentObjectJson !== undefined &&
       currentObjectJson !== null &&
@@ -368,6 +383,7 @@ class EnumFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseFor
 
       // Only emit if we have valid partial matches and the result isn't empty
       if (partialResult.length > 0 && bestMatch && bestMatch !== this.textPreviousEnumResult) {
+        console.log('bestMatch', bestMatch);
         this.textPreviousEnumResult = bestMatch;
         return {
           shouldEmit: true,
@@ -381,14 +397,15 @@ class EnumFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseFor
   }
 
   async validateAndTransformFinal(rawFinalValue: string): Promise<ValidateAndTransformFinalResult<OUTPUT>> {
-    const { value } = await parsePartialJson(rawFinalValue);
+    const processedValue = this.preprocessText(rawFinalValue);
+    const { value } = await parsePartialJson(processedValue);
     if (!(typeof value === 'object' && value !== null && 'result' in value)) {
       return {
         success: false,
         error: new Error('Invalid enum format: expected object with result property'),
       };
     }
-    const finalValue = (value as { result: InferSchemaOutput<OUTPUT> }).result;
+    const finalValue = value as { result: InferSchemaOutput<OUTPUT> };
 
     // For enums, check the wrapped format and unwrap
     if (!finalValue || typeof finalValue !== 'object' || typeof finalValue.result !== 'string') {


### PR DESCRIPTION
## Description

This PR fixes several critical issues with structured output streaming when LLMs wrap JSON responses in code blocks and improves overall reliability of `objectStream`.

### Issues Fixed

1. **JSON Code Block Handling**: Many LLMs (especially when using certain prompts or models) wrap their JSON responses in ```json...``` code blocks, which caused parsing failures during streaming
2. **Enum Result Bug**: Fixed a bug in `EnumFormatHandler.validateAndTransformFinal` where the enum result validation was broken due to incorrect type casting
3. **Inconsistent Processing**: Previously, only `ObjectFormatHandler.validateAndTransformFinal` handled JSON code blocks, while streaming processing (`processPartialChunk`) and other handlers did not, causing inconsistent behavior

### What Changed

#### Core Changes
- **Added `preprocessText` helper method** to `BaseFormatHandler` that:
  - Extracts content from complete ```json...``` code blocks 
  - Removes opening ```json` prefixes during partial streaming when no closing ``` is found yet
  - Handles both newline and non-newline variations

#### Handler Updates
- **ObjectFormatHandler**: Updated both `processPartialChunk` and `validateAndTransformFinal` to use the new preprocessor
- **ArrayFormatHandler**: Updated `processPartialChunk` to use the preprocessor (final validation uses cached results)
- **EnumFormatHandler**: Updated both `processPartialChunk` and `validateAndTransformFinal` to use the preprocessor, and fixed the broken enum result validation

#### Comprehensive Test Coverage
- Added 227 lines of tests covering all three output formats (object, array, enum)
- Tests cover both complete code blocks and partial streaming scenarios
- Validates that streaming chunks work correctly without ```json` prefixes appearing in output

### Before vs After

**Before**: 
```bash
# Console logs showed this during streaming:
processPartialChunk ```json
{
  "idea": "Smart Portioning...",
  ...
```

**After**:
```bash  
# Clean JSON content during streaming:
processPartialChunk {
  "idea": "Smart Portioning...",
  ...
```

### Impact

- **Improved Reliability**: `objectStream` now works consistently with any LLM that wraps responses in code blocks
- **Better User Experience**: No more parsing errors when models use code block formatting
- **Consistent Behavior**: All format handlers now process text the same way during both streaming and final validation
- **Enhanced Testing**: Comprehensive test coverage ensures these scenarios don't regress

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works