### PR TITLE
[Fix] DataTimePicker style issue

### DIFF
--- a/.changeset/metal-buttons-read.md
+++ b/.changeset/metal-buttons-read.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground-ui': patch
----
-
-Fix DateTimePicker style issue

--- a/.changeset/metal-buttons-read.md
+++ b/.changeset/metal-buttons-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix DateTimePicker style issue

--- a/.changeset/quiet-teeth-make.md
+++ b/.changeset/quiet-teeth-make.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Fix DateTimePicker style issue

--- a/packages/playground-ui/src/components/ui/elements/date-time-picker/date-time-picker.tsx
+++ b/packages/playground-ui/src/components/ui/elements/date-time-picker/date-time-picker.tsx
@@ -53,7 +53,7 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
         )}
       </PopoverTrigger>
       <PopoverContent
-        className="backdrop-blur-4xl w-auto p-0 bg-surface4 max-w-[16.5rem]"
+        className="backdrop-blur-4xl w-auto !p-0 bg-surface4"
         align="start"
         data-testid="datepicker-calendar"
       >
@@ -196,7 +196,7 @@ export const DateTimePickerContent = ({
   return (
     <div
       aria-label="Choose date"
-      className={cn('relative mt-2 flex flex-col ', className)}
+      className={cn('relative flex flex-col', className)}
       onKeyDown={e => {
         e.stopPropagation();
         if (e.key === 'Escape') {

--- a/packages/playground-ui/src/components/ui/elements/date-time-picker/date-time-picker.tsx
+++ b/packages/playground-ui/src/components/ui/elements/date-time-picker/date-time-picker.tsx
@@ -53,7 +53,7 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
         )}
       </PopoverTrigger>
       <PopoverContent
-        className="backdrop-blur-4xl w-auto !p-0 bg-surface4"
+        className="backdrop-blur-4xl w-auto !p-0 bg-surface4 max-w-[16.5rem]"
         align="start"
         data-testid="datepicker-calendar"
       >


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Fix style/padding issue at DateTimePicker Popover content

before

<img width="1622" height="927" alt="CleanShot 2025-09-23 at 13 16 21" src="https://github.com/user-attachments/assets/ecad013c-2771-430b-8cb0-b24735b67194" />


after 

 
<img width="1589" height="933" alt="CleanShot 2025-09-23 at 13 17 44" src="https://github.com/user-attachments/assets/4faa0bf6-d0f2-4d4a-87cd-e32b88f609df" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
