### PR TITLE
fix: shorten tool failure logs

### DIFF
--- a/.changeset/full-taxes-taste.md
+++ b/.changeset/full-taxes-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed logging of massive model objects in tool failures

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -112,7 +112,12 @@ export class CoreToolBuilder extends MastraBase {
 
   private createExecute(tool: ToolToConvert, options: ToolOptions, logType?: 'tool' | 'toolset' | 'client-tool') {
     // dont't add memory or mastra to logging
-    const { logger, mastra: _mastra, memory: _memory, runtimeContext, ...rest } = options;
+    const { logger, mastra: _mastra, memory: _memory, runtimeContext, model, ...rest } = options;
+    const logModelObject = {
+      modelId: model?.modelId,
+      provider: model?.provider,
+      specificationVersion: model?.specificationVersion,
+    };
 
     const { start, error } = this.createLogMessageOptions({
       agentName: options.agentName,
@@ -197,7 +202,7 @@ export class CoreToolBuilder extends MastraBase {
     return async (args: unknown, execOptions?: ToolInvocationOptions) => {
       let logger = options.logger || this.logger;
       try {
-        logger.debug(start, { ...rest, args });
+        logger.debug(start, { ...rest, model: logModelObject, args });
 
         // Validate input parameters if schema exists
         const parameters = this.getParameters();
@@ -233,13 +238,13 @@ export class CoreToolBuilder extends MastraBase {
             details: {
               errorMessage: String(error),
               argsJson: JSON.stringify(args),
-              model: rest.model?.modelId ?? '',
+              model: model?.modelId ?? '',
             },
           },
           err,
         );
         logger.trackException(mastraError);
-        logger.error(error, { ...rest, error: mastraError, args });
+        logger.error(error, { ...rest, model: logModelObject, error: mastraError, args });
         return mastraError;
       }
     };


### PR DESCRIPTION
before:
<img width="1184" height="1744" alt="Screenshot 2025-10-14 at 3 49 33 PM" src="https://github.com/user-attachments/assets/ef93eace-9d67-4895-b62b-b0e4bf2d492e" />
+1000 more lines