### PR TITLE
fix(docs): Update Alibaba(China) documentation links

### DIFF
--- a/docs/src/content/en/models/providers/alibaba-cn.mdx
+++ b/docs/src/content/en/models/providers/alibaba-cn.mdx
@@ -14,7 +14,7 @@ import { Callout } from "nextra/components";
 
 Access 61 Alibaba (China) models through Mastra's model router. Authentication is handled automatically using the `DASHSCOPE_API_KEY` environment variable.
 
-Learn more in the [Alibaba (China) documentation](https://www.alibabacloud.com/help/en/model-studio/models).
+Learn more in the [Alibaba (China) documentation](https://bailian.console.aliyun.com/?tab=doc#/doc/?type=model&url=2840914).
 
 ```bash
 DASHSCOPE_API_KEY=your-api-key
@@ -40,7 +40,7 @@ for await (const chunk of stream) {
 ```
 
 <Callout type="info">
-Mastra uses the OpenAI-compatible `/chat/completions` endpoint. Some provider-specific features may not be available. Check the [Alibaba (China) documentation](https://www.alibabacloud.com/help/en/model-studio/models) for details.
+Mastra uses the OpenAI-compatible `/chat/completions` endpoint. Some provider-specific features may not be available. Check the [Alibaba (China) documentation](https://bailian.console.aliyun.com/?tab=doc#/doc/?type=model&url=2840914) for details.
 </Callout>
 
 ## Models


### PR DESCRIPTION
## Description

Corrected the link to the Alibaba China documentation. The link provided by Alibaba China differs from the international version.

Before: https://www.alibabacloud.com/help/en/model-studio/models

After: https://bailian.console.aliyun.com/?tab=doc#/doc/?type=model&url=2840914

## Related Issue(s)

Nothing

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
