### PR TITLE
ci: use npx for tsx in generate:providers script

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -182,7 +182,7 @@
     "pre-build": "tsup --silent --config tsup.config.ts --no-dts",
     "build": "node ./tools/commonjs-tsc-fixer.js",
     "build:watch": "pnpm build --watch",
-    "generate:providers": "tsx scripts/generate-providers.ts",
+    "generate:providers": "pnpx tsx scripts/generate-providers.ts",
     "test:unit": "vitest run --exclude '**/tool-builder/**'",
     "test:types:zod": "node test-zod-compat.mjs",
     "test": "npm run test:types:zod && npm run test:unit"


### PR DESCRIPTION
The model router regen GitHub Action was failing because `tsx` wasn't available when running `pnpm --filter @mastra/core generate:providers`. https://github.com/mastra-ai/mastra/actions/runs/18538080810/job/52838300329

Changed the script from `tsx scripts/generate-providers.ts` to `pnpx tsx scripts/generate-providers.ts`