### PR TITLE
fixed issue with missing traceId with aisdk output format

### DIFF
--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -4,9 +4,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 // Core Mastra imports
-import { Agent, type StructuredOutputOptions } from '../agent';
+import { Agent } from '../agent';
+import type { StructuredOutputOptions } from '../agent';
 import { Mastra } from '../mastra';
 import { MockStore } from '../storage/mock';
+import type { OutputSchema } from '../stream';
 import type { ToolExecutionContext } from '../tools';
 import { createTool } from '../tools';
 import { createWorkflow, createStep } from '../workflows';
@@ -15,7 +17,6 @@ import { createWorkflow, createStep } from '../workflows';
 import { clearAITracingRegistry, shutdownAITracingRegistry } from './registry';
 import { AISpanType, AITracingEventType } from './types';
 import type { AITracingExporter, AITracingEvent, ExportedAISpan, AnyExportedAISpan } from './types';
-import type { OutputSchema } from '../stream';
 
 /**
  * Test exporter for AI tracing events with real-time span lifecycle validation.
@@ -1293,8 +1294,8 @@ describe('AI Tracing Integration Tests', () => {
     },
   );
 
-// Only test VNext methods for structuredOutput
-describe.each(agentMethods.filter(m => m.name.includes('VNext')))(
+  // Only test VNext methods for structuredOutput
+  describe.each(agentMethods.filter(m => m.name.includes('VNext')))(
     'should trace agent using structuredOutput format using $name',
     ({ method, model }) => {
       it(`should trace spans correctly`, async () => {
@@ -1305,12 +1306,12 @@ describe.each(agentMethods.filter(m => m.name.includes('VNext')))(
         });
 
         const outputSchema = z.object({
-          "items" : z.string(),
-        })
+          items: z.string(),
+        });
 
-        const structuredOutput : StructuredOutputOptions<OutputSchema> = {
+        const structuredOutput: StructuredOutputOptions<OutputSchema> = {
           schema: outputSchema,
-        }
+        };
 
         const mastra = new Mastra({
           ...getBaseMastraConfig(testExporter),
@@ -1349,11 +1350,11 @@ describe.each(agentMethods.filter(m => m.name.includes('VNext')))(
         expect(llmGenerationSpan?.output.text).toBe('Mock V2 streaming response');
         expect(agentRunSpan?.output.text).toBe('Mock V2 streaming response');
 
-        console.log("llmGenerationSpan?.output")
-        console.log(llmGenerationSpan?.output)
+        console.log('llmGenerationSpan?.output');
+        console.log(llmGenerationSpan?.output);
 
-        console.log("agentRunSpan?.output")
-        console.log(agentRunSpan?.output)
+        console.log('agentRunSpan?.output');
+        console.log(agentRunSpan?.output);
 
         // Verify structured output
         expect(result.object).toBeDefined();

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -122,7 +122,7 @@ class TestExporter implements AITracingExporter {
         // Check the final span's type, not the first event
         const finalEvent =
           state.events.find(e => e.type === AITracingEventType.SPAN_ENDED) || state.events[state.events.length - 1];
-        return state.hasEnd && finalEvent.exportedSpan.type === type;
+        return state.hasEnd && finalEvent?.exportedSpan.type === type;
       })
       .map(state => {
         // Return the final span from SPAN_ENDED event
@@ -132,12 +132,12 @@ class TestExporter implements AITracingExporter {
   }
 
   // Helper to get all incomplete spans (spans that started but never ended)
-  getIncompleteSpans(): Array<{ spanId: string; span: AnyExportedAISpan; state: any }> {
+  getIncompleteSpans(): Array<{ spanId: string; span: AnyExportedAISpan | undefined; state: any }> {
     return Array.from(this.spanStates.entries())
       .filter(([_, state]) => !state.hasEnd)
       .map(([spanId, state]) => ({
         spanId,
-        span: state.events[0].exportedSpan,
+        span: state.events[0]?.exportedSpan,
         state: { hasStart: state.hasStart, hasUpdate: state.hasUpdate, hasEnd: state.hasEnd },
       }));
   }
@@ -149,11 +149,11 @@ class TestExporter implements AITracingExporter {
    *
    * Note: For specific span types, prefer using getSpansByType() for more precise filtering
    */
