### PR TITLE
fix name for listThreadsByResourceId to remove Paginated

### DIFF
--- a/.changeset/fair-lights-rhyme.md
+++ b/.changeset/fair-lights-rhyme.md
@@ -12,4 +12,4 @@
 '@mastra/pg': major
 ---
 
-Add new list methods to storage API: `listMessages`, `listMessagesById`, `listThreadsByResourceIdPaginated`, and `listWorkflowRuns`. Most methods are currently wrappers around existing methods. Full implementations will be added when migrating away from legacy methods.
+Add new list methods to storage API: `listMessages`, `listMessagesById`, `listThreadsByResourceId`, and `listWorkflowRuns`. Most methods are currently wrappers around existing methods. Full implementations will be added when migrating away from legacy methods.

--- a/docs/src/content/en/models/sidebars.js
+++ b/docs/src/content/en/models/sidebars.js
@@ -14,26 +14,26 @@ const sidebars = {
       label: "Gateways",
       collapsed: false,
       items: [
-            {
-                  "type": "doc",
-                  "id": "gateways/index",
-                  "label": "Gateways"
-            },
-            {
-                  "type": "doc",
-                  "id": "gateways/netlify",
-                  "label": "Netlify"
-            },
-            {
-                  "type": "doc",
-                  "id": "gateways/openrouter",
-                  "label": "OpenRouter"
-            },
-            {
-                  "type": "doc",
-                  "id": "gateways/vercel",
-                  "label": "Vercel"
-            }
+        {
+          type: "doc",
+          id: "gateways/index",
+          label: "Gateways",
+        },
+        {
+          type: "doc",
+          id: "gateways/netlify",
+          label: "Netlify",
+        },
+        {
+          type: "doc",
+          id: "gateways/openrouter",
+          label: "OpenRouter",
+        },
+        {
+          type: "doc",
+          id: "gateways/vercel",
+          label: "Vercel",
+        },
       ],
     },
     {
@@ -41,266 +41,266 @@ const sidebars = {
       label: "Providers",
       collapsed: false,
       items: [
-            {
-                  "type": "doc",
-                  "id": "providers/index",
-                  "label": "Providers"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/openai",
-                  "label": "OpenAI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/anthropic",
-                  "label": "Anthropic"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/google",
-                  "label": "Google"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/deepseek",
-                  "label": "DeepSeek"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/groq",
-                  "label": "Groq"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/mistral",
-                  "label": "Mistral"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/xai",
-                  "label": "xAI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/aihubmix",
-                  "label": "AIHubMix"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/alibaba",
-                  "label": "Alibaba"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/alibaba-cn",
-                  "label": "Alibaba (China)"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/amazon-bedrock",
-                  "label": "Amazon Bedrock"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/azure",
-                  "label": "Azure"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/baseten",
-                  "label": "Baseten"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/cerebras",
-                  "label": "Cerebras"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/chutes",
-                  "label": "Chutes"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/cloudflare-workers-ai",
-                  "label": "Cloudflare Workers AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/cortecs",
-                  "label": "Cortecs"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/deepinfra",
-                  "label": "Deep Infra"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/fastrouter",
-                  "label": "FastRouter"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/fireworks-ai",
-                  "label": "Fireworks AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/github-models",
-                  "label": "GitHub Models"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/google-vertex",
-                  "label": "Google Vertex AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/huggingface",
-                  "label": "Hugging Face"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/inception",
-                  "label": "Inception"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/inference",
-                  "label": "Inference"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/llama",
-                  "label": "Llama"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/lmstudio",
-                  "label": "LMStudio"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/lucidquery",
-                  "label": "LucidQuery AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/modelscope",
-                  "label": "ModelScope"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/moonshotai",
-                  "label": "Moonshot AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/moonshotai-cn",
-                  "label": "Moonshot AI (China)"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/morph",
-                  "label": "Morph"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/nebius",
-                  "label": "Nebius AI Studio"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/nvidia",
-                  "label": "Nvidia"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/ollama",
-                  "label": "Ollama"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/opencode",
-                  "label": "OpenCode Zen"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/perplexity",
-                  "label": "Perplexity"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/requesty",
-                  "label": "Requesty"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/scaleway",
-                  "label": "Scaleway"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/submodel",
-                  "label": "submodel"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/synthetic",
-                  "label": "Synthetic"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/togetherai",
-                  "label": "Together AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/upstage",
-                  "label": "Upstage"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/venice",
-                  "label": "Venice AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/vultr",
-                  "label": "Vultr"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/wandb",
-                  "label": "Weights & Biases"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/zai",
-                  "label": "Z.AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/zai-coding-plan",
-                  "label": "Z.AI Coding Plan"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/zenmux",
-                  "label": "ZenMux"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/zhipuai",
-                  "label": "Zhipu AI"
-            },
-            {
-                  "type": "doc",
-                  "id": "providers/zhipuai-coding-plan",
-                  "label": "Zhipu AI Coding Plan"
-            }
+        {
+          type: "doc",
+          id: "providers/index",
+          label: "Providers",
+        },
+        {
+          type: "doc",
+          id: "providers/openai",
+          label: "OpenAI",
+        },
+        {
+          type: "doc",
+          id: "providers/anthropic",
+          label: "Anthropic",
+        },
+        {
+          type: "doc",
+          id: "providers/google",
+          label: "Google",
+        },
+        {
+          type: "doc",
+          id: "providers/deepseek",
+          label: "DeepSeek",
+        },
+        {
+          type: "doc",
+          id: "providers/groq",
+          label: "Groq",
+        },
+        {
+          type: "doc",
+          id: "providers/mistral",
+          label: "Mistral",
+        },
+        {
+          type: "doc",
+          id: "providers/xai",
+          label: "xAI",
+        },
+        {
+          type: "doc",
+          id: "providers/aihubmix",
+          label: "AIHubMix",
+        },
+        {
+          type: "doc",
+          id: "providers/alibaba",
+          label: "Alibaba",
+        },
+        {
+          type: "doc",
+          id: "providers/alibaba-cn",
+          label: "Alibaba (China)",
+        },
+        {
+          type: "doc",
+          id: "providers/amazon-bedrock",
+          label: "Amazon Bedrock",
+        },
+        {
+          type: "doc",
+          id: "providers/azure",
+          label: "Azure",
+        },
+        {
+          type: "doc",
+          id: "providers/baseten",
+          label: "Baseten",
+        },
+        {
+          type: "doc",
+          id: "providers/cerebras",
+          label: "Cerebras",
+        },
+        {
+          type: "doc",
+          id: "providers/chutes",
+          label: "Chutes",
+        },
+        {
+          type: "doc",
+          id: "providers/cloudflare-workers-ai",
+          label: "Cloudflare Workers AI",
+        },
+        {
+          type: "doc",
+          id: "providers/cortecs",
+          label: "Cortecs",
+        },
+        {
+          type: "doc",
+          id: "providers/deepinfra",
+          label: "Deep Infra",
+        },
+        {
+          type: "doc",
+          id: "providers/fastrouter",
+          label: "FastRouter",
+        },
+        {
+          type: "doc",
+          id: "providers/fireworks-ai",
+          label: "Fireworks AI",
+        },
+        {
+          type: "doc",
+          id: "providers/github-models",
+          label: "GitHub Models",
+        },
+        {
+          type: "doc",
+          id: "providers/google-vertex",
+          label: "Google Vertex AI",
+        },
+        {
+          type: "doc",
+          id: "providers/huggingface",
+          label: "Hugging Face",
+        },
+        {
+          type: "doc",
+          id: "providers/inception",
+          label: "Inception",
+        },
+        {
+          type: "doc",
+          id: "providers/inference",
+          label: "Inference",
+        },
+        {
+          type: "doc",
+          id: "providers/llama",
+          label: "Llama",
+        },
+        {
+          type: "doc",
+          id: "providers/lmstudio",
+          label: "LMStudio",
+        },
+        {
+          type: "doc",
+          id: "providers/lucidquery",
+          label: "LucidQuery AI",
+        },
+        {
+          type: "doc",
+          id: "providers/modelscope",
+          label: "ModelScope",
+        },
+        {
+          type: "doc",
+          id: "providers/moonshotai",
+          label: "Moonshot AI",
+        },
+        {
+          type: "doc",
+          id: "providers/moonshotai-cn",
+          label: "Moonshot AI (China)",
+        },
+        {
+          type: "doc",
+          id: "providers/morph",
+          label: "Morph",
+        },
+        {
+          type: "doc",
+          id: "providers/nebius",
+          label: "Nebius AI Studio",
+        },
+        {
+          type: "doc",
+          id: "providers/nvidia",
+          label: "Nvidia",
+        },
+        {
+          type: "doc",
+          id: "providers/ollama",
+          label: "Ollama",
+        },
+        {
+          type: "doc",
+          id: "providers/opencode",
+          label: "OpenCode Zen",
+        },
+        {
+          type: "doc",
+          id: "providers/perplexity",
+          label: "Perplexity",
+        },
+        {
+          type: "doc",
+          id: "providers/requesty",
+          label: "Requesty",
+        },
+        {
+          type: "doc",
+          id: "providers/scaleway",
+          label: "Scaleway",
+        },
+        {
+          type: "doc",
+          id: "providers/submodel",
+          label: "submodel",
+        },
+        {
+          type: "doc",
+          id: "providers/synthetic",
+          label: "Synthetic",
+        },
+        {
+          type: "doc",
+          id: "providers/togetherai",
+          label: "Together AI",
+        },
+        {
+          type: "doc",
+          id: "providers/upstage",
+          label: "Upstage",
+        },
+        {
+          type: "doc",
+          id: "providers/venice",
+          label: "Venice AI",
+        },
+        {
+          type: "doc",
+          id: "providers/vultr",
+          label: "Vultr",
+        },
+        {
+          type: "doc",
+          id: "providers/wandb",
+          label: "Weights & Biases",
+        },
+        {
+          type: "doc",
+          id: "providers/zai",
+          label: "Z.AI",
+        },
+        {
+          type: "doc",
+          id: "providers/zai-coding-plan",
+          label: "Z.AI Coding Plan",
+        },
+        {
+          type: "doc",
+          id: "providers/zenmux",
+          label: "ZenMux",
+        },
+        {
+          type: "doc",
+          id: "providers/zhipuai",
+          label: "Zhipu AI",
+        },
+        {
+          type: "doc",
+          id: "providers/zhipuai-coding-plan",
+          label: "Zhipu AI Coding Plan",
+        },
       ],
     },
   ],

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -38,8 +38,8 @@ import type {
   StorageListMessagesInput,
   StorageListMessagesOutput,
   StorageListWorkflowRunsInput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from './types';
 
 export type StorageDomains = {
@@ -285,11 +285,11 @@ export abstract class MastraStorage extends MastraBase {
     });
   }
 
