### PR TITLE
fix(core): zod v3/v4 compatibility for tool schemas

### DIFF
--- a/.changeset/ready-falcons-dance.md
+++ b/.changeset/ready-falcons-dance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed createTool types due totight coupling to Zod's internal structure, which changed between v3 and v4. Instead of checking for exact Zod types, we now use structural typing - checking for the presence of parse/safeParse methods

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:cli": "pnpm --filter ./packages/cli test",
     "test:deployer": "pnpm --filter ./packages/deployer test",
     "test:server": "pnpm --filter ./packages/server test",
-    "test:core": "pnpm --filter ./packages/core test --exclude \"./src/tools/tool-builder/**\"",
+    "test:core": "pnpm --filter ./packages/core test",
     "test:mcp": "pnpm --filter ./packages/mcp test",
     "test:rag": "pnpm --filter ./packages/rag test",
     "test:clients": "pnpm --filter \"./client-sdks/*\" test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -177,11 +177,14 @@
   "scripts": {
     "check": "tsc --noEmit",
     "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "typecheck:zod-compat": "NODE_OPTIONS='--max-old-space-size=4096' tsc --project tsconfig.zod-compat.json",
     "lint": "eslint .",
     "pre-build": "tsup --silent --config tsup.config.ts --no-dts",
     "build": "node ./tools/commonjs-tsc-fixer.js",
     "build:watch": "pnpm build --watch",
-    "test": "vitest run"
+    "test:unit": "vitest run",
+    "test:types:zod": "node test-zod-compat.mjs",
+    "test": "npm run test:types:zod && npm run test:unit"
   },
   "dependencies": {
     "@a2a-js/sdk": "~0.2.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -182,7 +182,7 @@
     "pre-build": "tsup --silent --config tsup.config.ts --no-dts",
     "build": "node ./tools/commonjs-tsc-fixer.js",
     "build:watch": "pnpm build --watch",
-    "test:unit": "vitest run",
+    "test:unit": "vitest run --exclude '**/tool-builder/**'",
     "test:types:zod": "node test-zod-compat.mjs",
     "test": "npm run test:types:zod && npm run test:unit"
   },

--- a/packages/core/src/action/index.ts
+++ b/packages/core/src/action/index.ts
@@ -1,5 +1,3 @@
-import type { z } from 'zod';
-
 import type { Agent } from '../agent';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
@@ -7,6 +5,7 @@ import type { MastraMemory } from '../memory';
 import type { MastraStorage } from '../storage';
 import type { Telemetry } from '../telemetry';
 import type { MastraTTS } from '../tts';
