### PR TITLE
fix(deployer): Use optimize-lodash only on JS/TS files

### DIFF
--- a/.changeset/nine-carrots-wish.md
+++ b/.changeset/nine-carrots-wish.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix bug when lodash dependencies where used in subdependencies

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -1,9 +1,8 @@
 import { noopLogger, type IMastraLogger } from '@mastra/core/logger';
 import commonjs from '@rollup/plugin-commonjs';
-import nodeResolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
 import virtual from '@rollup/plugin-virtual';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { rollup, type OutputChunk, type Plugin, type SourceMap } from 'rollup';
 import resolveFrom from 'resolve-from';
 import { esbuild } from '../plugins/esbuild';
@@ -14,7 +13,6 @@ import { getPackageName, getPackageRootPath, slash } from '../utils';
 import { type WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import type { DependencyMetadata } from '../types';
 import { DEPS_TO_IGNORE } from './constants';
-import { getPackageInfo } from 'local-pkg';
 
 /**
  * Configures and returns the Rollup plugins needed for analyzing entry files.

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -177,7 +177,9 @@ async function getInputPlugins(
           },
         } satisfies Plugin)
       : null,
-    optimizeLodashImports(),
+    optimizeLodashImports({
+      include: '**/*.{js,ts,mjs,cjs}',
+    }),
     commonjs({
       strictRequires: 'strict',
       transformMixedEsModules: true,

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -134,7 +134,9 @@ export async function getInputOptions(
         platform,
         define: env,
       }),
-      optimizeLodashImports(),
+      optimizeLodashImports({
+        include: '**/*.{js,ts,mjs,cjs}',
+      }),
       commonjs({
         extensions: ['.js', '.ts'],
         transformMixedEsModules: true,

--- a/packages/deployer/src/build/shared/extract-mastra-option.ts
+++ b/packages/deployer/src/build/shared/extract-mastra-option.ts
@@ -33,7 +33,9 @@ export function extractMastraOptionBundler(
       tsConfigPaths(),
       // transpile typescript to something we understand
       esbuild(),
-      optimizeLodashImports(),
+      optimizeLodashImports({
+        include: '**/*.{js,ts,mjs,cjs}',
+      }),
       commonjs({
         extensions: ['.js', '.ts'],
         strictRequires: 'strict',


### PR DESCRIPTION
## Description

For https://www.npmjs.com/package/@optimize-lodash/rollup-plugin use the `include` option to only target js,ts,mjs,cjs files. The linked issue was caused by the plugin trying to parse a `.json` file because it contained the `lodash` string in it.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/8465

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
