### PR TITLE
fix(core): compile nested subdirectories in tsup build

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     'src/utils.ts',
     '!src/action/index.ts',
     'src/*/index.ts',
+    'src/*/*/index.ts',
     'src/tools/is-vercel-tool.ts',
     'src/workflows/legacy/index.ts',
     'src/workflows/constants.ts',


### PR DESCRIPTION
Add `src/*/*/index.ts `to tsup entry array to ensure nested subdirectories like 'ai-tracing/exporters/' are compiled to JavaScript.

This fixes the @mastra/langfuse integration which was failing with "Cannot find module '@mastra/core/dist/ai-tracing/exporters/index.js'" because the exporters directory (at depth 2) wasn't being compiled.

The previous pattern 'src/*/index.ts' only matched one level deep, missing 'src/ai-tracing/exporters/index.ts' and any other nested modules.

Fixes: Missing JS/CJS files in dist/ai-tracing/exporters/
Affects: @mastra/langfuse integration and any future nested modules

fixes [#9272 ](https://github.com/mastra-ai/mastra/issues/9272)