-  async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     if (this.stores?.memory) {
-      return this.stores.memory.listThreadsByResourceIdPaginated(args);
+      return this.stores.memory.listThreadsByResourceId(args);
     }
     throw new MastraError({
       id: 'MASTRA_STORAGE_LIST_THREADS_BY_RESOURCE_ID_PAGINATED_NOT_SUPPORTED',

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -10,8 +10,8 @@ import type {
   ThreadSortOptions,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '../../types';
 
 export abstract class MemoryStorage extends MastraBase {
@@ -92,9 +92,9 @@ export abstract class MemoryStorage extends MastraBase {
     } & ThreadSortOptions,
   ): Promise<PaginationInfo & { threads: StorageThreadType[] }>;
 
-  abstract listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput>;
+  abstract listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput>;
 
   abstract getMessagesPaginated(
     args: StorageGetMessagesArg & { format?: 'v1' | 'v2' },

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -470,156 +470,160 @@ export class InMemoryMemory extends MemoryStorage {
   > {
     this.logger.debug(`MockStore: getMessagesPaginated called for thread ${threadId}`);
 
-    if (!threadId.trim()) throw new Error('threadId must be a non-empty string');
-
     const { page = 0, perPage = 40 } = selectBy?.pagination || {};
 
-    // Handle include messages first
-    const messages: MastraMessageV2[] = [];
+    try {
+      if (!threadId.trim()) throw new Error('threadId must be a non-empty string');
 
-    if (selectBy?.include && selectBy.include.length > 0) {
-      for (const includeItem of selectBy.include) {
-        const targetMessage = this.collection.messages.get(includeItem.id);
-        if (targetMessage) {
-          // Convert StorageMessageType to MastraMessageV2
-          const convertedMessage = {
-            id: targetMessage.id,
-            threadId: targetMessage.thread_id,
-            content: safelyParseJSON(targetMessage.content),
-            role: targetMessage.role as 'user' | 'assistant' | 'system' | 'tool',
-            type: targetMessage.type,
-            createdAt: targetMessage.createdAt,
-            resourceId: targetMessage.resourceId,
-          } as MastraMessageV2;
+      // Handle include messages first
+      const messages: MastraMessageV2[] = [];
 
-          messages.push(convertedMessage);
+      if (selectBy?.include && selectBy.include.length > 0) {
+        for (const includeItem of selectBy.include) {
+          const targetMessage = this.collection.messages.get(includeItem.id);
+          if (targetMessage) {
+            // Convert StorageMessageType to MastraMessageV2
+            const convertedMessage = {
+              id: targetMessage.id,
+              threadId: targetMessage.thread_id,
+              content: safelyParseJSON(targetMessage.content),
+              role: targetMessage.role as 'user' | 'assistant' | 'system' | 'tool',
+              type: targetMessage.type,
+              createdAt: targetMessage.createdAt,
+              resourceId: targetMessage.resourceId,
+            } as MastraMessageV2;
 
-          // Add previous messages if requested
-          if (includeItem.withPreviousMessages) {
-            const allThreadMessages = Array.from(this.collection.messages.values())
-              .filter((msg: any) => msg.thread_id === includeItem.threadId)
-              .sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+            messages.push(convertedMessage);
 
-            const targetIndex = allThreadMessages.findIndex(msg => msg.id === includeItem.id);
-            if (targetIndex !== -1) {
-              const startIndex = Math.max(0, targetIndex - (includeItem.withPreviousMessages || 0));
-              for (let i = startIndex; i < targetIndex; i++) {
-                const message = allThreadMessages[i];
-                if (message && !messages.some(m => m.id === message.id)) {
-                  const convertedPrevMessage = {
-                    id: message.id,
-                    threadId: message.thread_id,
-                    content: safelyParseJSON(message.content),
-                    role: message.role as 'user' | 'assistant' | 'system' | 'tool',
-                    type: message.type,
-                    createdAt: message.createdAt,
-                    resourceId: message.resourceId,
-                  } as MastraMessageV2;
-                  messages.push(convertedPrevMessage);
+            // Add previous messages if requested
+            if (includeItem.withPreviousMessages) {
+              const allThreadMessages = Array.from(this.collection.messages.values())
+                .filter((msg: any) => msg.thread_id === includeItem.threadId)
+                .sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+              const targetIndex = allThreadMessages.findIndex(msg => msg.id === includeItem.id);
+              if (targetIndex !== -1) {
+                const startIndex = Math.max(0, targetIndex - (includeItem.withPreviousMessages || 0));
+                for (let i = startIndex; i < targetIndex; i++) {
+                  const message = allThreadMessages[i];
+                  if (message && !messages.some(m => m.id === message.id)) {
+                    const convertedPrevMessage = {
+                      id: message.id,
+                      threadId: message.thread_id,
+                      content: safelyParseJSON(message.content),
+                      role: message.role as 'user' | 'assistant' | 'system' | 'tool',
+                      type: message.type,
+                      createdAt: message.createdAt,
+                      resourceId: message.resourceId,
+                    } as MastraMessageV2;
+                    messages.push(convertedPrevMessage);
+                  }
+                }
+              }
+            }
+
+            // Add next messages if requested
+            if (includeItem.withNextMessages) {
+              const allThreadMessages = Array.from(this.collection.messages.values())
+                .filter((msg: any) => msg.thread_id === includeItem.threadId)
+                .sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+              const targetIndex = allThreadMessages.findIndex(msg => msg.id === includeItem.id);
+              if (targetIndex !== -1) {
+                const endIndex = Math.min(
+                  allThreadMessages.length,
+                  targetIndex + (includeItem.withNextMessages || 0) + 1,
+                );
+                for (let i = targetIndex + 1; i < endIndex; i++) {
+                  const message = allThreadMessages[i];
+                  if (message && !messages.some(m => m.id === message.id)) {
+                    const convertedNextMessage = {
+                      id: message.id,
+                      threadId: message.thread_id,
+                      content: safelyParseJSON(message.content),
+                      role: message.role as 'user' | 'assistant' | 'system' | 'tool',
+                      type: message.type,
+                      createdAt: message.createdAt,
+                      resourceId: message.resourceId,
+                    } as MastraMessageV2;
+                    messages.push(convertedNextMessage);
+                  }
                 }
               }
             }
           }
+        }
+      }
 
-          // Add next messages if requested
-          if (includeItem.withNextMessages) {
-            const allThreadMessages = Array.from(this.collection.messages.values())
-              .filter((msg: any) => msg.thread_id === includeItem.threadId)
-              .sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+      // Get regular messages from the thread only if no include items or if last is specified
+      if (!selectBy?.include || selectBy.include.length === 0 || selectBy?.last) {
+        let threadMessages = Array.from(this.collection.messages.values())
+          .filter((msg: any) => msg.thread_id === threadId)
+          .filter((msg: any) => !messages.some(m => m.id === msg.id)); // Exclude already included messages
 
-            const targetIndex = allThreadMessages.findIndex(msg => msg.id === includeItem.id);
-            if (targetIndex !== -1) {
-              const endIndex = Math.min(
-                allThreadMessages.length,
-                targetIndex + (includeItem.withNextMessages || 0) + 1,
-              );
-              for (let i = targetIndex + 1; i < endIndex; i++) {
-                const message = allThreadMessages[i];
-                if (message && !messages.some(m => m.id === message.id)) {
-                  const convertedNextMessage = {
-                    id: message.id,
-                    threadId: message.thread_id,
-                    content: safelyParseJSON(message.content),
-                    role: message.role as 'user' | 'assistant' | 'system' | 'tool',
-                    type: message.type,
-                    createdAt: message.createdAt,
-                    resourceId: message.resourceId,
-                  } as MastraMessageV2;
-                  messages.push(convertedNextMessage);
-                }
-              }
-            }
+        // Apply date filtering
+        if (selectBy?.pagination?.dateRange) {
+          const { start: from, end: to } = selectBy.pagination.dateRange;
+          threadMessages = threadMessages.filter((msg: any) => {
+            const msgDate = new Date(msg.createdAt);
+            const fromDate = from ? new Date(from) : null;
+            const toDate = to ? new Date(to) : null;
+
+            if (fromDate && msgDate < fromDate) return false;
+            if (toDate && msgDate > toDate) return false;
+            return true;
+          });
+        }
+
+        // Apply selectBy logic
+        if (selectBy?.last) {
+          threadMessages.sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+          const lastMessages = threadMessages.slice(-selectBy.last);
+          // Convert and add last messages
+          for (const msg of lastMessages) {
+            const convertedMessage = {
+              id: msg.id,
+              threadId: msg.thread_id,
+              content: safelyParseJSON(msg.content),
+              role: msg.role as 'user' | 'assistant' | 'system' | 'tool',
+              type: msg.type,
+              createdAt: msg.createdAt,
+              resourceId: msg.resourceId,
+            } as MastraMessageV2;
+            messages.push(convertedMessage);
+          }
+        } else if (!selectBy?.include || selectBy.include.length === 0) {
+          // Convert and add all thread messages only if no include items
+          for (const msg of threadMessages) {
+            const convertedMessage = {
+              id: msg.id,
+              threadId: msg.thread_id,
+              content: safelyParseJSON(msg.content),
+              role: msg.role as 'user' | 'assistant' | 'system' | 'tool',
+              type: msg.type,
+              createdAt: msg.createdAt,
+              resourceId: msg.resourceId,
+            } as MastraMessageV2;
+            messages.push(convertedMessage);
           }
         }
       }
+
+      // Sort by createdAt
+      messages.sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+      const start = page * perPage;
+      const end = start + perPage;
+      return {
+        messages: messages.slice(start, end),
+        total: messages.length,
+        page,
+        perPage,
+        hasMore: messages.length > end,
+      };
+    } catch (error) {
+      return { messages: [], total: 0, page, perPage, hasMore: false };
     }
-
-    // Get regular messages from the thread only if no include items or if last is specified
-    if (!selectBy?.include || selectBy.include.length === 0 || selectBy?.last) {
-      let threadMessages = Array.from(this.collection.messages.values())
-        .filter((msg: any) => msg.thread_id === threadId)
-        .filter((msg: any) => !messages.some(m => m.id === msg.id)); // Exclude already included messages
-
-      // Apply date filtering
-      if (selectBy?.pagination?.dateRange) {
-        const { start: from, end: to } = selectBy.pagination.dateRange;
-        threadMessages = threadMessages.filter((msg: any) => {
-          const msgDate = new Date(msg.createdAt);
-          const fromDate = from ? new Date(from) : null;
-          const toDate = to ? new Date(to) : null;
-
-          if (fromDate && msgDate < fromDate) return false;
-          if (toDate && msgDate > toDate) return false;
-          return true;
-        });
-      }
-
-      // Apply selectBy logic
-      if (selectBy?.last) {
-        threadMessages.sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-        const lastMessages = threadMessages.slice(-selectBy.last);
-        // Convert and add last messages
-        for (const msg of lastMessages) {
-          const convertedMessage = {
-            id: msg.id,
-            threadId: msg.thread_id,
-            content: safelyParseJSON(msg.content),
-            role: msg.role as 'user' | 'assistant' | 'system' | 'tool',
-            type: msg.type,
-            createdAt: msg.createdAt,
-            resourceId: msg.resourceId,
-          } as MastraMessageV2;
-          messages.push(convertedMessage);
-        }
-      } else if (!selectBy?.include || selectBy.include.length === 0) {
-        // Convert and add all thread messages only if no include items
-        for (const msg of threadMessages) {
-          const convertedMessage = {
-            id: msg.id,
-            threadId: msg.thread_id,
-            content: safelyParseJSON(msg.content),
-            role: msg.role as 'user' | 'assistant' | 'system' | 'tool',
-            type: msg.type,
-            createdAt: msg.createdAt,
-            resourceId: msg.resourceId,
-          } as MastraMessageV2;
-          messages.push(convertedMessage);
-        }
-      }
-    }
-
-    // Sort by createdAt
-    messages.sort((a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-
-    const start = page * perPage;
-    const end = start + perPage;
-    return {
-      messages: messages.slice(start, end),
-      total: messages.length,
-      page,
-      perPage,
-      hasMore: messages.length > end,
-    };
   }
 
   async getResourceById({ resourceId }: { resourceId: string }): Promise<StorageResourceType | null> {

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -10,8 +10,8 @@ import type {
   ThreadSortOptions,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '../../types';
 import { safelyParseJSON } from '../../utils';
 import type { StoreOperations } from '../operations';
@@ -453,9 +453,9 @@ export class InMemoryMemory extends MemoryStorage {
     };
   }
 
-  async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset, orderBy, sortDirection } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -108,13 +108,13 @@ export type StorageListWorkflowRunsInput = {
   resourceId?: string;
 };
 
-export type StorageListThreadsByResourceIdPaginatedInput = {
+export type StoragelistThreadsByResourceIdInput = {
   resourceId: string;
   limit: number;
   offset: number;
 } & ThreadSortOptions;
 
-export type StorageListThreadsByResourceIdPaginatedOutput = PaginationInfo & {
+export type StoragelistThreadsByResourceIdOutput = PaginationInfo & {
   threads: StorageThreadType[];
 };
 

--- a/stores/_test-utils/src/domains/memory/messages-paginated.ts
+++ b/stores/_test-utils/src/domains/memory/messages-paginated.ts
@@ -486,14 +486,12 @@ export function createMessagesPaginatedTest({ storage }: { storage: MastraStorag
       expect(retrievedMessages.find(m => m.id === baseMessage.id)?.content.content).toBe('Updated');
     });
 
-    it('should throw if threadId is an empty string or whitespace only', async () => {
-      await expect(storage.getMessagesPaginated({ threadId: '' })).rejects.toThrowError(
-        'threadId must be a non-empty string',
-      );
+    it('should return empty array if threadId is an empty string or whitespace only', async () => {
+      const result = await storage.getMessagesPaginated({ threadId: '' });
+      expect(result.messages).toHaveLength(0);
 
-      await expect(storage.getMessagesPaginated({ threadId: '   ' })).rejects.toThrowError(
-        'threadId must be a non-empty string',
-      );
+      const result2 = await storage.getMessagesPaginated({ threadId: '   ' });
+      expect(result2.messages).toHaveLength(0);
     });
   });
 

--- a/stores/clickhouse/src/storage/domains/memory/index.ts
+++ b/stores/clickhouse/src/storage/domains/memory/index.ts
@@ -9,8 +9,8 @@ import type {
   StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import {
   MemoryStorage,
@@ -769,9 +769,9 @@ export class MemoryStorageClickhouse extends MemoryStorage {
    * @todo When migrating from getThreadsByResourceIdPaginated to this method,
    * implement orderBy and sortDirection support for full sorting capabilities
    */
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/cloudflare-d1/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/memory/index.ts
@@ -17,8 +17,8 @@ import type {
   StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import { createSqlBuilder } from '../../sql-builder';
 import type { StoreOperationsD1 } from '../operations';
@@ -775,9 +775,9 @@ export class MemoryStorageD1 extends MemoryStorage {
    * @todo When migrating from getThreadsByResourceIdPaginated to this method,
    * implement orderBy and sortDirection support for full sorting capabilities
    */
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/cloudflare/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/storage/domains/memory/index.ts
@@ -8,8 +8,8 @@ import type {
   StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import {
   ensureDate,
@@ -895,9 +895,9 @@ export class MemoryStorageCloudflare extends MemoryStorage {
    * @todo When migrating from getThreadsByResourceIdPaginated to this method,
    * implement orderBy and sortDirection support for full sorting capabilities
    */
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -10,8 +10,8 @@ import type {
   ThreadSortOptions,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import type { Service } from 'electrodb';
 
@@ -428,9 +428,9 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
    * @todo When migrating from getThreadsByResourceIdPaginated to this method,
    * implement orderBy and sortDirection support for full sorting capabilities
    */
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/lance/src/storage/domains/memory/index.ts
+++ b/stores/lance/src/storage/domains/memory/index.ts
@@ -16,8 +16,8 @@ import type {
   StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import type { StoreOperationsLance } from '../operations';
 import { getTableSchema, processResultWithTypeConversion } from '../utils';
@@ -356,9 +356,9 @@ export class StoreMemoryLance extends MemoryStorage {
    * @todo When migrating from getThreadsByResourceIdPaginated to this method,
    * implement orderBy and sortDirection support for full sorting capabilities
    */
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -10,8 +10,8 @@ import type {
   ThreadSortOptions,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import {
   MemoryStorage,
@@ -237,9 +237,9 @@ export class MemoryLibSQL extends MemoryStorage {
     return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset, orderBy, sortDirection } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -16,8 +16,8 @@ import type {
   StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import type { StoreOperationsMongoDB } from '../operations';
 import { formatDateForMongoDB } from '../utils';
@@ -224,9 +224,9 @@ export class MemoryStorageMongoDB extends MemoryStorage {
    * @todo When migrating from getThreadsByResourceIdPaginated to this method,
    * implement orderBy and sortDirection support for full sorting capabilities
    */
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/mssql/src/storage/domains/memory/index.ts
+++ b/stores/mssql/src/storage/domains/memory/index.ts
@@ -17,8 +17,8 @@ import type {
   ThreadSortOptions,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import sql from 'mssql';
 import type { StoreOperationsMSSQL } from '../operations';
@@ -593,9 +593,9 @@ export class MemoryMSSQL extends MemoryStorage {
     return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset, orderBy, sortDirection } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -16,8 +16,8 @@ import type {
   ThreadSortOptions,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import type { IDatabase } from 'pg-promise';
 import type { StoreOperationsPG } from '../operations';
@@ -588,9 +588,9 @@ export class MemoryPG extends MemoryStorage {
     return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset, orderBy, sortDirection } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -15,8 +15,8 @@ import type {
   StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
-  StorageListThreadsByResourceIdPaginatedInput,
-  StorageListThreadsByResourceIdPaginatedOutput,
+  StoragelistThreadsByResourceIdInput,
+  StoragelistThreadsByResourceIdOutput,
 } from '@mastra/core/storage';
 import type { Redis } from '@upstash/redis';
 import type { StoreOperationsUpstash } from '../operations';
@@ -172,9 +172,9 @@ export class StoreMemoryUpstash extends MemoryStorage {
    * @todo When migrating from getThreadsByResourceIdPaginated to this method,
    * implement orderBy and sortDirection support for full sorting capabilities
    */
-  public async listThreadsByResourceIdPaginated(
-    args: StorageListThreadsByResourceIdPaginatedInput,
-  ): Promise<StorageListThreadsByResourceIdPaginatedOutput> {
+  public async listThreadsByResourceId(
+    args: StoragelistThreadsByResourceIdInput,
+  ): Promise<StoragelistThreadsByResourceIdOutput> {
     const { resourceId, limit, offset } = args;
     const page = Math.floor(offset / limit);
     const perPage = limit;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Change listThreadsByResourceIdPaginated to listThreadsByResourceId

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified storage thread-listing API renamed to a simplified form across all storage implementations; exported type names updated. This is a breaking change for integrations that call the storage API directly.
* **Bug Fixes**
  * More defensive handling in memory-backed retrievals: failures now yield stable empty paged results instead of throwing.
* **Style**
  * Documentation sidebar entries reformatted for consistent indentation (no content changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->