### PR TITLE
Update agent overview intro

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -7,19 +7,11 @@ import { Steps, Tabs } from "nextra/components";
 
 # Using Agents
 
-Agents let you build intelligent assistants powered by language models that can make decisions and perform actions. Each agent has required instructions and an LLM, with optional tools and memory.
+Agents let you build intelligent assistants powered by language models that can make decisions and perform actions. Each agent has required instructions and an LLM, with optional tools and memory, and they can respond in one step or run in a loop until they achieve a goal.
 
 An agent coordinates conversations, calls tools when needed, maintains context through memory, and produces responses tailored to the interaction. Agents can operate on their own or work as part of larger workflows.
 
 ![Agents overview](/image/agents/agents-overview.jpg)
-
-To create an agent:
-
-- Define **instructions** with the `Agent` class and set the **LLM** it will use.
-- Optionally configure **tools** and **memory** to extend functionality.
-- Run the agent to generate responses, with support for streaming, structured output, and dynamic configuration.
-
-This approach provides type safety and runtime validation, ensuring reliable behavior across all agent interactions.
 
 > **📹 Watch**:  → An introduction to agents, and how they compare to workflows [YouTube (7 minutes)](https://youtu.be/0jg2g3sNvgw)
 


### PR DESCRIPTION
## Summary
- highlight that agents can respond once or loop until they reach a goal
- remove redundant step-by-step creation section from the overview copy

## Testing
- Not run (docs only change)


------
https://chatgpt.com/codex/tasks/task_b_68e2981b6028832895797dff4da29802