### PR TITLE
fix(core): generateVNext tripwrire

### DIFF
--- a/.changeset/quiet-symbols-move.md
+++ b/.changeset/quiet-symbols-move.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix generateVNext tripwire return value

--- a/packages/core/src/agent/agent-processor.test.ts
+++ b/packages/core/src/agent/agent-processor.test.ts
@@ -324,8 +324,9 @@ describe('Input and Output Processors with VNext Methods', () => {
 
       const stream = await agentWithStreamAbort.streamVNext('Stream abort test');
 
-      expect(stream.tripwire).toBe(true);
-      expect(stream.tripwireReason).toBe('Stream aborted');
+      const fullOutput = await stream.getFullOutput();
+      expect(fullOutput.tripwire).toBe(true);
+      expect(fullOutput.tripwireReason).toBe('Stream aborted');
 
       // Stream should be empty
       let textReceived = '';

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -23,6 +23,7 @@ import { createScorer } from '../scores';
 import { runScorer } from '../scores/hooks';
 import { MockStore } from '../storage';
 import type { AIV5FullStreamPart } from '../stream/aisdk/v5/output';
+import type { MastraModelOutput } from '../stream/base/output';
 import type { ChunkType } from '../stream/types';
 import { createMockModel } from '../test-utils/llm-mock';
 import { createTool } from '../tools';
@@ -8083,6 +8084,8 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         let stream;
         if (version === 'v1') {
           stream = await agentWithStreamAbort.stream('Stream abort test');
+          expect(stream.tripwire).toBe(true);
+          expect(stream.tripwireReason).toBe('Stream aborted');
         } else {
           stream = await agentWithStreamAbort.streamVNext('Stream abort test');
 
@@ -8090,10 +8093,10 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
             expect(chunk.type).toBe('tripwire');
             expect(chunk.payload.tripwireReason).toBe('Stream aborted');
           }
+          const fullOutput = await (stream as MastraModelOutput<any>).getFullOutput();
+          expect(fullOutput.tripwire).toBe(true);
+          expect(fullOutput.tripwireReason).toBe('Stream aborted');
         }
-
-        expect(stream.tripwire).toBe(true);
-        expect(stream.tripwireReason).toBe('Stream aborted');
 
         // Stream should be empty
         let textReceived = '';
@@ -8126,10 +8129,9 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           stream = await agentWithDeployerAbort.streamVNext('Deployer abort test');
         }
 
-        expect(stream.tripwire).toBe(true);
-        expect(stream.tripwireReason).toBe('Deployer test abort');
-
         if (version === 'v1') {
+          expect(stream.tripwire).toBe(true);
+          expect(stream.tripwireReason).toBe('Deployer test abort');
           // Verify deployer methods exist and return Response objects
           expect(typeof stream.toDataStreamResponse).toBe('function');
           expect(typeof stream.toTextStreamResponse).toBe('function');
@@ -8147,6 +8149,10 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
           expect(typeof stream.pipeTextStreamToResponse).toBe('function');
           expect(stream.experimental_partialOutputStream).toBeDefined();
           expect(typeof stream.experimental_partialOutputStream[Symbol.asyncIterator]).toBe('function');
+        } else if (version === 'v2') {
+          const fullOutput = await (stream as MastraModelOutput<any>).getFullOutput();
+          expect(fullOutput.tripwire).toBe(true);
+          expect(fullOutput.tripwireReason).toBe('Deployer test abort');
         }
       });
     });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3316,14 +3316,7 @@ export class Agent<
       : Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>
   > {
     const result = await this.streamVNext(messages, options);
-
-    if (result.tripwire) {
-      return result as unknown as FORMAT extends 'aisdk'
-        ? Awaited<ReturnType<AISDKV5OutputStream<OUTPUT>['getFullOutput']>>
-        : Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>;
-    }
-
-    let fullOutput = await result.getFullOutput();
+    const fullOutput = await result.getFullOutput();
 
     const error = fullOutput.error;
 
@@ -3331,7 +3324,7 @@ export class Agent<
       throw error;
     }
 
