### PR TITLE
DRAFT: perf(pre-commit): optimize typecheck to only run on changed packages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,8 +3,8 @@ pnpm --version || {
   exit 0
 }
 
-# Run TS typecheck
-pnpm typecheck
+# Run TS typecheck only on changed packages
+pnpm typecheck:changed
 
 # Formatting on staged files
 pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "list-prettier-files": "pnpm --silent list-changed-files | grep -E '\\.(js|mjs|ts|tsx|md|mdx|json|graphql|gql)$' || true",
     "prettier:changed": "pnpm --silent list-prettier-files | xargs prettier --write --log-level warn",
     "typecheck": "pnpm --filter \"!./explorations/**/*\" -r typecheck",
+    "typecheck:changed": "pnpm turbo typecheck --filter=\"...[HEAD]\"",
     "format": "pnpm turbo --filter \"!./examples/**/*\" --filter \"!./docs/**/*\" --filter \"!@internal/playground\" lint -- --fix",
     "dev:services:up": "docker compose -f .dev/docker-compose.yaml up -d",
     "dev:services:down": "docker compose -f .dev/docker-compose.yaml down",

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
       "env": ["RAPID_API_KEY", "ANTHROPIC_API_KEY"]
     },
+    "typecheck": {},
     "lint": {
       "dependsOn": []
     },


### PR DESCRIPTION
## Description

Before this change, the pre-commit hook recursively, pulling in any other typechecks in the repo. This would often mean that 4 separate typechecks would run, many often on files that hadn't changed.

Changes:
- Added typecheck:changed script that uses Turbo's git-based filtering (--filter="...[HEAD]")
- Updated .husky/pre-commit to use typecheck:changed instead of typecheck
- Added typecheck task to turbo.json to enable Turbo coordination and caching

Now pre-commit only typechecks packages with staged changes, significantly reducing commit time while maintaining type safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [X] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
