### PR TITLE
fix(core): add `strictJsonSchema` to openai `providerOptions` when using json response format

### DIFF
--- a/.changeset/purple-feet-know.md
+++ b/.changeset/purple-feet-know.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+When using OpenAI models with JSON response format, automatically enable strict schema validation.

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -110,6 +110,12 @@ export function execute<OUTPUT extends OutputSchema = undefined>({
     });
   }
 
+  /**
+   * Enable OpenAI's strict JSON schema mode to ensure schema compliance.
+   * Without this, OpenAI may omit required fields or violate type constraints.
+   * @see https://platform.openai.com/docs/guides/structured-outputs#structured-outputs-vs-json-mode
+   * @see https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data#accessing-reasoning
+   */
   const providerOptionsToUse =
     model.provider === 'openai' && responseFormat?.type === 'json' && !structuredOutput?.jsonPromptInjection
       ? {

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -109,6 +109,18 @@ export function execute<OUTPUT extends OutputSchema = undefined>({
       schema: responseFormat.schema,
     });
   }
+
+  const providerOptionsToUse =
+    model.provider === 'openai' && responseFormat?.type === 'json' && !structuredOutput?.jsonPromptInjection
+      ? {
+          ...(providerOptions ?? {}),
+          openai: {
+            strictJsonSchema: true,
+            ...(providerOptions?.openai ?? {}),
+          },
+        }
+      : providerOptions;
+
   const stream = v5.initialize({
     runId,
     onResult,
@@ -122,7 +134,7 @@ export function execute<OUTPUT extends OutputSchema = undefined>({
             const streamResult = await model.doStream({
               ...toolsAndToolChoice,
               prompt,
-              providerOptions,
+              providerOptions: providerOptionsToUse,
               abortSignal,
               includeRawChunks,
               responseFormat:

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -117,7 +117,7 @@ export function execute<OUTPUT extends OutputSchema = undefined>({
    * @see https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data#accessing-reasoning
    */
   const providerOptionsToUse =
-    model.provider === 'openai' && responseFormat?.type === 'json' && !structuredOutput?.jsonPromptInjection
+    model.provider.startsWith('openai') && responseFormat?.type === 'json' && !structuredOutput?.jsonPromptInjection
       ? {
           ...(providerOptions ?? {}),
           openai: {


### PR DESCRIPTION
## Description

When using OpenAI models with JSON response format, the provider does not automatically enable strict schema validation. This causes the LLM to sometimes not fully respect the provided JSON schema, resulting in issues like missing required fields or incorrect data types.

This PR adds  to the OpenAI provider options when:
- The model provider is OpenAI
- Response format is JSON

This ensures consistent, schema-compliant JSON responses from OpenAI models.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works