+import type { ZodLikeSchema, InferZodLikeSchema } from '../types/zod-compat';
 import type { MastraVector } from '../vector';
 
 export type MastraPrimitives = {
@@ -23,8 +22,8 @@ export type MastraUnion = {
   [K in keyof Mastra]: Mastra[K];
 } & MastraPrimitives;
 
-export interface IExecutionContext<TSchemaIn extends z.ZodSchema | undefined = undefined> {
-  context: TSchemaIn extends z.ZodSchema ? z.infer<TSchemaIn> : {};
+export interface IExecutionContext<TSchemaIn extends ZodLikeSchema | undefined = undefined> {
+  context: TSchemaIn extends ZodLikeSchema ? InferZodLikeSchema<TSchemaIn> : {};
   runId?: string;
   threadId?: string;
   resourceId?: string;
@@ -33,8 +32,8 @@ export interface IExecutionContext<TSchemaIn extends z.ZodSchema | undefined = u
 
 export interface IAction<
   TId extends string,
-  TSchemaIn extends z.ZodSchema | undefined,
-  TSchemaOut extends z.ZodSchema | undefined,
+  TSchemaIn extends ZodLikeSchema | undefined,
+  TSchemaOut extends ZodLikeSchema | undefined,
   TContext extends IExecutionContext<TSchemaIn>,
   TOptions extends unknown = unknown,
 > {
@@ -47,5 +46,5 @@ export interface IAction<
   execute?: (
     context: TContext,
     options?: TOptions,
-  ) => Promise<TSchemaOut extends z.ZodSchema ? z.infer<TSchemaOut> : unknown>;
+  ) => Promise<TSchemaOut extends ZodLikeSchema ? InferZodLikeSchema<TSchemaOut> : unknown>;
 }

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -1,16 +1,16 @@
 import type { ToolExecutionOptions } from 'ai';
 import type { ToolCallOptions } from 'ai-v5';
-import type { z } from 'zod';
 
 import type { Mastra } from '../mastra';
+import type { ZodLikeSchema } from '../types/zod-compat';
 import type { ToolAction, ToolExecutionContext, ToolInvocationOptions } from './types';
 import { validateToolInput } from './validation';
 
 export class Tool<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
-  TSchemaOut extends z.ZodSchema | undefined = undefined,
-  TSuspendSchema extends z.ZodSchema = any,
-  TResumeSchema extends z.ZodSchema = any,
+  TSchemaIn extends ZodLikeSchema | undefined = undefined,
+  TSchemaOut extends ZodLikeSchema | undefined = undefined,
+  TSuspendSchema extends ZodLikeSchema = any,
+  TResumeSchema extends ZodLikeSchema = any,
   TContext extends ToolExecutionContext<TSchemaIn, TSuspendSchema, TResumeSchema> = ToolExecutionContext<
     TSchemaIn,
     TSuspendSchema,
@@ -59,10 +59,10 @@ export class Tool<
 }
 
 export function createTool<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
-  TSchemaOut extends z.ZodSchema | undefined = undefined,
-  TSuspendSchema extends z.ZodSchema = any,
-  TResumeSchema extends z.ZodSchema = any,
+  TSchemaIn extends ZodLikeSchema | undefined = undefined,
+  TSchemaOut extends ZodLikeSchema | undefined = undefined,
+  TSuspendSchema extends ZodLikeSchema = any,
+  TResumeSchema extends ZodLikeSchema = any,
   TContext extends ToolExecutionContext<TSchemaIn, TSuspendSchema, TResumeSchema> = ToolExecutionContext<
     TSchemaIn,
     TSuspendSchema,
@@ -79,7 +79,7 @@ export function createTool<
   opts: ToolAction<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext> & {
     execute?: TExecute;
   },
-): [TSchemaIn, TSchemaOut, TExecute] extends [z.ZodSchema, z.ZodSchema, Function]
+): [TSchemaIn, TSchemaOut, TExecute] extends [ZodLikeSchema, ZodLikeSchema, Function]
   ? Tool<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext> & {
       inputSchema: TSchemaIn;
       outputSchema: TSchemaOut;

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -1,12 +1,13 @@
 import type { ToolExecutionOptions, Tool, Schema } from 'ai';
 import type { ToolCallOptions, Tool as ToolV5 } from 'ai-v5';
 import type { JSONSchema7Type } from 'json-schema';
-import type { ZodSchema, z } from 'zod';
+import type { ZodSchema } from 'zod';
 
 import type { IAction, IExecutionContext, MastraUnion } from '../action';
 import type { TracingContext } from '../ai-tracing';
 import type { Mastra } from '../mastra';
 import type { RuntimeContext } from '../runtime-context';
+import type { ZodLikeSchema, InferZodLikeSchema } from '../types/zod-compat';
 import type { ToolStream } from './stream';
 
 export type VercelTool = Tool;
@@ -53,23 +54,23 @@ export type InternalCoreTool = {
 );
 
 export interface ToolExecutionContext<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
-  TSuspendSchema extends z.ZodSchema = any,
-  TResumeSchema extends z.ZodSchema = any,
+  TSchemaIn extends ZodLikeSchema | undefined = undefined,
+  TSuspendSchema extends ZodLikeSchema = any,
+  TResumeSchema extends ZodLikeSchema = any,
 > extends IExecutionContext<TSchemaIn> {
   mastra?: MastraUnion;
   runtimeContext: RuntimeContext;
   writer?: ToolStream<any>;
   tracingContext?: TracingContext;
-  suspend: (suspendPayload: z.infer<TSuspendSchema>) => Promise<any>;
-  resumeData?: z.infer<TResumeSchema>;
+  suspend: (suspendPayload: InferZodLikeSchema<TSuspendSchema>) => Promise<any>;
+  resumeData?: InferZodLikeSchema<TResumeSchema>;
 }
 
 export interface ToolAction<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
-  TSchemaOut extends z.ZodSchema | undefined = undefined,
-  TSuspendSchema extends z.ZodSchema = any,
-  TResumeSchema extends z.ZodSchema = any,
+  TSchemaIn extends ZodLikeSchema | undefined = undefined,
+  TSchemaOut extends ZodLikeSchema | undefined = undefined,
+  TSuspendSchema extends ZodLikeSchema = any,
+  TResumeSchema extends ZodLikeSchema = any,
   TContext extends ToolExecutionContext<TSchemaIn, TSuspendSchema, TResumeSchema> = ToolExecutionContext<
     TSchemaIn,
     TSuspendSchema,
@@ -82,7 +83,7 @@ export interface ToolAction<
   execute?: (
     context: TContext,
     options?: ToolInvocationOptions,
-  ) => Promise<TSchemaOut extends z.ZodSchema ? z.infer<TSchemaOut> : unknown>;
+  ) => Promise<TSchemaOut extends ZodLikeSchema ? InferZodLikeSchema<TSchemaOut> : unknown>;
   mastra?: Mastra;
   requireApproval?: boolean;
   onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
