### PR TITLE
fix(playground-ui): initialize message history for v1 models in playground

### DIFF
--- a/.changeset/salty-jars-push.md
+++ b/.changeset/salty-jars-push.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+---
+
+fix playground message history initial state for v1 models

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -169,8 +169,9 @@ export function MastraRuntimeProvider({
   children: ReactNode;
 }> &
   ChatProps) {
+  const initializeMessages = () => (memory ? initializeMessageState(initialMessages || []) : []);
   const [isLegacyRunning, setIsLegacyRunning] = useState(false);
-  const [legacyMessages, setLegacyMessages] = useState<ThreadMessageLike[]>([]);
+  const [legacyMessages, setLegacyMessages] = useState<ThreadMessageLike[]>(initializeMessages());
 
   const {
     setMessages,
@@ -182,7 +183,7 @@ export function MastraRuntimeProvider({
     isRunning: isRunningStreamVNext,
   } = useChat<ThreadMessageLike>({
     agentId,
-    initializeMessages: () => (memory ? initializeMessageState(initialMessages || []) : []),
+    initializeMessages,
   });
 
   const { refetch: refreshWorkingMemory } = useWorkingMemory();


### PR DESCRIPTION
## Description

Initialize message history for v1 models in playground. Previously they were always an empty array so the history was not rendering when refreshing a thread for a v1 model.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
