### PR TITLE
Make step optional in resumeStreamVNext API

### DIFF
--- a/.changeset/some-ducks-beg.md
+++ b/.changeset/some-ducks-beg.md
@@ -1,0 +1,7 @@
+---
+'@mastra/client-js': patch
+'@mastra/deployer': patch
+'@mastra/server': patch
+---
+
+Make step optional in resumeStreamVNext API

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -739,7 +739,7 @@ export class Workflow extends BaseResource {
    */
   async resumeStreamVNext(params: {
     runId: string;
-    step: string | string[];
+    step?: string | string[];
     resumeData?: Record<string, any>;
     runtimeContext?: RuntimeContext | Record<string, any>;
     tracingOptions?: TracingOptions;

--- a/packages/deployer/src/server/handlers/routes/workflows/router.ts
+++ b/packages/deployer/src/server/handlers/routes/workflows/router.ts
@@ -564,7 +564,6 @@ export function workflowsRouter(bodyLimitOptions: BodyLimitOptions) {
                   },
                 },
               },
-              required: ['step'],
             },
           },
         },

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -740,10 +740,6 @@ export async function resumeStreamWorkflowHandler({
       throw new HTTPException(400, { message: 'runId required to resume workflow' });
     }
 
-    if (!body.step) {
-      throw new HTTPException(400, { message: 'step required to resume workflow' });
-    }
-
     const { workflow } = await getWorkflowsFromSystem({ mastra, workflowId });
 
     if (!workflow) {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Make step optional in resumeStreamVNext API

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

#8972 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the step parameter optional in the resume stream workflow API, allowing more flexible workflow resumption operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->