### PR TITLE
feat(observability): Add LangSmith observability package

### DIFF
--- a/.changeset/nice-coats-wash.md
+++ b/.changeset/nice-coats-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langsmith': major
+---
+
+Initial commit

--- a/.changeset/nice-coats-wash.md
+++ b/.changeset/nice-coats-wash.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/langsmith': major
+'@mastra/langsmith': patch
 ---
 
 Initial commit

--- a/observability/langsmith/README.md
+++ b/observability/langsmith/README.md
@@ -1,0 +1,46 @@
+# @mastra/langsmith
+
+LangSmith AI Observability exporter for Mastra applications.
+
+## Installation
+
+```bash
+npm install @mastra/langsmith
+```
+
+## Usage
+
+```typescript
+import { LangSmithExporter } from '@mastra/langsmith';
+
+// Set process.env.LANGSMITH_TRACING = "true";
+
+// Use with Mastra
+const mastra = new Mastra({
+  ...,
+  observability: {
+    configs: {
+      langsmith: {
+        serviceName: 'service',
+        exporters: [
+          new LangSmithExporter({
+            apiKey: process.env.LANGSMITH_API_KEY, // Defaults to process.env.LANGSMITH_API_KEY
+            projectName: process.env.LANGSMITH_PROJECT, // optional
+            endpoint: process.env.LANGSMITH_ENDPOINT, // optional
+          }),
+        ],
+      },
+    },
+  },
+});
+```
+
+## Features
+
+### AI Tracing
+
+- **Automatic span mapping**: Root spans become LangSmith traces
+- **Type-specific metadata**: Extracts relevant metadata for each span type (agents, tools, workflows)
+- **Error tracking**: Automatic error status and message tracking
+- **Hierarchical traces**: Maintains parent-child relationships
+- **Event span support**: Zero-duration spans for event-type traces

--- a/observability/langsmith/eslint.config.js
+++ b/observability/langsmith/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/observability/langsmith/package.json
+++ b/observability/langsmith/package.json
@@ -34,15 +34,18 @@
     "langsmith": ">=0.3.69"
   },
   "devDependencies": {
+    "@ai-sdk/openai": "^2.0.35",
     "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
     "@microsoft/api-extractor": "^7.52.8",
     "@types/node": "^20.19.0",
+    "dotenv": "^17.2.2",
     "eslint": "^9.35.0",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4",
-    "@internal/types-builder": "workspace:*"
+    "zod": "^3.25.76"
   },
   "peerDependencies": {
     "@mastra/core": ">=0.16.4-0 <0.19.0-0"

--- a/observability/langsmith/package.json
+++ b/observability/langsmith/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@mastra/langsmith",
+  "version": "0.1.0-rc.0",
+  "description": "Langsmith observability provider for Mastra - includes AI tracing and future observability features",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "langsmith": ">=0.3.69"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@microsoft/api-extractor": "^7.52.8",
+    "@types/node": "^20.19.0",
+    "eslint": "^9.35.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4",
+    "@internal/types-builder": "workspace:*"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=0.16.4-0 <0.19.0-0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "observability/langsmith"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  }
+}

--- a/observability/langsmith/package.json
+++ b/observability/langsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/langsmith",
-  "version": "0.1.0-rc.0",
+  "version": "0.0.0",
   "description": "Langsmith observability provider for Mastra - includes AI tracing and future observability features",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/langsmith/src/ai-tracing.int.test.ts
+++ b/observability/langsmith/src/ai-tracing.int.test.ts
@@ -1,0 +1,46 @@
+import 'dotenv/config';
+
+import { it } from 'vitest';
+import { createTool } from '@mastra/core/tools';
+import { Agent } from '@mastra/core/agent';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+import { Mastra } from '@mastra/core';
+import { LangSmithExporter } from './ai-tracing';
+
+it.skip('should initialize with correct configuration', async () => {
+  const calculator = createTool({
+    id: 'calculator',
+    description: 'Add two numbers',
+    inputSchema: z.object({ a: z.number(), b: z.number() }),
+    outputSchema: z.object({ result: z.number() }),
+    execute: async ({ context }) => ({ result: context.a + context.b }),
+  });
+
+  const agent = new Agent({
+    name: 'Agent',
+    instructions: 'Use tools when helpful.',
+    model: openai('gpt-5-nano'),
+    tools: { calculator },
+  });
+
+  const mastra = new Mastra({
+    agents: { agent },
+    observability: {
+      configs: {
+        langsmith: {
+          serviceName: 'ai',
+          exporters: [new LangSmithExporter({ logLevel: 'debug' })],
+        },
+      },
+    },
+  });
+
+  // Use generateVNext (AI SDK v5 method) with tools
+  const res = await mastra.getAgent('agent').generateVNext('What is 21 + 21? Use tools if needed.');
+  console.log(res?.text ?? res);
+
+  // Use streamVNext for streaming responses
+  const stream = await mastra.getAgent('agent').streamVNext('What is 21 + 21? Use tools if needed.');
+  console.log(await stream.text);
+}, 30000);

--- a/observability/langsmith/src/ai-tracing.int.test.ts
+++ b/observability/langsmith/src/ai-tracing.int.test.ts
@@ -9,7 +9,7 @@ import { it } from 'vitest';
 import { z } from 'zod';
 import { LangSmithExporter } from './ai-tracing';
 
