### PR TITLE
removed example config props that don't exist

### DIFF
--- a/observability/langsmith/README.md
+++ b/observability/langsmith/README.md
@@ -25,8 +25,6 @@ const mastra = new Mastra({
         exporters: [
           new LangSmithExporter({
             apiKey: process.env.LANGSMITH_API_KEY, // Defaults to process.env.LANGSMITH_API_KEY
-            projectName: process.env.LANGSMITH_PROJECT, // optional
-            endpoint: process.env.LANGSMITH_ENDPOINT, // optional
           }),
         ],
       },


### PR DESCRIPTION
## Description

When I tested this exporter that @jacoblee93 contributed to our repo, I noticed that the 
`projectName` and `endpoint` params aren't valid in the LangsmithExporterConfig.

Removing those from the example in the Readme for now.

## Related Issue(s)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
