### PR TITLE
fix: correct turbo.json configurations across packages

### DIFF
--- a/packages/_external-types/turbo.json
+++ b/packages/_external-types/turbo.json
@@ -10,7 +10,7 @@
     "build": {
       "dependsOn": ["build:lib"],
       "outputs": ["dist/**"],
-      "inputs": ["$TURBO_DEFAULT$", "../playground/dist/**"]
+      "inputs": ["$TURBO_DEFAULT$"]
     }
   }
 }

--- a/packages/_external-types/turbo.json
+++ b/packages/_external-types/turbo.json
@@ -9,8 +9,7 @@
     },
     "build": {
       "dependsOn": ["build:lib"],
-      "outputs": ["dist/**"],
-      "inputs": ["$TURBO_DEFAULT$"]
+      "outputs": ["dist/**"]
     }
   }
 }

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -9,8 +9,7 @@
     },
     "build": {
       "dependsOn": ["build:lib", "@internal/playground#build"],
-      "outputs": ["dist/**"],
-      "inputs": ["$TURBO_DEFAULT$"]
+      "outputs": ["dist/**"]
     }
   }
 }

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -8,9 +8,9 @@
       "inputs": ["$TURBO_DEFAULT$", "./tsup.config.js"]
     },
     "build": {
-      "dependsOn": ["build:lib"],
+      "dependsOn": ["build:lib", "@internal/playground#build"],
       "outputs": ["dist/**"],
-      "inputs": ["$TURBO_DEFAULT$", "../playground/dist/**"]
+      "inputs": ["$TURBO_DEFAULT$"]
     }
   }
 }

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -8,7 +8,7 @@
       "inputs": ["$TURBO_DEFAULT$", "./tsup.config.js"]
     },
     "build": {
-      "dependsOn": ["build:lib", "@internal/playground#build"],
+      "dependsOn": ["^build", "build:lib", "@internal/playground#build"],
       "outputs": ["dist/**"]
     }
   }

--- a/packages/deployer/turbo.json
+++ b/packages/deployer/turbo.json
@@ -1,8 +1,11 @@
 {
+  "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["$TURBO_DEFAULT$", "public/**/*"]
+      "inputs": ["$TURBO_DEFAULT$", "public/**/*"],
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
     }
   }
 }

--- a/packages/playground/turbo.json
+++ b/packages/playground/turbo.json
@@ -4,7 +4,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "./vite.config.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixed incorrect turbo.json configurations that were causing potential build issues
- Ensured proper dependency chains for reliable parallel builds

## Changes
- Removed incorrect playground dist input references from CLI and external-types packages
- Created missing turbo.json for playground package to properly define its build task
- Fixed create-mastra package dependencies to use standard `^build` pattern
- Added missing schema field and proper build configuration to deployer turbo.json

## Impact
These changes improve build reliability and ensure correct dependency resolution in the monorepo build process.