### PR TITLE
feat(pg): add SSL support to connection string configuration

### DIFF
--- a/.changeset/wide-yaks-obey.md
+++ b/.changeset/wide-yaks-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+add SSL support to connection string configuration


### PR DESCRIPTION
## Description

Add optional `ssl` property to connection string config type and pass it through to the pool configuration. This enables SSL/TLS encryption for PostgreSQL connections when using connection strings.

Also refactor config type guards for better type safety and replace fallback 'any' casting with proper error throwing for invalid configurations.

## Related Issue(s)

Fixes https://discord.com/channels/1309558646228779139/1420774343625150556

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
