### PR TITLE
Print 'null' as empty value of scorer prompts

### DIFF
--- a/.changeset/three-nails-doubt.md
+++ b/.changeset/three-nails-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Set null as empty value for score prompts

--- a/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
+++ b/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
@@ -45,12 +45,20 @@ export function ScoreDialog({ scorer, score, isOpen, onClose, onNext, onPrevious
           />
           <SideDialogCodeSection title="Input" codeStr={JSON.stringify(score?.input || null, null, 2)} />
           <SideDialogCodeSection title="Output" codeStr={JSON.stringify(score?.output || null, null, 2)} />
-          <SideDialogCodeSection title="Preprocess Prompt" codeStr={score?.preprocessPrompt} simplified={true} />
-          <SideDialogCodeSection title="Analyze Prompt" codeStr={score?.analyzePrompt} simplified={true} />
-          <SideDialogCodeSection title="Generate Score Prompt" codeStr={score?.generateScorePrompt} simplified={true} />
+          <SideDialogCodeSection
+            title="Preprocess Prompt"
+            codeStr={score?.preprocessPrompt || 'null'}
+            simplified={true}
+          />
+          <SideDialogCodeSection title="Analyze Prompt" codeStr={score?.analyzePrompt || 'null'} simplified={true} />
+          <SideDialogCodeSection
+            title="Generate Score Prompt"
+            codeStr={score?.generateScorePrompt || 'null'}
+            simplified={true}
+          />
           <SideDialogCodeSection
             title="Generate Reason Prompt"
-            codeStr={score?.generateReasonPrompt}
+            codeStr={score?.generateReasonPrompt || 'null'}
             simplified={true}
           />
         </div>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

instead of rendering empty component we explicitly print `null` for empty values

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
