### PR TITLE
update handlers to use listThreadsByResourceId

### DIFF
--- a/.changeset/curvy-states-hide.md
+++ b/.changeset/curvy-states-hide.md
@@ -1,0 +1,10 @@
+---
+'@mastra/playground-ui': major
+'@mastra/client-js': major
+'@mastra/deployer': major
+'@mastra/memory': major
+'@mastra/server': major
+'@mastra/core': major
+---
+
+Replace `getThreadsByResourceIdPaginated` with `listThreadsByResourceId` across memory handlers. Update client SDK to use `listThreads()` with `offset`/`limit` parameters instead of deprecated `getMemoryThreads()`. Consolidate `/api/memory/threads` routes to single paginated endpoint.

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -21,8 +21,6 @@ import type {
   GetLogParams,
   GetLogsParams,
   GetLogsResponse,
-  GetMemoryThreadParams,
-  GetMemoryThreadResponse,
   GetToolResponse,
   GetWorkflowResponse,
   SaveMessageToMemoryParams,
@@ -43,6 +41,8 @@ import type {
   GetMemoryThreadMessagesResponse,
   MemorySearchResponse,
   ListAgentsModelProvidersResponse,
+  ListMemoryThreadsParams,
+  ListMemoryThreadsResponse,
 } from './types';
 import { base64RuntimeContext, parseClientRuntimeContext, runtimeContextQueryString } from './utils';
 
@@ -85,13 +85,22 @@ export class MastraClient extends BaseResource {
   }
 
   /**
-   * Retrieves memory threads for a resource
-   * @param params - Parameters containing the resource ID and optional runtime context
-   * @returns Promise containing array of memory threads
+   * Lists memory threads for a resource with pagination support
+   * @param params - Parameters containing resource ID, pagination options, and optional runtime context
+   * @returns Promise containing paginated array of memory threads with metadata
    */
-  public getMemoryThreads(params: GetMemoryThreadParams): Promise<GetMemoryThreadResponse> {
+  public listMemoryThreads(params: ListMemoryThreadsParams): Promise<ListMemoryThreadsResponse> {
+    const queryParams = new URLSearchParams({
+      resourceId: params.resourceId,
+      agentId: params.agentId,
+      ...(params.offset !== undefined && { offset: params.offset.toString() }),
+      ...(params.limit !== undefined && { limit: params.limit.toString() }),
+      ...(params.orderBy && { orderBy: params.orderBy }),
+      ...(params.sortDirection && { sortDirection: params.sortDirection }),
+    });
+
     return this.request(
-      `/api/memory/threads?resourceid=${params.resourceId}&agentId=${params.agentId}${runtimeContextQueryString(params.runtimeContext, '&')}`,
+      `/api/memory/threads?${queryParams.toString()}${runtimeContextQueryString(params.runtimeContext, '&')}`,
     );
   }
 

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -252,11 +252,19 @@ export interface CreateMemoryThreadParams {
 
 export type CreateMemoryThreadResponse = StorageThreadType;
 
-export interface GetMemoryThreadParams {
+export interface ListMemoryThreadsParams {
   resourceId: string;
   agentId: string;
+  offset?: number;
+  limit?: number;
+  orderBy?: 'createdAt' | 'updatedAt';
+  sortDirection?: 'ASC' | 'DESC';
   runtimeContext?: RuntimeContext | Record<string, any>;
 }
+
+export type ListMemoryThreadsResponse = PaginationInfo & {
+  threads: StorageThreadType[];
+};
 
 export interface GetMemoryConfigParams {
   agentId: string;
@@ -264,8 +272,6 @@ export interface GetMemoryConfigParams {
 }
 
 export type GetMemoryConfigResponse = { config: MemoryConfig };
-
-export type GetMemoryThreadResponse = StorageThreadType[];
 
 export interface UpdateMemoryThreadParams {
   title: string;

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -380,6 +380,8 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
     describe('tool approval and suspension', () => {
       describe.skipIf(version === 'v1')('requireToolApproval', () => {
         it('should call findUserTool with requireToolApproval on tool and be able to reject the tool call', async () => {
+          mockFindUser.mockClear(); // Reset mock call count before this test
+
           const findUserTool = createTool({
             id: 'Find user tool',
             description: 'This is a test tool that returns the name and email',

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -5,7 +5,14 @@ import type { MastraMessageV2, UIMessageWithMetadata } from '../agent/message-li
 import { MastraBase } from '../base';
 import { ModelRouterEmbeddingModel } from '../llm/model/index.js';
 import type { Mastra } from '../mastra';
-import type { MastraStorage, PaginationInfo, StorageGetMessagesArg, ThreadSortOptions } from '../storage';
+import type {
+  MastraStorage,
+  PaginationInfo,
+  StorageGetMessagesArg,
+  StorageListThreadsByResourceIdInput,
+  StorageListThreadsByResourceIdOutput,
+  ThreadSortOptions,
+} from '../storage';
 import { augmentWithInit } from '../storage/storageWithInit';
 import type { ToolAction } from '../tools';
 import { deepMerge } from '../utils';
@@ -315,6 +322,10 @@ export abstract class MastraMemory extends MastraBase {
       perPage: number;
     } & ThreadSortOptions,
   ): Promise<PaginationInfo & { threads: StorageThreadType[] }>;
+
+  abstract listThreadsByResourceId(
+    args: StorageListThreadsByResourceIdInput,
+  ): Promise<StorageListThreadsByResourceIdOutput>;
 
   /**
    * Saves or updates a thread

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -4,7 +4,12 @@ import type { CoreMessage } from '../llm';
 import { MastraMemory } from '../memory';
 import type { StorageThreadType, MastraMessageV1, MastraMessageV2, MemoryConfig, MessageDeleteInput } from '../memory';
 import { InMemoryStore } from '../storage';
-import type { StorageGetMessagesArg, ThreadSortOptions } from '../storage';
+import type {
+  StorageGetMessagesArg,
+  StorageListThreadsByResourceIdInput,
+  StorageListThreadsByResourceIdOutput,
+  ThreadSortOptions,
+} from '../storage';
 
 export class MockMemory extends MastraMemory {
   threads: Record<string, StorageThreadType> = {};
@@ -73,6 +78,13 @@ export class MockMemory extends MastraMemory {
   ): Promise<any & { threads: StorageThreadType[] }> {
     return this.storage.getThreadsByResourceIdPaginated(args);
   }
+
+  async listThreadsByResourceId(
+    args: StorageListThreadsByResourceIdInput,
+  ): Promise<StorageListThreadsByResourceIdOutput> {
+    return this.storage.listThreadsByResourceId(args);
+  }
+
   async query({ threadId, resourceId, selectBy }: StorageGetMessagesArg): Promise<{
     messages: CoreMessage[];
     uiMessages: UIMessageWithMetadata[];

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -15,7 +15,7 @@ export class MockMemory extends MastraMemory {
   threads: Record<string, StorageThreadType> = {};
   messages: Map<string, MastraMessageV1 | MastraMessageV2> = new Map();
 
-  constructor(storage?: InMemoryStore) {
+  constructor({ storage }: { storage?: InMemoryStore } = {}) {
     super({ name: 'mock', storage: storage || new InMemoryStore() });
     this._hasOwnStorage = true;
   }

--- a/packages/core/src/storage/mock.test.ts
+++ b/packages/core/src/storage/mock.test.ts
@@ -221,22 +221,20 @@ describe('InMemoryStore - Message Fetching', () => {
     store = new InMemoryStore();
   });
 
-  it('getMessages should throw when threadId is an empty string or whitespace only', async () => {
-    await expect(() => store.getMessages({ threadId: '' })).rejects.toThrowError('threadId must be a non-empty string');
+  it('getMessages should return empty array if threadId is an empty string or whitespace only', async () => {
+    const messages = await store.getMessages({ threadId: '' });
+    expect(messages).toHaveLength(0);
 
-    await expect(() => store.getMessages({ threadId: '   ' })).rejects.toThrowError(
-      'threadId must be a non-empty string',
-    );
+    const messages2 = await store.getMessages({ threadId: '   ' });
+    expect(messages2).toHaveLength(0);
   });
 
-  it('getMessagesPaginated should throw when threadId is an empty string or whitespace only', async () => {
-    await expect(() => store.getMessagesPaginated({ threadId: '' })).rejects.toThrowError(
-      'threadId must be a non-empty string',
-    );
+  it('getMessagesPaginated should return empty array if threadId is an empty string or whitespace only', async () => {
+    const result = await store.getMessagesPaginated({ threadId: '' });
+    expect(result.messages).toHaveLength(0);
 
-    await expect(() => store.getMessagesPaginated({ threadId: '   ' })).rejects.toThrowError(
-      'threadId must be a non-empty string',
-    );
+    const result2 = await store.getMessagesPaginated({ threadId: '   ' });
+    expect(result2.messages).toHaveLength(0);
   });
 });
 

--- a/packages/deployer/src/server/handlers/routes/memory/handlers.ts
+++ b/packages/deployer/src/server/handlers/routes/memory/handlers.ts
@@ -8,8 +8,7 @@ import type {
 import {
   getMemoryStatusHandler as getOriginalMemoryStatusHandler,
   getMemoryConfigHandler as getOriginalMemoryConfigHandler,
-  getThreadsHandler as getOriginalThreadsHandler,
-  getThreadsPaginatedHandler as getOriginalGetThreadsPaginatedHandler,
+  listThreadsHandler as getOriginalListThreadsHandler,
   getThreadByIdHandler as getOriginalThreadByIdHandler,
   saveMessagesHandler as getOriginalSaveMessagesHandler,
   createThreadHandler as getOriginalCreateThreadHandler,
@@ -64,47 +63,23 @@ export async function getMemoryConfigHandler(c: Context) {
   }
 }
 
-export async function getThreadsHandler(c: Context) {
-  try {
-    const mastra: Mastra = c.get('mastra');
-    const agentId = c.req.query('agentId');
-    const resourceId = c.req.query('resourceid');
-    const orderBy = c.req.query('orderBy') as ThreadOrderBy | undefined;
-    const sortDirection = c.req.query('sortDirection') as ThreadSortDirection | undefined;
-    const runtimeContext = c.get('runtimeContext');
-
-    const result = await getOriginalThreadsHandler({
-      mastra,
-      agentId,
-      resourceId,
-      orderBy,
-      sortDirection,
-      runtimeContext,
-    });
-
-    return c.json(result);
-  } catch (error) {
-    return handleError(error, 'Error getting threads');
-  }
-}
-
-export async function getThreadsPaginatedHandler(c: Context) {
+export async function listThreadsHandler(c: Context) {
   try {
     const mastra: Mastra = c.get('mastra');
     const agentId = c.req.query('agentId');
     const resourceId = c.req.query('resourceId');
-    const page = parseInt(c.req.query('page') || '0', 10);
-    const perPage = parseInt(c.req.query('perPage') || '100', 10);
+    const offset = parseInt(c.req.query('offset') || '0', 10);
+    const limit = parseInt(c.req.query('limit') || '100', 10);
     const orderBy = c.req.query('orderBy') as ThreadOrderBy | undefined;
     const sortDirection = c.req.query('sortDirection') as ThreadSortDirection | undefined;
     const runtimeContext = c.get('runtimeContext');
 
-    const result = await getOriginalGetThreadsPaginatedHandler({
+    const result = await getOriginalListThreadsHandler({
       mastra,
       agentId,
       resourceId,
-      page,
-      perPage,
+      offset,
+      limit,
       orderBy,
       sortDirection,
       runtimeContext,
@@ -112,7 +87,7 @@ export async function getThreadsPaginatedHandler(c: Context) {
 
     return c.json(result);
   } catch (error) {
-    return handleError(error, 'Error getting paginated threads');
+    return handleError(error, 'Error listing threads');
   }
 }
 

--- a/packages/deployer/src/server/handlers/routes/memory/router.ts
+++ b/packages/deployer/src/server/handlers/routes/memory/router.ts
@@ -10,8 +10,7 @@ import {
   getMessagesHandler,
   getMessagesPaginatedHandler,
   getThreadByIdHandler,
-  getThreadsHandler,
-  getThreadsPaginatedHandler,
+  listThreadsHandler,
   getWorkingMemoryHandler,
   saveMessagesHandler,
   searchMemoryHandler,
@@ -65,6 +64,20 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
           schema: { type: 'string' },
         },
         {
+          name: 'offset',
+          in: 'query',
+          required: false,
+          schema: { type: 'number', default: 0 },
+          description: 'Page number',
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          schema: { type: 'number', default: 100 },
+          description: 'Number of threads per page',
+        },
+        {
           name: 'orderBy',
           in: 'query',
           required: false,
@@ -93,7 +106,7 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
         },
       },
     }),
-    getThreadsHandler,
+    listThreadsHandler,
   );
 
   router.get(
@@ -535,56 +548,6 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
   router.get(
     '/threads',
     describeRoute({
-      description: 'Get all threads',
-      tags: ['memory'],
-      parameters: [
-        {
-          name: 'resourceid',
-          in: 'query',
-          required: true,
-          schema: { type: 'string' },
-        },
-        {
-          name: 'agentId',
-          in: 'query',
-          required: true,
-          schema: { type: 'string' },
-        },
-        {
-          name: 'orderBy',
-          in: 'query',
-          required: false,
-          schema: {
-            type: 'string',
-            enum: ['createdAt', 'updatedAt'],
-            default: 'createdAt',
-          },
-          description: 'Field to sort by',
-        },
-        {
-          name: 'sortDirection',
-          in: 'query',
-          required: false,
-          schema: {
-            type: 'string',
-            enum: ['ASC', 'DESC'],
-            default: 'DESC',
-          },
-          description: 'Sort direction',
-        },
-      ],
-      responses: {
-        200: {
-          description: 'List of all threads',
-        },
-      },
-    }),
-    getThreadsHandler,
-  );
-
-  router.get(
-    '/threads/paginated',
-    describeRoute({
       description: 'Get paginated threads',
       tags: ['memory'],
       parameters: [
@@ -601,14 +564,14 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
           schema: { type: 'string' },
         },
         {
-          name: 'page',
+          name: 'offset',
           in: 'query',
           required: false,
           schema: { type: 'number', default: 0 },
           description: 'Page number',
         },
         {
-          name: 'perPage',
+          name: 'limit',
           in: 'query',
           required: false,
           schema: { type: 'number', default: 100 },
@@ -641,7 +604,7 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
         },
       },
     }),
-    getThreadsPaginatedHandler,
+    listThreadsHandler,
   );
 
   router.get(

--- a/packages/deployer/src/server/handlers/routes/memory/router.ts
+++ b/packages/deployer/src/server/handlers/routes/memory/router.ts
@@ -68,14 +68,14 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
           in: 'query',
           required: false,
           schema: { type: 'number', default: 0 },
-          description: 'Page number',
+          description: 'Number of records to skip',
         },
         {
           name: 'limit',
           in: 'query',
           required: false,
           schema: { type: 'number', default: 100 },
-          description: 'Number of threads per page',
+          description: 'Maximum number of threads to return',
         },
         {
           name: 'orderBy',
@@ -568,14 +568,14 @@ export function memoryRoutes(bodyLimitOptions: BodyLimitOptions) {
           in: 'query',
           required: false,
           schema: { type: 'number', default: 0 },
-          description: 'Page number',
+          description: 'Number of records to skip',
         },
         {
           name: 'limit',
           in: 'query',
           required: false,
           schema: { type: 'number', default: 100 },
-          description: 'Number of threads per page',
+          description: 'Maximum number of threads to return',
         },
         {
           name: 'orderBy',

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -9,7 +9,13 @@ import type {
   WorkingMemoryTemplate,
   MessageDeleteInput,
 } from '@mastra/core/memory';
-import type { StorageGetMessagesArg, ThreadSortOptions, PaginationInfo } from '@mastra/core/storage';
+import type {
+  StorageGetMessagesArg,
+  ThreadSortOptions,
+  PaginationInfo,
+  StorageListThreadsByResourceIdOutput,
+  StorageListThreadsByResourceIdInput,
+} from '@mastra/core/storage';
 import type { ToolAction } from '@mastra/core/tools';
 import { generateEmptyFromSchema } from '@mastra/core/utils';
 import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
@@ -335,6 +341,12 @@ export class Memory extends MastraMemory {
       orderBy,
       sortDirection,
     });
+  }
+
+  async listThreadsByResourceId(
+    args: StorageListThreadsByResourceIdInput,
+  ): Promise<StorageListThreadsByResourceIdOutput> {
+    return this.storage.listThreadsByResourceId(args);
   }
 
   private async handleWorkingMemoryFromMetadata({

--- a/packages/playground-ui/src/domains/memory/hooks/use-memory.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-memory.ts
@@ -48,7 +48,7 @@ export const useThreads = ({
 
   return useQuery({
     queryKey: ['memory', 'threads', resourceId, agentId],
-    queryFn: () => (isMemoryEnabled ? client.getMemoryThreads({ resourceId, agentId, runtimeContext }) : null),
+    queryFn: () => (isMemoryEnabled ? client.listMemoryThreads({ resourceId, agentId, runtimeContext }) : null),
     enabled: Boolean(isMemoryEnabled),
     staleTime: 0,
     gcTime: 0,

--- a/packages/playground-ui/src/domains/memory/hooks/use-memory.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-memory.ts
@@ -48,7 +48,11 @@ export const useThreads = ({
 
   return useQuery({
     queryKey: ['memory', 'threads', resourceId, agentId],
-    queryFn: () => (isMemoryEnabled ? client.listMemoryThreads({ resourceId, agentId, runtimeContext }) : null),
+    queryFn: async () => {
+      if (!isMemoryEnabled) return null;
+      const result = await client.listMemoryThreads({ resourceId, agentId, runtimeContext });
+      return result.threads;
+    },
     enabled: Boolean(isMemoryEnabled),
     staleTime: 0,
     gcTime: 0,

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -104,46 +104,18 @@ export async function getMemoryConfigHandler({
   }
 }
 
-export async function getThreadsHandler({
+export async function listThreadsHandler({
   mastra,
   agentId,
   resourceId,
   runtimeContext,
-  orderBy,
-  sortDirection,
-}: Pick<MemoryContext, 'mastra' | 'agentId' | 'resourceId' | 'runtimeContext'> & ThreadSortOptions) {
-  try {
-    const memory = await getMemoryFromContext({ mastra, agentId, runtimeContext });
-
-    if (!memory) {
-      throw new HTTPException(400, { message: 'Memory is not initialized' });
-    }
-
-    validateBody({ resourceId });
-
-    const threads = await memory.getThreadsByResourceId({
-      resourceId: resourceId!,
-      orderBy,
-      sortDirection,
-    });
-    return threads;
-  } catch (error) {
-    return handleError(error, 'Error getting threads');
-  }
-}
-
-export async function getThreadsPaginatedHandler({
-  mastra,
-  agentId,
-  resourceId,
-  runtimeContext,
-  page,
-  perPage,
+  offset,
+  limit,
   orderBy,
   sortDirection,
 }: Pick<MemoryContext, 'mastra' | 'agentId' | 'resourceId' | 'runtimeContext'> & {
-  page: number;
-  perPage: number;
+  offset: number;
+  limit: number;
 } & ThreadSortOptions) {
   try {
     const memory = await getMemoryFromContext({ mastra, agentId, runtimeContext });
@@ -154,16 +126,16 @@ export async function getThreadsPaginatedHandler({
 
     validateBody({ resourceId });
 
-    const result = await memory.getThreadsByResourceIdPaginated({
+    const result = await memory.listThreadsByResourceId({
       resourceId: resourceId!,
-      page,
-      perPage,
+      offset,
+      limit,
       orderBy,
       sortDirection,
     });
     return result;
   } catch (error) {
-    return handleError(error, 'Error getting paginated threads');
+    return handleError(error, 'Error listing threads');
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Major version bumps across multiple packages.
  * Memory thread endpoints and parameters changed to a single paginated interface using offset/limit.

* **New Features**
  * Paginated memory thread listings with offset/limit and sorting support.
  * Client SDK surfaces pagination metadata alongside thread results.

* **Bug Fixes / Tests**
  * Tests updated for the new listing behavior and pagination params; mock state cleared before relevant tests.
  * Storage now returns empty results for invalid thread IDs instead of throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->