@@ -93,7 +94,7 @@ export interface ToolAction<
   ) => void | PromiseLike<void>;
   onInputAvailable?: (
     options: {
-      input: TSchemaIn extends z.ZodSchema ? z.infer<TSchemaIn> : unknown;
+      input: InferZodLikeSchema<TSchemaIn>;
     } & ToolCallOptions,
   ) => void | PromiseLike<void>;
 }

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import type { ZodLikeSchema } from '../types/zod-compat';
 
 export interface ValidationError<T = any> {
   error: true;
@@ -14,7 +15,7 @@ export interface ValidationError<T = any> {
  * @returns The validation error object if validation fails, undefined if successful
  */
 export function validateToolInput<T = any>(
-  schema: z.ZodSchema<T> | undefined,
+  schema: ZodLikeSchema | undefined,
   input: unknown,
   toolId?: string,
 ): { data: T | unknown; error?: ValidationError<T> } {
@@ -24,7 +25,7 @@ export function validateToolInput<T = any>(
 
   // Store validation results to avoid duplicate validation
   type ValidationAttempt = {
-    result: z.SafeParseReturnType<any, T>;
+    result: { success: boolean; data?: any; error?: any };
     data: unknown;
     structure: 'direct' | 'context' | 'inputData';
   };

--- a/packages/core/src/tools/zod-compatibility.test.ts
+++ b/packages/core/src/tools/zod-compatibility.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { z } from 'zod';
+import { z as zv4 } from 'zod/v4';
+
+import type { ZodLikeSchema } from '../types/zod-compat';
+import { createTool } from './tool';
+
+describe('Zod v3 and v4 Compatibility', () => {
+  describe('Type Compatibility', () => {
+    it('should accept Zod v3 schemas', () => {
+      // This should compile without type errors
+      const tool = createTool({
+        id: 'v3-tool',
+        description: 'Tool with Zod v3 schemas',
+        inputSchema: z.object({
+          name: z.string(),
+          age: z.number(),
+        }),
+        outputSchema: z.object({
+          message: z.string(),
+        }),
+        execute: async ({ context }) => {
+          // Type checking: context should have name and age
+          expectTypeOf(context).toHaveProperty('name');
+          expectTypeOf(context).toHaveProperty('age');
+          return {
+            message: `Hello ${context.name}, you are ${context.age} years old`,
+          };
+        },
+      });
+
+      expect(tool).toBeDefined();
+      expect(tool.id).toBe('v3-tool');
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.outputSchema).toBeDefined();
+    });
+
+    it('should accept Zod v4 schemas', () => {
+      // This test reproduces the fix for issue #8060
+      // Previously, this would cause type errors with Zod v4
+      const tool = createTool({
+        id: 'v4-tool',
+        description: 'Tool with Zod v4 schemas',
+        inputSchema: zv4.object({
+          input: zv4.string(),
+        }),
+        outputSchema: zv4.object({
+          output: zv4.string(),
+        }),
+        execute: async ({ context }) => {
+          const { input } = context;
+          const reversed = input.split('').reverse().join('');
+          return {
+            output: reversed,
+          };
+        },
+      });
+
+      expect(tool).toBeDefined();
+      expect(tool.id).toBe('v4-tool');
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.outputSchema).toBeDefined();
+    });
+
+    it('should validate that both v3 and v4 schemas match ZodLikeSchema interface', () => {
+      // Zod v3 schema
+      const v3Schema = z.object({ test: z.string() });
+
+      // Zod v4 schema
+      const v4Schema = zv4.object({ test: zv4.string() });
+
+      // Both should have the required methods
+      expect(v3Schema).toHaveProperty('parse');
+      expect(v3Schema).toHaveProperty('safeParse');
+      expect(typeof v3Schema.parse).toBe('function');
+      expect(typeof v3Schema.safeParse).toBe('function');
+
+      expect(v4Schema).toHaveProperty('parse');
+      expect(v4Schema).toHaveProperty('safeParse');
+      expect(typeof v4Schema.parse).toBe('function');
+      expect(typeof v4Schema.safeParse).toBe('function');
+
+      // Type assertion to ensure they match our interface
+      const testV3: ZodLikeSchema = v3Schema;
+      const testV4: ZodLikeSchema = v4Schema;
+
+      expect(testV3).toBeDefined();
+      expect(testV4).toBeDefined();
+    });
+  });
+
+  describe('Runtime Behavior', () => {
+    it('should execute tools with Zod v3 schemas correctly', async () => {
+      const tool = createTool({
+        id: 'runtime-v3',
+        description: 'Runtime test with v3',
+        inputSchema: z.object({
+          x: z.number(),
+          y: z.number(),
+        }),
+        outputSchema: z.object({
+          sum: z.number(),
+        }),
+        execute: async ({ context }) => {
+          return {
+            sum: context.x + context.y,
+          };
+        },
+      });
+
+      const result = await tool.execute?.({
+        context: { x: 5, y: 3 },
+        runId: 'test',
+        threadId: 'test',
+        runtimeContext: {} as any,
+        suspend: async () => {},
+      });
+
+      expect(result).toEqual({ sum: 8 });
+    });
+
+    it('should execute tools with Zod v4 schemas correctly', async () => {
+      const tool = createTool({
+        id: 'runtime-v4',
+        description: 'Runtime test with v4',
+        inputSchema: zv4.object({
+          text: zv4.string(),
+        }),
+        outputSchema: zv4.object({
+          length: zv4.number(),
+        }),
+        execute: async ({ context }) => {
+          return {
+            length: context.text.length,
+          };
+        },
+      });
+
+      const result = await tool.execute?.({
+        context: { text: 'hello' },
+        runId: 'test',
+        threadId: 'test',
+        runtimeContext: {} as any,
+        suspend: async () => {},
+      });
+
+      expect(result).toEqual({ length: 5 });
+    });
+
+    it('should handle validation with both v3 and v4 schemas', async () => {
+      const v3Tool = createTool({
+        id: 'validation-v3',
+        description: 'Validation test with v3',
+        inputSchema: z.object({
+          email: z.string().email(),
+        }),
+        execute: async () => {
+          return { validated: true };
+        },
+      });
+
+      const v4Tool = createTool({
+        id: 'validation-v4',
+        description: 'Validation test with v4',
+        inputSchema: zv4.object({
+          email: zv4.string().email(),
+        }),
+        execute: async () => {
+          return { validated: true };
+        },
+      });
+
+      // Both tools should have validation working
+      expect(v3Tool.inputSchema).toBeDefined();
+      expect(v4Tool.inputSchema).toBeDefined();
+
+      // Test that the schemas can parse valid input
+      const validEmail = { email: 'test@example.com' };
+      expect(() => v3Tool.inputSchema?.parse(validEmail)).not.toThrow();
+      expect(() => v4Tool.inputSchema?.parse(validEmail)).not.toThrow();
+
+      // Test that the schemas reject invalid input
+      const invalidEmail = { email: 'not-an-email' };
+      expect(() => v3Tool.inputSchema?.parse(invalidEmail)).toThrow();
+      expect(() => v4Tool.inputSchema?.parse(invalidEmail)).toThrow();
+    });
+  });
+
+  describe('Regression Tests for Issue #8060', () => {
+    it('should compile without type errors when using Zod v4 object schemas', () => {
+      // This is the exact code from the issue report
+      // It should compile without type errors
+      const tool = createTool({
+        id: 'test-tool',
+        description: 'Reverse the input string',
+        inputSchema: zv4.object({
+          input: zv4.string(),
+        }),
+        outputSchema: zv4.object({
+          output: zv4.string(),
+        }),
+        execute: async ({ context }) => {
+          const { input } = context;
+          const reversed = input.split('').reverse().join('');
+          return {
+            output: reversed,
+          };
+        },
+      });
+
+      expect(tool).toBeDefined();
+      expect(tool.id).toBe('test-tool');
+      expect(tool.description).toBe('Reverse the input string');
+    });
+
+    it('should handle mixed v3 and v4 schemas in the same codebase', () => {
+      // Some tools might use v3
+      const v3Tool = createTool({
+        id: 'mixed-v3',
+        description: 'Uses v3',
+        inputSchema: z.object({ v3Input: z.string() }),
+        execute: async ({ context }) => ({ result: context.v3Input }),
+      });
+
+      // Others might use v4
+      const v4Tool = createTool({
+        id: 'mixed-v4',
+        description: 'Uses v4',
+        inputSchema: zv4.object({ v4Input: zv4.string() }),
+        execute: async ({ context }) => ({ result: context.v4Input }),
+      });
+
+      // Both should work
+      expect(v3Tool).toBeDefined();
+      expect(v4Tool).toBeDefined();
+      expect(v3Tool.id).toBe('mixed-v3');
+      expect(v4Tool.id).toBe('mixed-v4');
+    });
+
+    it('should maintain type inference with both Zod versions', () => {
+      const v3Tool = createTool({
+        id: 'inference-v3',
+        description: 'Type inference with v3',
+        inputSchema: z.object({
+          str: z.string(),
+          num: z.number(),
+          bool: z.boolean(),
+        }),
+        execute: async ({ context }) => {
+          // These type checks ensure inference is working
+          expectTypeOf(context.str).toBeString();
+          expectTypeOf(context.num).toBeNumber();
+          expectTypeOf(context.bool).toBeBoolean();
+          return { success: true };
+        },
+      });
+
+      const v4Tool = createTool({
+        id: 'inference-v4',
+        description: 'Type inference with v4',
+        inputSchema: zv4.object({
+          str: zv4.string(),
+          num: zv4.number(),
+          bool: zv4.boolean(),
+        }),
+        execute: async ({ context }) => {
+          // These type checks ensure inference is working
+          expectTypeOf(context.str).toBeString();
+          expectTypeOf(context.num).toBeNumber();
+          expectTypeOf(context.bool).toBeBoolean();
+          return { success: true };
+        },
+      });
+
+      expect(v3Tool).toBeDefined();
+      expect(v4Tool).toBeDefined();
+    });
+  });
+});

--- a/packages/core/src/types/zod-compat.ts
+++ b/packages/core/src/types/zod-compat.ts
@@ -1,0 +1,17 @@
+/**
+ * Type compatibility layer for Zod v3 and v4
+ *
+ * Zod v3 and v4 have different internal type structures, but they share
+ * the same public API. This type uses structural typing to accept schemas
+ * from both versions by checking for the presence of key methods rather
+ * than relying on exact type matching.
+ */
+export type ZodLikeSchema = {
+  parse: (data: unknown) => any;
+  safeParse: (data: unknown) => { success: boolean; data?: any; error?: any };
+};
+
+/**
+ * Helper type for extracting the inferred type from a Zod-like schema
+ */
+export type InferZodLikeSchema<T> = T extends { parse: (data: unknown) => infer U } ? U : any;

--- a/packages/core/src/workflows/legacy/step.ts
+++ b/packages/core/src/workflows/legacy/step.ts
@@ -1,11 +1,11 @@
-import type { z } from 'zod';
 import type { Mastra } from '../../mastra';
+import type { ZodLikeSchema, InferZodLikeSchema } from '../../types/zod-compat';
 import type { RetryConfig, StepAction, StepExecutionContext } from './types';
 
 export class LegacyStep<
   TStepId extends string = any,
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
-  TSchemaOut extends z.ZodSchema | undefined = undefined,
+  TSchemaIn extends ZodLikeSchema | undefined = undefined,
+  TSchemaOut extends ZodLikeSchema | undefined = undefined,
   TContext extends StepExecutionContext<TSchemaIn> = StepExecutionContext<TSchemaIn>,
 > implements StepAction<TStepId, TSchemaIn, TSchemaOut, TContext>
 {
@@ -13,8 +13,8 @@ export class LegacyStep<
   description?: string;
   inputSchema?: TSchemaIn;
   outputSchema?: TSchemaOut;
-  payload?: TSchemaIn extends z.ZodSchema ? Partial<z.infer<TSchemaIn>> : unknown;
-  execute: (context: TContext) => Promise<TSchemaOut extends z.ZodSchema ? z.infer<TSchemaOut> : unknown>;
+  payload?: TSchemaIn extends ZodLikeSchema ? Partial<InferZodLikeSchema<TSchemaIn>> : unknown;
+  execute: (context: TContext) => Promise<TSchemaOut extends ZodLikeSchema ? InferZodLikeSchema<TSchemaOut> : unknown>;
   retryConfig?: RetryConfig;
   mastra?: Mastra;
 

--- a/packages/core/src/workflows/legacy/types.ts
+++ b/packages/core/src/workflows/legacy/types.ts
@@ -1,9 +1,10 @@
 import type { Query } from 'sift';
 import type { z } from 'zod';
-import type { IAction, IExecutionContext, MastraUnion } from '../../action';
+import type { IExecutionContext, MastraUnion } from '../../action';
 import type { BaseLogMessage, RegisteredLogger } from '../../logger';
 import type { Mastra } from '../../mastra';
 import type { RuntimeContext } from '../../runtime-context';
+import type { ZodLikeSchema, InferZodLikeSchema } from '../../types/zod-compat';
 import type { LegacyStep as Step } from './step';
 import type { LegacyWorkflow } from './workflow';
 
@@ -29,10 +30,10 @@ export interface WorkflowOptions<
 }
 
 export interface StepExecutionContext<
-  TSchemaIn extends z.ZodSchema | undefined = undefined,
+  TSchemaIn extends ZodLikeSchema | undefined = undefined,
   TContext extends WorkflowContext = WorkflowContext,
-> extends IExecutionContext<TSchemaIn> {
-  context: TSchemaIn extends z.ZodSchema ? { inputData: z.infer<TSchemaIn> } & TContext : TContext;
+> extends Omit<IExecutionContext<TSchemaIn>, 'context'> {
+  context: TSchemaIn extends ZodLikeSchema ? { inputData: InferZodLikeSchema<TSchemaIn> } & TContext : TContext;
   suspend: (payload?: unknown, softSuspend?: any) => Promise<void>;
   runId: string;
   emit: (event: string, data: any) => void;
@@ -42,13 +43,17 @@ export interface StepExecutionContext<
 
 export interface StepAction<
   TId extends string,
-  TSchemaIn extends z.ZodSchema | undefined,
-  TSchemaOut extends z.ZodSchema | undefined,
+  TSchemaIn extends ZodLikeSchema | undefined,
+  TSchemaOut extends ZodLikeSchema | undefined,
   TContext extends StepExecutionContext<TSchemaIn>,
-> extends IAction<TId, TSchemaIn, TSchemaOut, TContext> {
+> {
+  id: TId;
+  description?: string;
+  inputSchema?: TSchemaIn;
+  outputSchema?: TSchemaOut;
   mastra?: Mastra;
-  payload?: TSchemaIn extends z.ZodSchema ? Partial<z.infer<TSchemaIn>> : unknown;
-  execute: (context: TContext) => Promise<TSchemaOut extends z.ZodSchema ? z.infer<TSchemaOut> : unknown>;
+  payload?: TSchemaIn extends ZodLikeSchema ? Partial<InferZodLikeSchema<TSchemaIn>> : unknown;
+  execute: (context: TContext) => Promise<TSchemaOut extends ZodLikeSchema ? InferZodLikeSchema<TSchemaOut> : unknown>;
   retryConfig?: RetryConfig;
   workflow?: LegacyWorkflow;
   workflowId?: string;

--- a/packages/core/test-zod-compat.mjs
+++ b/packages/core/test-zod-compat.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+/**
+ * This script is run as part of CI to ensure that our tool system remains
+ * compatible with both Zod v3 and v4. It creates a temporary TypeScript file
+ * with code that uses both Zod versions and attempts to compile it.
+ *
+ * If compilation fails with type errors, it means we've introduced a regression
+ * and broken compatibility with one of the Zod versions.
+ *
+ * This test is crucial because:
+ * 1. Users may have either Zod v3 or v4 in their projects
+ * 2. Runtime tests alone won't catch type incompatibilities
+ * 3. Full project type checking often runs out of memory
+ *
+ * Run manually: npm run test:types:zod
+ * Runs in CI: As part of npm test
+ */
+
+import { exec } from 'child_process';
+import { writeFile, unlink } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Test code that should compile with both Zod v3 and v4
+const testCode = `
+import { z } from 'zod';
+import { z as zv4 } from 'zod/v4';
+import { createTool } from './src/tools/tool';
+
+// Test with Zod v4
+const v4Tool = createTool({
+  id: "test-tool",
+  description: "Reverse the input string",
+  inputSchema: zv4.object({
+    input: zv4.string()
+  }),
+  outputSchema: zv4.object({
+    output: zv4.string()
+  }),
+  execute: async ({ context }) => {
+    const { input } = context;
+    const reversed = input.split("").reverse().join("");
+    return {
+      output: reversed
+    };
+  }
+});
+
+// Test with Zod v3
+const v3Tool = createTool({
+  id: 'v3-tool',
+  description: 'Tool with v3 schemas',
+  inputSchema: z.object({
+    message: z.string()
+  }),
+  outputSchema: z.object({
+    result: z.string()
+  }),
+  execute: async ({ context }) => ({
+    result: context.message.toUpperCase()
+  })
+});
+
+export { v3Tool, v4Tool };
+`;
+
+async function runTest() {
+  const testFile = path.join(__dirname, '.zod-compat-test.ts');
+
+  try {
+    console.log('🔍 Testing Zod v3/v4 compatibility...');
+
+    // Write test file
+    await writeFile(testFile, testCode);
+
+    // Try to compile with limited memory and timeout
+    const { stderr } = await execAsync(`npx tsc --noEmit --skipLibCheck --strict ${testFile}`, {
+      cwd: __dirname,
+      timeout: 30000, // 30 second timeout
+      env: {
+        ...process.env,
+        NODE_OPTIONS: '--max-old-space-size=1024', // Limit memory
+      },
+    }).catch(err => ({ stderr: err.stderr || err.message }));
+
+    // Clean up
+    await unlink(testFile).catch(() => {});
+
+    // Check for type errors
+    if (stderr && (stderr.includes('error TS') || stderr.includes('Type '))) {
+      console.error('❌ Zod compatibility check failed!');
+      console.error('Type errors detected:');
+      console.error(stderr);
+      process.exit(1);
+    }
+
+    console.log('✅ Zod v3/v4 compatibility check passed');
+    process.exit(0);
+  } catch (error) {
+    // Clean up on error
+    await unlink(testFile).catch(() => {});
+
+    if (error.code === 'ETIMEDOUT') {
+      console.warn('⚠️  Zod compatibility check timed out (might be due to large codebase)');
+      console.warn('    Skipping type check - consider running manually');
+      process.exit(0); // Don't fail CI on timeout
+    }
+
+    console.error('❌ Zod compatibility check failed with error:', error.message);
+    process.exit(1);
+  }
+}
+
+runTest();


### PR DESCRIPTION
Fixes #8060 where users with Zod v4 were getting type errors when using createTool.

The issue was that our types were too tightly coupled to Zod's internal structure, which changed between v3 and v4. Instead of checking for exact Zod types, we now use structural typing - checking for the presence of parse/safeParse methods.

Before (breaks with Zod v4):
```typescript
export interface ToolAction<TSchemaIn extends z.ZodSchema | undefined>
```

After (works with both v3 and v4):
```typescript
export interface ToolAction<TSchemaIn extends ZodLikeSchema | undefined>

// Where ZodLikeSchema is:
type ZodLikeSchema = {
  parse: (data: unknown) => any;
  safeParse: (data: unknown) => { success: boolean; data?: any; error?: any };
}
```

Also added a CI test that compiles code using both Zod versions to prevent regressions.