### PR TITLE
chore(docs): Add codex mcp setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ After installing Claude Code run:
 claude mcp add mastra-docs -- npx -y @mastra/mcp-docs-server
 ```
 
+### In OpenAI Codex
+
+Add the server with:
+
+```sh
+codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server@latest
+```
+
 ## Contributing
 
 Looking to contribute? All types of help are appreciated, from coding to testing and feature specification.

--- a/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
@@ -7,7 +7,7 @@ import YouTube from "@/components/youtube";
 
 # Mastra Docs Server
 
-The `@mastra/mcp-docs-server` package provides direct access to Mastra’s full knowledge base, including documentation, code examples, blog posts, and changelogs, via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro). It works with Cursor, Windsurf, Cline, Claude Code, or any tool that supports MCP.
+The `@mastra/mcp-docs-server` package provides direct access to Mastra’s full knowledge base, including documentation, code examples, blog posts, and changelogs, via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro). It works with Cursor, Windsurf, Cline, Claude Code, Codex or any tool that supports MCP.
 
 These tools are designed to help agents retrieve precise, task-specific information — whether you're adding a feature to an agent, scaffolding a new project, or exploring how something works.
 
@@ -46,6 +46,18 @@ claude mcp add mastra -- npx -y @mastra/mcp-docs-server
 ```
 
 [More info on using MCP servers with Claude Code](https://docs.claude.com/en/docs/claude-code/mcp)
+
+### OpenAI Codex CLI
+
+1. Register it from the terminal:
+
+    ```bash copy
+    codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server@latest
+    ```
+
+2. Run `codex mcp list` to confirm the server shows as `enabled`.
+
+[More info on using MCP servers with OpenAI Codex](https://developers.openai.com/codex/mcp)
 
 ### Cursor
 

--- a/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
@@ -52,7 +52,7 @@ claude mcp add mastra -- npx -y @mastra/mcp-docs-server
 1. Register it from the terminal:
 
     ```bash copy
-    codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server@latest
+    codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server
     ```
 
 2. Run `codex mcp list` to confirm the server shows as `enabled`.

--- a/docs/src/content/ja/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/ja/docs/getting-started/mcp-docs-server.mdx
@@ -62,7 +62,7 @@ LLM コンテキスト: この Tabs コンポーネントは、MacOS/Linux 上�
 各タブには、その IDE の MCP 設定に必要な正確な JSON 構造とファイルパスが記載されています。
 */}
 
-<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code"]}>
+<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code", "Codex"]}>
   <Tabs.Tab>
 ```json
 {
@@ -105,6 +105,11 @@ LLM コンテキスト: この Tabs コンポーネントは、MacOS/Linux 上�
 claude mcp add mastra -- npx -y @mastra/mcp-docs-server
 ```
   </Tabs.Tab>
+  <Tabs.Tab>
+```bash
+codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server@latest
+```
+  </Tabs.Tab>
 </Tabs>
 
 ### Windows
@@ -117,7 +122,7 @@ LLM コンテキスト: この Tabs コンポーネントは、Windows 上の複
 最新の Windsurf と Cursor では直接の npx コマンドが機能しますが、VSCode で修正済みかどうかは未確認です。
 */}
 
-<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code"]}>
+<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code", "Codex"]}>
   <Tabs.Tab>
 ```json
 {
@@ -158,6 +163,11 @@ LLM コンテキスト: この Tabs コンポーネントは、Windows 上の複
   <Tabs.Tab>
 ```bash
 claude mcp add mastra -- npx -y @mastra/mcp-docs-server
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash
+codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server@latest
 ```
   </Tabs.Tab>
 </Tabs>

--- a/docs/src/content/ja/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/ja/docs/getting-started/mcp-docs-server.mdx
@@ -62,7 +62,7 @@ LLM コンテキスト: この Tabs コンポーネントは、MacOS/Linux 上�
 各タブには、その IDE の MCP 設定に必要な正確な JSON 構造とファイルパスが記載されています。
 */}
 
-<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code", "Codex"]}>
+<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code"]}>
   <Tabs.Tab>
 ```json
 {
@@ -105,11 +105,6 @@ LLM コンテキスト: この Tabs コンポーネントは、MacOS/Linux 上�
 claude mcp add mastra -- npx -y @mastra/mcp-docs-server
 ```
   </Tabs.Tab>
-  <Tabs.Tab>
-```bash
-codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server@latest
-```
-  </Tabs.Tab>
 </Tabs>
 
 ### Windows
@@ -122,7 +117,7 @@ LLM コンテキスト: この Tabs コンポーネントは、Windows 上の複
 最新の Windsurf と Cursor では直接の npx コマンドが機能しますが、VSCode で修正済みかどうかは未確認です。
 */}
 
-<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code", "Codex"]}>
+<Tabs items={["Cursor", "Windsurf", "VSCode", "Claude Code"]}>
   <Tabs.Tab>
 ```json
 {
@@ -163,11 +158,6 @@ LLM コンテキスト: この Tabs コンポーネントは、Windows 上の複
   <Tabs.Tab>
 ```bash
 claude mcp add mastra -- npx -y @mastra/mcp-docs-server
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-```bash
-codex mcp add mastra-docs -- npx -y @mastra/mcp-docs-server@latest
 ```
   </Tabs.Tab>
 </Tabs>


### PR DESCRIPTION
## Description

I've just started exploring Mastra today and first thing I wanted to do was adding mcp server to codex. Checking docs I didn't see any specific instruction about Codex. Although the syntax is same with Cluade, given Codex users might not be aware of or haven't added an mcp server before I believe it's beneficial to have Codex separately. Especially after release of gpt-5 and gpt-5-codex, openai is gaining fast on coding tools and Codex already has more github stars than Cluade Code. 

I've also modified Japanase docs since it was only adding the command in a separate tab without writing anything verbose. 

## Related Issue(s)

None

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable) -- this is a documentation change
- [ ] I have added tests that prove my fix is effective or that my feature works -- tested on desktop and mobile 

eng desktop:
<img width="1398" height="1002" alt="image" src="https://github.com/user-attachments/assets/f9174323-05a4-4a02-a56b-f0434a64d43f" />

ja desktop:
<img width="1462" height="1062" alt="image" src="https://github.com/user-attachments/assets/6eb3d04b-5aa6-45bf-b32c-90dbbbb20468" />

ja mobile:
<img width="356" height="430" alt="image" src="https://github.com/user-attachments/assets/add967a5-4459-4514-921e-89151aca98e3" />


