### PR TITLE
fix(lance): Update eval filtering for LanceDB (#9191)

### DIFF
--- a/.changeset/sour-ants-bake.md
+++ b/.changeset/sour-ants-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/lance': patch
+---
+
+Fix eval filtering to use NULL checks instead of length function for compatibility with LanceDB 0.22.x

--- a/stores/lance/src/storage/domains/legacy-evals/index.ts
+++ b/stores/lance/src/storage/domains/legacy-evals/index.ts
@@ -75,9 +75,9 @@ export class StoreLegacyEvalsLance extends LegacyEvalsStorage {
 
       // Apply type filtering
       if (options.type === 'live') {
-        conditions.push('length(test_info) = 0');
+        conditions.push('test_info IS NULL');
       } else if (options.type === 'test') {
-        conditions.push('length(test_info) > 0');
+        conditions.push('test_info IS NOT NULL');
       }
 
       // Apply date filtering


### PR DESCRIPTION
Backporting #9191 to the 0.x branch

(cherry picked from commit ebc5eba97ee85905e43315e16867d36c056397d9)