### PR TITLE
Update agent overview page agent creation guidance

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -40,7 +40,7 @@ OPENAI_API_KEY=<your-api-key>
 
 ### Create an agent
 
-Import the `Agent` class and point the `model` field to the provider/model combination you want to use:
+To create an agent in Mastra, use the `Agent` class. Every agent must include `instructions` to define its behavior, and a `model` parameter to specify the LLM provider and model you want to use:
 
 ```typescript filename="src/mastra/agents/test-agent.ts" showLineNumbers copy
 import { Agent } from "@mastra/core/agent";
@@ -75,7 +75,7 @@ OPENAI_API_KEY=<your-api-key>
 
 ### Create an agent
 
-Import the AI SDK client and provide it to your agent's `model` field:
+To create an agent in Mastra, use the `Agent` class. Every agent must include `instructions` to define its behavior, and a `model` parameter to specify the LLM provider and model. When using the Vercel AI SDK, provide the client to your agent's `model` field:
 
 ```typescript filename="src/mastra/agents/test-agent.ts" showLineNumbers copy
 import { openai } from "@ai-sdk/openai";
@@ -90,20 +90,6 @@ export const testAgent = new Agent({
     </Steps>
   </Tabs.Tab>
 </Tabs>
-
-### Creating an agent
-
-To create an agent in Mastra, use the `Agent` class. Every agent must include `instructions` to define its behavior, and a `model` parameter to specify the LLM provider and model:
-
-```typescript filename="src/mastra/agents/test-agent.ts" showLineNumbers copy
-import { Agent } from "@mastra/core/agent";
-
-export const testAgent = new Agent({
-  name: "test-agent",
-  instructions: "You are a helpful assistant.",
-  model: "openai/gpt-4o-mini"
-});
-```
 
 #### Instruction formats
 


### PR DESCRIPTION
## Summary
- embed the agent creation guidance within each "Create an agent" tab on the overview page
- remove the outdated standalone "Creating an agent" section

## Testing
- pnpm --filter '!./explorations/**/*' -r typecheck *(fails: missing @mastra/schema-compat module)*

------
https://chatgpt.com/codex/tasks/task_b_68e29eb5e49c832897ff7b49bea3ab2e