### PR TITLE
fix(cli): Windows shell option

### DIFF
--- a/.changeset/whole-bags-remain.md
+++ b/.changeset/whole-bags-remain.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix shell option breaking server start on windows env


### PR DESCRIPTION
## Description

Fix shell option breaking server start on windows env

## Related Issue(s)

Fixes #8376 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [-] I have made corresponding changes to the documentation (if applicable)
- [-] I have added tests that prove my fix is effective or that my feature works

Ps: I've run the tests but a lot failed, some asked for OpenAI API key that I don't have, so if anyone could review this and/or run the tests for us, I appreciate.
