### PR TITLE
Add type for scorers

### DIFF
--- a/.changeset/nice-monkeys-lie.md
+++ b/.changeset/nice-monkeys-lie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add scorer type, for automatic type inferrence when creating scorers for agents


### PR DESCRIPTION
## Description

Allows to add a type when creating scorers. For now we have a single type Agent. What this will allow us to do is to have the input and output of the run when creating a scorer to be typed. We can also create the correct payload when these scorers are scoring on a trace.

Old:
```
createScorer<ScorerRunInputForAgent, ScorerRunOutputForAgent>({
  name: 'scorer1',
  description: 'Scorer 1',
}).generateScore(({ run }) => {
  
  run.input <---- typed as ScorerRunInputForAgent
  run.output <---- typed as ScorerRunOutputForAgent
  
  return 1;
});
```

New:
```
// No longer have to specify the ScorerRunInputForAgent and ScorerRunOutputForAgent types
createScorer({
  name: 'scorer1',
  description: 'Scorer 1',
  type: 'agent'
}).generateScore(({ run }) => {
  
  run.input <---- typed as ScorerRunInputForAgent
  run.output <---- typed as ScorerRunOutputForAgent
  
  return 1;
});
```

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
