### PR TITLE
feat(core): add-tracing-to-processors

### DIFF
--- a/.changeset/chatty-crabs-hide.md
+++ b/.changeset/chatty-crabs-hide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/otel-exporter': minor
+---
+
+Update peer dependencies to match core package version bump (0.21.0)

--- a/.changeset/many-schools-tap.md
+++ b/.changeset/many-schools-tap.md
@@ -1,0 +1,6 @@
+---
+'@mastra/otel-exporter': patch
+'@mastra/core': patch
+---
+
+Added tracing of input & output processors (this includes using structuredOutput)

--- a/.changeset/plain-bears-visit.md
+++ b/.changeset/plain-bears-visit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add tracing to processors that use agents within them (this includes using structuredOutput)

--- a/.changeset/plain-bears-visit.md
+++ b/.changeset/plain-bears-visit.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Add tracing to processors that use agents within them (this includes using structuredOutput)

--- a/observability/otel-exporter/package.json
+++ b/observability/otel-exporter/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@grpc/grpc-js": "^1.13.4",
-    "@mastra/core": ">=0.18.0-0 <0.22.0-0",
+    "@mastra/core": ">=0.21.0-0 <0.22.0-0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.205.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.205.0",

--- a/observability/otel-exporter/src/span-converter.ts
+++ b/observability/otel-exporter/src/span-converter.ts
@@ -18,28 +18,18 @@ import type { Resource } from '@opentelemetry/resources';
 import { MastraReadableSpan } from './mastra-span.js';
 
 // Map Mastra span types to OpenTelemetry span kinds following OTEL conventions
