### PR TITLE
feat: create empty @mastra/observability package

### DIFF
--- a/.changeset/gentle-trees-dream.md
+++ b/.changeset/gentle-trees-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Create new @mastra/observability package at version 0.0.1. This empty package serves as a placeholder for AI tracing and scorer code that will be migrated from other packages, allowing users to add it as a dependency before the code migration.

--- a/observability/mastra/eslint.config.js
+++ b/observability/mastra/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@mastra/observability",
+  "version": "0.0.1",
+  "description": "Core observability package for Mastra - includes AI tracing and scoring features",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@microsoft/api-extractor": "^7.52.8",
+    "@types/node": "^20.19.0",
+    "eslint": "^9.37.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4",
+    "@internal/types-builder": "workspace:*"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=0.18.1-0 <0.23.0-0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "observability/mastra"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  }
+}

--- a/observability/mastra/src/index.ts
+++ b/observability/mastra/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Mastra Observability Package
+ *
+ * Core observability package for Mastra applications.
+ * This package will include AI tracing and scoring features.
+ */
+
+// Placeholder for future exports
+export {};

--- a/observability/mastra/tsconfig.build.json
+++ b/observability/mastra/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/observability/mastra/tsconfig.json
+++ b/observability/mastra/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/observability/mastra/tsup.config.ts
+++ b/observability/mastra/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/observability/mastra/vitest.config.ts
+++ b/observability/mastra/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,36 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
 
+  observability/mastra:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@microsoft/api-extractor':
+        specifier: ^7.52.8
+        version: 7.53.1(@types/node@20.19.21)
+      '@types/node':
+        specifier: ^20.19.21
+        version: 20.19.21
+      eslint:
+        specifier: ^9.37.0
+        version: 9.37.0(jiti@2.6.0)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(@microsoft/api-extractor@7.53.1(@types/node@20.19.21))(jiti@2.6.0)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.21)(@vitest/ui@3.2.4)(jiti@2.6.0)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(lightningcss@1.30.1)(msw@2.11.3(@types/node@20.19.21)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
+
   observability/otel-exporter:
     dependencies:
       '@opentelemetry/api':
@@ -20983,7 +21013,6 @@ snapshots:
       '@rushstack/node-core-library': 5.17.0(@types/node@20.19.21)
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.52.8(@types/node@20.19.21)':
     dependencies:
@@ -21020,7 +21049,6 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/tsdoc-config@0.17.1':
     dependencies:
@@ -23636,12 +23664,10 @@ snapshots:
       semver: 7.5.4
     optionalDependencies:
       '@types/node': 20.19.21
-    optional: true
 
   '@rushstack/problem-matcher@0.1.1(@types/node@20.19.21)':
     optionalDependencies:
       '@types/node': 20.19.21
-    optional: true
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
@@ -23652,7 +23678,6 @@ snapshots:
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
-    optional: true
 
   '@rushstack/terminal@0.15.3(@types/node@20.19.21)':
     dependencies:
@@ -23668,7 +23693,6 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.19.21
-    optional: true
 
   '@rushstack/ts-command-line@5.0.1(@types/node@20.19.21)':
     dependencies:
@@ -23687,7 +23711,6 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
 


### PR DESCRIPTION
## Description

Create new @mastra/observability package in observability/mastra folder with version 0.0.1. This empty package will serve as a placeholder for AI tracing and scorer code to be migrated from other packages.

We will add this package to `create-mastra` and also tell known customers using observability features to add it to their dependency list. Then we can start to migrate code without effecting their setups.

- Set up package structure following existing observability packages
- Configured build, test, and lint scripts
- Ready for users to add as dependency before code migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
