### PR TITLE
Remove `getMessagesById` in favor of `listMessagesById`

### DIFF
--- a/.changeset/hungry-nights-admire.md
+++ b/.changeset/hungry-nights-admire.md
@@ -1,0 +1,15 @@
+---
+'@mastra/cloudflare-d1': major
+'@mastra/clickhouse': major
+'@mastra/cloudflare': major
+'@mastra/dynamodb': major
+'@mastra/mongodb': major
+'@mastra/upstash': major
+'@mastra/core': major
+'@mastra/libsql': major
+'@mastra/lance': major
+'@mastra/mssql': major
+'@mastra/pg': major
+---
+
+remove getMessagesById

--- a/.changeset/hungry-nights-admire.md
+++ b/.changeset/hungry-nights-admire.md
@@ -12,4 +12,4 @@
 '@mastra/pg': major
 ---
 
-remove getMessagesById
+Remove `getMessagesById` method from storage interfaces in favor of `listMessagesById`. The new method only returns V2-format messages and removes the format parameter, simplifying the API surface. Users should migrate from `getMessagesById({ messageIds, format })` to `listMessagesById({ messageIds })`.

--- a/docs/src/content/en/docs/server-db/storage.mdx
+++ b/docs/src/content/en/docs/server-db/storage.mdx
@@ -486,16 +486,12 @@ const messagesV2 = await mastra
   .getMessages({ threadId: "your-thread-id", format: "v2" });
 ```
 
-You can also retrieve messages using an array of message IDs. Note that unlike `getMessages`, this defaults to the V2 format:
+You can also retrieve messages using an array of message IDs:
 
 ```typescript copy
-const messagesV1 = await mastra
+const messages = await mastra
   .getStorage()
