### PR TITLE
feat(observability): Add parent span context to MastraSpan

### DIFF
--- a/.changeset/kind-falcons-allow.md
+++ b/.changeset/kind-falcons-allow.md
@@ -1,0 +1,6 @@
+---
+'@mastra/otel-exporter': patch
+'@mastra/arize': patch
+---
+
+fix(observability): Add ParentSpanContext to MastraSpan's with parentage

--- a/observability/otel-exporter/src/mastra-span.ts
+++ b/observability/otel-exporter/src/mastra-span.ts
@@ -16,6 +16,7 @@ export class MastraReadableSpan implements ReadableSpan {
   readonly name: string;
   readonly kind: SpanKind;
   readonly spanContext: () => SpanContext;
+  readonly parentSpanContext?: SpanContext;
   readonly parentSpanId?: string;
   readonly startTime: [number, number];
   readonly endTime: [number, number];
@@ -103,6 +104,16 @@ export class MastraReadableSpan implements ReadableSpan {
       traceFlags: TraceFlags.SAMPLED,
       isRemote: false,
     });
+
+    // Set parent span context if parent span ID is provided
+    if (parentSpanId) {
+      this.parentSpanContext = {
+        traceId: aiSpan.traceId,
+        spanId: parentSpanId,
+        traceFlags: TraceFlags.SAMPLED,
+        isRemote: false,
+      };
+    }
 
     // Set resource and instrumentation library
     this.resource = resource || ({} as Resource);


### PR DESCRIPTION
## Description

When a MastraSpan is instantiated with a parent span id, also create a ParentSpanContext.

This allows for trace UIs to construct a tree of trace spans using parent hierarchy, with semantic attribute access via `parentId`.

This is what a trace tree looks like in a third party collector UI with parent span context added and no further changes needed.
 
<img width="1238" height="1510" alt="image (7)" src="https://github.com/user-attachments/assets/8972de10-0db4-49f1-a633-9308539e07b3" />

Prior to this change, the tree would be completely flat.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
