### PR TITLE
Fix orphaned spans in langfuse exporter

### DIFF
--- a/.changeset/major-rules-flow.md
+++ b/.changeset/major-rules-flow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': patch
+---
+
+Fix orphaned spans in langfuse exporter

--- a/observability/langfuse/src/ai-tracing.test.ts
+++ b/observability/langfuse/src/ai-tracing.test.ts
@@ -8,7 +8,12 @@
  * - Langfuse-specific error handling
  */
 
-import type { AITracingEvent, AnyAISpan, LLMGenerationAttributes, ToolCallAttributes } from '@mastra/core/ai-tracing';
+import type {
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+  ToolCallAttributes,
+} from '@mastra/core/ai-tracing';
 import { AISpanType, AITracingEventType } from '@mastra/core/ai-tracing';
 import { Langfuse } from 'langfuse';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -170,7 +175,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: rootSpan,
+        exportedSpan: rootSpan,
       };
 
       await exporter.exportEvent(event);
@@ -200,7 +205,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: childSpan,
+        exportedSpan: childSpan,
       };
 
       await exporter.exportEvent(event);
@@ -239,7 +244,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: llmSpan,
+        exportedSpan: llmSpan,
       };
 
       await exporter.exportEvent(event);
@@ -285,7 +290,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: minimalLlmSpan,
+        exportedSpan: minimalLlmSpan,
       };
 
       await exporter.exportEvent(event);
@@ -319,7 +324,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: toolSpan,
+        exportedSpan: toolSpan,
       };
 
       await exporter.exportEvent(event);
@@ -357,7 +362,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: agentSpan,
+        exportedSpan: agentSpan,
       };
 
       await exporter.exportEvent(event);
@@ -391,7 +396,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: mcpSpan,
+        exportedSpan: mcpSpan,
       };
 
       await exporter.exportEvent(event);
@@ -423,7 +428,7 @@ describe('LangfuseExporter', () => {
 
       const event: AITracingEvent = {
         type: AITracingEventType.SPAN_STARTED,
-        span: workflowSpan,
+        exportedSpan: workflowSpan,
       };
 
       await exporter.exportEvent(event);
@@ -453,7 +458,7 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span: llmSpan,
+        exportedSpan: llmSpan,
       });
 
       // Then update it
@@ -465,7 +470,7 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_UPDATED,
-        span: llmSpan,
+        exportedSpan: llmSpan,
       });
 
       expect(mockGeneration.update).toHaveBeenCalledWith({
@@ -491,7 +496,7 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span: toolSpan,
+        exportedSpan: toolSpan,
       });
 
       // Update with success
