### PR TITLE
fix(pg): properly stringify all JSONB values for PostgreSQL

### DIFF
--- a/.changeset/quiet-ducks-speak.md
+++ b/.changeset/quiet-ducks-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixes "invalid input syntax for type json" error in AI tracing with PostgreSQL.

--- a/stores/_test-utils/src/domains/observability/index.ts
+++ b/stores/_test-utils/src/domains/observability/index.ts
@@ -48,6 +48,37 @@ export function createObservabilityTests({ storage }: { storage: MastraStorage }
         expect(retrievedSpan?.createdAt).toBeDefined();
         expect(retrievedSpan?.updatedAt).toBeDefined();
       });
+
+      it('should handle primitive values in JSONB fields (strings, numbers, booleans)', async () => {
+        // Regression test for PostgreSQL "invalid input syntax for type json" bug
+        // Bug: JSONB columns require valid JSON, but primitive strings were not being stringified
+        // This test ensures all storage providers properly handle primitives in JSONB fields
+        const span = createRootSpan({
+          name: 'test-primitive-jsonb',
+          scope: 'test-scope',
+        });
+
+        // Override with primitive values that should be JSON-encoded
+        span.input = 'Tell me a story about a dragon' as any; // Plain string
+        span.output = 'Once upon a time there was a dragon...' as any; // Plain string
+        span.attributes = { temperature: 0.7, maxTokens: 100 } as any; // Object with number values
+        span.metadata = { isTest: true, retryCount: 3 } as any; // Object with boolean and number
+
+        await storage.createAISpan(span);
+
+        const trace = await storage.getAITrace(span.traceId);
+        const retrievedSpan = trace?.spans[0];
+
+        expect(retrievedSpan).toBeDefined();
+
+        // Verify primitive strings are retrieved as strings (not corrupted)
+        expect(retrievedSpan?.input).toBe('Tell me a story about a dragon');
+        expect(retrievedSpan?.output).toBe('Once upon a time there was a dragon...');
+
+        // Verify objects with primitives are retrieved correctly
+        expect(retrievedSpan?.attributes).toEqual({ temperature: 0.7, maxTokens: 100 });
+        expect(retrievedSpan?.metadata).toEqual({ isTest: true, retryCount: 3 });
+      });
     });
 
     describe('parent and child spans', () => {

--- a/stores/pg/src/storage/domains/operations/index.ts
+++ b/stores/pg/src/storage/domains/operations/index.ts
@@ -57,8 +57,9 @@ export class StoreOperationsPG extends StoreOperations {
       const schema = TABLE_SCHEMAS[tableName];
       const columnSchema = schema?.[key];
 
-      // If the column is JSONB and the value is an object/array, stringify it
-      if (columnSchema?.type === 'jsonb' && value !== null && typeof value === 'object') {
+      // If the column is JSONB, stringify the value (unless it's null/undefined)
+      // PostgreSQL JSONB columns require valid JSON, so even primitives need to be stringified
+      if (columnSchema?.type === 'jsonb' && value !== null && value !== undefined) {
         return JSON.stringify(value);
       }
       return value;
@@ -82,15 +83,33 @@ export class StoreOperationsPG extends StoreOperations {
 
   /**
    * Prepares a value for database operations, handling Date objects and JSON serialization
+   * This is schema-aware and only stringifies objects for JSONB columns
    */
-  private prepareValue(value: any): any {
-    if (value instanceof Date) {
-      return value.toISOString();
-    } else if (typeof value === 'object' && value !== null) {
-      return JSON.stringify(value);
-    } else {
+  private prepareValue(value: any, columnName: string, tableName: TABLE_NAMES): any {
+    if (value === null || value === undefined) {
       return value;
     }
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    // Get the schema for this table to determine column types
+    const schema = TABLE_SCHEMAS[tableName];
+    const columnSchema = schema?.[columnName];
+
+    // If the column is JSONB, stringify the value
+    // PostgreSQL JSONB columns require valid JSON, so all non-null values need to be stringified
+    if (columnSchema?.type === 'jsonb') {
+      return JSON.stringify(value);
+    }
+
+    // For non-JSONB columns with object values, stringify them (for backwards compatibility)
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+
+    return value;
   }
 
   private async setupSchema() {
@@ -877,7 +896,7 @@ export class StoreOperationsPG extends StoreOperations {
       Object.entries(data).forEach(([key, value]) => {
         const parsedKey = parseSqlIdentifier(key, 'column name');
         setColumns.push(`"${parsedKey}" = $${paramIndex++}`);
-        setValues.push(this.prepareValue(value));
+        setValues.push(this.prepareValue(value, key, tableName));
       });
 
       // Build WHERE clause
@@ -887,7 +906,7 @@ export class StoreOperationsPG extends StoreOperations {
       Object.entries(keys).forEach(([key, value]) => {
         const parsedKey = parseSqlIdentifier(key, 'column name');
         whereConditions.push(`"${parsedKey}" = $${paramIndex++}`);
-        whereValues.push(this.prepareValue(value));
+        whereValues.push(this.prepareValue(value, key, tableName));
       });
 
       const tableName_ = getTableName({


### PR DESCRIPTION
## Description

Fixes "invalid input syntax for type json" error in AI tracing with PostgreSQL.

Root cause: Primitive values (strings, numbers) weren't being JSON-encoded for JSONB columns. PostgreSQL requires all JSONB values to be valid JSON.

Solution: Always stringify non-null values for JSONB columns, regardless of type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Related Issue(s)

Fixes #9145

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
