### PR TITLE
docs: update structuredOutput related docs

### DIFF
--- a/docs/src/content/en/docs/agents/networks.mdx
+++ b/docs/src/content/en/docs/agents/networks.mdx
@@ -65,7 +65,6 @@ const agentStep1 = createStep({
           text: z.string(),
         })
       },
-      maxSteps: 1
     });
 
     return { text: resp.object.text };
@@ -88,7 +87,6 @@ const agentStep2 = createStep({
           text: z.string(),
         })
       },
-      maxSteps: 1
     });
 
     return { text: resp.object.text };

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -251,12 +251,78 @@ const response = await testAgent.generate(
         keywords: z.array(z.string())
       })
     },
-    maxSteps: 1
   }
 );
 
 console.log(response.object);
 ```
+
+### With Tool Calling
+
+Use the `model` property to ensure that your agent can execute multi-step LLM calls with tool calling.
+
+```typescript showLineNumbers copy
+import { z } from "zod";
+
+const response = await testAgentWithTools.generate(
+  [
+    {
+      role: "system",
+      content: "Provide a summary and keywords for the following text:"
+    },
+    {
+      role: "user",
+      content: "Please use your test tool and let me know the results"
+    }
+  ],
+  {
+    structuredOutput: {
+      schema: z.object({
+        summary: z.string(),
+        keywords: z.array(z.string())
+      }),
+      model: "openai/gpt-4o"
+    },
+  }
+);
+
+console.log(response.object);
+console.log(response.toolResults)
+```
+
+### Response format
+
+By default `structuredOutput` will use `response_format` to pass the schema to the model provider. If the model provider does not natively support `response_format` it's possible that this will error or not give the desired results. To keep using the same model use `jsonPromptInjection` to bypass response format and inject a system prompt message to coerce the model to return structured output.
+
+```typescript showLineNumbers copy
+import { z } from "zod";
+
+const response = await testAgentThatDoesntSupportStructuredOutput.generate(
+  [
+    {
+      role: "system",
+      content: "Provide a summary and keywords for the following text:"
+    },
+    {
+      role: "user",
+      content: "Monkey, Ice Cream, Boat"
+    }
+  ],
+  {
+    structuredOutput: {
+      schema: z.object({
+        summary: z.string(),
+        keywords: z.array(z.string())
+      }),
+      jsonPromptInjection: true
+    },
+  }
+);
+
+console.log(response.object);
+```
+
+
 ## Working with images
 
 Agents can analyze and describe images by processing both the visual content and any text within them. To enable image analysis, pass an object with `type: 'image'` and the image URL in the `content` array. You can combine image content with text prompts to guide the agent's analysis.

--- a/docs/src/content/en/examples/evals/custom-llm-judge-eval.mdx
+++ b/docs/src/content/en/examples/evals/custom-llm-judge-eval.mdx
@@ -73,7 +73,6 @@ class WorldCountryJudge extends MastraAgentJudge {
           })
         })
       },
-      maxSteps: 1
     });
 
     return result.object;

--- a/docs/src/content/en/examples/workflows/human-in-the-loop-multi-turn.mdx
+++ b/docs/src/content/en/examples/workflows/human-in-the-loop-multi-turn.mdx
@@ -185,7 +185,6 @@ const gameStep = createStep({
             gameWon: z.boolean(),
           })
         },
-        maxSteps: 1
       },
     );
 

--- a/docs/src/content/en/guides/guide/ai-recruiter.mdx
+++ b/docs/src/content/en/guides/guide/ai-recruiter.mdx
@@ -89,7 +89,6 @@ const gatherCandidateInfo = createStep({
           resumeText: z.string(),
         })
       },
-      maxSteps: 1
     });
 
     return res.object;

--- a/docs/src/content/en/guides/guide/chef-michel.mdx
+++ b/docs/src/content/en/guides/guide/chef-michel.mdx
@@ -172,7 +172,6 @@ async function main() {
       structuredOutput: {
         schema
       },
-      maxSteps: 1
     },
   );
   console.log("\n👨‍🍳 Chef Michel:", response.object);

--- a/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
+++ b/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
@@ -144,7 +144,7 @@ const result = await agent.stream(messages, {
 ```
 
 - `structuredOutput` - Enhanced structured output with model override and custom options.
