### PR TITLE
fix navigating between scores and entity types

### DIFF
--- a/.changeset/ready-houses-stand.md
+++ b/.changeset/ready-houses-stand.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/core': patch
+---
+
+Fix navigating between scores and entity types

--- a/.changeset/ready-houses-stand.md
+++ b/.changeset/ready-houses-stand.md
@@ -1,6 +1,7 @@
 ---
 '@mastra/playground-ui': patch
 '@mastra/core': patch
+'mastra': patch
 ---
 
 Fix navigating between scores and entity types

--- a/packages/core/src/mastra/hook.test.ts
+++ b/packages/core/src/mastra/hook.test.ts
@@ -120,7 +120,7 @@ describe('createOnScorerHook', () => {
 
     await hookWithoutStorage({
       runId: 'test-run',
-      scorer: { id: 'test-scorer' },
+      scorer: { name: 'test-scorer' },
       input: [],
       output: {},
       source: 'LIVE',
@@ -135,7 +135,7 @@ describe('createOnScorerHook', () => {
   it('should save score', async () => {
     const hookData = {
       runId: 'test-run',
-      scorer: { id: 'test-scorer' },
+      scorer: { name: 'test-scorer' },
       input: [{ message: 'test' }],
       output: { result: 'test' },
       source: 'LIVE' as const,
@@ -195,7 +195,7 @@ describe('createOnScorerHook', () => {
   it('should handle scorer run failure without throwing', async () => {
     const hookData = {
       runId: 'test-run',
-      scorer: { id: 'test-scorer' },
+      scorer: { name: 'test-scorer' },
       input: [],
       output: {},
       source: 'LIVE' as const,
@@ -221,7 +221,7 @@ describe('createOnScorerHook', () => {
   it('should handle validation errors without throwing', async () => {
     const hookData = {
       runId: 'test-run',
-      scorer: { id: 'test-scorer' },
+      scorer: { name: 'test-scorer' },
       input: [],
       output: {},
       source: 'LIVE' as const,

--- a/packages/core/src/mastra/hooks.ts
+++ b/packages/core/src/mastra/hooks.ts
@@ -17,7 +17,7 @@ export function createOnScorerHook(mastra: Mastra) {
     const entityType = hookData.entityType;
     const scorer = hookData.scorer;
     try {
-      const scorerToUse = await findScorer(mastra, entityId, entityType, scorer.id);
+      const scorerToUse = await findScorer(mastra, entityId, entityType, scorer.name);
 
       if (!scorerToUse) {
         throw new MastraError({
@@ -43,7 +43,7 @@ export function createOnScorerHook(mastra: Mastra) {
         ...rest,
         ...runResult,
         entityId,
-        scorerId: hookData.scorer.id,
+        scorerId: hookData.scorer.name,
         metadata: {
           structuredOutput: !!structuredOutput,
         },

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -214,7 +214,7 @@ export const AgentMetadataScorerList = ({ entityId, entityType }: AgentMetadataS
     .filter(scorerKey => {
       const scorer = scorers[scorerKey];
       if (entityType === 'AGENT') {
-        return scorer.agentIds.includes(entityId);
+        return scorer.agentNames.includes(entityId);
       }
 
       return scorer.workflowIds.includes(entityId);

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -117,7 +117,7 @@ export default function Scorer({ computeTraceLink }: ScorerProps) {
       value: (scorerEntities || []).map(entity => ({
         id: entity.id,
         name: entity.name || entity.id,
-        path: `${entity.type === 'AGENT' ? '/agents' : '/workflows'}/${entity.id}`,
+        path: `${entity.type === 'AGENT' ? '/agents' : '/workflows'}/${entity.name}`,
       })),
     },
   ];


### PR DESCRIPTION
## Description

Instead of using scorerId (the ID of the scorer from the scorer config object), we will now use the scorer name.

This PR fixes two bugs:

Navigating between scorers and entities was broken.

The scorers page displayed multiple scorers for the same scorer instance.

For example, if you had two agents like this:
```
const scorer = createScorer({ name: 'test-scorer' })
const agent1 = new Agent({ ...scorer: { scorerForAgent1: { scorer } } })
const agent2 = new Agent({ ...scorer: { scorerForAgent2: { scorer } } })
```

The scorers page would show scorerForAgent1 and scorerForAgent2 as separate scorers.

This PR changes the logic so that we use the scorer name (test-scorer) when collecting scores, preventing duplicates.


heres a clip to show the navigation works

https://github.com/user-attachments/assets/4ba8bfce-d719-4dbe-9350-a427fe486b51



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
