### PR TITLE
fix(core): agent network iteration counter and usage promise resolution

### DIFF
--- a/.changeset/soft-papers-sin.md
+++ b/.changeset/soft-papers-sin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix network usage by properly resolving or rejecting usage promise on stream close

--- a/.changeset/soft-papers-sin.md
+++ b/.changeset/soft-papers-sin.md
@@ -2,4 +2,7 @@
 '@mastra/core': patch
 ---
 
-Fix network usage by properly resolving or rejecting usage promise on stream close
+Fix network loop iteration counter and usage promise handling:
+
+- Fixed iteration counter in network loop that was stuck at 0 due to falsy check. Properly handled zero values to ensure maxSteps is correctly enforced.
+- Fixed usage promise resolution in RunOutput stream by properly resolving or rejecting the promise on stream close, preventing hanging promises when streams complete.

--- a/packages/core/src/agent/agent-gemini.test.ts
+++ b/packages/core/src/agent/agent-gemini.test.ts
@@ -239,6 +239,9 @@ describe('Gemini Model Compatibility Tests', () => {
         name: 'helper-agent',
         instructions: 'You help with tasks',
         model: MODEL,
+        defaultVNextStreamOptions: {
+          maxSteps: 1,
+        },
       });
 
       const agent = new Agent({
@@ -248,11 +251,14 @@ describe('Gemini Model Compatibility Tests', () => {
         model: MODEL,
         agents: { helperAgent },
         memory,
+        defaultVNextStreamOptions: {
+          maxSteps: 1,
+        },
       });
 
       const stream = await agent.network('', {
         runtimeContext,
-        maxSteps: 2,
+        maxSteps: 1,
       });
 
       const chunks: ChunkType[] = [];

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -134,8 +134,8 @@ describe('Agent - network', () => {
       runtimeContext,
     });
 
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
   });
 
@@ -144,8 +144,8 @@ describe('Agent - network', () => {
       runtimeContext,
     });
 
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
   });
 
@@ -154,8 +154,8 @@ describe('Agent - network', () => {
       runtimeContext,
     });
 
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
   });
 
@@ -168,11 +168,9 @@ describe('Agent - network', () => {
       },
     );
 
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
-
-    console.log('SUH', anStream);
   });
 
   it('LOOP - should track usage data from agent.network()', async () => {
@@ -273,8 +271,8 @@ describe('Agent - network', () => {
     });
 
     // Consume the stream
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
 
     // Wait a bit for async title generation to complete
@@ -334,8 +332,8 @@ describe('Agent - network', () => {
     });
 
     // Consume the stream
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
 
     // Wait a bit for async title generation to complete
@@ -383,8 +381,8 @@ describe('Agent - network', () => {
     });
 
     // Consume the stream
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
 
     // Wait for any async operations
@@ -432,8 +430,8 @@ describe('Agent - network', () => {
     });
 
     // Consume the stream
-    for await (const chunk of anStream) {
-      console.log(chunk);
+    for await (const _chunk of anStream) {
+      // console.log(chunk);
     }
 
     // Wait for any async operations

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -271,7 +271,7 @@ export async function createNetworkLoop({
 
       let completionResult;
 
-      let iterationCount = inputData.iteration ? inputData.iteration + 1 : 0;
+      let iterationCount = (inputData.iteration ?? -1) + 1;
 
       await writer.write({
         type: 'routing-agent-start',

--- a/packages/core/src/stream/RunOutput.ts
+++ b/packages/core/src/stream/RunOutput.ts
@@ -107,6 +107,14 @@ export class WorkflowRunOutput<TResult extends WorkflowResult<any, any, any, any
               },
             });
 
+            self.#delayedPromises.usage.resolve(self.#usageCount);
+
+            Object.entries(self.#delayedPromises).forEach(([key, promise]) => {
+              if (promise.status.type === 'pending') {
+                promise.reject(new Error(`promise '${key}' was not resolved or rejected when stream finished`));
+              }
+            });
+
             self.#streamFinished = true;
             self.#emitter.emit('finish');
           },


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fixes two bugs causing agent network tests to hang/timeout:

**1. Iteration counter stuck at 0**
- Changed `inputData.iteration ? inputData.iteration + 1 : 0` to `(inputData.iteration ?? -1) + 1`
- The ternary treated `0` as falsy, preventing counter from incrementing
- `maxSteps` now enforces correctly, preventing infinite loops

**2. Usage promise never resolved on stream close**
- Added proper promise resolution in RunOutput close handler
- Resolves usage and rejects pending delayed promises
- Prevents indefinite hangs when awaiting usage

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented streams from hanging at shutdown by ensuring all pending usage promises are settled when a stream finishes.
  * Fixed loop iteration handling so zero-valued iterations are incremented correctly, enforcing max step limits.

* **Tests**
  * Silenced noisy test output and adjusted test step limits to reflect clarified iteration behavior.

* **Chores**
  * Added a changeset entry documenting the fixes for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->