### PR TITLE
feat(inngest): add register options to serve function

### DIFF
--- a/.changeset/tame-bottles-strive.md
+++ b/.changeset/tame-bottles-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+add register options to serve function

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -30,7 +30,7 @@ import type {
 } from '@mastra/core/workflows';
 import { EMITTER_SYMBOL, STREAM_FORMAT_SYMBOL } from '@mastra/core/workflows/_constants';
 import type { Span } from '@opentelemetry/api';
-import type { Inngest, BaseContext, InngestFunction } from 'inngest';
+import type { Inngest, BaseContext, InngestFunction, RegisterOptions } from 'inngest';
 import { serve as inngestServe } from 'inngest/hono';
 import { z } from 'zod';
 
@@ -66,6 +66,7 @@ export function serve({
   mastra,
   inngest,
   functions: userFunctions = [],
+  registerOptions,
 }: {
   mastra: Mastra;
   inngest: Inngest;
@@ -73,6 +74,7 @@ export function serve({
    * Optional array of additional functions to serve and register with Inngest.
    */
   functions?: InngestFunction.Like[];
+  registerOptions?: RegisterOptions;
 }): ReturnType<typeof inngestServe> {
   const wfs = mastra.getWorkflows();
   const workflowFunctions = Array.from(
@@ -88,6 +90,7 @@ export function serve({
   );
 
   return inngestServe({
+    ...registerOptions,
     client: inngest,
     functions: [...workflowFunctions, ...userFunctions],
   });


### PR DESCRIPTION
## Description

Add support for passing `registerOptions` to the Inngest serve function, allowing users to configure additional registration settings when serving Mastra workflows through Inngest. This provides more flexibility in how functions are registered with the Inngest platform.

## Related Issue(s)

slack

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
