### PR TITLE
#8683 - workflows: implements watch-v2 and new conditions to deal with differ…

### DIFF
--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -493,6 +493,7 @@ export type TypedChunkType<OUTPUT extends OutputSchema = undefined> =
   | (BaseChunkType & { type: 'step-output'; payload: StepOutputPayload })
   | (BaseChunkType & { type: 'workflow-step-output'; payload: StepOutputPayload })
   | (BaseChunkType & { type: 'watch'; payload: WatchPayload })
+  | (BaseChunkType & { type: 'watch-v2'; payload: WatchPayload })
   | (BaseChunkType & { type: 'tripwire'; payload: TripwirePayload })
   | (BaseChunkType & WorkflowStreamEvent)
   | NetworkChunkType;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -2,6 +2,7 @@ import type { TextStreamPart } from 'ai';
 import type { z } from 'zod';
 import type { TracingPolicy, TracingProperties } from '../ai-tracing';
 import type { Mastra } from '../mastra';
+import type { ChunkFrom, ChunkType } from '../stream';
 import type { ExecutionEngine } from './execution-engine';
 import type { ConditionFunction, ExecuteFunction, LoopConditionFunction, Step } from './step';
 
@@ -259,6 +260,17 @@ export type WatchEvent = {
     };
   };
   eventTimestamp: Date;
+  from?: ChunkFrom;
+};
+
+export type WatchEventV2 = {
+  type: 'watch-v2';
+  from: ChunkFrom;
+  payload?: {
+    output?: ChunkType;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
 };
 
 // Type to get the inferred type at a specific path in a Zod schema


### PR DESCRIPTION
## Description

This bug happened in a very specific scenario where agent A have a workflow X as tool, and workflow X has an agent B as a step.

The crash occurs when the watch/unwatch functions try to set `stepName` as `payload.id`, which doesn't seems to exist when dealing with `watch` (v1) payloads.

Reproduction repo: https://github.com/victorhcvp/mastra-agent-as-step-repro (call the custom API route to trigger the workflow from the agent execution)

This PR implements watch-v2 and new conditions to deal with `watch` and `watch-v2` payloads.

## Related Issue(s)

#8683 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [-] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
