### PR TITLE
fix(braintrust,langsmith,langfuse): Bad core import

### DIFF
--- a/.changeset/small-rules-hide.md
+++ b/.changeset/small-rules-hide.md
@@ -1,0 +1,7 @@
+---
+'@mastra/braintrust': patch
+'@mastra/langsmith': patch
+'@mastra/langfuse': patch
+---
+
+Fix a `ERR_MODULE_NOT_FOUND` error that was caused by a bad import to `@mastra/core/dist/ai-tracing/exporters/index.js`

--- a/observability/braintrust/src/ai-tracing.ts
+++ b/observability/braintrust/src/ai-tracing.ts
@@ -6,10 +6,13 @@
  * Events are handled as zero-duration spans with matching start/end times.
  */
 
-import type { AITracingEvent, AnyExportedAISpan, LLMGenerationAttributes } from '@mastra/core/ai-tracing';
-import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
-import { BaseExporter } from '@mastra/core/ai-tracing/exporters';
-import type { BaseExporterConfig } from '@mastra/core/ai-tracing/exporters';
+import { AISpanType, omitKeys, BaseExporter } from '@mastra/core/ai-tracing';
+import type {
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+  BaseExporterConfig,
+} from '@mastra/core/ai-tracing';
 import { initLogger } from 'braintrust';
 import type { Span, Logger } from 'braintrust';
 import { normalizeUsageMetrics } from './metrics';

--- a/observability/langfuse/src/ai-tracing.ts
+++ b/observability/langfuse/src/ai-tracing.ts
@@ -12,10 +12,13 @@
  * - Adapts to v5 streaming protocol changes
  */
 
-import type { AITracingEvent, AnyExportedAISpan, LLMGenerationAttributes } from '@mastra/core/ai-tracing';
-import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
-import { BaseExporter } from '@mastra/core/ai-tracing/exporters';
-import type { BaseExporterConfig } from '@mastra/core/ai-tracing/exporters';
+import { AISpanType, omitKeys, BaseExporter } from '@mastra/core/ai-tracing';
+import type {
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+  BaseExporterConfig,
+} from '@mastra/core/ai-tracing';
 import { Langfuse } from 'langfuse';
 import type { LangfuseTraceClient, LangfuseSpanClient, LangfuseGenerationClient, LangfuseEventClient } from 'langfuse';
 

--- a/observability/langsmith/src/ai-tracing.ts
+++ b/observability/langsmith/src/ai-tracing.ts
@@ -6,10 +6,13 @@
  * Events are handled as zero-duration RunTrees with matching start/end times.
  */
 
-import type { AITracingEvent, AnyExportedAISpan, LLMGenerationAttributes } from '@mastra/core/ai-tracing';
-import { AISpanType, omitKeys } from '@mastra/core/ai-tracing';
-import { BaseExporter } from '@mastra/core/ai-tracing/exporters';
-import type { BaseExporterConfig } from '@mastra/core/ai-tracing/exporters';
+import { AISpanType, omitKeys, BaseExporter } from '@mastra/core/ai-tracing';
+import type {
+  AITracingEvent,
+  AnyExportedAISpan,
+  LLMGenerationAttributes,
+  BaseExporterConfig,
+} from '@mastra/core/ai-tracing';
 import type { ClientConfig, RunTreeConfig } from 'langsmith';
 import { Client, RunTree } from 'langsmith';
 import type { KVMap } from 'langsmith/schemas';


### PR DESCRIPTION
## Description

Three packages were using an import to `@mastra/core/ai-tracing/exporters` which isn't valid. Changed to `@mastra/core/ai-tracing`.

## Related Issue(s)

Fixes #9125

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
