### PR TITLE
feat(cli): Improve create wizard flow

### DIFF
--- a/.changeset/wild-brooms-mate.md
+++ b/.changeset/wild-brooms-mate.md
@@ -1,0 +1,6 @@
+---
+'create-mastra': patch
+'mastra': patch
+---
+
+Improve the overall flow of the `create-mastra` CLI by first asking all questions and then creating the project structure.

--- a/.changeset/wild-brooms-mate.md
+++ b/.changeset/wild-brooms-mate.md
@@ -3,4 +3,4 @@
 'mastra': patch
 ---
 
-Improve the overall flow of the `create-mastra` CLI by first asking all questions and then creating the project structure.
+Improve the overall flow of the `create-mastra` CLI by first asking all questions and then creating the project structure. If you skip entering an API key during the wizard, the `your-api-key` placeholder will now be added to an `.env.example` file instead of `.env`.

--- a/packages/cli/src/commands/actions/create-project.ts
+++ b/packages/cli/src/commands/actions/create-project.ts
@@ -26,7 +26,7 @@ export const createProject = async (projectNameArg: any, args: any) => {
         components: args.components ? args.components.split(',') : [],
         llmProvider: args.llm,
         addExample: args.example,
-        llmApiKey: args['llm-api-key'],
+        llmApiKey: args.llmApiKey,
         timeout,
         projectName,
         directory: args.dir,

--- a/packages/cli/src/commands/create/create.test.ts
+++ b/packages/cli/src/commands/create/create.test.ts
@@ -431,6 +431,9 @@ describe('create command with --template flag', () => {
         projectName: 'regular-project',
         createVersionTag: undefined,
         timeout: undefined,
+        llmApiKey: undefined,
+        llmProvider: undefined,
+        needsInteractive: true,
       });
       expect(init).toHaveBeenCalled();
     });

