### PR TITLE
fix(deployer): Improve error message w/ binary dep

### DIFF
--- a/.changeset/small-bees-heal.md
+++ b/.changeset/small-bees-heal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Improve error related to finding possible binary dependencies

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -227,7 +227,7 @@ async function getInputPlugins(
             },
             text: `We found a possible binary dependency in your bundle. ${id} was not found when imported at ${importer}.
             
-Please consider adding \`${packageName}\` to your externals, or updating this import.
+Please consider adding \`${packageName}\` to your externals, or updating this import to not end with ".node".
   
 export const mastra = new Mastra({
   bundler: {

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -225,7 +225,9 @@ async function getInputPlugins(
               importFile: importer,
               packageName,
             },
-            text: `We found a binary dependency in your bundle. Please add \`${packageName}\` to your externals.
+            text: `We found a possible binary dependency in your bundle. ${id} was not found when imported at ${importer}.
+            
+Please consider adding \`${packageName}\` to your externals, or updating this import.
   
 export const mastra = new Mastra({
   bundler: {


### PR DESCRIPTION
This is particularly useful for workspace dependencies ending with `.node` where the current error is a bit misleading.

## Description
I hit an interesting issue this morning, I have a workspace import like this:
`import { serverSideOnlyDbUtility } from "@our-monorepo/internalUtils/dbActions.node";

We use the `.node` convention alongside webpack in a next.js app to prevent accidental import of server-side code in any webapps.

This inadvertently triggered the `!id.endsWith('.node')` [here](https://github.com/mastra-ai/mastra/blob/959c6e9896e5edcfd99d03c1661baadb84a4842b/packages/deployer/src/build/analyze/bundleExternals.ts#L214), resulting in a rather misleading message:

```
We found a binary dependency in your bundle. Please add `@our-monorepo/anotherPackage` to your externals.
  
export const mastra = new Mastra({
  bundler: {
    externals: ["@our-monorepo/anotherPackage"],
  }
})
```

Once I ran `mastra dev` in a debugger I could immediately see what was going on, and adjust the import statement above to not have `.node` in it. I didn't want to propose a change to the actual bundler behavior.

## Related Issue(s)

#6852

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [NA] I have made corresponding changes to the documentation (if applicable)
- [NA] I have added tests that prove my fix is effective or that my feature works
