### PR TITLE
fix: resolve hanging stream for non-self executing client tools

### DIFF
--- a/.changeset/calm-buttons-cry.md
+++ b/.changeset/calm-buttons-cry.md
@@ -2,4 +2,4 @@
 '@mastra/client-js': patch
 ---
 
-Fix hanging stream for non-self exeucting client-tools
+Fix hanging stream for non-self executing client-tools

--- a/.changeset/calm-buttons-cry.md
+++ b/.changeset/calm-buttons-cry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fix hanging stream for non-self exeucting client-tools

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1144,7 +1144,7 @@ export class Agent extends BaseResource {
       body: processedParams,
       stream: true,
     });
-    console.log(processedParams);
+    });
     if (!response.body) {
       throw new Error('No response body');
     }

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1144,7 +1144,7 @@ export class Agent extends BaseResource {
       body: processedParams,
       stream: true,
     });
-    });
+
     if (!response.body) {
       throw new Error('No response body');
     }
@@ -1430,7 +1430,6 @@ export class Agent extends BaseResource {
       await processMastraStream({
         stream: streamResponse.body as ReadableStream<Uint8Array>,
         onChunk,
-      });
       });
     };
 

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1431,7 +1431,7 @@ export class Agent extends BaseResource {
         stream: streamResponse.body as ReadableStream<Uint8Array>,
         onChunk,
       });
-      console.log('processDataStream done');
+      });
     };
 
     return streamResponse;

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1144,7 +1144,7 @@ export class Agent extends BaseResource {
       body: processedParams,
       stream: true,
     });
-
+    console.log(processedParams);
     if (!response.body) {
       throw new Error('No response body');
     }
@@ -1207,10 +1207,12 @@ export class Agent extends BaseResource {
               toolCalls.push(toolCall);
             }
 
+            let shouldExecuteClientTool = false;
             // Handle tool calls if needed
             for (const toolCall of toolCalls) {
               const clientTool = processedParams.clientTools?.[toolCall.toolName] as Tool;
               if (clientTool && clientTool.execute) {
+                shouldExecuteClientTool = true;
                 const result = await clientTool.execute(
                   {
                     context: toolCall?.args,
@@ -1270,6 +1272,12 @@ export class Agent extends BaseResource {
                   console.error('Error processing stream response:', error);
                 });
               }
+            }
+
+            if (!shouldExecuteClientTool) {
+              setTimeout(() => {
+                writable.close();
+              }, 0);
             }
           } else {
             setTimeout(() => {
@@ -1423,6 +1431,7 @@ export class Agent extends BaseResource {
         stream: streamResponse.body as ReadableStream<Uint8Array>,
         onChunk,
       });
+      console.log('processDataStream done');
     };
 
     return streamResponse;

--- a/client-sdks/client-js/src/resources/agent.vnext.test.ts
+++ b/client-sdks/client-js/src/resources/agent.vnext.test.ts
@@ -145,7 +145,6 @@ describe('Agent vNext', () => {
       .mockResolvedValueOnce(sseResponse(firstCycle))
       .mockResolvedValueOnce(sseResponse(secondCycle));
 
-    const executeSpy = vi.fn(async () => ({ ok: true }));
     const weatherTool = createTool({
       id: 'weatherTool',
       description: 'Weather',


### PR DESCRIPTION
Fixed an issue where client-side tools would hang during streaming when they weren't self-executing. The problem was that the stream wasn't properly closing when we didn't run any client tools