-it('should initialize with correct configuration', async () => {
+it.skip('should initialize with correct configuration', async () => {
   const client = new Client();
   const calculator = createTool({
     id: 'calculator',

--- a/observability/langsmith/src/ai-tracing.int.test.ts
+++ b/observability/langsmith/src/ai-tracing.int.test.ts
@@ -4,11 +4,13 @@ import { openai } from '@ai-sdk/openai';
 import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { createTool } from '@mastra/core/tools';
+import { Client } from 'langsmith';
 import { it } from 'vitest';
 import { z } from 'zod';
 import { LangSmithExporter } from './ai-tracing';
 
-it.skip('should initialize with correct configuration', async () => {
+it('should initialize with correct configuration', async () => {
+  const client = new Client();
   const calculator = createTool({
     id: 'calculator',
     description: 'Add two numbers',
@@ -30,7 +32,7 @@ it.skip('should initialize with correct configuration', async () => {
       configs: {
         langsmith: {
           serviceName: 'ai',
-          exporters: [new LangSmithExporter({ logLevel: 'debug' })],
+          exporters: [new LangSmithExporter({ logLevel: 'debug', client })],
         },
       },
     },
@@ -43,4 +45,8 @@ it.skip('should initialize with correct configuration', async () => {
   // Use streamVNext for streaming responses
   const stream = await mastra.getAgent('agent').streamVNext('What is 21 + 21? Use tools if needed.');
   console.log(await stream.text);
+
+  // TODO: Flush properly
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  await client.awaitPendingTraceBatches();
 }, 30000);

--- a/observability/langsmith/src/ai-tracing.int.test.ts
+++ b/observability/langsmith/src/ai-tracing.int.test.ts
@@ -1,11 +1,11 @@
 import 'dotenv/config';
 
-import { it } from 'vitest';
-import { createTool } from '@mastra/core/tools';
-import { Agent } from '@mastra/core/agent';
 import { openai } from '@ai-sdk/openai';
-import { z } from 'zod';
 import { Mastra } from '@mastra/core';
+import { Agent } from '@mastra/core/agent';
+import { createTool } from '@mastra/core/tools';
+import { it } from 'vitest';
+import { z } from 'zod';
 import { LangSmithExporter } from './ai-tracing';
 
 it.skip('should initialize with correct configuration', async () => {

--- a/observability/langsmith/src/ai-tracing.test.ts
+++ b/observability/langsmith/src/ai-tracing.test.ts
@@ -16,8 +16,8 @@ import type {
   ToolCallAttributes,
 } from '@mastra/core/ai-tracing';
 import { AISpanType, AITracingEventType } from '@mastra/core/ai-tracing';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Client, RunTree } from 'langsmith';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangSmithExporter } from './ai-tracing';
 import type { LangSmithExporterConfig } from './ai-tracing';
 

--- a/observability/langsmith/src/ai-tracing.test.ts
+++ b/observability/langsmith/src/ai-tracing.test.ts
@@ -418,7 +418,7 @@ describe('LangSmithExporter', () => {
         outputs: { content: 'Hi there!' },
         metadata: {
           mastra_span_type: 'llm_generation',
-          ls_model: 'gpt-4',
+          ls_model_name: 'gpt-4',
           ls_provider: 'openai',
           provider: 'openai',
           usage_metadata: {
@@ -458,7 +458,7 @@ describe('LangSmithExporter', () => {
         client: mockClient,
         metadata: {
           mastra_span_type: 'llm_generation',
-          ls_model: 'gpt-3.5-turbo',
+          ls_model_name: 'gpt-3.5-turbo',
           usage_metadata: {},
         },
       });
@@ -535,7 +535,7 @@ describe('LangSmithExporter', () => {
       expect(mockRunTree.metadata).toEqual(
         expect.objectContaining({
           mastra_span_type: 'llm_generation',
-          ls_model: 'gpt-4',
+          ls_model_name: 'gpt-4',
           usage_metadata: {
             total_tokens: 150,
           },

--- a/observability/langsmith/src/ai-tracing.test.ts
+++ b/observability/langsmith/src/ai-tracing.test.ts
@@ -1,0 +1,1009 @@
+/**
+ * LangSmith Exporter Tests
+ *
+ * These tests focus on LangSmith-specific functionality:
+ * - LangSmith client interactions and RunTree creation
+ * - Mapping logic (spans -> LangSmith RunTrees with correct types)
+ * - Event handling as zero-duration RunTrees
+ * - Type-specific metadata extraction and usage metrics
+ * - LangSmith-specific error handling
+ */
+
+import type {
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+  ToolCallAttributes,
+} from '@mastra/core/ai-tracing';
+import { AISpanType, AITracingEventType } from '@mastra/core/ai-tracing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client, RunTree } from 'langsmith';
+import { LangSmithExporter } from './ai-tracing';
+import type { LangSmithExporterConfig } from './ai-tracing';
+
+// Mock LangSmith (must be at the top level)
+vi.mock('langsmith');
+
+describe('LangSmithExporter', () => {
+  // Mock objects
+  let mockRunTree: any;
+  let mockClient: any;
+  let MockRunTreeClass: any;
+  let MockClientClass: any;
+
+  let exporter: LangSmithExporter;
+  let config: LangSmithExporterConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set up mocks for RunTree
+    mockRunTree = {
+      createChild: vi.fn(),
+      postRun: vi.fn().mockResolvedValue(undefined),
+      patchRun: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      inputs: {},
+      outputs: {},
+      metadata: {},
+      error: undefined,
+    };
+
+    // Set up circular reference for child RunTrees
+    mockRunTree.createChild.mockReturnValue(mockRunTree);
+
+    // Mock RunTree constructor
+    MockRunTreeClass = vi.mocked(RunTree);
+    MockRunTreeClass.mockImplementation(() => mockRunTree);
+
+    // Set up mock for Client
+    mockClient = {
+      createRun: vi.fn(),
+      updateRun: vi.fn(),
+    };
+
+    MockClientClass = vi.mocked(Client);
+    MockClientClass.mockImplementation(() => mockClient);
+
+    config = {
+      apiKey: 'test-api-key',
+      apiUrl: 'https://test-langsmith.com',
+      logLevel: 'debug' as const,
+    };
+
+    exporter = new LangSmithExporter(config);
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with correct configuration', () => {
+      expect(exporter.name).toBe('langsmith');
+    });
+
+    it('should disable exporter when apiKey is missing', async () => {
+      const mockConsole = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const invalidConfig = {
+        // Missing apiKey
+        apiUrl: 'https://test.com',
+      };
+
+      const disabledExporter = new LangSmithExporter(invalidConfig);
+
+      // Should log error about missing credentials
+      expect(mockConsole).toHaveBeenCalledWith(
+        expect.stringContaining('LangSmithExporter: Missing required credentials, exporter will be disabled'),
+        expect.objectContaining({
+          hasApiKey: false,
+        }),
+      );
+
+      // Should not create spans when disabled
+      const rootSpan = createMockSpan({
+        id: 'test-span',
+        name: 'test',
+        type: AISpanType.GENERIC,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await disabledExporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      expect(MockRunTreeClass).not.toHaveBeenCalled();
+
+      mockConsole.mockRestore();
+    });
+  });
+
+  describe('RunTree Creation', () => {
+    it('should create LangSmith RunTree for root spans', async () => {
+      const rootSpan = createMockSpan({
+        id: 'root-span-id',
+        name: 'root-agent',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {
+          agentId: 'agent-123',
+          instructions: 'Test agent',
+        },
+        metadata: { userId: 'user-456', sessionId: 'session-789' },
+      });
+
+      const event: AITracingEvent = {
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      };
+
+      await exporter.exportEvent(event);
+
+      // Should create LangSmith RunTree with correct configuration
+      expect(MockRunTreeClass).toHaveBeenCalledWith({
+        name: 'root-agent',
+        run_type: 'chain', // Default span type mapping for AGENT_RUN
+        client: mockClient,
+        metadata: {
+          mastra_span_type: 'agent_run',
+          agentId: 'agent-123',
+          instructions: 'Test agent',
+          userId: 'user-456',
+          sessionId: 'session-789',
+        },
+      });
+
+      // Should post the run to LangSmith
+      expect(mockRunTree.postRun).toHaveBeenCalled();
+    });
+
+    it('should create child RunTree for child spans', async () => {
+      // First create root span
+      const rootSpan = createMockSpan({
+        id: 'root-span-id',
+        name: 'root-agent',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Store the call count after root span creation
+      const rootCallCount = MockRunTreeClass.mock.calls.length;
+
+      // Then create child span
+      const childSpan = createMockSpan({
+        id: 'child-span-id',
+        name: 'child-tool',
+        type: AISpanType.TOOL_CALL,
+        isRoot: false,
+        attributes: { toolId: 'calculator' },
+      });
+      childSpan.traceId = 'root-span-id';
+      childSpan.parentSpanId = 'root-span-id';
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: childSpan,
+      });
+
+      // Should not create new RunTree class instance for child spans (uses createChild instead)
+      expect(MockRunTreeClass).toHaveBeenCalledTimes(rootCallCount); // Same as root span count
+
+      // Should create child RunTree on parent
+      expect(mockRunTree.createChild).toHaveBeenCalledWith({
+        name: 'child-tool',
+        run_type: 'tool', // TOOL_CALL maps to 'tool'
+        client: mockClient,
+        metadata: {
+          mastra_span_type: 'tool_call',
+          toolId: 'calculator',
+        },
+      });
+
+      // Should post the child run
+      expect(mockRunTree.postRun).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Span Type Mappings', () => {
+    it('should map LLM_GENERATION to "llm" type', async () => {
+      const llmSpan = createMockSpan({
+        id: 'llm-span',
+        name: 'gpt-4-call',
+        type: AISpanType.LLM_GENERATION,
+        isRoot: true,
+        attributes: { model: 'gpt-4' },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'llm',
+        }),
+      );
+    });
+
+    it('should map LLM_CHUNK to "llm" type', async () => {
+      const chunkSpan = createMockSpan({
+        id: 'chunk-span',
+        name: 'llm-chunk',
+        type: AISpanType.LLM_CHUNK,
+        isRoot: true,
+        attributes: { chunkType: 'text-delta' },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: chunkSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'llm',
+        }),
+      );
+    });
+
+    it('should map TOOL_CALL to "tool" type', async () => {
+      const toolSpan = createMockSpan({
+        id: 'tool-span',
+        name: 'calculator',
+        type: AISpanType.TOOL_CALL,
+        isRoot: true,
+        attributes: { toolId: 'calc' },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: toolSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'tool',
+        }),
+      );
+    });
+
+    it('should map MCP_TOOL_CALL to "tool" type', async () => {
+      const mcpSpan = createMockSpan({
+        id: 'mcp-span',
+        name: 'mcp-tool',
+        type: AISpanType.MCP_TOOL_CALL,
+        isRoot: true,
+        attributes: { toolId: 'file-reader', mcpServer: 'fs-server' },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: mcpSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'tool',
+        }),
+      );
+    });
+
+    it('should map WORKFLOW_CONDITIONAL_EVAL to "chain" type', async () => {
+      const condSpan = createMockSpan({
+        id: 'cond-span',
+        name: 'condition-eval',
+        type: AISpanType.WORKFLOW_CONDITIONAL_EVAL,
+        isRoot: true,
+        attributes: { conditionIndex: 0, result: true },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: condSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'chain',
+        }),
+      );
+    });
+
+    it('should map WORKFLOW_WAIT_EVENT to "chain" type', async () => {
+      const waitSpan = createMockSpan({
+        id: 'wait-span',
+        name: 'wait-event',
+        type: AISpanType.WORKFLOW_WAIT_EVENT,
+        isRoot: true,
+        attributes: { eventName: 'user-input', timeoutMs: 30000 },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: waitSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'chain',
+        }),
+      );
+    });
+
+    it('should default to "task" type for other span types', async () => {
+      const genericSpan = createMockSpan({
+        id: 'generic-span',
+        name: 'generic',
+        type: AISpanType.GENERIC,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: genericSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'chain',
+        }),
+      );
+
+      // Test other span types that should default to 'chain'
+      const agentSpan = createMockSpan({
+        id: 'agent-span',
+        name: 'agent',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: { agentId: 'test-agent' },
+      });
+
+      vi.clearAllMocks();
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: agentSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_type: 'chain',
+        }),
+      );
+    });
+  });
+
+  describe('LLM Generation Attributes', () => {
+    it('should handle LLM generation with full attributes', async () => {
+      const llmSpan = createMockSpan({
+        id: 'llm-span',
+        name: 'gpt-4-call',
+        type: AISpanType.LLM_GENERATION,
+        isRoot: true,
+        input: { messages: [{ role: 'user', content: 'Hello' }] },
+        output: { content: 'Hi there!' },
+        attributes: {
+          model: 'gpt-4',
+          provider: 'openai',
+          usage: {
+            promptTokens: 10,
+            completionTokens: 5,
+            totalTokens: 15,
+          },
+          parameters: {
+            temperature: 0.7,
+            maxTokens: 100,
+          },
+          streaming: false,
+          resultType: 'response_generation',
+        },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith({
+        name: 'gpt-4-call',
+        run_type: 'llm',
+        client: mockClient,
+        inputs: { messages: [{ role: 'user', content: 'Hello' }] },
+        outputs: { content: 'Hi there!' },
+        metadata: {
+          mastra_span_type: 'llm_generation',
+          ls_model: 'gpt-4',
+          ls_provider: 'openai',
+          provider: 'openai',
+          usage_metadata: {
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+          },
+          streaming: false,
+          resultType: 'response_generation',
+          modelParameters: {
+            temperature: 0.7,
+            maxTokens: 100,
+          },
+        },
+      });
+    });
+
+    it('should handle minimal LLM generation attributes', async () => {
+      const llmSpan = createMockSpan({
+        id: 'minimal-llm',
+        name: 'simple-llm',
+        type: AISpanType.LLM_GENERATION,
+        isRoot: true,
+        attributes: {
+          model: 'gpt-3.5-turbo',
+        },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
+      });
+
+      expect(MockRunTreeClass).toHaveBeenCalledWith({
+        name: 'simple-llm',
+        run_type: 'llm',
+        client: mockClient,
+        metadata: {
+          mastra_span_type: 'llm_generation',
+          ls_model: 'gpt-3.5-turbo',
+          usage_metadata: {},
+        },
+      });
+    });
+  });
+
+  describe('RunTree Updates', () => {
+    it('should update existing RunTrees', async () => {
+      // First, start a span
+      const toolSpan = createMockSpan({
+        id: 'tool-span',
+        name: 'calculator',
+        type: AISpanType.TOOL_CALL,
+        isRoot: true,
+        attributes: { toolId: 'calc', success: false },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: toolSpan,
+      });
+
+      // Then update it
+      toolSpan.attributes = {
+        ...toolSpan.attributes,
+        success: true,
+      } as ToolCallAttributes;
+      toolSpan.output = { result: 42 };
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_UPDATED,
+        exportedSpan: toolSpan,
+      });
+
+      // Should update the RunTree properties
+      expect(mockRunTree.outputs).toEqual({ result: 42 });
+      expect(mockRunTree.metadata).toEqual(
+        expect.objectContaining({
+          mastra_span_type: 'tool_call',
+          toolId: 'calc',
+          success: true,
+        }),
+      );
+    });
+
+    it('should update LLM generation RunTrees', async () => {
+      const llmSpan = createMockSpan({
+        id: 'llm-span',
+        name: 'gpt-4-call',
+        type: AISpanType.LLM_GENERATION,
+        isRoot: true,
+        attributes: { model: 'gpt-4' },
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
+      });
+
+      // Update with usage info
+      llmSpan.attributes = {
+        ...llmSpan.attributes,
+        usage: { totalTokens: 150 },
+      } as LLMGenerationAttributes;
+      llmSpan.output = { content: 'Updated response' };
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_UPDATED,
+        exportedSpan: llmSpan,
+      });
+
+      // Should update the RunTree properties
+      expect(mockRunTree.outputs).toEqual({ content: 'Updated response' });
+      expect(mockRunTree.metadata).toEqual(
+        expect.objectContaining({
+          mastra_span_type: 'llm_generation',
+          ls_model: 'gpt-4',
+          usage_metadata: {
+            total_tokens: 150,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('RunTree Ending', () => {
+    it('should end RunTree and patch final data', async () => {
+      const span = createMockSpan({
+        id: 'test-span',
+        name: 'test',
+        type: AISpanType.GENERIC,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: span,
+      });
+
+      span.endTime = new Date();
+      span.output = { result: 'success' };
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: span,
+      });
+
+      // Should update final data
+      expect(mockRunTree.outputs).toEqual({ result: 'success' });
+      expect(mockRunTree.metadata).toEqual(
+        expect.objectContaining({
+          mastra_span_type: 'generic',
+        }),
+      );
+
+      // Should end the RunTree
+      expect(mockRunTree.end).toHaveBeenCalledWith({ endTime: span.endTime.getTime() / 1000 });
+      expect(mockRunTree.patchRun).toHaveBeenCalled();
+    });
+
+    it('should handle RunTrees with error information', async () => {
+      const errorSpan = createMockSpan({
+        id: 'error-span',
+        name: 'failing-operation',
+        type: AISpanType.TOOL_CALL,
+        isRoot: true,
+        attributes: { toolId: 'failing-tool' },
+        errorInfo: {
+          message: 'Tool execution failed',
+          id: 'TOOL_ERROR',
+          category: 'EXECUTION',
+        },
+      });
+
+      errorSpan.endTime = new Date();
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: errorSpan,
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: errorSpan,
+      });
+
+      // Should set error information
+      expect(mockRunTree.error).toBe('Tool execution failed');
+      expect(mockRunTree.metadata).toEqual(
+        expect.objectContaining({
+          mastra_span_type: 'tool_call',
+          toolId: 'failing-tool',
+          errorDetails: {
+            message: 'Tool execution failed',
+            id: 'TOOL_ERROR',
+            category: 'EXECUTION',
+          },
+        }),
+      );
+
+      expect(mockRunTree.end).toHaveBeenCalledWith({ endTime: errorSpan.endTime.getTime() / 1000 });
+      expect(mockRunTree.patchRun).toHaveBeenCalled();
+    });
+
+    it('should clean up traceMap when root span ends', async () => {
+      const rootSpan = createMockSpan({
+        id: 'root-span',
+        name: 'root',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Verify trace was created
+      expect((exporter as any).traceMap.has('root-span')).toBe(true);
+
+      rootSpan.endTime = new Date();
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_ENDED,
+        exportedSpan: rootSpan,
+      });
+
+      // Should clean up traceMap
+      expect((exporter as any).traceMap.has('root-span')).toBe(false);
+    });
+  });
+
+  describe('Event Span Handling', () => {
+    it('should create zero-duration RunTrees for root event spans', async () => {
+      const eventSpan = createMockSpan({
+        id: 'event-span',
+        name: 'user-feedback',
+        type: AISpanType.GENERIC,
+        isRoot: true,
+        attributes: {
+          eventType: 'user_feedback',
+          rating: 5,
+        },
+        output: { message: 'Great response!' },
+      });
+      eventSpan.isEvent = true;
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: eventSpan,
+      });
+
+      // Should create RunTree for root event
+      expect(MockRunTreeClass).toHaveBeenCalledWith({
+        name: 'user-feedback',
+        type: 'chain',
+        client: mockClient,
+        startTime: eventSpan.startTime.getTime() / 1000,
+        outputs: { message: 'Great response!' },
+        metadata: {
+          mastra_span_type: 'generic',
+          eventType: 'user_feedback',
+          rating: 5,
+        },
+      });
+
+      // Should post the run
+      expect(mockRunTree.postRun).toHaveBeenCalled();
+
+      // Should immediately end with same timestamp
+      expect(mockRunTree.end).toHaveBeenCalledWith({ endTime: eventSpan.startTime.getTime() / 1000 });
+      expect(mockRunTree.patchRun).toHaveBeenCalled();
+    });
+
+    it('should create zero-duration child RunTrees for child event spans', async () => {
+      // First create root span
+      const rootSpan = createMockSpan({
+        id: 'root-span',
+        name: 'root-agent',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Then create child event span
+      const childEventSpan = createMockSpan({
+        id: 'child-event',
+        name: 'tool-result',
+        type: AISpanType.GENERIC,
+        isRoot: false,
+        attributes: {
+          toolName: 'calculator',
+          success: true,
+        },
+        output: { result: 42 },
+      });
+      childEventSpan.isEvent = true;
+      childEventSpan.traceId = 'root-span';
+      childEventSpan.parentSpanId = 'root-span';
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: childEventSpan,
+      });
+
+      // Should create child RunTree on parent
+      expect(mockRunTree.createChild).toHaveBeenCalledWith({
+        name: 'tool-result',
+        type: 'chain',
+        client: mockClient,
+        startTime: childEventSpan.startTime.getTime() / 1000,
+        outputs: { result: 42 },
+        metadata: {
+          mastra_span_type: 'generic',
+          toolName: 'calculator',
+          success: true,
+        },
+      });
+
+      // Should post and immediately end the child
+      expect(mockRunTree.postRun).toHaveBeenCalledTimes(2);
+      expect(mockRunTree.end).toHaveBeenCalledWith({ endTime: childEventSpan.startTime.getTime() / 1000 });
+      expect(mockRunTree.patchRun).toHaveBeenCalled();
+    });
+
+    it('should handle orphan event spans gracefully', async () => {
+      const orphanEventSpan = createMockSpan({
+        id: 'orphan-event',
+        name: 'orphan',
+        type: AISpanType.GENERIC,
+        isRoot: false,
+        attributes: {},
+      });
+      orphanEventSpan.isEvent = true;
+      orphanEventSpan.traceId = 'missing-trace';
+
+      // Should not throw
+      await expect(
+        exporter.exportEvent({
+          type: AITracingEventType.SPAN_STARTED,
+          exportedSpan: orphanEventSpan,
+        }),
+      ).resolves.not.toThrow();
+
+      // Should not create any RunTrees
+      expect(MockRunTreeClass).not.toHaveBeenCalled();
+      expect(mockRunTree.createChild).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle missing traces gracefully', async () => {
+      const orphanSpan = createMockSpan({
+        id: 'orphan-span',
+        name: 'orphan',
+        type: AISpanType.TOOL_CALL,
+        isRoot: false,
+        attributes: { toolId: 'orphan-tool' },
+      });
+
+      // Should not throw when trying to create child span without parent
+      await expect(
+        exporter.exportEvent({
+          type: AITracingEventType.SPAN_STARTED,
+          exportedSpan: orphanSpan,
+        }),
+      ).resolves.not.toThrow();
+
+      // Should not create any RunTrees
+      expect(MockRunTreeClass).not.toHaveBeenCalled();
+    });
+
+    it('should handle missing spans gracefully', async () => {
+      const span = createMockSpan({
+        id: 'missing-span',
+        name: 'missing',
+        type: AISpanType.GENERIC,
+        isRoot: true,
+        attributes: {},
+      });
+
+      // Try to update non-existent span
+      await expect(
+        exporter.exportEvent({
+          type: AITracingEventType.SPAN_UPDATED,
+          exportedSpan: span,
+        }),
+      ).resolves.not.toThrow();
+
+      // Try to end non-existent span
+      await expect(
+        exporter.exportEvent({
+          type: AITracingEventType.SPAN_ENDED,
+          exportedSpan: span,
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('Shutdown', () => {
+    it('should end all RunTrees and clear traceMap', async () => {
+      // Create some spans
+      const rootSpan = createMockSpan({
+        id: 'root-span',
+        name: 'root',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({
+        type: AITracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Verify maps have data
+      expect((exporter as any).traceMap.size).toBeGreaterThan(0);
+
+      // Shutdown
+      await exporter.shutdown();
+
+      // Verify all RunTrees were ended and patched
+      expect(mockRunTree.end).toHaveBeenCalled();
+      expect(mockRunTree.patchRun).toHaveBeenCalled();
+
+      // Verify maps were cleared
+      expect((exporter as any).traceMap.size).toBe(0);
+    });
+
+    it('should handle shutdown when exporter is disabled', async () => {
+      const disabledExporter = new LangSmithExporter({});
+
+      // Should not throw
+      await expect(disabledExporter.shutdown()).resolves.not.toThrow();
+    });
+  });
+
+  describe('Out-of-Order Events', () => {
+    it('keeps trace until last child ends when root ends first', async () => {
+      // Start root span
+      const rootSpan = createMockSpan({
+        id: 'root-span-oOO',
+        name: 'root-agent',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_STARTED, exportedSpan: rootSpan });
+
+      // Start child span
+      const childSpan = createMockSpan({
+        id: 'child-span-oOO',
+        name: 'child-step',
+        type: AISpanType.GENERIC,
+        isRoot: false,
+        attributes: { stepId: 'child-step' },
+      });
+      childSpan.traceId = rootSpan.traceId;
+      childSpan.parentSpanId = rootSpan.id;
+
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_STARTED, exportedSpan: childSpan });
+
+      // End root BEFORE child ends (out-of-order end sequence)
+      rootSpan.endTime = new Date();
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_ENDED, exportedSpan: rootSpan });
+
+      // Now end child
+      childSpan.endTime = new Date();
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_ENDED, exportedSpan: childSpan });
+
+      // Both LangSmith RunTrees should be ended (root then child)
+      expect(mockRunTree.end).toHaveBeenCalledTimes(2);
+      expect(mockRunTree.patchRun).toHaveBeenCalledTimes(2);
+
+      // Shutdown should not end anything further (cleanup already done)
+      await exporter.shutdown();
+      expect(mockRunTree.end).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows starting new child after root ended if another child is still active', async () => {
+      // Start root span
+      const rootSpan = createMockSpan({
+        id: 'root-span-keepalive',
+        name: 'root-agent',
+        type: AISpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_STARTED, exportedSpan: rootSpan });
+
+      // Start first child to keep the trace alive
+      const childA = createMockSpan({
+        id: 'child-A',
+        name: 'child-A',
+        type: AISpanType.GENERIC,
+        isRoot: false,
+        attributes: { stepId: 'A' },
+      });
+      childA.traceId = rootSpan.traceId;
+      childA.parentSpanId = rootSpan.id;
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_STARTED, exportedSpan: childA });
+
+      // End root while childA is still active
+      rootSpan.endTime = new Date();
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_ENDED, exportedSpan: rootSpan });
+
+      // Start another child AFTER root has ended
+      const childB = createMockSpan({
+        id: 'child-B',
+        name: 'child-B',
+        type: AISpanType.GENERIC,
+        isRoot: false,
+        attributes: { stepId: 'B' },
+      });
+      childB.traceId = rootSpan.traceId;
+      childB.parentSpanId = rootSpan.id;
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_STARTED, exportedSpan: childB });
+
+      // Finish both children
+      childA.endTime = new Date();
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_ENDED, exportedSpan: childA });
+
+      childB.endTime = new Date();
+      await exporter.exportEvent({ type: AITracingEventType.SPAN_ENDED, exportedSpan: childB });
+
+      // Ends: root, childA, childB
+      expect(mockRunTree.end).toHaveBeenCalledTimes(3);
+      expect(mockRunTree.patchRun).toHaveBeenCalledTimes(3);
+
+      // Shutdown should not end anything further
+      await exporter.shutdown();
+      expect(mockRunTree.end).toHaveBeenCalledTimes(3);
+    });
+  });
+});
+
+// Helper function to create mock spans
+function createMockSpan({
+  id,
+  name,
+  type,
+  isRoot,
+  attributes,
+  metadata,
+  input,
+  output,
+  errorInfo,
+}: {
+  id: string;
+  name: string;
+  type: AISpanType;
+  isRoot: boolean;
+  attributes: any;
+  metadata?: Record<string, any>;
+  input?: any;
+  output?: any;
+  errorInfo?: any;
+}): AnyExportedAISpan {
+  const mockSpan = {
+    id,
+    name,
+    type,
+    attributes,
+    metadata,
+    input,
+    output,
+    errorInfo,
+    startTime: new Date(),
+    endTime: undefined,
+    traceId: isRoot ? id : 'parent-trace-id',
+    get isRootSpan() {
+      return isRoot;
+    },
+    parentSpanId: isRoot ? undefined : 'parent-id',
+    isEvent: false,
+  } as AnyExportedAISpan;
+
+  return mockSpan;
+}

--- a/observability/langsmith/src/ai-tracing.ts
+++ b/observability/langsmith/src/ai-tracing.ts
@@ -106,6 +106,7 @@ export class LangSmithExporter implements AITracingExporter {
   }
 
   private async handleSpanStarted(span: AnyExportedAISpan): Promise<void> {
+    this.logger.debug('LangSmith exporter: handleSpanStarted', span.id, span.name);
     if (span.isRootSpan) {
       this.initializeRootSpan(span);
     }
@@ -135,12 +136,13 @@ export class LangSmithExporter implements AITracingExporter {
       langsmithRunTree = langsmithParent.createChild(payload);
     }
 
-    await langsmithRunTree.postRun();
-
     spanData.spans.set(span.id, langsmithRunTree);
+
+    await langsmithRunTree.postRun();
   }
 
   private async handleSpanUpdateOrEnd(span: AnyExportedAISpan, isEnd: boolean): Promise<void> {
+    this.logger.debug('LangSmith exporter: handleSpanUpdateOrEnd', span.id, span.name, 'isEnd:', isEnd);
     const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
 
     const spanData = this.getSpanData({ span, method });
@@ -162,7 +164,6 @@ export class LangSmithExporter implements AITracingExporter {
       return;
     }
 
-    // langsmithRunTree.log(this.buildRunTreePayload(span));
     const updatePayload = this.buildRunTreePayload(span);
     langsmithRunTree.metadata = {
       ...langsmithRunTree.metadata,

--- a/observability/langsmith/src/ai-tracing.ts
+++ b/observability/langsmith/src/ai-tracing.ts
@@ -14,9 +14,10 @@ import type {
 } from '@mastra/core/ai-tracing';
 import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
 import { ConsoleLogger } from '@mastra/core/logger';
-import { RunTree, Client, type ClientConfig, type RunTreeConfig } from 'langsmith';
-import { normalizeUsageMetrics } from './metrics';
+import type { ClientConfig, RunTreeConfig } from 'langsmith';
+import { Client, RunTree } from 'langsmith';
 import type { KVMap } from 'langsmith/schemas';
+import { normalizeUsageMetrics } from './metrics';
 
 export interface LangSmithExporterConfig extends ClientConfig {
   /** Logger level for diagnostic messages (default: 'warn') */
@@ -361,10 +362,10 @@ export class LangSmithExporter implements AITracingExporter {
 
     // End all active spans
     for (const [_traceId, spanData] of this.traceMap) {
-      for (const [_spanId, span] of spanData.spans) {
-        span.end();
+      for (const [_spanId, runTree] of spanData.spans) {
+        await runTree.end();
+        await runTree.patchRun();
       }
-      // Loggers don't have an explicit shutdown method
     }
     this.traceMap.clear();
   }

--- a/observability/langsmith/src/ai-tracing.ts
+++ b/observability/langsmith/src/ai-tracing.ts
@@ -315,7 +315,7 @@ export class LangSmithExporter implements AITracingExporter {
       if (llmAttr.model !== undefined) {
         // Note - this should map to a model name recognized by LangSmith
         // eg “gpt-4o-mini”, “claude-3-opus-20240307”, etc.
-        payload.metadata.ls_model = llmAttr.model;
+        payload.metadata.ls_model_name = llmAttr.model;
       }
 
       // Provider goes to metadata (if provided by attributes)

--- a/observability/langsmith/src/ai-tracing.ts
+++ b/observability/langsmith/src/ai-tracing.ts
@@ -1,0 +1,371 @@
+/**
+ * LangSmith Exporter for Mastra AI Tracing
+ *
+ * This exporter sends tracing data to LangSmith for AI observability.
+ * Root spans become top-level LangSmith RunTrees (no trace wrapper).
+ * Events are handled as zero-duration RunTrees with matching start/end times.
+ */
+
+import type {
+  AITracingExporter,
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+} from '@mastra/core/ai-tracing';
+import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
+import { ConsoleLogger } from '@mastra/core/logger';
+import { RunTree, Client, type ClientConfig, type RunTreeConfig } from 'langsmith';
+import { normalizeUsageMetrics } from './metrics';
+import type { KVMap } from 'langsmith/schemas';
+
+export interface LangSmithExporterConfig extends ClientConfig {
+  /** Logger level for diagnostic messages (default: 'warn') */
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
+  /** LangSmith client instance */
+  client?: Client;
+}
+
+type SpanData = {
+  spans: Map<string, RunTree>; // Maps span.id to LangSmith RunTrees
+  activeIds: Set<string>; // Tracks started (non-event) spans not yet ended, including root
+};
+
+// Default span type for all spans
+const DEFAULT_SPAN_TYPE = 'chain';
+
+// Exceptions to the default mapping
+const SPAN_TYPE_EXCEPTIONS: Partial<Record<AISpanType, string>> = {
+  [AISpanType.LLM_GENERATION]: 'llm',
+  [AISpanType.LLM_CHUNK]: 'llm',
+  [AISpanType.TOOL_CALL]: 'tool',
+  [AISpanType.MCP_TOOL_CALL]: 'tool',
+  [AISpanType.WORKFLOW_CONDITIONAL_EVAL]: 'chain',
+  [AISpanType.WORKFLOW_WAIT_EVENT]: 'chain',
+};
+
+// Mapping function - returns valid LangSmith span types
+function mapSpanType(spanType: AISpanType): 'llm' | 'tool' | 'chain' {
+  return (SPAN_TYPE_EXCEPTIONS[spanType] as any) ?? DEFAULT_SPAN_TYPE;
+}
+
+function isKVMap(value: unknown): value is KVMap {
+  return value != null && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date);
+}
+
+export class LangSmithExporter implements AITracingExporter {
+  name = 'langsmith';
+  private traceMap = new Map<string, SpanData>();
+  private logger: ConsoleLogger;
+  private config: LangSmithExporterConfig;
+  private client: Client;
+
+  constructor(config: LangSmithExporterConfig) {
+    this.logger = new ConsoleLogger({ level: config.logLevel ?? 'warn' });
+
+    config.apiKey = config.apiKey ?? process.env.LANGSMITH_API_KEY;
+
+    if (!config.apiKey) {
+      this.logger.error('LangSmithExporter: Missing required credentials, exporter will be disabled', {
+        hasApiKey: !!config.apiKey,
+      });
+      this.config = null as any;
+      this.client = null as any;
+      return;
+    }
+
+    this.client = config.client ?? new Client(config);
+    this.config = config;
+  }
+
+  async exportEvent(event: AITracingEvent): Promise<void> {
+    if (!this.config) {
+      return;
+    }
+
+    if (event.exportedSpan.isEvent) {
+      await this.handleEventSpan(event.exportedSpan);
+      return;
+    }
+
+    switch (event.type) {
+      case 'span_started':
+        await this.handleSpanStarted(event.exportedSpan);
+        break;
+      case 'span_updated':
+        await this.handleSpanUpdateOrEnd(event.exportedSpan, false);
+        break;
+      case 'span_ended':
+        await this.handleSpanUpdateOrEnd(event.exportedSpan, true);
+        break;
+    }
+  }
+
+  private initializeRootSpan(span: AnyExportedAISpan) {
+    this.traceMap.set(span.traceId, { spans: new Map(), activeIds: new Set() });
+  }
+
+  private async handleSpanStarted(span: AnyExportedAISpan): Promise<void> {
+    if (span.isRootSpan) {
+      this.initializeRootSpan(span);
+    }
+
+    const method = 'handleSpanStarted';
+    const spanData = this.getSpanData({ span, method });
+    if (!spanData) {
+      return;
+    }
+
+    // Refcount: track active non-event spans (including root)
+    if (!span.isEvent) {
+      spanData.activeIds.add(span.id);
+    }
+
+    const payload = {
+      name: span.name,
+      run_type: mapSpanType(span.type),
+      ...this.buildRunTreePayload(span),
+    };
+
+    const langsmithParent = this.getLangSmithParent({ spanData, span, method });
+    let langsmithRunTree: RunTree;
+    if (!langsmithParent) {
+      langsmithRunTree = new RunTree(payload);
+    } else {
+      langsmithRunTree = langsmithParent.createChild(payload);
+    }
+
+    await langsmithRunTree.postRun();
+
+    spanData.spans.set(span.id, langsmithRunTree);
+  }
+
+  private async handleSpanUpdateOrEnd(span: AnyExportedAISpan, isEnd: boolean): Promise<void> {
+    const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
+
+    const spanData = this.getSpanData({ span, method });
+    if (!spanData) {
+      return;
+    }
+
+    const langsmithRunTree = spanData.spans.get(span.id);
+    if (!langsmithRunTree) {
+      this.logger.warn('LangSmith exporter: No LangSmith span found for span update/end', {
+        traceId: span.traceId,
+        spanId: span.id,
+        spanName: span.name,
+        spanType: span.type,
+        isRootSpan: span.isRootSpan,
+        parentSpanId: span.parentSpanId,
+        method,
+      });
+      return;
+    }
+
+    // langsmithRunTree.log(this.buildRunTreePayload(span));
+    const updatePayload = this.buildRunTreePayload(span);
+    langsmithRunTree.metadata = {
+      ...langsmithRunTree.metadata,
+      ...updatePayload.metadata,
+    };
+    if (updatePayload.inputs != null) {
+      langsmithRunTree.inputs = updatePayload.inputs;
+    }
+    if (updatePayload.outputs != null) {
+      langsmithRunTree.outputs = updatePayload.outputs;
+    }
+    if (updatePayload.error != null) {
+      langsmithRunTree.error = updatePayload.error;
+    }
+
+    if (isEnd) {
+      // End the span with the correct endTime (convert milliseconds to seconds)
+      if (span.endTime) {
+        await langsmithRunTree.end({ endTime: span.endTime.getTime() / 1000 });
+      } else {
+        await langsmithRunTree.end();
+      }
+      await langsmithRunTree.patchRun();
+
+      // Refcount: mark this span as ended
+      if (!span.isEvent) {
+        spanData.activeIds.delete(span.id);
+      }
+
+      // If no more active spans remain for this trace, clean up the trace entry
+      if (spanData.activeIds.size === 0) {
+        this.traceMap.delete(span.traceId);
+      }
+    }
+  }
+
+  private async handleEventSpan(span: AnyExportedAISpan): Promise<void> {
+    if (span.isRootSpan) {
+      this.logger.debug('LangSmith exporter: Creating logger for event', {
+        traceId: span.traceId,
+        spanId: span.id,
+        spanName: span.name,
+        method: 'handleEventSpan',
+      });
+      this.initializeRootSpan(span);
+    }
+
+    const method = 'handleEventSpan';
+    const spanData = this.getSpanData({ span, method });
+    if (!spanData) {
+      return;
+    }
+
+    const langsmithParent = this.getLangSmithParent({ spanData, span, method });
+    const payload = {
+      ...this.buildRunTreePayload(span),
+      name: span.name,
+      type: mapSpanType(span.type),
+      startTime: span.startTime.getTime() / 1000,
+    };
+
+    let langsmithRunTree: RunTree;
+    if (!langsmithParent) {
+      langsmithRunTree = new RunTree(payload);
+    } else {
+      langsmithRunTree = langsmithParent.createChild(payload);
+    }
+
+    await langsmithRunTree.postRun();
+
+    await langsmithRunTree.end({ endTime: span.startTime.getTime() / 1000 });
+    await langsmithRunTree.patchRun();
+  }
+
+  private getSpanData(options: { span: AnyExportedAISpan; method: string }): SpanData | undefined {
+    const { span, method } = options;
+    if (this.traceMap.has(span.traceId)) {
+      return this.traceMap.get(span.traceId);
+    }
+
+    this.logger.warn('LangSmith exporter: No span data found for span', {
+      traceId: span.traceId,
+      spanId: span.id,
+      spanName: span.name,
+      spanType: span.type,
+      isRootSpan: span.isRootSpan,
+      parentSpanId: span.parentSpanId,
+      method,
+    });
+  }
+
+  private getLangSmithParent(options: {
+    spanData: SpanData;
+    span: AnyExportedAISpan;
+    method: string;
+  }): RunTree | undefined {
+    const { spanData, span, method } = options;
+
+    const parentId = span.parentSpanId;
+    if (!parentId) {
+      return undefined;
+    }
+
+    if (spanData.spans.has(parentId)) {
+      return spanData.spans.get(parentId);
+    }
+
+    if (parentId && !spanData.spans.has(parentId)) {
+      // This means the parent exists but isn't tracked as a LangSmith span,
+      // which happens when the parent is the root span
+      return undefined;
+    }
+
+    this.logger.warn('LangSmith exporter: No parent data found for span', {
+      traceId: span.traceId,
+      spanId: span.id,
+      spanName: span.name,
+      spanType: span.type,
+      isRootSpan: span.isRootSpan,
+      parentSpanId: span.parentSpanId,
+      method,
+    });
+  }
+
+  private buildRunTreePayload(span: AnyExportedAISpan): Partial<RunTreeConfig> {
+    const payload: Partial<RunTreeConfig> & { metadata: KVMap } = {
+      client: this.client,
+      metadata: {
+        mastra_span_type: span.type,
+        ...span.metadata,
+      },
+    };
+
+    // Core span data
+    if (span.input !== undefined) {
+      payload.inputs = isKVMap(span.input) ? span.input : { input: span.input };
+    }
+
+    if (span.output !== undefined) {
+      payload.outputs = isKVMap(span.output) ? span.output : { output: span.output };
+    }
+
+    const attributes = (span.attributes ?? {}) as Record<string, any>;
+
+    if (span.type === AISpanType.LLM_GENERATION) {
+      const llmAttr = attributes as LLMGenerationAttributes;
+
+      // See: https://docs.langchain.com/langsmith/log-llm-trace
+      if (llmAttr.model !== undefined) {
+        // Note - this should map to a model name recognized by LangSmith
+        // eg “gpt-4o-mini”, “claude-3-opus-20240307”, etc.
+        payload.metadata.ls_model = llmAttr.model;
+      }
+
+      // Provider goes to metadata (if provided by attributes)
+      if (llmAttr.provider !== undefined) {
+        // Note - this should map to a provider name recognized by
+        // LangSmith eg “openai”, “anthropic”, etc.
+        payload.metadata.ls_provider = llmAttr.provider;
+      }
+
+      // Usage/token info goes to metrics
+      payload.metadata.usage_metadata = normalizeUsageMetrics(llmAttr);
+
+      // Model parameters go to metadata
+      if (llmAttr.parameters !== undefined) {
+        payload.metadata.modelParameters = llmAttr.parameters;
+      }
+
+      // Other LLM attributes go to metadata
+      const otherAttributes = omitKeys(attributes, ['model', 'usage', 'parameters']);
+      payload.metadata = {
+        ...payload.metadata,
+        ...otherAttributes,
+      };
+    } else {
+      // For non-LLM spans, put all attributes in metadata
+      payload.metadata = {
+        ...payload.metadata,
+        ...attributes,
+      };
+    }
+
+    // Handle errors
+    if (span.errorInfo) {
+      payload.error = span.errorInfo.message;
+      payload.metadata.errorDetails = span.errorInfo;
+    }
+
+    return payload;
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.config) {
+      return;
+    }
+
+    // End all active spans
+    for (const [_traceId, spanData] of this.traceMap) {
+      for (const [_spanId, span] of spanData.spans) {
+        span.end();
+      }
+      // Loggers don't have an explicit shutdown method
+    }
+    this.traceMap.clear();
+  }
+}

--- a/observability/langsmith/src/ai-tracing.ts
+++ b/observability/langsmith/src/ai-tracing.ts
@@ -35,7 +35,7 @@ type SpanData = {
 const DEFAULT_SPAN_TYPE = 'chain';
 
 // Exceptions to the default mapping
-const SPAN_TYPE_EXCEPTIONS: Partial<Record<AISpanType, string>> = {
+const SPAN_TYPE_EXCEPTIONS: Partial<Record<AISpanType, 'llm' | 'tool' | 'chain'>> = {
   [AISpanType.LLM_GENERATION]: 'llm',
   [AISpanType.LLM_CHUNK]: 'llm',
   [AISpanType.TOOL_CALL]: 'tool',
@@ -46,7 +46,7 @@ const SPAN_TYPE_EXCEPTIONS: Partial<Record<AISpanType, string>> = {
 
 // Mapping function - returns valid LangSmith span types
 function mapSpanType(spanType: AISpanType): 'llm' | 'tool' | 'chain' {
-  return (SPAN_TYPE_EXCEPTIONS[spanType] as any) ?? DEFAULT_SPAN_TYPE;
+  return SPAN_TYPE_EXCEPTIONS[spanType] ?? DEFAULT_SPAN_TYPE;
 }
 
 function isKVMap(value: unknown): value is KVMap {

--- a/observability/langsmith/src/index.ts
+++ b/observability/langsmith/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * LangSmith Observability Provider for Mastra
+ *
+ * This package provides LangSmith-specific observability features for Mastra applications.
+ * Currently includes AI tracing support with plans for additional observability features.
+ */
+
+// AI Tracing
+export * from './ai-tracing';

--- a/observability/langsmith/src/metrics.ts
+++ b/observability/langsmith/src/metrics.ts
@@ -1,15 +1,9 @@
 import type { LLMGenerationAttributes } from '@mastra/core/ai-tracing';
 /**
- * BraintrustUsageMetrics
+ * LangSmithUsageMetrics
  *
- * Canonical metric keys expected by Braintrust for LLM usage accounting.
- * These map various provider/SDK-specific usage fields to a common schema.
- * - prompt_tokens: input-side tokens (aka inputTokens/promptTokens)
- * - completion_tokens: output-side tokens (aka outputTokens/completionTokens)
- * - tokens: total tokens (provided or derived)
- * - completion_reasoning_tokens: reasoning tokens, when available
- * - prompt_cached_tokens: tokens served from cache (provider-specific)
- * - prompt_cache_creation_tokens: tokens used to create cache (provider-specific)
+ * Canonical metric keys expected by LangSmith for LLM usage accounting.
+ * See: https://docs.langchain.com/langsmith/log-llm-trace#provide-token-and-cost-information
  */
 export interface LangSmithUsageMetrics {
   input_tokens?: number;
@@ -24,7 +18,6 @@ export interface LangSmithUsageMetrics {
   [key: string]: number | { [key: string]: number } | undefined;
 }
 
-// See: https://docs.langchain.com/langsmith/log-llm-trace#provide-token-and-cost-information
 export function normalizeUsageMetrics(llmAttr: LLMGenerationAttributes): LangSmithUsageMetrics {
   const metrics: LangSmithUsageMetrics = {};
 

--- a/observability/langsmith/src/metrics.ts
+++ b/observability/langsmith/src/metrics.ts
@@ -1,0 +1,68 @@
+import type { LLMGenerationAttributes } from '@mastra/core/ai-tracing';
+/**
+ * BraintrustUsageMetrics
+ *
+ * Canonical metric keys expected by Braintrust for LLM usage accounting.
+ * These map various provider/SDK-specific usage fields to a common schema.
+ * - prompt_tokens: input-side tokens (aka inputTokens/promptTokens)
+ * - completion_tokens: output-side tokens (aka outputTokens/completionTokens)
+ * - tokens: total tokens (provided or derived)
+ * - completion_reasoning_tokens: reasoning tokens, when available
+ * - prompt_cached_tokens: tokens served from cache (provider-specific)
+ * - prompt_cache_creation_tokens: tokens used to create cache (provider-specific)
+ */
+export interface LangSmithUsageMetrics {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  input_token_details?: {
+    [key: string]: number;
+  };
+  output_token_details?: {
+    [key: string]: number;
+  };
+  [key: string]: number | { [key: string]: number } | undefined;
+}
+
+// See: https://docs.langchain.com/langsmith/log-llm-trace#provide-token-and-cost-information
+export function normalizeUsageMetrics(llmAttr: LLMGenerationAttributes): LangSmithUsageMetrics {
+  const metrics: LangSmithUsageMetrics = {};
+
+  if (llmAttr.usage?.inputTokens !== undefined) {
+    metrics.input_tokens = llmAttr.usage?.inputTokens;
+  } else if (llmAttr.usage?.promptTokens !== undefined) {
+    metrics.input_tokens = llmAttr.usage?.promptTokens;
+  }
+
+  if (llmAttr.usage?.outputTokens !== undefined) {
+    metrics.output_tokens = llmAttr.usage?.outputTokens;
+  } else if (llmAttr.usage?.completionTokens !== undefined) {
+    metrics.output_tokens = llmAttr.usage?.completionTokens;
+  }
+
+  if (llmAttr.usage?.totalTokens !== undefined) {
+    metrics.total_tokens = llmAttr.usage?.totalTokens;
+  } else if (typeof llmAttr.usage?.inputTokens === 'number' && typeof llmAttr.usage?.outputTokens === 'number') {
+    metrics.total_tokens = llmAttr.usage?.inputTokens + llmAttr.usage?.outputTokens;
+  }
+  if (llmAttr.usage?.reasoningTokens !== undefined) {
+    metrics.output_token_details = {
+      ...(metrics.output_token_details ?? {}),
+      reasoning_tokens: llmAttr.usage?.reasoningTokens,
+    };
+  }
+  if (llmAttr.usage?.promptCacheHitTokens !== undefined) {
+    metrics.input_token_details = {
+      ...(metrics.input_token_details ?? {}),
+      cache_read: llmAttr.usage?.promptCacheHitTokens,
+    };
+  }
+  if (llmAttr.usage?.promptCacheMissTokens !== undefined) {
+    metrics.input_token_details = {
+      ...(metrics.input_token_details ?? {}),
+      cache_write: llmAttr.usage?.promptCacheMissTokens,
+    };
+  }
+
+  return metrics;
+}

--- a/observability/langsmith/tsconfig.build.json
+++ b/observability/langsmith/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/observability/langsmith/tsconfig.json
+++ b/observability/langsmith/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/observability/langsmith/tsup.config.ts
+++ b/observability/langsmith/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/observability/langsmith/vitest.config.ts
+++ b/observability/langsmith/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -735,6 +735,40 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.14)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(msw@2.11.2(@types/node@20.19.14)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
 
+  observability/langsmith:
+    dependencies:
+      langsmith:
+        specifier: '>=0.3.69'
+        version: 0.3.69(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76))
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@microsoft/api-extractor':
+        specifier: ^7.52.8
+        version: 7.52.8(@types/node@20.19.14)
+      '@types/node':
+        specifier: ^20.17.57
+        version: 20.19.14
+      eslint:
+        specifier: ^9.35.0
+        version: 9.35.0(jiti@2.4.2)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(@microsoft/api-extractor@7.52.8(@types/node@20.19.14))(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.8.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.14)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(msw@2.11.2(@types/node@20.19.14)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+
   packages/_config:
     dependencies:
       '@vitest/eslint-plugin':
@@ -9813,6 +9847,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
@@ -9854,6 +9891,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -11073,6 +11113,9 @@ packages:
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
+  console-table-printer@2.14.6:
+    resolution: {integrity: sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -11725,6 +11768,9 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -13103,6 +13149,23 @@ packages:
     resolution: {integrity: sha512-pvcq9qJh/q/OFGPET4/sFfXRhCcEgONx1NTqZ8bu/hnorD5xZ/qpS+er0esXJ5cuRILEGw9ydKezAeULf8tpyQ==}
     engines: {node: '>=18'}
 
+  langsmith@0.3.69:
+    resolution: {integrity: sha512-YKzu92YAP2o+d+1VmR38xqFX0RIRLKYj1IqdflVEY83X0FoiVlrWO3xDLXgnu7vhZ2N2M6jx8VO9fVF8yy9gHA==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+
   latest-version@7.0.0:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
     engines: {node: '>=14.16'}
@@ -14094,6 +14157,10 @@ packages:
     resolution: {integrity: sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -14137,6 +14204,18 @@ packages:
   p-map@7.0.3:
     resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
     engines: {node: '>=18'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
 
   p-timeout@5.1.0:
     resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
@@ -15190,6 +15269,9 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
 
   sirv@3.0.1:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
@@ -24148,6 +24230,8 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/retry@0.12.0': {}
+
   '@types/semver@7.7.1': {}
 
   '@types/send@0.17.5':
@@ -24184,6 +24268,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -25671,6 +25757,10 @@ snapshots:
 
   console-control-strings@1.1.0: {}
 
+  console-table-printer@2.14.6:
+    dependencies:
+      simple-wcswidth: 1.1.2
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -26486,6 +26576,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.1: {}
 
@@ -28029,6 +28121,21 @@ snapshots:
     dependencies:
       langfuse-core: 3.38.5
 
+  langsmith@0.3.69(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.14.6
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      semver: 7.7.2
+      uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+      openai: 5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76)
+
   latest-version@7.0.0:
     dependencies:
       package-json: 8.1.1
@@ -29241,6 +29348,8 @@ snapshots:
     dependencies:
       p-map: 5.5.0
 
+  p-finally@1.0.0: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -29279,6 +29388,20 @@ snapshots:
   p-map@6.0.0: {}
 
   p-map@7.0.3: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   p-timeout@5.1.0: {}
 
@@ -30164,8 +30287,7 @@ snapshots:
   retry@0.12.0:
     optional: true
 
-  retry@0.13.1:
-    optional: true
+  retry@0.13.1: {}
 
   rettime@0.7.0: {}
 
@@ -30533,6 +30655,8 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+
+  simple-wcswidth@1.1.2: {}
 
   sirv@3.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
     dependencies:
       '@mastra/core':
         specifier: '>=0.18.0-0 <0.19.0-0'
-        version: 0.18.0-alpha.2(openapi-types@12.1.3)(react@19.1.1)(zod@4.1.9)
+        version: 0.18.0-alpha.2(openapi-types@12.1.3)(react@19.1.1)(zod@4.1.11)
       '@mastra/deployer':
         specifier: workspace:^
         version: link:../../packages/deployer
@@ -671,7 +671,7 @@ importers:
     dependencies:
       braintrust:
         specifier: ^0.3.8
-        version: 0.3.8(@aws-sdk/credential-provider-web-identity@3.883.0)(zod@4.1.9)
+        version: 0.3.8(@aws-sdk/credential-provider-web-identity@3.883.0)(zod@4.1.11)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -741,6 +741,9 @@ importers:
         specifier: '>=0.3.69'
         version: 0.3.69(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.3))(zod@3.25.76))
     devDependencies:
+      '@ai-sdk/openai':
+        specifier: ^2.0.35
+        version: 2.0.35(zod@3.25.76)
       '@internal/lint':
         specifier: workspace:*
         version: link:../../packages/_config
@@ -756,6 +759,9 @@ importers:
       '@types/node':
         specifier: ^20.17.57
         version: 20.19.14
+      dotenv:
+        specifier: ^17.2.2
+        version: 17.2.2
       eslint:
         specifier: ^9.35.0
         version: 9.35.0(jiti@2.4.2)
@@ -768,6 +774,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.14)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(msw@2.11.2(@types/node@20.19.14)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   packages/_config:
     dependencies:
@@ -1588,7 +1597,7 @@ importers:
     dependencies:
       ai:
         specifier: ^4.3.19
-        version: 4.3.19(react@19.1.1)(zod@4.1.9)
+        version: 4.3.19(react@19.1.1)(zod@4.1.11)
       fastembed:
         specifier: ^1.14.4
         version: 1.14.4
@@ -4074,6 +4083,12 @@ packages:
 
   '@ai-sdk/openai@2.0.23':
     resolution: {integrity: sha512-uOXk8HzmMUoCmD0JMX/Y1HC/ABOR/Jza2Z2rkCaJISDYz3fp5pnb6eNjcPRL48JSMzRAGp9UP5p0OpxS06IJZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/openai@2.0.35':
+    resolution: {integrity: sha512-LelCyotLQtL6lRYAvmtNvLyWirCR4YXr2aE4gXUXtpE+Y43eU1xdI3Jyq3Ugsvv2VhyKEceZRkrSFBmozrt21w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -11477,6 +11492,10 @@ packages:
     resolution: {integrity: sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==}
     engines: {node: '>=12'}
 
+  dotenv@17.2.2:
+    resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
+    engines: {node: '>=12'}
+
   drizzle-kit@0.30.6:
     resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
     hasBin: true
@@ -16642,6 +16661,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
   zod@4.1.9:
     resolution: {integrity: sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==}
 
@@ -16720,11 +16742,11 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/gateway@1.0.23(zod@4.1.9)':
+  '@ai-sdk/gateway@1.0.23(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.9)
-      zod: 4.1.9
+      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.11)
+      zod: 4.1.11
 
   '@ai-sdk/google@1.2.22(zod@3.25.76)':
     dependencies:
@@ -16780,6 +16802,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.7(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/openai@2.0.35(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@2.1.10(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.0.9
@@ -16795,6 +16823,13 @@ snapshots:
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@2.2.8(zod@4.1.11)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 4.1.11
 
   '@ai-sdk/provider-utils@2.2.8(zod@4.1.9)':
     dependencies:
@@ -16825,12 +16860,12 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.9(zod@4.1.9)':
+  '@ai-sdk/provider-utils@3.0.9(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
-      zod: 4.1.9
+      zod: 4.1.11
 
   '@ai-sdk/provider@1.0.9':
     dependencies:
@@ -16854,15 +16889,15 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  '@ai-sdk/react@1.2.12(react@19.1.1)(zod@4.1.9)':
+  '@ai-sdk/react@1.2.12(react@19.1.1)(zod@4.1.11)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.9)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.11)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.11)
       react: 19.1.1
       swr: 2.3.6(react@19.1.1)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 4.1.9
+      zod: 4.1.11
 
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
     dependencies:
@@ -16870,6 +16905,13 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
+
+  '@ai-sdk/ui-utils@1.2.11(zod@4.1.11)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.11)
+      zod: 4.1.11
+      zod-to-json-schema: 3.24.6(zod@4.1.11)
 
   '@ai-sdk/ui-utils@1.2.11(zod@4.1.9)':
     dependencies:
@@ -16998,7 +17040,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-textarea-autosize: 8.5.9(@types/react@19.1.9)(react@19.1.1)
-      zod: 4.1.9
+      zod: 4.1.11
       zustand: 5.0.8(@types/react@19.1.9)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     optionalDependencies:
       '@types/react': 19.1.9
@@ -20667,16 +20709,16 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mastra/core@0.18.0-alpha.2(openapi-types@12.1.3)(react@19.1.1)(zod@4.1.9)':
+  '@mastra/core@0.18.0-alpha.2(openapi-types@12.1.3)(react@19.1.1)(zod@4.1.11)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.9(zod@4.1.9)'
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.11)
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.9(zod@4.1.11)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.0'
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.9)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.11)
       '@isaacs/ttlcache': 1.4.1
-      '@mastra/schema-compat': 0.11.3(ai@4.3.19(react@19.1.1)(zod@4.1.9))(zod@4.1.9)
+      '@mastra/schema-compat': 0.11.3(ai@4.3.19(react@19.1.1)(zod@4.1.11))(zod@4.1.11)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/auto-instrumentations-node': 0.62.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -20691,12 +20733,12 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.36.0
       '@sindresorhus/slugify': 2.2.1
-      ai: 4.3.19(react@19.1.1)(zod@4.1.9)
-      ai-v5: ai@5.0.44(zod@4.1.9)
+      ai: 4.3.19(react@19.1.1)(zod@4.1.11)
+      ai-v5: ai@5.0.44(zod@4.1.11)
       date-fns: 3.6.0
       dotenv: 16.6.1
       hono: 4.9.7
-      hono-openapi: 0.4.8(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.9)
+      hono-openapi: 0.4.8(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.11)
       js-tiktoken: 1.0.21
       json-schema: 0.4.0
       json-schema-to-zod: 2.6.1
@@ -20706,8 +20748,8 @@ snapshots:
       radash: 12.1.1
       sift: 17.1.3
       xstate: 5.20.1
-      zod: 4.1.9
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
+      zod: 4.1.11
+      zod-to-json-schema: 3.24.6(zod@4.1.11)
     transitivePeerDependencies:
       - '@hono/arktype-validator'
       - '@hono/effect-validator'
@@ -20741,14 +20783,14 @@ snapshots:
       - aws-crt
       - encoding
 
-  '@mastra/schema-compat@0.11.3(ai@4.3.19(react@19.1.1)(zod@4.1.9))(zod@4.1.9)':
+  '@mastra/schema-compat@0.11.3(ai@4.3.19(react@19.1.1)(zod@4.1.11))(zod@4.1.11)':
     dependencies:
-      ai: 4.3.19(react@19.1.1)(zod@4.1.9)
+      ai: 4.3.19(react@19.1.1)(zod@4.1.11)
       json-schema: 0.4.0
-      zod: 4.1.9
+      zod: 4.1.11
       zod-from-json-schema: 0.5.0
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
+      zod-to-json-schema: 3.24.6(zod@4.1.11)
 
   '@mdx-js/react@3.1.0(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
@@ -24843,15 +24885,15 @@ snapshots:
     optionalDependencies:
       react: 19.1.1
 
-  ai@4.3.19(react@19.1.1)(zod@4.1.9):
+  ai@4.3.19(react@19.1.1)(zod@4.1.11):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.9)
-      '@ai-sdk/react': 1.2.12(react@19.1.1)(zod@4.1.9)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.9)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.1.11)
+      '@ai-sdk/react': 1.2.12(react@19.1.1)(zod@4.1.11)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.1.11)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 4.1.9
+      zod: 4.1.11
     optionalDependencies:
       react: 19.1.1
 
@@ -24863,13 +24905,13 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ai@5.0.44(zod@4.1.9):
+  ai@5.0.44(zod@4.1.11):
     dependencies:
-      '@ai-sdk/gateway': 1.0.23(zod@4.1.9)
+      '@ai-sdk/gateway': 1.0.23(zod@4.1.11)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.9)
+      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.11)
       '@opentelemetry/api': 1.9.0
-      zod: 4.1.9
+      zod: 4.1.11
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
@@ -25272,7 +25314,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.3.8(@aws-sdk/credential-provider-web-identity@3.883.0)(zod@4.1.9):
+  braintrust@0.3.8(@aws-sdk/credential-provider-web-identity@3.883.0)(zod@4.1.11):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@next/env': 14.2.32
@@ -25294,8 +25336,8 @@ snapshots:
       slugify: 1.6.6
       source-map: 0.7.6
       uuid: 9.0.1
-      zod: 4.1.9
-      zod-to-json-schema: 3.24.6(zod@4.1.9)
+      zod: 4.1.11
+      zod-to-json-schema: 3.24.6(zod@4.1.11)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - supports-color
@@ -26083,6 +26125,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.0.1: {}
+
+  dotenv@17.2.2: {}
 
   drizzle-kit@0.30.6:
     dependencies:
@@ -27419,13 +27463,13 @@ snapshots:
       hono: 4.9.7
       zod: 3.25.76
 
-  hono-openapi@0.4.8(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.9):
+  hono-openapi@0.4.8(hono@4.9.7)(openapi-types@12.1.3)(zod@4.1.11):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
       hono: 4.9.7
-      zod: 4.1.9
+      zod: 4.1.11
 
   hono@4.9.7: {}
 
@@ -32132,11 +32176,15 @@ snapshots:
 
   zod-from-json-schema@0.5.0:
     dependencies:
-      zod: 4.1.9
+      zod: 4.1.11
 
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.24.6(zod@4.1.11):
+    dependencies:
+      zod: 4.1.11
 
   zod-to-json-schema@3.24.6(zod@4.1.9):
     dependencies:
@@ -32147,6 +32195,8 @@ snapshots:
   zod@3.22.5: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.11: {}
 
   zod@4.1.9: {}
 


### PR DESCRIPTION
## Description

Adds LangSmith observability package, adapted from existing Braintrust implementation

Known limitations:

- Will not inherit context from encompassing `traceable`s
- Will not act as a parent to `traceable`s in tool calls (or wrapped AI SDK methods)
- Providers differ from 

Looks okay for `generateVNext` and stream: https://smith.langchain.com/public/f9f0382d-8f19-4f9f-a769-b27766a640a1/r

Some weirdness around flushing, not sure if there's some OTEL flush method I should be calling instead

Feel free to remove int test

CC @epinzur @calcsam 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
