### PR TITLE
refactor(core): validate structured output at text-end instead of flush

### DIFF
--- a/packages/core/src/stream/base/output-format-handlers.test.ts
+++ b/packages/core/src/stream/base/output-format-handlers.test.ts
@@ -19,7 +19,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -93,7 +92,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -134,7 +132,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -177,7 +174,6 @@ describe('output-format-handlers', () => {
       );
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -218,7 +214,6 @@ describe('output-format-handlers', () => {
       const schema = z.enum(['red', 'green', 'blue']);
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -256,7 +251,6 @@ describe('output-format-handlers', () => {
       const schema = z.enum(['red', 'green', 'blue']);
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -304,7 +298,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -351,7 +344,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -393,7 +385,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -439,7 +430,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -483,7 +473,6 @@ describe('output-format-handlers', () => {
       const aiSdkSchema = asSchema(zodSchema);
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema: aiSdkSchema },
       });
 
@@ -529,7 +518,6 @@ describe('output-format-handlers', () => {
       };
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -573,7 +561,6 @@ describe('output-format-handlers', () => {
       };
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -616,7 +603,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -663,7 +649,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -706,7 +691,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -751,7 +735,6 @@ describe('output-format-handlers', () => {
       });
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: { schema },
       });
 
@@ -804,7 +787,6 @@ describe('output-format-handlers', () => {
       };
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: {
           schema,
           errorStrategy: 'warn',
@@ -863,7 +845,6 @@ describe('output-format-handlers', () => {
       const fallbackValue = { name: 'Default', age: 0 };
 
       const transformer = createObjectStreamTransformer({
-        isLLMExecutionStep: true,
         structuredOutput: {
           schema,
           errorStrategy: 'fallback',

--- a/packages/core/src/stream/base/output-format-handlers.test.ts
+++ b/packages/core/src/stream/base/output-format-handlers.test.ts
@@ -48,6 +48,12 @@ describe('output-format-handlers', () => {
           from: ChunkFrom.AGENT,
           payload: { id: '1', text: '"email":"invalid"}' },
         },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: '1' },
+        },
       ];
       // @ts-expect-error - web/stream readable stream type error
       const stream = convertArrayToReadableStream(streamParts).pipeThrough(transformer);
@@ -262,6 +268,12 @@ describe('output-format-handlers', () => {
           payload: { id: '1', text: '{"result":"yellow"}' },
         },
         {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: '1' },
+        },
+        {
           type: 'finish',
           runId: 'test-run',
           from: ChunkFrom.AGENT,
@@ -302,6 +314,12 @@ describe('output-format-handlers', () => {
           runId: 'test-run',
           from: ChunkFrom.AGENT,
           payload: { id: '1', text: '{"name":"Jo","age":-5}' },
+        },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: '1' },
         },
         {
           type: 'finish',
@@ -384,7 +402,13 @@ describe('output-format-handlers', () => {
           type: 'text-delta',
           runId: 'test-run',
           from: ChunkFrom.AGENT,
-          payload: { id: '1', text: '{"email":"notanemail","score":150}' },
+          payload: { id: '1', text: '{"name":"Jo","age":-5}' },
+        },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: '1' },
         },
         {
           type: 'finish',
@@ -739,6 +763,12 @@ describe('output-format-handlers', () => {
           payload: { id: '1', text: '{"name":"Jo","age":-5}' },
         },
         {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: '1' },
+        },
+        {
           type: 'finish',
           runId: 'test-run',
           from: ChunkFrom.AGENT,
@@ -788,6 +818,12 @@ describe('output-format-handlers', () => {
           runId: 'test-run',
           from: ChunkFrom.AGENT,
           payload: { id: '1', text: '{"name":"Jo","age":-5}' },
+        },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: '1' },
         },
         {
           type: 'finish',
@@ -841,6 +877,12 @@ describe('output-format-handlers', () => {
           runId: 'test-run',
           from: ChunkFrom.AGENT,
           payload: { id: '1', text: '{"name":"Jo","age":-5}' },
+        },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: '1' },
         },
         {
           type: 'finish',

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -515,7 +515,6 @@ export function createObjectStreamTransformer<OUTPUT extends OutputSchema = unde
 
   let accumulatedText = '';
   let previousObject: any = undefined;
-  let finishReason: string | undefined;
   let currentRunId: string | undefined;
   let objectResolved = false;
 
@@ -534,7 +533,6 @@ export function createObjectStreamTransformer<OUTPUT extends OutputSchema = unde
       }
 
       if (chunk.type === 'finish') {
-        finishReason = chunk.payload.stepResult.reason;
         controller.enqueue(chunk);
         return;
       }

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -523,11 +523,6 @@ export function createObjectStreamTransformer<OUTPUT extends OutputSchema = unde
         currentRunId = chunk.runId;
       }
 
-      if (chunk.type === 'finish') {
-        controller.enqueue(chunk);
-        return;
-      }
-
       if (chunk.type === 'text-delta' && typeof chunk.payload?.text === 'string') {
         accumulatedText += chunk.payload.text;
 

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -284,10 +284,9 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
 
     // Only apply object transformer in 'direct' mode (LLM generates JSON directly)
     // In 'processor' mode, the StructuredOutputProcessor handles object transformation
-    if (self.#structuredOutputMode === 'direct') {
+    if (self.#structuredOutputMode === 'direct' && self.#options.isLLMExecutionStep) {
       processedStream = processedStream.pipeThrough(
         createObjectStreamTransformer({
-          isLLMExecutionStep: self.#options.isLLMExecutionStep,
           structuredOutput: self.#options.structuredOutput,
           logger: self.logger,
         }),


### PR DESCRIPTION
## Description

Move structured output validation from `flush()` to `text-end` chunk handling to eliminate finishReason heuristics and improve architectural clarity.

**Key Changes:**
- Validate and emit `object-result` when `text-end` chunk arrives (instead of waiting for stream end)
- Emit `text-end` before `object-result` for correct semantic ordering
- Add `objectResolved` flag to prevent double-resolution in edge cases
- Keep `flush()` as safety net for providers that may skip `text-end`
- Update all unit tests to include `text-end` chunks

**Benefits:**
- Eliminates `finishReason: 'tool-calls'` special casing
- Validation happens at the correct point in stream lifecycle
- Object resolves when text generation completes (not at stream end)

## Related Issue(s)

Fixes issues with Bedrock and LMStudio structured output where `object: undefined` but valid JSON exists in `text` field.

Related to #8934

## Type of Change

- [x] Code refactoring
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works