### PR TITLE
fix(deployer): Transitive deps fixes

### DIFF
--- a/.changeset/lemon-eels-marry.md
+++ b/.changeset/lemon-eels-marry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix edge case bug around transitive dependencies in monorepos

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/index.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/index.ts
@@ -4,9 +4,10 @@ import { innerAgent } from '@/agents';
 import { testRoute } from '@/api/route/test';
 import { allRoute } from '@/api/route/all';
 import { streamingRoute } from '@/api/route/streaming';
+import { myAgent } from '@inner/hello-world/agent';
 
 export const mastra = new Mastra({
-  agents: { innerAgent },
+  agents: { innerAgent, myAgent },
   server: {
     port: process.env.MASTRA_PORT ? parseInt(process.env.MASTRA_PORT) : 3000,
     apiRoutes: [testRoute, allRoute, streamingRoute],

--- a/e2e-tests/monorepo/template/packages/hello-world/package.json
+++ b/e2e-tests/monorepo/template/packages/hello-world/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./agent": "./src/agent/index.ts"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -15,6 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mastra/core": "monorepo-test",
-    "round-to": "^6.0.0"
+    "round-to": "^6.0.0",
+    "tinyrainbow": "^3.0.3"
   }
 }

--- a/e2e-tests/monorepo/template/packages/hello-world/src/agent/index.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/agent/index.ts
@@ -1,0 +1,1 @@
+export * from './my-agent';

--- a/e2e-tests/monorepo/template/packages/hello-world/src/agent/my-agent.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/agent/my-agent.ts
@@ -1,0 +1,10 @@
+import { Agent } from '@mastra/core/agent';
+import { colorful } from '../shared/colorful';
+
+export const myAgent = new Agent({
+  instructions: async () => {
+    return colorful(`Hello`);
+  },
+  model: 'google/gemini-2.5-flash-lite',
+  name: 'My agent',
+});

--- a/e2e-tests/monorepo/template/packages/hello-world/src/agent/my-agent.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/agent/my-agent.ts
@@ -1,9 +1,10 @@
 import { Agent } from '@mastra/core/agent';
 import { colorful } from '../shared/colorful';
+import { bold } from '../shared/bold';
 
 export const myAgent = new Agent({
   instructions: async () => {
-    return colorful(`Hello`);
+    return bold(colorful(`Hello`));
   },
   model: 'google/gemini-2.5-flash-lite',
   name: 'My agent',

--- a/e2e-tests/monorepo/template/packages/hello-world/src/round.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/round.ts
@@ -1,5 +1,8 @@
 import { roundTo } from 'round-to';
+import { colorful } from './shared/colorful';
 
 export function roundToOneNumber(num: number): number {
+  console.debug(colorful('Rounding number:'), num);
+
   return roundTo(num, 0);
 }

--- a/e2e-tests/monorepo/template/packages/hello-world/src/shared/bold.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/shared/bold.ts
@@ -1,0 +1,3 @@
+import c from 'tinyrainbow';
+
+export const bold = (text: string) => c.bold(text);

--- a/e2e-tests/monorepo/template/packages/hello-world/src/shared/colorful.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/shared/colorful.ts
@@ -1,0 +1,3 @@
+import c from 'tinyrainbow';
+
+export const colorful = (text: string) => c.red(text);

--- a/e2e-tests/monorepo/template/packages/hello-world/src/tool.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/tool.ts
@@ -1,8 +1,9 @@
 import { createTool } from '@mastra/core/tools';
 import { HELLO_WORLD, TEST_PATH } from './constants';
+import { colorful } from './shared/colorful';
 
 export const helloWorldTool = createTool({
   id: 'hello-world',
   description: 'A tool that returns hello world',
-  execute: async () => HELLO_WORLD + ' from ' + TEST_PATH,
+  execute: async () => colorful(HELLO_WORLD + ' from ' + TEST_PATH),
 });

--- a/e2e-tests/monorepo/template/packages/hello-world/src/tool.ts
+++ b/e2e-tests/monorepo/template/packages/hello-world/src/tool.ts
@@ -1,9 +1,10 @@
 import { createTool } from '@mastra/core/tools';
 import { HELLO_WORLD, TEST_PATH } from './constants';
 import { colorful } from './shared/colorful';
+import { bold } from './shared/bold';
 
 export const helloWorldTool = createTool({
   id: 'hello-world',
   description: 'A tool that returns hello world',
-  execute: async () => colorful(HELLO_WORLD + ' from ' + TEST_PATH),
+  execute: async () => bold(colorful(HELLO_WORLD + ' from ' + TEST_PATH)),
 });

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -299,7 +299,47 @@ async function buildExternalDependencies(
      * Rollup creates chunks for common dependencies, but these chunks are by default written to the root directory instead of respecting the entryFileNames structure.
      * So we want to write them to the `.mastra/output` folder as well.
      */
-    chunkFileNames: `${outputDirRelative}/[name].mjs`,
+    chunkFileNames: chunkInfo => {
+      /**
+       * This whole bunch of logic directly below is for the edge case shown in the e2e-tests/monorepo with "tinyrainbow" package. It's used in multiple places in the package and as such Rollup creates a shared chunk for it. During 'mastra dev', we don't want that chunk to show up in the '.mastra/output' folder (outputDirRelative) but inside <pkg>/node_modules/.cache instead.
+       * We only care about this during 'mastra dev'!
+       */
+      if (bundlerOptions.isDev) {
+        const importedFromPackages = new Set<string>();
+
+        for (const moduleId of chunkInfo.moduleIds) {
+          const normalized = slash(moduleId);
+          for (const [pkgName, pkgInfo] of workspaceMap.entries()) {
+            const location = slash(pkgInfo.location);
+            if (normalized.startsWith(location)) {
+              importedFromPackages.add(pkgName);
+              break;
+            }
+          }
+        }
+
+        if (importedFromPackages.size > 1) {
+          throw new MastraBaseError({
+            id: 'DEPLOYER_BUNDLE_EXTERNALS_SHARED_CHUNK',
+            domain: ErrorDomain.DEPLOYER,
+            category: ErrorCategory.USER,
+            details: {
+              chunkName: chunkInfo.name,
+              packages: JSON.stringify(Array.from(importedFromPackages)),
+            },
+            text: `Please open an issue. We found a shared chunk "${chunkInfo.name}" used by multiple workspace packages: ${Array.from(importedFromPackages).join(', ')}.`,
+          });
+        }
+
+        if (importedFromPackages.size === 1) {
+          const [pkgName] = importedFromPackages;
+          const workspaceLocation = workspaceMap.get(pkgName!)!.location;
+          return prepareEntryFileName(getCompiledDepCachePath(workspaceLocation, '[name].mjs'), rootDir);
+        }
+      }
+
+      return `${outputDirRelative}/[name].mjs`;
+    },
     hoistTransitiveImports: false,
   });
 


### PR DESCRIPTION
## Description

- Fix Rollup chunk placement in dev mode for monorepo workspace packages by writing shared chunks to package-specific cache directories instead of the global
output folder
- Add validation to detect and reject invalid cross-package chunks with helpful error message

Changes:

- Convert chunkFileNames from static string to function that inspects chunk module origins
- Route workspace package chunks to <pkg>/node_modules/.cache during dev mode
- Throw error when a chunk spans multiple workspace packages (edge case requiring investigation)
- Fall back to default .mastra/output path for external dependencies

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/8218

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
