### PR TITLE
feat: add crumb action to show popovers

### DIFF
--- a/.changeset/forty-groups-buy.md
+++ b/.changeset/forty-groups-buy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Add breacrumb action for popovers

--- a/packages/playground-ui/src/components/ui/button.tsx
+++ b/packages/playground-ui/src/components/ui/button.tsx
@@ -30,9 +30,7 @@ const buttonVariants = cva(
   },
 );
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/packages/playground-ui/src/components/ui/button.tsx
+++ b/packages/playground-ui/src/components/ui/button.tsx
@@ -30,9 +30,10 @@ const buttonVariants = cva(
   },
 );
 
-export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-}
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -35,7 +35,11 @@ export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps
       <li className="flex h-full shrink-0 items-center gap-1">
         <Root
           aria-current={isCurrent ? 'page' : undefined}
-          className={clsx('text-ui-lg leading-ui-lg font-medium', isCurrent ? 'text-white' : 'text-icon3', className)}
+          className={clsx(
+            'text-ui-lg leading-ui-lg font-medium flex items-center gap-2',
+            isCurrent ? 'text-white' : 'text-icon3',
+            className,
+          )}
           {...props}
         />
         {action}

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -24,23 +24,21 @@ export interface CrumbProps {
   to: string;
   prefetch?: boolean | null;
   children: React.ReactNode;
+  action?: React.ReactNode;
 }
 
-export const Crumb = ({ className, as, isCurrent, ...props }: CrumbProps) => {
+export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps) => {
   const Root = as || 'span';
 
   return (
     <>
-      <li className="flex h-full items-center">
+      <li className="flex h-full shrink-0 items-center gap-1">
         <Root
           aria-current={isCurrent ? 'page' : undefined}
-          className={clsx(
-            'text-ui-lg leading-ui-lg font-medium flex items-center gap-2',
-            isCurrent ? 'text-white' : 'text-icon3',
-            className,
-          )}
+          className={clsx('text-ui-lg leading-ui-lg font-medium', isCurrent ? 'text-white' : 'text-icon3', className)}
           {...props}
         />
+        {action}
       </li>
       {!isCurrent && (
         <li role="separator" className="flex h-full items-center">


### PR DESCRIPTION
## Description

Cloud requires the breadcrumbs to have an additional actions that triggers popover.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumb components now support optional action elements for enhanced interactivity, including popover functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->