### PR TITLE
chatroute run id overwite

### DIFF
--- a/.changeset/chatty-chefs-ask.md
+++ b/.changeset/chatty-chefs-ask.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+fix: overwrite runId with messageId.

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -154,9 +154,15 @@ export function chatRoute<OUTPUT extends OutputSchema = undefined>({
         throw new Error(`Agent ${agentToUse} not found`);
       }
 
+      let runId: string | undefined;
+      if (messages.length > 0 && messages[messages.length - 1].role === 'assistant') {
+        runId = messages[messages.length - 1].id;
+      }
+
       const result = await agentObj.stream<OUTPUT, 'mastra'>(messages, {
         ...defaultOptions,
         ...rest,
+        runId,
         requestContext: requestContext || defaultOptions?.requestContext,
       });
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
runId is automatically generated within the stream method, but it overwrites messageId when converting to the ai-sdk format.
By overwriting runId with the assistant's lastMessageId, it is treated as the same message, avoiding duplicate tool calls.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
https://github.com/mastra-ai/mastra/issues/8830

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Fixed request tracking in AI chat streaming to properly extract and propagate identifiers through streaming operations, ensuring consistent request identification across chat interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->