### PR TITLE
[Fix] cannot read VSCODE_TEXTMATE_DEBUG error

### DIFF
--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       process: {},
+      'process.env.VSCODE_TEXTMATE_DEBUG': JSON.stringify(process.env.VSCODE_TEXTMATE_DEBUG || ''),
     },
   };
 

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -22,8 +22,9 @@ export default defineConfig(({ mode }) => {
       },
     },
     define: {
-      process: {},
-      'process.env.VSCODE_TEXTMATE_DEBUG': JSON.stringify(process.env.VSCODE_TEXTMATE_DEBUG || ''),
+      process: {
+        env: {},
+      },
     },
   };
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Fix "Uncaught TypeError: Cannot read properties of undefined (reading 'VSCODE_TEXTMATE_DEBUG')" which breaks Playground when working on it locally http://localhost:5173/

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
