### PR TITLE
Fix `generateTitle: false` and `generateTitle: { model: ... }` not working

### DIFF
--- a/.changeset/tasty-showers-pay.md
+++ b/.changeset/tasty-showers-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix broken `generateTitle` behaviour #8726, make `generateTitle: true` default memory setting

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -42,7 +42,7 @@ export const memoryDefaultOptions = {
   lastMessages: 10,
   semanticRecall: false,
   threads: {
-    generateTitle: false,
+    generateTitle: true,
   },
   workingMemory: {
     enabled: false,
@@ -212,12 +212,6 @@ export abstract class MastraMemory extends MastraBase {
         mergedConfig.workingMemory.schema = config.workingMemory.schema;
       }
     }
-
-    if (!mergedConfig?.threads) {
-      mergedConfig.threads = {};
-    }
-
-    mergedConfig.threads.generateTitle = config?.threads?.generateTitle !== false;
 
     return mergedConfig;
   }


### PR DESCRIPTION
## Description

Fixes #8726, also makes `generateTitle: true` the default behaviour which appears to be the intent of the changes made in https://github.com/mastra-ai/mastra/pull/8381/files.

Instead of casting `false` in to `true`, we can just make it the default setting and allow it to be overwritten.

The current logic results in custom memory config being like this
```ts
const memory = new Memory({
    storage,
    processors: [new TokenLimiter(promptConfig.tokenLimit || 150_000)],
    options: {
      threads: {
        generateTitle: {
          model: async ({ runtimeContext }) => {
            return litellm(promptConfig.generateTitleModel || 'claude-3-5-haiku-20241022', { runtimeContext });
          },
        },
      },
    },
  });
```

Results in `generateTitle: true`

## Related Issue(s)

#8726

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
