### PR TITLE
chore(ci): Build packages again during "exit prerelease"

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -96,6 +96,7 @@ jobs:
           git push
           echo "executed=true" >> "$GITHUB_OUTPUT"
           pnpm install
+          pnpm build
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Description

https://app.unpkg.com/mastra@0.16.0/files/dist/index.js#L29 shows that the `0.16.0` source code of `mastra` contains

```js
// package.json
var package_default = {
  version: "0.16.0-alpha.1"};
```

In .github/workflows/create-release.yml we build the packages and then exit pre-release mode to bump the versions. But we don't currently rebuild again then, changing the `dist` output to update the `package.json` reference. This PR fixes this.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
