### PR TITLE
fix: color contrast on code block for legacy traces

### DIFF
--- a/.changeset/itchy-geckos-report.md
+++ b/.changeset/itchy-geckos-report.md
@@ -1,0 +1,8 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'@mastra/core': patch
+'create-mastra': patch
+---
+
+fix codeblock line number color contrast for legacy traces

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -54,4 +54,9 @@ export const mastra = new Mastra({
   // telemetry: {
   //   enabled: false,
   // }
+  observability: {
+    default: {
+      enabled: true,
+    },
+  },
 });

--- a/packages/playground-ui/src/components/syntax-highlighter.tsx
+++ b/packages/playground-ui/src/components/syntax-highlighter.tsx
@@ -1,4 +1,4 @@
-import { Colors } from '@/ds/tokens';
+import { IconColors } from '@/ds/tokens';
 import { jsonLanguage } from '@codemirror/lang-json';
 import { tags as t } from '@lezer/highlight';
 import { draculaInit } from '@uiw/codemirror-theme-dracula';
@@ -14,7 +14,7 @@ export const useCodemirrorTheme = () => {
           fontSize: '0.8rem',
           lineHighlight: 'transparent',
           gutterBackground: 'transparent',
-          gutterForeground: Colors.surface3,
+          gutterForeground: IconColors.icon3,
           background: 'transparent',
         },
         styles: [{ tag: [t.className, t.propertyName] }],


### PR DESCRIPTION
## Description

Quick fix for the traces color, but we have mutliple "codeblocks" and should only have one in the future

<img width="3840" height="2160" alt="CleanShot 2025-10-02 at 09 28 13@2x" src="https://github.com/user-attachments/assets/5917286c-203d-4d5b-a938-ef8c96ab4e3a" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
