### PR TITLE
fix(core): dont enqueue chunks on a closed controller

### DIFF
--- a/.changeset/legal-badgers-rush.md
+++ b/.changeset/legal-badgers-rush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+When an error would happen in a function like onStepResult, there are other code that executes synchronously and will execute after the controller already closes. We need to make sure we're only trying to enqueue chunks when the controller is still open.

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -6,6 +6,14 @@ import { ChunkFrom } from '../../stream/types';
 import type { LoopRun } from '../types';
 import { createAgenticLoopWorkflow } from './agentic-loop';
 
+/**
+ * Check if a ReadableStreamDefaultController is open and can accept data.
+ * Controllers are closed when desiredSize is 0 or null (errored).
+ */
+export function isControllerOpen(controller: ReadableStreamDefaultController<any>): boolean {
+  return controller.desiredSize !== 0 && controller.desiredSize !== null;
+}
+
 export function workflowLoopStream<
   Tools extends ToolSet = ToolSet,
   OUTPUT extends OutputSchema | undefined = undefined,

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -8,7 +8,15 @@ import { createAgenticLoopWorkflow } from './agentic-loop';
 
 /**
  * Check if a ReadableStreamDefaultController is open and can accept data.
- * Controllers are closed when desiredSize is 0 or null (errored).
+ *
+ * Note: While the ReadableStream spec indicates desiredSize can be:
+ * - positive (ready), 0 (full but open), or null (closed/errored),
+ * our empirical testing shows that after controller.close(), desiredSize becomes 0.
+ * Therefore, we treat both 0 and null as closed states to prevent
+ * "Invalid state: Controller is already closed" errors.
+ *
+ * @param controller - The ReadableStreamDefaultController to check
+ * @returns true if the controller is open and can accept data
  */
 export function isControllerOpen(controller: ReadableStreamDefaultController<any>): boolean {
   return controller.desiredSize !== 0 && controller.desiredSize !== null;


### PR DESCRIPTION
Problem

  When running multiple agent tests sequentially, we were seeing "Controller is
  already closed" errors. This only occurred when tests ran one after another, not
  in isolation.

  Root Cause

  The issue was a race condition in the stream pipeline:

  1. When a test throws an error in onStepFinish callback, it causes the stream
  pipeline to error out
  2. This closes the ReadableStreamDefaultController
  3. However, async callbacks (like onResult) that were already scheduled still
  attempt to enqueue data to the now-closed controller
  4. When the next test runs, these stale callbacks from the previous test execute
  and try to write to the closed controller, causing "Invalid state: Controller is
  already closed" errors

  Solution

  Added proper controller state checking before all enqueue operations:

  1. Created utility function isControllerOpen()

  - Checks if a ReadableStreamDefaultController is open and can accept data
  - Returns true when desiredSize > 0 (controller is open)
  - Returns false when desiredSize === 0 (closed) or null (errored)

  2. Protected all controller.enqueue() calls

  - Added state checks before enqueueing in:
    - llm-execution-step.ts - All chunk processing cases
    - agentic-loop/index.ts - Step finish enqueue
    - Error handling paths