### PR TITLE
docs(fix): move mongodb example from /examples to /docs

### DIFF
--- a/docs/config/redirects.mjs
+++ b/docs/config/redirects.mjs
@@ -262,6 +262,11 @@ export const redirectList = [
     permanent: true,
   },
   {
+    source: "/:locale/examples/memory/memory-with-mongodb",
+    destination: "/:locale/docs/memory/storage/memory-with-mongodb",
+    permanent: true,
+  },
+  {
     source: "/:locale/examples/memory/short-term-working-memory",
     destination: "/:locale/docs/memory/storage/memory-with-libsql",
     permanent: true,

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -51,7 +51,7 @@ That memory instance has options you can configure for working memory, conversat
 
 ## Different types of memory
 
-Mastra supports three types of memory: working memory, conversation history, and semantic recall. 
+Mastra supports three types of memory: working memory, conversation history, and semantic recall.
 
 [**Working memory**](./working-memory.mdx) stores persistent user-specific details such as names, preferences, goals, and other structured data. (Compare this to ChatGPT where you can ask it to tell you about yourself). This is implemented as a block of Markdown text that the agent is able to update over time (or alternately, as a Zod schema)
 
@@ -69,7 +69,7 @@ All memory types are [resource-scoped](./working-memory.mdx#resource-scoped-memo
 
 To persist and recall information between conversations, memory requires a storage adapter.
 
-Supported options include [LibSQL](/docs/memory/storage/memory-with-libsql), [MongoDB](/docs/memory/storage/memory-with-mongodb), [Postgres](/docs/memory/storage/memory-with-pg), and [Upstash](/docs/memory/storage/memory-with-upstash)
+Supported options include [LibSQL](/docs/memory/storage/memory-with-libsql.mdx), [MongoDB](/docs/memory/storage/memory-with-mongodb.mdx), [Postgres](/docs/memory/storage/memory-with-pg.mdx), and [Upstash](/docs/memory/storage/memory-with-upstash.mdx)
 
 We use LibSQL out of the box because it is file-based or in-memory, so it is easy to install and works well with the playground.
 

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -91,7 +91,7 @@ const agent = new Agent({
 **Storage/vector code Examples**:
 
 - [LibSQL](/docs/memory/storage/memory-with-libsql.mdx)
-- [MongoDB](/examples/memory/memory-with-mongodb.mdx)
+- [MongoDB](/docs/memory/storage/memory-with-mongodb.mdx)
 - [Postgres](/docs/memory/storage/memory-with-pg.mdx)
 - [Upstash](/docs/memory/storage/memory-with-upstash.mdx)
 

--- a/docs/src/content/en/docs/memory/storage/_meta.ts
+++ b/docs/src/content/en/docs/memory/storage/_meta.ts
@@ -1,5 +1,6 @@
 const meta = {
   "memory-with-libsql": "Memory with LibSQL",
+  "memory-with-mongodb": "Memory with MongoDB",
   "memory-with-pg": "Memory with PostgreSQL",
   "memory-with-upstash": "Memory with Upstash",
 };

--- a/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
@@ -53,11 +53,11 @@ export const mongodbAgent = new Agent({
 
 ## Vector embeddings with MongoDB
 
-Embeddings are numeric vectors used by memory's `semanticRecall` to retrieve related messages by meaning (not keywords). 
+Embeddings are numeric vectors used by memory's `semanticRecall` to retrieve related messages by meaning (not keywords).
 
 > Note: You must use a deployment hosted on MongoDB Atlas to successfully use the MongoDB Vector database.
 
-This setup uses FastEmbed, a local embedding model, to generate vector embeddings. 
+This setup uses FastEmbed, a local embedding model, to generate vector embeddings.
 To use this, install `@mastra/fastembed`:
 
 ```bash copy


### PR DESCRIPTION
## Description

Move mongodb storage example from /examples to /docs next to upstash, libsql, etc.
Redirect from old mongodb link to new one.
Fix links to mongodb page in overview page and semantic recall page.

## Related Issue(s)

Closes GRWTH-945, GRWTH-944

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
