### PR TITLE
Improve pkg version detection for bundle dependencies

### DIFF
--- a/.changeset/honest-cooks-learn.md
+++ b/.changeset/honest-cooks-learn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Improve pkg version detection for internal deps during build and Unify getPackgeInfo bundling util

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -10,11 +10,10 @@ import { esbuild } from '../plugins/esbuild';
 import { isNodeBuiltin } from '../isNodeBuiltin';
 import { removeDeployer } from '../plugins/remove-deployer';
 import { tsConfigPaths } from '../plugins/tsconfig-paths';
-import { getPackageName, getPackageRootPath, slash } from '../utils';
+import { getPackageName, getPackageInfo, slash } from '../utils';
 import { type WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import type { DependencyMetadata } from '../types';
 import { DEPS_TO_IGNORE } from './constants';
-import { getPackageInfo } from 'local-pkg';
 
 /**
  * Configures and returns the Rollup plugins needed for analyzing entry files.
@@ -97,7 +96,7 @@ async function captureDependenciesToOptimize(
 
   let entryRootPath = projectRoot;
   if (!output.facadeModuleId.startsWith('\x00virtual:')) {
-    entryRootPath = (await getPackageRootPath(output.facadeModuleId)) || projectRoot;
+    entryRootPath = (await getPackageInfo(output.facadeModuleId))?.rootPath || projectRoot;
   }
 
   for (const [dependency, bindings] of Object.entries(output.importedBindings)) {
@@ -111,7 +110,8 @@ async function captureDependenciesToOptimize(
     let isWorkspace = false;
 
     if (pkgName) {
-      rootPath = await getPackageRootPath(dependency, entryRootPath);
+      const pkg = await getPackageInfo(dependency, entryRootPath);
+      rootPath = pkg?.rootPath || null;
       isWorkspace = workspaceMap.has(pkgName);
     }
 

--- a/packages/deployer/src/build/utils.ts
+++ b/packages/deployer/src/build/utils.ts
@@ -48,7 +48,10 @@ export async function getPackageInfo(packageName: string, parentPath?: string): 
   // Get package info
   pkg = (await getPackageInfoLocal(packageName, options)) as PackageInfo | undefined;
 
-  //Extra logic for packageInfo resolution
+  /**
+   * Extra logic for packageInfo resolution. For scenarios where default rootPath is resolved to
+   * treeshaken cjs,esm output and rootPath !== real rootPath of the package
+   */
   if (pkg && pkg.rootPath && !pkg?.version) {
     const realRootPath = pkg.rootPath.includes(pkg.name)
       ? pkg.rootPath.slice(0, pkg.rootPath.lastIndexOf(pkg.name) + pkg.name.length)

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -6,7 +6,7 @@ import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import virtual from '@rollup/plugin-virtual';
 import * as pkg from 'empathic/package';
-import fsExtra, { copy, ensureDir, readJSON, emptyDir } from 'fs-extra/esm';
+import fsExtra, { copy, ensureDir, emptyDir } from 'fs-extra/esm';
 import type { InputOptions, OutputOptions } from 'rollup';
 import { glob } from 'tinyglobby';
 import { analyzeBundle } from '../build/analyze';
@@ -14,7 +14,7 @@ import { createBundler as createBundlerUtil, getInputOptions } from '../build/bu
 import { getBundlerOptions } from '../build/bundlerOptions';
 import { writeCustomInstrumentation } from '../build/customInstrumentation';
 import { writeTelemetryConfig } from '../build/telemetry';
-import { getPackageRootPath } from '../build/utils';
+import { getPackageInfo } from '../build/utils';
 import { DepsService } from '../services/deps';
 import { FileService } from '../services/fs';
 import {
@@ -364,10 +364,8 @@ export abstract class Bundler extends MastraBundler {
           continue;
         }
 
-        const rootPath = await getPackageRootPath(dep);
-        const pkg = await readJSON(`${rootPath}/package.json`);
-
-        dependenciesToInstall.set(dep, pkg.version || 'latest');
+        const pkg = await getPackageInfo(dep, projectRoot);
+        dependenciesToInstall.set(dep, pkg?.version ?? 'latest');
       } catch {
         dependenciesToInstall.set(dep, 'latest');
       }


### PR DESCRIPTION
- **Improve pkg version detection for deps**
- Unify getPackageInfo bundling util
- **changeset**

## Description
Leverage proper logic for finding externalized deps pkg versions during build

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)
Fixes #8266

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
