### PR TITLE
fix(lance): Update eval filtering for LanceDB

### DIFF
--- a/.changeset/sour-ants-bake.md
+++ b/.changeset/sour-ants-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/lance': patch
+---
+
+Fix eval filtering to use NULL checks instead of length function for compatibility with LanceDB 0.22.x

--- a/stores/lance/src/storage/domains/legacy-evals/index.ts
+++ b/stores/lance/src/storage/domains/legacy-evals/index.ts
@@ -75,9 +75,9 @@ export class StoreLegacyEvalsLance extends LegacyEvalsStorage {
 
       // Apply type filtering
       if (options.type === 'live') {
-        conditions.push('length(test_info) = 0');
+        conditions.push('test_info IS NULL');
       } else if (options.type === 'test') {
-        conditions.push('length(test_info) > 0');
+        conditions.push('test_info IS NOT NULL');
       }
 
       // Apply date filtering


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fixes eval filtering in the Lance storage adapter to use NULL checks instead of length function.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
