### PR TITLE
Fix studio crashing when message contains non JSON text output of tool call

### DIFF
--- a/.changeset/wet-webs-appear.md
+++ b/.changeset/wet-webs-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix studio crashing when message contains non JSON text output of tool call

--- a/packages/playground-ui/src/components/assistant-ui/tools/badges/agent-badge.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/tools/badges/agent-badge.tsx
@@ -55,7 +55,13 @@ export const AgentBadge = ({ agentId, messages = [], metadata, toolCallId, toolA
           return <Markdown key={index}>{message.content}</Markdown>;
         }
 
-        const result = typeof message.toolOutput === 'string' ? JSON.parse(message.toolOutput) : message.toolOutput;
+        let result;
+
+        try {
+          result = typeof message.toolOutput === 'string' ? JSON.parse(message.toolOutput) : message.toolOutput;
+        } catch (error) {
+          result = message.toolOutput;
+        }
 
         return (
           <React.Fragment key={index}>


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Fix studio crashing when message contains non JSON text output of tool call

<img width="1504" height="850" alt="Screenshot 2025-10-23 at 4 02 21 PM" src="https://github.com/user-attachments/assets/f80b2797-ad81-4a99-a91a-0b1beae4d130" />

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#9124 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
