### PR TITLE
fix(deployer-netlify): Disable ESM shim

### DIFF
--- a/.changeset/cuddly-ways-send.md
+++ b/.changeset/cuddly-ways-send.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-netlify': patch
+---
+
+Do not apply ESM shim to output as Netlify should handle this already

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -40,7 +40,7 @@ export class NetlifyDeployer extends Deployer {
     const result = await this._bundle(
       this.getEntry(),
       entryFile,
-      { outputDirectory, projectRoot },
+      { outputDirectory, projectRoot, enableEsmShim: false },
       toolsPaths,
       join(outputDirectory, this.outputDir),
     );


### PR DESCRIPTION
## Description

Netlify already adds ESM shim to their code here:
- https://github.com/netlify/build/blob/3bf580227e8efae895429a3c3871fcd6f7185a74/packages/zip-it-and-ship-it/src/runtimes/node/utils/esm_cjs_compat.ts
- https://github.com/netlify/build/blob/3bf580227e8efae895429a3c3871fcd6f7185a74/packages/zip-it-and-ship-it/src/runtimes/node/bundlers/esbuild/bundler.ts#L143

So I think it's safe to disable our ESM shim for the Netlify deployer.

Locally when I ran `netlify dev` I saw it adding that shim.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/9169

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
