### PR TITLE
fix: pass writable stream through workflow resume path

### DIFF
--- a/.changeset/large-berries-jump.md
+++ b/.changeset/large-berries-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Forward the workflow’s writable stream into the resume execution path so resumed steps still have a writer and continue emitting workflow-step-output chunks.

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2412,6 +2412,7 @@ export class Run<
         runtimeContext: runtimeContextToUse,
         abortController: this.abortController,
         workflowAISpan,
+        writableStream: params.writableStream,
         outputOptions: params.outputOptions,
       })
       .then(result => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1172,6 +1172,7 @@ export class Workflow<
           step: resume.steps as any,
           runtimeContext,
           tracingContext,
+          writableStream: writer,
           outputOptions: { includeState: true },
         })
       : await run.start({


### PR DESCRIPTION
## Description

Forward the workflow’s writable stream into the resume execution path so resumed steps still have a writer and continue emitting workflow-step-output chunks.

## Related Issue(s)

#8956 
More info in Discord https://discord.com/channels/1309558646228779139/1428490649078071407

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
