### PR TITLE
fix(deployer-netlify): Disable ESM shim (#9239)

### DIFF
--- a/.changeset/cuddly-ways-send.md
+++ b/.changeset/cuddly-ways-send.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-netlify': patch
+---
+
+Do not apply ESM shim to output as Netlify should handle this already

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -40,7 +40,7 @@ export class NetlifyDeployer extends Deployer {
     const result = await this._bundle(
       this.getEntry(),
       entryFile,
-      { outputDirectory, projectRoot },
+      { outputDirectory, projectRoot, enableEsmShim: false },
       toolsPaths,
       join(outputDirectory, this.outputDir),
     );


### PR DESCRIPTION
Backporting #9239 to the 0.x branch

(cherry picked from commit 816a03dcd9db03b208729100aeaedcc91d886eb3)