### PR TITLE
Add tracing option for workflow start and resume server apis

### DIFF
--- a/.changeset/calm-cameras-design.md
+++ b/.changeset/calm-cameras-design.md
@@ -1,0 +1,7 @@
+---
+'@mastra/client-js': patch
+'@mastra/deployer': patch
+'@mastra/server': patch
+---
+
+Support passing tracing options for start/resume workflows for server APIs and client sdk

--- a/client-sdks/client-js/src/resources/workflow.test.ts
+++ b/client-sdks/client-js/src/resources/workflow.test.ts
@@ -104,6 +104,58 @@ describe('Workflow (fetch-mocked)', () => {
     const res = await wf.start({ runId: 'r-x', inputData: { b: 2 } });
     expect(res).toEqual({ message: 'started' });
   });
+
+  it('starts workflow run synchronously with tracingOptions', async () => {
+    const run = await wf.createRunAsync();
+    const tracingOptions = { metadata: { foo: 'bar' } };
+    const result = await run.start({ inputData: { a: 1 }, tracingOptions });
+    expect(result).toEqual({ message: 'started' });
+
+    const call = fetchMock.mock.calls.find((args: any[]) => String(args[0]).includes('/start?runId='));
+    expect(call).toBeTruthy();
+    const options = call[1];
+    const body = JSON.parse(options.body);
+    expect(body.tracingOptions).toEqual(tracingOptions);
+  });
+
+  it('starts workflow run asynchronously with tracingOptions', async () => {
+    const run = await wf.createRunAsync();
+    const tracingOptions = { metadata: { traceId: 't-1' } };
+    const result = await run.startAsync({ inputData: { a: 1 }, tracingOptions });
+    expect(result).toEqual({ result: 'started-async' });
+
+    const call = fetchMock.mock.calls.find((args: any[]) => String(args[0]).includes('/start-async'));
+    expect(call).toBeTruthy();
+    const options = call[1];
+    const body = JSON.parse(options.body);
+    expect(body.tracingOptions).toEqual(tracingOptions);
+  });
+
+  it('resumes workflow run synchronously with tracingOptions', async () => {
+    const run = await wf.createRunAsync();
+    const tracingOptions = { metadata: { resume: true } };
+    const result = await run.resume({ step: 's1', tracingOptions });
+    expect(result).toEqual({ message: 'resumed' });
+
+    const call = fetchMock.mock.calls.find((args: any[]) => String(args[0]).includes('/resume?runId='));
+    expect(call).toBeTruthy();
+    const options = call[1];
+    const body = JSON.parse(options.body);
+    expect(body.tracingOptions).toEqual(tracingOptions);
+  });
+
+  it('resumes workflow run asynchronously with tracingOptions', async () => {
+    const run = await wf.createRunAsync();
+    const tracingOptions = { metadata: { async: true } };
+    const result = await run.resumeAsync({ step: 's1', tracingOptions });
+    expect(result).toEqual({ result: 'resumed-async' });
+
+    const call = fetchMock.mock.calls.find((args: any[]) => String(args[0]).includes('/resume-async'));
+    expect(call).toBeTruthy();
+    const options = call[1];
+    const body = JSON.parse(options.body);
+    expect(body.tracingOptions).toEqual(tracingOptions);
+  });
 });
 
 // Mock fetch globally for client tests

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -1,3 +1,4 @@
+import type { TracingOptions } from '@mastra/core/ai-tracing';
 import type { RuntimeContext } from '@mastra/core/runtime-context';
 import type {
   ClientOptions,
@@ -12,7 +13,6 @@ import type {
 
 import { parseClientRuntimeContext, base64RuntimeContext, runtimeContextQueryString } from '../utils';
 import { BaseResource } from './base';
-import type { TracingOptions } from '@mastra/core/ai-tracing';
 
 const RECORD_SEPARATOR = '\x1E';
 

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -12,6 +12,7 @@ import type {
 
 import { parseClientRuntimeContext, base64RuntimeContext, runtimeContextQueryString } from '../utils';
 import { BaseResource } from './base';
+import type { TracingOptions } from '@mastra/core/ai-tracing';
 
 const RECORD_SEPARATOR = '\x1E';
 
@@ -240,12 +241,14 @@ export class Workflow extends BaseResource {
     start: (params: {
       inputData: Record<string, any>;
       runtimeContext?: RuntimeContext | Record<string, any>;
+      tracingOptions?: TracingOptions;
     }) => Promise<{ message: string }>;
     watch: (onRecord: (record: WorkflowWatchResult) => void) => Promise<void>;
     resume: (params: {
       step: string | string[];
       resumeData?: Record<string, any>;
       runtimeContext?: RuntimeContext | Record<string, any>;
+      tracingOptions?: TracingOptions;
     }) => Promise<{ message: string }>;
     stream: (params: {
       inputData: Record<string, any>;
@@ -254,11 +257,13 @@ export class Workflow extends BaseResource {
     startAsync: (params: {
       inputData: Record<string, any>;
       runtimeContext?: RuntimeContext | Record<string, any>;
+      tracingOptions?: TracingOptions;
     }) => Promise<WorkflowRunResult>;
     resumeAsync: (params: {
       step: string | string[];
       resumeData?: Record<string, any>;
       runtimeContext?: RuntimeContext | Record<string, any>;
+      tracingOptions?: TracingOptions;
     }) => Promise<WorkflowRunResult>;
     resumeStreamVNext: (params: {
       step: string | string[];
@@ -283,14 +288,29 @@ export class Workflow extends BaseResource {
 
     return {
       runId,
-      start: async (p: { inputData: Record<string, any>; runtimeContext?: RuntimeContext | Record<string, any> }) => {
-        return this.start({ runId, inputData: p.inputData, runtimeContext: p.runtimeContext });
+      start: async (p: {
+        inputData: Record<string, any>;
+        runtimeContext?: RuntimeContext | Record<string, any>;
+        tracingOptions?: TracingOptions;
+      }) => {
+        return this.start({
+          runId,
+          inputData: p.inputData,
+          runtimeContext: p.runtimeContext,
+          tracingOptions: p.tracingOptions,
+        });
       },
       startAsync: async (p: {
         inputData: Record<string, any>;
         runtimeContext?: RuntimeContext | Record<string, any>;
+        tracingOptions?: TracingOptions;
       }) => {
-        return this.startAsync({ runId, inputData: p.inputData, runtimeContext: p.runtimeContext });
+        return this.startAsync({
+          runId,
+          inputData: p.inputData,
+          runtimeContext: p.runtimeContext,
+          tracingOptions: p.tracingOptions,
+        });
       },
       watch: async (onRecord: (record: WorkflowWatchResult) => void) => {
         return this.watch({ runId }, onRecord);
@@ -302,15 +322,29 @@ export class Workflow extends BaseResource {
         step: string | string[];
         resumeData?: Record<string, any>;
         runtimeContext?: RuntimeContext | Record<string, any>;
+        tracingOptions?: TracingOptions;
       }) => {
-        return this.resume({ runId, step: p.step, resumeData: p.resumeData, runtimeContext: p.runtimeContext });
+        return this.resume({
+          runId,
+          step: p.step,
+          resumeData: p.resumeData,
+          runtimeContext: p.runtimeContext,
+          tracingOptions: p.tracingOptions,
+        });
       },
       resumeAsync: async (p: {
         step: string | string[];
         resumeData?: Record<string, any>;
         runtimeContext?: RuntimeContext | Record<string, any>;
+        tracingOptions?: TracingOptions;
       }) => {
-        return this.resumeAsync({ runId, step: p.step, resumeData: p.resumeData, runtimeContext: p.runtimeContext });
+        return this.resumeAsync({
+          runId,
+          step: p.step,
+          resumeData: p.resumeData,
+          runtimeContext: p.runtimeContext,
+          tracingOptions: p.tracingOptions,
+        });
       },
       resumeStreamVNext: async (p: {
         step: string | string[];
@@ -336,11 +370,12 @@ export class Workflow extends BaseResource {
     runId: string;
     inputData: Record<string, any>;
     runtimeContext?: RuntimeContext | Record<string, any>;
+    tracingOptions?: TracingOptions;
   }): Promise<{ message: string }> {
     const runtimeContext = parseClientRuntimeContext(params.runtimeContext);
     return this.request(`/api/workflows/${this.workflowId}/start?runId=${params.runId}`, {
       method: 'POST',
-      body: { inputData: params?.inputData, runtimeContext },
+      body: { inputData: params?.inputData, runtimeContext, tracingOptions: params.tracingOptions },
     });
   }
 
@@ -353,12 +388,14 @@ export class Workflow extends BaseResource {
     step,
     runId,
     resumeData,
+    tracingOptions,
     ...rest
   }: {
     step: string | string[];
     runId: string;
     resumeData?: Record<string, any>;
     runtimeContext?: RuntimeContext | Record<string, any>;
+    tracingOptions?: TracingOptions;
   }): Promise<{ message: string }> {
     const runtimeContext = parseClientRuntimeContext(rest.runtimeContext);
     return this.request(`/api/workflows/${this.workflowId}/resume?runId=${runId}`, {
@@ -367,6 +404,7 @@ export class Workflow extends BaseResource {
         step,
         resumeData,
         runtimeContext,
+        tracingOptions,
       },
     });
   }
@@ -380,6 +418,7 @@ export class Workflow extends BaseResource {
     runId?: string;
     inputData: Record<string, any>;
     runtimeContext?: RuntimeContext | Record<string, any>;
+    tracingOptions?: TracingOptions;
   }): Promise<WorkflowRunResult> {
     const searchParams = new URLSearchParams();
 
@@ -391,7 +430,7 @@ export class Workflow extends BaseResource {
 
     return this.request(`/api/workflows/${this.workflowId}/start-async?${searchParams.toString()}`, {
       method: 'POST',
-      body: { inputData: params.inputData, runtimeContext },
+      body: { inputData: params.inputData, runtimeContext, tracingOptions: params.tracingOptions },
     });
   }
 
@@ -612,6 +651,7 @@ export class Workflow extends BaseResource {
     step: string | string[];
     resumeData?: Record<string, any>;
     runtimeContext?: RuntimeContext | Record<string, any>;
+    tracingOptions?: TracingOptions;
   }): Promise<WorkflowRunResult> {
     const runtimeContext = parseClientRuntimeContext(params.runtimeContext);
     return this.request(`/api/workflows/${this.workflowId}/resume-async?runId=${params.runId}`, {
@@ -620,6 +660,7 @@ export class Workflow extends BaseResource {
         step: params.step,
         resumeData: params.resumeData,
         runtimeContext,
+        tracingOptions: params.tracingOptions,
       },
     });
   }
@@ -634,6 +675,7 @@ export class Workflow extends BaseResource {
     step: string | string[];
     resumeData?: Record<string, any>;
     runtimeContext?: RuntimeContext | Record<string, any>;
+    tracingOptions?: TracingOptions;
   }): Promise<ReadableStream> {
     const runtimeContext = parseClientRuntimeContext(params.runtimeContext);
     return this.request(`/api/workflows/${this.workflowId}/resume-stream?runId=${params.runId}`, {
@@ -642,6 +684,7 @@ export class Workflow extends BaseResource {
         step: params.step,
         resumeData: params.resumeData,
         runtimeContext,
+        tracingOptions: params.tracingOptions,
       },
     });
   }

--- a/packages/deployer/src/server/handlers/routes/agents/handlers.ts
+++ b/packages/deployer/src/server/handlers/routes/agents/handlers.ts
@@ -76,6 +76,17 @@ export const vNextBodyOptions: any = {
     description: 'Controls how tools are selected during generation',
   },
   format: { type: 'string', enum: ['mastra', 'aisdk'], description: 'Response format' },
+  tracingOptions: {
+    type: 'object',
+    description: 'Tracing options for the agent execution',
+    properties: {
+      metadata: {
+        type: 'object',
+        description: 'Custom metadata to attach to the trace',
+        additionalProperties: true,
+      },
+    },
+  },
   ...sharedBodyOptions,
 };
 

--- a/packages/deployer/src/server/handlers/routes/agents/router.ts
+++ b/packages/deployer/src/server/handlers/routes/agents/router.ts
@@ -147,6 +147,17 @@ export function agentsRouter(bodyLimitOptions: BodyLimitOptions) {
                 },
                 runId: { type: 'string' },
                 output: { type: 'object' },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the agent execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
+                },
               },
               required: ['messages'],
             },
@@ -199,6 +210,17 @@ export function agentsRouter(bodyLimitOptions: BodyLimitOptions) {
                 },
                 runId: { type: 'string' },
                 output: { type: 'object' },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the agent execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
+                },
               },
               required: ['messages'],
             },
@@ -357,6 +379,17 @@ export function agentsRouter(bodyLimitOptions: BodyLimitOptions) {
                 },
                 runId: { type: 'string' },
                 output: { type: 'object' },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the agent execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
+                },
               },
               required: ['messages'],
             },
