### PR TITLE
Fix/workflow snapshot workflow name param

### DIFF
--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -126,7 +126,7 @@ export function workflowLoopStream<
       }
 
       const existingSnapshot = await rest.mastra?.getStorage()?.loadWorkflowSnapshot({
-        workflowName: 'agentic-loop',
+        workflowId: 'agentic-loop',
         runId,
       });
       if (existingSnapshot) {

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -394,12 +394,12 @@ export abstract class MastraStorage extends MastraBase {
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
@@ -407,14 +407,14 @@ export abstract class MastraStorage extends MastraBase {
     await this.init();
 
     const data = {
-      workflow_name: workflowName,
+      workflow_name: workflowId,
       run_id: runId,
       resourceId,
       snapshot,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
-    this.logger.debug('Persisting workflow snapshot', { workflowName, runId, data });
+    this.logger.debug('Persisting workflow snapshot', { workflowId, runId, data });
     await this.insert({
       tableName: TABLE_WORKFLOW_SNAPSHOT,
       record: data,
@@ -422,12 +422,12 @@ export abstract class MastraStorage extends MastraBase {
   }
 
   abstract updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
@@ -435,11 +435,11 @@ export abstract class MastraStorage extends MastraBase {
   }): Promise<Record<string, StepResult<any, any, any, any>>>;
 
   abstract updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -451,19 +451,19 @@ export abstract class MastraStorage extends MastraBase {
   }): Promise<WorkflowRunState | undefined>;
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
     if (!this.hasInitialized) {
       await this.init();
     }
-    this.logger.debug('Loading workflow snapshot', { workflowName, runId });
+    this.logger.debug('Loading workflow snapshot', { workflowId, runId });
     const d = await this.load<{ snapshot: WorkflowRunState }>({
       tableName: TABLE_WORKFLOW_SNAPSHOT,
-      keys: { workflow_name: workflowName, run_id: runId },
+      keys: { workflow_name: workflowId, run_id: runId },
     });
 
     return d ? d.snapshot : null;
@@ -536,7 +536,7 @@ export abstract class MastraStorage extends MastraBase {
   abstract getEvalsByAgentName(agentName: string, type?: 'test' | 'live'): Promise<EvalRow[]>;
 
   abstract getWorkflowRuns(args?: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
@@ -544,7 +544,7 @@ export abstract class MastraStorage extends MastraBase {
     resourceId?: string;
   }): Promise<WorkflowRuns>;
 
-  abstract getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null>;
+  abstract getWorkflowRunById(args: { runId: string; workflowId?: string }): Promise<WorkflowRun | null>;
 
   abstract getThreadsByResourceIdPaginated(
     args: {

--- a/packages/core/src/storage/domains/workflows/base.ts
+++ b/packages/core/src/storage/domains/workflows/base.ts
@@ -11,13 +11,13 @@ export abstract class WorkflowsStorage extends MastraBase {
   }
 
   abstract updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
@@ -25,11 +25,11 @@ export abstract class WorkflowsStorage extends MastraBase {
   }): Promise<Record<string, StepResult<any, any, any, any>>>;
 
   abstract updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -41,22 +41,22 @@ export abstract class WorkflowsStorage extends MastraBase {
   }): Promise<WorkflowRunState | undefined>;
 
   abstract persistWorkflowSnapshot(_: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void>;
 
   abstract loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null>;
 
   abstract getWorkflowRuns(args?: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
@@ -64,5 +64,5 @@ export abstract class WorkflowsStorage extends MastraBase {
     resourceId?: string;
   }): Promise<WorkflowRuns>;
 
-  abstract getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null>;
+  abstract getWorkflowRunById(args: { runId: string; workflowId?: string }): Promise<WorkflowRun | null>;
 }

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -105,27 +105,27 @@ export class InMemoryStore extends MastraStorage {
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    await this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    await this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
   async createTable({
@@ -163,27 +163,27 @@ export class InMemoryStore extends MastraStorage {
   }
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -193,7 +193,7 @@ export class InMemoryStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
@@ -415,31 +415,25 @@ export class InMemoryStore extends MastraStorage {
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    return this.stores.workflows.getWorkflowRuns({ workflowName, fromDate, toDate, limit, offset, resourceId });
+    return this.stores.workflows.getWorkflowRuns({ workflowId, fromDate, toDate, limit, offset, resourceId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async createAISpan(span: AISpanRecord): Promise<void> {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -25,7 +25,7 @@ export interface LegacyWorkflowRuns {
 }
 
 export interface LegacyWorkflowRun {
-  workflowName: string;
+  workflowId: string;
   runId: string;
   snapshot: LegacyWorkflowRunState | string;
   createdAt: Date;
@@ -47,7 +47,7 @@ export interface StorageWorkflowRun {
   updatedAt: Date;
 }
 export interface WorkflowRun {
-  workflowName: string;
+  workflowId: string;
   runId: string;
   snapshot: WorkflowRunState | string;
   createdAt: Date;

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -1952,7 +1952,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     });
 
     await this.mastra?.getStorage()?.persistWorkflowSnapshot({
-      workflowName: workflowId,
+      workflowId,
       runId,
       resourceId,
       snapshot: {

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -5795,7 +5795,7 @@ describe('Workflow', () => {
       expect(total).toBe(2);
       expect(runs).toHaveLength(2);
       expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId, run2.runId]));
-      expect(runs[0]?.workflowName).toBe('test-workflow');
+      expect(runs[0]?.workflowId).toBe('test-workflow');
       expect(runs[0]?.snapshot).toBeDefined();
       expect(runs[1]?.snapshot).toBeDefined();
 
@@ -5841,13 +5841,13 @@ describe('Workflow', () => {
       expect(total).toBe(1);
       expect(runs).toHaveLength(1);
       expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId]));
-      expect(runs[0]?.workflowName).toBe('test-workflow');
+      expect(runs[0]?.workflowId).toBe('test-workflow');
       expect(runs[0]?.snapshot).toBeDefined();
 
       const run3 = await workflow.getWorkflowRunById(run1.runId);
       console.dir({ run3 }, { depth: null });
       expect(run3?.runId).toBe(run1.runId);
-      expect(run3?.workflowName).toBe('test-workflow');
+      expect(run3?.workflowId).toBe('test-workflow');
       expect(run3?.snapshot).toEqual(runs[0].snapshot);
 
       await mastra.stopEventEngine();

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -88,7 +88,7 @@ export class WorkflowEventProcessor extends EventProcessor {
 
   protected async processWorkflowCancel({ workflowId, runId }: ProcessorArgs) {
     const currentState = await this.mastra.getStorage()?.updateWorkflowState({
-      workflowName: workflowId,
+      workflowId,
       runId,
       opts: {
         status: 'canceled',
@@ -123,7 +123,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     runtimeContext,
   }: ProcessorArgs) {
     await this.mastra.getStorage()?.persistWorkflowSnapshot({
-      workflowName: workflow.id,
+      workflowId: workflow.id,
       runId,
       snapshot: {
         activePaths: [],
@@ -164,7 +164,7 @@ export class WorkflowEventProcessor extends EventProcessor {
   protected async endWorkflow(args: ProcessorArgs) {
     const { stepResults, workflowId, runId, prevResult } = args;
     await this.mastra.getStorage()?.updateWorkflowState({
-      workflowName: workflowId,
+      workflowId,
       runId,
       opts: {
         status: 'success',
@@ -287,7 +287,7 @@ export class WorkflowEventProcessor extends EventProcessor {
       args;
 
     await this.mastra.getStorage()?.updateWorkflowState({
-      workflowName: workflowId,
+      workflowId,
       runId,
       opts: {
         status: 'failed',
@@ -475,7 +475,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     } else if (step?.type === 'waitForEvent' && !resumeData) {
       // wait for event to arrive externally (with resumeData)
       await this.mastra.getStorage()?.updateWorkflowResults({
-        workflowName: workflowId,
+        workflowId,
         runId,
         stepId: step.step.id,
         result: {
@@ -486,7 +486,7 @@ export class WorkflowEventProcessor extends EventProcessor {
         runtimeContext,
       });
       await this.mastra.getStorage()?.updateWorkflowState({
-        workflowName: workflowId,
+        workflowId,
         runId,
         opts: {
           status: 'waiting',
@@ -588,7 +588,7 @@ export class WorkflowEventProcessor extends EventProcessor {
         }
 
         const snapshot = await this.mastra?.getStorage()?.loadWorkflowSnapshot({
-          workflowName: step.step.id,
+          workflowId: step.step.id,
           runId: nestedRunId,
         });
 
@@ -861,7 +861,7 @@ export class WorkflowEventProcessor extends EventProcessor {
 
     if (step.type === 'foreach') {
       const snapshot = await this.mastra.getStorage()?.loadWorkflowSnapshot({
-        workflowName: workflowId,
+        workflowId,
         runId,
       });
 
@@ -878,7 +878,7 @@ export class WorkflowEventProcessor extends EventProcessor {
         }
       }
       const newStepResults = await this.mastra.getStorage()?.updateWorkflowResults({
-        workflowName: workflow.id,
+        workflowId: workflow.id,
         runId,
         stepId: step.step.id,
         result: newResult,
@@ -903,7 +903,7 @@ export class WorkflowEventProcessor extends EventProcessor {
       }
 
       const newStepResults = await this.mastra.getStorage()?.updateWorkflowResults({
-        workflowName: workflow.id,
+        workflowId: workflow.id,
         runId,
         stepId: step.step.id,
         result: prevResult,
@@ -943,7 +943,7 @@ export class WorkflowEventProcessor extends EventProcessor {
       }
 
       await this.mastra.getStorage()?.updateWorkflowState({
-        workflowName: workflowId,
+        workflowId,
         runId,
         opts: {
           status: 'suspended',
@@ -1143,7 +1143,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     runId: string;
   }): Promise<WorkflowRunState | null | undefined> {
     const snapshot = await this.mastra.getStorage()?.loadWorkflowSnapshot({
-      workflowName: workflowId,
+      workflowId,
       runId,
     });
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
@@ -185,7 +185,7 @@ export async function processWorkflowForEach(
     const dummyResult = Array.from({ length: concurrency }, () => null);
 
     await mastra.getStorage()?.updateWorkflowResults({
-      workflowName: workflowId,
+      workflowId,
       runId,
       stepId: step.step.id,
       result: {
@@ -221,7 +221,7 @@ export async function processWorkflowForEach(
 
   (currentResult as any).output.push(null);
   await mastra.getStorage()?.updateWorkflowResults({
-    workflowName: workflowId,
+    workflowId,
     runId,
     stepId: step.step.id,
     result: {

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -346,7 +346,7 @@ export class EventedWorkflow<
 
     if (!workflowSnapshotInStorage && shouldPersistSnapshot) {
       await this.mastra?.getStorage()?.persistWorkflowSnapshot({
-        workflowName: this.id,
+        workflowId: this.id,
         runId: runIdToUse,
         snapshot: {
           runId: runIdToUse,
@@ -418,7 +418,7 @@ export class EventedRun<
     runtimeContext = runtimeContext ?? new RuntimeContext();
 
     await this.mastra?.getStorage()?.persistWorkflowSnapshot({
-      workflowName: this.workflowId,
+      workflowId: this.workflowId,
       runId: this.runId,
       snapshot: {
         runId: this.runId,
@@ -500,7 +500,7 @@ export class EventedRun<
     }
 
     const snapshot = await this.mastra?.getStorage()?.loadWorkflowSnapshot({
-      workflowName: this.workflowId,
+      workflowId: this.workflowId,
       runId: this.runId,
     });
 

--- a/packages/core/src/workflows/legacy/types.ts
+++ b/packages/core/src/workflows/legacy/types.ts
@@ -274,7 +274,7 @@ export interface WorkflowContext<
 
 export interface WorkflowLogMessage extends BaseLogMessage {
   type: typeof RegisteredLogger.WORKFLOW;
-  workflowName: string;
+  workflowId: string;
   stepId?: StepId;
   data?: unknown;
   runId?: string;

--- a/packages/core/src/workflows/legacy/workflow-instance.ts
+++ b/packages/core/src/workflows/legacy/workflow-instance.ts
@@ -417,7 +417,7 @@ export class WorkflowInstance<
     }
 
     const existingSnapshot = (await storage.loadWorkflowSnapshot({
-      workflowName: this.name,
+      workflowId: this.name,
       runId: this.#runId,
     })) as unknown as WorkflowRunState;
 
@@ -444,7 +444,7 @@ export class WorkflowInstance<
       existingSnapshot.childStates = { ...existingSnapshot.childStates, ...machineSnapshots };
       existingSnapshot.suspendedSteps = { ...existingSnapshot.suspendedSteps, ...suspendedSteps };
       await storage.persistWorkflowSnapshot({
-        workflowName: this.name,
+        workflowId: this.name,
         runId: this.#runId,
         snapshot: existingSnapshot as unknown as NewWorkflowRunState,
       });
@@ -454,7 +454,7 @@ export class WorkflowInstance<
       snapshot.suspendedSteps = suspendedSteps;
       snapshot.childStates = { ...machineSnapshots };
       await storage.persistWorkflowSnapshot({
-        workflowName: this.name,
+        workflowId: this.name,
         runId: this.#runId,
         snapshot: snapshot as unknown as NewWorkflowRunState,
       });
@@ -468,7 +468,7 @@ export class WorkflowInstance<
 
     if (!existingSnapshot || snapshot === existingSnapshot) {
       await storage.persistWorkflowSnapshot({
-        workflowName: this.name,
+        workflowId: this.name,
         runId: this.#runId,
         snapshot: snapshot as unknown as NewWorkflowRunState,
       });
@@ -483,7 +483,7 @@ export class WorkflowInstance<
     }
 
     await storage.persistWorkflowSnapshot({
-      workflowName: this.name,
+      workflowId: this.name,
       runId: this.#runId,
       snapshot: snapshot as unknown as NewWorkflowRunState,
     });
@@ -491,7 +491,7 @@ export class WorkflowInstance<
 
   async getState(): Promise<WorkflowRunState | null> {
     const storedSnapshot = await this.#mastra?.storage?.loadWorkflowSnapshot({
-      workflowName: this.name,
+      workflowId: this.name,
       runId: this.runId,
     });
     const prevSnapshot = storedSnapshot
@@ -575,7 +575,7 @@ export class WorkflowInstance<
 
     await this.persistWorkflowSnapshot();
 
-    return storage.loadWorkflowSnapshot({ runId, workflowName: this.name });
+    return storage.loadWorkflowSnapshot({ runId, workflowId: this.name });
   }
 
   async _resume({

--- a/packages/core/src/workflows/legacy/workflow-legacy.test.ts
+++ b/packages/core/src/workflows/legacy/workflow-legacy.test.ts
@@ -3162,7 +3162,7 @@ describe('LegacyWorkflow', async () => {
       expect(total).toBe(2);
       expect(runs).toHaveLength(2);
       expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId, run2.runId]));
-      expect(runs[0]?.workflowName).toBe('test-workflow');
+      expect(runs[0]?.workflowId).toBe('test-workflow');
       expect(runs[0]?.snapshot).toBeDefined();
       expect(runs[1]?.snapshot).toBeDefined();
     });

--- a/packages/core/src/workflows/legacy/workflow.ts
+++ b/packages/core/src/workflows/legacy/workflow.ts
@@ -958,7 +958,7 @@ export class LegacyWorkflow<
       this.logger.debug('Cannot get workflow run. Mastra engine is not initialized');
       return null;
     }
-    return await storage.getWorkflowRunById({ runId, workflowName: this.name });
+    return await storage.getWorkflowRunById({ runId, workflowId: this.name });
   }
 
   /**
@@ -1016,7 +1016,7 @@ export class LegacyWorkflow<
       return { runs: [], total: 0 };
     }
 
-    return storage.getWorkflowRuns({ workflowName: this.name, ...(args ?? {}) }) as unknown as LegacyWorkflowRuns;
+    return storage.getWorkflowRuns({ workflowId: this.name, ...(args ?? {}) }) as unknown as LegacyWorkflowRuns;
   }
 
   getExecutionSpan(runId: string) {
@@ -1179,7 +1179,7 @@ export class LegacyWorkflow<
     const storage = this.#mastra?.getStorage();
     const storedSnapshot = await storage?.loadWorkflowSnapshot({
       runId,
-      workflowName: this.name,
+      workflowId: this.name,
     });
 
     if (storedSnapshot) {

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -9633,7 +9633,7 @@ describe('Workflow', () => {
       expect(total).toBe(2);
       expect(runs).toHaveLength(2);
       expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId, run2.runId]));
-      expect(runs[0]?.workflowName).toBe('test-workflow');
+      expect(runs[0]?.workflowId).toBe('test-workflow');
       expect(runs[0]?.snapshot).toBeDefined();
       expect(runs[1]?.snapshot).toBeDefined();
     });
@@ -9697,7 +9697,7 @@ describe('Workflow', () => {
       expect(afterResumeTotal).toBe(1);
       expect(afterResumeRuns).toHaveLength(1);
       expect(afterResumeRuns.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId]));
-      expect(afterResumeRuns[0]?.workflowName).toBe('test-workflow');
+      expect(afterResumeRuns[0]?.workflowId).toBe('test-workflow');
       expect(afterResumeRuns[0]?.snapshot).toBeDefined();
       expect((afterResumeRuns[0]?.snapshot as any).status).toBe('suspended');
     });
@@ -9738,12 +9738,12 @@ describe('Workflow', () => {
       expect(total).toBe(1);
       expect(runs).toHaveLength(1);
       expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId]));
-      expect(runs[0]?.workflowName).toBe('test-workflow');
+      expect(runs[0]?.workflowId).toBe('test-workflow');
       expect(runs[0]?.snapshot).toBeDefined();
 
       const run3 = await workflow.getWorkflowRunById(run1.runId);
       expect(run3?.runId).toBe(run1.runId);
-      expect(run3?.workflowName).toBe('test-workflow');
+      expect(run3?.workflowId).toBe('test-workflow');
       expect(run3?.snapshot).toEqual(runs[0].snapshot);
     });
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1032,7 +1032,7 @@ export class Workflow<
 
     if (!workflowSnapshotInStorage && shouldPersistSnapshot) {
       await this.mastra?.getStorage()?.persistWorkflowSnapshot({
-        workflowName: this.id,
+        workflowId: this.id,
         runId: runIdToUse,
         resourceId: options?.resourceId,
         snapshot: {
@@ -1224,7 +1224,7 @@ export class Workflow<
       return { runs: [], total: 0 };
     }
 
-    return storage.getWorkflowRuns({ workflowName: this.id, ...(args ?? {}) });
+    return storage.getWorkflowRuns({ workflowId: this.id, ...(args ?? {}) });
   }
 
   async getWorkflowRunById(runId: string) {
@@ -1233,14 +1233,14 @@ export class Workflow<
       this.logger.debug('Cannot get workflow runs from storage. Mastra storage is not initialized');
       //returning in memory run if no storage is initialized
       return this.#runs.get(runId)
-        ? ({ ...this.#runs.get(runId), workflowName: this.id } as unknown as WorkflowRun)
+        ? ({ ...this.#runs.get(runId), workflowId: this.id } as unknown as WorkflowRun)
         : null;
     }
-    const run = await storage.getWorkflowRunById({ runId, workflowName: this.id });
+    const run = await storage.getWorkflowRunById({ runId, workflowId: this.id });
 
     return (
       run ??
-      (this.#runs.get(runId) ? ({ ...this.#runs.get(runId), workflowName: this.id } as unknown as WorkflowRun) : null)
+      (this.#runs.get(runId) ? ({ ...this.#runs.get(runId), workflowId: this.id } as unknown as WorkflowRun) : null)
     );
   }
 
@@ -1251,7 +1251,7 @@ export class Workflow<
       return {};
     }
 
-    const run = await storage.getWorkflowRunById({ runId, workflowName: workflowId });
+    const run = await storage.getWorkflowRunById({ runId, workflowId });
 
     let snapshot: WorkflowRunState | string = run?.snapshot!;
 
@@ -1305,7 +1305,7 @@ export class Workflow<
       return null;
     }
 
-    const run = await storage.getWorkflowRunById({ runId, workflowName: this.id });
+    const run = await storage.getWorkflowRunById({ runId, workflowId: this.id });
 
     let snapshot: WorkflowRunState | string = run?.snapshot!;
 
@@ -2271,7 +2271,7 @@ export class Run<
     };
   }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     const snapshot = await this.#mastra?.getStorage()?.loadWorkflowSnapshot({
-      workflowName: this.workflowId,
+      workflowId: this.workflowId,
       runId: this.runId,
     });
 

--- a/pubsub/google-cloud-pubsub/src/index.test.ts
+++ b/pubsub/google-cloud-pubsub/src/index.test.ts
@@ -5661,7 +5661,7 @@ describe.sequential(
         expect(total).toBe(2);
         expect(runs).toHaveLength(2);
         expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId, run2.runId]));
-        expect(runs[0]?.workflowName).toBe('test-workflow');
+        expect(runs[0]?.workflowId).toBe('test-workflow');
         expect(runs[0]?.snapshot).toBeDefined();
         expect(runs[1]?.snapshot).toBeDefined();
         await mastra.stopEventEngine();
@@ -5707,12 +5707,12 @@ describe.sequential(
         expect(total).toBe(1);
         expect(runs).toHaveLength(1);
         expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId]));
-        expect(runs[0]?.workflowName).toBe('test-workflow');
+        expect(runs[0]?.workflowId).toBe('test-workflow');
         expect(runs[0]?.snapshot).toBeDefined();
 
         const run3 = await workflow.getWorkflowRunById(run1.runId);
         expect(run3?.runId).toBe(run1.runId);
-        expect(run3?.workflowName).toBe('test-workflow');
+        expect(run3?.workflowId).toBe('test-workflow');
         expect(run3?.snapshot).toEqual(runs[0].snapshot);
         await mastra.stopEventEngine();
       });

--- a/stores/_test-utils/src/domains/workflows/index.ts
+++ b/stores/_test-utils/src/domains/workflows/index.ts
@@ -16,20 +16,20 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     });
 
     it('returns all workflows by default', async () => {
-      const workflowName1 = 'default_test_1';
-      const workflowName2 = 'default_test_2';
+      const workflowId1 = 'default_test_1';
+      const workflowId2 = 'default_test_2';
 
       const { snapshot: workflow1, runId: runId1, stepId: stepId1 } = createSampleWorkflowSnapshot('completed');
       const { snapshot: workflow2, runId: runId2, stepId: stepId2 } = createSampleWorkflowSnapshot('running');
 
-      await storage.persistWorkflowSnapshot({ workflowName: workflowName1, runId: runId1, snapshot: workflow1 });
+      await storage.persistWorkflowSnapshot({ workflowId: workflowId1, runId: runId1, snapshot: workflow1 });
       await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
-      await storage.persistWorkflowSnapshot({ workflowName: workflowName2, runId: runId2, snapshot: workflow2 });
+      await storage.persistWorkflowSnapshot({ workflowId: workflowId2, runId: runId2, snapshot: workflow2 });
 
       const { runs, total } = await storage.getWorkflowRuns();
 
-      const wfRun2 = runs.find(r => r.workflowName === workflowName2);
-      const wfRun1 = runs.find(r => r.workflowName === workflowName1);
+      const wfRun2 = runs.find(r => r.workflowId === workflowId2);
+      const wfRun1 = runs.find(r => r.workflowId === workflowId1);
       expect(wfRun2).toBeDefined();
       expect(wfRun1).toBeDefined();
 
@@ -43,20 +43,20 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     });
 
     it('filters by workflow name', async () => {
-      const workflowName1 = 'filter_test_1';
-      const workflowName2 = 'filter_test_2';
+      const workflowId1 = 'filter_test_1';
+      const workflowId2 = 'filter_test_2';
 
       const { snapshot: workflow1, runId: runId1, stepId: stepId1 } = createSampleWorkflowSnapshot('completed');
       const { snapshot: workflow2, runId: runId2 } = createSampleWorkflowSnapshot('failed');
 
-      await storage.persistWorkflowSnapshot({ workflowName: workflowName1, runId: runId1, snapshot: workflow1 });
+      await storage.persistWorkflowSnapshot({ workflowId: workflowId1, runId: runId1, snapshot: workflow1 });
       await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
-      await storage.persistWorkflowSnapshot({ workflowName: workflowName2, runId: runId2, snapshot: workflow2 });
+      await storage.persistWorkflowSnapshot({ workflowId: workflowId2, runId: runId2, snapshot: workflow2 });
 
-      const { runs, total } = await storage.getWorkflowRuns({ workflowName: workflowName1 });
+      const { runs, total } = await storage.getWorkflowRuns({ workflowId: workflowId1 });
       expect(runs).toHaveLength(1);
       expect(total).toBe(1);
-      expect(runs[0]!.workflowName).toBe(workflowName1);
+      expect(runs[0]!.workflowId).toBe(workflowId1);
       const snapshot = runs[0]!.snapshot as WorkflowRunState;
       expect(snapshot.context?.[stepId1]?.status).toBe('completed');
     });
@@ -65,9 +65,9 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       const now = new Date();
       const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
       const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
-      const workflowName1 = 'date_test_1';
-      const workflowName2 = 'date_test_2';
-      const workflowName3 = 'date_test_3';
+      const workflowId1 = 'date_test_1';
+      const workflowId2 = 'date_test_2';
+      const workflowId3 = 'date_test_3';
 
       const { snapshot: workflow1, runId: runId1 } = createSampleWorkflowSnapshot('completed');
       const { snapshot: workflow2, runId: runId2, stepId: stepId2 } = createSampleWorkflowSnapshot('running');
@@ -76,7 +76,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       await storage.insert({
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         record: {
-          workflow_name: workflowName1,
+          workflow_name: workflowId1,
           run_id: runId1,
           snapshot: workflow1,
           createdAt: twoDaysAgo,
@@ -86,7 +86,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       await storage.insert({
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         record: {
-          workflow_name: workflowName2,
+          workflow_name: workflowId2,
           run_id: runId2,
           snapshot: workflow2,
           createdAt: yesterday,
@@ -96,7 +96,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       await storage.insert({
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         record: {
-          workflow_name: workflowName3,
+          workflow_name: workflowId3,
           run_id: runId3,
           snapshot: workflow3,
           createdAt: now,
@@ -110,8 +110,8 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       });
 
       expect(runs).toHaveLength(2);
-      const wfName3Run = runs.find(r => r.workflowName === workflowName3);
-      const wfName2Run = runs.find(r => r.workflowName === workflowName2);
+      const wfName3Run = runs.find(r => r.workflowId === workflowId3);
+      const wfName2Run = runs.find(r => r.workflowId === workflowId2);
       expect(wfName3Run).toBeDefined();
       expect(wfName2Run).toBeDefined();
       const firstSnapshot = wfName3Run!.snapshot as WorkflowRunState;
@@ -121,19 +121,19 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     });
 
     it('handles pagination', async () => {
-      const workflowName1 = 'page_test_1';
-      const workflowName2 = 'page_test_2';
-      const workflowName3 = 'page_test_3';
+      const workflowId1 = 'page_test_1';
+      const workflowId2 = 'page_test_2';
+      const workflowId3 = 'page_test_3';
 
       const { snapshot: workflow1, runId: runId1, stepId: stepId1 } = createSampleWorkflowSnapshot('completed');
       const { snapshot: workflow2, runId: runId2, stepId: stepId2 } = createSampleWorkflowSnapshot('running');
       const { snapshot: workflow3, runId: runId3, stepId: stepId3 } = createSampleWorkflowSnapshot('waiting');
 
-      await storage.persistWorkflowSnapshot({ workflowName: workflowName1, runId: runId1, snapshot: workflow1 });
+      await storage.persistWorkflowSnapshot({ workflowId: workflowId1, runId: runId1, snapshot: workflow1 });
       await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
-      await storage.persistWorkflowSnapshot({ workflowName: workflowName2, runId: runId2, snapshot: workflow2 });
+      await storage.persistWorkflowSnapshot({ workflowId: workflowId2, runId: runId2, snapshot: workflow2 });
       await new Promise(resolve => setTimeout(resolve, 10)); // Small delay to ensure different timestamps
-      await storage.persistWorkflowSnapshot({ workflowName: workflowName3, runId: runId3, snapshot: workflow3 });
+      await storage.persistWorkflowSnapshot({ workflowId: workflowId3, runId: runId3, snapshot: workflow3 });
 
       // Get first page
       const page1 = await storage.getWorkflowRuns({ limit: 2, offset: 0 });
@@ -149,7 +149,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
   });
 
   describe('getWorkflowRunById', () => {
-    const workflowName = 'workflow-id-test';
+    const workflowId = 'workflow-id-test';
     let runId: string;
     let stepId: string;
 
@@ -159,7 +159,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       runId = sample.runId;
       stepId = sample.stepId;
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         snapshot: sample.snapshot,
       });
@@ -168,7 +168,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     it('should retrieve a workflow run by ID', async () => {
       const found = await storage.getWorkflowRunById({
         runId,
-        workflowName,
+        workflowId,
       });
       expect(found).not.toBeNull();
       expect(found?.runId).toBe(runId);
@@ -178,14 +178,14 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     it('should return null for non-existent workflow run ID', async () => {
       const notFound = await storage.getWorkflowRunById({
         runId: 'non-existent-id',
-        workflowName,
+        workflowId,
       });
       expect(notFound).toBeNull();
     });
   });
 
   describe('getWorkflowRuns with resourceId', () => {
-    const workflowName = 'workflow-id-test';
+    const workflowId = 'workflow-id-test';
     let resourceId: string;
     let runIds: string[] = [];
 
@@ -198,7 +198,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
         await storage.insert({
           tableName: TABLE_WORKFLOW_SNAPSHOT,
           record: {
-            workflow_name: workflowName,
+            workflow_name: workflowId,
             run_id: sample.runId,
             resourceId,
             snapshot: sample.snapshot,
@@ -212,7 +212,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       await storage.insert({
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         record: {
-          workflow_name: workflowName,
+          workflow_name: workflowId,
           run_id: other.runId,
           resourceId: 'resource-other',
           snapshot: other.snapshot,
@@ -225,7 +225,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     it('should retrieve all workflow runs by resourceId', async () => {
       const { runs } = await storage.getWorkflowRuns({
         resourceId,
-        workflowName,
+        workflowId,
       });
 
       expect(Array.isArray(runs)).toBe(true);
@@ -238,7 +238,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     it('should return an empty array if no workflow runs match resourceId', async () => {
       const { runs } = await storage.getWorkflowRuns({
         resourceId: 'non-existent-resource',
-        workflowName,
+        workflowId,
       });
       expect(Array.isArray(runs)).toBe(true);
       expect(runs.length).toBe(0);
@@ -247,7 +247,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
 
   it('should store valid ISO date strings for createdAt and updatedAt in workflow runs', async () => {
     // Use the storage instance from the test context
-    const workflowName = 'test-workflow';
+    const workflowId = 'test-workflow';
     const runId = 'test-run-id';
     const snapshot = {
       runId,
@@ -262,12 +262,12 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       status: 'success' as WorkflowRunState['status'],
     };
     await storage.persistWorkflowSnapshot({
-      workflowName,
+      workflowId,
       runId,
       snapshot,
     });
     // Fetch the row directly from the database
-    const run = await storage.getWorkflowRunById({ workflowName, runId });
+    const run = await storage.getWorkflowRunById({ workflowId, runId });
     expect(run).toBeTruthy();
     // Check that these are valid Date objects
     expect(run?.createdAt instanceof Date).toBe(true);
@@ -278,7 +278,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
 
   it('getWorkflowRuns should return valid createdAt and updatedAt', async () => {
     // Use the storage instance from the test context
-    const workflowName = 'test-workflow';
+    const workflowId = 'test-workflow';
     const runId = 'test-run-id-2';
     const snapshot = {
       runId,
@@ -293,12 +293,12 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       status: 'success' as WorkflowRunState['status'],
     };
     await storage.persistWorkflowSnapshot({
-      workflowName,
+      workflowId,
       runId,
       snapshot,
     });
 
-    const { runs } = await storage.getWorkflowRuns({ workflowName });
+    const { runs } = await storage.getWorkflowRuns({ workflowId });
     expect(runs.length).toBeGreaterThan(0);
     const run = runs.find(r => r.runId === runId);
     expect(run).toBeTruthy();
@@ -310,7 +310,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
 
   describe('Workflow Snapshots', () => {
     it('should persist and load workflow snapshots', async () => {
-      const workflowName = 'test-workflow';
+      const workflowId = 'test-workflow';
       const runId = `run-${randomUUID()}`;
       const snapshot = {
         status: 'running',
@@ -322,13 +322,13 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       } as any;
 
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         snapshot,
       });
 
       const loadedSnapshot = await storage.loadWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
       });
 
@@ -337,7 +337,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
 
     it('should return null for non-existent workflow snapshot', async () => {
       const result = await storage.loadWorkflowSnapshot({
-        workflowName: 'non-existent',
+        workflowId: 'non-existent',
         runId: 'non-existent',
       });
 
@@ -345,7 +345,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     });
 
     it('should update existing workflow snapshot', async () => {
-      const workflowName = 'test-workflow';
+      const workflowId = 'test-workflow';
       const runId = `run-${randomUUID()}`;
       const initialSnapshot = {
         status: 'running',
@@ -357,7 +357,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       };
 
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         snapshot: initialSnapshot as any,
       });
@@ -374,13 +374,13 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       } as any;
 
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         snapshot: updatedSnapshot,
       });
 
       const loadedSnapshot = await storage.loadWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
       });
 
@@ -388,7 +388,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     });
 
     it('should handle complex workflow state', async () => {
-      const workflowName = 'complex-workflow';
+      const workflowId = 'complex-workflow';
       const runId = `run-${randomUUID()}`;
       const complexSnapshot = {
         value: { currentState: 'running' },
@@ -435,13 +435,13 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       };
 
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         snapshot: complexSnapshot as unknown as WorkflowRunState,
       });
 
       const loadedSnapshot = await storage.loadWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
       });
 
@@ -449,7 +449,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
     });
 
     it('should persist resourceId when creating workflow runs', async () => {
-      const workflowName = 'test-workflow';
+      const workflowId = 'test-workflow';
       const runId = `run-${randomUUID()}`;
       const resourceId = `resource-${randomUUID()}`;
       const snapshot = {
@@ -458,7 +458,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       } as any;
 
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         resourceId,
         snapshot,
@@ -466,19 +466,19 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
 
       const run = await storage.getWorkflowRunById({
         runId,
-        workflowName,
+        workflowId,
       });
 
       expect(run?.resourceId).toBe(resourceId);
 
       expect(run?.snapshot).toEqual(snapshot);
-      expect(run?.workflowName).toBe(workflowName);
+      expect(run?.workflowId).toBe(workflowId);
       expect(run?.runId).toBe(runId);
     });
 
     // implement on other stores
     it.todo('should update workflow results in snapshot', async () => {
-      const workflowName = 'test-workflow';
+      const workflowId = 'test-workflow';
       const runId = `run-${randomUUID()}`;
       const snapshot = {
         status: 'running',
@@ -486,13 +486,13 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       } as any;
 
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         snapshot,
       });
 
       const updatedSnapshot = await storage.updateWorkflowResults({
-        workflowName,
+        workflowId,
         runId,
         stepId: 'step-1',
         result: {
@@ -519,7 +519,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
 
       await Promise.all([
         storage.updateWorkflowResults({
-          workflowName,
+          workflowId,
           runId,
           stepId: 'step-1',
           result: {
@@ -532,7 +532,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
           runtimeContext: { test: 'test' },
         }),
         storage.updateWorkflowResults({
-          workflowName,
+          workflowId,
           runId,
           stepId: 'step-2',
           result: {
@@ -547,7 +547,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       ]);
 
       const finalSnapshot = await storage.loadWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
       });
 
@@ -571,7 +571,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
 
     // implement on other stores
     it.todo('should update workflow state in snapshot', async () => {
-      const workflowName = 'test-workflow';
+      const workflowId = 'test-workflow';
       const runId = `run-${randomUUID()}`;
       const snapshot = {
         status: 'running',
@@ -579,14 +579,14 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       } as any;
 
       await storage.persistWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
         snapshot,
       });
 
       await Promise.all([
         storage.updateWorkflowState({
-          workflowName,
+          workflowId,
           runId,
           opts: {
             status: 'success',
@@ -596,7 +596,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
           },
         }),
         storage.updateWorkflowState({
-          workflowName,
+          workflowId,
           runId,
           opts: {
             status: 'success',
@@ -612,7 +612,7 @@ export function createWorkflowsTests({ storage }: { storage: MastraStorage }) {
       ]);
 
       const finalSnapshot = await storage.loadWorkflowSnapshot({
-        workflowName,
+        workflowId,
         runId,
       });
 

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -208,27 +208,27 @@ export class ClickhouseStore extends MastraStorage {
   }
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -238,59 +238,53 @@ export class ClickhouseStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    return this.stores.workflows.getWorkflowRuns({ workflowName, fromDate, toDate, limit, offset, resourceId });
+    return this.stores.workflows.getWorkflowRuns({ workflowId, fromDate, toDate, limit, offset, resourceId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async getTraces(args: StorageGetTracesArg): Promise<any[]> {

--- a/stores/cloudflare-d1/src/storage/binding-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/binding-api.test.ts
@@ -958,8 +958,8 @@ createTestSuite(
 //       const { runs, total } = await store.getWorkflowRuns();
 //       expect(runs).toHaveLength(2);
 //       expect(total).toBe(2);
-//       expect(runs[0]!.workflowName).toBe(workflowName2); // Most recent first
-//       expect(runs[1]!.workflowName).toBe(workflowName1);
+//       expect(runs[0]!.workflowId).toBe(workflowName2); // Most recent first
+//       expect(runs[1]!.workflowId).toBe(workflowName1);
 //       const firstSnapshot = runs[0]!.snapshot;
 //       const secondSnapshot = runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId2, 'failed');
@@ -980,7 +980,7 @@ createTestSuite(
 //       const { runs, total } = await store.getWorkflowRuns({ workflowName: workflowName1 });
 //       expect(runs).toHaveLength(1);
 //       expect(total).toBe(1);
-//       expect(runs[0]!.workflowName).toBe(workflowName1);
+//       expect(runs[0]!.workflowId).toBe(workflowName1);
 //       const snapshot = runs[0]!.snapshot;
 //       checkWorkflowSnapshot(snapshot, stepId1, 'success');
 //     });
@@ -1034,8 +1034,8 @@ createTestSuite(
 //       });
 
 //       expect(runs).toHaveLength(2);
-//       expect(runs[0]!.workflowName).toBe(workflowName3);
-//       expect(runs[1]!.workflowName).toBe(workflowName2);
+//       expect(runs[0]!.workflowId).toBe(workflowName3);
+//       expect(runs[1]!.workflowId).toBe(workflowName2);
 //       const firstSnapshot = runs[0]!.snapshot;
 //       const secondSnapshot = runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId3, 'suspended');
@@ -1061,8 +1061,8 @@ createTestSuite(
 //       const page1 = await store.getWorkflowRuns({ limit: 2, offset: 0 });
 //       expect(page1.runs).toHaveLength(2);
 //       expect(page1.total).toBe(3); // Total count of all records
-//       expect(page1.runs[0]!.workflowName).toBe(workflowName3);
-//       expect(page1.runs[1]!.workflowName).toBe(workflowName2);
+//       expect(page1.runs[0]!.workflowId).toBe(workflowName3);
+//       expect(page1.runs[1]!.workflowId).toBe(workflowName2);
 //       const firstSnapshot = page1.runs[0]!.snapshot;
 //       const secondSnapshot = page1.runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId3, 'suspended');
@@ -1072,7 +1072,7 @@ createTestSuite(
 //       const page2 = await store.getWorkflowRuns({ limit: 2, offset: 2 });
 //       expect(page2.runs).toHaveLength(1);
 //       expect(page2.total).toBe(3);
-//       expect(page2.runs[0]!.workflowName).toBe(workflowName1);
+//       expect(page2.runs[0]!.workflowId).toBe(workflowName1);
 //       const snapshot = page2.runs[0]!.snapshot;
 //       checkWorkflowSnapshot(snapshot, stepId1, 'success');
 //     });

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -312,27 +312,27 @@ export class D1Store extends MastraStorage {
   }
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -342,53 +342,47 @@ export class D1Store extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
-  async loadWorkflowSnapshot(params: { workflowName: string; runId: string }): Promise<WorkflowRunState | null> {
+  async loadWorkflowSnapshot(params: { workflowId: string; runId: string }): Promise<WorkflowRunState | null> {
     return this.stores.workflows.loadWorkflowSnapshot(params);
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    return this.stores.workflows.getWorkflowRuns({ workflowName, fromDate, toDate, limit, offset, resourceId });
+    return this.stores.workflows.getWorkflowRuns({ workflowId, fromDate, toDate, limit, offset, resourceId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   /**

--- a/stores/cloudflare-d1/src/storage/rest-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/rest-api.test.ts
@@ -893,8 +893,8 @@ describe.skip('D1Store REST API', () => {
       const { runs, total } = await store.getWorkflowRuns();
       expect(runs).toHaveLength(2);
       expect(total).toBe(2);
-      expect(runs[0]!.workflowName).toBe(workflowName2); // Most recent first
-      expect(runs[1]!.workflowName).toBe(workflowName1);
+      expect(runs[0]!.workflowId).toBe(workflowName2); // Most recent first
+      expect(runs[1]!.workflowId).toBe(workflowName1);
       const firstSnapshot = runs[0]!.snapshot;
       const secondSnapshot = runs[1]!.snapshot;
       checkWorkflowSnapshot(firstSnapshot, stepId2, 'failed');
@@ -915,7 +915,7 @@ describe.skip('D1Store REST API', () => {
       const { runs, total } = await store.getWorkflowRuns({ workflowName: workflowName1 });
       expect(runs).toHaveLength(1);
       expect(total).toBe(1);
-      expect(runs[0]!.workflowName).toBe(workflowName1);
+      expect(runs[0]!.workflowId).toBe(workflowName1);
       const snapshot = runs[0]!.snapshot;
       checkWorkflowSnapshot(snapshot, stepId1, 'success');
     });
@@ -969,8 +969,8 @@ describe.skip('D1Store REST API', () => {
       });
 
       expect(runs).toHaveLength(2);
-      expect(runs[0]!.workflowName).toBe(workflowName3);
-      expect(runs[1]!.workflowName).toBe(workflowName2);
+      expect(runs[0]!.workflowId).toBe(workflowName3);
+      expect(runs[1]!.workflowId).toBe(workflowName2);
       const firstSnapshot = runs[0]!.snapshot;
       const secondSnapshot = runs[1]!.snapshot;
       checkWorkflowSnapshot(firstSnapshot, stepId3, 'suspended');
@@ -996,8 +996,8 @@ describe.skip('D1Store REST API', () => {
       const page1 = await store.getWorkflowRuns({ limit: 2, offset: 0 });
       expect(page1.runs).toHaveLength(2);
       expect(page1.total).toBe(3); // Total count of all records
-      expect(page1.runs[0]!.workflowName).toBe(workflowName3);
-      expect(page1.runs[1]!.workflowName).toBe(workflowName2);
+      expect(page1.runs[0]!.workflowId).toBe(workflowName3);
+      expect(page1.runs[1]!.workflowId).toBe(workflowName2);
       const firstSnapshot = page1.runs[0]!.snapshot;
       const secondSnapshot = page1.runs[1]!.snapshot;
       checkWorkflowSnapshot(firstSnapshot, stepId3, 'suspended');
@@ -1007,7 +1007,7 @@ describe.skip('D1Store REST API', () => {
       const page2 = await store.getWorkflowRuns({ limit: 2, offset: 2 });
       expect(page2.runs).toHaveLength(1);
       expect(page2.total).toBe(3);
-      expect(page2.runs[0]!.workflowName).toBe(workflowName1);
+      expect(page2.runs[0]!.workflowId).toBe(workflowName1);
       const snapshot = page2.runs[0]!.snapshot;
       checkWorkflowSnapshot(snapshot, stepId1, 'success');
     });

--- a/stores/cloudflare/src/storage/binding-api.test.ts
+++ b/stores/cloudflare/src/storage/binding-api.test.ts
@@ -1135,8 +1135,8 @@ createTestSuite(new CloudflareStore(TEST_CONFIG));
 //       const { runs, total } = await store.getWorkflowRuns({ namespace: 'test' });
 //       expect(runs).toHaveLength(2);
 //       expect(total).toBe(2);
-//       expect(runs[0]!.workflowName).toBe(workflowName2); // Most recent first
-//       expect(runs[1]!.workflowName).toBe(workflowName1);
+//       expect(runs[0]!.workflowId).toBe(workflowName2); // Most recent first
+//       expect(runs[1]!.workflowId).toBe(workflowName1);
 //       const firstSnapshot = runs[0]!.snapshot;
 //       const secondSnapshot = runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId2, 'waiting');
@@ -1172,7 +1172,7 @@ createTestSuite(new CloudflareStore(TEST_CONFIG));
 //       const { runs, total } = await store.getWorkflowRuns({ namespace: 'test', workflowName: workflowName1 });
 //       expect(runs).toHaveLength(1);
 //       expect(total).toBe(1);
-//       expect(runs[0]!.workflowName).toBe(workflowName1);
+//       expect(runs[0]!.workflowId).toBe(workflowName1);
 //       const snapshot = runs[0]!.snapshot;
 //       if (typeof snapshot === 'string') {
 //         throw new Error('Expected WorkflowRunState, got string');
@@ -1242,8 +1242,8 @@ createTestSuite(new CloudflareStore(TEST_CONFIG));
 //       });
 
 //       expect(runs).toHaveLength(2);
-//       expect(runs[0]!.workflowName).toBe(workflowName3);
-//       expect(runs[1]!.workflowName).toBe(workflowName2);
+//       expect(runs[0]!.workflowId).toBe(workflowName3);
+//       expect(runs[1]!.workflowId).toBe(workflowName2);
 //       const firstSnapshot = runs[0]!.snapshot;
 //       const secondSnapshot = runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId3, 'skipped');
@@ -1301,8 +1301,8 @@ createTestSuite(new CloudflareStore(TEST_CONFIG));
 //       });
 //       expect(page1.runs).toHaveLength(2);
 //       expect(page1.total).toBe(3); // Total count of all records
-//       expect(page1.runs[0]!.workflowName).toBe(workflowName3);
-//       expect(page1.runs[1]!.workflowName).toBe(workflowName2);
+//       expect(page1.runs[0]!.workflowId).toBe(workflowName3);
+//       expect(page1.runs[1]!.workflowId).toBe(workflowName2);
 //       const firstSnapshot = page1.runs[0]!.snapshot;
 //       const secondSnapshot = page1.runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId3, 'skipped');
@@ -1316,7 +1316,7 @@ createTestSuite(new CloudflareStore(TEST_CONFIG));
 //       });
 //       expect(page2.runs).toHaveLength(1);
 //       expect(page2.total).toBe(3);
-//       expect(page2.runs[0]!.workflowName).toBe(workflowName1);
+//       expect(page2.runs[0]!.workflowId).toBe(workflowName1);
 //       const snapshot = page2.runs[0]!.snapshot;
 //       checkWorkflowSnapshot(snapshot, stepId1, 'success');
 //     });

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -247,27 +247,27 @@ export class CloudflareStore extends MastraStorage {
   }
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -277,7 +277,7 @@ export class CloudflareStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
@@ -293,7 +293,7 @@ export class CloudflareStore extends MastraStorage {
   }
 
   async persistWorkflowSnapshot(params: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
@@ -301,7 +301,7 @@ export class CloudflareStore extends MastraStorage {
     return this.stores.workflows.persistWorkflowSnapshot(params);
   }
 
-  async loadWorkflowSnapshot(params: { workflowName: string; runId: string }): Promise<WorkflowRunState | null> {
+  async loadWorkflowSnapshot(params: { workflowId: string; runId: string }): Promise<WorkflowRunState | null> {
     return this.stores.workflows.loadWorkflowSnapshot(params);
   }
 
@@ -348,14 +348,14 @@ export class CloudflareStore extends MastraStorage {
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     limit = 20,
     offset = 0,
     resourceId,
     fromDate,
     toDate,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     limit?: number;
     offset?: number;
     resourceId?: string;
@@ -363,7 +363,7 @@ export class CloudflareStore extends MastraStorage {
     toDate?: Date;
   } = {}): Promise<WorkflowRuns> {
     return this.stores.workflows.getWorkflowRuns({
-      workflowName,
+      workflowId,
       limit,
       offset,
       resourceId,
@@ -372,14 +372,8 @@ export class CloudflareStore extends MastraStorage {
     });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async getTracesPaginated(args: StorageGetTracesPaginatedArg): Promise<PaginationInfo & { traces: Trace[] }> {

--- a/stores/cloudflare/src/storage/rest-api.test.ts
+++ b/stores/cloudflare/src/storage/rest-api.test.ts
@@ -1038,8 +1038,8 @@ describe.skip('CloudflareStore REST API', () => {
       const { runs, total } = await store.getWorkflowRuns({ namespace: 'test' });
       expect(runs).toHaveLength(2);
       expect(total).toBe(2);
-      expect(runs[0]!.workflowName).toBe(workflowName2); // Most recent first
-      expect(runs[1]!.workflowName).toBe(workflowName1);
+      expect(runs[0]!.workflowId).toBe(workflowName2); // Most recent first
+      expect(runs[1]!.workflowId).toBe(workflowName1);
       const firstSnapshot = runs[0]!.snapshot;
       const secondSnapshot = runs[1]!.snapshot;
       checkWorkflowSnapshot(firstSnapshot, stepId2, 'waiting');
@@ -1075,7 +1075,7 @@ describe.skip('CloudflareStore REST API', () => {
       const { runs, total } = await store.getWorkflowRuns({ namespace: 'test', workflowName: workflowName1 });
       expect(runs).toHaveLength(1);
       expect(total).toBe(1);
-      expect(runs[0]!.workflowName).toBe(workflowName1);
+      expect(runs[0]!.workflowId).toBe(workflowName1);
       const snapshot = runs[0]!.snapshot;
       if (typeof snapshot === 'string') {
         throw new Error('Expected WorkflowRunState, got string');
@@ -1145,8 +1145,8 @@ describe.skip('CloudflareStore REST API', () => {
       });
 
       expect(runs).toHaveLength(2);
-      expect(runs[0]!.workflowName).toBe(workflowName3);
-      expect(runs[1]!.workflowName).toBe(workflowName2);
+      expect(runs[0]!.workflowId).toBe(workflowName3);
+      expect(runs[1]!.workflowId).toBe(workflowName2);
       const firstSnapshot = runs[0]!.snapshot;
       const secondSnapshot = runs[1]!.snapshot;
       checkWorkflowSnapshot(firstSnapshot, stepId3, 'skipped');
@@ -1204,8 +1204,8 @@ describe.skip('CloudflareStore REST API', () => {
       });
       expect(page1.runs).toHaveLength(2);
       expect(page1.total).toBe(3); // Total count of all records
-      expect(page1.runs[0]!.workflowName).toBe(workflowName3);
-      expect(page1.runs[1]!.workflowName).toBe(workflowName2);
+      expect(page1.runs[0]!.workflowId).toBe(workflowName3);
+      expect(page1.runs[1]!.workflowId).toBe(workflowName2);
       const firstSnapshot = page1.runs[0]!.snapshot;
       const secondSnapshot = page1.runs[1]!.snapshot;
       checkWorkflowSnapshot(firstSnapshot, stepId3, 'skipped');
@@ -1219,7 +1219,7 @@ describe.skip('CloudflareStore REST API', () => {
       });
       expect(page2.runs).toHaveLength(1);
       expect(page2.total).toBe(3);
-      expect(page2.runs[0]!.workflowName).toBe(workflowName1);
+      expect(page2.runs[0]!.workflowId).toBe(workflowName1);
       const snapshot = page2.runs[0]!.snapshot;
       checkWorkflowSnapshot(snapshot, stepId1, 'success');
     });

--- a/stores/dynamodb/src/storage/index.test.ts
+++ b/stores/dynamodb/src/storage/index.test.ts
@@ -1252,7 +1252,7 @@ describe('DynamoDBStore', () => {
 //       const found = await store.getWorkflowRunById({ runId: runId1, workflowName: wfName });
 //       expect(found).toBeDefined();
 //       expect(found!.runId).toBe(runId1);
-//       expect(found!.workflowName).toBe(wfName);
+//       expect(found!.workflowId).toBe(wfName);
 
 //       const notFound = await store.getWorkflowRunById({ runId: 'non-existent', workflowName: wfName });
 //       expect(notFound).toBeNull();

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -360,27 +360,27 @@ export class DynamoDBStore extends MastraStorage {
 
   // Workflow operations
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -390,35 +390,35 @@ export class DynamoDBStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
   async getWorkflowRuns(args?: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
@@ -428,7 +428,7 @@ export class DynamoDBStore extends MastraStorage {
     return this.stores.workflows.getWorkflowRuns(args);
   }
 
-  async getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null> {
+  async getWorkflowRunById(args: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
     return this.stores.workflows.getWorkflowRunById(args);
   }
 

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -372,7 +372,7 @@ export class LanceStorage extends MastraStorage {
 
   async getWorkflowRuns(args?: {
     namespace?: string;
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
@@ -381,8 +381,8 @@ export class LanceStorage extends MastraStorage {
     return this.stores.workflows.getWorkflowRuns(args);
   }
 
-  async getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<{
-    workflowName: string;
+  async getWorkflowRunById(args: { runId: string; workflowId?: string }): Promise<{
+    workflowId: string;
     runId: string;
     snapshot: any;
     createdAt: Date;
@@ -392,27 +392,27 @@ export class LanceStorage extends MastraStorage {
   }
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -422,31 +422,31 @@ export class LanceStorage extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
   async getScoreById({ id: _id }: { id: string }): Promise<ScoreRowData | null> {

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -361,27 +361,27 @@ export class LibSQLStore extends MastraStorage {
    */
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -391,59 +391,53 @@ export class LibSQLStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    return this.stores.workflows.getWorkflowRuns({ workflowName, fromDate, toDate, limit, offset, resourceId });
+    return this.stores.workflows.getWorkflowRuns({ workflowId, fromDate, toDate, limit, offset, resourceId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async getResourceById({ resourceId }: { resourceId: string }): Promise<StorageResourceType | null> {

--- a/stores/mongodb/src/storage/domains/workflows/index.ts
+++ b/stores/mongodb/src/storage/domains/workflows/index.ts
@@ -14,13 +14,13 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
 
   updateWorkflowResults(
     {
-      // workflowName,
+      // workflowId,
       // runId,
       // stepId,
       // result,
       // runtimeContext,
     }: {
-      workflowName: string;
+      workflowId: string;
       runId: string;
       stepId: string;
       result: StepResult<any, any, any, any>;
@@ -31,11 +31,11 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
   }
   updateWorkflowState(
     {
-      // workflowName,
+      // workflowId,
       // runId,
       // opts,
     }: {
-      workflowName: string;
+      workflowId: string;
       runId: string;
       opts: {
         status: string;
@@ -50,12 +50,12 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
@@ -63,10 +63,10 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
     try {
       const collection = await this.operations.getCollection(TABLE_WORKFLOW_SNAPSHOT);
       await collection.updateOne(
-        { workflow_name: workflowName, run_id: runId },
+        { workflow_name: workflowId, run_id: runId },
         {
           $set: {
-            workflow_name: workflowName,
+            workflow_name: workflowId,
             run_id: runId,
             resourceId,
             snapshot,
@@ -82,7 +82,7 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
           id: 'STORAGE_MONGODB_STORE_PERSIST_WORKFLOW_SNAPSHOT_FAILED',
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
-          details: { workflowName, runId },
+          details: { workflowId, runId },
         },
         error,
       );
@@ -90,17 +90,17 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
     try {
       const result = await this.operations.load<any[]>({
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         keys: {
-          workflow_name: workflowName,
+          workflow_name: workflowId,
           run_id: runId,
         },
       });
@@ -116,7 +116,7 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
           id: 'STORAGE_MONGODB_STORE_LOAD_WORKFLOW_SNAPSHOT_FAILED',
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
-          details: { workflowName, runId },
+          details: { workflowId, runId },
         },
         error,
       );
@@ -124,7 +124,7 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
   }
 
   async getWorkflowRuns(args?: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
@@ -134,8 +134,8 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
     const options = args || {};
     try {
       const query: any = {};
-      if (options.workflowName) {
-        query['workflow_name'] = options.workflowName;
+      if (options.workflowId) {
+        query['workflow_name'] = options.workflowId;
       }
       if (options.fromDate) {
         query['createdAt'] = { $gte: options.fromDate };
@@ -176,21 +176,21 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
           id: 'STORAGE_MONGODB_STORE_GET_WORKFLOW_RUNS_FAILED',
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
-          details: { workflowName: options.workflowName || 'unknown' },
+          details: { workflowId: options.workflowId || 'unknown' },
         },
         error,
       );
     }
   }
 
-  async getWorkflowRunById(args: { runId: string; workflowName?: string }): Promise<WorkflowRun | null> {
+  async getWorkflowRunById(args: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
     try {
       const query: any = {};
       if (args.runId) {
         query['run_id'] = args.runId;
       }
-      if (args.workflowName) {
-        query['workflow_name'] = args.workflowName;
+      if (args.workflowId) {
+        query['workflow_name'] = args.workflowId;
       }
 
       const collection = await this.operations.getCollection(TABLE_WORKFLOW_SNAPSHOT);
@@ -225,7 +225,7 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
     }
 
     return {
-      workflowName: row.workflow_name as string,
+      workflowId: row.workflow_name as string,
       runId: row.run_id as string,
       snapshot: parsedSnapshot,
       createdAt: new Date(row.createdAt as string),

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -260,7 +260,7 @@ export class MongoDBStore extends MastraStorage {
   }
 
   async getWorkflowRuns(args?: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
@@ -284,27 +284,27 @@ export class MongoDBStore extends MastraStorage {
   }
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -314,41 +314,35 @@ export class MongoDBStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async close(): Promise<void> {

--- a/stores/mssql/src/storage/domains/workflows/index.ts
+++ b/stores/mssql/src/storage/domains/workflows/index.ts
@@ -15,7 +15,7 @@ function parseWorkflowRun(row: any): WorkflowRun {
     }
   }
   return {
-    workflowName: row.workflow_name,
+    workflowId: row.workflow_name,
     runId: row.run_id,
     snapshot: parsedSnapshot,
     createdAt: row.createdAt,
@@ -46,13 +46,13 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
 
   updateWorkflowResults(
     {
-      // workflowName,
+      // workflowId,
       // runId,
       // stepId,
       // result,
       // runtimeContext,
     }: {
-      workflowName: string;
+      workflowId: string;
       runId: string;
       stepId: string;
       result: StepResult<any, any, any, any>;
@@ -63,11 +63,11 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
   }
   updateWorkflowState(
     {
-      // workflowName,
+      // workflowId,
       // runId,
       // opts,
     }: {
-      workflowName: string;
+      workflowId: string;
       runId: string;
       opts: {
         status: string;
@@ -82,12 +82,12 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
@@ -96,7 +96,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
     const now = new Date().toISOString();
     try {
       const request = this.pool.request();
-      request.input('workflow_name', workflowName);
+      request.input('workflow_name', workflowId);
       request.input('run_id', runId);
       request.input('resourceId', resourceId);
       request.input('snapshot', JSON.stringify(snapshot));
@@ -119,7 +119,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: {
-            workflowName,
+            workflowId,
             runId,
           },
         },
@@ -129,17 +129,17 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
     try {
       const result = await this.operations.load({
         tableName: TABLE_WORKFLOW_SNAPSHOT,
         keys: {
-          workflow_name: workflowName,
+          workflow_name: workflowId,
           run_id: runId,
         },
       });
@@ -154,7 +154,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: {
-            workflowName,
+            workflowId,
             runId,
           },
         },
@@ -163,13 +163,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
     }
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
     try {
       const conditions: string[] = [];
       const paramMap: Record<string, any> = {};
@@ -179,9 +173,9 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
         paramMap['runId'] = runId;
       }
 
-      if (workflowName) {
-        conditions.push(`[workflow_name] = @workflowName`);
-        paramMap['workflowName'] = workflowName;
+      if (workflowId) {
+        conditions.push(`[workflow_name] = @workflowId`);
+        paramMap['workflowId'] = workflowId;
       }
 
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -204,7 +198,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
           category: ErrorCategory.THIRD_PARTY,
           details: {
             runId,
-            workflowName: workflowName || '',
+            workflowId: workflowId || '',
           },
         },
         error,
@@ -213,14 +207,14 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
@@ -231,9 +225,9 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
       const conditions: string[] = [];
       const paramMap: Record<string, any> = {};
 
-      if (workflowName) {
-        conditions.push(`[workflow_name] = @workflowName`);
-        paramMap['workflowName'] = workflowName;
+      if (workflowId) {
+        conditions.push(`[workflow_name] = @workflowId`);
+        paramMap['workflowId'] = workflowId;
       }
 
       if (resourceId) {
@@ -290,7 +284,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: {
-            workflowName: workflowName || 'all',
+            workflowId: workflowId || 'all',
           },
         },
         error,

--- a/stores/mssql/src/storage/index.test.ts
+++ b/stores/mssql/src/storage/index.test.ts
@@ -888,8 +888,8 @@ if (process.env.ENABLE_TESTS === 'true') {
 //       const { runs, total } = await store.getWorkflowRuns();
 //       expect(runs).toHaveLength(2);
 //       expect(total).toBe(2);
-//       expect(runs[0]!.workflowName).toBe(workflowName2); // Most recent first
-//       expect(runs[1]!.workflowName).toBe(workflowName1);
+//       expect(runs[0]!.workflowId).toBe(workflowName2); // Most recent first
+//       expect(runs[1]!.workflowId).toBe(workflowName1);
 //       const firstSnapshot = runs[0]!.snapshot;
 //       const secondSnapshot = runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId2, 'failed');
@@ -910,7 +910,7 @@ if (process.env.ENABLE_TESTS === 'true') {
 //       const { runs, total } = await store.getWorkflowRuns({ workflowName: workflowName1 });
 //       expect(runs).toHaveLength(1);
 //       expect(total).toBe(1);
-//       expect(runs[0]!.workflowName).toBe(workflowName1);
+//       expect(runs[0]!.workflowId).toBe(workflowName1);
 //       const snapshot = runs[0]!.snapshot;
 //       checkWorkflowSnapshot(snapshot, stepId1, 'success');
 //     });
@@ -965,8 +965,8 @@ if (process.env.ENABLE_TESTS === 'true') {
 //       });
 
 //       expect(runs).toHaveLength(2);
-//       expect(runs[0]!.workflowName).toBe(workflowName3);
-//       expect(runs[1]!.workflowName).toBe(workflowName2);
+//       expect(runs[0]!.workflowId).toBe(workflowName3);
+//       expect(runs[1]!.workflowId).toBe(workflowName2);
 //       const firstSnapshot = runs[0]!.snapshot;
 //       const secondSnapshot = runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId3, 'suspended');
@@ -992,8 +992,8 @@ if (process.env.ENABLE_TESTS === 'true') {
 //       const page1 = await store.getWorkflowRuns({ limit: 2, offset: 0 });
 //       expect(page1.runs).toHaveLength(2);
 //       expect(page1.total).toBe(3); // Total count of all records
-//       expect(page1.runs[0]!.workflowName).toBe(workflowName3);
-//       expect(page1.runs[1]!.workflowName).toBe(workflowName2);
+//       expect(page1.runs[0]!.workflowId).toBe(workflowName3);
+//       expect(page1.runs[1]!.workflowId).toBe(workflowName2);
 //       const firstSnapshot = page1.runs[0]!.snapshot;
 //       const secondSnapshot = page1.runs[1]!.snapshot;
 //       checkWorkflowSnapshot(firstSnapshot, stepId3, 'suspended');
@@ -1003,7 +1003,7 @@ if (process.env.ENABLE_TESTS === 'true') {
 //       const page2 = await store.getWorkflowRuns({ limit: 2, offset: 2 });
 //       expect(page2.runs).toHaveLength(1);
 //       expect(page2.total).toBe(3);
-//       expect(page2.runs[0]!.workflowName).toBe(workflowName1);
+//       expect(page2.runs[0]!.workflowId).toBe(workflowName1);
 //       const snapshot = page2.runs[0]!.snapshot;
 //       checkWorkflowSnapshot(snapshot, stepId1, 'success');
 //     });

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -360,27 +360,27 @@ export class MSSQLStore extends MastraStorage {
    * Workflows
    */
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -390,59 +390,53 @@ export class MSSQLStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    return this.stores.workflows.getWorkflowRuns({ workflowName, fromDate, toDate, limit, offset, resourceId });
+    return this.stores.workflows.getWorkflowRuns({ workflowId, fromDate, toDate, limit, offset, resourceId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async close(): Promise<void> {

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -374,27 +374,27 @@ export class PostgresStore extends MastraStorage {
    * Workflows
    */
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -404,59 +404,53 @@ export class PostgresStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
     resourceId,
     snapshot,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
   }): Promise<void> {
-    return this.stores.workflows.persistWorkflowSnapshot({ workflowName, runId, resourceId, snapshot });
+    return this.stores.workflows.persistWorkflowSnapshot({ workflowId, runId, resourceId, snapshot });
   }
 
   async loadWorkflowSnapshot({
-    workflowName,
+    workflowId,
     runId,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
-    return this.stores.workflows.loadWorkflowSnapshot({ workflowName, runId });
+    return this.stores.workflows.loadWorkflowSnapshot({ workflowId, runId });
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    return this.stores.workflows.getWorkflowRuns({ workflowName, fromDate, toDate, limit, offset, resourceId });
+    return this.stores.workflows.getWorkflowRuns({ workflowId, fromDate, toDate, limit, offset, resourceId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async close(): Promise<void> {

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -238,27 +238,27 @@ export class UpstashStore extends MastraStorage {
   }
 
   async updateWorkflowResults({
-    workflowName,
+    workflowId,
     runId,
     stepId,
     result,
     runtimeContext,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     stepId: string;
     result: StepResult<any, any, any, any>;
     runtimeContext: Record<string, any>;
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
-    return this.stores.workflows.updateWorkflowResults({ workflowName, runId, stepId, result, runtimeContext });
+    return this.stores.workflows.updateWorkflowResults({ workflowId, runId, stepId, result, runtimeContext });
   }
 
   async updateWorkflowState({
-    workflowName,
+    workflowId,
     runId,
     opts,
   }: {
-    workflowName: string;
+    workflowId: string;
     runId: string;
     opts: {
       status: string;
@@ -268,12 +268,12 @@ export class UpstashStore extends MastraStorage {
       waitingPaths?: Record<string, number[]>;
     };
   }): Promise<WorkflowRunState | undefined> {
-    return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
+    return this.stores.workflows.updateWorkflowState({ workflowId, runId, opts });
   }
 
   async persistWorkflowSnapshot(params: {
     namespace: string;
-    workflowName: string;
+    workflowId: string;
     runId: string;
     resourceId?: string;
     snapshot: WorkflowRunState;
@@ -283,38 +283,32 @@ export class UpstashStore extends MastraStorage {
 
   async loadWorkflowSnapshot(params: {
     namespace: string;
-    workflowName: string;
+    workflowId: string;
     runId: string;
   }): Promise<WorkflowRunState | null> {
     return this.stores.workflows.loadWorkflowSnapshot(params);
   }
 
   async getWorkflowRuns({
-    workflowName,
+    workflowId,
     fromDate,
     toDate,
     limit,
     offset,
     resourceId,
   }: {
-    workflowName?: string;
+    workflowId?: string;
     fromDate?: Date;
     toDate?: Date;
     limit?: number;
     offset?: number;
     resourceId?: string;
   } = {}): Promise<WorkflowRuns> {
-    return this.stores.workflows.getWorkflowRuns({ workflowName, fromDate, toDate, limit, offset, resourceId });
+    return this.stores.workflows.getWorkflowRuns({ workflowId, fromDate, toDate, limit, offset, resourceId });
   }
 
-  async getWorkflowRunById({
-    runId,
-    workflowName,
-  }: {
-    runId: string;
-    workflowName?: string;
-  }): Promise<WorkflowRun | null> {
-    return this.stores.workflows.getWorkflowRunById({ runId, workflowName });
+  async getWorkflowRunById({ runId, workflowId }: { runId: string; workflowId?: string }): Promise<WorkflowRun | null> {
+    return this.stores.workflows.getWorkflowRunById({ runId, workflowId });
   }
 
   async close(): Promise<void> {

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -9227,7 +9227,7 @@ describe('MastraInngestWorkflow', () => {
       expect(afterResumeTotal).toBe(1);
       expect(afterResumeRuns).toHaveLength(1);
       expect(afterResumeRuns.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId]));
-      expect(afterResumeRuns[0]?.workflowName).toBe('test-workflow');
+      expect(afterResumeRuns[0]?.workflowId).toBe('test-workflow');
       expect(afterResumeRuns[0]?.snapshot).toBeDefined();
       expect((afterResumeRuns[0]?.snapshot as any).status).toBe('suspended');
 
@@ -9295,12 +9295,12 @@ describe('MastraInngestWorkflow', () => {
       expect(total).toBe(1);
       expect(runs).toHaveLength(1);
       expect(runs.map(r => r.runId)).toEqual(expect.arrayContaining([run1.runId]));
-      expect(runs[0]?.workflowName).toBe('test-workflow');
+      expect(runs[0]?.workflowId).toBe('test-workflow');
       expect(runs[0]?.snapshot).toBeDefined();
 
       const run3 = await workflow.getWorkflowRunById(run1.runId);
       expect(run3?.runId).toBe(run1.runId);
-      expect(run3?.workflowName).toBe('test-workflow');
+      expect(run3?.workflowId).toBe('test-workflow');
       expect(run3?.snapshot).toEqual(runs[0].snapshot);
       srv.close();
     });

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -154,7 +154,7 @@ export class InngestRun<
 
       if (runs?.[0]?.status === 'Failed') {
         const snapshot = await this.#mastra?.storage?.loadWorkflowSnapshot({
-          workflowName: this.workflowId,
+          workflowId: this.workflowId,
           runId: this.runId,
         });
         return {
@@ -164,7 +164,7 @@ export class InngestRun<
 
       if (runs?.[0]?.status === 'Cancelled') {
         const snapshot = await this.#mastra?.storage?.loadWorkflowSnapshot({
-          workflowName: this.workflowId,
+          workflowId: this.workflowId,
           runId: this.runId,
         });
         return { output: { result: { steps: snapshot?.context, status: 'canceled' } } };
@@ -189,12 +189,12 @@ export class InngestRun<
     });
 
     const snapshot = await this.#mastra?.storage?.loadWorkflowSnapshot({
-      workflowName: this.workflowId,
+      workflowId: this.workflowId,
       runId: this.runId,
     });
     if (snapshot) {
       await this.#mastra?.storage?.persistWorkflowSnapshot({
-        workflowName: this.workflowId,
+        workflowId: this.workflowId,
         runId: this.runId,
         resourceId: this.resourceId,
         snapshot: {
@@ -214,7 +214,7 @@ export class InngestRun<
     initialState?: z.infer<TState>;
   }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     await this.#mastra.getStorage()?.persistWorkflowSnapshot({
-      workflowName: this.workflowId,
+      workflowId: this.workflowId,
       runId: this.runId,
       resourceId: this.resourceId,
       snapshot: {
@@ -294,7 +294,7 @@ export class InngestRun<
       typeof step === 'string' ? step : step?.id,
     );
     const snapshot = await this.#mastra?.storage?.loadWorkflowSnapshot({
-      workflowName: this.workflowId,
+      workflowId: this.workflowId,
       runId: this.runId,
     });
 
@@ -447,7 +447,7 @@ export class InngestWorkflow<
       return { runs: [], total: 0 };
     }
 
-    return storage.getWorkflowRuns({ workflowName: this.id, ...(args ?? {}) }) as unknown as WorkflowRuns;
+    return storage.getWorkflowRuns({ workflowId: this.id, ...(args ?? {}) }) as unknown as WorkflowRuns;
   }
 
   async getWorkflowRunById(runId: string): Promise<WorkflowRun | null> {
@@ -455,15 +455,13 @@ export class InngestWorkflow<
     if (!storage) {
       this.logger.debug('Cannot get workflow runs. Mastra engine is not initialized');
       //returning in memory run if no storage is initialized
-      return this.runs.get(runId)
-        ? ({ ...this.runs.get(runId), workflowName: this.id } as unknown as WorkflowRun)
-        : null;
+      return this.runs.get(runId) ? ({ ...this.runs.get(runId), workflowId: this.id } as unknown as WorkflowRun) : null;
     }
-    const run = (await storage.getWorkflowRunById({ runId, workflowName: this.id })) as unknown as WorkflowRun;
+    const run = (await storage.getWorkflowRunById({ runId, workflowId: this.id })) as unknown as WorkflowRun;
 
     return (
       run ??
-      (this.runs.get(runId) ? ({ ...this.runs.get(runId), workflowName: this.id } as unknown as WorkflowRun) : null)
+      (this.runs.get(runId) ? ({ ...this.runs.get(runId), workflowId: this.id } as unknown as WorkflowRun) : null)
     );
   }
 
@@ -541,7 +539,7 @@ export class InngestWorkflow<
 
     if (!workflowSnapshotInStorage && shouldPersistSnapshot) {
       await this.mastra?.getStorage()?.persistWorkflowSnapshot({
-        workflowName: this.id,
+        workflowId: this.id,
         runId: runIdToUse,
         resourceId: options?.resourceId,
         snapshot: {
@@ -1443,7 +1441,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           runId = stepResults[resume?.steps?.[0]]?.suspendPayload?.__workflow_meta?.runId ?? randomUUID();
 
           const snapshot: any = await this.mastra?.getStorage()?.loadWorkflowSnapshot({
-            workflowName: step.id,
+            workflowId: step.id,
             runId: runId,
           });
 
@@ -1930,7 +1928,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
         }
 
         await this.mastra?.getStorage()?.persistWorkflowSnapshot({
-          workflowName: workflowId,
+          workflowId,
           runId,
           resourceId,
           snapshot: {


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/7888

The `workflowName` parameter was confusing because it actually expects the workflow's ID value, not the variable name. This caused bugs where developers would pass the variable name instead of the `workflow.id` value.

```ts
// Before:

await storage.persistWorkflowSnapshot({
  workflowName: workflow.id,  // misleading parameter name
  runId,
  snapshot
});

// After:
await storage.persistWorkflowSnapshot({
  workflowId: workflow.id,  // now it's clear what's expected
  runId,
  snapshot
});
```
Renamed across type definitions, storage adapters, and workflow code. Database schema unchanged. Breaking change for direct storage API usage. 

Co-authored-by: Richard LoRicco [rtlo9962@gmail.com](mailto:rtlo9962@gmail.com)