### PR TITLE
fix(cli): Get init working again

### DIFF
--- a/.changeset/famous-swans-wish.md
+++ b/.changeset/famous-swans-wish.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix a bug where `mastra init` didn't work correctly when core dependencies were missing in the project

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -20,8 +20,7 @@ interface InitArgs {
 export const initProject = async (args: InitArgs) => {
   await analytics.trackCommandExecution({
     command: 'init',
-    // @ts-expect-error: TODO - Fix this
-    args,
+    args: { ...args },
     execution: async () => {
       await checkForPkgJson();
       await checkAndInstallCoreDeps(Boolean(args?.example || args?.default));
@@ -48,10 +47,9 @@ export const initProject = async (args: InitArgs) => {
         return;
       }
 
-      const componentsArr = args.components ? args.components : [];
       await init({
         directory: args.dir,
-        components: componentsArr,
+        components: args.components ? args.components : [],
         llmProvider: args.llm,
         addExample: args.example,
         llmApiKey: args.llmApiKey,

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -5,7 +5,6 @@ import { FileService } from '../../services/service.file';
 import { BuildBundler } from './BuildBundler';
 import { getDeployer } from '@mastra/deployer';
 import { createLogger } from '../../utils/logger';
-import { MastraError } from '@mastra/core/error';
 
 export async function build({
   dir,
@@ -64,11 +63,18 @@ export async function build({
     });
     logger.info('You can now deploy the .mastra/output directory to your target platform.');
   } catch (error) {
-    if (error instanceof MastraError) {
-      const { message, ...details } = error.toJSONDetails();
-      logger.error(`${message}`, details);
-    } else if (error instanceof Error) {
-      logger.error(`Mastra Build failed`, { error });
+    try {
+      const { MastraError } = await import('@mastra/core/error');
+      if (error instanceof MastraError) {
+        const { message, ...details } = error.toJSONDetails();
+        logger.error(`${message}`, details);
+      } else if (error instanceof Error) {
+        logger.error(`Mastra Build failed`, { error });
+      }
+    } catch {
+      if (error instanceof Error) {
+        logger.error(`Mastra Build failed`, { error });
+      }
     }
     process.exit(1);
   }

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -401,55 +401,42 @@ export const checkInitialization = async (dirPath: string) => {
 };
 
 export const checkAndInstallCoreDeps = async (addExample: boolean) => {
-  const depService = new DepsService();
-  const needsCore = (await depService.checkDependencies(['@mastra/core'])) !== `ok`;
-  const needsZod = (await depService.checkDependencies(['zod'])) !== `ok`;
+  const spinner = yoctoSpinner({ text: 'Installing Mastra core dependencies' });
+  let packages: Array<{ name: string; version: string }> = [];
 
-  if (needsCore) {
-    await installCoreDeps('@mastra/core');
-  }
-
-  if (needsZod) {
-    await installCoreDeps('zod', '^4');
-  }
-
-  if (addExample) {
-    const needsLibsql = (await depService.checkDependencies(['@mastra/libsql'])) !== `ok`;
-
-    if (needsLibsql) {
-      await installCoreDeps('@mastra/libsql');
-    }
-  }
-};
-
-const spinner = yoctoSpinner({ text: 'Installing Mastra core dependencies\n' });
-export async function installCoreDeps(pkg: string, version = 'latest') {
   try {
-    const confirm = await p.confirm({
-      message: `You do not have the ${pkg} package installed. Would you like to install it?`,
-      initialValue: false,
-    });
-
-    if (p.isCancel(confirm)) {
-      p.cancel('Installation Cancelled');
-      process.exit(0);
-    }
-
-    if (!confirm) {
-      p.cancel('Installation Cancelled');
-      process.exit(0);
-    }
+    const depService = new DepsService();
 
     spinner.start();
 
-    const depsService = new DepsService();
+    const needsCore = (await depService.checkDependencies(['@mastra/core'])) !== `ok`;
+    const needsZod = (await depService.checkDependencies(['zod'])) !== `ok`;
 
-    await depsService.installPackages([`${pkg}@${version}`]);
-    spinner.success(`${pkg} installed successfully`);
+    if (needsCore) {
+      packages.push({ name: '@mastra/core', version: 'latest' });
+    }
+
+    if (needsZod) {
+      packages.push({ name: 'zod', version: '^4' });
+    }
+
+    if (addExample) {
+      const needsLibsql = (await depService.checkDependencies(['@mastra/libsql'])) !== `ok`;
+
+      if (needsLibsql) {
+        packages.push({ name: '@mastra/libsql', version: 'latest' });
+      }
+    }
+
+    if (packages.length > 0) {
+      await depService.installPackages(packages.map(pkg => `${pkg.name}@${pkg.version}`));
+    }
+
+    spinner.success('Successfully installed Mastra core dependencies');
   } catch (err) {
-    console.error(err);
+    spinner.error(`Failed to install core dependencies: ${err instanceof Error ? err.message : 'Unknown error'}`);
   }
-}
+};
 
 export const getAPIKey = async (provider: LLMProvider) => {
   let key = 'OPENAI_API_KEY';


### PR DESCRIPTION
## Description

The `mastra init` CLI had two problems:

- Import from `@mastra/core` which is a peer-dep and not installed during `npx` run
  - Error then: `Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@mastra/core' imported from /Users/lejoe/.npm/_npx/6d834dabfb7dcda4/node_modules/mastra/dist/index.js`
- Asked for confirmation to install core deps that we know are required. Just install them without asking

## Related Issue(s)

Fixes #7729

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
