### PR TITLE
feat(cli): add @mastra/observability to starter project dependencies

### DIFF
--- a/.changeset/tidy-pots-jump.md
+++ b/.changeset/tidy-pots-jump.md
@@ -1,0 +1,5 @@
+---
+"mastra": patch
+---
+
+Add `@mastra/observability` to starter project dependencies

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -72,6 +72,11 @@ export const init = async ({
         await depService.installPackages(['@mastra/loggers']);
       }
 
+      const needsObservability = (await depService.checkDependencies(['@mastra/observability'])) !== `ok`;
+      if (needsObservability) {
+        await depService.installPackages(['@mastra/observability']);
+      }
+
       const needsEvals =
         components.includes(`scorers`) && (await depService.checkDependencies(['@mastra/evals'])) !== `ok`;
       if (needsEvals) {


### PR DESCRIPTION
## Description

Add `@mastra/observability` package installation during mastra init
when example code is generated. This ensures the package is available
since observability is enabled by default in the generated index.ts.

Currently this adds an empty package, but we will be moving most of the AI-tracing code to `@mastra/observability` very soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
