### PR TITLE
fix(core): use schema-compat transformed schemas for tool input validation (#9258)

### DIFF
--- a/.changeset/quiet-bananas-knock.md
+++ b/.changeset/quiet-bananas-knock.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool input validation to use schema-compat transformed schemas
+
+Previously, tool input validation used the original Zod schema while the LLM received a schema-compat transformed version. This caused validation failures when LLMs (like OpenAI o3 or Claude 3.5 Haiku) sent arguments matching the transformed schema but not the original.
+
+For example:
+- OpenAI o3 reasoning models convert `.optional()` to `.nullable()`, sending `null` values
+- Claude 3.5 Haiku strips `min`/`max` string constraints, sending shorter strings
+- Validation would reject these valid responses because it checked against the original schema
+
+The fix ensures validation uses the same schema-compat processed schema that was sent to the LLM, eliminating this mismatch.

--- a/packages/core/src/tools/provider-tools.test.ts
+++ b/packages/core/src/tools/provider-tools.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { Agent } from '../agent';
 
 describe('provider-defined tools', () => {
-  it('should handle Google search tool', { timeout: 30000 }, async () => {
+  it('should handle Google search tool', { timeout: 120000 }, async () => {
     const search = google.tools.googleSearch({});
 
     const agent = new Agent({

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -293,8 +293,9 @@ async function runSingleInputTest(
 // to make sure that we still have good coverage, for both input and output schemas.
 describe('Tool Schema Compatibility', () => {
   // Set a longer timeout for the entire test suite
-  const SUITE_TIMEOUT = 120000; // 2 minutes
-  const TEST_TIMEOUT = 60000; // 1 minute
+  // These tests make real API calls to LLMs which can be slow, especially reasoning models
+  const SUITE_TIMEOUT = 300000; // 5 minutes
+  const TEST_TIMEOUT = 180000; // 3 minutes
 
   if (!process.env.OPENROUTER_API_KEY) throw new Error('OPENROUTER_API_KEY environment variable is required');
   const openrouter = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -146,7 +146,12 @@ export class CoreToolBuilder extends MastraBase {
     };
   }
 
-  private createExecute(tool: ToolToConvert, options: ToolOptions, logType?: 'tool' | 'toolset' | 'client-tool') {
+  private createExecute(
+    tool: ToolToConvert,
+    options: ToolOptions,
+    logType?: 'tool' | 'toolset' | 'client-tool',
+    processedSchema?: z.ZodTypeAny,
+  ) {
     // dont't add memory or mastra to logging
     const { logger, mastra: _mastra, memory: _memory, runtimeContext, model, ...rest } = options;
     const logModelObject = {
@@ -245,7 +250,8 @@ export class CoreToolBuilder extends MastraBase {
         logger.debug(start, { ...rest, model: logModelObject, args });
 
         // Validate input parameters if schema exists
-        const parameters = this.getParameters();
+        // Use the processed schema for validation if available, otherwise fall back to original
+        const parameters = processedSchema || this.getParameters();
         const { data, error } = validateToolInput(parameters, args, options.name);
         if (error) {
           logger.warn(`Tool input validation failed for '${options.name}'`, {
@@ -327,21 +333,6 @@ export class CoreToolBuilder extends MastraBase {
       return providerTool;
     }
 
-    const definition = {
-      type: 'function' as const,
-      description: this.originalTool.description,
-      parameters: this.getParameters(),
-      outputSchema: this.getOutputSchema(),
-      requireApproval: this.options.requireApproval,
-      execute: this.originalTool.execute
-        ? this.createExecute(
-            this.originalTool,
-            { ...this.options, description: this.originalTool.description },
-            this.logType,
-          )
-        : undefined,
-    };
-
     const model = this.options.model;
 
     const schemaCompatLayers = [];
@@ -366,11 +357,34 @@ export class CoreToolBuilder extends MastraBase {
       );
     }
 
-    const processedSchema = applyCompatLayer({
-      schema: this.getParameters(),
-      compatLayers: schemaCompatLayers,
-      mode: 'aiSdkSchema',
-    });
+    // Apply schema compatibility to get both the transformed Zod schema (for validation)
+    // and the AI SDK Schema (for the LLM)
+    let processedZodSchema: z.ZodTypeAny | undefined;
+    let processedSchema;
+
+    const originalSchema = this.getParameters();
+
+    // Find the first applicable compatibility layer
+    const applicableLayer = schemaCompatLayers.find(layer => layer.shouldApply());
+
+    if (applicableLayer && originalSchema) {
+      // Get the transformed Zod schema (with constraints removed/modified)
+      processedZodSchema = applicableLayer.processZodType(originalSchema);
+      // Convert to AI SDK Schema for the LLM
+      processedSchema = applyCompatLayer({
+        schema: originalSchema,
+        compatLayers: schemaCompatLayers,
+        mode: 'aiSdkSchema',
+      });
+    } else {
+      // No compatibility layer applies, use original schema
+      processedZodSchema = originalSchema;
+      processedSchema = applyCompatLayer({
+        schema: originalSchema,
+        compatLayers: schemaCompatLayers,
+        mode: 'aiSdkSchema',
+      });
+    }
 
     let processedOutputSchema;
 
@@ -381,6 +395,22 @@ export class CoreToolBuilder extends MastraBase {
         mode: 'aiSdkSchema',
       });
     }
+
+    const definition = {
+      type: 'function' as const,
+      description: this.originalTool.description,
+      parameters: this.getParameters(),
+      outputSchema: this.getOutputSchema(),
+      requireApproval: this.options.requireApproval,
+      execute: this.originalTool.execute
+        ? this.createExecute(
+            this.originalTool,
+            { ...this.options, description: this.originalTool.description },
+            this.logType,
+            processedZodSchema, // Pass the processed Zod schema for validation
+          )
+        : undefined,
+    };
 
     return {
       ...definition,

--- a/packages/core/src/tools/tool-builder/schema-compat-validation.test.ts
+++ b/packages/core/src/tools/tool-builder/schema-compat-validation.test.ts
@@ -1,0 +1,274 @@
+import { AnthropicSchemaCompatLayer } from '@mastra/schema-compat';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { RuntimeContext } from '../../runtime-context';
+import type { ToolAction } from '../types';
+import { CoreToolBuilder } from './builder';
+
+describe('CoreToolBuilder - Schema Compatibility in Validation', () => {
+  it('should use schema-compat transformed schema for BOTH LLM parameters AND validation', async () => {
+    // Create a tool with string min constraint
+    const inputSchema = z.object({
+      message: z.string().min(10).describe('A message with minimum 10 characters'),
+    });
+
+    const toolWithConstraints: ToolAction<any, any> = {
+      id: 'test-tool',
+      description: 'A test tool with string constraints',
+      inputSchema,
+      execute: async ({ context }: { context: z.infer<typeof inputSchema> }) => {
+        const { message } = context;
+        return { result: `Received: ${message}` };
+      },
+    };
+
+    // Create a model config that requires schema transformation (Claude 3.5 Haiku strips min/max from strings)
+    const modelConfig = {
+      provider: 'anthropic',
+      modelId: 'claude-3.5-haiku-20241022',
+      specificationVersion: 'v4' as const,
+      supportsStructuredOutputs: false,
+    } as const;
+
+    // Build the tool
+    const builder = new CoreToolBuilder({
+      originalTool: toolWithConstraints,
+      options: {
+        name: 'test-tool',
+        model: modelConfig as any,
+        runtimeContext: new RuntimeContext(),
+      },
+    });
+
+    const coreTool = builder.build();
+
+    // ASSERTION 1: The parameters sent to the LLM should be transformed
+    // (Claude 3.5 Haiku compatibility layer removes min/max constraints from strings)
+    const anthropicLayer = new AnthropicSchemaCompatLayer(modelConfig as any);
+
+    // The original schema has a min constraint
+    const originalSchema = inputSchema;
+    const messageField = originalSchema.shape.message as z.ZodString;
+    expect(messageField._def.checks).toContainEqual(expect.objectContaining({ kind: 'min', value: 10 }));
+
+    // The transformed schema should NOT have the min constraint (for Claude 3.5 Haiku)
+    // This is what the LLM sees
+    const transformedSchema = anthropicLayer.processZodType(originalSchema);
+    const transformedMessageField = (transformedSchema as any).shape.message as z.ZodString;
+
+    // This assertion should PASS - the LLM receives transformed schema without min constraint
+    expect(transformedMessageField._def.checks).not.toContainEqual(expect.objectContaining({ kind: 'min' }));
+
+    // ASSERTION 2: The validation should use the SAME transformed schema
+    // This is the bug - validation currently uses the original schema with constraints
+
+    // Simulate what happens when the LLM calls the tool with a short string (< 10 chars)
+    // The LLM was told there's no minimum, so it might send a short string
+    const shortMessage = 'Hi there'; // Only 8 characters, less than the original min of 10
+
+    // Mock the execute function to capture what gets validated
+
+    const executeResult = await coreTool.execute?.(
+      { message: shortMessage },
+      {
+        abortSignal: new AbortController().signal,
+        toolCallId: 'test-call-id',
+        messages: [],
+      },
+    );
+
+    // THIS ASSERTION WILL FAIL - demonstrating the bug
+    // The validation should accept the short string because the LLM was told there's no minimum
+    // But currently, validation uses the original schema with min(10), so it will reject it
+    expect(executeResult).not.toHaveProperty('error');
+    expect(executeResult).toHaveProperty('result');
+    expect(executeResult.result).toBe('Received: Hi there');
+  });
+
+  it('should validate against transformed schema for number constraints with Anthropic', async () => {
+    // Create a tool with number constraints
+    const inputSchema2 = z.object({
+      age: z.number().min(18).max(100).describe('Age between 18 and 100'),
+    });
+
+    const toolWithNumberConstraints: ToolAction<any, any> = {
+      id: 'number-tool',
+      description: 'A test tool with number constraints',
+      inputSchema: inputSchema2,
+      execute: async ({ context }: { context: z.infer<typeof inputSchema2> }) => {
+        const { age } = context;
+        return { result: `Age: ${age}` };
+      },
+    };
+
+    const modelConfig = {
+      provider: 'anthropic',
+      modelId: 'claude-3-opus-20240229',
+      specificationVersion: 'v2' as const,
+      supportsStructuredOutputs: false,
+    };
+
+    const builder = new CoreToolBuilder({
+      originalTool: toolWithNumberConstraints,
+      options: {
+        name: 'number-tool',
+        model: modelConfig as any,
+        runtimeContext: new RuntimeContext(),
+      },
+    });
+
+    const coreTool = builder.build();
+
+    // Anthropic's schema compat layer transforms number constraints
+    // The LLM receives a schema without strict min/max enforcement
+
+    // If the LLM sends a value that would fail the original schema
+    // but passes the transformed schema, validation should accept it
+    const executeResult = await coreTool.execute?.(
+      { age: 25 }, // Valid in both schemas
+      {
+        abortSignal: new AbortController().signal,
+        toolCallId: 'test-call-id',
+        messages: [],
+      },
+    );
+
+    // THIS SHOULD PASS - validation should use transformed schema
+    expect(executeResult).not.toHaveProperty('error');
+    expect(executeResult).toHaveProperty('result');
+  });
+
+  it('should demonstrate the bug: validation rejects input that LLM was told is valid', async () => {
+    // This test explicitly demonstrates the bug
+    const inputSchema4 = z.object({
+      text: z.string().min(20).describe('Text with minimum 20 characters'),
+    });
+
+    const toolWithMinConstraint: ToolAction<any, any> = {
+      id: 'bug-demo-tool',
+      description: 'Demonstrates the validation bug',
+      inputSchema: inputSchema4,
+      execute: async ({ context }: { context: z.infer<typeof inputSchema4> }) => {
+        const { text } = context;
+        return { success: true, text };
+      },
+    };
+
+    const modelConfig = {
+      provider: 'anthropic',
+      modelId: 'claude-3.5-haiku-20241022',
+      specificationVersion: 'v4' as const,
+      supportsStructuredOutputs: false,
+    };
+
+    const builder = new CoreToolBuilder({
+      originalTool: toolWithMinConstraint,
+      options: {
+        name: 'bug-demo-tool',
+        model: modelConfig as any,
+        runtimeContext: new RuntimeContext(),
+      },
+    });
+
+    const coreTool = builder.build();
+
+    // The LLM receives a schema WITHOUT the min(20) constraint
+    // So it might send a string with only 10 characters
+    const shortText = 'Short text'; // Only 10 characters
+
+    const executeResult = await coreTool.execute?.(
+      { text: shortText },
+      {
+        abortSignal: new AbortController().signal,
+        toolCallId: 'test-call-id',
+        messages: [],
+      },
+    );
+
+    // EXPECTED BEHAVIOR (this will fail, demonstrating the bug):
+    // Since the LLM was told there's no minimum length requirement,
+    // validation should accept this input
+    expect(executeResult).not.toHaveProperty('error');
+    expect(executeResult).toEqual({
+      success: true,
+      text: shortText,
+    });
+
+    // ACTUAL BEHAVIOR (what currently happens):
+    // Validation uses the original schema with min(20),
+    // so it rejects the input even though the LLM was told it's valid
+    // Uncomment these to see the current (incorrect) behavior:
+    // expect(executeResult).toHaveProperty('error');
+    // expect(executeResult.error).toContain('String must contain at least 20 character(s)');
+  });
+
+  it('should handle OpenAI o3 reasoning model converting optional to nullable (working memory bug)', async () => {
+    // This reproduces the exact bug reported by the user with updateWorkingMemory tool
+    // OpenAI o3 converts .optional() to .nullable(), then sends null, but validation
+    // was checking against the original schema which expects string | undefined
+    const inputSchema5 = z.object({
+      newMemory: z.string().describe('New memory to add'),
+      searchString: z.string().optional().describe('Optional search string'),
+      updateReason: z.string().describe('Reason for update'),
+    });
+
+    const updateWorkingMemoryTool: ToolAction<any, any> = {
+      id: 'updateWorkingMemory',
+      description: 'Update working memory',
+      inputSchema: inputSchema5,
+      execute: async ({ context }: { context: z.infer<typeof inputSchema5> }) => {
+        const { newMemory, searchString, updateReason } = context;
+        return { success: true, newMemory, searchString, updateReason };
+      },
+    };
+
+    const modelConfig = {
+      provider: 'openai',
+      modelId: 'o3-mini',
+      specificationVersion: 'v4' as const,
+      supportsStructuredOutputs: true,
+    };
+
+    const builder = new CoreToolBuilder({
+      originalTool: updateWorkingMemoryTool,
+      options: {
+        name: 'updateWorkingMemory',
+        model: modelConfig as any,
+        runtimeContext: new RuntimeContext(),
+      },
+    });
+
+    const coreTool = builder.build();
+
+    // OpenAI o3 converts .optional() to .nullable() via OpenAIReasoningSchemaCompatLayer
+    // So the LLM sends null instead of undefined for optional fields
+    const newMemoryValue = '#User\n- First Name: Randy\n- Last Name: Lynn';
+    const executeResult = await coreTool.execute?.(
+      {
+        newMemory: newMemoryValue,
+        searchString: null, // LLM sends null because schema was converted to nullable
+        updateReason: 'append-new-memory',
+      },
+      {
+        abortSignal: new AbortController().signal,
+        toolCallId: 'call_W84bP8Lo2qCwIYe03QDLCgTJ',
+        messages: [],
+      },
+    );
+
+    // EXPECTED BEHAVIOR (with the fix):
+    // Validation should accept null because the schema sent to the LLM was .nullable()
+    expect(executeResult).not.toHaveProperty('error');
+    expect(executeResult).toEqual({
+      success: true,
+      newMemory: newMemoryValue,
+      searchString: null,
+      updateReason: 'append-new-memory',
+    });
+
+    // BEFORE THE FIX:
+    // This would fail with "Expected string, received null" because validation
+    // was using the original schema with .optional() instead of the transformed
+    // schema with .nullable()
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // Increase default timeout for tests that make real API calls to LLMs
+    testTimeout: 120000, // 2 minutes default
   },
 });


### PR DESCRIPTION
Backporting #9258 to the 0.x branch

(cherry picked from commit cfae73394f4920635e6c919c8e95ff9a0788e2e5)