### PR TITLE
fix(core): Detect thenable objects in `resolveMaybePromise` (#8905)

### DIFF
--- a/.changeset/loud-pots-taste.md
+++ b/.changeset/loud-pots-taste.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Detect thenable objects returned by AI model providers

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -102,12 +102,12 @@ type ModelFallbacks = {
   enabled: boolean;
 }[];
 
-function resolveMaybePromise<T, R = void>(value: T | Promise<T>, cb: (value: T) => R) {
-  if (value instanceof Promise) {
-    return value.then(cb);
+function resolveMaybePromise<T, R = void>(value: T | Promise<T> | PromiseLike<T>, cb: (value: T) => R): R | Promise<R> {
+  if (value instanceof Promise || (value != null && typeof (value as PromiseLike<T>).then === 'function')) {
+    return Promise.resolve(value).then(cb);
   }
 
-  return cb(value);
+  return cb(value as T);
 }
 
 // Helper to resolve threadId from args (supports both new and old API)


### PR DESCRIPTION
Backporting #8905 to the 0.x branch

(cherry picked from commit 2a90c55a86a9210697d5adaab5ee94584b079adc)