### PR TITLE
paul/grwth-971-add-meta-1.x

### DIFF
--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "@docusaurus/theme-common";
 import { useKeyboardNavigation } from "@docusaurus/theme-common/internal";
 import { useLocation } from "@docusaurus/router";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import AnnouncementBar from "@theme/AnnouncementBar";
 import ErrorPageContent from "@theme/ErrorPageContent";
 import Footer from "@theme/Footer";
@@ -31,8 +32,9 @@ export default function Layout(props: Props): ReactNode {
   useKeyboardNavigation();
 
   const location = useLocation();
-  const cleanPath = location.pathname.replace(/^\/ja\//, "/");
-  const canonicalUrl = `https://mastra.ai${cleanPath}`;
+  const { siteConfig } = useDocusaurusContext();
+  const cleanPath = location.pathname.replace(/^\/ja(\/|$)/, "/");
+  const canonicalUrl = `${siteConfig.url}${cleanPath}`;
 
   return (
     <LayoutProvider>
@@ -44,7 +46,7 @@ export default function Layout(props: Props): ReactNode {
         <link
           rel="alternate"
           hrefLang="ja"
-          href={`https://mastra.ai/ja${cleanPath}`}
+          href={`${siteConfig.url}/ja${cleanPath}`}
         />
         <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
       </Head>

--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -1,10 +1,12 @@
 import ErrorBoundary from "@docusaurus/ErrorBoundary";
+import Head from "@docusaurus/Head";
 import {
   PageMetadata,
   SkipToContentFallbackId,
   ThemeClassNames,
 } from "@docusaurus/theme-common";
 import { useKeyboardNavigation } from "@docusaurus/theme-common/internal";
+import { useLocation } from "@docusaurus/router";
 import AnnouncementBar from "@theme/AnnouncementBar";
 import ErrorPageContent from "@theme/ErrorPageContent";
 import Footer from "@theme/Footer";
@@ -28,9 +30,24 @@ export default function Layout(props: Props): ReactNode {
 
   useKeyboardNavigation();
 
+  const location = useLocation();
+  const cleanPath = location.pathname.replace(/^\/ja\//, "/");
+  const canonicalUrl = `https://mastra.ai${cleanPath}`;
+
   return (
     <LayoutProvider>
       <PageMetadata title={title} description={description} />
+
+      <Head>
+        <link rel="canonical" href={canonicalUrl} />
+        <link rel="alternate" hrefLang="en" href={canonicalUrl} />
+        <link
+          rel="alternate"
+          hrefLang="ja"
+          href={`https://mastra.ai/ja${cleanPath}`}
+        />
+        <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
+      </Head>
 
       <SkipToContent />
 


### PR DESCRIPTION
## Description

- add meta to head. 

Should renders as, e.g:

```html
<link rel="canonical" href="https://mastra.ai/docs/getting-started/studio">
<link rel="alternate" hreflang="en" href="https://mastra.ai/docs/getting-started/studio">
<link rel="alternate" hreflang="ja" href="https://mastra.ai/ja/docs/getting-started/studio">
<link rel="alternate" hreflang="x-default" href="https://mastra.ai/docs/getting-started/studio">
```


## Related Issue(s)

- https://github.com/mastra-ai/mastra/pull/9532

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Implemented canonical URL tags to improve SEO and ensure pages point to a single preferred URL.
  * Added alternate language links (en, ja, x-default) including a locale-aware ja alternate to improve language-specific discovery and navigation.
  * Enabled location-based URL handling so canonical and alternate links reflect the current page path correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->