### PR TITLE
fix: removing references to the cedar team in first person

### DIFF
--- a/docs/src/content/en/docs/frameworks/agentic-uis/cedar-os.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/cedar-os.mdx
@@ -8,19 +8,19 @@ import { Tabs, Steps } from "nextra/components";
 
 # Integrate Cedar-OS with Mastra
 
-Cedar-OS is an open-source agentic UI framework designed specifically for building the most ambitious AI-native applications. We built Cedar with Mastra in mind.
+Cedar-OS is an open-source agentic UI framework designed specifically for building the most ambitious AI-native applications. Cedar was built with Mastra in mind.
 
 ## Should you use Cedar?
 
-There are a few pillars we care about strongly that you can read more about [here](https://docs.cedarcopilot.com/introduction/philosophy):
+There are a few pillars Cedar cares about strongly that you can read more about [here](https://docs.cedarcopilot.com/introduction/philosophy):
 
 #### 1. Developer experience
 - **Every single component is downloaded shadcn-style** – You own all the code and can style it however you want
-- **Works out of the box** – Just drop in our chat component, and it'll work
+- **Works out of the box** – Just drop in the chat component, and it'll work
 - **Fully extensible** - Built on a [Zustand store architecture](https://docs.cedarcopilot.com/introduction/architecture) that you can customize completely. Every single internal function can be overridden in one line.
 
 #### 2. Enabling truly AI-native applications
-For the first time in history, products can come to life. We want to help you build something with life.
+For the first time in history, products can come to life. Cedar is aimed at helping you build something with life.
 - **[Spells](https://docs.cedarcopilot.com/spells/spells#what-are-spells)** - Users can trigger AI from keyboard shortcuts, mouse events, text selection, and other components
 - **[State Diff Management](https://docs.cedarcopilot.com/state-diff/using-state-diff)** - Give users control over accepting/rejecting agent outputs 
 - **[Voice Integration](https://docs.cedarcopilot.com/voice/voice-integration)** - Let users control your app with their voice
@@ -38,7 +38,7 @@ npx cedar-os-cli plant-seed
 If starting from scratch, select the **Mastra starter** template for a complete setup with both frontend and backend in a monorepo
 
 If you already have a Mastra backend, use the **blank frontend cedar repo** option instead.
-- This will give you the option to download components and download all dependencies for Cedar. We recommend at least downloading one of the chat components to get started. 
+- This will give you the option to download components and download all dependencies for Cedar. It is recommended to download at least one of the chat components to get started. 
 
 ### Wrap your app with CedarCopilot
 
@@ -101,8 +101,8 @@ Your backend and frontend are now linked! You're ready to start building AI-nati
 ## More information
 
 - Check out the [detailed Mastra integration guide](https://docs.cedarcopilot.com/agent-backend-connection/mastra#extending-mastra) for more configuration options (or for manual installation instructions if something goes wrong)
-- Explore Mastra-specific optimizations and features we've built
+- Explore Mastra-specific optimizations and features Cedar has built
   - **Seamless event streaming** - Automatic rendering of [Mastra streamed events](https://docs.cedarcopilot.com/chat/custom-message-rendering#mastra-event-renderer)
   - **Voice endpoint support** - Built-in [voice backend integration](https://docs.cedarcopilot.com/voice/agentic-backend#endpoint-configuration)
   - **End-to-End type safety** - [Types](https://docs.cedarcopilot.com/type-safety/typing-agent-requests) for communicating between your app and Mastra backend
-- [Join our Discord!](https://discord.gg/4AWawRjNdZ) We're excited to have you :)
+- [Join the Discord!](https://discord.gg/4AWawRjNdZ) The Cedar team is excited to have you :)


### PR DESCRIPTION
## Description

Removed use of 'we' and 'our' in the Cedar docs
