### PR TITLE
fix: use pnpm prettier in regenerate workflow

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: Format generated files with Prettier
         run: |
-          prettier --write packages/core/src/llm/model/provider-registry.json
-          prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
+          pnpm prettier --write packages/core/src/llm/model/provider-registry.json
+          pnpm prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
 
       - name: Check for changes
         id: git-check

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -10,6 +10,10 @@ on:
   # Allow manual triggering for testing
   workflow_dispatch:
 
+concurrency:
+  group: regenerate-provider-registry
+  cancel-in-progress: false
+
 jobs:
   regenerate:
     # Only run on the main repository, not on forks

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: main
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -112,6 +112,7 @@ jobs:
           git add packages/core/src/llm/model/provider-types.generated.d.ts
           git add "${CHANGESET_FILE}"
           git commit -m "chore: regenerate provider registry [skip ci]"
+          git pull --rebase
           git push
 
       - name: Log summary

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -15,6 +15,8 @@ jobs:
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
 
     steps:
       - name: Get Github App Token


### PR DESCRIPTION
The workflow was failing with `prettier: not found` when trying to format the generated files.

Changed from `prettier --write` to `pnpm prettier --write` to match the pattern used in the root package.json scripts (e.g., `prettier:format` uses `prettier --write` but is run via pnpm).

This ensures prettier is available from the workspace dependencies.