### PR TITLE
fix(core): prevent duplicate deprecation warning logs and deprecate `modelSettings.abortSignal` in favor of top-level `abortSignal`

### DIFF
--- a/.changeset/fruity-laws-retire.md
+++ b/.changeset/fruity-laws-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+prevent duplicate deprecation warning logs and deprecate modelSettings.abortSignal in favor of top-level abortSignal

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -97,7 +97,6 @@ export type AgentExecutionOptions<
   activeTools?: LoopConfig['activeTools'];
   /**
    * Signal to abort the streaming operation
-   * @deprecated Use `modelSettings.abortSignal` instead. This top-level option will be removed in a future version.
    */
   abortSignal?: LoopConfig['abortSignal'];
 


### PR DESCRIPTION


## Description
- Add @deprecated JSDoc to modelSettings.abortSignal in type definition
- Remove @deprecated from top-level abortSignal in agent types
- Update fallback logic to prefer options.abortSignal over modelSettings.abortSignal
- Add runtime deprecation warning that logs only once

This aligns with the design decision that abortSignal should be at the top level since it controls the entire execution loop, not just model settings.
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
