### PR TITLE
add configurable table mapping to PostgresStore

### DIFF
--- a/stores/pg/src/storage/domains/legacy-evals/index.ts
+++ b/stores/pg/src/storage/domains/legacy-evals/index.ts
@@ -3,6 +3,7 @@ import type { MetricResult } from '@mastra/core/eval';
 import { LegacyEvalsStorage, TABLE_EVALS } from '@mastra/core/storage';
 import type { PaginationArgs, PaginationInfo, EvalRow } from '@mastra/core/storage';
 import type { IDatabase } from 'pg-promise';
+import type { TableMapConfig } from '../utils';
 import { getSchemaName, getTableName } from '../utils';
 
 function transformEvalRow(row: Record<string, any>): EvalRow {
@@ -32,16 +33,18 @@ function transformEvalRow(row: Record<string, any>): EvalRow {
 export class LegacyEvalsPG extends LegacyEvalsStorage {
   private client: IDatabase<{}>;
   private schema: string;
-  constructor({ client, schema }: { client: IDatabase<{}>; schema: string }) {
+  private tableMap: TableMapConfig;
+  constructor({ client, schema, tableMap }: { client: IDatabase<{}>; schema: string; tableMap?: TableMapConfig }) {
     super();
     this.client = client;
     this.schema = schema;
+    this.tableMap = tableMap || {};
   }
 
   /** @deprecated use getEvals instead */
   async getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]> {
     try {
-      const baseQuery = `SELECT * FROM ${getTableName({ indexName: TABLE_EVALS, schemaName: getSchemaName(this.schema) })} WHERE agent_name = $1`;
+      const baseQuery = `SELECT * FROM ${getTableName({ indexName: TABLE_EVALS, schemaName: getSchemaName(this.schema), tableMap: this.tableMap })} WHERE agent_name = $1`;
       const typeCondition =
         type === 'test'
           ? " AND test_info IS NOT NULL AND test_info->>'testPath' IS NOT NULL"
@@ -69,7 +72,7 @@ export class LegacyEvalsPG extends LegacyEvalsStorage {
       type?: 'test' | 'live';
     } & PaginationArgs = {},
   ): Promise<PaginationInfo & { evals: EvalRow[] }> {
-    const tableName = getTableName({ indexName: TABLE_EVALS, schemaName: getSchemaName(this.schema) });
+    const tableName = getTableName({ indexName: TABLE_EVALS, schemaName: getSchemaName(this.schema), tableMap: this.tableMap });
 
     const { agentName, type, page = 0, perPage = 100, dateRange } = options;
     const fromDate = dateRange?.start;

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -11,26 +11,31 @@ import type {
 } from '@mastra/core/storage';
 import type { IDatabase } from 'pg-promise';
 import type { StoreOperationsPG } from '../operations';
+import type { TableMapConfig } from '../utils';
 import { buildDateRangeFilter, prepareWhereClause, transformFromSqlRow, getTableName, getSchemaName } from '../utils';
 
 export class ObservabilityPG extends ObservabilityStorage {
   public client: IDatabase<{}>;
   private operations: StoreOperationsPG;
   private schema?: string;
+  private tableMap: TableMapConfig;
 
   constructor({
     client,
     operations,
     schema,
+    tableMap,
   }: {
     client: IDatabase<{}>;
     operations: StoreOperationsPG;
     schema?: string;
+    tableMap?: TableMapConfig;
   }) {
     super();
     this.client = client;
     this.operations = operations;
     this.schema = schema;
+    this.tableMap = tableMap || {};
   }
 
   public override get aiTracingStrategy(): {
@@ -81,6 +86,7 @@ export class ObservabilityPG extends ObservabilityStorage {
       const tableName = getTableName({
         indexName: TABLE_AI_SPANS,
         schemaName: getSchemaName(this.schema),
+        tableMap: this.tableMap,
       });
 
       const spans = await this.client.manyOrNone<AISpanRecord>(
@@ -361,6 +367,7 @@ export class ObservabilityPG extends ObservabilityStorage {
       const tableName = getTableName({
         indexName: TABLE_AI_SPANS,
         schemaName: getSchemaName(this.schema),
+        tableMap: this.tableMap,
       });
 
       const placeholders = args.traceIds.map((_, i) => `$${i + 1}`).join(', ');

--- a/stores/pg/src/storage/domains/traces/index.ts
+++ b/stores/pg/src/storage/domains/traces/index.ts
@@ -5,26 +5,31 @@ import type { Trace } from '@mastra/core/telemetry';
 import { parseFieldKey } from '@mastra/core/utils';
 import type { IDatabase } from 'pg-promise';
 import type { StoreOperationsPG } from '../operations';
+import type { TableMapConfig } from '../utils';
 import { getSchemaName, getTableName } from '../utils';
 
 export class TracesPG extends TracesStorage {
   public client: IDatabase<{}>;
   private operations: StoreOperationsPG;
   private schema?: string;
+  private tableMap: TableMapConfig;
 
   constructor({
     client,
     operations,
     schema,
+    tableMap,
   }: {
     client: IDatabase<{}>;
     operations: StoreOperationsPG;
     schema?: string;
+    tableMap?: TableMapConfig;
   }) {
     super();
     this.client = client;
     this.operations = operations;
     this.schema = schema;
+    this.tableMap = tableMap || {};
   }
 
   async getTraces(args: StorageGetTracesArg): Promise<Trace[]> {
@@ -94,7 +99,7 @@ export class TracesPG extends TracesStorage {
 
     try {
       const countResult = await this.client.oneOrNone<{ count: string }>(
-        `SELECT COUNT(*) FROM ${getTableName({ indexName: TABLE_TRACES, schemaName: getSchemaName(this.schema) })} ${whereClause}`,
+        `SELECT COUNT(*) FROM ${getTableName({ indexName: TABLE_TRACES, schemaName: getSchemaName(this.schema), tableMap: this.tableMap })} ${whereClause}`,
         queryParams,
       );
       const total = Number(countResult?.count ?? 0);
@@ -110,7 +115,7 @@ export class TracesPG extends TracesStorage {
       }
 
       const dataResult = await this.client.manyOrNone<Record<string, any>>(
-        `SELECT * FROM ${getTableName({ indexName: TABLE_TRACES, schemaName: getSchemaName(this.schema) })} ${whereClause} ORDER BY "startTime" DESC LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+        `SELECT * FROM ${getTableName({ indexName: TABLE_TRACES, schemaName: getSchemaName(this.schema), tableMap: this.tableMap })} ${whereClause} ORDER BY "startTime" DESC LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
         [...queryParams, perPage, currentOffset],
       );
 

--- a/stores/pg/src/storage/domains/utils.ts
+++ b/stores/pg/src/storage/domains/utils.ts
@@ -2,12 +2,23 @@ import type { PaginationArgs, StorageColumn, TABLE_NAMES } from '@mastra/core/st
 import { TABLE_SCHEMAS } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 
+export type TableMapConfig = Partial<Record<TABLE_NAMES, string>>;
+
 export function getSchemaName(schema?: string) {
   return schema ? `"${parseSqlIdentifier(schema, 'schema name')}"` : undefined;
 }
 
-export function getTableName({ indexName, schemaName }: { indexName: string; schemaName?: string }) {
-  const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
+export function getTableName({
+  indexName,
+  schemaName,
+  tableMap,
+}: {
+  indexName: string;
+  schemaName?: string;
+  tableMap?: TableMapConfig;
+}) {
+  const actualTableName = tableMap?.[indexName as TABLE_NAMES] || indexName;
+  const parsedIndexName = parseSqlIdentifier(actualTableName, 'index name');
   const quotedIndexName = `"${parsedIndexName}"`;
   const quotedSchemaName = schemaName;
   return quotedSchemaName ? `${quotedSchemaName}.${quotedIndexName}` : quotedIndexName;

--- a/stores/pg/src/storage/table-map.test.ts
+++ b/stores/pg/src/storage/table-map.test.ts
@@ -1,0 +1,255 @@
+import {
+  TABLE_MESSAGES,
+  TABLE_THREADS,
+  TABLE_RESOURCES,
+  TABLE_SCORERS,
+  TABLE_TRACES,
+  TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_AI_SPANS,
+} from '@mastra/core/storage';
+import { describe, it, expect, afterEach } from 'vitest';
+import { PostgresStore } from './index';
+
+describe('PostgresStore tableMap configuration', () => {
+  let store: PostgresStore;
+  const connectionString = process.env.TEST_DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/mastra_test';
+
+  afterEach(async () => {
+    if (store) {
+      try {
+        await store.close();
+      } catch {
+        // Ignore errors during cleanup
+      }
+    }
+  });
+
+  it('should use custom table names from tableMap', async () => {
+    const customTableMap = {
+      [TABLE_MESSAGES]: 'custom_messages',
+      [TABLE_THREADS]: 'custom_threads',
+      [TABLE_RESOURCES]: 'custom_resources',
+    };
+
+    store = new PostgresStore({
+      connectionString,
+      tableMap: customTableMap,
+      schemaName: 'test_table_map',
+    });
+
+    await store.init();
+
+    // Verify tables were created with custom names
+    const tables = await store.db.manyOrNone(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_name IN ($2, $3, $4)`,
+      ['test_table_map', 'custom_messages', 'custom_threads', 'custom_resources'],
+    );
+
+    const tableNames = tables.map((t: any) => t.table_name);
+    expect(tableNames).toContain('custom_messages');
+    expect(tableNames).toContain('custom_threads');
+    expect(tableNames).toContain('custom_resources');
+  });
+
+  it('should work with default table names when tableMap is not provided', async () => {
+    store = new PostgresStore({
+      connectionString,
+      schemaName: 'test_default_tables',
+    });
+
+    await store.init();
+
+    // Verify default table names
+    const tables = await store.db.manyOrNone(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_name LIKE 'mastra_%'`,
+      ['test_default_tables'],
+    );
+
+    const tableNames = tables.map((t: any) => t.table_name);
+    expect(tableNames.length).toBeGreaterThan(0);
+    expect(tableNames.some((name: string) => name.startsWith('mastra_'))).toBe(true);
+  });
+
+  it('should allow partial tableMap (some tables mapped, others default)', async () => {
+    const partialTableMap = {
+      [TABLE_MESSAGES]: 'chat_messages',
+      [TABLE_THREADS]: 'conversations',
+    };
+
+    store = new PostgresStore({
+      connectionString,
+      tableMap: partialTableMap,
+      schemaName: 'test_partial_map',
+    });
+
+    await store.init();
+
+    // Verify custom and default tables coexist
+    const tables = await store.db.manyOrNone(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = $1`,
+      ['test_partial_map'],
+    );
+
+    const tableNames = tables.map((t: any) => t.table_name);
+    expect(tableNames).toContain('chat_messages');
+    expect(tableNames).toContain('conversations');
+    // Other tables should use default names
+    expect(tableNames).toContain(TABLE_RESOURCES);
+  });
+
+  it('should support multi-tenant scenario with different table prefixes', async () => {
+    const tenant1Map = {
+      [TABLE_TRACES]: 'app_traces',
+      [TABLE_AI_SPANS]: 'app_spans',
+      [TABLE_SCORERS]: 'app_scores',
+    };
+
+    const tenant2Map = {
+      [TABLE_TRACES]: 'ml_traces',
+      [TABLE_AI_SPANS]: 'ml_spans',
+      [TABLE_SCORERS]: 'ml_scores',
+    };
+
+    const store1 = new PostgresStore({
+      connectionString,
+      tableMap: tenant1Map,
+      schemaName: 'tenant_app',
+    });
+
+    const store2 = new PostgresStore({
+      connectionString,
+      tableMap: tenant2Map,
+      schemaName: 'tenant_ml',
+    });
+
+    try {
+      await store1.init();
+      await store2.init();
+
+      // Verify both tenants have their custom tables
+      const tenant1Tables = await store1.db.manyOrNone(
+        `SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_name IN ($2, $3, $4)`,
+        ['tenant_app', 'app_traces', 'app_spans', 'app_scores'],
+      );
+
+      const tenant2Tables = await store2.db.manyOrNone(
+        `SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_name IN ($2, $3, $4)`,
+        ['tenant_ml', 'ml_traces', 'ml_spans', 'ml_scores'],
+      );
+
+      expect(tenant1Tables.length).toBe(3);
+      expect(tenant2Tables.length).toBe(3);
+    } finally {
+      await store1.close();
+      await store2.close();
+    }
+  });
+
+  it('should handle SQL injection attempts in table names', async () => {
+    const maliciousTableMap = {
+      [TABLE_MESSAGES]: "messages'; DROP TABLE users--",
+    };
+
+    store = new PostgresStore({
+      connectionString,
+      tableMap: maliciousTableMap,
+      schemaName: 'test_sql_injection',
+    });
+
+    // The parseSqlIdentifier should sanitize the table name
+    // This test verifies that initialization doesn't execute malicious SQL
+    await expect(store.init()).rejects.toThrow();
+  });
+
+  it('should work with workflow operations using custom table name', async () => {
+    store = new PostgresStore({
+      connectionString,
+      tableMap: {
+        [TABLE_WORKFLOW_SNAPSHOT]: 'workflow_runs',
+      },
+      schemaName: 'test_workflow_map',
+    });
+
+    await store.init();
+
+    const workflowName = 'test_workflow';
+    const runId = 'run_123';
+    const snapshot = {
+      status: 'running',
+      results: {},
+      suspendedPaths: {},
+      waitingPaths: {},
+      errors: {},
+      stepStack: [],
+    };
+
+    await store.persistWorkflowSnapshot({
+      workflowName,
+      runId,
+      snapshot,
+    });
+
+    const loaded = await store.loadWorkflowSnapshot({ workflowName, runId });
+    expect(loaded).toEqual(snapshot);
+  });
+
+  it('should work with memory operations using custom table names', async () => {
+    store = new PostgresStore({
+      connectionString,
+      tableMap: {
+        [TABLE_MESSAGES]: 'chat',
+        [TABLE_THREADS]: 'conversation',
+        [TABLE_RESOURCES]: 'user',
+      },
+      schemaName: 'test_memory_map',
+    });
+
+    await store.init();
+
+    const resourceId = 'user_123';
+    const threadId = 'thread_456';
+
+    // Create resource
+    await store.saveResource({
+      resource: {
+        id: resourceId,
+        workingMemory: 'test memory',
+        metadata: { name: 'Test User' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    // Create thread
+    const thread = await store.saveThread({
+      thread: {
+        id: threadId,
+        resourceId,
+        title: 'Test Thread',
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    expect(thread.id).toBe(threadId);
+    expect(thread.resourceId).toBe(resourceId);
+
+    // Save messages
+    const messages = await store.saveMessages({
+      messages: [
+        {
+          id: 'msg_1',
+          threadId,
+          resourceId,
+          role: 'user',
+          content: 'Hello',
+          createdAt: new Date(),
+        },
+      ],
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('Hello');
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/8695

## Description

Add tableMap configuration option to PostgresStore that allows users to override default table names for all storage domains (messages, threads, traces, workflows, operations, scores, evals, and observability).

Key changes:
- Add TableMapConfig type for custom table name mappings
- Update getTableName utility to resolve custom table names
- Pass tableMap through all storage domain constructors
- Add comprehensive test coverage for table mapping functionality
- Maintain backward compatibility (tableMap is optional)

This enables multi-tenant scenarios and custom table naming conventions while maintaining SQL identifier security through proper sanitization.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
