### PR TITLE
chore: keep cloud deployer peer dependencies in sync

### DIFF
--- a/.changeset/smooth-geckos-share.md
+++ b/.changeset/smooth-geckos-share.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-cloud': patch
+---
+
+Add dynamic creation of peerdeps

--- a/deployers/cloud/.gitignore
+++ b/deployers/cloud/.gitignore
@@ -1,0 +1,1 @@
+./versions.json

--- a/deployers/cloud/package.json
+++ b/deployers/cloud/package.json
@@ -29,7 +29,7 @@
     "build:watch": "tsup --watch --silent --config tsup.config.ts",
     "test": "vitest run",
     "lint": "eslint .",
-    "prepare": "node scripts/sync-versions.mjs"
+    "prepack": "node scripts/sync-versions.mjs"
   },
   "keywords": [],
   "license": "Apache-2.0",

--- a/deployers/cloud/package.json
+++ b/deployers/cloud/package.json
@@ -6,7 +6,8 @@
   "files": [
     "dist",
     "CHANGELOG.md",
-    "templates"
+    "templates",
+    "versions.json"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +28,8 @@
     "build": "tsup --silent --config tsup.config.ts",
     "build:watch": "tsup --watch --silent --config tsup.config.ts",
     "test": "vitest run",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prepare": "node scripts/sync-versions.mjs"
   },
   "keywords": [],
   "license": "Apache-2.0",
@@ -42,6 +44,7 @@
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
+    "@manypkg/get-packages": "^3.1.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.19.0",
     "eslint": "^9.35.0",

--- a/deployers/cloud/scripts/sync-versions.mjs
+++ b/deployers/cloud/scripts/sync-versions.mjs
@@ -1,0 +1,21 @@
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { getPackages } from '@manypkg/get-packages';
+import { writeJson } from 'fs-extra/esm';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { packages } = await getPackages(process.cwd());
+const versionsToSync = ['@mastra/loggers', '@mastra/libsql', '@mastra/cloud'];
+
+const versionsToWrite = {};
+packages.forEach(pkg => {
+  if (versionsToSync.includes(pkg.packageJson.name)) {
+    const version = pkg.packageJson.version;
+    versionsToWrite[pkg.packageJson.name] = version;
+  }
+});
+
+console.log(`Writing versions to versions.json:\n${JSON.stringify(versionsToWrite, null, 2)}`);
+
+await writeJson(join(__dirname, '../versions.json'), versionsToWrite);

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'path';
 import { Deployer } from '@mastra/deployer';
-import { copy } from 'fs-extra';
+import { copy, readJSON } from 'fs-extra';
 
 import { getAuthEntrypoint } from './utils/auth.js';
 import { MASTRA_DIRECTORY, BUILD_ID, PROJECT_ID, TEAM_ID } from './utils/constants.js';
@@ -21,10 +21,14 @@ export class CloudDeployer extends Deployer {
 
     await copy(join(__dirname, '../templates', 'instrumentation-template.js'), instrumentationFile);
   }
-  writePackageJson(outputDirectory: string, dependencies: Map<string, string>) {
-    dependencies.set('@mastra/loggers', '0.10.14');
-    dependencies.set('@mastra/libsql', '0.15.0');
-    dependencies.set('@mastra/cloud', '0.1.17');
+  async writePackageJson(outputDirectory: string, dependencies: Map<string, string>) {
+    const { versions } = (await readJSON(join(dirname(fileURLToPath(import.meta.url)), '../versions.json'))) as {
+      versions: Record<string, string>;
+    };
+    for (const [pkgName, version] of Object.entries(versions)) {
+      dependencies.set(pkgName, version);
+    }
+
     return super.writePackageJson(outputDirectory, dependencies);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder
+      '@manypkg/get-packages':
+        specifier: ^3.1.0
+        version: 3.1.0
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -6994,8 +6997,20 @@ packages:
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
+  '@manypkg/find-root@3.1.0':
+    resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
+    engines: {node: '>=20.0.0'}
+
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@manypkg/get-packages@3.1.0':
+    resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@manypkg/tools@2.1.0':
+    resolution: {integrity: sha512-0FOIepYR4ugPYaHwK7hDeHDkfPOBVvayt9QpvRbi2LT/h2b0GaE/gM9Gag7fsnyYyNaTZ2IGyOuVg07IYepvYQ==}
+    engines: {node: '>=20.0.0'}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -20594,6 +20609,10 @@ snapshots:
       find-up: 4.1.0
       fs-extra: 8.1.0
 
+  '@manypkg/find-root@3.1.0':
+    dependencies:
+      '@manypkg/tools': 2.1.0
+
   '@manypkg/get-packages@1.1.3':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -20602,6 +20621,17 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@manypkg/get-packages@3.1.0':
+    dependencies:
+      '@manypkg/find-root': 3.1.0
+      '@manypkg/tools': 2.1.0
+
+  '@manypkg/tools@2.1.0':
+    dependencies:
+      jju: 1.4.0
+      js-yaml: 4.1.0
+      tinyglobby: 0.2.15
 
   '@marijn/find-cluster-break@1.0.2': {}
 


### PR DESCRIPTION
Updates the cloud deployer peer dependencies to stay in sync with the core package versions. This prevents version mismatches when deploying to cloud platforms.

We sync the dependencies right before we publish so we have to correct versions assigned.