### PR TITLE
fix typo in playground causing semantic recall is always false

### DIFF
--- a/.changeset/calm-chicken-accept.md
+++ b/.changeset/calm-chicken-accept.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix typo in playground causing semantic recall to always be false when enabled.

--- a/packages/playground/src/domains/agents/agent-memory-config.tsx
+++ b/packages/playground/src/domains/agents/agent-memory-config.tsx
@@ -46,7 +46,7 @@ export const AgentMemoryConfig = ({ agentId }: AgentMemoryConfigProps) => {
 
     // Semantic Recall section
     if (config.semanticRecall) {
-      const enabled = !Boolean(config.semanticRecall);
+      const enabled = Boolean(config.semanticRecall);
       const semanticRecall = typeof config.semanticRecall === 'object' ? config.semanticRecall : ({} as SemanticRecall);
 
       sections.push({
@@ -169,7 +169,7 @@ export const AgentMemoryConfig = ({ agentId }: AgentMemoryConfigProps) => {
             </button>
             {expandedSections.has(section.title) && (
               <div className="px-3 pb-2 space-y-1">
-                {section.items.map((item, index) => (
+                {section.items.map(item => (
                   <div key={`${section.title}-${item.label}`} className="flex items-center justify-between py-1">
                     <span className="text-xs text-icon3">{item.label}</span>
                     {renderValue(item.value || '', item.badge)}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
When semantic recall is true, a typo in a check causes the other elements connected to semantic recall to not be displayed

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
