### PR TITLE
feat: add scheduled GitHub Action to regenerate provider registry

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -62,7 +62,7 @@ jobs:
           # Generate a unique changeset filename with timestamp
           CHANGESET_ID="automated-provider-registry-$(date +%Y%m%d-%H%M%S)"
           CHANGESET_FILE=".changeset/${CHANGESET_ID}.md"
-          
+
           # Create changeset for @mastra/core with patch bump
           cat > "${CHANGESET_FILE}" << 'EOF'
           ---
@@ -71,7 +71,7 @@ jobs:
 
           Update provider registry with latest models and providers
           EOF
-          
+
           echo "Created changeset: ${CHANGESET_FILE}"
           echo "CHANGESET_FILE=${CHANGESET_FILE}" >> $GITHUB_ENV
 

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -17,11 +17,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get Github App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.DANE_APP_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - run: |
+          cat <<- EOF > $HOME/.netrc
+            machine github.com
+            login ${{ steps.app-token.outputs.app-slug }}
+            password ${{ steps.app-token.outputs.token }}
+            machine api.github.com
+            login ${{ steps.app-token.outputs.app-slug }}
+            password ${{ steps.app-token.outputs.token }}
+          EOF
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          # Use default token for direct commits to main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Configure npm registry
@@ -78,8 +102,6 @@ jobs:
       - name: Commit and push changes
         if: steps.git-check.outputs.changed == 'true'
         run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
           git add packages/core/src/llm/model/provider-registry.json
           git add packages/core/src/llm/model/provider-types.generated.d.ts
           git add "${CHANGESET_FILE}"

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -1,0 +1,94 @@
+name: Regenerate Provider Registry
+
+permissions:
+  contents: write
+
+on:
+  # Run daily to keep provider registry up-to-date
+  schedule:
+    - cron: '0 0 * * *' # Daily at midnight UTC
+  # Allow manual triggering for testing
+  workflow_dispatch:
+
+jobs:
+  regenerate:
+    # Only run on the main repository, not on forks
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          # Use default token for direct commits to main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure npm registry
+        run: mkdir -p ~/setup-pnpm && echo "registry=https://registry.yarnpkg.com" > ~/setup-pnpm/.npmrc
+
+      - uses: wardpeet/action-setup@pnpm-registry
+        name: Install pnpm
+        with:
+          registry: https://registry.yarnpkg.com
+          run_install: false
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.1
+          cache: 'pnpm'
+          registry-url: 'https://registry.yarnpkg.com'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Generate provider registry
+        run: pnpm --filter @mastra/core generate:providers
+
+      - name: Format generated files with Prettier
+        run: |
+          prettier --write packages/core/src/llm/model/provider-registry.json
+          prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code packages/core/src/llm/model/provider-registry.json packages/core/src/llm/model/provider-types.generated.d.ts || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Create changeset
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          # Generate a unique changeset filename
+          CHANGESET_ID="automated-provider-registry-$(date +%Y%m%d)"
+          CHANGESET_FILE=".changeset/${CHANGESET_ID}.md"
+          
+          # Create changeset for @mastra/core with patch bump
+          cat > "${CHANGESET_FILE}" << 'EOF'
+          ---
+          '@mastra/core': patch
+          ---
+
+          Update provider registry with latest models and providers
+          EOF
+          
+          echo "Created changeset: ${CHANGESET_FILE}"
+
+      - name: Commit and push changes
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add packages/core/src/llm/model/provider-registry.json
+          git add packages/core/src/llm/model/provider-types.generated.d.ts
+          git add .changeset/*.md
+          git commit -m "chore: regenerate provider registry [skip ci]"
+          git push
+
+      - name: Log summary
+        if: steps.git-check.outputs.changed == 'true'
+        run: echo "✅ Provider registry updated with changeset and committed to main"
+
+      - name: Log no changes
+        if: steps.git-check.outputs.changed != 'true'
+        run: echo "ℹ️ No changes detected in provider registry"

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Create changeset
         if: steps.git-check.outputs.changed == 'true'
         run: |
-          # Generate a unique changeset filename
-          CHANGESET_ID="automated-provider-registry-$(date +%Y%m%d)"
+          # Generate a unique changeset filename with timestamp
+          CHANGESET_ID="automated-provider-registry-$(date +%Y%m%d-%H%M%S)"
           CHANGESET_FILE=".changeset/${CHANGESET_ID}.md"
           
           # Create changeset for @mastra/core with patch bump
@@ -73,6 +73,7 @@ jobs:
           EOF
           
           echo "Created changeset: ${CHANGESET_FILE}"
+          echo "CHANGESET_FILE=${CHANGESET_FILE}" >> $GITHUB_ENV
 
       - name: Commit and push changes
         if: steps.git-check.outputs.changed == 'true'
@@ -81,7 +82,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git add packages/core/src/llm/model/provider-registry.json
           git add packages/core/src/llm/model/provider-types.generated.d.ts
-          git add .changeset/*.md
+          git add "${CHANGESET_FILE}"
           git commit -m "chore: regenerate provider registry [skip ci]"
           git push
 

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -4,9 +4,9 @@ permissions:
   contents: write
 
 on:
-  # Run daily to keep provider registry up-to-date
+  # Run every 6 hours to keep provider registry up-to-date
   schedule:
-    - cron: '0 0 * * *' # Daily at midnight UTC
+    - cron: '0 */6 * * *' # Every 6 hours
   # Allow manual triggering for testing
   workflow_dispatch:
 

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -4,6 +4,7 @@
  */
 
 import fs from 'fs/promises';
+import path from 'path';
 import type { MastraModelGateway, ProviderConfig } from './gateways/base.js';
 
 /**
@@ -139,6 +140,12 @@ export async function writeRegistryFiles(
   providers: Record<string, ProviderConfig>,
   models: Record<string, string[]>,
 ): Promise<void> {
+  // 0. Ensure directories exist
+  const jsonDir = path.dirname(jsonPath);
+  const typesDir = path.dirname(typesPath);
+  await fs.mkdir(jsonDir, { recursive: true });
+  await fs.mkdir(typesDir, { recursive: true });
+
   // 1. Write JSON file
   const registryData = {
     providers,


### PR DESCRIPTION
Adds a scheduled workflow that automatically regenerates the provider registry every 6 hours, keeping the model/provider data fresh without manual intervention.

The workflow fetches the latest data from models.dev and Netlify, generates the registry files, formats them with Prettier, and commits directly to main when changes are detected. It also creates a changeset for @mastra/core to trigger a patch version bump.

This works alongside the existing runtime auto-refresh system - the GitHub Action keeps the repo source files up-to-date while the runtime system keeps local dev environments fresh between git pulls.

Can be manually triggered from the Actions tab for testing.