### PR TITLE
fix(core): Don't call `os.homedir()` at top level (#9211)

### DIFF
--- a/.changeset/little-knives-wonder.md
+++ b/.changeset/little-knives-wonder.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Don't call `os.homedir()` at top level (but lazy invoke it) to accommodate sandboxed environments


### PR DESCRIPTION
Backporting #9211 to the 0.x branch

(cherry picked from commit 57d157f0b163a95c3e6c9eae31bdb11d1bfc64f9)