### PR TITLE
Add getScoresBySpan API method

### DIFF
--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -114,6 +114,7 @@ export abstract class MastraStorage extends MastraBase {
     deleteMessages: boolean;
     aiTracing?: boolean;
     indexManagement?: boolean;
+    getScoresBySpan?: boolean;
   } {
     return {
       selectByIncludeResourceScope: false,
@@ -123,6 +124,7 @@ export abstract class MastraStorage extends MastraBase {
       deleteMessages: false,
       aiTracing: false,
       indexManagement: false,
+      getScoresBySpan: false,
     };
   }
 
@@ -504,6 +506,23 @@ export abstract class MastraStorage extends MastraBase {
     entityId: string;
     entityType: string;
   }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }>;
+
+  async getScoresBySpan({
+    traceId,
+    spanId,
+    pagination: _pagination,
+  }: {
+    traceId: string;
+    spanId: string;
+    pagination: StoragePagination;
+  }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
+    throw new MastraError({
+      id: 'SCORES_STORAGE_GET_SCORES_BY_SPAN_NOT_IMPLEMENTED',
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.SYSTEM,
+      details: { traceId, spanId },
+    });
+  }
 
   abstract getEvals(
     options: {

--- a/packages/core/src/storage/domains/scores/base.ts
+++ b/packages/core/src/storage/domains/scores/base.ts
@@ -47,7 +47,7 @@ export abstract class ScoresStorage extends MastraBase {
     entityType: string;
   }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }>;
 
-  getScoresBySpan({
+  async getScoresBySpan({
     traceId,
     spanId,
     pagination: _pagination,

--- a/packages/core/src/storage/domains/scores/base.ts
+++ b/packages/core/src/storage/domains/scores/base.ts
@@ -1,4 +1,5 @@
 import { MastraBase } from '../../../base';
+import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
 import type { ScoreRowData, ScoringSource } from '../../../scores/types';
 import type { PaginationInfo, StoragePagination } from '../../types';
 
@@ -45,4 +46,21 @@ export abstract class ScoresStorage extends MastraBase {
     entityId: string;
     entityType: string;
   }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }>;
+
+  getScoresBySpan({
+    traceId,
+    spanId,
+    pagination: _pagination,
+  }: {
+    traceId: string;
+    spanId: string;
+    pagination: StoragePagination;
+  }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
+    throw new MastraError({
+      id: 'SCORES_STORAGE_GET_SCORES_BY_SPAN_NOT_IMPLEMENTED',
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.SYSTEM,
+      details: { traceId, spanId },
+    });
+  }
 }

--- a/packages/core/src/storage/domains/scores/inmemory.ts
+++ b/packages/core/src/storage/domains/scores/inmemory.ts
@@ -108,4 +108,27 @@ export class ScoresInMemory extends ScoresStorage {
       },
     };
   }
+
+  async getScoresBySpan({
+    traceId,
+    spanId,
+    pagination,
+  }: {
+    traceId: string;
+    spanId: string;
+    pagination: StoragePagination;
+  }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
+    const scores = Array.from(this.scores.values()).filter(
+      score => score.traceId === traceId && score.spanId === spanId,
+    );
+    return {
+      scores: scores.slice(pagination.page * pagination.perPage, (pagination.page + 1) * pagination.perPage),
+      pagination: {
+        total: scores.length,
+        page: pagination.page,
+        perPage: pagination.perPage,
+        hasMore: scores.length > (pagination.page + 1) * pagination.perPage,
+      },
+    };
+  }
 }

