### PR TITLE
refactor: compute links from provider instead of prop drilling

### DIFF
--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -16,11 +16,10 @@ import { AgentMetadataModelSwitcher, AgentMetadataModelSwitcherProps } from './a
 import { LoadingBadge } from '@/components/assistant-ui/tools/badges/loading-badge';
 
 export interface AgentMetadataProps {
+  agentId: string;
   agent: GetAgentResponse;
   promptSlot: ReactNode;
   hasMemoryEnabled: boolean;
-  computeToolLink: (tool: GetToolResponse) => string;
-  computeWorkflowLink: (workflowId: string, workflow: GetWorkflowResponse) => string;
   computeScorerLink: (scorerId: string) => string;
   modelProviders: string[];
   updateModel: AgentMetadataModelSwitcherProps['updateModel'];
@@ -53,11 +52,10 @@ export const AgentMetadataNetworkList = ({ agents }: AgentMetadataNetworkListPro
 };
 
 export const AgentMetadata = ({
+  agentId,
   agent,
   promptSlot,
   hasMemoryEnabled,
-  computeToolLink,
-  computeWorkflowLink,
   computeScorerLink,
   updateModel,
   modelProviders,
@@ -135,7 +133,7 @@ export const AgentMetadata = ({
           title: 'Using Tools and MCP documentation',
         }}
       >
-        <AgentMetadataToolList tools={tools} computeToolLink={computeToolLink} />
+        <AgentMetadataToolList tools={tools} agentId={agentId} />
       </AgentMetadataSection>
 
       <AgentMetadataSection
@@ -145,7 +143,7 @@ export const AgentMetadata = ({
           title: 'Workflows documentation',
         }}
       >
-        <AgentMetadataWorkflowList workflows={workflows} computeWorkflowLink={computeWorkflowLink} />
+        <AgentMetadataWorkflowList workflows={workflows} />
       </AgentMetadataSection>
 
       <AgentMetadataSection title="Scorers">
@@ -158,11 +156,11 @@ export const AgentMetadata = ({
 
 export interface AgentMetadataToolListProps {
   tools: GetToolResponse[];
-  computeToolLink: (tool: GetToolResponse) => string;
+  agentId: string;
 }
 
-export const AgentMetadataToolList = ({ tools, computeToolLink }: AgentMetadataToolListProps) => {
-  const { Link } = useLinkComponent();
+export const AgentMetadataToolList = ({ tools, agentId }: AgentMetadataToolListProps) => {
+  const { Link, paths } = useLinkComponent();
 
   if (tools.length === 0) {
     return <AgentMetadataListEmpty>No tools</AgentMetadataListEmpty>;
@@ -172,7 +170,7 @@ export const AgentMetadataToolList = ({ tools, computeToolLink }: AgentMetadataT
     <AgentMetadataList>
       {tools.map(tool => (
         <AgentMetadataListItem key={tool.id}>
-          <Link href={computeToolLink(tool)}>
+          <Link href={paths.agentToolLink(agentId, tool.id)}>
             <Badge icon={<ToolsIcon className="text-[#ECB047]" />}>{tool.id}</Badge>
           </Link>
         </AgentMetadataListItem>
@@ -183,11 +181,10 @@ export const AgentMetadataToolList = ({ tools, computeToolLink }: AgentMetadataT
 
 export interface AgentMetadataWorkflowListProps {
   workflows: Array<{ id: string } & GetWorkflowResponse>;
-  computeWorkflowLink: (workflowId: string, workflow: GetWorkflowResponse) => string;
 }
 
-export const AgentMetadataWorkflowList = ({ workflows, computeWorkflowLink }: AgentMetadataWorkflowListProps) => {
-  const { Link } = useLinkComponent();
+export const AgentMetadataWorkflowList = ({ workflows }: AgentMetadataWorkflowListProps) => {
+  const { Link, paths } = useLinkComponent();
 
   if (workflows.length === 0) {
     return <AgentMetadataListEmpty>No workflows</AgentMetadataListEmpty>;
@@ -197,7 +194,7 @@ export const AgentMetadataWorkflowList = ({ workflows, computeWorkflowLink }: Ag
     <AgentMetadataList>
       {workflows.map(workflow => (
         <AgentMetadataListItem key={workflow.id}>
-          <Link href={computeWorkflowLink(workflow.id, workflow)}>
+          <Link href={paths.workflowLink(workflow.id)}>
             <Badge icon={<WorkflowIcon className="text-accent3" />}>{workflow.name}</Badge>
           </Link>
         </AgentMetadataListItem>

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -32,7 +32,7 @@ export const AgentMetadataNetworkList = ({ agents }: AgentMetadataNetworkListPro
   const { Link, paths } = useLinkComponent();
 
   if (agents.length === 0) {
-    return <AgentMetadataListEmpty>No tools</AgentMetadataListEmpty>;
+    return <AgentMetadataListEmpty>No agents</AgentMetadataListEmpty>;
   }
 
   return (

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -3,7 +3,7 @@ import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { MemoryIcon } from '@/ds/icons/MemoryIcon';
 import { providerMapToIcon } from '../provider-map-icon';
 import { useLinkComponent } from '@/lib/framework';
-import { GetAgentResponse, GetScorerResponse, GetToolResponse, GetWorkflowResponse } from '@mastra/client-js';
+import { GetAgentResponse, GetToolResponse, GetWorkflowResponse } from '@mastra/client-js';
 import { AgentMetadataSection } from './agent-metadata-section';
 import { AgentMetadataList, AgentMetadataListEmpty, AgentMetadataListItem } from './agent-metadata-list';
 import { AgentMetadataWrapper } from './agent-metadata-wrapper';
@@ -19,7 +19,6 @@ export interface AgentMetadataProps {
   agent: GetAgentResponse;
   promptSlot: ReactNode;
   hasMemoryEnabled: boolean;
-  computeAgentLink: (agent: { id: string; name: string }) => string;
   computeToolLink: (tool: GetToolResponse) => string;
   computeWorkflowLink: (workflowId: string, workflow: GetWorkflowResponse) => string;
   computeScorerLink: (scorerId: string) => string;
@@ -29,11 +28,10 @@ export interface AgentMetadataProps {
 
 export interface AgentMetadataNetworkListProps {
   agents: { id: string; name: string }[];
-  computeAgentLink: (agent: { id: string; name: string }) => string;
 }
 
-export const AgentMetadataNetworkList = ({ agents, computeAgentLink }: AgentMetadataNetworkListProps) => {
-  const { Link } = useLinkComponent();
+export const AgentMetadataNetworkList = ({ agents }: AgentMetadataNetworkListProps) => {
+  const { Link, paths } = useLinkComponent();
 
   if (agents.length === 0) {
     return <AgentMetadataListEmpty>No tools</AgentMetadataListEmpty>;
@@ -43,7 +41,7 @@ export const AgentMetadataNetworkList = ({ agents, computeAgentLink }: AgentMeta
     <AgentMetadataList>
       {agents.map(agent => (
         <AgentMetadataListItem key={agent.id}>
-          <Link href={computeAgentLink(agent)}>
+          <Link href={paths.agentLink(agent.id)}>
             <Badge variant="success" icon={<AgentIcon />}>
               {agent.name}
             </Badge>
@@ -58,7 +56,6 @@ export const AgentMetadata = ({
   agent,
   promptSlot,
   hasMemoryEnabled,
-  computeAgentLink,
   computeToolLink,
   computeWorkflowLink,
   computeScorerLink,
@@ -127,7 +124,7 @@ export const AgentMetadata = ({
             title: 'Agents documentation',
           }}
         >
-          <AgentMetadataNetworkList agents={networkAgents} computeAgentLink={computeAgentLink} />
+          <AgentMetadataNetworkList agents={networkAgents} />
         </AgentMetadataSection>
       )}
 

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -20,7 +20,6 @@ export interface AgentMetadataProps {
   agent: GetAgentResponse;
   promptSlot: ReactNode;
   hasMemoryEnabled: boolean;
-  computeScorerLink: (scorerId: string) => string;
   modelProviders: string[];
   updateModel: AgentMetadataModelSwitcherProps['updateModel'];
 }
@@ -56,7 +55,6 @@ export const AgentMetadata = ({
   agent,
   promptSlot,
   hasMemoryEnabled,
-  computeScorerLink,
   updateModel,
   modelProviders,
 }: AgentMetadataProps) => {
@@ -147,7 +145,7 @@ export const AgentMetadata = ({
       </AgentMetadataSection>
 
       <AgentMetadataSection title="Scorers">
-        <AgentMetadataScorerList entityId={agent.name} entityType="AGENT" computeScorerLink={computeScorerLink} />
+        <AgentMetadataScorerList entityId={agent.name} entityType="AGENT" />
       </AgentMetadataSection>
       <AgentMetadataSection title="System Prompt">{promptSlot}</AgentMetadataSection>
     </AgentMetadataWrapper>
@@ -204,13 +202,12 @@ export const AgentMetadataWorkflowList = ({ workflows }: AgentMetadataWorkflowLi
 };
 
 interface AgentMetadataScorerListProps {
-  computeScorerLink: (scorerId: string) => string;
   entityId: string;
   entityType: string;
 }
 
-export const AgentMetadataScorerList = ({ entityId, entityType, computeScorerLink }: AgentMetadataScorerListProps) => {
-  const { Link } = useLinkComponent();
+export const AgentMetadataScorerList = ({ entityId, entityType }: AgentMetadataScorerListProps) => {
+  const { Link, paths } = useLinkComponent();
   const { scorers, isLoading } = useScorers();
 
   const scorerList = Object.keys(scorers)
@@ -236,7 +233,7 @@ export const AgentMetadataScorerList = ({ entityId, entityType, computeScorerLin
     <AgentMetadataList>
       {scorerList.map(scorer => (
         <AgentMetadataListItem key={scorer.id}>
-          <Link href={computeScorerLink(scorer.id)}>
+          <Link href={paths.scorerLink(scorer.id)}>
             <Badge icon={<GaugeIcon className="text-icon3" />}>{scorer.scorer.config.name}</Badge>
           </Link>
         </AgentMetadataListItem>

--- a/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
@@ -17,11 +17,10 @@ import { useLinkComponent } from '@/lib/framework';
 export interface AgentsTableProps {
   agents: Record<string, GetAgentResponse>;
   isLoading: boolean;
-  computeLink: (agentId: string) => string;
 }
 
-export function AgentsTable({ agents, isLoading, computeLink }: AgentsTableProps) {
-  const { navigate } = useLinkComponent();
+export function AgentsTable({ agents, isLoading }: AgentsTableProps) {
+  const { navigate, paths } = useLinkComponent();
   const projectData: AgentTableData[] = useMemo(
     () =>
       Object.keys(agents).map(key => {
@@ -37,7 +36,7 @@ export function AgentsTable({ agents, isLoading, computeLink }: AgentsTableProps
           repoUrl: undefined,
           tools: agent.tools,
           modelId: agent.modelId,
-          link: computeLink(key),
+          link: paths.agentLink(key),
         };
       }),
     [agents],

--- a/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
+++ b/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
@@ -9,23 +9,16 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Txt } from '@/ds/components/Txt/Txt';
 
 export interface ChatThreadsProps {
-  computeNewThreadLink: () => string;
-  computeThreadLink: (threadId: string) => string;
   threads: StorageThreadType[];
   isLoading: boolean;
   threadId: string;
   onDelete: (threadId: string) => void;
+  resourceId: string;
+  resourceType: 'agent' | 'network';
 }
 
-export const ChatThreads = ({
-  computeNewThreadLink,
-  computeThreadLink,
-  threads,
-  isLoading,
-  threadId,
-  onDelete,
-}: ChatThreadsProps) => {
-  const { Link } = useLinkComponent();
+export const ChatThreads = ({ threads, isLoading, threadId, onDelete, resourceId, resourceType }: ChatThreadsProps) => {
+  const { Link, paths } = useLinkComponent();
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
   if (isLoading) {
@@ -34,12 +27,15 @@ export const ChatThreads = ({
 
   const reverseThreads = [...threads].reverse();
 
+  const newThreadLink =
+    resourceType === 'agent' ? paths.agentNewThreadLink(resourceId) : paths.networkNewThreadLink(resourceId);
+
   return (
     <div className="overflow-y-auto h-full w-full">
       <Threads>
         <ThreadList>
           <ThreadItem>
-            <ThreadLink as={Link} to={computeNewThreadLink()}>
+            <ThreadLink as={Link} to={newThreadLink}>
               <span className="text-accent1 flex items-center gap-4">
                 <Icon className="bg-surface4 rounded-lg" size="lg">
                   <Plus />
@@ -58,9 +54,14 @@ export const ChatThreads = ({
           {reverseThreads.map(thread => {
             const isActive = thread.id === threadId;
 
+            const threadLink =
+              resourceType === 'agent'
+                ? paths.agentThreadLink(resourceId, thread.id)
+                : paths.networkThreadLink(resourceId, thread.id);
+
             return (
               <ThreadItem isActive={isActive} key={thread.id}>
-                <ThreadLink as={Link} to={computeThreadLink(thread.id)}>
+                <ThreadLink as={Link} to={threadLink}>
                   <ThreadTitle title={thread.title} />
                   <span>{formatDay(thread.createdAt)}</span>
                 </ThreadLink>

--- a/packages/playground-ui/src/domains/networks/components/network-table/network-table.tsx
+++ b/packages/playground-ui/src/domains/networks/components/network-table/network-table.tsx
@@ -17,11 +17,10 @@ import { useLinkComponent } from '@/lib/framework';
 export interface NetworkTableProps {
   networks: GetVNextNetworkResponse[];
   isLoading: boolean;
-  computeLink: (networkId: string) => string;
 }
 
-export const NetworkTable = ({ networks, isLoading, computeLink }: NetworkTableProps) => {
-  const { navigate } = useLinkComponent();
+export const NetworkTable = ({ networks, isLoading }: NetworkTableProps) => {
+  const { navigate, paths } = useLinkComponent();
   const allNetworks: NetworkTableColumn[] = useMemo(
     () => [
       ...(networks?.map(network => ({
@@ -62,7 +61,7 @@ export const NetworkTable = ({ networks, isLoading, computeLink }: NetworkTableP
         </Thead>
         <Tbody>
           {rows.map(row => (
-            <Row key={row.id} onClick={() => navigate(computeLink(row.original.id))} className="cursor-pointer">
+            <Row key={row.id} onClick={() => navigate(paths.networkLink(row.original.id))} className="cursor-pointer">
               {row.getVisibleCells().map(cell => (
                 <React.Fragment key={cell.id}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/playground-ui/src/domains/observability/components/helpers.tsx
+++ b/packages/playground-ui/src/domains/observability/components/helpers.tsx
@@ -1,25 +1,17 @@
 import { format } from 'date-fns';
 import { AISpanRecord } from '@mastra/core';
+import { useLinkComponent } from '@/lib/framework';
 
-export function getTraceInfo(
-  trace: AISpanRecord | undefined,
-  computeAgentsLink?: () => string,
-  computeWorkflowsLink?: () => string,
-) {
+export function useTraceInfo(trace: AISpanRecord | undefined) {
+  const { paths } = useLinkComponent();
   if (!trace) {
     return [];
   }
 
-  const agentsLink = computeAgentsLink ? computeAgentsLink() : '/agents';
-  const workflowsLink = computeWorkflowsLink ? computeWorkflowsLink() : '/workflows';
-
-  const agentLink = computeAgentsLink
-    ? `${agentsLink}/${trace?.metadata?.resourceId}`
-    : `/agents/${trace?.metadata?.resourceId}`;
-
-  const workflowLink = computeWorkflowsLink
-    ? `${workflowsLink}/${trace?.metadata?.resourceId}`
-    : `/workflows/${trace?.metadata?.resourceId}`;
+  const agentsLink = paths.agentsLink();
+  const workflowsLink = paths.workflowsLink();
+  const agentLink = paths.agentLink(trace?.metadata?.resourceId!);
+  const workflowLink = paths.workflowLink(trace?.metadata?.resourceId!);
 
   return [
     {

--- a/packages/playground-ui/src/domains/observability/components/trace-dialog.tsx
+++ b/packages/playground-ui/src/domains/observability/components/trace-dialog.tsx
@@ -14,7 +14,7 @@ import { TraceTimeline } from './trace-timeline';
 import { TraceSpanUsage } from './trace-span-usage';
 import { useLinkComponent } from '@/lib/framework';
 import { AISpanRecord } from '@mastra/core';
-import { getTraceInfo, getSpanInfo } from './helpers';
+import { getTraceInfo, getSpanInfo, useTraceInfo } from './helpers';
 import { SpanDialog } from './span-dialog';
 import { SpanDetails } from './span-details';
 import { formatHierarchicalSpans } from '../utils/format-hierarchical-spans';
@@ -29,8 +29,6 @@ type TraceDialogProps = {
   onNext?: () => void;
   onPrevious?: () => void;
   isLoadingSpans?: boolean;
-  computeAgentsLink?: () => string;
-  computeWorkflowsLink?: () => string;
 };
 
 export function TraceDialog({
@@ -42,14 +40,13 @@ export function TraceDialog({
   onNext,
   onPrevious,
   isLoadingSpans,
-  computeAgentsLink,
-  computeWorkflowsLink,
 }: TraceDialogProps) {
   const { Link } = useLinkComponent();
   const [dialogIsOpen, setDialogIsOpen] = useState<boolean>(false);
   const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(undefined);
   const [combinedView, setCombinedView] = useState<boolean>(false);
   const selectedSpan = traceSpans.find(span => span.spanId === selectedSpanId);
+  const traceInfo = useTraceInfo(traceDetails);
 
   const hierarchicalSpans = useMemo(() => {
     return formatHierarchicalSpans(traceSpans);
@@ -106,7 +103,6 @@ export function TraceDialog({
     return currentIndex > 0;
   };
 
-  const traceInfo = getTraceInfo(traceDetails, computeAgentsLink, computeWorkflowsLink);
   const selectedSpanInfo = getSpanInfo({ span: selectedSpan, withTraceId: !combinedView, withSpanId: combinedView });
 
   return (

--- a/packages/playground-ui/src/domains/observability/components/trace-dialog.tsx
+++ b/packages/playground-ui/src/domains/observability/components/trace-dialog.tsx
@@ -14,7 +14,7 @@ import { TraceTimeline } from './trace-timeline';
 import { TraceSpanUsage } from './trace-span-usage';
 import { useLinkComponent } from '@/lib/framework';
 import { AISpanRecord } from '@mastra/core';
-import { getTraceInfo, getSpanInfo, useTraceInfo } from './helpers';
+import { getSpanInfo, useTraceInfo } from './helpers';
 import { SpanDialog } from './span-dialog';
 import { SpanDetails } from './span-details';
 import { formatHierarchicalSpans } from '../utils/format-hierarchical-spans';

--- a/packages/playground-ui/src/domains/scores/components/scorers-table/scorers-table.tsx
+++ b/packages/playground-ui/src/domains/scores/components/scorers-table/scorers-table.tsx
@@ -17,11 +17,10 @@ import { useLinkComponent } from '@/lib/framework';
 export interface ScorersTableProps {
   scorers: Record<string, GetScorerResponse>;
   isLoading: boolean;
-  computeScorerLink: (scorerId: string) => string;
 }
 
-export function ScorersTable({ scorers, isLoading, computeScorerLink }: ScorersTableProps) {
-  const { navigate } = useLinkComponent();
+export function ScorersTable({ scorers, isLoading }: ScorersTableProps) {
+  const { navigate, paths } = useLinkComponent();
   const scorersData: ScorerTableData[] = useMemo(
     () =>
       Object.keys(scorers).map(key => {
@@ -63,7 +62,7 @@ export function ScorersTable({ scorers, isLoading, computeScorerLink }: ScorersT
         </Thead>
         <Tbody>
           {rows.map(row => (
-            <Row key={row.id} onClick={() => navigate(computeScorerLink(row.original.id))}>
+            <Row key={row.id} onClick={() => navigate(paths.scorerLink(row.original.id))}>
               {row.getVisibleCells().map(cell => (
                 <React.Fragment key={cell.id}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/playground-ui/src/domains/tools/components/tool-list.tsx
+++ b/packages/playground-ui/src/domains/tools/components/tool-list.tsx
@@ -11,7 +11,7 @@ import { ToolCoinIcon } from '@/ds/icons/ToolCoinIcon';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { useLinkComponent } from '@/lib/framework';
 import { GetAgentResponse, GetToolResponse } from '@mastra/client-js';
-import { SearchIcon } from 'lucide-react';
+
 import { startTransition, useMemo, useRef, useState } from 'react';
 
 export interface ToolListProps {
@@ -19,7 +19,6 @@ export interface ToolListProps {
   tools: Record<string, GetToolResponse>;
   agents: Record<string, GetAgentResponse>;
   computeLink: (toolId: string, agentId?: string) => string;
-  computeAgentLink: (toolId: string, agentId: string) => string;
 }
 
 interface ToolWithAgents {
@@ -28,7 +27,7 @@ interface ToolWithAgents {
   agents: Array<{ id: string; name: string }>;
 }
 
-export const ToolList = ({ tools, agents, isLoading, computeLink, computeAgentLink }: ToolListProps) => {
+export const ToolList = ({ tools, agents, isLoading, computeLink }: ToolListProps) => {
   const toolsWithAgents = useMemo(() => prepareAgents(tools, agents), [tools, agents]);
 
   if (isLoading)
@@ -38,20 +37,15 @@ export const ToolList = ({ tools, agents, isLoading, computeLink, computeAgentLi
       </div>
     );
 
-  return (
-    <ToolListInner toolsWithAgents={toolsWithAgents} computeLink={computeLink} computeAgentLink={computeAgentLink} />
-  );
+  return <ToolListInner toolsWithAgents={toolsWithAgents} computeLink={computeLink} />;
 };
 
-const ToolListInner = ({
-  toolsWithAgents,
-  computeLink,
-  computeAgentLink,
-}: {
+interface ToolListInnerProps {
   toolsWithAgents: ToolWithAgents[];
   computeLink: (toolId: string, agentId?: string) => string;
-  computeAgentLink: (toolId: string, agentId: string) => string;
-}) => {
+}
+
+const ToolListInner = ({ toolsWithAgents, computeLink }: ToolListInnerProps) => {
   const [filteredTools, setFilteredTools] = useState<ToolWithAgents[]>(toolsWithAgents);
   const [value, setValue] = useState('');
 
@@ -90,7 +84,7 @@ const ToolListInner = ({
 
       <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4 max-w-5xl mx-auto py-8">
         {filteredTools.map(tool => (
-          <ToolEntity key={tool.id} tool={tool} computeLink={computeLink} computeAgentLink={computeAgentLink} />
+          <ToolEntity key={tool.id} tool={tool} computeLink={computeLink} />
         ))}
       </div>
     </div>
@@ -100,12 +94,11 @@ const ToolListInner = ({
 interface ToolEntityProps {
   tool: ToolWithAgents;
   computeLink: (toolId: string, agentId?: string) => string;
-  computeAgentLink: (toolId: string, agentId: string) => string;
 }
 
-const ToolEntity = ({ tool, computeLink, computeAgentLink }: ToolEntityProps) => {
+const ToolEntity = ({ tool, computeLink }: ToolEntityProps) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
-  const { Link } = useLinkComponent();
+  const { Link, paths } = useLinkComponent();
 
   return (
     <Entity onClick={() => linkRef.current?.click()}>
@@ -125,7 +118,7 @@ const ToolEntity = ({ tool, computeLink, computeAgentLink }: ToolEntityProps) =>
           {tool.agents.map(agent => {
             return (
               <Link
-                href={computeAgentLink(tool.id, agent.id)}
+                href={paths.agentToolLink(agent.id, tool.id)}
                 onClick={e => e.stopPropagation()}
                 key={agent.id}
                 className="group/link"

--- a/packages/playground-ui/src/domains/tools/components/tool-list.tsx
+++ b/packages/playground-ui/src/domains/tools/components/tool-list.tsx
@@ -11,14 +11,13 @@ import { ToolCoinIcon } from '@/ds/icons/ToolCoinIcon';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { useLinkComponent } from '@/lib/framework';
 import { GetAgentResponse, GetToolResponse } from '@mastra/client-js';
-
+import { SearchIcon } from 'lucide-react';
 import { startTransition, useMemo, useRef, useState } from 'react';
 
 export interface ToolListProps {
   isLoading: boolean;
   tools: Record<string, GetToolResponse>;
   agents: Record<string, GetAgentResponse>;
-  computeLink: (toolId: string, agentId?: string) => string;
 }
 
 interface ToolWithAgents {
@@ -27,7 +26,7 @@ interface ToolWithAgents {
   agents: Array<{ id: string; name: string }>;
 }
 
-export const ToolList = ({ tools, agents, isLoading, computeLink }: ToolListProps) => {
+export const ToolList = ({ tools, agents, isLoading }: ToolListProps) => {
   const toolsWithAgents = useMemo(() => prepareAgents(tools, agents), [tools, agents]);
 
   if (isLoading)
@@ -37,15 +36,14 @@ export const ToolList = ({ tools, agents, isLoading, computeLink }: ToolListProp
       </div>
     );
 
-  return <ToolListInner toolsWithAgents={toolsWithAgents} computeLink={computeLink} />;
+  return <ToolListInner toolsWithAgents={toolsWithAgents} />;
 };
 
 interface ToolListInnerProps {
   toolsWithAgents: ToolWithAgents[];
-  computeLink: (toolId: string, agentId?: string) => string;
 }
 
-const ToolListInner = ({ toolsWithAgents, computeLink }: ToolListInnerProps) => {
+const ToolListInner = ({ toolsWithAgents }: ToolListInnerProps) => {
   const [filteredTools, setFilteredTools] = useState<ToolWithAgents[]>(toolsWithAgents);
   const [value, setValue] = useState('');
 
@@ -84,7 +82,7 @@ const ToolListInner = ({ toolsWithAgents, computeLink }: ToolListInnerProps) => 
 
       <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4 max-w-5xl mx-auto py-8">
         {filteredTools.map(tool => (
-          <ToolEntity key={tool.id} tool={tool} computeLink={computeLink} />
+          <ToolEntity key={tool.id} tool={tool} />
         ))}
       </div>
     </div>
@@ -93,10 +91,9 @@ const ToolListInner = ({ toolsWithAgents, computeLink }: ToolListInnerProps) => 
 
 interface ToolEntityProps {
   tool: ToolWithAgents;
-  computeLink: (toolId: string, agentId?: string) => string;
 }
 
-const ToolEntity = ({ tool, computeLink }: ToolEntityProps) => {
+const ToolEntity = ({ tool }: ToolEntityProps) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const { Link, paths } = useLinkComponent();
 
@@ -108,7 +105,7 @@ const ToolEntity = ({ tool, computeLink }: ToolEntityProps) => {
 
       <EntityContent>
         <EntityName>
-          <Link ref={linkRef} href={computeLink(tool.id, tool.agents[0]?.id)}>
+          <Link ref={linkRef} href={paths.toolLink(tool.id)}>
             {tool.id}
           </Link>
         </EntityName>

--- a/packages/playground-ui/src/domains/workflows/components/workflow-table/workflow-table.tsx
+++ b/packages/playground-ui/src/domains/workflows/components/workflow-table/workflow-table.tsx
@@ -18,11 +18,10 @@ export interface WorkflowTableProps {
   workflows?: Record<string, GetWorkflowResponse>;
   legacyWorkflows?: Record<string, GetLegacyWorkflowResponse>;
   isLoading: boolean;
-  computeLink: (agentId: string) => string;
 }
 
-export function WorkflowTable({ workflows, legacyWorkflows, isLoading, computeLink }: WorkflowTableProps) {
-  const { navigate } = useLinkComponent();
+export function WorkflowTable({ workflows, legacyWorkflows, isLoading }: WorkflowTableProps) {
+  const { navigate, paths } = useLinkComponent();
   const workflowData: WorkflowTableData[] = useMemo(() => {
     const _workflowsData = Object.keys(workflows ?? {}).map(key => {
       const workflow = workflows?.[key];
@@ -32,7 +31,7 @@ export function WorkflowTable({ workflows, legacyWorkflows, isLoading, computeLi
         name: workflow?.name || 'N/A',
         stepsCount: Object.keys(workflow?.steps ?? {})?.length,
         isLegacy: false,
-        link: computeLink(key),
+        link: paths.workflowLink(key),
       };
     });
 
@@ -44,7 +43,7 @@ export function WorkflowTable({ workflows, legacyWorkflows, isLoading, computeLi
         name: workflow?.name || 'N/A',
         stepsCount: Object.keys(workflow?.steps ?? {})?.length,
         isLegacy: true,
-        link: computeLink(key),
+        link: paths.workflowLink(key),
       };
     });
 

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -17,11 +17,15 @@ type LinkComponentPaths = {
   agentLink: (agentId: string) => string;
   agentsLink: () => string;
   agentToolLink: (agentId: string, toolId: string) => string;
+  agentThreadLink: (agentId: string, threadId: string) => string;
+  agentNewThreadLink: (agentId: string) => string;
 
   workflowsLink: () => string;
   workflowLink: (workflowId: string) => string;
 
   networkLink: (networkId: string) => string;
+  networkNewThreadLink: (networkId: string) => string;
+  networkThreadLink: (networkId: string, threadId: string) => string;
 
   scorerLink: (scorerId: string) => string;
 };
@@ -37,9 +41,13 @@ const LinkComponentContext = createContext<{
     agentLink: () => '',
     agentsLink: () => '',
     agentToolLink: () => '',
+    agentThreadLink: () => '',
+    agentNewThreadLink: () => '',
     workflowsLink: () => '',
     workflowLink: () => '',
     networkLink: () => '',
+    networkNewThreadLink: () => '',
+    networkThreadLink: () => '',
     scorerLink: () => '',
   },
 });

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -20,6 +20,8 @@ type LinkComponentPaths = {
 
   workflowsLink: () => string;
   workflowLink: (workflowId: string) => string;
+
+  networkLink: (networkId: string) => string;
 };
 
 const LinkComponentContext = createContext<{
@@ -35,6 +37,7 @@ const LinkComponentContext = createContext<{
     agentToolLink: () => '',
     workflowsLink: () => '',
     workflowLink: () => '',
+    networkLink: () => '',
   },
 });
 

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -22,6 +22,8 @@ type LinkComponentPaths = {
   workflowLink: (workflowId: string) => string;
 
   networkLink: (networkId: string) => string;
+
+  scorerLink: (scorerId: string) => string;
 };
 
 const LinkComponentContext = createContext<{
@@ -38,6 +40,7 @@ const LinkComponentContext = createContext<{
     workflowsLink: () => '',
     workflowLink: () => '',
     networkLink: () => '',
+    scorerLink: () => '',
   },
 });
 

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -13,22 +13,33 @@ export type LinkComponentProps = AnchorHTMLAttributes<HTMLAnchorElement>;
 // Define the actual component type with ref attributes
 export type LinkComponent = ForwardRefExoticComponent<LinkComponentProps & RefAttributes<HTMLAnchorElement>>;
 
+type LinkComponentPaths = {
+  agentLink: (agentId: string) => string;
+  agentToolLink: (agentId: string, toolId: string) => string;
+};
+
 const LinkComponentContext = createContext<{
   Link: LinkComponent;
   navigate: (path: string) => void;
+  paths: LinkComponentPaths;
 }>({
   Link: forwardRef<HTMLAnchorElement, LinkComponentProps>(() => null),
   navigate: () => {},
+  paths: {
+    agentLink: () => '',
+    agentToolLink: () => '',
+  },
 });
 
 export interface LinkComponentProviderProps {
   children: React.ReactNode;
   Link: LinkComponent;
   navigate: (path: string) => void;
+  paths: LinkComponentPaths;
 }
 
-export const LinkComponentProvider = ({ children, Link, navigate }: LinkComponentProviderProps) => {
-  return <LinkComponentContext.Provider value={{ Link, navigate }}>{children}</LinkComponentContext.Provider>;
+export const LinkComponentProvider = ({ children, Link, navigate, paths }: LinkComponentProviderProps) => {
+  return <LinkComponentContext.Provider value={{ Link, navigate, paths }}>{children}</LinkComponentContext.Provider>;
 };
 
 export const useLinkComponent = () => {

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -28,6 +28,8 @@ type LinkComponentPaths = {
   networkThreadLink: (networkId: string, threadId: string) => string;
 
   scorerLink: (scorerId: string) => string;
+
+  toolLink: (toolId: string) => string;
 };
 
 const LinkComponentContext = createContext<{
@@ -49,6 +51,7 @@ const LinkComponentContext = createContext<{
     networkNewThreadLink: () => '',
     networkThreadLink: () => '',
     scorerLink: () => '',
+    toolLink: () => '',
   },
 });
 

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -15,7 +15,11 @@ export type LinkComponent = ForwardRefExoticComponent<LinkComponentProps & RefAt
 
 type LinkComponentPaths = {
   agentLink: (agentId: string) => string;
+  agentsLink: () => string;
   agentToolLink: (agentId: string, toolId: string) => string;
+
+  workflowsLink: () => string;
+  workflowLink: (workflowId: string) => string;
 };
 
 const LinkComponentContext = createContext<{
@@ -27,7 +31,10 @@ const LinkComponentContext = createContext<{
   navigate: () => {},
   paths: {
     agentLink: () => '',
+    agentsLink: () => '',
     agentToolLink: () => '',
+    workflowsLink: () => '',
+    workflowLink: () => '',
   },
 });
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -1,3 +1,4 @@
+import { v4 as uuid } from '@lukeed/uuid';
 import { Routes, Route, BrowserRouter, Outlet, useNavigate } from 'react-router';
 
 import { Layout } from '@/components/layout';
@@ -46,9 +47,13 @@ const paths: LinkComponentProviderProps['paths'] = {
   agentLink: (agentId: string) => `/agents/${agentId}`,
   agentToolLink: (agentId: string, toolId: string) => `/agents/${agentId}/tools/${toolId}`,
   agentsLink: () => `/agents`,
+  agentNewThreadLink: (agentId: string) => `/agents/${agentId}/chat/${uuid()}`,
+  agentThreadLink: (agentId: string, threadId: string) => `/agents/${agentId}/chat/${threadId}`,
   workflowsLink: () => `/workflows`,
   workflowLink: (workflowId: string) => `/workflows/${workflowId}`,
   networkLink: (networkId: string) => `/networks/v-next/${networkId}/chat`,
+  networkNewThreadLink: (networkId: string) => `/networks/v-next/${networkId}/chat/${uuid()}`,
+  networkThreadLink: (networkId: string, threadId: string) => `/networks/v-next/${networkId}/chat/${threadId}`,
   scorerLink: (scorerId: string) => `/scorers/${scorerId}`,
 };
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -55,7 +55,7 @@ const paths: LinkComponentProviderProps['paths'] = {
   networkNewThreadLink: (networkId: string) => `/networks/v-next/${networkId}/chat/${uuid()}`,
   networkThreadLink: (networkId: string, threadId: string) => `/networks/v-next/${networkId}/chat/${threadId}`,
   scorerLink: (scorerId: string) => `/scorers/${scorerId}`,
-  toolLink: (toolId: string) => `/tools/${toolId}`,
+  toolLink: (toolId: string) => `/tools/all/${toolId}`,
 };
 
 const LinkComponentWrapper = ({ children }: { children: React.ReactNode }) => {
@@ -143,6 +143,7 @@ function App() {
                 >
                   <Route path="/agents" element={<Agents />} />
                   <Route path="/agents/:agentId" element={<NavigateTo to="/agents/:agentId/chat" />} />
+                  <Route path="/agents/:agentId/tools/:toolId" element={<AgentTool />} />
                   <Route
                     path="/agents/:agentId"
                     element={
@@ -157,7 +158,7 @@ function App() {
                     <Route path="traces" element={<AgentTracesPage />} />
                   </Route>
                   <Route path="/tools" element={<Tools />} />
-                  <Route path="/tools/:agentId/:toolId" element={<AgentTool />} />
+
                   <Route path="/tools/all/:toolId" element={<Tool />} />
                   <Route path="/mcps" element={<MCPs />} />
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -45,6 +45,9 @@ import Template from './pages/templates/template';
 const paths: LinkComponentProviderProps['paths'] = {
   agentLink: (agentId: string) => `/agents/${agentId}`,
   agentToolLink: (agentId: string, toolId: string) => `/agents/${agentId}/tools/${toolId}`,
+  agentsLink: () => `/agents`,
+  workflowsLink: () => `/workflows`,
+  workflowLink: (workflowId: string) => `/workflows/${workflowId}`,
 };
 
 const LinkComponentWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -49,6 +49,7 @@ const paths: LinkComponentProviderProps['paths'] = {
   workflowsLink: () => `/workflows`,
   workflowLink: (workflowId: string) => `/workflows/${workflowId}`,
   networkLink: (networkId: string) => `/networks/v-next/${networkId}/chat`,
+  scorerLink: (scorerId: string) => `/scorers/${scorerId}`,
 };
 
 const LinkComponentWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -55,6 +55,7 @@ const paths: LinkComponentProviderProps['paths'] = {
   networkNewThreadLink: (networkId: string) => `/networks/v-next/${networkId}/chat/${uuid()}`,
   networkThreadLink: (networkId: string, threadId: string) => `/networks/v-next/${networkId}/chat/${threadId}`,
   scorerLink: (scorerId: string) => `/scorers/${scorerId}`,
+  toolLink: (toolId: string) => `/tools/${toolId}`,
 };
 
 const LinkComponentWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -48,6 +48,7 @@ const paths: LinkComponentProviderProps['paths'] = {
   agentsLink: () => `/agents`,
   workflowsLink: () => `/workflows`,
   workflowLink: (workflowId: string) => `/workflows/${workflowId}`,
+  networkLink: (networkId: string) => `/networks/v-next/${networkId}/chat`,
 };
 
 const LinkComponentWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -27,7 +27,12 @@ import MCPServerToolExecutor from './pages/mcps/tool';
 
 import { McpServerPage } from './pages/mcps/[serverId]';
 
-import { LinkComponentProvider, MastraClientProvider, PlaygroundQueryClient } from '@mastra/playground-ui';
+import {
+  LinkComponentProvider,
+  LinkComponentProviderProps,
+  MastraClientProvider,
+  PlaygroundQueryClient,
+} from '@mastra/playground-ui';
 import VNextNetwork from './pages/networks/network/v-next';
 import { NavigateTo } from './lib/react-router';
 import { Link } from './lib/framework';
@@ -37,6 +42,11 @@ import Observability from './pages/observability';
 import Templates from './pages/templates';
 import Template from './pages/templates/template';
 
+const paths: LinkComponentProviderProps['paths'] = {
+  agentLink: (agentId: string) => `/agents/${agentId}`,
+  agentToolLink: (agentId: string, toolId: string) => `/agents/${agentId}/tools/${toolId}`,
+};
+
 const LinkComponentWrapper = ({ children }: { children: React.ReactNode }) => {
   const navigate = useNavigate();
   const frameworkNavigate = (path: string) => {
@@ -44,7 +54,7 @@ const LinkComponentWrapper = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <LinkComponentProvider Link={Link} navigate={frameworkNavigate}>
+    <LinkComponentProvider Link={Link} navigate={frameworkNavigate} paths={paths}>
       {children}
     </LinkComponentProvider>
   );

--- a/packages/playground/src/domains/agents/agent-information.tsx
+++ b/packages/playground/src/domains/agents/agent-information.tsx
@@ -75,7 +75,6 @@ export function AgentInformation({ agentId }: { agentId: string }) {
                 updateModel={updateModel}
                 modelProviders={modelProviders || []}
                 hasMemoryEnabled={Boolean(memory?.result)}
-                computeAgentLink={() => `/agents/${agentId}`}
                 computeToolLink={tool => `/tools/${agentId}/${tool.id}`}
                 computeWorkflowLink={workflowId => `/workflows/${workflowId}/graph`}
                 promptSlot={<AgentPromptEnhancer agentId={agentId} />}

--- a/packages/playground/src/domains/agents/agent-information.tsx
+++ b/packages/playground/src/domains/agents/agent-information.tsx
@@ -77,7 +77,6 @@ export function AgentInformation({ agentId }: { agentId: string }) {
                 modelProviders={modelProviders || []}
                 hasMemoryEnabled={Boolean(memory?.result)}
                 promptSlot={<AgentPromptEnhancer agentId={agentId} />}
-                computeScorerLink={(scorerId: string) => `/scorers/${scorerId}`}
               />
             )}
           </TabContent>

--- a/packages/playground/src/domains/agents/agent-information.tsx
+++ b/packages/playground/src/domains/agents/agent-information.tsx
@@ -71,12 +71,11 @@ export function AgentInformation({ agentId }: { agentId: string }) {
             {isLoading && <Skeleton className="h-full" />}
             {agent && (
               <AgentMetadata
+                agentId={agentId}
                 agent={agent}
                 updateModel={updateModel}
                 modelProviders={modelProviders || []}
                 hasMemoryEnabled={Boolean(memory?.result)}
-                computeToolLink={tool => `/tools/${agentId}/${tool.id}`}
-                computeWorkflowLink={workflowId => `/workflows/${workflowId}/graph`}
                 promptSlot={<AgentPromptEnhancer agentId={agentId} />}
                 computeScorerLink={(scorerId: string) => `/scorers/${scorerId}`}
               />

--- a/packages/playground/src/domains/agents/agent-sidebar.tsx
+++ b/packages/playground/src/domains/agents/agent-sidebar.tsx
@@ -1,6 +1,4 @@
-import { v4 as uuid } from '@lukeed/uuid';
-import { useNavigate } from 'react-router';
-import { ChatThreads } from '@mastra/playground-ui';
+import { ChatThreads, useLinkComponent } from '@mastra/playground-ui';
 
 import { useDeleteThread } from '@/hooks/use-memory';
 import { StorageThreadType } from '@mastra/core/memory';
@@ -17,19 +15,19 @@ export function AgentSidebar({
   isLoading: boolean;
 }) {
   const { mutateAsync } = useDeleteThread();
-  const navigate = useNavigate();
+  const { paths, navigate } = useLinkComponent();
 
   const handleDelete = async (deleteId: string) => {
     await mutateAsync({ threadId: deleteId!, agentId });
     if (deleteId === threadId) {
-      navigate(`/agents/${agentId}/chat/${uuid()}`);
+      navigate(paths.agentNewThreadLink(agentId));
     }
   };
 
   return (
     <ChatThreads
-      computeNewThreadLink={() => `/agents/${agentId}/chat/${uuid()}`}
-      computeThreadLink={threadId => `/agents/${agentId}/chat/${threadId}`}
+      resourceId={agentId}
+      resourceType={'agent'}
       threads={threads || []}
       isLoading={isLoading}
       threadId={threadId}

--- a/packages/playground/src/domains/networks/network-sidebar.tsx
+++ b/packages/playground/src/domains/networks/network-sidebar.tsx
@@ -1,6 +1,4 @@
-import { v4 as uuid } from '@lukeed/uuid';
-import { useNavigate } from 'react-router';
-import { ChatThreads } from '@mastra/playground-ui';
+import { ChatThreads, useLinkComponent } from '@mastra/playground-ui';
 import { StorageThreadType } from '@mastra/core/memory';
 import { useDeleteThread } from '@/hooks/use-memory';
 
@@ -16,23 +14,23 @@ export function NetworkSidebar({
   isLoading: boolean;
 }) {
   const { mutateAsync } = useDeleteThread();
-  const navigate = useNavigate();
+  const { navigate, paths } = useLinkComponent();
 
   const handleDelete = async (deleteId: string) => {
     await mutateAsync({ threadId: deleteId!, networkId });
     if (deleteId === threadId) {
-      navigate(`/networks/v-next/${networkId}/chat/${uuid()}`);
+      navigate(paths.networkNewThreadLink(networkId));
     }
   };
 
   return (
     <ChatThreads
-      computeNewThreadLink={() => `/networks/v-next/${networkId}/chat/${uuid()}`}
-      computeThreadLink={threadId => `/networks/v-next/${networkId}/chat/${threadId}`}
       threads={threads || []}
       isLoading={isLoading}
       threadId={threadId}
       onDelete={handleDelete}
+      resourceId={networkId}
+      resourceType={'network'}
     />
   );
 }

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -13,7 +13,7 @@ function Agents() {
       </Header>
 
       <MainContentContent isCentered={!isLoading && Object.keys(agents || {}).length === 0}>
-        <AgentsTable agents={agents} isLoading={isLoading} computeLink={agentId => `/agents/${agentId}/chat/new`} />
+        <AgentsTable agents={agents} isLoading={isLoading} />
       </MainContentContent>
     </MainContentLayout>
   );

--- a/packages/playground/src/pages/networks/index.tsx
+++ b/packages/playground/src/pages/networks/index.tsx
@@ -13,13 +13,7 @@ function Networks() {
       </Header>
 
       <MainContentContent isCentered={isEmpty && !isVNextLoading}>
-        <NetworkTable
-          networks={vNextNetworks}
-          isLoading={isVNextLoading}
-          computeLink={(networkId: string) => {
-            return `/networks/v-next/${networkId}/chat`;
-          }}
-        />
+        <NetworkTable networks={vNextNetworks} isLoading={isVNextLoading} />
       </MainContentContent>
     </MainContentLayout>
   );

--- a/packages/playground/src/pages/scorers/index.tsx
+++ b/packages/playground/src/pages/scorers/index.tsx
@@ -10,7 +10,7 @@ export default function Scorers() {
         <HeaderTitle>Scorers</HeaderTitle>
       </Header>
 
-      <ScorersTable isLoading={isLoading} scorers={scorers} computeScorerLink={scorerId => `/scorers/${scorerId}`} />
+      <ScorersTable isLoading={isLoading} scorers={scorers} />
     </MainContentLayout>
   );
 }

--- a/packages/playground/src/pages/tools/index.tsx
+++ b/packages/playground/src/pages/tools/index.tsx
@@ -16,13 +16,7 @@ export default function Tools() {
       </Header>
 
       <MainContentContent isCentered={isEmpty}>
-        <ToolList
-          tools={tools}
-          agents={agentsRecord}
-          isLoading={isLoadingAgents || isLoadingTools}
-          computeLink={(toolId, agentId) => (agentId ? `/tools/${agentId}/${toolId}` : `/tools/all/${toolId}`)}
-          computeAgentLink={(_, agentId) => `/agents/${agentId}/chat`}
-        />
+        <ToolList tools={tools} agents={agentsRecord} isLoading={isLoadingAgents || isLoadingTools} />
       </MainContentContent>
     </MainContentLayout>
   );

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -15,12 +15,7 @@ function Workflows() {
       </Header>
 
       <MainContentContent isCentered={isEmpty}>
-        <WorkflowTable
-          workflows={workflows}
-          legacyWorkflows={legacyWorkflows}
-          isLoading={isLoading}
-          computeLink={workflowId => `/workflows/${workflowId}/graph`}
-        />
+        <WorkflowTable workflows={workflows} legacyWorkflows={legacyWorkflows} isLoading={isLoading} />
       </MainContentContent>
     </MainContentLayout>
   );


### PR DESCRIPTION
## Description

Looks better for config and usage than props drilling

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
