### PR TITLE
fix(@mastra/arize): Auto-detect arize endpoint when endpoint field is not provided

### DIFF
--- a/.changeset/sparkly-news-smell.md
+++ b/.changeset/sparkly-news-smell.md
@@ -1,0 +1,7 @@
+---
+'@mastra/arize': minor
+---
+
+fix(@mastra/arize): Auto-detect arize endpoint when endpoint field is not provided
+
+When spaceId is provided to ArizeExporter constructor, and endpoint is not, pre-populate endpoint with default ArizeAX endpoint.

--- a/observability/arize/src/ai-tracing.config.test.ts
+++ b/observability/arize/src/ai-tracing.config.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ARIZE_AX_ENDPOINT, ArizeExporter } from './ai-tracing';
+
+// Mock OtelExporter to spy on its constructor
+vi.mock('@mastra/otel-exporter', () => ({
+  OtelExporter: vi.fn().mockImplementation(() => ({
+    exportEvent: vi.fn(),
+    shutdown: vi.fn(),
+  })),
+}));
+
+describe('ArizeExporterConfig', () => {
+  it('uses ARIZE_AX_ENDPOINT as fallback when spaceId is provided but no endpoint', async () => {
+    const { OtelExporter } = await import('@mastra/otel-exporter');
+    const otelExporterSpy = vi.mocked(OtelExporter);
+
+    new ArizeExporter({
+      spaceId: 'test-space-id',
+      apiKey: 'test-api-key',
+      projectName: 'test-project',
+    });
+
+    // Verify OtelExporter was called with the correct config
+    expect(otelExporterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: {
+          custom: {
+            endpoint: ARIZE_AX_ENDPOINT,
+            headers: {
+              space_id: 'test-space-id',
+              api_key: 'test-api-key',
+            },
+            protocol: 'http/protobuf',
+          },
+        },
+        resourceAttributes: {
+          'openinference.project.name': 'test-project',
+        },
+      }),
+    );
+  });
+  it('uses the provided endpoint when provided', async () => {
+    const { OtelExporter } = await import('@mastra/otel-exporter');
+    const otelExporterSpy = vi.mocked(OtelExporter);
+
+    new ArizeExporter({
+      endpoint: 'https://test-endpoint.com/v1/traces',
+      spaceId: 'test-space-id',
+      apiKey: 'test-api-key',
+    });
+
+    expect(otelExporterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'https://test-endpoint.com/v1/traces',
+        spaceId: 'test-space-id',
+        apiKey: 'test-api-key',
+      }),
+    );
+  });
+  it('merges headers when provided', async () => {
+    const { OtelExporter } = await import('@mastra/otel-exporter');
+    const otelExporterSpy = vi.mocked(OtelExporter);
+
+    new ArizeExporter({
+      endpoint: 'https://test-endpoint.com/v1/traces',
+      spaceId: 'test-space-id',
+      apiKey: 'test-api-key',
+      headers: {
+        'x-custom-header': 'value',
+      },
+    });
+
+    expect(otelExporterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          'x-custom-header': 'value',
+        },
+      }),
+    );
+  });
+  it('merges resource attributes when provided', async () => {
+    const { OtelExporter } = await import('@mastra/otel-exporter');
+    const otelExporterSpy = vi.mocked(OtelExporter);
+
+    new ArizeExporter({
+      endpoint: 'https://test-endpoint.com/v1/traces',
+      spaceId: 'test-space-id',
+      apiKey: 'test-api-key',
+      projectName: 'test-project',
+      resourceAttributes: {
+        'custom.attribute': 'value',
+      },
+    });
+
+    expect(otelExporterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceAttributes: {
+          'openinference.project.name': 'test-project',
+          'custom.attribute': 'value',
+        },
+      }),
+    );
+  });
+});

--- a/observability/arize/src/ai-tracing.ts
+++ b/observability/arize/src/ai-tracing.ts
@@ -70,7 +70,7 @@ export class ArizeExporter extends OtelExporter {
       },
       provider: {
         custom: {
-          endpoint: config.endpoint,
+          endpoint,
           headers,
           protocol: 'http/protobuf',
         },


### PR DESCRIPTION
## Description

When spaceId is provided to ArizeExporter constructor, and endpoint is not, pre-populate endpoint with default ArizeAX endpoint.

## Related Issue(s)



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
