### PR TITLE
use only zod validation in dynamic form

### DIFF
--- a/.changeset/lucky-pens-move.md
+++ b/.changeset/lucky-pens-move.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Use only zod validation in dynamic form

--- a/packages/playground-ui/src/components/dynamic-form/index.tsx
+++ b/packages/playground-ui/src/components/dynamic-form/index.tsx
@@ -71,6 +71,7 @@ export function DynamicForm<T extends z.ZodSchema>({
     defaultValues: isNotZodObject ? (defaultValues ? { '\u200B': defaultValues } : undefined) : (defaultValues as any),
     formProps: {
       className,
+      noValidate: true,
     },
     uiComponents: {
       SubmitButton: ({ children }) =>


### PR DESCRIPTION
## Description

This prevents HTML form validation from throwing error when it shouldn't. `DynamicForm` already uses the zod schema to validate the inputs

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#8764 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
