### PR TITLE
fix(client-js): WritableStream locked error

### DIFF
--- a/.changeset/heavy-ideas-camp.md
+++ b/.changeset/heavy-ideas-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fix `[ERR_INVALID_STATE]: Invalid state: WritableStream is locked` errors


### PR DESCRIPTION
## Description

This fixes a race condition where the WritableStream gets locked during `pipeTo()` operations and can't be accessed by subsequent operations like `getWriter()` or `close()`. This was causing crashes in production.

When a client tool executed and triggered a recursive stream call, the code would try to access the WritableStream while it was still locked from an ongoing pipe operation, throwing `TypeError: Invalid state: WritableStream is locked`.

We now capture the `pipeTo()` promise and await it before accessing the stream again. This ensures the lock is released before any subsequent access attempts.

## Related Issue(s)

Fixes #8302

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works