### PR TITLE
[Braintrust] Use Mastra's `traceId` as `root_span_id` for braintrust traces

### DIFF
--- a/.changeset/clean-rabbits-pay.md
+++ b/.changeset/clean-rabbits-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': patch
+---
+
+add traceId as root_span_id for braintrust traces

--- a/observability/braintrust/package.json
+++ b/observability/braintrust/package.json
@@ -31,7 +31,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "braintrust": "^0.3.8"
+    "braintrust": "^0.4.3"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/observability/braintrust/src/ai-tracing.test.ts
+++ b/observability/braintrust/src/ai-tracing.test.ts
@@ -139,8 +139,13 @@ describe('BraintrustExporter', () => {
 
       // Should create Braintrust span with correct type and payload
       expect(mockLogger.startSpan).toHaveBeenCalledWith({
+        spanId: 'root-span-id',
         name: 'root-agent',
         type: 'task', // Default span type mapping for AGENT_RUN
+        parentSpanIds: {
+          spanId: 'root-span-id',
+          rootSpanId: 'root-span-id',
+        },
         input: undefined,
         metadata: {
           spanType: 'agent_run',
@@ -190,8 +195,13 @@ describe('BraintrustExporter', () => {
 
       // Should create child span on parent span
       expect(mockSpan.startSpan).toHaveBeenCalledWith({
+        spanId: 'child-span-id',
         name: 'child-tool',
         type: 'tool', // TOOL_CALL maps to 'tool'
+        parentSpanIds: {
+          spanId: 'root-span-id',
+          rootSpanId: 'root-span-id',
+        },
         input: undefined,
         metadata: {
           spanType: 'tool_call',
@@ -403,8 +413,13 @@ describe('BraintrustExporter', () => {
       });
 
       expect(mockLogger.startSpan).toHaveBeenCalledWith({
+        spanId: 'llm-span',
         name: 'gpt-4-call',
         type: 'llm',
+        parentSpanIds: {
+          spanId: 'llm-span',
+          rootSpanId: 'llm-span',
+        },
         input: { messages: [{ role: 'user', content: 'Hello' }] },
         output: { content: 'Hi there!' },
         metrics: {
@@ -443,8 +458,13 @@ describe('BraintrustExporter', () => {
       });
 
       expect(mockLogger.startSpan).toHaveBeenCalledWith({
+        spanId: 'minimal-llm',
         name: 'simple-llm',
         type: 'llm',
+        parentSpanIds: {
+          spanId: 'minimal-llm',
+          rootSpanId: 'minimal-llm',
+        },
         metadata: {
           spanType: 'llm_generation',
           model: 'gpt-3.5-turbo',
@@ -662,8 +682,13 @@ describe('BraintrustExporter', () => {
 
       // Should create span with zero duration (matching start/end times)
       expect(mockLogger.startSpan).toHaveBeenCalledWith({
+        spanId: 'event-span',
         name: 'user-feedback',
         type: 'task',
+        parentSpanIds: {
+          spanId: 'event-span',
+          rootSpanId: 'event-span',
+        },
         startTime: eventSpan.startTime.getTime() / 1000,
         output: { message: 'Great response!' },
         metadata: {
@@ -715,8 +740,13 @@ describe('BraintrustExporter', () => {
 
       // Should create child span on parent
       expect(mockSpan.startSpan).toHaveBeenCalledWith({
+        spanId: 'child-event',
         name: 'tool-result',
         type: 'task',
+        parentSpanIds: {
+          spanId: 'root-span',
+          rootSpanId: 'root-span',
+        },
         startTime: childEventSpan.startTime.getTime() / 1000,
         output: { result: 42 },
         metadata: {

--- a/observability/braintrust/src/ai-tracing.ts
+++ b/observability/braintrust/src/ai-tracing.ts
@@ -125,6 +125,9 @@ export class BraintrustExporter implements AITracingExporter {
       spanId: span.id,
       name: span.name,
       type: mapSpanType(span.type),
+      parentSpanIds: span.parentSpanId
+        ? { spanId: span.parentSpanId, rootSpanId: span.traceId }
+        : { spanId: span.traceId, rootSpanId: span.traceId },
       ...payload,
     });
 
@@ -204,6 +207,9 @@ export class BraintrustExporter implements AITracingExporter {
       spanId: span.id,
       name: span.name,
       type: mapSpanType(span.type),
+      parentSpanIds: span.parentSpanId
+        ? { spanId: span.parentSpanId, rootSpanId: span.traceId }
+        : { spanId: span.traceId, rootSpanId: span.traceId },
       startTime: span.startTime.getTime() / 1000,
       ...payload,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -768,8 +768,8 @@ importers:
   observability/braintrust:
     dependencies:
       braintrust:
-        specifier: ^0.3.8
-        version: 0.3.8(@aws-sdk/credential-provider-web-identity@3.906.0)(zod@4.1.12)
+        specifier: ^0.4.3
+        version: 0.4.3(@aws-sdk/credential-provider-web-identity@3.906.0)(zod@4.1.12)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -1179,7 +1179,7 @@ importers:
         version: link:../mcp
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.62.1
-        version: 0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))
       '@opentelemetry/core':
         specifier: ^2.0.1
         version: 2.1.0(@opentelemetry/api@1.9.0)
@@ -1379,7 +1379,7 @@ importers:
         version: 1.9.0
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.62.1
-        version: 0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))
       '@opentelemetry/core':
         specifier: ^2.0.1
         version: 2.1.0(@opentelemetry/api@1.9.0)
@@ -10661,8 +10661,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  braintrust@0.3.8:
-    resolution: {integrity: sha512-FOJy0I8C2ri4em7hPhgiMOYnhTAoZqIvQal+jxsY5PYUhb6q0aZnhTyu1JqvOpokvLlBUleXQ+ppkjZ+LoPQSg==}
+  braintrust@0.4.3:
+    resolution: {integrity: sha512-tnq11rDCEiBTrPPlZU4s2M0XjHAMrymnrhBAHsr7OBa9OWyl7hcChGxBxHC844EVOUQbgXdWAuHrcXACQ6u/AQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.34
@@ -19852,7 +19852,7 @@ snapshots:
       '@mastra/schema-compat': 0.11.4(ai@4.3.19(react@19.2.0)(zod@4.1.12))(zod@4.1.12)
       '@openrouter/ai-sdk-provider-v5': '@openrouter/ai-sdk-provider@1.2.0(ai@4.3.19(react@19.2.0)(zod@4.1.12))(zod@4.1.12)'
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/auto-instrumentations-node': 0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@opentelemetry/auto-instrumentations-node': 0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
@@ -20273,7 +20273,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@opentelemetry/auto-instrumentations-node@0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+  '@opentelemetry/auto-instrumentations-node@0.62.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
@@ -20322,7 +20322,7 @@ snapshots:
       '@opentelemetry/resource-detector-aws': 2.6.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resource-detector-azure': 0.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resource-detector-container': 0.7.9(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resource-detector-gcp': 0.37.0(@opentelemetry/api@1.9.0)(encoding@0.1.13)
+      '@opentelemetry/resource-detector-gcp': 0.37.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.203.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
@@ -21474,7 +21474,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@opentelemetry/resource-detector-gcp@0.37.0(@opentelemetry/api@1.9.0)(encoding@0.1.13)':
+  '@opentelemetry/resource-detector-gcp@0.37.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
@@ -24588,7 +24588,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.3.8(@aws-sdk/credential-provider-web-identity@3.906.0)(zod@4.1.12):
+  braintrust@0.4.3(@aws-sdk/credential-provider-web-identity@3.906.0)(zod@4.1.12):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@next/env': 14.2.33


### PR DESCRIPTION
## Description

This PR adds traceId as the `root_span_id` for braintrust traces. this enables workflows such as logFeedback so users can asynchronously add feedback to LLM traces.

example code using `logFeedback` & generating braintrust trace using `traceId`
```typescript
    const demoAgent = mastra.getAgent("demoAgent");

    console.log(
      'Message: "What\'s the weather in Paris and calculate 15 + 27?"'
    );
    const combinedResponse = await demoAgent.generate(
      "What's the weather in Paris and calculate 15 + 27?",
    );

    if (combinedResponse.traceId) {
      try {
        const project = await logger.project;
        const rowId = await resolveRowIdByTraceId(combinedResponse.traceId, project.id);
        if (rowId) {
          logger.logFeedback({
            id: rowId,
            scores: { quality: 1 },
            comment: "Test 3: Combined Query",
          });
          console.log("✓ Logged feedback for row:", rowId);
        } else {
          console.warn("No span_id found for traceId; skipping feedback log");
        }
      } catch (e) {
        console.warn("Failed to resolve span_id for feedback:", e);
      }
    }
    
```
<img width="873" height="1128" alt="image" src="https://github.com/user-attachments/assets/50ab8906-2b46-4a77-8b98-608cba132f0a" />


## Related Issue(s)

https://github.com/mastra-ai/mastra/pull/8714

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
