### PR TITLE
feat(cli,server): HTTPS support for mastra dev

### DIFF
--- a/.changeset/five-candies-leave.md
+++ b/.changeset/five-candies-leave.md
@@ -1,0 +1,25 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Add support for running the Mastra dev server over HTTPS for local development.
+
+- Add `--https` flag for `mastra dev`. This automatically creates a local key and certificate for you.
+- Alternatively, you can provide your own key and cert through `server.https`:
+
+    ```ts
+    // src/mastra/index.ts
+    import { Mastra } from "@mastra/core/mastra";
+    import fs from 'node:fs'
+
+    export const mastra = new Mastra({
+      server: {
+        https: {
+          key: fs.readFileSync('path/to/key.pem'),
+          cert: fs.readFileSync('path/to/cert.pem')
+        }
+      },
+    });
+    ```

--- a/docs/src/content/en/docs/server-db/local-dev-playground.mdx
+++ b/docs/src/content/en/docs/server-db/local-dev-playground.mdx
@@ -126,11 +126,10 @@ The local development server includes an OpenAPI specification available at: [ht
 
 To include OpenAPI documentation in your production server, enable it in the Mastra instance:
 
-```typescript {7} filename="src/mastra/index.ts" showLineNumbers copy
+```typescript {6} filename="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core/mastra";
 
 export const mastra = new Mastra({
-  // ...
   server: {
     build: {
       openAPIDocs: true
@@ -145,11 +144,10 @@ The local development server includes an interactive Swagger UI - API explorer a
 
 To include Swagger UI in your production server, enable it in the Mastra instance:
 
-```typescript {7} filename="src/mastra/index.ts" showLineNumbers copy
+```typescript {6} filename="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core/mastra";
 
 export const mastra = new Mastra({
-  // ...
   server: {
     build: {
       swaggerUI: true
@@ -170,13 +168,12 @@ This setup lets you start developing immediately with production-like behavior, 
 
 ## Configuration
 
-By default, the server runs on port `4111`. You can customize the host and port through the Mastra server configuration.
+By default, the server runs on port `4111`. You can customize the `host` and `port` through the Mastra server configuration.
 
-```typescript {6,7} filename="src/mastra/index.ts" showLineNumbers copy
+```typescript {5,6} filename="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core/mastra";
 
 export const mastra = new Mastra({
-  // ...
   server: {
     port: 8080,
     host: "0.0.0.0",
@@ -184,15 +181,40 @@ export const mastra = new Mastra({
 });
 ```
 
+### Local HTTPS
+
+Mastra provides a way to use a local HTTPS server for `mastra dev` (through [expo/devcert](https://github.com/expo/devcert)). When you use the `--https` flag, a private key and certificate will be created and used for your project. By default, certificates are issues for `localhost` unless you defined another `host` value.
+
+```bash
+mastra dev --https
+```
+
+You can provide your own key and cert file by specifying the `server.https` option in the Mastra server configuration.
+
+```typescript {2,6-9} filename="src/mastra/index.ts" copy
+import { Mastra } from "@mastra/core/mastra";
+import fs from 'node:fs'
+
+export const mastra = new Mastra({
+  server: {
+    https: {
+      key: fs.readFileSync('path/to/key.pem'),
+      cert: fs.readFileSync('path/to/cert.pem')
+    }
+  },
+});
+```
+
+When you provide both `--https` and `server.https` the latter will take precedence.
+
 ## Bundler options
 
 Use `transpilePackages` to compile TypeScript packages or libraries. Use `externals` to exclude dependencies resolved at runtime, and `sourcemap` to emit readable stack traces.
 
-```typescript filename="src/mastra/index.ts" showLineNumbers copy
+```typescript filename="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core/mastra";
 
 export const mastra = new Mastra({
-  // ...
   bundler: {
     transpilePackages: ["utils"],
     externals: ["ui"],

--- a/docs/src/content/en/docs/server-db/local-dev-playground.mdx
+++ b/docs/src/content/en/docs/server-db/local-dev-playground.mdx
@@ -183,7 +183,7 @@ export const mastra = new Mastra({
 
 ### Local HTTPS
 
-Mastra provides a way to use a local HTTPS server for `mastra dev` (through [expo/devcert](https://github.com/expo/devcert)). When you use the `--https` flag, a private key and certificate will be created and used for your project. By default, certificates are issues for `localhost` unless you defined another `host` value.
+Mastra provides a way to use a local HTTPS server for `mastra dev` (through [expo/devcert](https://github.com/expo/devcert)). When you use the `--https` flag, a private key and certificate will be created and used for your project. By default, certificates are issued for `localhost` unless you defined another `host` value.
 
 ```bash
 mastra dev --https

--- a/docs/src/content/en/reference/cli/dev.mdx
+++ b/docs/src/content/en/reference/cli/dev.mdx
@@ -72,6 +72,12 @@ mastra dev [options]
       description: "display help for command",
       isOptional: true,
     },
+    {
+      name: "--https",
+      type: "boolean",
+      description: "Enable local HTTPS",
+      isOptional: true,
+    },
   ]}
 />
 
@@ -161,7 +167,7 @@ Workflows are expected to be exported from `src/mastra/workflows` (or the config
 
 ## Additional Notes
 
-The port defaults to 4111. Both the port and hostname can be configured via the mastra server config. See [Launch Development Server](/docs/server-db/local-dev-playground) for configuration details.
+The port defaults to `4111`. The port, hostname, and HTTPS settings can also be configured via the Mastra server configuration. See [Launch Development Server](/docs/server-db/local-dev-playground) for configuration details.
 
 Make sure you have your environment variables set up in your `.env.development` or `.env` file for any providers you use (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.).
 

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -6,6 +6,6 @@ const config = await createConfig();
 export default [
   ...config,
   {
-    ignores: ['src/playground/**', 'src/starter-files/**'],
+    ignores: ['src/public/**'],
   },
 ];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,14 +51,15 @@
   "author": "",
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "@expo/devcert": "^1.2.0",
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:^",
     "@mastra/mcp": "workspace:^",
-    "@opentelemetry/core": "^2.0.1",
-    "@opentelemetry/instrumentation": "^0.203.0",
     "@opentelemetry/auto-instrumentations-node": "^0.62.1",
+    "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
+    "@opentelemetry/instrumentation": "^0.203.0",
     "@opentelemetry/resources": "^2.0.1",
     "@opentelemetry/sdk-node": "^0.203.0",
     "@opentelemetry/sdk-trace-base": "^2.0.1",
@@ -82,6 +83,7 @@
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/playground": "workspace:*",
+    "@internal/types-builder": "workspace:*",
     "@mastra/client-js": "workspace:*",
     "@mastra/core": "workspace:*",
     "@microsoft/api-extractor": "^7.52.8",
@@ -96,8 +98,7 @@
     "tsup": "^8.5.0",
     "type-fest": "^4.41.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4",
-    "@internal/types-builder": "workspace:*"
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "@mastra/core": ">=0.10.2-0 <0.17.0-0",

--- a/packages/cli/src/commands/actions/start-dev-server.ts
+++ b/packages/cli/src/commands/actions/start-dev-server.ts
@@ -20,6 +20,7 @@ export const startDevServer = async (args: any) => {
     inspect: args?.inspect && !args?.inspectBrk,
     inspectBrk: args?.inspectBrk,
     customArgs: args?.customArgs ? args.customArgs.split(',') : [],
+    https: args?.https,
   }).catch(err => {
     logger.error(err.message);
   });

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from 'child_process';
 import process from 'node:process';
 import { join } from 'path';
+import devcert from '@expo/devcert';
 import { FileService } from '@mastra/deployer';
 import { getServerOptions } from '@mastra/deployer/build';
 import { isWebContainer } from '@webcontainer/env';
@@ -17,6 +18,18 @@ let isRestarting = false;
 let serverStartTime: number | undefined;
 const ON_ERROR_MAX_RESTARTS = 3;
 
+interface HTTPSOptions {
+  key: Buffer<ArrayBufferLike>;
+  cert: Buffer<ArrayBufferLike>;
+}
+
+interface StartOptions {
+  inspect?: boolean;
+  inspectBrk?: boolean;
+  customArgs?: string[];
+  https?: HTTPSOptions;
+}
+
 const startServer = async (
   dotMastraPath: string,
   {
@@ -27,7 +40,7 @@ const startServer = async (
     host: string;
   },
   env: Map<string, string>,
-  startOptions: { inspect?: boolean; inspectBrk?: boolean; customArgs?: string[] } = {},
+  startOptions: StartOptions = {},
   errorRestartCount = 0,
 ) => {
   let serverIsReady = false;
@@ -68,6 +81,12 @@ const startServer = async (
         MASTRA_DEV: 'true',
         PORT: port.toString(),
         MASTRA_DEFAULT_STORAGE_URL: `file:${join(dotMastraPath, '..', 'mastra.db')}`,
+        ...(startOptions?.https
+          ? {
+              MASTRA_HTTPS_KEY: startOptions.https.key.toString('base64'),
+              MASTRA_HTTPS_CERT: startOptions.https.cert.toString('base64'),
+            }
+          : {}),
       },
       stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
       reject: false,
@@ -112,7 +131,7 @@ const startServer = async (
     currentServerProcess.on('message', async (message: any) => {
       if (message?.type === 'server-ready') {
         serverIsReady = true;
-        devLogger.ready(host, port, serverStartTime);
+        devLogger.ready(host, port, serverStartTime, startOptions.https);
         devLogger.watching();
 
         // Send refresh signal
@@ -188,7 +207,7 @@ async function checkAndRestart(
     host: string;
   },
   bundler: DevBundler,
-  startOptions: { inspect?: boolean; inspectBrk?: boolean; customArgs?: string[] } = {},
+  startOptions: StartOptions = {},
 ) {
   if (isRestarting) {
     return;
@@ -224,7 +243,7 @@ async function rebundleAndRestart(
     host: string;
   },
   bundler: DevBundler,
-  startOptions: { inspect?: boolean; inspectBrk?: boolean; customArgs?: string[] } = {},
+  startOptions: StartOptions = {},
 ) {
   if (isRestarting) {
     return;
@@ -269,6 +288,7 @@ export async function dev({
   inspect,
   inspectBrk,
   customArgs,
+  https,
 }: {
   dir?: string;
   root?: string;
@@ -278,6 +298,7 @@ export async function dev({
   inspect?: boolean;
   inspectBrk?: boolean;
   customArgs?: string[];
+  https?: boolean;
 }) {
   const rootDir = root || process.cwd();
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(process.cwd(), dir)) : join(process.cwd(), 'src', 'mastra');
@@ -292,7 +313,6 @@ export async function dev({
   // We pass an array to globby to allow for the aforementioned negations
   const defaultTools = [defaultToolsPath, ...defaultToolsIgnorePaths];
   const discoveredTools = [defaultTools, ...(tools ?? [])];
-  const startOptions = { inspect, inspectBrk, customArgs };
 
   const fileService = new FileService();
   const entryFile = fileService.getFirstExistingFile([join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')]);
@@ -318,6 +338,27 @@ export async function dev({
       }),
     );
   }
+
+  let httpsOptions: HTTPSOptions | undefined = undefined;
+
+  /**
+   * A user can enable HTTPS in two ways:
+   * 1. By passing the --https flag to the dev command (we then generate a cert for them)
+   * 2. By specifying https options in the mastra server config
+   *
+   * If both are specified, the config options takes precedence.
+   */
+  if (https && serverOptions?.https) {
+    devLogger.warn('--https flag and server.https config are both specified. Using server.https config.');
+  }
+  if (serverOptions?.https) {
+    httpsOptions = serverOptions.https;
+  } else if (https) {
+    const { key, cert } = await devcert.certificateFor(serverOptions?.host ?? 'localhost');
+    httpsOptions = { key, cert };
+  }
+
+  const startOptions: StartOptions = { inspect, inspectBrk, customArgs, https: httpsOptions };
 
   await bundler.prepare(dotMastraPath);
 

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -19,8 +19,8 @@ let serverStartTime: number | undefined;
 const ON_ERROR_MAX_RESTARTS = 3;
 
 interface HTTPSOptions {
-  key: Buffer<ArrayBufferLike>;
-  cert: Buffer<ArrayBufferLike>;
+  key: Buffer;
+  cert: Buffer;
 }
 
 interface StartOptions {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,6 +101,7 @@ program
     '-c, --custom-args <args>',
     'Comma-separated list of custom arguments to pass to the dev server. IE: --experimental-transform-types',
   )
+  .option('-s, --https', 'Enable local HTTPS')
   .action(startDevServer);
 
 program

--- a/packages/cli/src/utils/dev-logger.ts
+++ b/packages/cli/src/utils/dev-logger.ts
@@ -6,6 +6,11 @@ interface DevLoggerOptions {
   colors?: boolean;
 }
 
+interface HTTPSOptions {
+  key: Buffer<ArrayBufferLike>;
+  cert: Buffer<ArrayBufferLike>;
+}
+
 export class DevLogger {
   private options: DevLoggerOptions;
 
@@ -53,13 +58,18 @@ export class DevLogger {
     console.log(`${prefix} ${pc.blue('Starting Mastra dev server...')}`);
   }
 
-  ready(host: string, port: number, startTime?: number): void {
+  ready(host: string, port: number, startTime?: number, https?: HTTPSOptions): void {
+    let protocol = 'http';
+    if (https && https.key && https.cert) {
+      protocol = 'https';
+    }
+
     console.log('');
     const timing = startTime ? `${Date.now() - startTime} ms` : 'XXX ms';
     console.log(pc.inverse(pc.green(' mastra ')) + ` ${pc.green(version)} ${pc.gray('ready in')} ${timing}`);
     console.log('');
-    console.log(`${pc.dim('│')} ${pc.bold('Playground:')}   ${pc.cyan(`http://${host}:${port}/`)}`);
-    console.log(`${pc.dim('│')} ${pc.bold('API:')}     ${`http://${host}:${port}/api`}`);
+    console.log(`${pc.dim('│')} ${pc.bold('Playground:')} ${pc.cyan(`${protocol}://${host}:${port}/`)}`);
+    console.log(`${pc.dim('│')} ${pc.bold('API:')}        ${`${protocol}://${host}:${port}/api`}`);
     console.log('');
   }
 

--- a/packages/cli/src/utils/dev-logger.ts
+++ b/packages/cli/src/utils/dev-logger.ts
@@ -7,8 +7,8 @@ interface DevLoggerOptions {
 }
 
 interface HTTPSOptions {
-  key: Buffer<ArrayBufferLike>;
-  cert: Buffer<ArrayBufferLike>;
+  key: Buffer;
+  cert: Buffer;
 }
 
 export class DevLogger {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,11 +1,4 @@
 {
   "extends": "../../tsconfig.node.json",
-  "exclude": [
-    "node_modules",
-    "**/*.test.ts",
-    "src/starter-files/**/*.ts",
-    "src/playground/**",
-    "dist/**",
-    "eslint.config.js"
-  ]
+  "exclude": ["node_modules", "**/*.test.ts", "src/public/**/*.ts", "dist/**", "eslint.config.js"]
 }

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -137,4 +137,12 @@ export type ServerConfig = {
    * Authentication configuration for the server
    */
   experimental_auth?: MastraAuthConfig<any> | MastraAuthProvider<any>;
+
+  /**
+   * If you want to run `mastra dev` with HTTPS, you can run it with the `--https` flag and provide the key and cert files here.
+   */
+  https?: {
+    key: Buffer<ArrayBufferLike>;
+    cert: Buffer<ArrayBufferLike>;
+  };
 };

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -142,7 +142,7 @@ export type ServerConfig = {
    * If you want to run `mastra dev` with HTTPS, you can run it with the `--https` flag and provide the key and cert files here.
    */
   https?: {
-    key: Buffer<ArrayBufferLike>;
-    cert: Buffer<ArrayBufferLike>;
+    key: Buffer;
+    cert: Buffer;
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -892,6 +892,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@expo/devcert':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@mastra/deployer':
         specifier: workspace:^
         version: link:../deployer
@@ -972,10 +975,10 @@ importers:
         version: 0.2.3
       zod:
         specifier: ^3.25.0 || ^4.0.0
-        version: 3.25.76
+        version: 4.1.5
       zod-to-json-schema:
         specifier: ^3.24.6
-        version: 3.24.6(zod@3.25.76)
+        version: 3.24.6(zod@4.1.5)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -6147,6 +6150,12 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@expo/devcert@1.2.0':
+    resolution: {integrity: sha512-Uilcv3xGELD5t/b0eM4cxBFEKQRIivB3v7i+VhWLV/gL98aw810unLKKJbGAxAIhY6Ipyz8ChWibFsKFXYwstA==}
+
+  '@expo/sudo-prompt@9.3.2':
+    resolution: {integrity: sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==}
 
   '@fastify/busboy@3.1.1':
     resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
@@ -19694,6 +19703,16 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@expo/devcert@1.2.0':
+    dependencies:
+      '@expo/sudo-prompt': 9.3.2
+      debug: 3.2.7
+      glob: 10.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/sudo-prompt@9.3.2': {}
 
   '@fastify/busboy@3.1.1': {}
 


### PR DESCRIPTION
## Description

This continues https://github.com/mastra-ai/mastra/pull/6485 - I opened a new PR to make it easier to run CI. I added the original authors as Co-Authors so contributions are not lost.

This PR adds local HTTPS support for `mastra dev`. A person can enable it in two ways:

- `--https` flag for `mastra dev`. Auto configuration for keys and certs
- `server.https` config on Mastra class

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
