### PR TITLE
Fix bundle analyze recursion

### DIFF
--- a/.changeset/bold-cooks-grow.md
+++ b/.changeset/bold-cooks-grow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Improve analyze recursion in bundler when using monorepos

--- a/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/apps/mastra/package.json
+++ b/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/apps/mastra/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "apps-mastra",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@internal/a": "workspace:*",
+    "@internal/shared": "workspace:*"
+  }
+}

--- a/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/apps/mastra/src/index.ts
+++ b/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/apps/mastra/src/index.ts
@@ -1,0 +1,6 @@
+import { shared } from '@internal/shared';
+import { a } from '@internal/a';
+
+export const fn = () => {
+  return `${shared} ${a}`;
+};

--- a/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/a/package.json
+++ b/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@internal/a",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@internal/shared": "workspace:*"
+  }
+}

--- a/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/a/src/index.ts
+++ b/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/a/src/index.ts
@@ -1,0 +1,3 @@
+import { shared, shared2 } from '@internal/shared';
+
+export const a = `${shared} a ${shared2}`;

--- a/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/shared/package.json
+++ b/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/shared/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@internal/shared",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/shared/src/index.ts
+++ b/packages/deployer/src/build/analyze/__fixtures__/nested-workspace/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export const shared = 'shared';
+export const shared2 = 'shared2';

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -20,6 +20,8 @@ vi.mock('rollup', async () => {
 describe('analyzeEntry', () => {
   beforeEach(() => {
     vi.mocked(rollup).mockClear();
+    vi.spyOn(process, 'cwd').mockReturnValue(join(import.meta.dirname, '__fixtures__', 'default'));
+    vi.mocked(resolveFrom).mockReset();
   });
 
   it('should analyze the entry file', async () => {
@@ -222,6 +224,7 @@ describe('analyzeEntry', () => {
         '@internal/shared',
         {
           location: `${root}/packages/shared`,
+          dependencies: {},
           version: '1.0.0',
         },
       ],
@@ -245,7 +248,8 @@ describe('analyzeEntry', () => {
     expect(result.dependencies.size).toBe(2);
     expect(result.dependencies.get('@internal/a')?.exports).toEqual(['a']);
     expect(result.dependencies.get('@internal/shared')?.exports).toEqual(['shared']);
-    // Verify that the analyzer doesn't get stuck in infinite loops
-    // (test will timeout if there's an infinite loop issue)
+    // Verify that the analyzer doesn't get stuck in infinite loops.
+    // The initialDepsToOptimize map tracks already-analyzed dependencies to prevent re-analysis.
+    // (Test will timeout if there's an infinite loop issue)
   });
 });

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -191,7 +191,7 @@ describe('analyzeEntry', () => {
     expect(result.output.code).toContain('greet');
   });
 
-  it.only('should handle recursive imports', async () => {
+  it('should handle recursive imports', async () => {
     const root = join(import.meta.dirname, '__fixtures__', 'nested-workspace');
     vi.spyOn(process, 'cwd').mockReturnValue(join(root, 'apps', 'mastra'));
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Large monorepos have an issue where we analyze a file multiple times, we shouldn't

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency analysis recursion in the bundler for monorepos, ensuring transitive dependencies are tracked correctly and preventing infinite recursion.

* **Tests**
  * Added tests covering recursive workspace imports and transitive dependency resolution, plus workspace fixtures to validate behavior.

* **Chores**
  * Added a changelog entry documenting the patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->