--- a/packages/cli/src/commands/create/create.test.ts
+++ b/packages/cli/src/commands/create/create.test.ts
@@ -404,7 +404,15 @@ describe('create command with --template flag', () => {
       const { init } = await import('../init/init');
       const { interactivePrompt } = await import('../init/utils');
 
-      vi.mocked(createMastraProject).mockResolvedValue({ projectName: 'regular-project' });
+      vi.mocked(createMastraProject).mockResolvedValue({
+        projectName: 'regular-project',
+        result: {
+          directory: '/some/path',
+          llmProvider: 'openai',
+          llmApiKey: 'test-key',
+          configureEditorWithDocsMCP: 'cursor',
+        },
+      });
       vi.mocked(interactivePrompt).mockResolvedValue({
         directory: '/some/path',
         llmProvider: 'openai',

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -30,25 +30,23 @@ export const create = async (args: {
     return;
   }
 
+  /**
+   * We need to explicitly check for undefined instead of using the falsy (!) check because the user might have passed args that are explicitly set to false (in this case, no example code) and we need to distinguish between those and the case where the args were not passed at all.
+   */
+  const needsInteractive =
+    args.components === undefined || args.llmProvider === undefined || args.addExample === undefined;
+
   const { projectName, result } = await createMastraProject({
     projectName: args?.projectName,
     createVersionTag: args?.createVersionTag,
     timeout: args?.timeout,
     llmProvider: args?.llmProvider,
     llmApiKey: args?.llmApiKey,
+    needsInteractive,
   });
   const directory = args.directory || 'src/';
 
-  // We need to explicitly check for undefined instead of using the falsy (!)
-  // check because the user might have passed args that are explicitly set
-  // to false (in this case, no example code) and we need to distinguish
-  // between those and the case where the args were not passed at all.
-  if (
-    args.components === undefined ||
-    args.llmProvider === undefined ||
-    args.addExample === undefined ||
-    args.llmApiKey === undefined
-  ) {
+  if (needsInteractive && result) {
     // Track model provider selection from interactive prompt
     const analytics = getAnalytics();
     if (analytics && result?.llmProvider) {

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -60,7 +60,7 @@ export const create = async (args: {
 
     await init({
       ...result,
-      llmApiKey: result?.llmApiKey as string,
+      llmApiKey: result?.llmApiKey as string | undefined,
       components: ['agents', 'tools', 'workflows'],
       addExample: true,
     });

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -7,7 +7,6 @@ import { cloneTemplate, installDependencies } from '../../utils/clone-template';
 import { loadTemplates, selectTemplate, findTemplateByName, getDefaultProjectName } from '../../utils/template-utils';
 import type { Template } from '../../utils/template-utils';
 import { init } from '../init/init';
-import { interactivePrompt } from '../init/utils';
 import type { LLMProvider } from '../init/utils';
 import { getPackageManager } from '../utils.js';
 
@@ -31,10 +30,12 @@ export const create = async (args: {
     return;
   }
 
-  const { projectName } = await createMastraProject({
+  const { projectName, result } = await createMastraProject({
     projectName: args?.projectName,
     createVersionTag: args?.createVersionTag,
     timeout: args?.timeout,
+    llmProvider: args?.llmProvider,
+    llmApiKey: args?.llmApiKey,
   });
   const directory = args.directory || 'src/';
 
@@ -42,9 +43,12 @@ export const create = async (args: {
   // check because the user might have passed args that are explicitly set
   // to false (in this case, no example code) and we need to distinguish
   // between those and the case where the args were not passed at all.
-  if (args.components === undefined || args.llmProvider === undefined || args.addExample === undefined) {
-    const result = await interactivePrompt();
-
+  if (
+    args.components === undefined ||
+    args.llmProvider === undefined ||
+    args.addExample === undefined ||
+    args.llmApiKey === undefined
+  ) {
     // Track model provider selection from interactive prompt
     const analytics = getAnalytics();
     if (analytics && result?.llmProvider) {

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -84,12 +84,14 @@ export const createMastraProject = async ({
   timeout,
   llmProvider,
   llmApiKey,
+  needsInteractive,
 }: {
   projectName?: string;
   createVersionTag?: string;
   timeout?: number;
   llmProvider?: LLMProvider;
   llmApiKey?: string;
+  needsInteractive?: boolean;
 }) => {
   p.intro(color.inverse(' Mastra Create '));
 
@@ -112,10 +114,14 @@ export const createMastraProject = async ({
     process.exit(0);
   }
 
-  const result = await interactivePrompt({
-    options: { showBanner: false },
-    skip: { llmProvider: llmProvider !== undefined, llmApiKey: llmApiKey !== undefined },
-  });
+  let result;
+
+  if (needsInteractive) {
+    result = await interactivePrompt({
+      options: { showBanner: false },
+      skip: { llmProvider: llmProvider !== undefined, llmApiKey: llmApiKey !== undefined },
+    });
+  }
   const s = p.spinner();
 
   try {

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -487,17 +487,16 @@ export const getAPIKey = async (provider: LLMProvider) => {
   }
 };
 
-export const writeAPIKey = async ({
-  provider,
-  apiKey = 'your-api-key',
-}: {
-  provider: LLMProvider;
-  apiKey?: string;
-}) => {
+export const writeAPIKey = async ({ provider, apiKey }: { provider: LLMProvider; apiKey?: string }) => {
+  /**
+   * If people skip entering an API key (because they e.g. have it in their environment already), we write to .env.example instead of .env so that they can immediately run Mastra without having to delete an .env file with an invalid key.
+   */
+  const envFileName = apiKey ? '.env' : '.env.example';
+
   const key = await getAPIKey(provider);
   const escapedKey = shellQuote.quote([key]);
-  const escapedApiKey = shellQuote.quote([apiKey]);
-  await exec(`echo ${escapedKey}=${escapedApiKey} >> .env`);
+  const escapedApiKey = shellQuote.quote([apiKey ? apiKey : 'your-api-key']);
+  await exec(`echo ${escapedKey}=${escapedApiKey} >> ${envFileName}`);
 };
 export const createMastraDir = async (directory: string): Promise<{ ok: true; dirPath: string } | { ok: false }> => {
   let dir = directory

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -568,7 +568,7 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
         skip?.llmProvider
           ? undefined
           : p.select({
-              message: 'Select a default provider',
+              message: 'Select a default provider:',
               options: LLM_PROVIDERS,
             }),
       llmApiKey: async ({ results: { llmProvider } }) => {

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -531,8 +531,31 @@ export const writeCodeSample = async (
   }
 };
 
-export const interactivePrompt = async () => {
-  p.intro(color.inverse(' Mastra Init '));
+const LLM_PROVIDERS: { value: LLMProvider; label: string; hint?: string }[] = [
+  { value: 'openai', label: 'OpenAI', hint: 'recommended' },
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'groq', label: 'Groq' },
+  { value: 'google', label: 'Google' },
+  { value: 'cerebras', label: 'Cerebras' },
+  { value: 'mistral', label: 'Mistral' },
+];
+
+interface InteractivePromptArgs {
+  options?: {
+    showBanner?: boolean;
+  };
+  skip?: {
+    llmProvider?: boolean;
+    llmApiKey?: boolean;
+  };
+}
+
+export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
+  const { skip = {}, options: { showBanner = true } = {} } = args;
+
+  if (showBanner) {
+    p.intro(color.inverse(' Mastra Init '));
+  }
   const mastraProject = await p.group(
     {
       directory: () =>
@@ -542,20 +565,18 @@ export const interactivePrompt = async () => {
           defaultValue: 'src/',
         }),
       llmProvider: () =>
-        p.select({
-          message: 'Select default provider:',
-          options: [
-            { value: 'openai', label: 'OpenAI', hint: 'recommended' },
-            { value: 'anthropic', label: 'Anthropic' },
-            { value: 'groq', label: 'Groq' },
-            { value: 'google', label: 'Google' },
-            { value: 'cerebras', label: 'Cerebras' },
-            { value: 'mistral', label: 'Mistral' },
-          ] satisfies { value: LLMProvider; label: string; hint?: string }[],
-        }),
+        skip?.llmProvider
+          ? undefined
+          : p.select({
+              message: 'Select a default provider',
+              options: LLM_PROVIDERS,
+            }),
       llmApiKey: async ({ results: { llmProvider } }) => {
+        if (skip?.llmApiKey) return undefined;
+
+        const llmName = LLM_PROVIDERS.find(p => p.value === llmProvider)?.label || 'provider';
         const keyChoice = await p.select({
-          message: `Enter your ${llmProvider} API key?`,
+          message: `Enter your ${llmName} API key?`,
           options: [
             { value: 'skip', label: 'Skip for now', hint: 'default' },
             { value: 'enter', label: 'Enter API key' },
@@ -567,6 +588,9 @@ export const interactivePrompt = async () => {
           return p.text({
             message: 'Enter your API key:',
             placeholder: 'sk-...',
+            validate: value => {
+              if (value.length === 0) return 'API key cannot be empty';
+            },
           });
         }
         return undefined;
@@ -577,7 +601,7 @@ export const interactivePrompt = async () => {
         const vscodeIsAlreadyInstalled = await globalMCPIsAlreadyInstalled(`vscode`);
 
         const editor = await p.select({
-          message: `Make your AI IDE into a Mastra expert? (installs Mastra docs MCP server)`,
+          message: `Make your IDE into a Mastra expert? (Installs Mastra's MCP server)`,
           options: [
             { value: 'skip', label: 'Skip for now', hint: 'default' },
             {

--- a/packages/create-mastra/src/index.ts
+++ b/packages/create-mastra/src/index.ts
@@ -76,7 +76,7 @@ program
       components: args.components ? args.components.split(',') : [],
       llmProvider: args.llm,
       addExample: args.example,
-      llmApiKey: args['llm-api-key'],
+      llmApiKey: args.llmApiKey,
       createVersionTag,
       timeout,
       projectName,


### PR DESCRIPTION
## Description

In this PR the interactive prompt inside `create` (used in `create-mastra`) is moved before the creation of project structures and dependency installs. This way only after every information is entered stuff is actually created.

List of QoL and bug fixes:
- Correctly pass `--llm-api-key` flag around
- Validate input for project name
- Do not show LLM or LLM API Key selection in wizard when `--llm` and/or `--llm-api-key` are provided

Expands the community PR https://github.com/mastra-ai/mastra/pull/7654 - I added them as co-authors to give credit.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/7573

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
