### PR TITLE
ci: add required API keys to core package tests workflow

### DIFF
--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -103,6 +103,9 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=8096'
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
 
   test-success:
     needs: [check-changes, test]


### PR DESCRIPTION
Need these for https://github.com/mastra-ai/mastra/pull/8688 but it'll only add them from the workflow on main