### PR TITLE
added resourceId and runId to workflow_run metadata in ai tracing

### DIFF
--- a/.changeset/public-turkeys-drum.md
+++ b/.changeset/public-turkeys-drum.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+added resourceId and runId to workflow_run metadata in ai tracing

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -803,8 +803,9 @@ describe('AI Tracing Integration Tests', () => {
       id2: 'tacos',
     };
 
+    const resourceId = 'test-resource-id';
     const workflow = mastra.getWorkflow('branchingWorkflow');
-    const run = await workflow.createRunAsync();
+    const run = await workflow.createRunAsync({ resourceId });
     const result = await run.start({ inputData: { value: 15 }, tracingOptions: { metadata: customMetadata } });
     expect(result.status).toBe('success');
     expect(result.traceId).toBeDefined();
@@ -818,6 +819,8 @@ describe('AI Tracing Integration Tests', () => {
 
     expect(workflowRunSpan?.traceId).toBe(result.traceId);
     expect(workflowRunSpan?.isRootSpan).toBe(true);
+    expect(workflowRunSpan?.metadata?.runId).toBeDefined();
+    expect(workflowRunSpan?.metadata?.resourceId).toBe(resourceId);
     expect(workflowRunSpan?.metadata?.id1).toBe(customMetadata.id1);
     expect(workflowRunSpan?.metadata?.id2).toBe(customMetadata.id2);
 
@@ -1109,8 +1112,9 @@ describe('AI Tracing Integration Tests', () => {
           agents: { testAgent },
         });
 
+        const resourceId = 'test-resource-id';
         const agent = mastra.getAgent('testAgent');
-        const result = await method(agent, 'Calculate 5 + 3');
+        const result = await method(agent, 'Calculate 5 + 3', { resourceId });
         expect(result.text).toBeDefined();
         expect(result.traceId).toBeDefined();
 
@@ -1131,6 +1135,8 @@ describe('AI Tracing Integration Tests', () => {
         const toolCallSpan = toolCallSpans[0];
 
         expect(agentRunSpan?.traceId).toBe(result.traceId);
+        expect(agentRunSpan?.metadata?.runId).toBeDefined();
+        expect(agentRunSpan?.metadata?.resourceId).toBe(resourceId);
 
         // verify span nesting
         expect(llmGenerationSpan?.parentSpanId).toEqual(agentRunSpan?.id);

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1604,6 +1604,10 @@ export class Run<
       attributes: {
         workflowId: this.workflowId,
       },
+      metadata: {
+        resourceId: this.resourceId,
+        runId: this.runId,
+      },
       tracingPolicy: this.tracingPolicy,
       tracingOptions,
       tracingContext,
@@ -2368,6 +2372,10 @@ export class Run<
       input: resumeDataToUse,
       attributes: {
         workflowId: this.workflowId,
+      },
+      metadata: {
+        resourceId: this.resourceId,
+        runId: this.runId,
       },
       tracingPolicy: this.tracingPolicy,
       tracingOptions: params.tracingOptions,


### PR DESCRIPTION
## Description

Adds `resourceId` and `runId` to `WORKFLOW_RUN` spans in ai-tracing.

Also adds tests to confirm both exist in Agent & Workflow executions.

## Related Issue(s)

fixes #8949

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
