### PR TITLE
fix: correct workflow chunk unwrapping and writer stream locking in network execution

### DIFF
--- a/.changeset/clever-times-tickle.md
+++ b/.changeset/clever-times-tickle.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': patch
+---
+
+fix: correct workflow chunk unwrapping and writer stream locking in network execution
+
+  - Fix MastraAgentNetworkStream to properly unwrap workflow subchunks in parallel
+  execution
+  - Adjust watch-v2 event handling to prevent execution steps from starting with locked
+  writer streams
+  - Ensure proper chunk type propagation through network stream for agents in parallel
+  workflows
+
+  Changes resolve uncaught stream errors when agents are invoked within parallel workflow
+   steps
+  by correctly extracting inner chunks and preventing writer stream conflicts.
+
+  test: add comprehensive test coverage for parallel workflow agent streaming
+  - Verify all stream events are properly typed and sequenced
+  - Validate text delta assembly and chunk propagation
+  - Ensure no writer stream locking issues occur

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -406,7 +406,7 @@ export async function createNetworkLoop({
       const result = await agentForStep.streamVNext(inputData.prompt, {
         // resourceId: inputData.resourceId,
         // threadId: inputData.threadId,
-        runtimeContext: runtimeContext,
+        runtimeContext,
         runId,
       });
 

--- a/packages/core/src/stream/MastraAgentNetworkStream.ts
+++ b/packages/core/src/stream/MastraAgentNetworkStream.ts
@@ -75,7 +75,11 @@ export class MastraAgentNetworkStream extends ReadableStream<ChunkType> {
             const innerChunk = chunk.payload.output;
             const innerChunkType = innerChunk.payload.output;
 
-            controller.enqueue(innerChunkType);
+            if (innerChunk && innerChunkType) {
+              controller.enqueue(innerChunkType);
+            } else {
+              controller.enqueue(innerChunk);
+            }
           }
         }
 

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -743,7 +743,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     });
 
     if (!skipEmits) {
-      emitter.emit('watch', {
+      await emitter.emit('watch', {
         type: 'watch',
         payload: {
           currentStep: {
@@ -765,7 +765,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
         eventTimestamp: Date.now(),
       });
 
-      emitter.emit('watch-v2', {
+      await emitter.emit('watch-v2', {
         type: 'workflow-step-start',
         payload: {
           id: step.id,
@@ -776,7 +776,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
 
       // maybe we don't have listeners and stream was not locked
       if (writableStream?.locked) {
-        await once(emitter as NodeJS.EventEmitter, kWritableStreamUnlocked);
+        await once(emitter as unknown as NodeJS.EventEmitter, kWritableStreamUnlocked);
       }
     }
 

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -399,8 +399,8 @@ export class EventedRun<
       serializedStepGraph: this.serializedStepGraph,
       input: inputData,
       emitter: {
-        emit: async (event: string, data: any) => {
-          this.emitter.emit(event, data);
+        emit: (event: string, data: any) => {
+          return this.emitter.emit(event, data);
         },
         on: (event: string, callback: (data: any) => void) => {
           this.emitter.on(event, callback);
@@ -492,8 +492,7 @@ export class EventedRun<
         },
         emitter: {
           emit: (event: string, data: any) => {
-            this.emitter.emit(event, data);
-            return Promise.resolve();
+            return this.emitter.emit(event, data);
           },
           on: (event: string, callback: (data: any) => void) => {
             this.emitter.on(event, callback);
@@ -585,7 +584,7 @@ export class EventedRun<
     });
   }
 
-  async sendEvent(eventName: string, data: any) {
+  override async sendEvent(eventName: string, data: any): Promise<void> {
     await this.mastra?.pubsub.publish('workflows', {
       type: `workflow.user-event.${eventName}`,
       runId: this.runId,

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -399,8 +399,8 @@ export class EventedRun<
       serializedStepGraph: this.serializedStepGraph,
       input: inputData,
       emitter: {
-        emit: (event: string, data: any) => {
-          return this.emitter.emit(event, data);
+        emit: async (event: string, data: any): Promise<void> => {
+          this.emitter.emit(event, data);
         },
         on: (event: string, callback: (data: any) => void) => {
           this.emitter.on(event, callback);
@@ -491,8 +491,8 @@ export class EventedRun<
           resumePath,
         },
         emitter: {
-          emit: (event: string, data: any) => {
-            return this.emitter.emit(event, data);
+          emit: async (event: string, data: any) => {
+            this.emitter.emit(event, data);
           },
           on: (event: string, callback: (data: any) => void) => {
             this.emitter.on(event, callback);

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -9,7 +9,7 @@ export type { ChunkType } from '../stream/types';
 export type { MastraWorkflowStream } from '../stream/MastraWorkflowStream';
 
 export type Emitter = {
-  emit: (event: string, data: any) => boolean;
+  emit: (event: string, data: any) => Promise<void>;
   on: (event: string, callback: (data: any) => void) => void;
   off: (event: string, callback: (data: any) => void) => void;
   once: (event: string, callback: (data: any) => void) => void;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -9,7 +9,7 @@ export type { ChunkType } from '../stream/types';
 export type { MastraWorkflowStream } from '../stream/MastraWorkflowStream';
 
 export type Emitter = {
-  emit: (event: string, data: any) => Promise<void>;
+  emit: (event: string, data: any) => boolean;
   on: (event: string, callback: (data: any) => void) => void;
   off: (event: string, callback: (data: any) => void) => void;
   once: (event: string, callback: (data: any) => void) => void;

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -19,7 +19,7 @@ import { Tool } from '../tools';
 import type { ToolExecutionContext } from '../tools/types';
 import type { DynamicArgument } from '../types';
 import { EMITTER_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
-import { DefaultExecutionEngine } from './default';
+import { DefaultExecutionEngine, kWritableStreamUnlocked } from './default';
 import type { ExecutionEngine, ExecutionGraph } from './execution-engine';
 import type { ExecuteFunction, Step } from './step';
 import type {
@@ -217,20 +217,20 @@ export function createStep<
         }
 
         if (streamFormat === 'aisdk') {
-          await emitter.emit('watch-v2', {
+          emitter.emit('watch-v2', {
             type: 'tool-call-streaming-start',
             ...(toolData ?? {}),
           });
           for await (const chunk of stream) {
             if (chunk.type === 'text-delta') {
-              await emitter.emit('watch-v2', {
+              emitter.emit('watch-v2', {
                 type: 'tool-call-delta',
                 ...(toolData ?? {}),
                 argsTextDelta: chunk.textDelta,
               });
             }
           }
-          await emitter.emit('watch-v2', {
+          emitter.emit('watch-v2', {
             type: 'tool-call-streaming-finish',
             ...(toolData ?? {}),
           });
@@ -1337,7 +1337,7 @@ export class Run<
     this.abortController?.abort();
   }
 
-  async sendEvent(event: string, data: any) {
+  async sendEvent(event: string, data: any): Promise<void> {
     this.emitter.emit(`user-event-${event}`, data);
   }
 
@@ -1381,8 +1381,8 @@ export class Run<
       serializedStepGraph: this.serializedStepGraph,
       input: inputData,
       emitter: {
-        emit: async (event: string, data: any) => {
-          this.emitter.emit(event, data);
+        emit: (event: string, data: any) => {
+          return this.emitter.emit(event, data);
         },
         on: (event: string, callback: (data: any) => void) => {
           this.emitter.on(event, callback);
@@ -1637,27 +1637,46 @@ export class Run<
 
         let buffer: ChunkType[] = [];
         let isWriting = false;
+
+        // TODO: implement queues system
         const tryWrite = async () => {
-          const chunkToWrite = buffer;
+          let chunkToWrite: ChunkType[] | null = buffer;
           buffer = [];
 
           if (chunkToWrite.length === 0 || isWriting) {
             return;
           }
+
+          if (writable.locked) {
+            // user may be still writing to the stream, so we need to wait for it to be unlocked
+            queueMicrotask(tryWrite);
+            return;
+          }
           isWriting = true;
 
+          // acquires lock
           let watchWriter = writable.getWriter();
 
           try {
-            for (const chunk of chunkToWrite) {
-              await watchWriter.write(chunk);
+            while (chunkToWrite !== null) {
+              for (const chunk of chunkToWrite) {
+                await watchWriter.write(chunk);
+              }
+
+              // if there are more chunks to write, set the next chunk to write
+              // goal is to finish writing all chunks before continuing with execution as we get exclusive lock
+              if (buffer.length > 0) {
+                chunkToWrite = buffer;
+                buffer = [];
+              } else {
+                chunkToWrite = null;
+              }
             }
           } finally {
             watchWriter.releaseLock();
+            this.emitter.emit(kWritableStreamUnlocked);
           }
           isWriting = false;
-
-          setImmediate(tryWrite);
         };
 
         // TODO: fix this, watch-v2 doesn't have a type
@@ -1673,6 +1692,7 @@ export class Run<
             },
           });
 
+          // TODO: this may throw, needs to be gracefully handled
           await tryWrite();
         }, 'watch-v2');
 
@@ -1747,27 +1767,45 @@ export class Run<
 
         let buffer: ChunkType[] = [];
         let isWriting = false;
+        // TODO: exact copy of StreamVNext, DRY or implement queue system on top of web stream
         const tryWrite = async () => {
-          const chunkToWrite = buffer;
+          let chunkToWrite: ChunkType[] | null = buffer;
           buffer = [];
 
           if (chunkToWrite.length === 0 || isWriting) {
             return;
           }
+
+          if (writable.locked) {
+            // user may be still writing to the stream, so we need to wait for it to be unlocked
+            queueMicrotask(tryWrite);
+            return;
+          }
           isWriting = true;
 
+          // acquires lock
           let watchWriter = writable.getWriter();
 
           try {
-            for (const chunk of chunkToWrite) {
-              await watchWriter.write(chunk);
+            while (chunkToWrite !== null) {
+              for (const chunk of chunkToWrite) {
+                await watchWriter.write(chunk);
+              }
+
+              // if there are more chunks to write, set the next chunk to write
+              // goal is to finish writing all chunks before continuing with execution as we get exclusive lock
+              if (buffer.length > 0) {
+                chunkToWrite = buffer;
+                buffer = [];
+              } else {
+                chunkToWrite = null;
+              }
             }
           } finally {
             watchWriter.releaseLock();
+            this.emitter.emit(kWritableStreamUnlocked);
           }
           isWriting = false;
-
-          setImmediate(tryWrite);
         };
 
         // TODO: fix this, watch-v2 doesn't have a type
@@ -2036,8 +2074,7 @@ export class Run<
         format: params.format,
         emitter: {
           emit: (event: string, data: any) => {
-            this.emitter.emit(event, data);
-            return Promise.resolve();
+            return this.emitter.emit(event, data);
           },
           on: (event: string, callback: (data: any) => void) => {
             this.emitter.on(event, callback);

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -217,20 +217,20 @@ export function createStep<
         }
 
         if (streamFormat === 'aisdk') {
-          emitter.emit('watch-v2', {
+          await emitter.emit('watch-v2', {
             type: 'tool-call-streaming-start',
             ...(toolData ?? {}),
           });
           for await (const chunk of stream) {
             if (chunk.type === 'text-delta') {
-              emitter.emit('watch-v2', {
+              await emitter.emit('watch-v2', {
                 type: 'tool-call-delta',
                 ...(toolData ?? {}),
                 argsTextDelta: chunk.textDelta,
               });
             }
           }
-          emitter.emit('watch-v2', {
+          await emitter.emit('watch-v2', {
             type: 'tool-call-streaming-finish',
             ...(toolData ?? {}),
           });
@@ -1381,8 +1381,8 @@ export class Run<
       serializedStepGraph: this.serializedStepGraph,
       input: inputData,
       emitter: {
-        emit: (event: string, data: any) => {
-          return this.emitter.emit(event, data);
+        emit: async (event: string, data: any) => {
+          this.emitter.emit(event, data);
         },
         on: (event: string, callback: (data: any) => void) => {
           this.emitter.on(event, callback);
@@ -2073,8 +2073,8 @@ export class Run<
         },
         format: params.format,
         emitter: {
-          emit: (event: string, data: any) => {
-            return this.emitter.emit(event, data);
+          emit: async (event: string, data: any) => {
+            this.emitter.emit(event, data);
           },
           on: (event: string, callback: (data: any) => void) => {
             this.emitter.on(event, callback);


### PR DESCRIPTION
## Description

I've been working on adjusting agent.network() to support parallel agent execution and had 2 fairly major issues:

1. write concurrency controls into writable web stream. watcher events are not correctly awaited as event emitter on nodejs executes functions synchronously, but watcher-v2 writes chunks in an async fashion. this is being addressed here
2. if we do not have a nested workflow - then network stream doesnt emit events properly, also addressed

### Summary of changes:
  - Fix MastraAgentNetworkStream to properly unwrap workflow subchunks in parallel
  execution
  - Adjust watch-v2 event handling to prevent execution steps from starting with locked
  writer streams
  - Ensure proper chunk type propagation through network stream for agents in parallel
  workflows

  Changes resolve uncaught stream errors when agents are invoked within parallel workflow
   steps
  by correctly extracting inner chunks and preventing writer stream conflicts.

  test: add comprehensive test coverage for parallel workflow agent streaming
  - Verify all stream events are properly typed and sequenced
  - Validate text delta assembly and chunk propagation
  - Ensure no writer stream locking issues occur

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
