### PR TITLE
fix(core): Handle agent maxRetries option

### DIFF
--- a/.changeset/plain-onions-accept.md
+++ b/.changeset/plain-onions-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Handle maxRetries in agent.generate/stream properly. Add deprecation warning to top level abortSignal in AgentExecuteOptions as that property is duplicated inside of modelSettings as well.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -219,6 +219,7 @@
     "json-schema": "^0.4.0",
     "json-schema-to-zod": "^2.6.1",
     "p-map": "^7.0.3",
+    "p-retry": "^7.1.0",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
     "radash": "^12.1.1",

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -6324,6 +6324,9 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
             errorCaught = true;
             caughtError = error;
           },
+          modelSettings: {
+            maxRetries: 0,
+          },
         });
 
         // Consume the stream to trigger the error

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -95,7 +95,10 @@ export type AgentExecutionOptions<
   onAbort?: LoopConfig['onAbort'];
   /** Tools that are active for this execution */
   activeTools?: LoopConfig['activeTools'];
-  /** Signal to abort the streaming operation */
+  /**
+   * Signal to abort the streaming operation
+   * @deprecated Use `modelSettings.abortSignal` instead. This top-level option will be removed in a future version.
+   */
   abortSignal?: LoopConfig['abortSignal'];
 
   /** Input processors to use for this execution (overrides agent's default) */

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -109,6 +109,9 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
             }),
           },
         ],
+        modelSettings: {
+          maxRetries: 0,
+        },
         messageList,
         options: {
           onError(event) {
@@ -3969,6 +3972,9 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
             }),
           },
         ],
+        modelSettings: {
+          maxRetries: 0,
+        },
         messageList,
         options: {
           onFinish() {}, // just defined; do nothing

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -282,6 +282,9 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
             options: {
               onError: () => {},
             },
+            modelSettings: {
+              maxRetries: 0,
+            },
           });
 
           expect(await convertAsyncIterableToArray(result.objectStream)).toStrictEqual([]);
@@ -310,6 +313,9 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
               onError(event) {
                 errors.push(event);
               },
+            },
+            modelSettings: {
+              maxRetries: 0,
             },
           });
 

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -3,7 +3,6 @@ import { injectJsonInstructionIntoMessages } from '@ai-sdk/provider-utils';
 import { isAbortError } from '@ai-sdk/provider-utils-v4';
 import type { Span } from '@opentelemetry/api';
 import type { CallSettings, TelemetrySettings, ToolChoice, ToolSet } from 'ai';
-import { omit } from 'lodash-es';
 import pRetry from 'p-retry';
 import type { StructuredOutputOptions } from '../../../agent/types';
 import { getResponseFormat } from '../../base/schema';
@@ -11,6 +10,14 @@ import type { OutputSchema } from '../../base/schema';
 import type { LanguageModelV2StreamResult, OnResult } from '../../types';
 import { prepareToolsAndToolChoice } from './compat';
 import { AISDKV5InputStream } from './input';
+
+function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {
+  const newObj = { ...obj };
+  for (const key of keys) {
+    delete newObj[key];
+  }
+  return newObj;
+}
 
 type ExecutionProps<OUTPUT extends OutputSchema = undefined> = {
   runId: string;

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -128,7 +128,7 @@ export function execute<OUTPUT extends OutputSchema = undefined>({
             // We have to cast this because doStream is missing the warnings property in its return type even though it exists
             return streamResult as unknown as LanguageModelV2StreamResult;
           },
-          { retries: modelSettings?.maxRetries || 2, signal: modelSettings?.abortSignal || options?.abortSignal },
+          { retries: modelSettings?.maxRetries ?? 2, signal: modelSettings?.abortSignal || options?.abortSignal },
         );
       } catch (error) {
         console.error('Error creating stream', error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1446,6 +1446,9 @@ importers:
       p-map:
         specifier: ^7.0.3
         version: 7.0.3
+      p-retry:
+        specifier: ^7.1.0
+        version: 7.1.0
       pino:
         specifier: ^9.7.0
         version: 9.13.1
@@ -12766,6 +12769,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.0:
+    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
+    engines: {node: '>=16'}
+
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -14205,6 +14212,10 @@ packages:
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-retry@7.1.0:
+    resolution: {integrity: sha512-xL4PiFRQa/f9L9ZvR4/gUCRNus4N8YX80ku8kv9Jqz+ZokkiZLM0bcvX0gm1F3PDi9SPRsww1BDsTWgE6Y1GLQ==}
+    engines: {node: '>=20'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -27144,6 +27155,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.3.0: {}
+
   is-node-process@1.2.0: {}
 
   is-npm@6.1.0: {}
@@ -28762,6 +28775,10 @@ snapshots:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-retry@7.1.0:
+    dependencies:
+      is-network-error: 1.3.0
 
   p-timeout@3.2.0:
     dependencies:


### PR DESCRIPTION
## Description

Fixes https://github.com/mastra-ai/mastra/issues/8694

- `maxRetries` wasn't being used properly, this introduces proper retry usage
- Defaults to 2 maxRetries (it's what our type says, but we didn't actually ever retry before
- Noticed abortSignal is duplicated in AgentExecuteOptions, so add deprecation warning to top level abort signal
- There were some cases of only handling one of those, rather than both.
