### PR TITLE
fix(core): persist output processor state across LLM execution steps

### DIFF
--- a/.changeset/lazy-hoops-dig.md
+++ b/.changeset/lazy-hoops-dig.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixes two issues, one where finish chunks were passed to output processors after every step, and the other where the processorState would get reset after every step, meaning that the final StructuredOutput process prompt was missing lots of context from the previous steps.

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -2,6 +2,7 @@ import { generateId } from 'ai-v5';
 import type { ToolSet } from 'ai-v5';
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
 import { ConsoleLogger } from '../logger';
+import type { ProcessorState } from '../processors';
 import { createDestructurableOutput, MastraModelOutput } from '../stream/base/output';
 import type { OutputSchema } from '../stream/base/schema';
 import { getRootSpan } from './telemetry';
@@ -99,6 +100,11 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
   const deserializeStreamState = (state: any) => {
     modelOutput?.deserializeState(state);
   };
+
+  // Create processor states map that will be shared across all LLM execution steps
+  const processorStates =
+    outputProcessors && outputProcessors.length > 0 ? new Map<string, ProcessorState<OUTPUT>>() : undefined;
+
   const workflowLoopProps: LoopRun<Tools, OUTPUT> = {
     resumeContext,
     models,
@@ -120,6 +126,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
       serialize: serializeStreamState,
       deserialize: deserializeStreamState,
     },
+    processorStates,
     ...rest,
   };
 

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -15,7 +15,7 @@ import type { MessageList } from '../agent/message-list';
 import type { AISpan, AISpanType } from '../ai-tracing';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
-import type { OutputProcessor } from '../processors';
+import type { OutputProcessor, ProcessorState } from '../processors';
 import type { OutputSchema } from '../stream/base/schema';
 import type {
   ChunkType,
@@ -102,6 +102,7 @@ export type LoopRun<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchema
     serialize: () => any;
     deserialize: (state: any) => void;
   };
+  processorStates?: Map<string, ProcessorState<OUTPUT>>;
 };
 
 export type OuterLLMRun<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchema = undefined> = {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -440,6 +440,7 @@ export function createLLMExecutionStep<Tools extends ToolSet = ToolSet, OUTPUT e
   headers,
   downloadRetries,
   downloadConcurrency,
+  processorStates,
 }: OuterLLMRun<Tools, OUTPUT>) {
   return createStep({
     id: 'llm-execution',
@@ -587,6 +588,7 @@ export function createLLMExecutionStep<Tools extends ToolSet = ToolSet, OUTPUT e
             outputProcessors,
             isLLMExecutionStep: true,
             tracingContext,
+            processorStates,
           },
         });
 

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -48,3 +48,4 @@ export type OutputProcessor =
 export type ProcessorTypes = InputProcessor | OutputProcessor;
 
 export * from './processors';
+export { ProcessorState } from './runner';

--- a/packages/core/src/processors/output-processor-tool-execution.test.ts
+++ b/packages/core/src/processors/output-processor-tool-execution.test.ts
@@ -1,0 +1,141 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Agent } from '../agent';
+import type { Processor } from './index';
+
+describe('Output Processor State Persistence Across Tool Execution', () => {
+  it('should filter intermediate finish chunks and maintain state during tool execution', async () => {
+    const capturedChunks: { type: string; accumulatedTypes: string[] }[] = [];
+
+    // Test processor that captures chunk types and accumulated state
+    class StateTrackingProcessor implements Processor {
+      name = 'state-tracking-processor';
+
+      async processOutputStream({ part, streamParts }: any) {
+        capturedChunks.push({
+          type: part.type,
+          accumulatedTypes: streamParts.map((p: any) => p.type),
+        });
+        return part;
+      }
+    }
+
+    // Mock tool that returns a result
+    const mockTool = {
+      description: 'A test tool',
+      parameters: {
+        type: 'object' as const,
+        properties: {
+          input: { type: 'string' as const },
+        },
+        required: ['input'] as const,
+      },
+      execute: vi.fn(async () => {
+        return { result: 'tool executed successfully' };
+      }),
+    };
+
+    // Create mock model that calls a tool
+    const mockModel = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        // Check if this is the first call (no tool results in messages) or second call (after tool execution)
+        const hasToolResults = prompt.some(
+          (msg: any) =>
+            msg.role === 'tool' ||
+            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
+        );
+
+        if (!hasToolResults) {
+          // First LLM call - request tool execution
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-123',
+                toolName: 'testTool',
+                input: JSON.stringify({ input: 'test' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        } else {
+          // Second LLM call - after tool execution
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'The tool executed successfully!' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'Test agent with tools',
+      model: mockModel as any,
+      tools: {
+        testTool: mockTool,
+      },
+      outputProcessors: [new StateTrackingProcessor()],
+    });
+
+    // Stream the response
+    const stream = await agent.streamVNext('Execute the test tool', {
+      format: 'aisdk',
+      maxSteps: 5, // Allow multiple steps to continue after tool execution
+    });
+
+    // Consume the stream
+    const fullStreamChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      fullStreamChunks.push(chunk);
+    }
+
+    console.log(
+      'Full stream chunk types:',
+      fullStreamChunks.map(c => c.type),
+    );
+
+    // VERIFICATION: Both issues are now fixed!
+
+    // Issue 2 Fix: Intermediate finish chunks with 'tool-calls' reason are filtered out
+    const finishChunks = capturedChunks.filter(c => c.type === 'finish');
+    // Before fix: Would see 2 finish chunks (one with 'tool-calls' reason that shouldn't reach processors)
+    // After fix: No finish chunks reach the processor (the intermediate one is filtered)
+    expect(finishChunks.length).toBe(0);
+
+    // Issue 1 Fix: Processor state persists across the stream (no reset)
+    // Find the tool-call chunk
+    const toolCallIndex = capturedChunks.findIndex(c => c.type === 'tool-call');
+    expect(toolCallIndex).toBe(1); // Should be the second chunk (after response-metadata)
+
+    // Verify state accumulation works
+    expect(capturedChunks[0]!.type).toBe('response-metadata');
+    expect(capturedChunks[0]!.accumulatedTypes).toEqual(['response-metadata']);
+
+    expect(capturedChunks[1]!.type).toBe('tool-call');
+    expect(capturedChunks[1]!.accumulatedTypes).toEqual(['response-metadata', 'tool-call']);
+
+    // This demonstrates the fix: state is accumulating properly across chunks
+    // Before the fix, we would have seen state reset after the tool-call
+  });
+});

