### PR TITLE
feat(docs): present instruction formats in tabs

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -3,7 +3,7 @@ title: "Agent Overview | Agents | Mastra Docs"
 description: Overview of agents in Mastra, detailing their capabilities and how they interact with tools, workflows, and external systems.
 ---
 
-import { Steps } from "nextra/components";
+import { Steps, Tabs } from "nextra/components";
 
 # Using Agents
 
@@ -69,41 +69,76 @@ export const testAgent = new Agent({
 Instructions define the agent's behavior, personality, and capabilities.
 They are system-level prompts that establish the agent's core identity and expertise.
 
-Instructions can be provided in multiple formats for greater flexibility:
+Instructions can be provided in multiple formats for greater flexibility. Choose the approach that best matches your agent’s configuration:
 
-```typescript showLineNumbers copy
+<Tabs
+  items={[
+    "String",
+    "System message",
+    "Array of strings",
+    "Array of system messages",
+    "With provider options"
+  ]}
+>
+  <Tabs.Tab>
+Use a simple string for quick prototypes or straightforward behaviors.
+
+```typescript copy
 // String (most common)
 instructions: "You are a helpful assistant."
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+Wrap the prompt in a system message object when you need to pass structured metadata.
 
+```typescript copy
 // System message object
 instructions: {
   role: "system",
   content: "You are an expert programmer."
 }
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+Provide multiple guidance statements while keeping the format lightweight with an array of strings.
 
+```typescript copy
 // Array of strings
 instructions: [
   "You are a helpful assistant.",
   "Always be polite.",
   "Provide detailed answers."
 ]
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+Use fully structured messages when you want fine-grained control over roles and sequencing.
 
+```typescript copy
 // Array of system messages
 instructions: [
   { role: "system", content: "You are a helpful assistant." },
   { role: "system", content: "You have expertise in TypeScript." }
 ]
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+Attach provider-specific configuration to unlock capabilities like caching or reasoning modes.
 
+```typescript copy
 // With provider-specific options (e.g., caching, reasoning)
 instructions: {
   role: "system",
-  content: "You are an expert code reviewer. Analyze code for bugs, performance issues, and best practices.",
+  content:
+    "You are an expert code reviewer. Analyze code for bugs, performance issues, and best practices.",
   providerOptions: {
     openai: { reasoning_effort: "high" },        // OpenAI's reasoning models
     anthropic: { cache_control: { type: "ephemeral" } }  // Anthropic's prompt caching
   }
 }
 ```
+  </Tabs.Tab>
+</Tabs>
 
 Provider-specific options allow you to leverage unique features of different LLM providers:
 - **Anthropic caching**: Reduce costs by caching frequently-used instructions


### PR DESCRIPTION
## Summary
- convert the instruction format examples on the agents overview page into a tabbed experience
- add per-format descriptions so readers understand when to use each option
- restore inline comments in each code example within the tabbed component

## Testing
- pnpm --filter '!./explorations/**/*' -r typecheck *(fails: `@mastra/dynamodb` and related store packages cannot resolve core modules and logger properties)*

------
https://chatgpt.com/codex/tasks/task_b_68e226c8a948832887c1052cbc064de7