### PR TITLE
perf: skip Zod compatibility checks in local unit test runs

### DIFF
--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -99,7 +99,7 @@ jobs:
         run: pnpm build:core
 
       - name: Run Zod compatibility checks
-        run: pnpm --filter ./packages/core test:types:zod
+        run: pnpm test:core:zod
 
       - name: Run Core tests
         run: pnpm test:core

--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Build cli
         run: pnpm build:core
 
+      - name: Run Zod compatibility checks
+        run: pnpm --filter ./packages/core test:types:zod
+
       - name: Run Core tests
         run: pnpm test:core
         env:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:deployer": "pnpm --filter ./packages/deployer test",
     "test:server": "pnpm --filter ./packages/server test",
     "test:core": "pnpm --filter ./packages/core test",
+    "test:core:zod": "pnpm --filter ./packages/core test:types:zod",
     "test:mcp": "pnpm --filter ./packages/mcp test",
     "test:rag": "pnpm --filter ./packages/rag test",
     "test:clients": "pnpm --filter \"./client-sdks/*\" test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -186,7 +186,8 @@
     "generate:model-router": "pnpx tsx scripts/generate-providers.ts && pnpx tsx scripts/generate-model-docs.ts && cd ../.. && pnpm prettier:changed",
     "test:unit": "vitest run --exclude '**/tool-builder/**'",
     "test:types:zod": "node test-zod-compat.mjs",
-    "test": "npm run test:types:zod && npm run test:unit"
+    "test": "npm run test:unit",
+    "test:ci": "npm run test:types:zod && npm run test:unit"
   },
   "dependencies": {
     "@a2a-js/sdk": "~0.2.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -186,8 +186,7 @@
     "generate:model-router": "pnpx tsx scripts/generate-providers.ts && pnpx tsx scripts/generate-model-docs.ts && cd ../.. && pnpm prettier:changed",
     "test:unit": "vitest run --exclude '**/tool-builder/**'",
     "test:types:zod": "node test-zod-compat.mjs",
-    "test": "npm run test:unit",
-    "test:ci": "npm run test:types:zod && npm run test:unit"
+    "test": "npm run test:unit"
   },
   "dependencies": {
     "@a2a-js/sdk": "~0.2.4",

--- a/packages/core/test-zod-compat.mjs
+++ b/packages/core/test-zod-compat.mjs
@@ -14,7 +14,8 @@
  * 3. Full project type checking often runs out of memory
  *
  * Run manually: npm run test:types:zod
- * Runs in CI: As part of npm test
+ * Runs in CI: As a separate step before unit tests
+ * Local dev: Skipped by default (use npm test for faster local testing)
  */
 
 import { exec } from 'child_process';

--- a/packages/core/test-zod-compat.mjs
+++ b/packages/core/test-zod-compat.mjs
@@ -15,7 +15,6 @@
  *
  * Run manually: npm run test:types:zod
  * Runs in CI: As a separate step before unit tests
- * Local dev: Skipped by default (use npm test for faster local testing)
  */
 
 import { exec } from 'child_process';


### PR DESCRIPTION
## Description

- Modified test script to run only unit tests by default
- Updated CI workflow to explicitly run Zod checks as separate step (.github/workflows/secrets.test-core.yml:101-102)

This reduces local test runtime by 5-10 seconds while maintaining comprehensive testing in CI.

Manual Zod testing still available via:
  `pnpm test:core:zod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [X] Performance improvement
- [X] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