-  .getMessagesById({ messageIds: messageIdArr, format: "v1" });
-
-const messagesV2 = await mastra
-  .getStorage()
-  .getMessagesById({ messageIds: messageIdArr });
+  .listMessagesById({ messageIds: messageIdArr });
 ```
 
 ## Storage Providers

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -252,14 +252,6 @@ export abstract class MastraStorage extends MastraBase {
     selectBy,
     format,
   }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]>;
-  abstract getMessagesById({ messageIds }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  abstract getMessagesById({ messageIds }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  abstract getMessagesById({
-    messageIds,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]>;
 
   async listMessages(args: StorageListMessagesInput): Promise<StorageListMessagesOutput> {
     if (this.stores?.memory) {

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -50,14 +50,6 @@ export abstract class MemoryStorage extends MastraBase {
     selectBy,
     format,
   }: StorageGetMessagesArg & { format?: 'v1' | 'v2' }): Promise<MastraMessageV1[] | MastraMessageV2[]>;
-  abstract getMessagesById({ messageIds }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  abstract getMessagesById({ messageIds }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  abstract getMessagesById({
-    messageIds,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]>;
 
   abstract listMessages(args: StorageListMessagesInput): Promise<StorageListMessagesOutput>;
 

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -245,24 +245,6 @@ export class InMemoryMemory extends MemoryStorage {
     } satisfies MastraMessageV2;
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    this.logger.debug(`MockStore: getMessagesById called`);
-
-    const rawMessages = messageIds.map(id => this.collection.messages.get(id)).filter(message => !!message);
-
-    const list = new MessageList().add(rawMessages.map(this.parseStoredMessage), 'memory');
-    if (format === 'v1') return list.get.all.v1();
-    return list.get.all.v2();
-  }
-
   async listMessages(_args: StorageListMessagesInput): Promise<StorageListMessagesOutput> {
     throw new Error(
       `listMessages is not yet implemented by this storage adapter (${this.constructor.name}). ` +
@@ -272,7 +254,12 @@ export class InMemoryMemory extends MemoryStorage {
   }
 
   async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
+    this.logger.debug(`MockStore: listMessagesById called`);
+
+    const rawMessages = messageIds.map(id => this.collection.messages.get(id)).filter(message => !!message);
+
+    const list = new MessageList().add(rawMessages.map(this.parseStoredMessage), 'memory');
+    return list.get.all.v2();
   }
 
   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;

--- a/packages/core/src/storage/mock.test.ts
+++ b/packages/core/src/storage/mock.test.ts
@@ -238,7 +238,7 @@ describe('InMemoryStore - Message Fetching', () => {
   });
 });
 
-describe('InMemoryStore - getMessagesById', () => {
+describe('InMemoryStore - listMessagesById', () => {
   let store: InMemoryStore;
   const resourceId = 'test-resource-id';
   const resourceId2 = 'test-resource-id-2';
@@ -322,7 +322,7 @@ describe('InMemoryStore - getMessagesById', () => {
   });
 
   it('should return an empty array if no message IDs are provided', async () => {
-    const messages = await store.getMessagesById({ messageIds: [] });
+    const messages = await store.listMessagesById({ messageIds: [] });
     expect(messages).toHaveLength(0);
   });
 
@@ -334,7 +334,7 @@ describe('InMemoryStore - getMessagesById', () => {
       thread1Messages[0]!.id,
       thread2Messages[1]!.id,
     ];
-    const messages = await store.getMessagesById({
+    const messages = await store.listMessagesById({
       messageIds,
     });
 
@@ -342,33 +342,17 @@ describe('InMemoryStore - getMessagesById', () => {
     expect(messages.every((msg, i, arr) => i === 0 || msg.createdAt >= arr[i - 1]!.createdAt)).toBe(true);
   });
 
-  it('should return V2 messages by default', async () => {
-    const messages: MastraMessageV2[] = await store.getMessagesById({ messageIds: thread1Messages.map(msg => msg.id) });
+  it('should return V2 messages', async () => {
+    const messages: MastraMessageV2[] = await store.listMessagesById({
+      messageIds: thread1Messages.map(msg => msg.id),
+    });
 
     expect(messages.length).toBeGreaterThan(0);
     expect(messages.every(MessageList.isMastraMessageV2)).toBe(true);
   });
 
-  it('should return messages in the specified format', async () => {
-    const v1messages: MastraMessageV1[] = await store.getMessagesById({
-      messageIds: thread1Messages.map(msg => msg.id),
-      format: 'v1',
-    });
-
-    expect(v1messages.length).toBeGreaterThan(0);
-    expect(v1messages.every(MessageList.isMastraMessageV1)).toBe(true);
-
-    const v2messages: MastraMessageV2[] = await store.getMessagesById({
-      messageIds: thread1Messages.map(msg => msg.id),
-      format: 'v2',
-    });
-
-    expect(v2messages.length).toBeGreaterThan(0);
-    expect(v2messages.every(MessageList.isMastraMessageV2)).toBe(true);
-  });
-
   it('should return messages from multiple threads', async () => {
-    const messages = await store.getMessagesById({
+    const messages = await store.listMessagesById({
       messageIds: [...thread1Messages.map(msg => msg.id), ...thread2Messages.map(msg => msg.id)],
     });
 
@@ -378,7 +362,7 @@ describe('InMemoryStore - getMessagesById', () => {
   });
 
   it('should return messages from multiple resources', async () => {
-    const messages = await store.getMessagesById({
+    const messages = await store.listMessagesById({
       messageIds: [...thread1Messages.map(msg => msg.id), ...resource2Messages.map(msg => msg.id)],
     });
 

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -251,16 +251,8 @@ export class InMemoryStore extends MastraStorage {
       .catch(() => []) as unknown as Promise<MastraMessageV1[] | MastraMessageV2[]>;
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
+  async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
+    return this.stores.memory.listMessagesById({ messageIds });
   }
 
   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;

--- a/stores/_test-utils/src/domains/memory/messages-paginated.ts
+++ b/stores/_test-utils/src/domains/memory/messages-paginated.ts
@@ -495,7 +495,7 @@ export function createMessagesPaginatedTest({ storage }: { storage: MastraStorag
     });
   });
 
-  describe('getMessagesById', () => {
+  describe('listMessagesById', () => {
     const resourceId = 'test-resource-id';
     const resourceId2 = 'test-resource-id-2';
     let threads: StorageThreadType[] = [];
@@ -587,7 +587,7 @@ export function createMessagesPaginatedTest({ storage }: { storage: MastraStorag
     });
 
     it('should return an empty array if no message IDs are provided', async () => {
-      const messages = await storage.getMessagesById({ messageIds: [] });
+      const messages = await storage.listMessagesById({ messageIds: [] });
       expect(messages).toHaveLength(0);
     });
 
@@ -599,7 +599,7 @@ export function createMessagesPaginatedTest({ storage }: { storage: MastraStorag
         thread1Messages[0]!.id,
         thread2Messages[1]!.id,
       ];
-      const messages = await storage.getMessagesById({
+      const messages = await storage.listMessagesById({
         messageIds,
       });
 
@@ -607,8 +607,8 @@ export function createMessagesPaginatedTest({ storage }: { storage: MastraStorag
       expect(messages.every((msg, i, arr) => i === 0 || msg.createdAt >= arr[i - 1]!.createdAt)).toBe(true);
     });
 
-    it('should return V2 messages by default', async () => {
-      const messages: MastraMessageV2[] = await storage.getMessagesById({
+    it('should return V2 messages', async () => {
+      const messages: MastraMessageV2[] = await storage.listMessagesById({
         messageIds: thread1Messages.map(msg => msg.id),
       });
 
@@ -616,26 +616,8 @@ export function createMessagesPaginatedTest({ storage }: { storage: MastraStorag
       expect(messages.every(MessageList.isMastraMessageV2)).toBe(true);
     });
 
-    it('should return messages in the specified format', async () => {
-      const v1messages: MastraMessageV1[] = await storage.getMessagesById({
-        messageIds: thread1Messages.map(msg => msg.id),
-        format: 'v1',
-      });
-
-      expect(v1messages.length).toBeGreaterThan(0);
-      expect(v1messages.every(MessageList.isMastraMessageV1)).toBe(true);
-
-      const v2messages: MastraMessageV2[] = await storage.getMessagesById({
-        messageIds: thread1Messages.map(msg => msg.id),
-        format: 'v2',
-      });
-
-      expect(v2messages.length).toBeGreaterThan(0);
-      expect(v2messages.every(MessageList.isMastraMessageV2)).toBe(true);
-    });
-
     it('should return messages from multiple threads', async () => {
-      const messages = await storage.getMessagesById({
+      const messages = await storage.listMessagesById({
         messageIds: [...thread1Messages.map(msg => msg.id), ...thread2Messages.map(msg => msg.id)],
       });
 
@@ -645,7 +627,7 @@ export function createMessagesPaginatedTest({ storage }: { storage: MastraStorag
     });
 
     it('should return messages from multiple resources', async () => {
-      const messages = await storage.getMessagesById({
+      const messages = await storage.listMessagesById({
         messageIds: [...thread1Messages.map(msg => msg.id), ...resource2Messages.map(msg => msg.id)],
       });
 

--- a/stores/clickhouse/src/storage/domains/memory/index.ts
+++ b/stores/clickhouse/src/storage/domains/memory/index.ts
@@ -179,27 +179,7 @@ export class MemoryStorageClickhouse extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
 
     try {
@@ -244,7 +224,6 @@ export class MemoryStorageClickhouse extends MemoryStorage {
       });
 
       const list = new MessageList().add(messages, 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       throw new MastraError(
@@ -265,10 +244,6 @@ export class MemoryStorageClickhouse extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -313,18 +313,6 @@ export class ClickhouseStore extends MastraStorage {
     return this.stores.memory.getMessages({ threadId, resourceId, selectBy, format });
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
   async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
   async saveMessages(

--- a/stores/cloudflare-d1/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/memory/index.ts
@@ -688,27 +688,7 @@ export class MemoryStorageD1 extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
     const fullTableName = this.operations.getTableName(TABLE_MESSAGES);
     const messages: any[] = [];
@@ -740,7 +720,6 @@ export class MemoryStorageD1 extends MemoryStorage {
       });
       this.logger.debug(`Retrieved ${messages.length} messages`);
       const list = new MessageList().add(processedMessages as MastraMessageV1[] | MastraMessageV2[], 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       const mastraError = new MastraError(
@@ -765,10 +744,6 @@ export class MemoryStorageD1 extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   /**

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -273,18 +273,6 @@ export class D1Store extends MastraStorage {
     return this.stores.memory.getMessages({ threadId, selectBy, format });
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   public async getMessagesPaginated({
     threadId,
     selectBy,

--- a/stores/cloudflare/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/storage/domains/memory/index.ts
@@ -821,27 +821,7 @@ export class MemoryStorageCloudflare extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
 
     try {
@@ -858,7 +838,6 @@ export class MemoryStorageCloudflare extends MemoryStorage {
       }));
       // For v2 format, use MessageList for proper conversion
       const list = new MessageList().add(prepared, 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       const mastraError = new MastraError(
@@ -885,10 +864,6 @@ export class MemoryStorageCloudflare extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   /**

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -257,18 +257,6 @@ export class CloudflareStore extends MastraStorage {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   async persistWorkflowSnapshot(params: {
     workflowName: string;
     runId: string;

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -356,27 +356,7 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     this.logger.debug('Getting messages by ID', { messageIds });
     if (messageIds.length === 0) return [];
 
@@ -397,7 +377,6 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
       );
 
       const list = new MessageList().add(uniqueMessages, 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       throw new MastraError(
@@ -418,10 +397,6 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   /**

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -283,18 +283,6 @@ export class DynamoDBStore extends MastraStorage {
     return this.stores.memory.getMessages({ threadId, resourceId, selectBy, format });
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
   async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
   async saveMessages(

--- a/stores/lance/src/storage/domains/memory/index.ts
+++ b/stores/lance/src/storage/domains/memory/index.ts
@@ -289,27 +289,7 @@ export class StoreMemoryLance extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
     try {
       const table = await this.client.openTable(TABLE_MESSAGES);
@@ -323,7 +303,6 @@ export class StoreMemoryLance extends MemoryStorage {
       );
 
       const list = new MessageList().add(messages.map(this.normalizeMessage), 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error: any) {
       throw new MastraError(
@@ -346,10 +325,6 @@ export class StoreMemoryLance extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   /**

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -284,18 +284,6 @@ export class LanceStorage extends MastraStorage {
     return this.stores.memory.getMessages({ threadId, resourceId, selectBy, format, threadConfig });
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
   async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
   async saveMessages(

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -169,27 +169,7 @@ export class MemoryLibSQL extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
 
     try {
@@ -210,7 +190,6 @@ export class MemoryLibSQL extends MemoryStorage {
       if (!result.rows) return [];
 
       const list = new MessageList().add(result.rows.map(this.parseRow), 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       throw new MastraError(
@@ -231,10 +210,6 @@ export class MemoryLibSQL extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   public async listThreadsByResourceId(

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -225,18 +225,6 @@ export class LibSQLStore extends MastraStorage {
     return this.stores.memory.getMessages({ threadId, selectBy, format });
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   public async getMessagesPaginated(
     args: StorageGetMessagesArg & {
       format?: 'v1' | 'v2';

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -163,27 +163,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
     try {
       const collection = await this.operations.getCollection(TABLE_MESSAGES);
@@ -193,7 +173,6 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         .toArray();
 
       const list = new MessageList().add(rawMessages.map(this.parseRow), 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       throw new MastraError(
@@ -214,10 +193,6 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   /**

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -216,18 +216,6 @@ export class MongoDBStore extends MastraStorage {
     return this.stores.memory.getMessagesPaginated(_args);
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   async saveMessages(args: { messages: MastraMessageV1[]; format?: undefined | 'v1' }): Promise<MastraMessageV1[]>;
   async saveMessages(args: { messages: MastraMessageV2[]; format: 'v2' }): Promise<MastraMessageV2[]>;
   async saveMessages(

--- a/stores/mssql/src/storage/domains/memory/index.ts
+++ b/stores/mssql/src/storage/domains/memory/index.ts
@@ -521,27 +521,7 @@ export class MemoryMSSQL extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
 
     const selectStatement = `SELECT seq_id, id, content, role, type, [createdAt], thread_id AS threadId, resourceId`;
@@ -561,8 +541,8 @@ export class MemoryMSSQL extends MemoryStorage {
         return timeDiff;
       });
       rows = rows.map(({ seq_id, ...rest }) => rest);
-      if (format === `v1`) return this._parseAndFormatMessages(rows, format);
-      return this._parseAndFormatMessages(rows, `v2`);
+      const messages = this._parseAndFormatMessages(rows, `v2`);
+      return messages as MastraMessageV2[];
     } catch (error) {
       const mastraError = new MastraError(
         {
@@ -587,10 +567,6 @@ export class MemoryMSSQL extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   public async listThreadsByResourceId(

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -275,18 +275,6 @@ export class MSSQLStore extends MastraStorage {
     return this.stores.memory.getMessages(args);
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   public async getMessagesPaginated(
     args: StorageGetMessagesArg & {
       format?: 'v1' | 'v2';

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -519,27 +519,7 @@ export class MemoryPG extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
     const selectStatement = `SELECT id, content, role, type, "createdAt", "createdAtZ", thread_id AS "threadId", "resourceId"`;
 
@@ -556,7 +536,6 @@ export class MemoryPG extends MemoryStorage {
         resultRows.map(row => this.parseRow(row)),
         'memory',
       );
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       const mastraError = new MastraError(
@@ -582,10 +561,6 @@ export class MemoryPG extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   public async listThreadsByResourceId(

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -265,18 +265,6 @@ export class PostgresStore extends MastraStorage {
     return this.stores.memory.getMessages(args);
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   public async getMessagesPaginated(
     args: StorageGetMessagesArg & {
       format?: 'v1' | 'v2';

--- a/stores/pg/src/storage/test-utils.ts
+++ b/stores/pg/src/storage/test-utils.ts
@@ -449,8 +449,8 @@ export function pgTests() {
         expect(messages[0]?.createdAt.getTime()).toBe(createdAtZValue.getTime());
         expect(messages[0]?.createdAt.getTime()).not.toBe(createdAtValue.getTime());
 
-        // Test getMessagesById
-        const messagesById = await store.getMessagesById({ messageIds: [testMessageId], format: 'v2' });
+        // Test listMessagesById
+        const messagesById = await store.listMessagesById({ messageIds: [testMessageId] });
         expect(messagesById.length).toBe(1);
         expect(messagesById[0]?.createdAt).toBeInstanceOf(Date);
         expect(messagesById[0]?.createdAt.getTime()).toBe(createdAtZValue.getTime());
@@ -487,8 +487,8 @@ export function pgTests() {
         expect(messages[0]?.createdAt).toBeInstanceOf(Date);
         expect(messages[0]?.createdAt.getTime()).toBe(createdAtValue.getTime());
 
-        // Test getMessagesById
-        const messagesById = await store.getMessagesById({ messageIds: [testMessageId], format: 'v2' });
+        // Test listMessagesById
+        const messagesById = await store.listMessagesById({ messageIds: [testMessageId] });
         expect(messagesById.length).toBe(1);
         expect(messagesById[0]?.createdAt).toBeInstanceOf(Date);
         expect(messagesById[0]?.createdAt.getTime()).toBe(createdAtValue.getTime());

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -589,27 +589,7 @@ export class StoreMemoryUpstash extends MemoryStorage {
     }
   }
 
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format: 'v1';
-  }): Promise<MastraMessageV1[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v2';
-  }): Promise<MastraMessageV2[]>;
-  public async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
+  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
     if (messageIds.length === 0) return [];
 
     try {
@@ -629,7 +609,6 @@ export class StoreMemoryUpstash extends MemoryStorage {
       const rawMessages = result.flat(1).filter(msg => !!msg) as (MastraMessageV2 & { _index?: number })[];
 
       const list = new MessageList().add(rawMessages.map(this.parseStoredMessage), 'memory');
-      if (format === `v1`) return list.get.all.v1();
       return list.get.all.v2();
     } catch (error) {
       throw new MastraError(
@@ -652,10 +631,6 @@ export class StoreMemoryUpstash extends MemoryStorage {
         `This method is currently being rolled out across all storage adapters. ` +
         `Please use getMessages or getMessagesPaginated as an alternative, or wait for the implementation.`,
     );
-  }
-
-  public async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<MastraMessageV2[]> {
-    return this.getMessagesById({ messageIds, format: 'v2' });
   }
 
   public async getMessagesPaginated(

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -165,18 +165,6 @@ export class UpstashStore extends MastraStorage {
     return this.stores.memory.getMessages({ threadId, selectBy, format });
   }
 
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format: 'v1' }): Promise<MastraMessageV1[]>;
-  async getMessagesById({ messageIds, format }: { messageIds: string[]; format?: 'v2' }): Promise<MastraMessageV2[]>;
-  async getMessagesById({
-    messageIds,
-    format,
-  }: {
-    messageIds: string[];
-    format?: 'v1' | 'v2';
-  }): Promise<MastraMessageV1[] | MastraMessageV2[]> {
-    return this.stores.memory.getMessagesById({ messageIds, format });
-  }
-
   public async getMessagesPaginated(
     args: StorageGetMessagesArg & {
       format?: 'v1' | 'v2';


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

This PR removes the `getMessagesById` method from storage interfaces across all storage adapters in favor of `listMessagesById`. The new method simplifies the API by only returning V2-format messages and removing the format parameter.

## Changes

- Remove `getMessagesById` method from base storage interfaces (`MastraStorage`, `MemoryStorage`)
- Remove `getMessagesById` implementations from all storage adapters (pg, mssql, mongodb, dynamodb, clickhouse, cloudflare, cloudflare-d1, libsql, lance, upstash)
- Update `listMessagesById` to consolidate the functionality (V2-format only)
- Update documentation to reflect the API change
- Update tests to use `listMessagesById` instead of `getMessagesById`

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `getMessagesById()` method from storage interfaces across all implementations.
  * Introduced `listMessagesById()` as the replacement for retrieving messages by IDs.
  * Simplified API: `listMessagesById()` no longer accepts a format parameter and always returns V2-format messages.
  * **Migration required**: Update calls from `getMessagesById({ messageIds, format })` to `listMessagesById({ messageIds })`.

* **Documentation**
  * Updated storage API documentation with migration guidance for the new message retrieval method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->