### PR TITLE
chore(ci): Fix regenerate-provider script

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: Format generated files with Prettier
         run: |
-          prettier --write packages/core/src/llm/model/provider-registry.json
-          prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
+          pnpm prettier --write packages/core/src/llm/model/provider-registry.json
+          pnpm prettier --write packages/core/src/llm/model/provider-types.generated.d.ts
 
       - name: Check for changes
         id: git-check


### PR DESCRIPTION
## Description

Action failed with `line 1: prettier: command not found`. A `pnpm` was missing for `pnpm prettier`

https://github.com/mastra-ai/mastra/actions/runs/18552051473/job/52881269418

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
