### PR TITLE
chore(repo): Update tests to not use --port

### DIFF
--- a/packages/agent-builder/integration-tests/src/template-integration.test.ts
+++ b/packages/agent-builder/integration-tests/src/template-integration.test.ts
@@ -171,12 +171,13 @@ describe('Template Workflow Integration Tests', () => {
     console.log('Starting Mastra server...');
 
     // Start the Mastra server
-    mastraServer = spawn('pnpm', ['dev', '--port', port.toString()], {
+    mastraServer = spawn('pnpm', ['dev'], {
       stdio: 'pipe',
       cwd: targetRepo,
       detached: true,
       env: {
         ...process.env,
+        PORT: port.toString(),
         MASTRA_TEST_PORT: port.toString(),
       },
     });

--- a/packages/mcp/integration-tests/src/server.test.ts
+++ b/packages/mcp/integration-tests/src/server.test.ts
@@ -16,15 +16,13 @@ describe('MCPServer through Mastra HTTP Integration (Subprocess)', () => {
   beforeAll(async () => {
     mastraServer = spawn(
       'pnpm',
-      [
-        path.resolve(import.meta.dirname, `..`, `..`, `..`, `cli`, `dist`, `index.js`),
-        'dev',
-        '--port',
-        port.toString(),
-      ],
+      [path.resolve(import.meta.dirname, `..`, `..`, `..`, `cli`, `dist`, `index.js`), 'dev'],
       {
         stdio: 'pipe',
         detached: true, // Run in a new process group so we can kill it and children
+        env: {
+          PORT: port.toString(),
+        },
       },
     );
 

--- a/packages/mcp/integration-tests/src/server.test.ts
+++ b/packages/mcp/integration-tests/src/server.test.ts
@@ -21,6 +21,7 @@ describe('MCPServer through Mastra HTTP Integration (Subprocess)', () => {
         stdio: 'pipe',
         detached: true, // Run in a new process group so we can kill it and children
         env: {
+          ...process.env,
           PORT: port.toString(),
         },
       },

--- a/packages/memory/integration-tests-v5/src/streaming-memory.test.ts
+++ b/packages/memory/integration-tests-v5/src/streaming-memory.test.ts
@@ -151,15 +151,13 @@ describe('Memory Streaming Tests', () => {
 
       mastraServer = spawn(
         'pnpm',
-        [
-          path.resolve(import.meta.dirname, `..`, `..`, `..`, `cli`, `dist`, `index.js`),
-          'dev',
-          '--port',
-          port.toString(),
-        ],
+        [path.resolve(import.meta.dirname, `..`, `..`, `..`, `cli`, `dist`, `index.js`), 'dev'],
         {
           stdio: 'pipe',
           detached: true, // Run in a new process group so we can kill it and children
+          env: {
+            PORT: port.toString(),
+          },
         },
       );
 

--- a/packages/memory/integration-tests-v5/src/streaming-memory.test.ts
+++ b/packages/memory/integration-tests-v5/src/streaming-memory.test.ts
@@ -156,6 +156,7 @@ describe('Memory Streaming Tests', () => {
           stdio: 'pipe',
           detached: true, // Run in a new process group so we can kill it and children
           env: {
+            ...process.env,
             PORT: port.toString(),
           },
         },

--- a/packages/memory/integration-tests/src/streaming-memory.test.ts
+++ b/packages/memory/integration-tests/src/streaming-memory.test.ts
@@ -144,15 +144,13 @@ describe('Memory Streaming Tests', () => {
 
       mastraServer = spawn(
         'pnpm',
-        [
-          path.resolve(import.meta.dirname, `..`, `..`, `..`, `cli`, `dist`, `index.js`),
-          'dev',
-          '--port',
-          port.toString(),
-        ],
+        [path.resolve(import.meta.dirname, `..`, `..`, `..`, `cli`, `dist`, `index.js`), 'dev'],
         {
           stdio: 'pipe',
           detached: true, // Run in a new process group so we can kill it and children
+          env: {
+            PORT: port.toString(),
+          },
         },
       );
 

--- a/packages/memory/integration-tests/src/streaming-memory.test.ts
+++ b/packages/memory/integration-tests/src/streaming-memory.test.ts
@@ -149,6 +149,7 @@ describe('Memory Streaming Tests', () => {
           stdio: 'pipe',
           detached: true, // Run in a new process group so we can kill it and children
           env: {
+            ...process.env,
             PORT: port.toString(),
           },
         },


### PR DESCRIPTION
## Description

In https://github.com/mastra-ai/mastra/pull/8798 I removed the `--port` CLI flag. This PR fixes some tests that weren't caught in that PR to not use `--port` anymore. Since we check the `PORT` env var we can just update the tests to set that instead.

## Related Issue(s)

https://github.com/mastra-ai/mastra/pull/8798

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [X] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