--- a/packages/core/src/processors/processors/structured-output.test.ts
+++ b/packages/core/src/processors/processors/structured-output.test.ts
@@ -1,9 +1,13 @@
 import type { TransformStreamDefaultController } from 'stream/web';
+import { openai } from '@ai-sdk/openai-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import z from 'zod';
+import { Agent } from '../../agent';
 import type { ChunkType } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
+import { createTool } from '../../tools';
+import type { Processor } from '../index';
 import { StructuredOutputProcessor } from './structured-output';
 
 describe('StructuredOutputProcessor', () => {
@@ -446,4 +450,237 @@ describe('StructuredOutputProcessor', () => {
       expect(prompt).toContain('The answer is blue and bright');
     });
   });
+});
+
+describe('Structured Output with Tool Execution', () => {
+  it('should generate structured output when tools are involved', async () => {
+    // Test processor to track streamParts state
+    const streamPartsLog: { type: string; streamPartsLength: number }[] = [];
+    class StateTrackingProcessor implements Processor {
+      name = 'state-tracking';
+      async processOutputStream({ part, streamParts }: any) {
+        streamPartsLog.push({ type: part.type, streamPartsLength: streamParts.length });
+        console.log(`Processor saw ${part.type}, streamParts.length: ${streamParts.length}`);
+        return part;
+      }
+    }
+
+    // Define the structured output schema
+    const responseSchema = z.object({
+      toolUsed: z.string(),
+      result: z.string(),
+      confidence: z.number(),
+    });
+
+    // Mock tool that returns a result
+    const mockTool = {
+      description: 'A calculator tool',
+      parameters: {
+        type: 'object' as const,
+        properties: {
+          a: { type: 'number' as const },
+          b: { type: 'number' as const },
+        },
+        required: ['a', 'b'] as const,
+      },
+      execute: vi.fn(async ({ a, b }: { a: number; b: number }) => {
+        return { sum: a + b };
+      }),
+    };
+
+    // Create mock model that calls a tool and returns structured output
+    const mockModel = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        // Check if this is the first call or after tool execution
+        const hasToolResults = prompt.some(
+          (msg: any) =>
+            msg.role === 'tool' ||
+            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
+        );
+
+        if (!hasToolResults) {
+          // First LLM call - request tool execution
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-123',
+                toolName: 'calculator',
+                input: JSON.stringify({ a: 5, b: 3 }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        } else {
+          // Second LLM call - after tool execution, return structured output
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: '{"toolUsed":"calculator","result":"8","confidence":0.95}' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        }
+      },
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'Test agent with structured output and tools',
+      model: mockModel as any,
+      tools: {
+        calculator: mockTool,
+      },
+      outputProcessors: [new StateTrackingProcessor()],
+    });
+
+    // Stream the response
+    const stream = await agent.streamVNext('Calculate 5 + 3 and return structured output', {
+      format: 'aisdk',
+      maxSteps: 5,
+      structuredOutput: {
+        schema: responseSchema,
+        model: openai('gpt-4o-mini'), // Use real model for structured output processor
+      },
+    });
+
+    console.log('Stream properties:', Object.keys(stream));
+    console.log('Has partialObjectStream?', 'partialObjectStream' in stream);
+    console.log('Has object?', 'object' in stream);
+
+    // Don't consume fullStream first - get the object while consuming
+    const fullStreamChunks: any[] = [];
+
+    // Consume full stream and wait for object in parallel
+    const [chunks, finalObject] = await Promise.all([
+      (async () => {
+        const collected: any[] = [];
+        for await (const chunk of stream.fullStream) {
+          collected.push(chunk);
+          console.log('Chunk:', chunk.type, chunk.type === 'finish' ? chunk : '');
+        }
+        return collected;
+      })(),
+      stream.object,
+    ]);
+
+    fullStreamChunks.push(...chunks);
+
+    console.log(
+      'Full stream chunk types:',
+      fullStreamChunks.map(c => c.type),
+    );
+    console.log(
+      'Finish chunks:',
+      fullStreamChunks.filter(c => c.type === 'finish'),
+    );
+    console.log(
+      'Tool result chunk:',
+      fullStreamChunks.find(c => c.type === 'tool-result'),
+    );
+    console.log('Mock tool execute called times:', mockTool.execute.mock.calls.length);
+    console.log('Final object:', finalObject);
+
+    // ISSUE: Before the fix, no structured output would be generated when tools are involved
+    // The structured output processor would lose state between LLM calls or not trigger at all
+
+    // Verify the final object matches the schema
+    expect(finalObject).toBeDefined();
+    expect(finalObject.toolUsed).toBe('calculator');
+    expect(finalObject.result).toBe('8');
+    expect(typeof finalObject.confidence).toBe('number');
+
+    // Verify the tool was actually executed
+    expect(fullStreamChunks.find(c => c.type === 'tool-result')).toBeDefined();
+  });
+
+  it('should handle structured output with multiple tool calls', async () => {
+    const responseSchema = z.object({
+      activities: z.array(z.string()),
+      toolsCalled: z.array(z.string()),
+      location: z.string(),
+    });
+
+    const weatherTool = createTool({
+      id: 'weather-tool',
+      description: 'Get weather for a location',
+      inputSchema: z.object({
+        location: z.string(),
+      }),
+      execute: async context => {
+        const { location } = context.context;
+        return {
+          temperature: 70,
+          feelsLike: 65,
+          humidity: 50,
+          windSpeed: 10,
+          windGust: 15,
+          conditions: 'sunny',
+          location,
+        };
+      },
+    });
+
+    const planActivities = createTool({
+      id: 'plan-activities',
+      description: 'Plan activities based on the weather',
+      inputSchema: z.object({
+        temperature: z.string(),
+      }),
+      execute: async () => {
+        return { activities: 'Plan activities based on the weather' };
+      },
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions:
+        'You are a helpful assistant. Figure out the weather and then using that weather plan some activities. Always use the weather tool first, and then the plan activities tool with the result of the weather tool. Every tool call you make IMMEDIATELY explain the tool results after executing the tool, before moving on to other steps or tool calls',
+      model: openai('gpt-4o-mini'),
+      tools: {
+        weatherTool,
+        planActivities,
+      },
+    });
+
+    const stream = await agent.streamVNext('What is the weather in Toronto?', {
+      format: 'aisdk',
+      maxSteps: 10,
+      structuredOutput: {
+        schema: responseSchema,
+      },
+    });
+
+    // Consume the stream
+    for await (const chunk of stream.fullStream) {
+      console.log('Chunk:', chunk.type);
+      // Just consume
+    }
+
+    const finalObject = await stream.object;
+    console.log('Final object with multiple tools:', finalObject);
+
+    // Verify the structured output was generated correctly
+    expect(finalObject).toBeDefined();
+    expect(finalObject.activities.length).toBeGreaterThanOrEqual(1);
+    expect(finalObject.toolsCalled).toHaveLength(2);
+    expect(finalObject.location).toBe('Toronto');
+  }, 15000);
 });

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -86,7 +86,6 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
   ): Promise<void> {
     if (this.isStructuringAgentStreamStarted) return;
     this.isStructuringAgentStreamStarted = true;
-
     try {
       const structuringPrompt = this.buildStructuringPrompt(streamParts);
       const prompt = `Extract and structure the key information from the following text according to the specified schema. Keep the original meaning and details:\n\n${structuringPrompt}`;

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -568,6 +568,7 @@ export type MastraModelOutputOptions<OUTPUT extends OutputSchema = undefined> = 
   isLLMExecutionStep?: boolean;
   returnScorerData?: boolean;
   tracingContext?: TracingContext;
+  processorStates?: Map<string, any>;
 };
 
 export type LLMStepResult = {


### PR DESCRIPTION
Fixed output processor state being reset between LLM execution steps when tools are involved. This was causing issues where processors like StructuredOutputProcessor would lose accumulated state after tool calls, preventing structured output from being generated correctly.

The issue was that `processorStates` was stored in the workflow closure but wasn't being passed through to the LLM execution step correctly - it was trying to access it from `inputData` instead of the closure parameters. Also needed to update the controller reference when new LLM execution steps create new TransformStreams.

Before:
```typescript
processorStates: inputData.processorStates  // ❌ not in inputData
```

After:
```typescript
processorStates  // ✅ from closure parameters
```

Also updates the controller reference in ProcessorState when new LLM execution steps start, since each step has its own TransformStream with a new controller.

Another thing this PR fixes is that `finish` chunks were being passed to the processors after every step, causing unwanted behaviour.