### PR TITLE
fix: playground UI handleStreamChunk part handling

### DIFF
--- a/.changeset/sad-grapes-allow.md
+++ b/.changeset/sad-grapes-allow.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Fixed an issue where text-start/end parts were ignored in useMastraChat and tool ordering vs text wasn't retained

--- a/.changeset/sad-grapes-allow.md
+++ b/.changeset/sad-grapes-allow.md
@@ -4,4 +4,4 @@
 'create-mastra': patch
 ---
 
-Fixed an issue where text-start/end parts were ignored in useMastraChat and tool ordering vs text wasn't retained
+Fixed an issue in playground where text-start/end parts were ignored in handleStreamChunk and tool ordering vs text wasn't retained

--- a/packages/playground-ui/src/services/stream-chunk-message.ts
+++ b/packages/playground-ui/src/services/stream-chunk-message.ts
@@ -4,7 +4,6 @@ import { StreamChunk } from '@/types';
 import { ThreadMessageLike } from '@assistant-ui/react';
 import { ChunkType } from '@mastra/core';
 import { ReadonlyJSONObject } from '@mastra/core/stream';
-import { flushSync } from 'react-dom';
 
 export interface HandleStreamChunkOptions {
   conversation: ThreadMessageLike[];

--- a/packages/playground-ui/src/services/stream-chunk-message.ts
+++ b/packages/playground-ui/src/services/stream-chunk-message.ts
@@ -25,17 +25,20 @@ export const handleStreamChunk = ({ chunk, conversation }: HandleStreamChunkOpti
     case 'text-delta': {
       // Always add a new last text chunk if one doesn't exist yet to maintain content ordering
       const lastMessage = conversation[conversation.length - 1];
+      if (!lastMessage) return conversation;
+
       if (
-        lastMessage &&
         lastMessage.role === 'assistant' &&
         typeof lastMessage.content !== `string` &&
-        (lastMessage.content.length === 0 || lastMessage.content[lastMessage.content.length - 1]?.type !== `text`)
+        (!lastMessage.content ||
+          lastMessage.content.length === 0 ||
+          lastMessage.content[lastMessage.content.length - 1]?.type !== `text`)
       ) {
         return [
           ...conversation.slice(0, -1),
           {
             ...lastMessage,
-            content: [...lastMessage.content, { type: 'text', text: '' }],
+            content: [...(lastMessage.content || []), { type: 'text', text: '' }],
           },
         ];
       }
@@ -54,9 +57,8 @@ export const handleStreamChunk = ({ chunk, conversation }: HandleStreamChunkOpti
         ];
       }
 
-      const lastPart = lastMessage.content[lastMessage.content.length - 1];
-
-      if (lastPart.type !== `text`) return conversation; // for TS! this is actually garunteed because we set the last part to be type text if it's not
+      const lastPart = lastMessage.content?.[lastMessage.content.length - 1];
+      if (!lastPart || lastPart.type !== `text`) return conversation;
 
       return [
         ...conversation.slice(0, -1),


### PR DESCRIPTION
I found that when a tool was first in the assistant message, it would get moved down by any streamed text. 
If a model didn't send text-start parts that would also break the UI, so this change
- adds an empty message on `start`
- adds an empty text part (if the message doesn't end in one) on `text-start` and `text-delta` parts
- handles content when it's a string instead of an array
- appends to the new text part, not the initial one, to retain part ordering (tool/text/reasoning/file/etc)