@@ -503,7 +508,7 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_UPDATED,
-        span: toolSpan,
+        exportedSpan: toolSpan,
       });
 
       expect(mockSpan.update).toHaveBeenCalledWith({
@@ -518,7 +523,7 @@ describe('LangfuseExporter', () => {
 
   describe('Span Ending', () => {
     it('should update span with endTime on span end', async () => {
-      const span = createMockSpan({
+      const exportedSpan = createMockSpan({
         id: 'test-span',
         name: 'test',
         type: AISpanType.GENERIC,
@@ -528,18 +533,18 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span,
+        exportedSpan,
       });
 
-      span.endTime = new Date();
+      exportedSpan.endTime = new Date();
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span,
+        exportedSpan,
       });
 
       expect(mockSpan.update).toHaveBeenCalledWith({
-        endTime: span.endTime,
+        endTime: exportedSpan.endTime,
         metadata: expect.objectContaining({
           spanType: 'generic',
         }),
@@ -566,12 +571,12 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span: errorSpan,
+        exportedSpan: errorSpan,
       });
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: errorSpan,
+        exportedSpan: errorSpan,
       });
 
       expect(mockSpan.update).toHaveBeenCalledWith({
@@ -585,7 +590,7 @@ describe('LangfuseExporter', () => {
       });
     });
 
-    it('should update root trace and delete from traceMap when root span ends', async () => {
+    it('should update root trace and clean up when root span ends (if no other active spans)', async () => {
       const rootSpan = createMockSpan({
         id: 'root-span-id',
         name: 'root-span',
@@ -599,15 +604,17 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span: rootSpan,
+        exportedSpan: rootSpan,
       });
 
-      // Verify trace was created
+      // Verify trace was created and span is tracked as active
       expect((exporter as any).traceMap.has('root-span-id')).toBe(true);
+      const traceData = (exporter as any).traceMap.get('root-span-id');
+      expect(traceData.activeSpans.has('root-span-id')).toBe(true);
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_ENDED,
-        span: rootSpan,
+        exportedSpan: rootSpan,
       });
 
       // Should update trace with output
@@ -615,7 +622,7 @@ describe('LangfuseExporter', () => {
         output: { result: 'success' },
       });
 
-      // Should remove trace from traceMap
+      // Trace should be cleaned up since this was the only active span
       expect((exporter as any).traceMap.has('root-span-id')).toBe(false);
     });
   });
@@ -634,7 +641,7 @@ describe('LangfuseExporter', () => {
       await expect(
         exporter.exportEvent({
           type: AITracingEventType.SPAN_STARTED,
-          span: orphanSpan,
+          exportedSpan: orphanSpan,
         }),
       ).resolves.not.toThrow();
 
@@ -644,7 +651,7 @@ describe('LangfuseExporter', () => {
     });
 
     it('should handle missing Langfuse objects gracefully', async () => {
-      const span = createMockSpan({
+      const exportedSpan = createMockSpan({
         id: 'missing-span',
         name: 'missing',
         type: AISpanType.GENERIC,
@@ -656,7 +663,7 @@ describe('LangfuseExporter', () => {
       await expect(
         exporter.exportEvent({
           type: AITracingEventType.SPAN_UPDATED,
-          span,
+          exportedSpan,
         }),
       ).resolves.not.toThrow();
 
@@ -664,7 +671,7 @@ describe('LangfuseExporter', () => {
       await expect(
         exporter.exportEvent({
           type: AITracingEventType.SPAN_ENDED,
-          span,
+          exportedSpan,
         }),
       ).resolves.not.toThrow();
     });
@@ -698,7 +705,7 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span: eventSpan,
+        exportedSpan: eventSpan,
       });
 
       // Should create trace for root event span
@@ -739,7 +746,7 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span: rootSpan,
+        exportedSpan: rootSpan,
       });
 
       // Then create a child event span
@@ -756,11 +763,11 @@ describe('LangfuseExporter', () => {
       });
       childEventSpan.isEvent = true;
       childEventSpan.traceId = 'root-span-id';
-      childEventSpan.parent = { id: 'root-span-id' };
+      childEventSpan.parentSpanId = 'root-span-id';
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span: childEventSpan,
+        exportedSpan: childEventSpan,
       });
 
       // Should create event under the parent span
@@ -792,7 +799,7 @@ describe('LangfuseExporter', () => {
       await expect(
         exporter.exportEvent({
           type: AITracingEventType.SPAN_STARTED,
-          span: orphanEventSpan,
+          exportedSpan: orphanEventSpan,
         }),
       ).resolves.not.toThrow();
 
@@ -802,10 +809,248 @@ describe('LangfuseExporter', () => {
     });
   });
 
+  describe('Out-of-order span handling with delayed ends', () => {
+    it('should handle spans that end after parent trace is removed', async () => {
+      // Create a root workflow span
+      const workflowSpan = createMockSpan({
+        id: 'workflow-1',
+        name: 'test-workflow',
+        type: AISpanType.WORKFLOW_RUN,
+        isRoot: true,
+        attributes: { workflowId: 'wf-123' },
+      });
+
+      // Create a child step span
+      const step1Span = createMockSpan({
+        id: 'step-1',
+        name: 'step-one',
+        type: AISpanType.WORKFLOW_STEP,
+        isRoot: false,
+        attributes: { stepId: 'step-1' },
+      });
+      step1Span.traceId = 'workflow-1';
+      step1Span.parentSpanId = 'workflow-1';
+
+      // Start workflow and step
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: workflowSpan,
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: step1Span,
+      });
+
+      // Verify trace and spans are tracked
+      expect((exporter as any).traceMap.has('workflow-1')).toBe(true);
+      const traceInfo = (exporter as any).traceMap.get('workflow-1');
+      expect(traceInfo.spans.has('step-1')).toBe(true);
+
+      // Clear mock calls to make assertions clearer
+      mockTrace.span.mockClear();
+      mockSpan.update.mockClear();
+      mockTrace.update.mockClear();
+
+      // Update step 1
+      step1Span.output = { result: 'step1-complete' };
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_UPDATED,
+        exportedSpan: step1Span,
+      });
+
+      expect(mockSpan.update).toHaveBeenCalledWith({
+        output: { result: 'step1-complete' },
+        metadata: expect.objectContaining({
+          spanType: 'workflow_step',
+          stepId: 'step-1',
+        }),
+      });
+
+      // End step 1
+      step1Span.endTime = new Date();
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: step1Span,
+      });
+
+      expect(mockSpan.update).toHaveBeenCalledWith({
+        endTime: step1Span.endTime,
+        output: { result: 'step1-complete' }, // Output is still included from previous update
+        metadata: expect.objectContaining({
+          spanType: 'workflow_step',
+          stepId: 'step-1',
+        }),
+      });
+
+      // Start step 2 (but don't end it yet - this is the key to testing out-of-order)
+      const step2Span = createMockSpan({
+        id: 'step-2',
+        name: 'step-two',
+        type: AISpanType.WORKFLOW_STEP,
+        isRoot: false,
+        attributes: { stepId: 'step-2' },
+      });
+      step2Span.traceId = 'workflow-1';
+      step2Span.parentSpanId = 'workflow-1';
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: step2Span,
+      });
+
+      // Update workflow
+      workflowSpan.output = { status: 'completed' };
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_UPDATED,
+        exportedSpan: workflowSpan,
+      });
+
+      // End workflow (root span) BEFORE step-2 ends - this is the out-of-order scenario
+      workflowSpan.endTime = new Date();
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: workflowSpan,
+      });
+
+      // Verify trace is still in map because step-2 hasn't ended yet
+      expect((exporter as any).traceMap.has('workflow-1')).toBe(true);
+      const traceData = (exporter as any).traceMap.get('workflow-1');
+      // step-2 should still be in activeSpans
+      expect(traceData.activeSpans.has('step-2')).toBe(true);
+      expect(traceData.activeSpans.has('step-1')).toBe(false); // step-1 already ended
+      expect(traceData.activeSpans.has('workflow-1')).toBe(false); // workflow ended
+
+      // Now end step-2 (the last active span) AFTER the root ended
+      step2Span.endTime = new Date();
+      step2Span.output = { result: 'step2-complete' };
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: step2Span,
+      });
+
+      // NOW the trace should be cleaned up since all spans have ended
+      expect((exporter as any).traceMap.has('workflow-1')).toBe(false);
+
+      // Clear mocks for late event testing
+      mockSpan.update.mockClear();
+      mockTrace.update.mockClear();
+
+      // Now try to send late updates/ends for already completed trace
+      const lateStep1Update = createMockSpan({
+        id: 'step-1',
+        name: 'step-one',
+        type: AISpanType.WORKFLOW_STEP,
+        isRoot: false,
+        attributes: { stepId: 'step-1', lateUpdate: true },
+      });
+      lateStep1Update.traceId = 'workflow-1';
+      lateStep1Update.parentSpanId = 'workflow-1';
+      lateStep1Update.output = { result: 'late-update' };
+
+      // This should handle gracefully without errors
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_UPDATED,
+        exportedSpan: lateStep1Update,
+      });
+
+      // Should not attempt to update since trace is gone
+      expect(mockSpan.update).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple rapid updates and ends in sequence', async () => {
+      // Simulate rapid-fire events that might arrive out of order
+      const rootSpan = createMockSpan({
+        id: 'root-1',
+        name: 'rapid-root',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: { agentId: 'rapid-agent' },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Create multiple child spans
+      const childSpans: AnyExportedAISpan[] = [];
+      for (let i = 1; i <= 5; i++) {
+        const child = createMockSpan({
+          id: `child-${i}`,
+          name: `rapid-child-${i}`,
+          type: AISpanType.TOOL_CALL,
+          isRoot: false,
+          attributes: { toolId: `tool-${i}` },
+        });
+        child.traceId = 'root-1';
+        child.parentSpanId = 'root-1';
+        childSpans.push(child);
+      }
+
+      // Start all children rapidly
+      for (const child of childSpans) {
+        await exporter.exportEvent({
+          type: AITracingEventType.SPAN_STARTED,
+          exportedSpan: child,
+        });
+      }
+
+      // Update and end children in mixed order
+      // End child 3
+      childSpans[2].endTime = new Date();
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: childSpans[2],
+      });
+
+      // Update child 1
+      childSpans[0].output = { result: 'child-1-result' };
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_UPDATED,
+        exportedSpan: childSpans[0],
+      });
+
+      // End child 5
+      childSpans[4].endTime = new Date();
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: childSpans[4],
+      });
+
+      // Update child 3 (after it ended)
+      childSpans[2].output = { result: 'late-update-3' };
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_UPDATED,
+        exportedSpan: childSpans[2],
+      });
+
+      // End remaining children
+      for (const child of [childSpans[0], childSpans[1], childSpans[3]]) {
+        child.endTime = new Date();
+        await exporter.exportEvent({
+          type: AITracingEventType.SPAN_ENDED,
+          exportedSpan: child,
+        });
+      }
+
+      // End root
+      rootSpan.endTime = new Date();
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: rootSpan,
+      });
+
+      // All operations should complete without errors
+      // Trace should be cleaned up since all spans have ended
+      expect((exporter as any).traceMap.has('root-1')).toBe(false);
+    });
+  });
+
   describe('Shutdown', () => {
     it('should shutdown Langfuse client and clear maps', async () => {
       // Add some data to internal maps
-      const span = createMockSpan({
+      const exportedSpan = createMockSpan({
         id: 'test-span',
         name: 'test',
         type: AISpanType.GENERIC,
@@ -815,7 +1060,7 @@ describe('LangfuseExporter', () => {
 
       await exporter.exportEvent({
         type: AITracingEventType.SPAN_STARTED,
-        span,
+        exportedSpan,
       });
 
       // Verify maps have data
@@ -855,8 +1100,8 @@ function createMockSpan({
   input?: any;
   output?: any;
   errorInfo?: any;
-}): AnyAISpan {
-  const mockSpan = {
+}): AnyExportedAISpan {
+  return {
     id,
     name,
     type,
@@ -868,22 +1113,8 @@ function createMockSpan({
     startTime: new Date(),
     endTime: undefined,
     traceId: isRoot ? id : 'parent-trace-id',
-    get isRootSpan() {
-      return isRoot;
-    },
-    trace: {
-      id: isRoot ? id : 'parent-trace-id',
-      traceId: isRoot ? id : 'parent-trace-id',
-    } as AnyAISpan,
-    parent: isRoot ? undefined : { id: 'parent-id' },
-    aiTracing: {} as any,
-    end: vi.fn(),
-    error: vi.fn(),
-    update: vi.fn(),
-    createChildSpan: vi.fn(),
-    createEventSpan: vi.fn(),
+    isRootSpan: isRoot,
+    parentSpanId: isRoot ? undefined : 'parent-id',
     isEvent: false,
-  } as AnyAISpan;
-
-  return mockSpan;
+  };
 }

--- a/observability/langfuse/src/ai-tracing.ts
+++ b/observability/langfuse/src/ai-tracing.ts
@@ -36,6 +36,8 @@ type TraceData = {
   trace: LangfuseTraceClient; // Langfuse trace object
   spans: Map<string, LangfuseSpanClient | LangfuseGenerationClient>; // Maps span.id to Langfuse span/generation
   events: Map<string, LangfuseEventClient>; // Maps span.id to Langfuse event
+  activeSpans: Set<string>; // Tracks which spans haven't ended yet
+  rootSpanId?: string; // Track the root span ID
 };
 
 type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient | LangfuseEventClient;
@@ -120,6 +122,7 @@ export class LangfuseExporter implements AITracingExporter {
       span.type === AISpanType.LLM_GENERATION ? langfuseParent.generation(payload) : langfuseParent.span(payload);
 
     traceData.spans.set(span.id, langfuseSpan);
+    traceData.activeSpans.add(span.id); // Track as active
   }
 
   private async handleSpanUpdateOrEnd(span: AnyExportedAISpan, isEnd: boolean): Promise<void> {
@@ -132,6 +135,16 @@ export class LangfuseExporter implements AITracingExporter {
 
     const langfuseSpan = traceData.spans.get(span.id);
     if (!langfuseSpan) {
+      // For event spans that only send SPAN_ENDED, we might not have the span yet
+      if (isEnd && span.isEvent) {
+        // Just make sure it's not in active spans
+        traceData.activeSpans.delete(span.id);
+        if (traceData.activeSpans.size === 0) {
+          this.traceMap.delete(span.traceId);
+        }
+        return;
+      }
+
       this.logger.warn('Langfuse exporter: No Langfuse span found for span update/end', {
         traceId: span.traceId,
         spanId: span.id,
@@ -148,9 +161,18 @@ export class LangfuseExporter implements AITracingExporter {
     // end time we set when ending the span.
     langfuseSpan.update(this.buildSpanPayload(span, false));
 
-    if (isEnd && span.isRootSpan) {
-      traceData.trace.update({ output: span.output });
-      this.traceMap.delete(span.traceId);
+    if (isEnd) {
+      // Remove from active spans
+      traceData.activeSpans.delete(span.id);
+
+      if (span.isRootSpan) {
+        traceData.trace.update({ output: span.output });
+      }
+
+      // Only clean up the trace when ALL spans have ended
+      if (traceData.activeSpans.size === 0) {
+        this.traceMap.delete(span.traceId);
+      }
     }
   }
 
@@ -181,18 +203,31 @@ export class LangfuseExporter implements AITracingExporter {
     const langfuseEvent = langfuseParent.event(payload);
 
     traceData.events.set(span.id, langfuseEvent);
+
+    // Event spans are typically immediately ended, but let's track them properly
+    if (!span.endTime) {
+      traceData.activeSpans.add(span.id);
+    }
   }
 
   private initTrace(span: AnyExportedAISpan): void {
     const trace = this.client.trace(this.buildTracePayload(span));
-    this.traceMap.set(span.traceId, { trace, spans: new Map(), events: new Map() });
+    this.traceMap.set(span.traceId, {
+      trace,
+      spans: new Map(),
+      events: new Map(),
+      activeSpans: new Set(),
+      rootSpanId: span.id,
+    });
   }
 
   private getTraceData(options: { span: AnyExportedAISpan; method: string }): TraceData | undefined {
     const { span, method } = options;
+
     if (this.traceMap.has(span.traceId)) {
       return this.traceMap.get(span.traceId);
     }
+
     this.logger.warn('Langfuse exporter: No trace data found for span', {
       traceId: span.traceId,
       spanId: span.id,


### PR DESCRIPTION
## Description

Fixes a critical issue where spans that completed after the root span finished were incorrectly treated as out-of-order and lost.

## Related Issue(s)

#6773

fixes #8041

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
