### PR TITLE
Bug fix the data-tool-agent part is not output

### DIFF
--- a/.changeset/fast-experts-march.md
+++ b/.changeset/fast-experts-march.md
@@ -1,0 +1,7 @@
+---
+'@mastra/ai-sdk': patch
+'@mastra/inngest': patch
+'@mastra/core': patch
+---
+
+fix: data-tool-agent type stream part

--- a/.changeset/violet-crabs-rule.md
+++ b/.changeset/violet-crabs-rule.md
@@ -1,0 +1,6 @@
+---
+'@mastra/ai-sdk': minor
+'@mastra/inngest': minor
+---
+
+Update peer dependencies to match core package version bump (0.22.3)

--- a/client-sdks/ai-sdk/package.json
+++ b/client-sdks/ai-sdk/package.json
@@ -22,7 +22,7 @@
     "CHANGELOG.md"
   ],
   "peerDependencies": {
-    "@mastra/core": ">=0.21.0-0 <0.24.0-0",
+    "@mastra/core": ">=0.22.3-0 <0.23.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -1,6 +1,6 @@
 import type { ChunkType } from '@mastra/core';
 import { DefaultGeneratedFile, DefaultGeneratedFileWithType } from '@mastra/core/stream';
-import type { PartialSchemaOutput, OutputSchema, DataChunkType } from '@mastra/core/stream';
+import type { PartialSchemaOutput, OutputSchema, DataChunkType, ChunkFrom } from '@mastra/core/stream';
 
 import type { InferUIMessageChunk, ObjectStreamPart, TextStreamPart, ToolSet, UIMessage } from 'ai';
 import { isDataChunkType } from './utils';
@@ -246,7 +246,7 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
   responseMessageId,
 }: {
   // tool-output is a custom mastra chunk type used in ToolStream
-  part: TextStreamPart<ToolSet> | DataChunkType | { type: 'tool-output'; toolCallId: string; output: any };
+  part: TextStreamPart<ToolSet> | DataChunkType | { type: 'tool-output'; toolCallId: string; output: any; from: ChunkFrom };
   messageMetadataValue?: unknown;
   sendReasoning?: boolean;
   sendSources?: boolean;
@@ -384,19 +384,19 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
     }
 
     case 'tool-output': {
-      if (part.output.from === 'AGENT') {
+      if (part.from === 'AGENT') {
         return {
           type: 'tool-agent',
           toolCallId: part.toolCallId,
           payload: part.output,
         };
-      } else if (part.output.from === 'WORKFLOW') {
+      } else if (part.from === 'WORKFLOW') {
         return {
           type: 'tool-workflow',
           toolCallId: part.toolCallId,
           payload: part.output,
         };
-      } else if (part.output.from === 'NETWORK') {
+      } else if (part.from === 'NETWORK') {
         return {
           type: 'tool-network',
           toolCallId: part.toolCallId,

--- a/packages/core/src/tools/stream.ts
+++ b/packages/core/src/tools/stream.ts
@@ -1,5 +1,5 @@
 import { WritableStream } from 'stream/web';
-import type { DataChunkType } from '../stream/types';
+import type { ChunkFrom, DataChunkType } from '../stream/types';
 
 export class ToolStream<T> extends WritableStream<T> {
   originalStream?: WritableStream;
@@ -10,11 +10,13 @@ export class ToolStream<T> extends WritableStream<T> {
       callId,
       name,
       runId,
+      from,
     }: {
       prefix: string;
       callId: string;
       name: string;
       runId: string;
+      from: ChunkFrom;
     },
     originalStream?: WritableStream,
   ) {
@@ -26,7 +28,7 @@ export class ToolStream<T> extends WritableStream<T> {
           await writer?.write({
             type: `${prefix}-output`,
             runId,
-            from: 'USER',
+            from,
             payload: {
               output: chunk,
               ...(prefix === 'workflow-step'

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -15,6 +15,7 @@ import { AISpanType, wrapMastra } from '../../ai-tracing';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
 import { RuntimeContext } from '../../runtime-context';
+import { ChunkFrom } from '../../stream/types';
 import { isVercelTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
 import { ToolStream } from '../stream';
@@ -222,6 +223,7 @@ export class CoreToolBuilder extends MastraBase {
                   callId: execOptions.toolCallId,
                   name: options.name,
                   runId: options.runId!,
+                  from: ChunkFrom.AGENT,
                 },
                 options.writableStream || execOptions.writableStream,
               ),

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -9,7 +9,7 @@ import type { IErrorDefinition } from '../error';
 import { safeParseErrorObject } from '../error/utils.js';
 import type { MastraScorers } from '../scores';
 import { runScorer } from '../scores/hooks';
-import type { ChunkType } from '../stream/types';
+import { ChunkFrom, type ChunkType } from '../stream/types';
 import { ToolStream } from '../tools/stream';
 import type { DynamicArgument } from '../types';
 import { EMITTER_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
@@ -554,6 +554,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
             callId: stepCallId,
             name: 'sleep',
             runId,
+            from: ChunkFrom.WORKFLOW,
           },
           writableStream,
         ),
@@ -661,6 +662,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
             callId: stepCallId,
             name: 'sleepUntil',
             runId,
+            from: ChunkFrom.WORKFLOW,
           },
           writableStream,
         ),
@@ -967,6 +969,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
               callId: stepCallId,
               name: step.id,
               runId,
+              from: ChunkFrom.WORKFLOW,
             },
             writableStream,
           ),
@@ -1383,6 +1386,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
                       callId: randomUUID(),
                       name: 'conditional',
                       runId,
+                      from: ChunkFrom.WORKFLOW,
                     },
                     writableStream,
                   ),
@@ -1685,6 +1689,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
                 callId: randomUUID(),
                 name: 'loop',
                 runId,
+                from: ChunkFrom.WORKFLOW,
               },
               writableStream,
             ),

--- a/workflows/inngest/package.json
+++ b/workflows/inngest/package.json
@@ -54,7 +54,7 @@
     "@internal/types-builder": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.22.3-0 <0.24.0-0",
+    "@mastra/core": ">=0.22.3-0 <0.23.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -7,7 +7,7 @@ import type { TracingContext, AnyAISpan } from '@mastra/core/ai-tracing';
 import { RuntimeContext } from '@mastra/core/di';
 import type { Mastra } from '@mastra/core/mastra';
 import type { WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
-import { WorkflowRunOutput } from '@mastra/core/stream';
+import { ChunkFrom, WorkflowRunOutput } from '@mastra/core/stream';
 import type { ToolExecutionContext } from '@mastra/core/tools';
 import { Tool, ToolStream } from '@mastra/core/tools';
 import {
@@ -1274,6 +1274,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
                   callId: stepCallId,
                   name: 'sleep',
                   runId,
+                  from: ChunkFrom.WORKFLOW,
                 },
                 writableStream,
               ),
@@ -1393,6 +1394,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
                   callId: stepCallId,
                   name: 'sleep',
                   runId,
+                  from: ChunkFrom.WORKFLOW,
                 },
                 writableStream,
               ),
@@ -2165,6 +2167,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
                         callId: randomUUID(),
                         name: 'conditional',
                         runId,
+                        from: ChunkFrom.WORKFLOW,
                       },
                       writableStream,
                     ),


### PR DESCRIPTION
## Description

Bug where the data-tool-agent part is not output

Since 'from' is always 'USER', parts like 'data-tool-agent' are not returned by 'convertFullStreamChunkToUIMessageStream'. Even if you call 'stream' within a tool, it will not be streamed in the ai-sdk format.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
