### PR TITLE
docs: add heading for provider options in agent overview

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -140,6 +140,8 @@ instructions: {
   </Tabs.Tab>
 </Tabs>
 
+## Provider-specific options
+
 Provider-specific options allow you to leverage unique features of different LLM providers:
 - **Anthropic caching**: Reduce costs by caching frequently-used instructions
 - **OpenAI reasoning**: Enable deeper analysis for complex tasks


### PR DESCRIPTION
## Summary
- add an H2 heading for the provider-specific options content on the agents overview page

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68e23156293c832891641cc0ed9836ce