### PR TITLE
fix options type for createTool

### DIFF
--- a/.changeset/lovely-berries-tease.md
+++ b/.changeset/lovely-berries-tease.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Bring back ToolInvocationOptions for createTool execute function

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -1,6 +1,3 @@
-import type { ToolExecutionOptions } from 'ai';
-import type { ToolCallOptions } from 'ai-v5';
-
 import type { Mastra } from '../mastra';
 import type { ZodLikeSchema } from '../types/zod-compat';
 import type { ToolAction, ToolExecutionContext, ToolInvocationOptions } from './types';
@@ -83,7 +80,7 @@ export function createTool<
   ? Tool<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext> & {
       inputSchema: TSchemaIn;
       outputSchema: TSchemaOut;
-      execute: (context: TContext, options: ToolExecutionOptions | ToolCallOptions) => Promise<any>;
+      execute: (context: TContext, options: ToolInvocationOptions) => Promise<any>;
     }
   : Tool<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext> {
   return new Tool(opts) as any;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes an issue where ToolInvocationOptions weren't being used in createTool's execute params.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#7548 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
