### PR TITLE
fix: update remaining createRun calls to createRunAsync

### DIFF
--- a/.changeset/some-friends-find.md
+++ b/.changeset/some-friends-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed createRun change in agent builder that was missed

--- a/packages/playground-ui/src/hooks/use-workflows.ts
+++ b/packages/playground-ui/src/hooks/use-workflows.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { toast } from 'sonner';
-import { LegacyWorkflowRunResult, WorkflowWatchResult, GetWorkflowResponse } from '@mastra/client-js';
+import { LegacyWorkflowRunResult, WorkflowWatchResult } from '@mastra/client-js';
 import type { LegacyWorkflow } from '@mastra/core/workflows/legacy';
 import { useMastraClient } from '@/contexts/mastra-client-context';
 import { usePlaygroundStore } from '@/store/playground-store';

--- a/packages/playground/src/hooks/use-templates.ts
+++ b/packages/playground/src/hooks/use-templates.ts
@@ -173,7 +173,7 @@ export const useCreateTemplateInstallRun = () => {
   return useMutation({
     mutationFn: async ({ runId }: { runId?: string }) => {
       const template = client.getAgentBuilderAction('merge-template');
-      return await template.createRun({ runId });
+      return await template.createRunAsync({ runId });
     },
   });
 };


### PR DESCRIPTION
Updated the last remaining instances where createRun was being called instead of createRunAsync.

Found one instance in the template installation hook that was still using the old method name. Also removed an unused import that was no longer needed.