-  - `jsonPromptInjection` - Used to override the default behaviour of pass response_format to the model. This will inject context into the prompt to coerce the model into returning structured outputs.
+  - `jsonPromptInjection` - Used to override the default behaviour of passing response_format to the model. This will inject context into the prompt to coerce the model into returning structured outputs.
   - `model` - If a model is added this will create a sub agent to structure the response from the main agent. The main agent will call tools and return text, and the sub agent will return an object that conforms to your schema provided. This is a replacement for `experimental_output`.
   - `errorStrategy` - Determines what happens when the output doesn’t match the schema:
       - warn' - log a warning

--- a/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
+++ b/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
@@ -294,8 +294,8 @@ const result = await agent.generate(messages, {
   structuredOutput: {
     schema: z.object({
       summary: z.string(),
-      model: "openai/gpt-4o"
-    })
+    }),
+    model: "openai/gpt-4o"
   }
 });
 ```

--- a/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
+++ b/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
@@ -147,7 +147,7 @@ const result = await agent.stream(messages, {
   - `jsonPromptInjection` - Used to override the default behaviour of passing response_format to the model. This will inject context into the prompt to coerce the model into returning structured outputs.
   - `model` - If a model is added this will create a sub agent to structure the response from the main agent. The main agent will call tools and return text, and the sub agent will return an object that conforms to your schema provided. This is a replacement for `experimental_output`.
   - `errorStrategy` - Determines what happens when the output doesn’t match the schema:
-      - warn' - log a warning
+      - 'warn' - log a warning
       - 'error' - throw an error
       - 'fallback' - return a fallback value you provide
 

--- a/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
+++ b/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
@@ -302,7 +302,7 @@ const result = await agent.generate(messages, {
 
 - `output`
 
-The `output` property is deprecated in favor of `structuredOutput`, to achieve the same results, omit the model and only pass `structuredOutput.schema`, optionally add `jsonPromptInjection: true` if you model does not natively support `response_format`.
+The `output` property is deprecated in favor of `structuredOutput`, to achieve the same results, omit the model and only pass `structuredOutput.schema`, optionally add `jsonPromptInjection: true` if your model does not natively support `response_format`.
 
 ```typescript showLineNumbers copy
 const result = await agent.generate(messages, {

--- a/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
+++ b/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
@@ -144,8 +144,9 @@ const result = await agent.stream(messages, {
 ```
 
 - `structuredOutput` - Enhanced structured output with model override and custom options.
-  - `model` - If no model is added it will use the agent's default model.
-  -  `errorStrategy` - Determines what happens when the output doesn’t match the schema:
+  - `jsonPromptInjection` - Used to override the default behaviour of pass response_format to the model. This will inject context into the prompt to coerce the model into returning structured outputs.
+  - `model` - If a model is added this will create a sub agent to structure the response from the main agent. The main agent will call tools and return text, and the sub agent will return an object that conforms to your schema provided. This is a replacement for `experimental_output`.
+  - `errorStrategy` - Determines what happens when the output doesn’t match the schema:
       - warn' - log a warning
       - 'error' - throw an error
       - 'fallback' - return a fallback value you provide
@@ -157,7 +158,7 @@ const result = await agent.generate(messages, {
       name: z.string(),
       age: z.number()
     }),
-    model: openai('gpt-4o-mini'), // Optional model override for structuring
+    model: "openai/gpt-4o-mini", // Optional model override for structuring
     errorStrategy: 'fallback',
     fallbackValue: { name: 'unknown', age: 0 },
     instructions: 'Extract user information' // Override default structuring instructions
@@ -292,7 +293,8 @@ Use `structuredOutput` instead to allow for tool calls and an object return.
 const result = await agent.generate(messages, {
   structuredOutput: {
     schema: z.object({
-      summary: z.string()
+      summary: z.string(),
+      model: "openai/gpt-4o"
     })
   }
 });
@@ -300,7 +302,7 @@ const result = await agent.generate(messages, {
 
 - `output`
 
-The `output` property is deprecated in favor of `structuredOutput`, to achieve the same results use maxSteps 1 with `structuredOutput`.
+The `output` property is deprecated in favor of `structuredOutput`, to achieve the same results, omit the model and only pass `structuredOutput.schema`, optionally add `jsonPromptInjection: true` if you model does not natively support `response_format`.
 
 ```typescript showLineNumbers copy
 const result = await agent.generate(messages, {
@@ -311,7 +313,6 @@ const result = await agent.generate(messages, {
       })
     }
   },
-  maxSteps: 1
 });
 ```
 

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -37,7 +37,7 @@ const aiSdkResult = await agent.generate("message for agent", {
     },
     {
       name: "options",
-      type: "AgentExecutionOptions<Output, StructuredOutput, Format>",
+      type: "AgentExecutionOptions<Output, Format>",
       isOptional: true,
       description: "Optional configuration for the generation process.",
     },
@@ -163,7 +163,7 @@ const aiSdkResult = await agent.generate("message for agent", {
       name: "structuredOutput",
       type: "StructuredOutputOptions<S extends ZodTypeAny = ZodTypeAny>",
       isOptional: true,
-      description: "Enables structured output generation with better developer experience. Automatically creates and uses a StructuredOutputProcessor internally.",
+      description: "Options to fine tune your structured output generation.",
       properties: [
         {
           parameters: [{
@@ -178,7 +178,7 @@ const aiSdkResult = await agent.generate("message for agent", {
             name: "model",
             type: "MastraLanguageModel",
             isOptional: true,
-            description: "Language model to use for structured output generation. If not provided, uses the agent's default model."
+            description: "Language model to use for structured output generation. If provided, enables the agent to respond in multi step with tool calls, text, and structured output"
           }]
         },
         {
@@ -202,7 +202,15 @@ const aiSdkResult = await agent.generate("message for agent", {
             name: "instructions",
             type: "string",
             isOptional: true,
-            description: "Additional instructions for structured output generation."
+            description: "Additional instructions for the structured output model."
+          }]
+        },
+        {
+          parameters: [{
+            name: "jsonPromptInjection",
+            type: "boolean",
+            isOptional: true,
+            description: "Injects system prompt into the main agent instructing it to return structured output, useful for when a model does not natively support structured outputs."
           }]
         }
       ]
@@ -235,7 +243,7 @@ const aiSdkResult = await agent.generate("message for agent", {
       name: "output",
       type: "Zod schema | JsonSchema7",
       isOptional: true,
-      description: "**Deprecated.** Use structuredOutput with maxSteps:1 to achieve the same thing. Defines the expected structure of the output. Can be a JSON Schema object or a Zod schema.",
+      description: "**Deprecated.** Use structuredOutput without a model to achieve the same thing. Defines the expected structure of the output. Can be a JSON Schema object or a Zod schema.",
     },
     {
       name: "memory",

--- a/docs/src/content/en/reference/agents/getDefaultStreamOptions.mdx
+++ b/docs/src/content/en/reference/agents/getDefaultStreamOptions.mdx
@@ -33,7 +33,7 @@ await agent.getDefaultStreamOptions();
   content={[
     {
       name: "defaultOptions",
-      type: "AgentExecutionOptions<Output, StructuredOutput> | Promise<AgentExecutionOptions<Output, StructuredOutput>>",
+      type: "AgentExecutionOptions<Output> | Promise<AgentExecutionOptions<Output>>",
       description: "The default vNext streaming options configured for the agent, either as a direct object or a promise that resolves to the options.",
     },
   ]}

--- a/docs/src/content/en/reference/streaming/agents/MastraModelOutput.mdx
+++ b/docs/src/content/en/reference/streaming/agents/MastraModelOutput.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraModelOutput (Experimental) | Agents | Mastra Docs"
+title: "Reference: MastraModelOutput | Agents | Mastra Docs"
 description: "Complete reference for MastraModelOutput - the stream object returned by agent.stream() with streaming and promise-based access to model outputs."
 ---
 
@@ -225,7 +225,6 @@ const stream = await agent.stream("Generate user data", {
       email: z.string()
     })
   },
-  maxSteps: 1
 });
 
 // Stream partial objects

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -38,7 +38,7 @@ const aiSdkStream = await agent.stream("message for agent", {
     },
     {
       name: "options",
-      type: "AgentExecutionOptions<Output, StructuredOutput, Format>",
+      type: "AgentExecutionOptions<Output, Format>",
       isOptional: true,
       description: "Optional configuration for the streaming process.",
     },
@@ -164,14 +164,14 @@ const aiSdkStream = await agent.stream("message for agent", {
       name: "structuredOutput",
       type: "StructuredOutputOptions<S extends ZodTypeAny = ZodTypeAny>",
       isOptional: true,
-      description: "Enables structured output generation with better developer experience. Automatically creates and uses a StructuredOutputProcessor internally.",
+      description: "Options to fine tune your structured output generation.",
       properties: [
         {
           parameters: [{
             name: "schema",
             type: "z.ZodSchema<S>",
             isOptional: false,
-            description: "Zod schema to validate the output against."
+            description: "Zod schema defining the expected output structure."
           }]
         },
         {
@@ -179,7 +179,7 @@ const aiSdkStream = await agent.stream("message for agent", {
             name: "model",
             type: "MastraLanguageModel",
             isOptional: true,
-            description: "Model to use for the internal structuring agent. If not provided, falls back to the agent's model."
+            description: "Language model to use for structured output generation. If provided, enables the agent to respond in multi step with tool calls, text, and structured output"
           }]
         },
         {
@@ -187,7 +187,7 @@ const aiSdkStream = await agent.stream("message for agent", {
             name: "errorStrategy",
             type: "'strict' | 'warn' | 'fallback'",
             isOptional: true,
-            description: "Strategy when parsing or validation fails. Defaults to 'strict'."
+            description: "Strategy for handling schema validation errors. 'strict' throws errors, 'warn' logs warnings, 'fallback' uses fallback values."
           }]
         },
         {
@@ -195,7 +195,7 @@ const aiSdkStream = await agent.stream("message for agent", {
             name: "fallbackValue",
             type: "<S extends ZodTypeAny>",
             isOptional: true,
-            description: "Fallback value when errorStrategy is 'fallback'."
+            description: "Fallback value to use when schema validation fails and errorStrategy is 'fallback'."
           }]
         },
         {
@@ -203,7 +203,15 @@ const aiSdkStream = await agent.stream("message for agent", {
             name: "instructions",
             type: "string",
             isOptional: true,
-            description: "Custom instructions for the structuring agent."
+            description: "Additional instructions for the structured output model."
+          }]
+        },
+        {
+          parameters: [{
+            name: "jsonPromptInjection",
+            type: "boolean",
+            isOptional: true,
+            description: "Injects system prompt into the main agent instructing it to return structured output, useful for when a model does not natively support structured outputs."
           }]
         }
       ]
@@ -238,7 +246,7 @@ const aiSdkStream = await agent.stream("message for agent", {
       type: "Zod schema | JsonSchema7",
       isOptional: true,
       description:
-        "**Deprecated.** Use structuredOutput with maxSteps:1 to achieve the same thing. Defines the expected structure of the output. Can be a JSON Schema object or a Zod schema.",
+        "**Deprecated.** Use structuredOutput without a model to achieve the same thing. Defines the expected structure of the output. Can be a JSON Schema object or a Zod schema.",
     },
     {
       name: "memory",
@@ -673,12 +681,12 @@ await agent.stream("message for agent", {
       sentiment: z.enum(['positive', 'negative', 'neutral']),
       confidence: z.number(),
     }),
-    model: openai("gpt-4o-mini"),
+    model: "openai/gpt-4o-mini",
     errorStrategy: 'warn',
   },
   // Output processors for streaming response validation
   outputProcessors: [
-    new ModerationProcessor({ model: openai("gpt-4.1-nano") }),
+    new ModerationProcessor({ model: "openai/gpt-4.1-nano" }),
     new BatchPartsProcessor({ maxBatchSize: 3, maxWaitTime: 100 }),
   ],
 });


### PR DESCRIPTION
## Description

- remove `maxSteps: 1` as this isn't needed another to make it not use structuredOutput processor
- update places that mention structuredOutput for more clarity
- change provider model functions to model router strings in the files I touched.
- Added section in `agent overview -> structured outputs` for tool calling and response format.
