### PR TITLE
feat: put fetch interval on ai traces

### DIFF
--- a/.changeset/eleven-hairs-take.md
+++ b/.changeset/eleven-hairs-take.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+'@mastra/core': patch
+'create-mastra': patch
+---
+
+add refetch interval to traces to make it feel "instant"

--- a/packages/playground/src/domains/observability/hooks/use-ai-trace.tsx
+++ b/packages/playground/src/domains/observability/hooks/use-ai-trace.tsx
@@ -13,8 +13,7 @@ export const useAITrace = (traceId: string | null | undefined, options?: { enabl
       return res;
     },
     enabled: !!traceId,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
+    refetchInterval: 3000,
     ...options,
   });
 

--- a/packages/playground/src/domains/observability/hooks/use-ai-traces.tsx
+++ b/packages/playground/src/domains/observability/hooks/use-ai-traces.tsx
@@ -57,6 +57,7 @@ export const useAITraces = ({ filters, dateRange }: AITracesFilters) => {
       return data.pages.flatMap(page => page);
     },
     retry: false,
+    refetchInterval: 3000,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Description

- makes UI feel a bit more responsive since the list of traces is refreshed every 3sec
- makes the trace detail feels better since it updates every 3 seconds even if the trace is not finished yet (we see the accumulaation on the screen)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
