### PR TITLE
[Fix] Undefined window issue when MainSidebar is used on Cloud

### DIFF
--- a/.changeset/strict-areas-hug.md
+++ b/.changeset/strict-areas-hug.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix undefined window issue when Sidebar used in Next app

--- a/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-context.tsx
+++ b/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-context.tsx
@@ -29,7 +29,7 @@ export function MainSidebarProvider({ children }: { children: React.ReactNode })
   const [state, setState] = React.useState<SidebarState>(() => 'default');
 
   // Sync with localStorage after hydration
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const storedState = window.localStorage.getItem(SIDEBAR_COOKIE_NAME);
     if (storedState === 'collapsed' || storedState === 'default') {
       setState(storedState);

--- a/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-context.tsx
+++ b/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-context.tsx
@@ -20,18 +20,25 @@ export function useMainSidebar() {
   return context;
 }
 
-function stateInitializer() {
-  const storedState = window.localStorage.getItem(SIDEBAR_COOKIE_NAME);
-
-  return storedState === 'collapsed' ? 'collapsed' : 'default';
-}
-
 const setLocalStorage = (value: SidebarState) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
   window.localStorage.setItem(SIDEBAR_COOKIE_NAME, value.toString());
 };
 
 export function MainSidebarProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = React.useState<SidebarState>(stateInitializer);
+  // Always start with 'default' to prevent hydration mismatch
+  const [state, setState] = React.useState<SidebarState>(() => 'default');
+
+  // Sync with localStorage after hydration
+  React.useEffect(() => {
+    const storedState = window.localStorage.getItem(SIDEBAR_COOKIE_NAME);
+    if (storedState === 'collapsed' || storedState === 'default') {
+      setState(storedState);
+    }
+  }, []);
 
   const toggleSidebar = React.useCallback(() => {
     setLocalStorage(state === 'default' ? 'collapsed' : 'default');

--- a/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-context.tsx
+++ b/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-context.tsx
@@ -21,10 +21,6 @@ export function useMainSidebar() {
 }
 
 const setLocalStorage = (value: SidebarState) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
   window.localStorage.setItem(SIDEBAR_COOKIE_NAME, value.toString());
 };
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an undefined window error when using the Sidebar in Next.js, preventing hydration mismatches and ensuring stored collapsed/default state is applied after hydration.
  * No public API or exported signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->