### PR TITLE
marked telemetry disabled in the default template

### DIFF
--- a/.changeset/curvy-experts-doubt.md
+++ b/.changeset/curvy-experts-doubt.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Marked telemetry as disabled in the default template, in preperation for the Nov 4th deprecation.

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -388,13 +388,21 @@ ${addAgent ? `import { weatherAgent } from './agents/weather-agent';` : ''}
 export const mastra = new Mastra({
   ${filteredExports.join('\n  ')}
   storage: new LibSQLStore({
-    // stores telemetry, evals, ... into memory storage, if it needs to persist, change to file:../mastra.db
+    // stores observability, scores, ... into memory storage, if it needs to persist, change to file:../mastra.db
     url: ":memory:",
   }),
   logger: new PinoLogger({
     name: 'Mastra',
     level: 'info',
   }),
+  telemetry: {
+    // Telemetry is deprecated and will be removed in the Nov 4th release
+    enabled: false, 
+  },
+  observability: {
+    // Enables DefaultExporter and CloudExporter for AI tracing
+    default: { enabled: true }, 
+  },
 });
 `,
     );


### PR DESCRIPTION
## Description

Telemetry is deprecated in our system. I thought we had already removed telemetry from the create-mastra configs... however it needs to be explicitly disabled.  Simply removing the config doesn't disable telemetry.

This PR disables telemetry and enables the new AI Tracing / Observability in the default `create-mastra` template.

## Related Issue(s)

#8577 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
