### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/src/content/en/guides/guide/research-assistant.mdx
+++ b/docs/src/content/en/guides/guide/research-assistant.mdx
@@ -163,7 +163,7 @@ In the following steps you'll fetch the research paper, split it into smaller ch
 
 ### Load and Process the Paper
 
-In this step the research paper is retrieved by providing an URL, then converted to a document object, and split into smaller, managable chunks. By splitting into chunks the processing is faster and more efficient.
+In this step the research paper is retrieved by providing an URL, then converted to a document object, and split into smaller, manageable chunks. By splitting into chunks the processing is faster and more efficient.
 
 Create a new file `src/store.ts` and add the following:
 

--- a/docs/src/content/ja/docs/deployment/deployment.mdx
+++ b/docs/src/content/ja/docs/deployment/deployment.mdx
@@ -125,4 +125,4 @@ npx mastra build
 ```
 
 Deployerを使用すると、ビルド出力は自動的にターゲットプラットフォーム用に準備されます。
-その後、プラットフォーム（Vercel、netlify、cloudfare など）のCLI/UIを通じて、ビルド出力 `.mastra/output` をデプロイできます。
+その後、プラットフォーム（Vercel、netlify、Cloudflare など）のCLI/UIを通じて、ビルド出力 `.mastra/output` をデプロイできます。

--- a/packages/playground-ui/src/components/assistant-ui/attachments/attachment-preview-dialog.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/attachments/attachment-preview-dialog.tsx
@@ -93,7 +93,7 @@ interface TxtEntryProps {
 export const TxtEntry = ({ data }: TxtEntryProps) => {
   const [open, setOpen] = useState(false);
 
-  // assistant-ui wraps txt related files with somethign like <attachment name=text.txt>
+  // assistant-ui wraps txt related files with something like <attachment name=text.txt>
   // We remove the <attachment> tag and everything inside it
   const formattedContent = data.replace(/<attachment[^>]*>/, '').replace(/<\/attachment>/g, '');
 


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `managable` → `manageable`
  - `cloudfare` → `Cloudflare`
  - `somethign` → `something`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.