### PR TITLE
feat(mcp): allow MCP server prompts and resources callbacks to access "extra" property

### DIFF
--- a/.changeset/odd-sides-build.md
+++ b/.changeset/odd-sides-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Allows MCP server resources and prompts callbacks to access the "extra" MCP property, allowing to pass auth info and arbitrary data to the server.

--- a/packages/mcp/src/server/types.ts
+++ b/packages/mcp/src/server/types.ts
@@ -12,28 +12,32 @@ import type { z } from 'zod';
 
 export type MCPServerResourceContentCallback = ({
   uri,
+  extra,
 }: {
   uri: string;
+  extra: MCPRequestHandlerExtra;
 }) => Promise<MCPServerResourceContent | MCPServerResourceContent[]>;
 export type MCPServerResourceContent = { text?: string } | { blob?: string };
 export type MCPServerResources = {
-  listResources: () => Promise<Resource[]>;
+  listResources: ({ extra }: { extra: MCPRequestHandlerExtra }) => Promise<Resource[]>;
   getResourceContent: MCPServerResourceContentCallback;
-  resourceTemplates?: () => Promise<ResourceTemplate[]>;
+  resourceTemplates?: ({ extra }: { extra: MCPRequestHandlerExtra }) => Promise<ResourceTemplate[]>;
 };
 
 export type MCPServerPromptMessagesCallback = ({
   name,
   version,
   args,
+  extra,
 }: {
   name: string;
   version?: string;
   args?: any;
+  extra: MCPRequestHandlerExtra;
 }) => Promise<PromptMessage[]>;
 
 export type MCPServerPrompts = {
-  listPrompts: () => Promise<Prompt[]>;
+  listPrompts: ({ extra }: { extra: MCPRequestHandlerExtra }) => Promise<Prompt[]>;
   getPromptMessages?: MCPServerPromptMessagesCallback;
 };
 


### PR DESCRIPTION
MCPServer resources and prompts callbacks passed to server now have access to the "extra" property that comes from the MCPServer which includes AuthInfo, allowing for authenticated or personalized prompts/resources

addresses https://github.com/mastra-ai/mastra/issues/8110

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
