### PR TITLE
feat: add model documentation generation to workflow

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: Format generated files with Prettier
         run: |
-          prettier --write packages/core/src/llm/model/provider-registry.json
-          prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
+          pnpm prettier --write packages/core/src/llm/model/provider-registry.json
+          pnpm prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
 
       - name: Check for changes
         id: git-check

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -10,6 +10,10 @@ on:
   # Allow manual triggering for testing
   workflow_dispatch:
 
+concurrency:
+  group: regenerate-provider-registry
+  cancel-in-progress: false
+
 jobs:
   regenerate:
     # Only run on the main repository, not on forks

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: main
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -112,6 +112,7 @@ jobs:
           git add packages/core/src/llm/model/provider-types.generated.d.ts
           git add "${CHANGESET_FILE}"
           git commit -m "chore: regenerate provider registry [skip ci]"
+          git pull --rebase
           git push
 
       - name: Log summary

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -15,6 +15,8 @@ jobs:
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
 
     steps:
       - name: Get Github App Token

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -77,15 +77,19 @@ jobs:
       - name: Generate provider registry
         run: pnpm --filter @mastra/core generate:providers
 
+      - name: Generate model documentation
+        run: pnpx tsx packages/core/scripts/generate-model-docs.ts
+
       - name: Format generated files with Prettier
         run: |
           pnpm prettier --write packages/core/src/llm/model/provider-registry.json
           pnpm prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
+          pnpm prettier --write docs/src/content/en/models/**/*.{mdx,ts}
 
       - name: Check for changes
         id: git-check
         run: |
-          git diff --exit-code packages/core/src/llm/model/provider-registry.json packages/core/src/llm/model/provider-types.generated.d.ts || echo "changed=true" >> $GITHUB_OUTPUT
+          git diff --exit-code packages/core/src/llm/model/provider-registry.json packages/core/src/llm/model/provider-types.generated.d.ts docs/src/content/en/models/ || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Create changeset
         if: steps.git-check.outputs.changed == 'true'
@@ -100,7 +104,7 @@ jobs:
           '@mastra/core': patch
           ---
 
-          Update provider registry with latest models and providers
+          Update provider registry and model documentation with latest models and providers
           EOF
 
           echo "Created changeset: ${CHANGESET_FILE}"
@@ -111,15 +115,16 @@ jobs:
         run: |
           git add packages/core/src/llm/model/provider-registry.json
           git add packages/core/src/llm/model/provider-types.generated.d.ts
+          git add docs/src/content/en/models/
           git add "${CHANGESET_FILE}"
-          git commit -m "chore: regenerate provider registry [skip ci]"
+          git commit -m "chore: regenerate provider registry and model documentation [skip ci]"
           git pull --rebase
           git push
 
       - name: Log summary
         if: steps.git-check.outputs.changed == 'true'
-        run: echo "✅ Provider registry updated with changeset and committed to main"
+        run: echo "✅ Provider registry and model documentation updated with changeset and committed to main"
 
       - name: Log no changes
         if: steps.git-check.outputs.changed != 'true'
-        run: echo "ℹ️ No changes detected in provider registry"
+        run: echo "ℹ️ No changes detected in provider registry or model documentation"


### PR DESCRIPTION
## Summary

This PR adds model documentation generation to the scheduled GitHub Action that regenerates the provider registry.

## Changes

- **Added documentation generation step**: Runs `generate-model-docs.ts` after generating the provider registry
- **Updated Prettier formatting**: Now formats both registry files and generated documentation files
- **Updated git diff check**: Includes `docs/src/content/en/models/` directory
- **Updated commit messages**: Reflects that both registry and documentation are being updated
- **Updated changeset description**: Mentions both registry and documentation updates

## Testing

The workflow will now:
1. Generate provider registry (`provider-registry.json` and `provider-types.generated.d.ts`)
2. Generate model documentation (MDX and TypeScript files in `docs/src/content/en/models/`)
3. Format all generated files with Prettier
4. Check for changes in both locations
5. Create a changeset and commit if any changes are detected

## Related

This addresses the issue where the workflow was successfully updating the provider registry but not regenerating the corresponding documentation.