### PR TITLE
Preserve Mastra span id

### DIFF
--- a/.changeset/fast-cups-turn.md
+++ b/.changeset/fast-cups-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': patch
+---
+
+preserve Mastra span id when exported to Braintrust

--- a/observability/braintrust/src/ai-tracing.ts
+++ b/observability/braintrust/src/ai-tracing.ts
@@ -122,6 +122,7 @@ export class BraintrustExporter implements AITracingExporter {
     const payload = this.buildSpanPayload(span);
 
     const braintrustSpan = braintrustParent.startSpan({
+      spanId: span.id,
       name: span.name,
       type: mapSpanType(span.type),
       ...payload,
@@ -200,6 +201,7 @@ export class BraintrustExporter implements AITracingExporter {
 
     // Create zero-duration span for event (convert milliseconds to seconds)
     const braintrustSpan = braintrustParent.startSpan({
+      spanId: span.id,
       name: span.name,
       type: mapSpanType(span.type),
       startTime: span.startTime.getTime() / 1000,


### PR DESCRIPTION
## Description

Now Mastra and Braintrust spans cannot be matched because all span ids are being re-generated before being exported to Braintrust. This makes it impossible to add new leaf spans to already finished spans. 

This change preserves Mastra's OTEL style span id when corresponding Braintrust spans are created. It enables Mastra users to record tracingContext span ids and emit new spans that will be attached to them. 

### Example

User wants to capture customer feedback. This becomes possible by recording root span id together with thread id in Mastra's memory. This can be retrieved and new span emitted attached to original conversation:

```ts
braintrustLogger
  .startSpan({
    parentSpanIds: {
      spanId: spanId, // from memory
      rootSpanId: spanId,
    },
    name: 'attached-span',
    event: {
      metadata,
      scores: {
        feedback: score,
      },
    },
  })
  .end()
```

<img width="771" height="667" alt="image" src="https://github.com/user-attachments/assets/8e0afca5-bc72-4698-b3e6-986de0979793" />

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
