### PR TITLE
temp skip windows

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -68,7 +68,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
+        # os: [ubuntu-latest, windows-latest] # <- windows is skipped for now because the CI setup doesn't work and is blocking PR merges
     timeout-minutes: 15
     permissions:
       contents: read


### PR DESCRIPTION
Seems these e2e tests haven't worked for a long time, skipping for now since it's a CI setup issue and not test failures and we need to unblock merging PRs without admin merge