### PR TITLE
Fix AN tools

### DIFF
--- a/.changeset/silly-brooms-lead.md
+++ b/.changeset/silly-brooms-lead.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Remove tools passed to the Routing Agent in .network()

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -70,11 +70,11 @@ async function getRoutingAgent({ runtimeContext, agent }: { agent: Agent; runtim
         `;
 
   return new Agent({
-    name: 'routing-agent',
+    id: 'routing-agent',
+    name: 'Routing Agent',
     instructions,
     model: model,
     memory: memoryToUse,
-    tools: { ...toolsToUse, ...memoryTools },
     // @ts-ignore
     _agentNetworkAppend: true,
   });


### PR DESCRIPTION
- Undo passing tools to Routing Agent
- Add changeset

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed tools parameter from Routing Agent initialization in the .network() method. Routing Agents now use predefined tooling automatically without requiring explicit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->