### PR TITLE
Update provider options section heading and copy

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -167,12 +167,9 @@ instructions: {
   </Tabs.Tab>
 </Tabs>
 
-### Provider-specific options
+#### Provider-specific options
 
-Provider-specific options allow you to leverage unique features of different LLM providers:
-- **Anthropic caching**: Reduce costs by caching frequently-used instructions
-- **OpenAI reasoning**: Enable deeper analysis for complex tasks
-- **Custom parameters**: Pass any provider-specific configuration
+Each model providers also enables a few different options, including prompt caching and configuring reasoning. We provide a `providerOptions` flag to manage these. You can set `providerOptions` on the instruction level to set different caching strategy per system instruction/prompt.
 
 > See the [Agent reference doc](../../reference/agents/agent.mdx) for more information.
 

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -169,7 +169,7 @@ instructions: {
 
 #### Provider-specific options
 
-Each model providers also enables a few different options, including prompt caching and configuring reasoning. We provide a `providerOptions` flag to manage these. You can set `providerOptions` on the instruction level to set different caching strategy per system instruction/prompt.
+Each model provider also enables a few different options, including prompt caching and configuring reasoning. We provide a `providerOptions` flag to manage these. You can set `providerOptions` on the instruction level to set different caching strategy per system instruction/prompt.
 
 > See the [Agent reference doc](../../reference/agents/agent.mdx) for more information.
 


### PR DESCRIPTION
## Summary
- change the provider-specific options section on the agent overview page to use an H4 heading
- update the copy to describe how to use the `providerOptions` flag and reference the agent documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e2b162bc388328b205b4e1d6092128