@@ -409,6 +442,17 @@ export function agentsRouter(bodyLimitOptions: BodyLimitOptions) {
                 },
                 runId: { type: 'string' },
                 output: { type: 'object' },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the agent execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
+                },
               },
               required: ['messages'],
             },
@@ -475,6 +519,17 @@ export function agentsRouter(bodyLimitOptions: BodyLimitOptions) {
                     { type: 'string', enum: ['auto', 'none', 'required'] },
                     { type: 'object', properties: { type: { type: 'string' }, toolName: { type: 'string' } } },
                   ],
+                },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the agent execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
                 },
               },
               required: ['messages'],

--- a/packages/deployer/src/server/handlers/routes/workflows/handlers.ts
+++ b/packages/deployer/src/server/handlers/routes/workflows/handlers.ts
@@ -1,4 +1,5 @@
 import type { Mastra } from '@mastra/core';
+import type { TracingOptions } from '@mastra/core/ai-tracing';
 import {
   getWorkflowsHandler as getOriginalWorkflowsHandler,
   getWorkflowByIdHandler as getOriginalWorkflowByIdHandler,
@@ -77,7 +78,7 @@ export async function startAsyncWorkflowHandler(c: Context) {
     const mastra: Mastra = c.get('mastra');
     const runtimeContext = c.get('runtimeContext');
     const workflowId = c.req.param('workflowId');
-    const { inputData } = await c.req.json();
+    const { inputData, tracingOptions } = await c.req.json();
     const runId = c.req.query('runId');
 
     const result = await getOriginalStartAsyncWorkflowHandler({
@@ -86,6 +87,7 @@ export async function startAsyncWorkflowHandler(c: Context) {
       workflowId,
       runId,
       inputData,
+      tracingOptions,
     });
 
     return c.json(result);
@@ -99,7 +101,7 @@ export async function startWorkflowRunHandler(c: Context) {
     const mastra: Mastra = c.get('mastra');
     const runtimeContext = c.get('runtimeContext');
     const workflowId = c.req.param('workflowId');
-    const { inputData } = await c.req.json();
+    const { inputData, tracingOptions } = await c.req.json();
     const runId = c.req.query('runId');
 
     await getOriginalStartWorkflowRunHandler({
@@ -108,6 +110,7 @@ export async function startWorkflowRunHandler(c: Context) {
       workflowId,
       runId,
       inputData,
+      tracingOptions,
     });
 
     return c.json({ message: 'Workflow run started' });
@@ -355,7 +358,7 @@ export async function resumeAsyncWorkflowHandler(c: Context) {
     const runtimeContext = c.get('runtimeContext');
     const workflowId = c.req.param('workflowId');
     const runId = c.req.query('runId');
-    const { step, resumeData } = await c.req.json();
+    const { step, resumeData, tracingOptions } = await c.req.json();
 
     if (!runId) {
       throw new HTTPException(400, { message: 'runId required to resume workflow' });
@@ -367,6 +370,7 @@ export async function resumeAsyncWorkflowHandler(c: Context) {
       workflowId,
       runId,
       body: { step, resumeData },
+      tracingOptions,
     });
 
     return c.json(result);
@@ -381,7 +385,7 @@ export async function resumeWorkflowHandler(c: Context) {
     const runtimeContext = c.get('runtimeContext');
     const workflowId = c.req.param('workflowId');
     const runId = c.req.query('runId');
-    const { step, resumeData } = await c.req.json();
+    const { step, resumeData, tracingOptions } = await c.req.json();
 
     if (!runId) {
       throw new HTTPException(400, { message: 'runId required to resume workflow' });
@@ -393,6 +397,7 @@ export async function resumeWorkflowHandler(c: Context) {
       workflowId,
       runId,
       body: { step, resumeData },
+      tracingOptions,
     });
 
     return c.json({ message: 'Workflow run resumed' });

--- a/packages/deployer/src/server/handlers/routes/workflows/handlers.ts
+++ b/packages/deployer/src/server/handlers/routes/workflows/handlers.ts
@@ -1,5 +1,4 @@
 import type { Mastra } from '@mastra/core';
-import type { TracingOptions } from '@mastra/core/ai-tracing';
 import {
   getWorkflowsHandler as getOriginalWorkflowsHandler,
   getWorkflowByIdHandler as getOriginalWorkflowByIdHandler,

--- a/packages/deployer/src/server/handlers/routes/workflows/router.ts
+++ b/packages/deployer/src/server/handlers/routes/workflows/router.ts
@@ -130,6 +130,17 @@ export function workflowsRouter(bodyLimitOptions: BodyLimitOptions) {
               properties: {
                 stepId: { type: 'string' },
                 context: { type: 'object' },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the workflow execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
+                },
               },
             },
           },
@@ -168,6 +179,17 @@ export function workflowsRouter(bodyLimitOptions: BodyLimitOptions) {
               properties: {
                 stepId: { type: 'string' },
                 context: { type: 'object' },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the workflow execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
+                },
               },
             },
           },
@@ -776,6 +798,17 @@ export function workflowsRouter(bodyLimitOptions: BodyLimitOptions) {
                   type: 'object',
                   description: 'Runtime context for the workflow execution',
                 },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the workflow execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
+                },
               },
             },
           },
