### PR TITLE
fix: threads not refreshing correctly

### DIFF
--- a/.changeset/lazy-showers-rule.md
+++ b/.changeset/lazy-showers-rule.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Threads are not refreshing correctly after generate / stream / network

--- a/e2e-tests/kitchen-sink/tests/chat-mode.spec.ts
+++ b/e2e-tests/kitchen-sink/tests/chat-mode.spec.ts
@@ -25,12 +25,12 @@ test.describe('chat modes', () => {
       const threadNav = await page.getByTestId('thread-list');
 
       // Assert partial streaming chunks
-      await expect(threadContent.locator(`text=${expectedResult.slice(0, 20)}`)).toBeVisible({ timeout: 20000 });
-      await expect(threadContent.locator(`text=${expectedResult.slice(0, 100)}`)).toBeVisible({ timeout: 20000 });
-      await expect(threadContent.locator(`text=${expectedResult}`)).not.toBeVisible({ timeout: 20000 });
+      await expect(threadContent.getByText(expectedResult.slice(0, 20))).toBeVisible({ timeout: 20000 });
+      await expect(threadContent.getByText(expectedResult.slice(0, 100))).toBeVisible({ timeout: 20000 });
+      await expect(threadContent.getByText(expectedResult)).not.toBeVisible({ timeout: 20000 });
 
       // Asset streaming result
-      await expect(threadContent.locator(`text=${expectedResult}`)).toBeVisible({ timeout: 20000 });
+      await expect(threadContent.getByText(expectedResult)).toBeVisible({ timeout: 20000 });
 
       // Assert thread entry refreshing
       await expect(threadNav.getByRole('link', { name: expectedResult })).toBeVisible({ timeout: 20000 });

--- a/e2e-tests/kitchen-sink/tests/chat-mode.spec.ts
+++ b/e2e-tests/kitchen-sink/tests/chat-mode.spec.ts
@@ -21,19 +21,27 @@ test.describe('chat modes', () => {
       await page.locator('textarea').fill('Give me the Lorem Ipsum thing');
       await page.click('button:has-text("Send")');
 
-      const threadContent = await page.getByTestId('thread-wrapper');
-      const threadNav = await page.getByTestId('thread-list');
-
       // Assert partial streaming chunks
-      await expect(threadContent.getByText(expectedResult.slice(0, 20))).toBeVisible({ timeout: 20000 });
-      await expect(threadContent.getByText(expectedResult.slice(0, 100))).toBeVisible({ timeout: 20000 });
-      await expect(threadContent.getByText(expectedResult)).not.toBeVisible({ timeout: 20000 });
+      await expect(page.getByTestId('thread-wrapper').getByText(`I can help you get accurate`)).toBeVisible({
+        timeout: 20000,
+      });
+
+      await expect(
+        page
+          .getByTestId('thread-wrapper')
+          .getByText(`I can help you get accurate weather forecasts by providing real-time`),
+      ).toBeVisible({
+        timeout: 20000,
+      });
+      await expect(page.getByTestId('thread-wrapper').getByText(expectedResult)).not.toBeVisible({ timeout: 20000 });
 
       // Asset streaming result
-      await expect(threadContent.getByText(expectedResult)).toBeVisible({ timeout: 20000 });
+      await expect(page.getByTestId('thread-wrapper').getByText(expectedResult)).toBeVisible({ timeout: 20000 });
 
       // Assert thread entry refreshing
-      await expect(threadNav.getByRole('link', { name: expectedResult })).toBeVisible({ timeout: 20000 });
+      await expect(page.getByTestId('thread-list').getByRole('link', { name: expectedResult })).toBeVisible({
+        timeout: 20000,
+      });
     });
   });
 });

--- a/packages/playground-ui/src/components/assistant-ui/thread.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/thread.tsx
@@ -63,7 +63,9 @@ export const Thread = ({ agentName, agentId, hasMemory, hasModelList }: ThreadPr
 
 const ThreadWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
-    <ThreadPrimitive.Root className="grid grid-rows-[1fr_auto] h-full overflow-y-auto">{children}</ThreadPrimitive.Root>
+    <ThreadPrimitive.Root className="grid grid-rows-[1fr_auto] h-full overflow-y-auto" data-testid="thread-wrapper">
+      {children}
+    </ThreadPrimitive.Root>
   );
 };
 

--- a/packages/playground-ui/src/components/threads.tsx
+++ b/packages/playground-ui/src/components/threads.tsx
@@ -39,7 +39,7 @@ export interface ThreadListProps {
 }
 
 export const ThreadList = ({ children }: ThreadListProps) => {
-  return <ol>{children}</ol>;
+  return <ol data-testid="thread-list">{children}</ol>;
 };
 
 export interface ThreadItemProps {

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -255,6 +255,10 @@ export function MastraRuntimeProvider({
               ) {
                 refreshWorkingMemory?.();
               }
+
+              if (chunk.type === 'network-execution-event-step-finish') {
+                refreshThreadList?.();
+              }
             },
           });
         } else {
@@ -269,6 +273,8 @@ export function MastraRuntimeProvider({
               signal: controller.signal,
             });
 
+            await refreshThreadList?.();
+
             return;
           } else {
             await sendMessage({
@@ -279,6 +285,10 @@ export function MastraRuntimeProvider({
               threadId,
               modelSettings: modelSettingsArgs,
               onChunk: async chunk => {
+                if (chunk.type === 'finish') {
+                  await refreshThreadList?.();
+                }
+
                 if (
                   chunk.type === 'tool-result' &&
                   chunk.payload?.toolName === 'updateWorkingMemory' &&


### PR DESCRIPTION
## Description

Make sure that the thread list is refreshed when finishing a chat operation with an agent

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