-const SPAN_KIND_MAPPING: Record<AISpanType, SpanKind> = {
+// Only non-INTERNAL mappings are specified - all others default to SpanKind.INTERNAL
+const SPAN_KIND_MAPPING: Partial<Record<AISpanType, SpanKind>> = {
   // LLM operations are CLIENT spans (calling external AI services)
   [AISpanType.LLM_GENERATION]: SpanKind.CLIENT,
   [AISpanType.LLM_CHUNK]: SpanKind.CLIENT,
 
-  // Tool calls can be CLIENT (external) or INTERNAL based on context
-  [AISpanType.TOOL_CALL]: SpanKind.INTERNAL,
+  // MCP tool calls are CLIENT (external service calls)
   [AISpanType.MCP_TOOL_CALL]: SpanKind.CLIENT,
 
   // Root spans for agent/workflow are SERVER (entry points)
   [AISpanType.AGENT_RUN]: SpanKind.SERVER,
   [AISpanType.WORKFLOW_RUN]: SpanKind.SERVER,
-
-  // Internal workflow operations
-  [AISpanType.WORKFLOW_STEP]: SpanKind.INTERNAL,
-  [AISpanType.WORKFLOW_LOOP]: SpanKind.INTERNAL,
-  [AISpanType.WORKFLOW_PARALLEL]: SpanKind.INTERNAL,
-  [AISpanType.WORKFLOW_CONDITIONAL]: SpanKind.INTERNAL,
-  [AISpanType.WORKFLOW_CONDITIONAL_EVAL]: SpanKind.INTERNAL,
-  [AISpanType.WORKFLOW_SLEEP]: SpanKind.INTERNAL,
-  [AISpanType.WORKFLOW_WAIT_EVENT]: SpanKind.INTERNAL,
-  [AISpanType.GENERIC]: SpanKind.INTERNAL,
 };
 
 export class SpanConverter {

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -1,5 +1,5 @@
-import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai/test';
-import { MockLanguageModelV1, simulateReadableStream } from 'ai-v4/test';
+import { MockLanguageModelV1, simulateReadableStream } from 'ai/test';
+import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai-v5/test';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -1295,7 +1295,7 @@ describe('AI Tracing Integration Tests', () => {
   );
 
   // Only test VNext methods for structuredOutput
-  describe.each(agentMethods.filter(m => m.name.includes('VNext')))(
+  describe.each(agentMethods.filter(m => m.name === 'generate' || m.name === 'stream'))(
     'should trace agent using structuredOutput format using $name',
     ({ method, model }) => {
       it(`should trace spans correctly`, async () => {
@@ -1311,6 +1311,7 @@ describe('AI Tracing Integration Tests', () => {
 
         const structuredOutput: StructuredOutputOptions<OutputSchema> = {
           schema: outputSchema,
+          model: openai('gpt-4o-mini'),
         };
 
         const mastra = new Mastra({

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -1,5 +1,5 @@
-import { MockLanguageModelV1, simulateReadableStream } from 'ai/test';
-import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai-v5/test';
+import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai/test';
+import { MockLanguageModelV1, simulateReadableStream } from 'ai-v4/test';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -1306,8 +1306,7 @@ describe('AI Tracing Integration Tests', () => {
     },
   );
 
-  // Only test VNext methods for structuredOutput
-  describe.each(agentMethods.filter(m => m.name === 'stream'))(
+  describe.each(agentMethods.filter(m => m.name === 'stream' || m.name === 'generate'))(
     'should trace agent using structuredOutput format using $name',
     ({ method, model }) => {
       it(`should trace spans correctly`, async () => {
@@ -1403,7 +1402,7 @@ describe('AI Tracing Integration Tests', () => {
     },
   );
 
-  describe.each(agentMethods.filter(m => m.name === 'stream'))(
+  describe.each(agentMethods.filter(m => m.name === 'stream' || m.name === 'generate'))(
     'agent with input and output processors using $name',
     ({ method, model }) => {
       it('should trace all processor spans including internal agent spans', async () => {

--- a/packages/core/src/ai-tracing/spans/base.test.ts
+++ b/packages/core/src/ai-tracing/spans/base.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { clearAITracingRegistry } from '../registry';
+import { DefaultAITracing } from '../tracers';
+import type { AITracingExporter, AITracingEvent } from '../types';
+import { AISpanType, SamplingStrategyType } from '../types';
+
+// Simple test exporter for capturing events
+class TestExporter implements AITracingExporter {
+  name = 'test-exporter';
+  events: AITracingEvent[] = [];
+
+  async exportEvent(event: AITracingEvent): Promise<void> {
+    this.events.push(event);
+  }
+
+  async shutdown(): Promise<void> {
+    this.events = [];
+  }
+}
+
+describe('AISpan', () => {
+  let testExporter: TestExporter;
+
+  beforeEach(() => {
+    clearAITracingRegistry();
+    testExporter = new TestExporter();
+  });
+
+  describe('findParent', () => {
+    it('should find parent span of specific type', () => {
+      const tracing = new DefaultAITracing({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+      });
+
+      // Create a hierarchy: AGENT_RUN -> WORKFLOW_RUN -> WORKFLOW_STEP -> LLM_GENERATION
+      const agentSpan = tracing.startSpan({
+        type: AISpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: {
+          agentId: 'agent-123',
+        },
+      });
+
+      const workflowSpan = agentSpan.createChildSpan({
+        type: AISpanType.WORKFLOW_RUN,
+        name: 'test-workflow',
+        attributes: {
+          workflowId: 'workflow-123',
+        },
+      });
+
+      const stepSpan = workflowSpan.createChildSpan({
+        type: AISpanType.WORKFLOW_STEP,
+        name: 'test-step',
+        attributes: {
+          stepId: 'step-1',
+        },
+      });
+
+      const llmSpan = stepSpan.createChildSpan({
+        type: AISpanType.LLM_GENERATION,
+        name: 'llm-call',
+        attributes: {
+          model: 'gpt-4',
+        },
+      });
+
+      // From LLM span, find AGENT_RUN parent
+      const foundAgentSpan = llmSpan.findParent(AISpanType.AGENT_RUN);
+      expect(foundAgentSpan).toBeDefined();
+      expect(foundAgentSpan?.id).toBe(agentSpan.id);
+      expect(foundAgentSpan?.name).toBe('test-agent');
+
+      // From LLM span, find WORKFLOW_RUN parent
+      const foundWorkflowSpan = llmSpan.findParent(AISpanType.WORKFLOW_RUN);
+      expect(foundWorkflowSpan).toBeDefined();
+      expect(foundWorkflowSpan?.id).toBe(workflowSpan.id);
+      expect(foundWorkflowSpan?.name).toBe('test-workflow');
+
+      // From LLM span, find WORKFLOW_STEP parent
+      const foundStepSpan = llmSpan.findParent(AISpanType.WORKFLOW_STEP);
+      expect(foundStepSpan).toBeDefined();
+      expect(foundStepSpan?.id).toBe(stepSpan.id);
+      expect(foundStepSpan?.name).toBe('test-step');
+
+      // From step span, find AGENT_RUN parent (should skip WORKFLOW_RUN)
+      const foundAgentFromStep = stepSpan.findParent(AISpanType.AGENT_RUN);
+      expect(foundAgentFromStep).toBeDefined();
+      expect(foundAgentFromStep?.id).toBe(agentSpan.id);
+
+      agentSpan.end();
+    });
+
+    it('should return undefined when parent type not found', () => {
+      const tracing = new DefaultAITracing({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: AISpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: {
+          agentId: 'agent-123',
+        },
+      });
+
+      const llmSpan = agentSpan.createChildSpan({
+        type: AISpanType.LLM_GENERATION,
+        name: 'llm-call',
+        attributes: {
+          model: 'gpt-4',
+        },
+      });
+
+      // Try to find a WORKFLOW_RUN parent that doesn't exist
+      const foundWorkflow = llmSpan.findParent(AISpanType.WORKFLOW_RUN);
+      expect(foundWorkflow).toBeUndefined();
+
+      // Try to find AGENT_RUN from root span (no parent)
+      const foundAgent = agentSpan.findParent(AISpanType.AGENT_RUN);
+      expect(foundAgent).toBeUndefined();
+
+      agentSpan.end();
+    });
+
+    it('should handle deep hierarchies correctly', () => {
+      const tracing = new DefaultAITracing({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+      });
+
+      // Create a very deep hierarchy
+      const agentSpan = tracing.startSpan({
+        type: AISpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: {
+          agentId: 'agent-123',
+        },
+      });
+
+      const workflowSpan = agentSpan.createChildSpan({
+        type: AISpanType.WORKFLOW_RUN,
+        name: 'workflow',
+        attributes: {
+          workflowId: 'workflow-1',
+        },
+      });
+
+      const stepSpan1 = workflowSpan.createChildSpan({
+        type: AISpanType.WORKFLOW_STEP,
+        name: 'step-1',
+        attributes: {
+          stepId: 'step-1',
+        },
+      });
+
+      const stepSpan2 = stepSpan1.createChildSpan({
+        type: AISpanType.WORKFLOW_STEP,
+        name: 'step-2',
+        attributes: {
+          stepId: 'step-2',
+        },
+      });
+
+      const toolSpan = stepSpan2.createChildSpan({
+        type: AISpanType.TOOL_CALL,
+        name: 'tool-call',
+        attributes: {
+          toolId: 'tool-1',
+        },
+      });
+
+      const llmSpan = toolSpan.createChildSpan({
+        type: AISpanType.LLM_GENERATION,
+        name: 'llm-call',
+        attributes: {
+          model: 'gpt-4',
+        },
+      });
+
+      // From deeply nested LLM span, find AGENT_RUN at the top
+      const foundAgent = llmSpan.findParent(AISpanType.AGENT_RUN);
+      expect(foundAgent).toBeDefined();
+      expect(foundAgent?.id).toBe(agentSpan.id);
+
+      // Find the first WORKFLOW_STEP (should be step-2, the immediate parent of TOOL_CALL)
+      const foundStep = llmSpan.findParent(AISpanType.WORKFLOW_STEP);
+      expect(foundStep).toBeDefined();
+      expect(foundStep?.name).toBe('step-2');
+
+      agentSpan.end();
+    });
+  });
+});

--- a/packages/core/src/ai-tracing/spans/base.ts
+++ b/packages/core/src/ai-tracing/spans/base.ts
@@ -134,6 +134,20 @@ export abstract class BaseAISpan<TType extends AISpanType = any> implements AISp
     return this.parent.id;
   }
 
+  /** Find the closest parent span of a specific type by walking up the parent chain */
+  public findParent<T extends AISpanType>(spanType: T): AISpan<T> | undefined {
+    let current: AnyAISpan | undefined = this.parent;
+
+    while (current) {
+      if (current.type === spanType) {
+        return current as AISpan<T>;
+      }
+      current = current.parent;
+    }
+
+    return undefined;
+  }
+
   /** Returns a lightweight span ready for export */
   public exportSpan(includeInternalSpans?: boolean): ExportedAISpan<TType> {
     return {

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -357,6 +357,9 @@ export interface AISpan<TType extends AISpanType> extends BaseSpan<TType> {
   /** Get the closest parent spanId that isn't an internal span */
   getParentSpanId(includeInternalSpans?: boolean): string | undefined;
 
+  /** Find the closest parent span of a specific type by walking up the parent chain */
+  findParent<T extends AISpanType>(spanType: T): AISpan<T> | undefined;
+
   /** Returns a lightweight span ready for export */
   exportSpan(includeInternalSpans?: boolean): ExportedAISpan<TType> | undefined;
 }

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -155,10 +155,12 @@ export interface MCPToolCallAttributes extends AIBaseAttributes {
  * Processor attributes
  */
 export interface ProcessorRunAttributes extends AIBaseAttributes {
-  /** Id of the Processor */
-  processorId: string;
+  /** Name of the Processor */
+  processorName: string;
   /** Processor type (input or output) */
   processorType: 'input' | 'output';
+  /** Processor index in the agent */
+  processorIndex?: number;
 }
 
 /**

--- a/packages/core/src/ai-tracing/types.ts
+++ b/packages/core/src/ai-tracing/types.ts
@@ -25,6 +25,8 @@ export enum AISpanType {
   LLM_CHUNK = 'llm_chunk',
   /** MCP (Model Context Protocol) tool execution */
   MCP_TOOL_CALL = 'mcp_tool_call',
+  /** Input or Output Processor execution */
+  PROCESSOR_RUN = 'processor_run',
   /** Function/tool execution with inputs, outputs, errors */
   TOOL_CALL = 'tool_call',
   /** Workflow run - root span for workflow processes */
@@ -150,6 +152,16 @@ export interface MCPToolCallAttributes extends AIBaseAttributes {
 }
 
 /**
+ * Processor attributes
+ */
+export interface ProcessorRunAttributes extends AIBaseAttributes {
+  /** Id of the Processor */
+  processorId: string;
+  /** Processor type (input or output) */
+  processorType: 'input' | 'output';
+}
+
+/**
  * Workflow Run attributes
  */
 export interface WorkflowRunAttributes extends AIBaseAttributes {
@@ -251,6 +263,7 @@ export interface AISpanTypeMap {
   [AISpanType.LLM_CHUNK]: LLMChunkAttributes;
   [AISpanType.TOOL_CALL]: ToolCallAttributes;
   [AISpanType.MCP_TOOL_CALL]: MCPToolCallAttributes;
+  [AISpanType.PROCESSOR_RUN]: ProcessorRunAttributes;
   [AISpanType.WORKFLOW_STEP]: WorkflowStepAttributes;
   [AISpanType.WORKFLOW_CONDITIONAL]: WorkflowConditionalAttributes;
   [AISpanType.WORKFLOW_CONDITIONAL_EVAL]: WorkflowConditionalEvalAttributes;

--- a/packages/core/src/processors/processors/language-detector.ts
+++ b/packages/core/src/processors/processors/language-detector.ts
@@ -2,7 +2,6 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import { InternalSpans } from '../../ai-tracing';
 import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';

--- a/packages/core/src/processors/processors/language-detector.ts
+++ b/packages/core/src/processors/processors/language-detector.ts
@@ -174,7 +174,6 @@ export class LanguageDetector implements Processor {
       name: 'language-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -2,7 +2,6 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import { InternalSpans } from '../../ai-tracing';
 import type { TracingContext } from '../../ai-tracing';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -128,7 +128,6 @@ export class ModerationProcessor implements Processor {
       name: 'content-moderator',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -177,7 +177,6 @@ export class PIIDetector implements Processor {
       name: 'pii-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -610,9 +610,11 @@ IMPORTANT: IF NO PII IS DETECTED, RETURN AN EMPTY OBJECT, DO NOT INCLUDE ANYTHIN
   async processOutputResult({
     messages,
     abort,
+    tracingContext,
   }: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> {
     try {
       if (messages.length === 0) {
@@ -630,7 +632,7 @@ IMPORTANT: IF NO PII IS DETECTED, RETURN AN EMPTY OBJECT, DO NOT INCLUDE ANYTHIN
           continue;
         }
 
-        const detectionResult = await this.detectPII(textContent);
+        const detectionResult = await this.detectPII(textContent, tracingContext);
 
         if (this.isPIIFlagged(detectionResult)) {
           const processedMessage = this.handleDetectedPII(message, detectionResult, this.strategy, abort);

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -3,7 +3,6 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import { InternalSpans } from '../../ai-tracing';
 import type { TracingContext } from '../../ai-tracing';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -2,7 +2,6 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
-import { InternalSpans } from '../../ai-tracing';
 import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { Processor } from '../index';

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -106,7 +106,6 @@ export class PromptInjectionDetector implements Processor {
       name: 'prompt-injection-detector',
       instructions: options.instructions || this.createDefaultInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -3,6 +3,7 @@ import { Agent } from '../../agent';
 import type { StructuredOutputOptions } from '../../agent/types';
 import { InternalSpans } from '../../ai-tracing';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
+import type { TracingContext } from '../../ai-tracing';
 import { ChunkFrom } from '../../stream';
 import type { ChunkType, OutputSchema } from '../../stream';
 import type { InferSchemaOutput } from '../../stream/base/schema';
@@ -73,8 +74,9 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
       controller: TransformStreamDefaultController<ChunkType<OUTPUT>>;
     };
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<ChunkType | null | undefined> {
-    const { part, state, streamParts, abort } = args;
+    const { part, state, streamParts, abort, tracingContext } = args;
     const controller = state.controller;
 
     switch (part.type) {
@@ -83,7 +85,7 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
         // - enqueue the structuring agent stream chunks into the main stream
         // - when the structuring agent stream is finished, enqueue the final chunk into the main stream
 
-        await this.processAndEmitStructuredOutput(streamParts, controller, abort);
+        await this.processAndEmitStructuredOutput(streamParts, controller, abort, tracingContext);
         return part;
 
       default:
@@ -95,6 +97,7 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
     streamParts: ChunkType[],
     controller: TransformStreamDefaultController<ChunkType<OUTPUT>>,
     abort: (reason?: string) => never,
+    tracingContext?: TracingContext,
   ): Promise<void> {
     if (this.isStructuringAgentStreamStarted) return;
     this.isStructuringAgentStreamStarted = true;
@@ -108,6 +111,8 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
           schema: this.schema as OUTPUT extends OutputSchema ? OUTPUT : never,
           jsonPromptInjection: this.jsonPromptInjection,
         },
+        output: this.schema,
+        tracingContext,
       });
 
       const excludedChunkTypes = [

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -109,7 +109,6 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
           schema: this.schema as OUTPUT extends OutputSchema ? OUTPUT : never,
           jsonPromptInjection: this.jsonPromptInjection,
         },
-        output: this.schema,
         tracingContext,
       });
 

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -1,9 +1,8 @@
 import type { TransformStreamDefaultController } from 'stream/web';
 import { Agent } from '../../agent';
 import type { StructuredOutputOptions } from '../../agent/types';
-import { InternalSpans } from '../../ai-tracing';
-import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import type { TracingContext } from '../../ai-tracing';
+import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import { ChunkFrom } from '../../stream';
 import type { ChunkType, OutputSchema } from '../../stream';
 import type { InferSchemaOutput } from '../../stream/base/schema';

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -63,7 +63,6 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
       name: 'structured-output-structurer',
       instructions: options.instructions || this.generateInstructions(),
       model: options.model,
-      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -81,7 +81,6 @@ export class SystemPromptScrubber implements Processor {
       name: 'system-prompt-detector',
       model: this.model,
       instructions: this.instructions,
-      options: { tracingPolicy: { internal: InternalSpans.ALL } },
     });
   }
 

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -95,7 +95,7 @@ export class SystemPromptScrubber implements Processor {
     abort: (reason?: string) => never;
     tracingContext?: TracingContext;
   }): Promise<ChunkType | null> {
-    const { part, abort } = args;
+    const { part, abort, tracingContext } = args;
 
     // Only process text-delta chunks
     if (part.type !== 'text-delta') {
@@ -108,7 +108,7 @@ export class SystemPromptScrubber implements Processor {
     }
 
     try {
-      const detectionResult = await this.detectSystemPrompts(text);
+      const detectionResult = await this.detectSystemPrompts(text, tracingContext);
 
       if (detectionResult.detections && detectionResult.detections.length > 0) {
         const detectedTypes = detectionResult.detections.map(detection => detection.type);
@@ -159,9 +159,11 @@ export class SystemPromptScrubber implements Processor {
   async processOutputResult({
     messages,
     abort,
+    tracingContext,
   }: {
     messages: MastraMessageV2[];
     abort: (reason?: string) => never;
+    tracingContext?: TracingContext;
   }): Promise<MastraMessageV2[]> {
     const processedMessages: MastraMessageV2[] = [];
 
@@ -178,7 +180,7 @@ export class SystemPromptScrubber implements Processor {
       }
 
       try {
-        const detectionResult = await this.detectSystemPrompts(textContent);
+        const detectionResult = await this.detectSystemPrompts(textContent, tracingContext);
 
         if (detectionResult.detections && detectionResult.detections.length > 0) {
           const detectedTypes = detectionResult.detections.map(detection => detection.type);

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { Agent } from '../../agent';
 import type { MastraMessageV2 } from '../../agent/message-list';
-import { InternalSpans } from '../../ai-tracing';
 import type { TracingContext } from '../../ai-tracing';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { ChunkType } from '../../stream';

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -136,7 +136,7 @@ export class ProcessorRunner {
             processableMessages = await processMethod({
               messages: processableMessages,
               abort: ctx.abort,
-              tracingContext,
+              tracingContext: { currentSpan: processorSpan },
             });
             return processableMessages;
           },
@@ -354,14 +354,18 @@ export class ProcessorRunner {
       });
 
       if (!telemetry) {
-        processableMessages = await processMethod({ messages: processableMessages, abort: ctx.abort, tracingContext });
+        processableMessages = await processMethod({
+          messages: processableMessages,
+          abort: ctx.abort,
+          tracingContext: { currentSpan: processorSpan },
+        });
       } else {
         await telemetry.traceMethod(
           async () => {
             processableMessages = await processMethod({
               messages: processableMessages,
               abort: ctx.abort,
-              tracingContext,
+              tracingContext: { currentSpan: processorSpan },
             });
             return processableMessages;
           },

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -237,7 +237,14 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
                * Need to update controller on each new LLM execution step since each step has its own TransformStream.
                */
               if (!processorStates.has(STRUCTURED_OUTPUT_PROCESSOR_NAME)) {
-                const structuredOutputProcessorState = new ProcessorState<OUTPUT>(STRUCTURED_OUTPUT_PROCESSOR_NAME);
+                const processorIndex = processorRunner.outputProcessors.findIndex(
+                  p => p.name === STRUCTURED_OUTPUT_PROCESSOR_NAME,
+                );
+                const structuredOutputProcessorState = new ProcessorState<OUTPUT>({
+                  processorName: STRUCTURED_OUTPUT_PROCESSOR_NAME,
+                  tracingContext: options.tracingContext,
+                  processorIndex: processorIndex !== -1 ? processorIndex : 0,
+                });
                 structuredOutputProcessorState.customState = { controller };
                 processorStates.set(STRUCTURED_OUTPUT_PROCESSOR_NAME, structuredOutputProcessorState);
               } else {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -248,7 +248,11 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
                 }
               }
 
-              const { part: processed, blocked, reason } = await processorRunner.processPart(chunk, processorStates);
+              const {
+                part: processed,
+                blocked,
+                reason,
+              } = await processorRunner.processPart(chunk, processorStates, options.tracingContext);
               if (blocked) {
                 // Emit a tripwire chunk so downstream knows about the abort
                 controller.enqueue({


### PR DESCRIPTION
Add tracing to all processors.  Each processor run will be wrapped in a `PROCESSOR_RUN` span.  If the processor uses an Agent internally, this will also be traced.

<img width="324" height="435" alt="Screenshot 2025-10-10 at 8 12 45 PM" src="https://github.com/user-attachments/assets/37dd1c5d-c2db-42cd-a185-bf7a44ea3e6b" />