--- a/packages/core/src/storage/domains/scores/inmemory.ts
+++ b/packages/core/src/storage/domains/scores/inmemory.ts
@@ -121,6 +121,7 @@ export class ScoresInMemory extends ScoresStorage {
     const scores = Array.from(this.scores.values()).filter(
       score => score.traceId === traceId && score.spanId === spanId,
     );
+    scores.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     return {
       scores: scores.slice(pagination.page * pagination.perPage, (pagination.page + 1) * pagination.perPage),
       pagination: {

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -100,6 +100,7 @@ export class InMemoryStore extends MastraStorage {
       deleteMessages: true,
       aiTracing: true,
       indexManagement: false,
+      getScoresBySpan: true,
     };
   }
 
@@ -389,6 +390,18 @@ export class InMemoryStore extends MastraStorage {
     pagination: StoragePagination;
   }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
     return this.stores.scores.getScoresByEntityId({ entityId, entityType, pagination });
+  }
+
+  async getScoresBySpan({
+    traceId,
+    spanId,
+    pagination,
+  }: {
+    traceId: string;
+    spanId: string;
+    pagination: StoragePagination;
+  }): Promise<{ pagination: PaginationInfo; scores: ScoreRowData[] }> {
+    return this.stores.scores.getScoresBySpan({ traceId, spanId, pagination });
   }
 
   async getEvals(

--- a/stores/_test-utils/src/domains/scores/data.ts
+++ b/stores/_test-utils/src/domains/scores/data.ts
@@ -6,17 +6,23 @@ export function createSampleScore({
   entityId,
   entityType,
   source,
+  traceId,
+  spanId,
 }: {
   scorerId: string;
   entityId?: string;
   entityType?: ScoringEntityType;
   source?: ScoringSource;
+  traceId?: string;
+  spanId?: string;
 }): ScoreRowData {
   return {
     id: randomUUID(),
     entityId: entityId ?? 'eval-agent',
     entityType: entityType ?? 'AGENT',
     scorerId,
+    traceId,
+    spanId,
     createdAt: new Date(),
     updatedAt: new Date(),
     runId: randomUUID(),

--- a/stores/_test-utils/src/domains/scores/index.ts
+++ b/stores/_test-utils/src/domains/scores/index.ts
@@ -1,10 +1,38 @@
 import { randomUUID } from 'crypto';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { TABLE_SCORERS, type MastraStorage } from '@mastra/core/storage';
 import { createSampleScore } from './data';
+import type { ScoreRowData } from '@mastra/core/scores';
+import { TABLE_SCORERS, type MastraStorage } from '@mastra/core/storage';
+
+// Helper function for creating test scores
+async function createScores(
+  storage: MastraStorage,
+  configs: Array<{
+    count: number;
+    scorerId: string;
+    traceId: string;
+    spanId: string;
+  }>,
+): Promise<ScoreRowData[]> {
+  const allScores: ScoreRowData[] = [];
+
+  for (const config of configs) {
+    for (let i = 0; i < config.count; i++) {
+      const score = createSampleScore({
+        scorerId: config.scorerId,
+        traceId: config.traceId,
+        spanId: config.spanId,
+      });
+      allScores.push(score);
+      await storage.saveScore(score);
+    }
+  }
+
+  return allScores;
+}
 
 export function createScoresTest({ storage }: { storage: MastraStorage }) {
-  describe('Score Operations', () => {
+  describe.only('Score Operations', () => {
     beforeEach(async () => {
       await storage.clearTable({ tableName: TABLE_SCORERS });
     });
@@ -83,5 +111,158 @@ export function createScoresTest({ storage }: { storage: MastraStorage }) {
       expect(result.pagination.perPage).toBe(10);
       expect(result.pagination.hasMore).toBe(false);
     });
+
+    if (storage.supports.getScoresBySpan) {
+      it('should retrieve scores by trace and span id', async () => {
+        const scorerId = `scorer-${randomUUID()}`;
+        const traceId = randomUUID();
+        const spanId = randomUUID();
+
+        const score = createSampleScore({ scorerId, traceId, spanId });
+        await storage.saveScore(score);
+
+        const result = await storage.getScoresBySpan({
+          traceId,
+          spanId,
+          pagination: { page: 0, perPage: 10 },
+        });
+
+        expect(result.scores.length).toBe(1);
+        expect(result.scores[0].traceId).toBe(traceId);
+        expect(result.scores[0].spanId).toBe(spanId);
+        expect(result.pagination.total).toBe(1);
+        expect(result.pagination.hasMore).toBe(false);
+      });
+
+      it('should retrieve multiple scores by trace and span id', async () => {
+        const scorerId = `scorer-${randomUUID()}`;
+        const traceId = randomUUID();
+        const spanId = randomUUID();
+
+        // Create multiple scores for the same trace/span
+        const score1 = createSampleScore({ scorerId, traceId, spanId });
+        const score2 = createSampleScore({ scorerId, traceId, spanId });
+        const score3 = createSampleScore({ scorerId, traceId, spanId });
+
+        await storage.saveScore(score1);
+        await storage.saveScore(score2);
+        await storage.saveScore(score3);
+
+        const result = await storage.getScoresBySpan({
+          traceId,
+          spanId,
+          pagination: { page: 0, perPage: 10 },
+        });
+
+        expect(result.scores.every(s => s.traceId === traceId)).toBe(true);
+        expect(result.scores.every(s => s.spanId === spanId)).toBe(true);
+        expect(result.scores.length).toBe(3);
+        expect(result.pagination.total).toBe(3);
+        expect(result.pagination.hasMore).toBe(false);
+      });
+
+      it('should handle first page pagination correctly', async () => {
+        const scorerId = `scorer-${randomUUID()}`;
+        const traceId = randomUUID();
+        const spanId = randomUUID();
+
+        await createScores(storage, [
+          { count: 5, scorerId, traceId, spanId }, // target scores
+          { count: 1, scorerId, traceId: randomUUID(), spanId }, // different trace
+          { count: 1, scorerId, traceId, spanId: randomUUID() }, // different span
+          { count: 1, scorerId, traceId: randomUUID(), spanId: randomUUID() }, // both different
+        ]);
+
+        const firstPage = await storage.getScoresBySpan({
+          traceId,
+          spanId,
+          pagination: { page: 0, perPage: 2 },
+        });
+
+        expect(firstPage.scores.length).toBe(2);
+        expect(firstPage.pagination.total).toBe(5);
+        expect(firstPage.pagination.page).toBe(0);
+        expect(firstPage.pagination.perPage).toBe(2);
+        expect(firstPage.pagination.hasMore).toBe(true);
+
+        expect(firstPage.scores.every(s => s.traceId === traceId && s.spanId === spanId)).toBe(true);
+      });
+
+      it('should handle middle page pagination correctly', async () => {
+        const scorerId = `scorer-${randomUUID()}`;
+        const traceId = randomUUID();
+        const spanId = randomUUID();
+
+        const allScores = await createScores(storage, [
+          { count: 5, scorerId, traceId, spanId }, // target scores
+          { count: 1, scorerId, traceId: randomUUID(), spanId }, // different trace
+          { count: 1, scorerId, traceId, spanId: randomUUID() }, // different span
+          { count: 1, scorerId, traceId: randomUUID(), spanId: randomUUID() }, // both different
+        ]);
+
+        const secondPage = await storage.getScoresBySpan({
+          traceId,
+          spanId,
+          pagination: { page: 1, perPage: 2 },
+        });
+
+        expect(secondPage.scores.length).toBe(2);
+        expect(secondPage.pagination.total).toBe(5);
+        expect(secondPage.pagination.page).toBe(1);
+        expect(secondPage.pagination.perPage).toBe(2);
+        expect(secondPage.pagination.hasMore).toBe(true);
+
+        expect(secondPage.scores.every(s => s.traceId === traceId && s.spanId === spanId)).toBe(true);
+      });
+
+      it('should handle last page pagination', async () => {
+        const scorerId = `scorer-${randomUUID()}`;
+        const traceId = randomUUID();
+        const spanId = randomUUID();
+
+        const otherTraceId1 = randomUUID();
+        const otherTraceId2 = randomUUID();
+        const otherSpanId1 = randomUUID();
+        const otherSpanId2 = randomUUID();
+
+        await createScores(storage, [
+          { count: 5, scorerId, traceId, spanId }, // target scores
+          { count: 1, scorerId, traceId: otherTraceId1, spanId }, // different trace, same span
+          { count: 1, scorerId, traceId, spanId: otherSpanId1 }, // same trace, different span
+          { count: 1, scorerId, traceId: otherTraceId2, spanId: otherSpanId2 }, // both different
+          { count: 1, scorerId, traceId: otherTraceId1, spanId }, // different trace, same span (again)
+          { count: 1, scorerId, traceId, spanId: otherSpanId2 }, // same trace, different span (again)
+        ]);
+
+        const firstPage = await storage.getScoresBySpan({
+          traceId,
+          spanId,
+          pagination: { page: 0, perPage: 2 },
+        });
+
+        const secondPage = await storage.getScoresBySpan({
+          traceId,
+          spanId,
+          pagination: { page: 1, perPage: 2 },
+        });
+
+        const lastPage = await storage.getScoresBySpan({
+          traceId,
+          spanId,
+          pagination: { page: 2, perPage: 2 },
+        });
+
+        expect(lastPage.scores.length).toBe(1);
+        expect(lastPage.pagination.total).toBe(5);
+        expect(lastPage.pagination.page).toBe(2);
+        expect(lastPage.pagination.perPage).toBe(2);
+        expect(lastPage.pagination.hasMore).toBe(false);
+
+        const allPages = [firstPage, secondPage, lastPage];
+        for (const page of allPages) {
+          expect(page.scores.every(s => s.traceId === traceId && s.spanId === spanId)).toBe(true);
+        }
+      });
+    }
   });
 }

--- a/stores/_test-utils/src/domains/scores/index.ts
+++ b/stores/_test-utils/src/domains/scores/index.ts
@@ -32,7 +32,7 @@ async function createScores(
 }
 
 export function createScoresTest({ storage }: { storage: MastraStorage }) {
-  describe.only('Score Operations', () => {
+  describe('Score Operations', () => {
     beforeEach(async () => {
       await storage.clearTable({ tableName: TABLE_SCORERS });
     });


### PR DESCRIPTION
## Description

Adds base storage method to get scores by trace and span ID. Also implements the in memory approach

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
