### PR TITLE
feat(core): Add initialState and outputOptions support to stream() and streamVNext()

### DIFF
--- a/.changeset/lazy-parents-lose.md
+++ b/.changeset/lazy-parents-lose.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add support for `initialState` in `stream()` and `outputOptions` parameters in `stream()` and `streamVNext()` methods.

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1794,6 +1794,11 @@ export class Run<
       tracingContext?: TracingContext;
       tracingOptions?: TracingOptions;
       closeOnSuspend?: boolean;
+      initialState?: z.input<TState>;
+      outputOptions?: {
+        includeState?: boolean;
+        includeResumeLabels?: boolean;
+      };
     } = {},
   ): ReturnType<typeof this.streamVNext> {
     return this.streamVNext(args);
@@ -1882,6 +1887,7 @@ export class Run<
     tracingOptions,
     closeOnSuspend = true,
     initialState,
+    outputOptions,
   }: {
     inputData?: z.input<TInput>;
     runtimeContext?: RuntimeContext;
@@ -1889,6 +1895,10 @@ export class Run<
     tracingOptions?: TracingOptions;
     closeOnSuspend?: boolean;
     initialState?: z.input<TState>;
+    outputOptions?: {
+      includeState?: boolean;
+      includeResumeLabels?: boolean;
+    };
   } = {}): WorkflowRunOutput<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     if (this.closeStreamAction && this.#streamOutput) {
       return this.#streamOutput;
@@ -1929,6 +1939,7 @@ export class Run<
           tracingContext,
           tracingOptions,
           initialState,
+          outputOptions,
           writableStream: new WritableStream<WorkflowStreamEvent>({
             write(chunk) {
               controller.enqueue(chunk);


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR adds initialState and outputOptions parameters to stream() and streamVNext() methods to match the existing API of start() and resume(). 
Changes:
- Added initialState parameter to stream() method signature
- Added outputOptions parameter (includeState, includeResumeLabels) to both stream() and streamVNext() methods
- Added test coverage for both parameters

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