-    return fullOutput as unknown as FORMAT extends 'aisdk'
+    return fullOutput as FORMAT extends 'aisdk'
       ? Awaited<ReturnType<AISDKV5OutputStream<OUTPUT>['getFullOutput']>>
       : Awaited<ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>>;
   }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3072,6 +3072,7 @@ export class Agent<
       executeOnFinish: this.#executeOnFinish.bind(this),
       outputProcessors: this.#outputProcessors,
       llm,
+      getTelemetry: this.#mastra?.getTelemetry?.bind(this.#mastra),
     };
 
     // Create the workflow with all necessary context

--- a/packages/core/src/agent/trip-wire.ts
+++ b/packages/core/src/agent/trip-wire.ts
@@ -1,3 +1,14 @@
+import { randomUUID } from 'crypto';
+import { ReadableStream } from 'stream/web';
+import type { TracingContext } from '../ai-tracing';
+import type { MastraLanguageModel } from '../llm/model/shared.types';
+import { getRootSpan } from '../loop/telemetry';
+import { ChunkFrom, MastraModelOutput } from '../stream';
+import type { OutputSchema } from '../stream/base/schema';
+import type { ChunkType } from '../stream/types';
+import type { InnerAgentExecutionOptions } from './agent.types';
+import type { MessageList } from './message-list';
+
 export class TripWire extends Error {
   constructor(reason: string) {
     super(reason);
@@ -5,3 +16,71 @@ export class TripWire extends Error {
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
+
+export const getModelOutputForTripwire = async <
+  OUTPUT extends OutputSchema | undefined = undefined,
+  FORMAT extends 'aisdk' | 'mastra' | undefined = undefined,
+>({
+  tripwireReason,
+  runId,
+  tracingContext,
+  options,
+  model,
+  messageList,
+}: {
+  tripwireReason: string;
+  runId: string;
+  tracingContext: TracingContext;
+  options: InnerAgentExecutionOptions<OUTPUT, FORMAT>;
+  model: MastraLanguageModel;
+  messageList: MessageList;
+}) => {
+  const tripwireStream = new ReadableStream<ChunkType<OUTPUT>>({
+    start(controller) {
+      controller.enqueue({
+        type: 'tripwire',
+        runId,
+        from: ChunkFrom.AGENT,
+        payload: {
+          tripwireReason: tripwireReason || '',
+        },
+      });
+      controller.close();
+    },
+  });
+
+  // Create a proper rootSpan using getRootSpan for tripwire response
+  const { rootSpan } = getRootSpan({
+    operationId: `mastra.stream.tripwire`,
+    model: {
+      modelId: model.modelId || 'unknown',
+      provider: model.provider || 'unknown',
+    },
+    modelSettings: options.modelSettings,
+    headers: options.modelSettings?.headers,
+    telemetry_settings: options.telemetry,
+  });
+
+  const modelOutput = new MastraModelOutput<OUTPUT>({
+    model: {
+      modelId: model.modelId,
+      provider: model.provider,
+      version: model.specificationVersion || 'v2',
+    },
+    stream: tripwireStream,
+    messageList,
+    options: {
+      runId,
+      rootSpan,
+      telemetry_settings: options.telemetry,
+      output: options.output,
+      tracingContext,
+      onFinish: options.onFinish as any, // Fix these types after the types PR is merged
+      onStepFinish: options.onStepFinish as any,
+      returnScorerData: options.returnScorerData,
+    },
+    messageId: randomUUID(),
+  });
+
+  return modelOutput;
+};

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -1,16 +1,14 @@
-import { randomUUID } from 'crypto';
-import type { AISpan, AISpanType } from '../../../ai-tracing';
+import type { AISpan, AISpanType, TracingContext } from '../../../ai-tracing';
 import type { SystemMessage } from '../../../llm';
 import type { ModelLoopStreamArgs } from '../../../llm/model/model.loop.types';
 import type { MastraMemory } from '../../../memory/memory';
 import type { MemoryConfig } from '../../../memory/types';
 import { StructuredOutputProcessor } from '../../../processors';
 import type { RuntimeContext } from '../../../runtime-context';
-import { ChunkFrom } from '../../../stream';
 import type { OutputSchema } from '../../../stream/base/schema';
-import type { ChunkType } from '../../../stream/types';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
 import type { SaveQueueManager } from '../../save-queue';
+import { getModelOutputForTripwire } from '../../trip-wire';
 import type { AgentCapabilities, PrepareMemoryStepOutput, PrepareToolsStepOutput } from './schema';
 
 interface MapResultsStepOptions<
@@ -47,12 +45,14 @@ export function createMapResultsStep<
   return async ({
     inputData,
     bail,
+    tracingContext,
   }: {
     inputData: {
       'prepare-tools-step': PrepareToolsStepOutput;
       'prepare-memory-step': PrepareMemoryStepOutput;
     };
     bail: <T>(value: T) => T;
+    tracingContext: TracingContext;
   }) => {
     const toolsData = inputData['prepare-tools-step'];
     const memoryData = inputData['prepare-memory-step'];
@@ -102,52 +102,18 @@ export function createMapResultsStep<
 
     // Check for tripwire and return early if triggered
     if (result.tripwire) {
-      const emptyResult = {
-        textStream: (async function* () {
-          // Empty async generator - yields nothing
-        })(),
-        fullStream: new globalThis.ReadableStream<ChunkType>({
-          start(controller) {
-            controller.enqueue({
-              type: 'tripwire',
-              runId: result.runId,
-              from: ChunkFrom.AGENT,
-              payload: {
-                tripwireReason: result.tripwireReason || '',
-              },
-            });
-            controller.close();
-          },
-        }),
-        objectStream: new globalThis.ReadableStream({
-          start(controller) {
-            controller.close();
-          },
-        }),
-        text: Promise.resolve(''),
-        usage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
-        finishReason: Promise.resolve('other'),
-        tripwire: true,
-        tripwireReason: result.tripwireReason,
-        response: {
-          id: randomUUID(),
-          timestamp: new Date(),
-          modelId: 'tripwire',
-          messages: [],
-        },
-        toolCalls: Promise.resolve([]),
-        toolResults: Promise.resolve([]),
-        warnings: Promise.resolve(undefined),
-        request: {
-          body: JSON.stringify({ messages: [] }),
-        },
-        object: undefined,
-        experimental_output: undefined,
-        steps: undefined,
-        experimental_providerMetadata: undefined,
-      };
+      const agentModel = await capabilities.getModel({ runtimeContext: result.runtimeContext! });
 
-      return bail(emptyResult);
+      const modelOutput = await getModelOutputForTripwire({
+        tripwireReason: result.tripwireReason!,
+        runId,
+        tracingContext,
+        options,
+        model: agentModel,
+        messageList: memoryData.messageList,
+      });
+
+      return bail(modelOutput);
     }
 
     let effectiveOutputProcessors =

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -3,6 +3,7 @@ import type { MastraBase } from '../../../base';
 import type { MastraLLMVNext } from '../../../llm/model/model.loop';
 import type { Mastra } from '../../../mastra';
 import type { OutputProcessor } from '../../../processors';
+import type { Telemetry } from '../../../telemetry';
 import type { DynamicArgument } from '../../../types';
 import type { Agent } from '../../agent';
 import { MessageList } from '../../message-list';
@@ -22,6 +23,7 @@ export type AgentCapabilities = {
   executeOnFinish: (args: AgentExecuteOnFinishOptions) => Promise<void>;
   outputProcessors?: DynamicArgument<OutputProcessor[]>;
   llm: MastraLLMVNext;
+  getTelemetry?: () => Telemetry | undefined;
 };
 
 const coreToolSchema = z.object({


### PR DESCRIPTION
## Description

Because we were casting the return types as unknown, we missed that the response we return for the tripwire case is actually a stream response, not a generate response.

I also removed the condition for returning tripwire as it should just return a normal response, there shouldn't be anything special with the return for it.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
