### PR TITLE
feat(rag): add llm option to document metadata extraction

### DIFF
--- a/.changeset/red-poems-work.md
+++ b/.changeset/red-poems-work.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+add llm option to document metadata extraction

--- a/packages/rag/src/document/document.ts
+++ b/packages/rag/src/document/document.ts
@@ -38,23 +38,23 @@ export class MDocument {
     this.type = type;
   }
 
-  async extractMetadata({ title, summary, questions, keywords }: ExtractParams): Promise<MDocument> {
+  async extractMetadata({ title, summary, questions, keywords, llm }: ExtractParams): Promise<MDocument> {
     const transformations = [];
 
     if (typeof summary !== 'undefined') {
-      transformations.push(new SummaryExtractor(typeof summary === 'boolean' ? {} : summary));
+      transformations.push(new SummaryExtractor(typeof summary === 'boolean' ? {} : { ...summary, llm }));
     }
 
     if (typeof questions !== 'undefined') {
-      transformations.push(new QuestionsAnsweredExtractor(typeof questions === 'boolean' ? {} : questions));
+      transformations.push(new QuestionsAnsweredExtractor(typeof questions === 'boolean' ? {} : { ...questions, llm }));
     }
 
     if (typeof keywords !== 'undefined') {
-      transformations.push(new KeywordExtractor(typeof keywords === 'boolean' ? {} : keywords));
+      transformations.push(new KeywordExtractor(typeof keywords === 'boolean' ? {} : { ...keywords, llm }));
     }
 
     if (typeof title !== 'undefined') {
-      transformations.push(new TitleExtractor(typeof title === 'boolean' ? {} : title));
+      transformations.push(new TitleExtractor(typeof title === 'boolean' ? {} : { ...title, llm }));
       this.chunks = this.chunks.map(doc =>
         doc?.metadata?.docId
           ? new Chunk({

--- a/packages/rag/src/document/types.ts
+++ b/packages/rag/src/document/types.ts
@@ -1,3 +1,4 @@
+import type { MastraLanguageModel } from '@mastra/core';
 import type { TiktokenEncoding, TiktokenModel } from 'js-tiktoken';
 import type {
   TitleExtractorsArgs,
@@ -40,6 +41,8 @@ export type ExtractParams = {
   summary?: SummaryExtractArgs | boolean;
   questions?: QuestionAnswerExtractArgs | boolean;
   keywords?: KeywordExtractArgs | boolean;
+  // Optional language model to use for extraction tasks
+  llm?: MastraLanguageModel;
 };
 
 export type BaseChunkOptions = {


### PR DESCRIPTION
## Description

Allow passing a custom language model to metadata extraction methods
for title, summary, questions, and keywords extraction. This provides
flexibility to use different LLMs for different extraction tasks while
maintaining backward compatibility with existing boolean parameters.

The llm parameter is optional and can be passed through the ExtractParams
interface to all extractor transformations.

## Related Issue(s)

Fixes discord https://discord.com/channels/1309558646228779139/1421135155200000010

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
