### PR TITLE
feat(openai-voice): improve options handling for speak method

### DIFF
--- a/.changeset/eager-groups-itch.md
+++ b/.changeset/eager-groups-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-openai': patch
+---
+
+improve options handling for speak method

--- a/voice/openai/src/index.ts
+++ b/voice/openai/src/index.ts
@@ -147,13 +147,16 @@ export class OpenAIVoice extends MastraVoice {
       throw new Error('Input text is empty');
     }
 
+    const { speaker, responseFormat, speed, ...otherOptions } = options || {};
+
     const audio = await this.traced(async () => {
       const response = await this.speechClient!.audio.speech.create({
         model: this.speechModel?.name ?? 'tts-1',
-        voice: (options?.speaker ?? this.speaker) as OpenAIVoiceId,
-        response_format: options?.responseFormat ?? 'mp3',
+        voice: (speaker ?? this.speaker) as OpenAIVoiceId,
+        response_format: responseFormat ?? 'mp3',
         input,
-        speed: options?.speed || 1.0,
+        speed: speed || 1.0,
+        ...otherOptions,
       });
 
       const passThrough = new PassThrough();


### PR DESCRIPTION
## Description

The options parameter for `speak` is now destructured to extract specific properties
(speaker, responseFormat, speed) while preserving other options. This
ensures that additional OpenAI voice parameters can be passed through
without being lost, providing better flexibility for callers.

## Related Issue(s)

fixes discord https://discord.com/channels/1309558646228779139/1420894025552236655

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
