### PR TITLE
fix: add typescript to global externals to prevent bundling OOM

### DIFF
--- a/.changeset/fluffy-buckets-camp.md
+++ b/.changeset/fluffy-buckets-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Add typescript to global externals to reduce bundling OOM

--- a/packages/deployer/src/build/analyze/constants.ts
+++ b/packages/deployer/src/build/analyze/constants.ts
@@ -1,4 +1,4 @@
 export const DEPS_TO_IGNORE = ['#tools'];
 
-export const GLOBAL_EXTERNALS = ['pino', 'pino-pretty', '@libsql/client', 'pg', 'libsql', '#tools'];
+export const GLOBAL_EXTERNALS = ['pino', 'pino-pretty', '@libsql/client', 'pg', 'libsql', '#tools', 'typescript'];
 export const DEPRECATED_EXTERNALS = ['fastembed', 'nodemailer', 'jsdom', 'sqlite3'];


### PR DESCRIPTION
Bundling typescript was causing out-of-memory errors during the build process. This adds typescript to the global externals list so it gets excluded from the bundle.