### PR TITLE
docs: fix vector store documentation issues from PR #8422 review

### DIFF
--- a/docs/src/content/en/reference/vectors/astra.mdx
+++ b/docs/src/content/en/reference/vectors/astra.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Astra Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Astra Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the AstraVector class in Mastra, which provides vector search using DataStax Astra DB.
 ---
 
@@ -255,4 +255,4 @@ Required environment variables:
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/chroma.mdx
+++ b/docs/src/content/en/reference/vectors/chroma.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Chroma Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Chroma Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the ChromaVector class in Mastra, which provides vector search using ChromaDB.
 ---
 
@@ -419,4 +419,4 @@ try {
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/couchbase.mdx
+++ b/docs/src/content/en/reference/vectors/couchbase.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Couchbase Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Couchbase Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the CouchbaseVector class in Mastra, which provides vector search using Couchbase Vector Search.
 ---
 
@@ -342,4 +342,4 @@ try {
 
 ## Related
 
-- [Metadata Filters](./metadata-filters) 
+- [Metadata Filters](../rag/metadata-filters) 

--- a/docs/src/content/en/reference/vectors/lance.mdx
+++ b/docs/src/content/en/reference/vectors/lance.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Lance Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Lance Vector Store | Vector Databases | Mastra Docs"
 description: "Documentation for the LanceVectorStore class in Mastra, which provides vector search using LanceDB, an embedded vector database based on the Lance columnar format."
 ---
 
@@ -448,4 +448,4 @@ try {
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -10,8 +10,6 @@ It's part of the `@mastra/libsql` package and offers efficient vector similarity
 
 ## Installation
 
-Default vector store is included in the core package:
-
 ```bash copy
 npm install @mastra/libsql@latest
 ```

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Default Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Default Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the LibSQLVector class in Mastra, which provides vector search using LibSQL with vector extensions.
 ---
 
@@ -354,4 +354,4 @@ Common error cases include:
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MongoDB Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: MongoDB Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the MongoDBVector class in Mastra, which provides vector search using MongoDB Atlas and Atlas Vector Search.
 ---
 
@@ -306,4 +306,4 @@ try {
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/opensearch.mdx
+++ b/docs/src/content/en/reference/vectors/opensearch.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: OpenSearch Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: OpenSearch Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the OpenSearchVector class in Mastra, which provides vector search using OpenSearch.
 ---
 
@@ -197,4 +197,4 @@ Deletes specific vector entries by their IDs from the index.
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/pg.mdx
+++ b/docs/src/content/en/reference/vectors/pg.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: PG Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: PG Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the PgVector class in Mastra, which provides vector search using PostgreSQL with pgvector extension.
 ---
 
@@ -548,4 +548,4 @@ This design supports advanced use cases but requires careful resource management
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/pinecone.mdx
+++ b/docs/src/content/en/reference/vectors/pinecone.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Pinecone Vector Store | Vector DBs | RAG | Mastra Docs"
+title: "Reference: Pinecone Vector Store | Vector DBs | Mastra Docs"
 description: Documentation for the PineconeVector class in Mastra, which provides an interface to Pinecone's vector database.
 ---
 
@@ -283,4 +283,4 @@ Pinecone supports hybrid search by combining dense and sparse vectors. To use hy
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/qdrant.mdx
+++ b/docs/src/content/en/reference/vectors/qdrant.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Qdrant Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Qdrant Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for integrating Qdrant with Mastra, a vector similarity search engine for managing vectors and payloads.
 ---
 
@@ -233,4 +233,4 @@ try {
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/s3vectors.mdx
+++ b/docs/src/content/en/reference/vectors/s3vectors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Amazon S3 Vectors Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Amazon S3 Vectors Store | Vector Databases | Mastra Docs"
 description: Documentation for the S3Vectors class in Mastra, which provides vector search using Amazon S3 Vectors (Preview).
 ---
 
@@ -383,4 +383,4 @@ Typical environment variables when wiring your app:
 
 ## Related
 
-* [Metadata Filters](./metadata-filters)
+* [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/turbopuffer.mdx
+++ b/docs/src/content/en/reference/vectors/turbopuffer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Turbopuffer Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Turbopuffer Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for integrating Turbopuffer with Mastra, a high-performance vector database for efficient similarity search.
 ---
 
@@ -246,4 +246,4 @@ try {
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/upstash.mdx
+++ b/docs/src/content/en/reference/vectors/upstash.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Upstash Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Upstash Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the UpstashVector class in Mastra, which provides vector search using Upstash Vector.
 ---
 
@@ -351,4 +351,4 @@ Required environment variables:
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)

--- a/docs/src/content/en/reference/vectors/vectorize.mdx
+++ b/docs/src/content/en/reference/vectors/vectorize.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Cloudflare Vector Store | Vector Databases | RAG | Mastra Docs"
+title: "Reference: Cloudflare Vector Store | Vector Databases | Mastra Docs"
 description: Documentation for the CloudflareVector class in Mastra, which provides vector search using Cloudflare Vectorize.
 ---
 
@@ -295,4 +295,4 @@ Required environment variables:
 
 ## Related
 
-- [Metadata Filters](./metadata-filters)
+- [Metadata Filters](../rag/metadata-filters)


### PR DESCRIPTION
## Description

Addresses all feedback from the Greptile bot review on PR #8422 (vector store reorganization). This PR fixes documentation inconsistencies that were identified after the vector stores were moved from the RAG section to their own dedicated section.

### Issues fixed:
- Remove "RAG" from page titles in all 14 vector store documentation files (they are no longer in the RAG section)
- Update all cross-references to `metadata-filters` to use correct relative path `../rag/metadata-filters` 
- Fix LibSQL documentation inconsistency that incorrectly stated "Default vector store is included in the core package"

## Related Issue(s)

Addresses review feedback from #8422

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works