-  getAllSpans(): AnyExportedAISpan[] {
+  getAllSpans(): (AnyExportedAISpan | undefined)[] {
     return Array.from(this.spanStates.values()).map(state => {
       // Return the final span from SPAN_ENDED event, or latest event if not ended
       const endEvent = state.events.find(e => e.type === AITracingEventType.SPAN_ENDED);
-      return endEvent ? endEvent.exportedSpan : state.events[state.events.length - 1].exportedSpan;
+      return endEvent ? endEvent.exportedSpan : state.events[state.events.length - 1]?.exportedSpan;
     });
   }
 
@@ -178,14 +178,14 @@ class TestExporter implements AITracingExporter {
     try {
       // All spans should share the same trace ID (context propagation)
       const allSpans = this.getAllSpans();
-      const traceIds = [...new Set(allSpans.map(span => span.traceId))];
+      const traceIds = [...new Set(allSpans.map(span => span?.traceId))];
       expect(traceIds).toHaveLength(1);
 
       // Ensure all spans completed properly
       const incompleteSpans = this.getIncompleteSpans();
       expect(
         incompleteSpans,
-        `Found incomplete spans: ${JSON.stringify(incompleteSpans.map(s => ({ type: s.span.type, name: s.span.name, state: s.state })))}`,
+        `Found incomplete spans: ${JSON.stringify(incompleteSpans.map(s => ({ type: s.span?.type, name: s.span?.name, state: s.state })))}`,
       ).toHaveLength(0);
     } catch (error) {
       // On failure, dump all logs to help with debugging
@@ -773,23 +773,23 @@ describe('AI Tracing Integration Tests', () => {
     expect(workflowRunSpans.length).toBe(1); // One workflow run
     const workflowRunSpan = workflowRunSpans[0];
 
-    expect(workflowRunSpan.traceId).toBe(result.traceId);
-    expect(workflowRunSpan.isRootSpan).toBe(true);
-    expect(workflowRunSpan.metadata?.id1).toBe(customMetadata.id1);
-    expect(workflowRunSpan.metadata?.id2).toBe(customMetadata.id2);
+    expect(workflowRunSpan?.traceId).toBe(result.traceId);
+    expect(workflowRunSpan?.isRootSpan).toBe(true);
+    expect(workflowRunSpan?.metadata?.id1).toBe(customMetadata.id1);
+    expect(workflowRunSpan?.metadata?.id2).toBe(customMetadata.id2);
 
     expect(workflowStepSpans.length).toBe(2); // checkCondition + processHigh (value=15 > 10)
     expect(conditionalSpans.length).toBe(1); // One branch evaluation
 
-    expect(workflowRunSpans[0].input).toMatchObject({ value: 15 });
-    expect(workflowRunSpans[0].output).toMatchObject({ 'process-high': { result: 'high-value-processing' } });
-    expect(workflowRunSpans[0].startTime).toBeDefined();
-    expect(workflowRunSpans[0].endTime).toBeDefined();
+    expect(workflowRunSpans[0]?.input).toMatchObject({ value: 15 });
+    expect(workflowRunSpans[0]?.output).toMatchObject({ 'process-high': { result: 'high-value-processing' } });
+    expect(workflowRunSpans[0]?.startTime).toBeDefined();
+    expect(workflowRunSpans[0]?.endTime).toBeDefined();
 
     const checkConditionSpan = workflowStepSpans[0];
-    expect(checkConditionSpan.name).toBe("workflow step: 'check-condition'");
-    expect(checkConditionSpan.input).toMatchObject({ value: 15 });
-    expect(checkConditionSpan.output).toMatchObject({ branch: 'high' });
+    expect(checkConditionSpan?.name).toBe("workflow step: 'check-condition'");
+    expect(checkConditionSpan?.input).toMatchObject({ value: 15 });
+    expect(checkConditionSpan?.output).toMatchObject({ branch: 'high' });
 
     testExporter.finalExpectations();
   });
@@ -827,7 +827,7 @@ describe('AI Tracing Integration Tests', () => {
 
     const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
-    expect(workflowRunSpans[0].traceId).toBe(result.traceId);
+    expect(workflowRunSpans[0]?.traceId).toBe(result.traceId);
 
     expect(workflowRunSpans.length).toBe(2); // Main + unregistered workflow
     expect(workflowStepSpans.length).toBe(3); // doWhile step + unregistered step + map step
@@ -876,7 +876,7 @@ describe('AI Tracing Integration Tests', () => {
 
     const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
-    expect(workflowRunSpans[0].traceId).toBe(result.traceId);
+    expect(workflowRunSpans[0]?.traceId).toBe(result.traceId);
 
     expect(workflowRunSpans.length).toBe(2); // Parent workflow + child workflow
     expect(workflowStepSpans.length).toBe(2); // nested-workflow-step + simple-step
@@ -912,7 +912,7 @@ describe('AI Tracing Integration Tests', () => {
     const workflowRunSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
     const workflowStepSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
     // const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
-    expect(workflowRunSpans[0].traceId).toBe(result.traceId);
+    expect(workflowRunSpans[0]?.traceId).toBe(result.traceId);
 
     expect(workflowRunSpans.length).toBe(1); // One workflow run
     expect(workflowStepSpans.length).toBe(1); // One step: tool-executor
@@ -967,10 +967,10 @@ describe('AI Tracing Integration Tests', () => {
     expect(workflowStepSpans.length).toBe(1);
     const stepSpan = workflowStepSpans[0];
 
-    expect(stepSpan.metadata?.customValue).toBe('tacos');
-    expect(stepSpan.metadata?.stepType).toBe('metadata-test');
-    expect(stepSpan.metadata?.executionTime).toBeDefined();
-    expect(stepSpan.traceId).toBe(result.traceId);
+    expect(stepSpan?.metadata?.customValue).toBe('tacos');
+    expect(stepSpan?.metadata?.stepType).toBe('metadata-test');
+    expect(stepSpan?.metadata?.executionTime).toBeDefined();
+    expect(stepSpan?.traceId).toBe(result.traceId);
 
     testExporter.finalExpectations();
   });
@@ -1027,9 +1027,9 @@ describe('AI Tracing Integration Tests', () => {
     expect(result.traceId).toBeDefined();
 
     const allSpans = testExporter.getAllSpans();
-    const childSpans = allSpans.filter(span => span.name === 'custom-child-operation');
+    const childSpans = allSpans.filter(span => span?.name === 'custom-child-operation');
     const stepSpans = allSpans.filter(
-      span => span.type === AISpanType.WORKFLOW_STEP && span.name?.includes('child-span'),
+      span => span?.type === AISpanType.WORKFLOW_STEP && span?.name?.includes('child-span'),
     );
 
     expect(childSpans.length).toBe(1);
@@ -1037,11 +1037,11 @@ describe('AI Tracing Integration Tests', () => {
     const childSpan = childSpans[0];
     const stepSpan = stepSpans[0];
 
-    expect(childSpan.traceId).toBe(stepSpan.traceId);
-    expect(childSpan.metadata?.childOperation).toBe('processing');
-    expect(childSpan.metadata?.inputValue).toBe('child-span-test');
-    expect(childSpan.metadata?.endValue).toBe('pizza');
-    expect(childSpan.traceId).toBe(result.traceId);
+    expect(childSpan?.traceId).toBe(stepSpan?.traceId);
+    expect(childSpan?.metadata?.childOperation).toBe('processing');
+    expect(childSpan?.metadata?.inputValue).toBe('child-span-test');
+    expect(childSpan?.metadata?.endValue).toBe('pizza');
+    expect(childSpan?.traceId).toBe(result.traceId);
 
     testExporter.finalExpectations();
   });
@@ -1087,27 +1087,29 @@ describe('AI Tracing Integration Tests', () => {
         const llmGenerationSpan = llmGenerationSpans[0];
         const toolCallSpan = toolCallSpans[0];
 
-        // verify span nesting
-        expect(llmGenerationSpan.parentSpanId).toEqual(agentRunSpan.id);
-        expect(toolCallSpan.parentSpanId).toEqual(agentRunSpan.id);
+        expect(agentRunSpan?.traceId).toBe(result.traceId);
 
-        expect(llmGenerationSpan.name).toBe("llm: 'mock-model-id'");
-        expect(llmGenerationSpan.input.messages).toHaveLength(2);
+        // verify span nesting
+        expect(llmGenerationSpan?.parentSpanId).toEqual(agentRunSpan?.id);
+        expect(toolCallSpan?.parentSpanId).toEqual(agentRunSpan?.id);
+
+        expect(llmGenerationSpan?.name).toBe("llm: 'mock-model-id'");
+        expect(llmGenerationSpan?.input.messages).toHaveLength(2);
         switch (name) {
           case 'generateLegacy':
-            expect(llmGenerationSpan.output.text).toBe('Mock response');
-            expect(agentRunSpan.output.text).toBe('Mock response');
+            expect(llmGenerationSpan?.output.text).toBe('Mock response');
+            expect(agentRunSpan?.output.text).toBe('Mock response');
             break;
           case 'streamLegacy':
-            expect(llmGenerationSpan.output.text).toBe('Mock streaming response');
-            expect(agentRunSpan.output.text).toBe('Mock streaming response');
+            expect(llmGenerationSpan?.output.text).toBe('Mock streaming response');
+            expect(agentRunSpan?.output.text).toBe('Mock streaming response');
             break;
           default: // VNext generate & stream
-            expect(llmGenerationSpan.output.text).toBe('Mock V2 streaming response');
-            expect(agentRunSpan.output.text).toBe('Mock V2 streaming response');
+            expect(llmGenerationSpan?.output.text).toBe('Mock V2 streaming response');
+            expect(agentRunSpan?.output.text).toBe('Mock V2 streaming response');
             break;
         }
-        expect(llmGenerationSpan.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+        expect(llmGenerationSpan?.attributes?.usage?.totalTokens).toBeGreaterThan(1);
 
         testExporter.finalExpectations();
       });
@@ -1153,36 +1155,108 @@ describe('AI Tracing Integration Tests', () => {
         const llmGenerationSpan = llmGenerationSpans[0];
         const toolCallSpan = toolCallSpans[0];
 
+        expect(agentRunSpan?.traceId).toBe(result.traceId);
+
         // verify span nesting
         if (name.includes('Legacy')) {
-          expect(llmGenerationSpan.parentSpanId).toEqual(agentRunSpan.id);
-          expect(toolCallSpan.parentSpanId).toEqual(agentRunSpan.id);
+          expect(llmGenerationSpan?.parentSpanId).toEqual(agentRunSpan?.id);
+          expect(toolCallSpan?.parentSpanId).toEqual(agentRunSpan?.id);
         } else {
           // VNext
           const executionWorkflowSpan = workflowSpans.filter(span => span.name?.includes('execution-workflow'))[0];
           const agenticLoopWorkflowSpan = workflowSpans.filter(span => span.name?.includes('agentic-loop'))[0];
           const streamTextStepSpan = workflowSteps.filter(span => span.name?.includes('stream-text-step'))[0];
-          expect(streamTextStepSpan.parentSpanId).toEqual(executionWorkflowSpan.id);
-          expect(agenticLoopWorkflowSpan.parentSpanId).toEqual(llmGenerationSpan.id);
+          expect(streamTextStepSpan?.parentSpanId).toEqual(executionWorkflowSpan?.id);
+          expect(agenticLoopWorkflowSpan?.parentSpanId).toEqual(llmGenerationSpan?.id);
         }
 
-        expect(llmGenerationSpan.name).toBe("llm: 'mock-model-id'");
-        expect(llmGenerationSpan.input.messages).toHaveLength(2);
+        expect(llmGenerationSpan?.name).toBe("llm: 'mock-model-id'");
+        expect(llmGenerationSpan?.input.messages).toHaveLength(2);
         switch (name) {
           case 'generateLegacy':
-            expect(llmGenerationSpan.output.text).toBe('Mock response');
-            expect(agentRunSpan.output.text).toBe('Mock response');
+            expect(llmGenerationSpan?.output.text).toBe('Mock response');
+            expect(agentRunSpan?.output.text).toBe('Mock response');
             break;
           case 'streamLegacy':
-            expect(llmGenerationSpan.output.text).toBe('Mock streaming response');
-            expect(agentRunSpan.output.text).toBe('Mock streaming response');
+            expect(llmGenerationSpan?.output.text).toBe('Mock streaming response');
+            expect(agentRunSpan?.output.text).toBe('Mock streaming response');
             break;
           default: // VNext generate & stream
-            expect(llmGenerationSpan.output.text).toBe('Mock V2 streaming response');
-            expect(agentRunSpan.output.text).toBe('Mock V2 streaming response');
+            expect(llmGenerationSpan?.output.text).toBe('Mock V2 streaming response');
+            expect(agentRunSpan?.output.text).toBe('Mock V2 streaming response');
             break;
         }
-        expect(llmGenerationSpan.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+        expect(llmGenerationSpan?.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+
+        testExporter.finalExpectations();
+      });
+    },
+  );
+
+  describe.each(agentMethods)(
+    'should trace agent with multiple tools using aisdk output format using $name',
+    ({ name, method, model }) => {
+      it(`should trace spans correctly`, async () => {
+        const testAgent = new Agent({
+          name: 'Test Agent',
+          instructions: 'You are a test agent',
+          model,
+          tools: {
+            calculator: calculatorTool,
+            apiCall: apiTool,
+            workflowExecutor: workflowExecutorTool,
+          },
+        });
+
+        const mastra = new Mastra({
+          ...getBaseMastraConfig(testExporter),
+          agents: { testAgent },
+        });
+
+        const agent = mastra.getAgent('testAgent');
+        const result = await method(agent, 'Calculate 5 + 3', { format: 'aisdk' });
+        expect(result.text).toBeDefined();
+        expect(result.traceId).toBeDefined();
+
+        const agentRunSpans = testExporter.getSpansByType(AISpanType.AGENT_RUN);
+        const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
+        const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
+        const workflowSpans = testExporter.getSpansByType(AISpanType.WORKFLOW_RUN);
+        const workflowSteps = testExporter.getSpansByType(AISpanType.WORKFLOW_STEP);
+
+        expect(agentRunSpans.length).toBe(1); // one agent run
+        expect(llmGenerationSpans.length).toBe(1); // tool call
+        expect(toolCallSpans.length).toBe(1); // one tool call (calculator)
+        expect(workflowSpans.length).toBe(0); // no workflows
+        expect(workflowSteps.length).toBe(0); // no workflows
+
+        const agentRunSpan = agentRunSpans[0];
+        const llmGenerationSpan = llmGenerationSpans[0];
+        const toolCallSpan = toolCallSpans[0];
+
+        expect(agentRunSpan?.traceId).toBe(result.traceId);
+
+        // verify span nesting
+        expect(llmGenerationSpan?.parentSpanId).toEqual(agentRunSpan?.id);
+        expect(toolCallSpan?.parentSpanId).toEqual(agentRunSpan?.id);
+
+        expect(llmGenerationSpan?.name).toBe("llm: 'mock-model-id'");
+        expect(llmGenerationSpan?.input.messages).toHaveLength(2);
+        switch (name) {
+          case 'generateLegacy':
+            expect(llmGenerationSpan?.output.text).toBe('Mock response');
+            expect(agentRunSpan?.output.text).toBe('Mock response');
+            break;
+          case 'streamLegacy':
+            expect(llmGenerationSpan?.output.text).toBe('Mock streaming response');
+            expect(agentRunSpan?.output.text).toBe('Mock streaming response');
+            break;
+          default: // VNext generate & stream
+            expect(llmGenerationSpan?.output.text).toBe('Mock V2 streaming response');
+            expect(agentRunSpan?.output.text).toBe('Mock V2 streaming response');
+            break;
+        }
+        expect(llmGenerationSpan?.attributes?.usage?.totalTokens).toBeGreaterThan(1);
 
         testExporter.finalExpectations();
       });
@@ -1236,7 +1310,7 @@ describe('AI Tracing Integration Tests', () => {
       const llmGenerationSpans = testExporter.getSpansByType(AISpanType.LLM_GENERATION);
 
       expect(workflowRunSpans.length).toBe(1); // One workflow run
-      expect(workflowRunSpans[0].traceId).toBe(result.traceId);
+      expect(workflowRunSpans[0]?.traceId).toBe(result.traceId);
       expect(workflowStepSpans.length).toBe(1); // One step: agent-executor
       expect(agentRunSpans.length).toBe(1); // One agent run within the step
       expect(llmGenerationSpans.length).toBe(1); // 1 llm span inside agent
@@ -1283,10 +1357,10 @@ describe('AI Tracing Integration Tests', () => {
       expect(agentRunSpans.length).toBe(1); // One agent run
       const agentRunSpan = agentRunSpans[0];
 
-      expect(agentRunSpan.traceId).toBe(result.traceId);
-      expect(agentRunSpan.isRootSpan).toBe(true);
-      expect(agentRunSpan.metadata?.id1).toBe(customMetadata.id1);
-      expect(agentRunSpan.metadata?.id2).toBe(customMetadata.id2);
+      expect(agentRunSpan?.traceId).toBe(result.traceId);
+      expect(agentRunSpan?.isRootSpan).toBe(true);
+      expect(agentRunSpan?.metadata?.id1).toBe(customMetadata.id1);
+      expect(agentRunSpan?.metadata?.id2).toBe(customMetadata.id2);
 
       expect(llmGenerationSpans.length).toBe(1); // one llmGeneration per agent run
       expect(toolCallSpans.length).toBe(1); // tool call
@@ -1331,7 +1405,7 @@ describe('AI Tracing Integration Tests', () => {
 
       expect(agentRunSpans.length).toBe(1); // One agent run
       expect(llmGenerationSpans.length).toBe(1); // one llm_generation span per agent run
-      expect(agentRunSpans[0].traceId).toBe(result.traceId);
+      expect(agentRunSpans[0]?.traceId).toBe(result.traceId);
       expect(toolCallSpans.length).toBe(1); // tool call (workflow is converted into a tool dynamically)
 
       expect(workflowRunSpans.length).toBe(1); // One workflow run (simpleWorkflow)
@@ -1386,7 +1460,7 @@ describe('AI Tracing Integration Tests', () => {
       const toolCallSpans = testExporter.getSpansByType(AISpanType.TOOL_CALL);
 
       expect(toolCallSpans.length).toBeGreaterThanOrEqual(1);
-      expect(toolCallSpans[0].traceId).toBe(result.traceId);
+      expect(toolCallSpans[0]?.traceId).toBe(result.traceId);
 
       // Find the metadata tool span and validate custom metadata
       const metadataToolSpan = toolCallSpans.find(span => span.name?.includes('metadataTool'));
@@ -1461,7 +1535,7 @@ describe('AI Tracing Integration Tests', () => {
 
       expect(toolCallSpans.length).toBe(1);
       expect(genericSpans.length).toBe(1);
-      expect(toolCallSpans[0].traceId).toBe(result.traceId);
+      expect(toolCallSpans[0]?.traceId).toBe(result.traceId);
 
       // Find the child span and validate metadata
       const childSpan = genericSpans.find(span => span.name === 'tool-child-operation');
@@ -1525,7 +1599,7 @@ describe('AI Tracing Integration Tests', () => {
 
     expect(agentRunSpans.length).toBe(1); // One agent run
     expect(llmGenerationSpans.length).toBe(1); // One LLM generation
-    expect(agentRunSpans[0].traceId).toBe(result.traceId);
+    expect(agentRunSpans[0]?.traceId).toBe(result.traceId);
 
     testExporter.finalExpectations();
   });

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -303,11 +303,12 @@ export class MastraLLMVNext extends MastraBase {
 
             llmAISpan?.end({
               output: {
-                text: props?.text,
+                files: props?.files,
+                object: props?.object,
                 reasoning: props?.reasoning,
                 reasoningText: props?.reasoningText,
-                files: props?.files,
                 sources: props?.sources,
+                text: props?.text,
                 warnings: props?.warnings,
               },
               attributes: {

--- a/packages/core/src/processors/processors/language-detector.ts
+++ b/packages/core/src/processors/processors/language-detector.ts
@@ -4,6 +4,7 @@ import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';
+import { InternalSpans } from '../../ai-tracing';
 
 /**
  * Language detection result for a single text
@@ -172,6 +173,7 @@ export class LanguageDetector implements Processor {
       name: 'language-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
+      options: { tracingPolicy: { internal: InternalSpans.ALL }},
     });
   }
 

--- a/packages/core/src/processors/processors/language-detector.ts
+++ b/packages/core/src/processors/processors/language-detector.ts
@@ -2,9 +2,9 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
+import { InternalSpans } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';
-import { InternalSpans } from '../../ai-tracing';
 
 /**
  * Language detection result for a single text
@@ -173,7 +173,7 @@ export class LanguageDetector implements Processor {
       name: 'language-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL }},
+      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import type { TracingContext } from '../../ai-tracing';
+import { InternalSpans, type TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
@@ -124,6 +124,7 @@ export class ModerationProcessor implements Processor {
       name: 'content-moderator',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
+      options: { tracingPolicy: { internal: InternalSpans.ALL }},
     });
   }
 

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -2,7 +2,8 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import { InternalSpans, type TracingContext } from '../../ai-tracing';
+import { InternalSpans } from '../../ai-tracing';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
@@ -124,7 +125,7 @@ export class ModerationProcessor implements Processor {
       name: 'content-moderator',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL }},
+      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -3,7 +3,8 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import { InternalSpans, type TracingContext } from '../../ai-tracing';
+import { InternalSpans } from '../../ai-tracing';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
@@ -173,7 +174,7 @@ export class PIIDetector implements Processor {
       name: 'pii-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL }},
+      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -3,7 +3,7 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import type { TracingContext } from '../../ai-tracing';
+import { InternalSpans, type TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
@@ -173,6 +173,7 @@ export class PIIDetector implements Processor {
       name: 'pii-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
+      options: { tracingPolicy: { internal: InternalSpans.ALL }},
     });
   }
 

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import type { TracingContext } from '../../ai-tracing';
+import { InternalSpans, type TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';
 
@@ -105,6 +105,7 @@ export class PromptInjectionDetector implements Processor {
       name: 'prompt-injection-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
+      options: { tracingPolicy: { internal: InternalSpans.ALL }},
     });
   }
 

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -2,7 +2,8 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import { InternalSpans, type TracingContext } from '../../ai-tracing';
+import { InternalSpans } from '../../ai-tracing';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';
 
@@ -105,7 +106,7 @@ export class PromptInjectionDetector implements Processor {
       name: 'prompt-injection-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL }},
+      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -6,6 +6,7 @@ import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { OutputSchema } from '../../stream';
 import type { InferSchemaOutput } from '../../stream/base/schema';
 import type { Processor } from '../index';
+import { InternalSpans } from '../../ai-tracing';
 
 export type { StructuredOutputOptions } from '../../agent/types';
 
@@ -45,6 +46,7 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
       name: 'structured-output-structurer',
       instructions: options.instructions || this.generateInstructions(),
       model: modelToUse,
+      options: { tracingPolicy: { internal: InternalSpans.ALL }},
     });
   }
 

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -2,11 +2,11 @@ import type { ZodTypeAny } from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import type { StructuredOutputOptions } from '../../agent/types';
+import { InternalSpans } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { OutputSchema } from '../../stream';
 import type { InferSchemaOutput } from '../../stream/base/schema';
 import type { Processor } from '../index';
-import { InternalSpans } from '../../ai-tracing';
 
 export type { StructuredOutputOptions } from '../../agent/types';
 
@@ -46,7 +46,7 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
       name: 'structured-output-structurer',
       instructions: options.instructions || this.generateInstructions(),
       model: modelToUse,
-      options: { tracingPolicy: { internal: InternalSpans.ALL }},
+      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
-import { InternalSpans, type TracingContext } from '../../ai-tracing';
+import { InternalSpans } from '../../ai-tracing';
+import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
@@ -80,7 +81,7 @@ export class SystemPromptScrubber implements Processor {
       name: 'system-prompt-detector',
       model: this.model,
       instructions: this.instructions,
-      options: { tracingPolicy: { internal: InternalSpans.ALL }},
+      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
-import type { TracingContext } from '../../ai-tracing';
+import { InternalSpans, type TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
@@ -80,6 +80,7 @@ export class SystemPromptScrubber implements Processor {
       name: 'system-prompt-detector',
       model: this.model,
       instructions: this.instructions,
+      options: { tracingPolicy: { internal: InternalSpans.ALL }},
     });
   }
 

--- a/packages/core/src/stream/aisdk/v5/output.ts
+++ b/packages/core/src/stream/aisdk/v5/output.ts
@@ -11,6 +11,8 @@ import {
 import type { ObjectStreamPart, TextStreamPart, ToolSet, UIMessage, UIMessageStreamOptions } from 'ai-v5';
 import type z from 'zod';
 import type { MessageList } from '../../../agent/message-list';
+import { getValidTraceId } from '../../../ai-tracing';
+import type { TracingContext } from '../../../ai-tracing';
 import type { MastraModelOutput } from '../../base/output';
 import { getResponseFormat } from '../../base/schema';
 import type { OutputSchema } from '../../base/schema';
@@ -19,7 +21,6 @@ import type { ConsumeStreamOptions } from './compat';
 import { getResponseUIMessageId, convertFullStreamChunkToUIMessageStream } from './compat';
 import { convertMastraChunkToAISDKv5 } from './transform';
 import type { OutputChunkType } from './transform';
-import { getValidTraceId, type TracingContext } from '../../../ai-tracing';
 
 type AISDKV5OutputStreamOptions<OUTPUT extends OutputSchema = undefined> = {
   toolCallStreaming?: boolean;

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -700,6 +700,7 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
       options: {
         toolCallStreaming: options?.toolCallStreaming,
         output: options?.output,
+        tracingContext: options?.tracingContext,
       },
     });
 


### PR DESCRIPTION
## Description

Fixes issue with missing traceId output when using `aisdk` output format

Also disables tracing in all input/output processors (so they don't appear as separate traces until we specifically want to include them in the trace output).

## Related Issue(s)

#6773 

Fixes #8113 and #8195

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] have added tests that prove my fix is effective or that my feature works
