### PR TITLE
fix(cli): Install mastra during init

### DIFF
--- a/.changeset/thick-times-carry.md
+++ b/.changeset/thick-times-carry.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Make sure that `mastra init` also installs the `mastra` CLI package (if not already installed)

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -542,10 +542,15 @@ export const checkAndInstallCoreDeps = async (addExample: boolean) => {
     spinner.start();
 
     const needsCore = (await depService.checkDependencies(['@mastra/core'])) !== `ok`;
+    const needsCli = (await depService.checkDependencies(['mastra'])) !== `ok`;
     const needsZod = (await depService.checkDependencies(['zod'])) !== `ok`;
 
     if (needsCore) {
       packages.push({ name: '@mastra/core', version: 'latest' });
+    }
+
+    if (needsCli) {
+      packages.push({ name: 'mastra', version: 'latest' });
     }
 
     if (needsZod) {


### PR DESCRIPTION
## Description

Follow up to https://github.com/mastra-ai/mastra/pull/9070 - We also need to install `mastra` if it's missing during `mastra init`.

## Related Issue(s)

https://github.com/mastra-ai/mastra/pull/9070

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
