### PR TITLE
fix: add region/cloud-provider passthrough for createIndex of pinecone client

### DIFF
--- a/docs-new/docs/reference/vectors/pinecone.md
+++ b/docs-new/docs/reference/vectors/pinecone.md
@@ -35,7 +35,7 @@ name: "region",
 type: "string",
 isOptional: true,
 defaultValue: "us-west1",
-description: 'Pinecone cloud region to use for new indexes ((e.g. "us-west1")',
+description: 'Pinecone cloud region to use for new indexes (e.g. "us-west1")',
 },
 ]}
 />

--- a/docs-new/docs/reference/vectors/pinecone.md
+++ b/docs-new/docs/reference/vectors/pinecone.md
@@ -21,7 +21,21 @@ description: "Pinecone API key",
 {
 name: "environment",
 type: "string",
-description: 'Pinecone environment (e.g., "us-west1-gcp")',
+description: 'Pinecone `controllerHostUrl` to bypass the control-plane',
+},
+{
+name: "cloud",
+type: "'gcp' | 'aws' | 'azure'",
+isOptional: true,
+defaultValue: "aws",
+description: 'Pinecone cloud provider to use for new indexes (e.g. "gcp" | "aws" | "azure")',
+},
+{
+name: "region",
+type: "string",
+isOptional: true,
+defaultValue: "us-west1",
+description: 'Pinecone cloud region to use for new indexes ((e.g. "us-west1")',
 },
 ]}
 />

--- a/docs/src/content/en/reference/vectors/pinecone.mdx
+++ b/docs/src/content/en/reference/vectors/pinecone.mdx
@@ -20,7 +20,21 @@ It provides real-time vector search, with features like hybrid search, metadata 
     {
       name: "environment",
       type: "string",
-      description: 'Pinecone environment (e.g., "us-west1-gcp")',
+      description: 'Pinecone `controllerHostUrl` to bypass the control-plane',
+    },
+    {
+      name: "cloud",
+      type: "'gcp' | 'aws' | 'azure'",
+      isOptional: true,
+      defaultValue: "aws",
+      description: 'Pinecone cloud provider to use for new indexes (e.g. "gcp" | "aws" | "azure")',
+    },
+    {
+      name: "region",
+      type: "string",
+      isOptional: true,
+      defaultValue: "us-west1",
+      description: 'Pinecone cloud region to use for new indexes ((e.g. "us-west1")',
     },
   ]}
 />

--- a/docs/src/content/en/reference/vectors/pinecone.mdx
+++ b/docs/src/content/en/reference/vectors/pinecone.mdx
@@ -34,7 +34,7 @@ It provides real-time vector search, with features like hybrid search, metadata 
       type: "string",
       isOptional: true,
       defaultValue: "us-west1",
-      description: 'Pinecone cloud region to use for new indexes ((e.g. "us-west1")',
+      description: 'Pinecone cloud region to use for new indexes (e.g. "us-west1")',
     },
   ]}
 />

--- a/stores/pinecone/src/vector/index.ts
+++ b/stores/pinecone/src/vector/index.ts
@@ -11,7 +11,7 @@ import type {
   DeleteVectorParams,
   UpdateVectorParams,
 } from '@mastra/core/vector';
-import { Pinecone } from '@pinecone-database/pinecone';
+import { Pinecone, ServerlessSpecCloudEnum } from '@pinecone-database/pinecone';
 import type {
   IndexStatsDescription,
   QueryOptions,
@@ -47,18 +47,26 @@ interface PineconeDeleteVectorParams extends DeleteVectorParams {
 export class PineconeVector extends MastraVector<PineconeVectorFilter> {
   private client: Pinecone;
 
+  private cloud: ServerlessSpecCloudEnum;
+
+  private region: string;
+
   /**
    * Creates a new PineconeVector client.
    * @param apiKey - The API key for Pinecone.
    * @param environment - The environment for Pinecone.
+   * @param cloud - The cloud to use for Pinecone index.
+   * @param region - The cloud to use for Pinecone index.
    */
-  constructor({ apiKey, environment }: { apiKey: string; environment?: string }) {
+  constructor({ apiKey, environment, cloud, region }: { apiKey: string; environment?: string, cloud?: ServerlessSpecCloudEnum; region?: string }) {
     super();
     const opts: { apiKey: string; controllerHostUrl?: string } = { apiKey };
     if (environment) {
       opts['controllerHostUrl'] = environment;
     }
     this.client = new Pinecone(opts);
+    this.cloud = cloud || 'aws';
+    this.region = region || 'us-east-1';
   }
 
   get indexSeparator(): string {
@@ -92,8 +100,8 @@ export class PineconeVector extends MastraVector<PineconeVectorFilter> {
         metric: metric,
         spec: {
           serverless: {
-            cloud: 'aws',
-            region: 'us-east-1',
+            cloud: this.cloud,
+            region: this.region,
           },
         },
       });


### PR DESCRIPTION
## Description

This adds paramaters to the Pinecone client constructor to use another region and cloud provider than the default one.

## Related Issue(s)

#9150

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Pinecone vector configuration reference with enhanced setup options and clarified the "environment" field to accept a Pinecone controllerHostUrl.

* **New Features**
  * Added `cloud` option to choose AWS, GCP, or Azure (default: AWS).
  * Added `region` option to specify the cloud region for new Pinecone indexes (default: us-west1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->