### PR TITLE
fix more ci flakiness

### DIFF
--- a/packages/rag/src/document/extractors/title.test.ts
+++ b/packages/rag/src/document/extractors/title.test.ts
@@ -9,7 +9,7 @@ const openai = createOpenAI({
 
 const model = openai('gpt-4o');
 
-vi.setConfig({ testTimeout: 100_000, hookTimeout: 100_000 });
+vi.setConfig({ testTimeout: 300_000, hookTimeout: 300_000 });
 
 describe('TitleExtractor', () => {
   it('can use a custom model from the test suite', async () => {

--- a/stores/vectorize/src/vector/index.test.ts
+++ b/stores/vectorize/src/vector/index.test.ts
@@ -336,7 +336,9 @@ describe('CloudflareVector', () => {
       expect(indexes).toContain(testIndexName);
     });
 
-    it('should insert vectors and query them', async () => {
+    // skipping because this fails in CI 80% of the time due to the test being stateful across all tests
+    // when we figure out how to make it not fail when multiple tests are running, we can re-enable, for now this test failing just makes us ignore vectorize tests
+    it.skip('should insert vectors and query them', async () => {
       const testVectors = [createVector(0, 1.0), createVector(1, 1.0), createVector(2, 1.0)];
 
       const testMetadata = [{ label: 'first-dimension' }, { label: 'second-dimension' }, { label: 'third-dimension' }];
@@ -415,7 +417,9 @@ describe('CloudflareVector', () => {
       }
     });
 
-    it('should update the vector by id', async () => {
+    // skipping because this fails in CI 80% of the time due to the test being stateful across all tests
+    // when we figure out how to make it not fail when multiple tests are running, we can re-enable, for now this test failing just makes us ignore vectorize tests
+    it.skip('should update the vector by id', async () => {
       const ids = await vectorDB.upsert({ indexName: indexName1, vectors: testVectors });
       expect(ids).toHaveLength(3);
 
@@ -503,7 +507,9 @@ describe('CloudflareVector', () => {
       }
     });
 
-    it('should delete the vector by id', async () => {
+    // skipping because this fails in CI 80% of the time due to the test being stateful across all tests
+    // when we figure out how to make it not fail when multiple tests are running, we can re-enable, for now this test failing just makes us ignore vectorize tests
+    it.skip('should delete the vector by id', async () => {
       const ids = await vectorDB.upsert({ indexName, vectors: testVectors });
       await waitUntilVectorsIndexed(vectorDB, indexName, testVectors.length);
       expect(ids).toHaveLength(3);


### PR DESCRIPTION
1. extended the timeout for title extractor test which seems to run very slow in gh actions
2. skipped vectorize tests that are stateful across concurrent PR test runs - we can re-enable _if_ we can figure out how to make them not stateful. for now these tests just condition us to expect them to fail