@@ -823,6 +856,17 @@ export function workflowsRouter(bodyLimitOptions: BodyLimitOptions) {
                 runtimeContext: {
                   type: 'object',
                   description: 'Runtime context for the workflow execution',
+                },
+                tracingOptions: {
+                  type: 'object',
+                  description: 'Tracing options for the workflow execution',
+                  properties: {
+                    metadata: {
+                      type: 'object',
+                      description: 'Custom metadata to attach to the trace',
+                      additionalProperties: true,
+                    },
+                  },
                 },
               },
             },

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -96,6 +96,7 @@ describe('vNext Workflow Handlers', () => {
   let mockMastra: Mastra;
   let mockWorkflow: Workflow;
   let reusableWorkflow: Workflow;
+  const tracingOptions = { metadata: { test: true } };
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -166,6 +167,7 @@ describe('vNext Workflow Handlers', () => {
         mastra: mockMastra,
         workflowId: 'test-workflow',
         inputData: {},
+        tracingOptions,
       });
 
       expect(result.steps['test-step'].status).toEqual('success');
@@ -177,6 +179,7 @@ describe('vNext Workflow Handlers', () => {
         workflowId: 'test-workflow',
         runId: 'test-run',
         inputData: {},
+        tracingOptions,
       });
 
       expect(result.steps['test-step'].status).toEqual('success');
@@ -369,6 +372,7 @@ describe('vNext Workflow Handlers', () => {
         workflowId: 'test-workflow',
         runId: 'test-run',
         inputData: { test: 'data' },
+        tracingOptions,
       });
 
       expect(result).toEqual({ message: 'Workflow run started' });
@@ -465,6 +469,7 @@ describe('vNext Workflow Handlers', () => {
         workflowId: reusableWorkflow.name,
         runId: 'test-run',
         body: { step: 'test-step', resumeData: { test: 'data' } },
+        tracingOptions,
       });
 
       expect(result).toEqual({ message: 'Workflow run resumed' });

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -1,4 +1,5 @@
 import { ReadableStream, TransformStream } from 'node:stream/web';
+import type { TracingOptions } from '@mastra/core/ai-tracing';
 import type { RuntimeContext } from '@mastra/core/di';
 import type { WorkflowRuns } from '@mastra/core/storage';
 import type { Workflow, WatchEvent, WorkflowInfo, StreamEvent } from '@mastra/core/workflows';
@@ -6,7 +7,6 @@ import { HTTPException } from '../http-exception';
 import type { Context } from '../types';
 import { getWorkflowInfo, WorkflowRegistry } from '../utils';
 import { handleError } from './error';
-import type { TracingOptions } from '@mastra/core/ai-tracing';
 
 export interface WorkflowContext extends Context {
   workflowId?: string;

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -6,6 +6,7 @@ import { HTTPException } from '../http-exception';
 import type { Context } from '../types';
 import { getWorkflowInfo, WorkflowRegistry } from '../utils';
 import { handleError } from './error';
+import type { TracingOptions } from '@mastra/core/ai-tracing';
 
 export interface WorkflowContext extends Context {
   workflowId?: string;
@@ -185,9 +186,11 @@ export async function startAsyncWorkflowHandler({
   workflowId,
   runId,
   inputData,
+  tracingOptions,
 }: Pick<WorkflowContext, 'mastra' | 'workflowId' | 'runId'> & {
   inputData?: unknown;
   runtimeContext?: RuntimeContext;
+  tracingOptions?: TracingOptions;
 }) {
   try {
     if (!workflowId) {
@@ -204,6 +207,7 @@ export async function startAsyncWorkflowHandler({
     const result = await _run.start({
       inputData,
       runtimeContext,
+      tracingOptions,
     });
     return result;
   } catch (error) {
@@ -217,9 +221,11 @@ export async function startWorkflowRunHandler({
   workflowId,
   runId,
   inputData,
+  tracingOptions,
 }: Pick<WorkflowContext, 'mastra' | 'workflowId' | 'runId'> & {
   inputData?: unknown;
   runtimeContext?: RuntimeContext;
+  tracingOptions?: TracingOptions;
 }) {
   try {
     if (!workflowId) {
@@ -246,6 +252,7 @@ export async function startWorkflowRunHandler({
     void _run.start({
       inputData,
       runtimeContext,
+      tracingOptions,
     });
 
     return { message: 'Workflow run started' };
@@ -463,9 +470,11 @@ export async function resumeAsyncWorkflowHandler({
   runId,
   body,
   runtimeContext,
+  tracingOptions,
 }: WorkflowContext & {
   body: { step: string | string[]; resumeData?: unknown };
   runtimeContext?: RuntimeContext;
+  tracingOptions?: TracingOptions;
 }) {
   try {
     if (!workflowId) {
@@ -497,6 +506,7 @@ export async function resumeAsyncWorkflowHandler({
       step: body.step,
       resumeData: body.resumeData,
       runtimeContext,
+      tracingOptions,
     });
 
     return result;
@@ -511,9 +521,11 @@ export async function resumeWorkflowHandler({
   runId,
   body,
   runtimeContext,
+  tracingOptions,
 }: WorkflowContext & {
   body: { step: string | string[]; resumeData?: unknown };
   runtimeContext?: RuntimeContext;
+  tracingOptions?: TracingOptions;
 }) {
   try {
     if (!workflowId) {
@@ -546,6 +558,7 @@ export async function resumeWorkflowHandler({
       step: body.step,
       resumeData: body.resumeData,
       runtimeContext,
+      tracingOptions,
     });
 
     return { message: 'Workflow run resumed' };


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Support passing tracing options when starting/resuming workflow from hono server apis and client sdk

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
