### PR TITLE
chore(repo): Fix dorny/paths-filter

### DIFF
--- a/.github/workflows/secrets.test-deployer.yml
+++ b/.github/workflows/secrets.test-deployer.yml
@@ -37,12 +37,9 @@ jobs:
         with:
           base: main
           ref: ${{ github.event.workflow_run.head_sha }}
-          predicate-quantifier: 'every'
           filters: |
             deployer:
-              - 'packages/deployer/**'
-              - 'packages/core/**'  # Deployer depends on core
-              - '!**/*.md'
+              - '!(**/*.md)packages/{deployer,core}/**' # Deployer depends on core
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-mcp.yml
+++ b/.github/workflows/secrets.test-mcp.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           base: main
           ref: ${{ github.event.workflow_run.head_sha }}
-          predicate-quantifier: 'every'
           filters: |
             mcp:
               - '!(**/*.md)packages/{mcp,core}/**' # MCP depends on core

--- a/.github/workflows/secrets.test-mcp.yml
+++ b/.github/workflows/secrets.test-mcp.yml
@@ -40,9 +40,7 @@ jobs:
           predicate-quantifier: 'every'
           filters: |
             mcp:
-              - 'packages/mcp/**'
-              - 'packages/core/**'  # MCP depends on core
-              - '!**/*.md'
+              - '!(**/*.md)packages/{mcp,core}/**' # MCP depends on core
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-memory-ai5.yml
+++ b/.github/workflows/secrets.test-memory-ai5.yml
@@ -37,16 +37,11 @@ jobs:
         with:
           base: main
           ref: ${{ github.event.workflow_run.head_sha }}
-          predicate-quantifier: 'every'
           filters: |
             memory:
-              - 'packages/memory/**'
-              - 'stores/**'
-              - 'packages/core/**'
-              - 'packages/deployer/**'
-              - 'packages/server/**'
-              - 'client-sdks/client-js/**'
-              - '!**/*.md'
+              - '!(**/*.md)packages/{memory,core,deployer,server}/**'
+              - '!(**/*.md)stores/**'
+              - '!(**/*.md)client-sdks/client-js/**'
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -37,16 +37,11 @@ jobs:
         with:
           base: main
           ref: ${{ github.event.workflow_run.head_sha }}
-          predicate-quantifier: 'every'
           filters: |
             memory:
-              - 'packages/memory/**'
-              - 'stores/**'
-              - 'packages/core/**'
-              - 'packages/deployer/**'
-              - 'packages/server/**'
-              - 'client-sdks/client-js/**'
-              - '!**/*.md'
+              - '!(**/*.md)packages/{memory,core,deployer,server}/**'
+              - '!(**/*.md)stores/**'
+              - '!(**/*.md)client-sdks/client-js/**'
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -37,12 +37,9 @@ jobs:
         with:
           base: main
           ref: ${{ github.event.workflow_run.head_sha }}
-          predicate-quantifier: 'every'
           filters: |
             rag:
-              - 'packages/rag/**'
-              - 'packages/core/**'  # RAG depends on core
-              - '!**/*.md'
+              - '!(**/*.md)packages/{rag,core}/**' # RAG depends on core
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-server.yml
+++ b/.github/workflows/secrets.test-server.yml
@@ -37,12 +37,9 @@ jobs:
         with:
           base: main
           ref: ${{ github.event.workflow_run.head_sha }}
-          predicate-quantifier: 'every'
           filters: |
             server:
-              - 'packages/server/**'
-              - 'packages/core/**'  # Server depends on core
-              - '!**/*.md'
+              - '!(**/*.md)packages/{server,core}/**' # Server depends on core
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.tool-builder-test.yml
+++ b/.github/workflows/secrets.tool-builder-test.yml
@@ -37,12 +37,10 @@ jobs:
         with:
           base: main
           ref: ${{ github.event.workflow_run.head_sha }}
-          predicate-quantifier: 'every'
           filters: |
             tool-builder:
-              - 'packages/core/src/tools/tool-builder/**'
-              - 'packages/schema-compat/**'
-              - '!**/*.md'
+              - '!(**/*.md)packages/core/src/tools/tool-builder/**'
+              - '!(**/*.md)packages/schema-compat/**'
 
   skip-tests:
     needs: check-changes


### PR DESCRIPTION
## Description

In https://github.com/mastra-ai/mastra/pull/7794 we added `every` predicate-quantifier to the CI filtering. But it's not working how one would expect.

Take https://github.com/mastra-ai/mastra/actions/runs/17797244511/job/50587697271 as an example. It finds 11 changes files but in the end it says no changes. Why? Because `every` is **AND**, not **OR**. As a person also discovered in https://github.com/dorny/paths-filter/issues/260.

So this PR removes `every` in some places and uses other patterns.

Also found this in a PR to update the README:

> `true` if **any** of the changed files match **all** filter rules with `predicate-quantifier` set to `'every'`

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
