### PR TITLE
fail early in e2e create-mastra test

### DIFF
--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -61,7 +61,7 @@ describe('create mastra', () => {
             const output = data?.toString() ?? '';
             console.error(output);
             const errorPatterns = ['Error', 'ERR', 'failed', 'ENOENT', 'MODULE_NOT_FOUND'];
-            if (errorPatterns.some(pattern => output.includes(pattern))) {
+            if (errorPatterns.some(pattern => output.toLowerCase().includes(pattern.toLowerCase()))) {
               reject(new Error('failed to start dev: ' + data?.toString()));
             }
           });

--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -58,8 +58,10 @@ describe('create mastra', () => {
         await new Promise<void>((resolve, reject) => {
           console.log('waiting for server to start');
           proc!.stderr?.on('data', data => {
-            console.error(data?.toString() ?? '');
-            if (data?.toString()) {
+            const output = data?.toString() ?? '';
+            console.error(output);
+            const errorPatterns = ['Error', 'ERR', 'failed', 'ENOENT', 'MODULE_NOT_FOUND'];
+            if (errorPatterns.some(pattern => output.includes(pattern))) {
               reject(new Error('failed to start dev: ' + data?.toString()));
             }
           });

--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -54,11 +54,15 @@ describe('create mastra', () => {
             PORT: port.toString(),
           },
         });
-        proc!.stderr?.on('data', data => {
-          console.error(data?.toString());
-        });
-        await new Promise<void>(resolve => {
+
+        await new Promise<void>((resolve, reject) => {
           console.log('waiting for server to start');
+          proc!.stderr?.on('data', data => {
+            console.error(data?.toString() ?? '');
+            if (data?.toString()) {
+              reject(new Error('failed to start dev: ' + data?.toString()));
+            }
+          });
           proc!.stdout?.on('data', data => {
             console.log(data?.toString());
             if (data?.toString()?.includes(`http://localhost:${port}`)) {

--- a/e2e-tests/create-mastra/setup.ts
+++ b/e2e-tests/create-mastra/setup.ts
@@ -36,6 +36,8 @@ export default async function setup(project: TestProject) {
       '--filter="@mastra/libsql"',
       '--filter="@mastra/memory"',
       '--filter="@mastra/loggers"',
+      '--filter="@mastra/evals"',
+      '--filter="@mastra/observability"',
     ],
     tag,
     rootDir,

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -62,6 +62,7 @@ export const create = async (args: {
       llmApiKey: result?.llmApiKey as string | undefined,
       components: ['agents', 'tools', 'workflows', 'scorers'],
       addExample: true,
+      versionTag: args.createVersionTag,
     });
     postCreate({ projectName });
     return;
@@ -85,6 +86,7 @@ export const create = async (args: {
     addExample,
     llmApiKey,
     configureEditorWithDocsMCP: args.mcpServer,
+    versionTag: args.createVersionTag,
   });
 
   postCreate({ projectName });

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -17,6 +17,7 @@ export const init = async ({
   llmApiKey,
   addExample = false,
   configureEditorWithDocsMCP,
+  versionTag,
 }: {
   directory?: string;
   components: Component[];
@@ -24,8 +25,10 @@ export const init = async ({
   llmApiKey?: string;
   addExample?: boolean;
   configureEditorWithDocsMCP?: Editor;
+  versionTag?: string;
 }) => {
   s.start('Initializing Mastra');
+  const packageVersionTag = versionTag ? `@${versionTag}` : '';
 
   try {
     const result = await createMastraDir(directory);
@@ -57,30 +60,31 @@ export const init = async ({
       ]);
 
       const depService = new DepsService();
+
       const needsLibsql = (await depService.checkDependencies(['@mastra/libsql'])) !== `ok`;
       if (needsLibsql) {
-        await depService.installPackages(['@mastra/libsql']);
+        await depService.installPackages([`@mastra/libsql${packageVersionTag}`]);
       }
       const needsMemory =
         components.includes(`agents`) && (await depService.checkDependencies(['@mastra/memory'])) !== `ok`;
       if (needsMemory) {
-        await depService.installPackages(['@mastra/memory']);
+        await depService.installPackages([`@mastra/memory${packageVersionTag}`]);
       }
 
       const needsLoggers = (await depService.checkDependencies(['@mastra/loggers'])) !== `ok`;
       if (needsLoggers) {
-        await depService.installPackages(['@mastra/loggers']);
+        await depService.installPackages([`@mastra/loggers${packageVersionTag}`]);
       }
 
       const needsObservability = (await depService.checkDependencies(['@mastra/observability'])) !== `ok`;
       if (needsObservability) {
-        await depService.installPackages(['@mastra/observability']);
+        await depService.installPackages([`@mastra/observability${packageVersionTag}`]);
       }
 
       const needsEvals =
         components.includes(`scorers`) && (await depService.checkDependencies(['@mastra/evals'])) !== `ok`;
       if (needsEvals) {
-        await depService.installPackages(['@mastra/evals']);
+        await depService.installPackages([`@mastra/evals${packageVersionTag}`]);
       }
     }
 


### PR DESCRIPTION
## Description
the test would take 10 minutes to time out before if there was an error. Now it should reject as soon as there is any stderr.


<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI create/init now accepts and propagates a version tag, installing tagged package versions when provided.
* **Tests**
  * Development startup test now treats any stderr output as a startup failure, causing runs to fail fast and surface initialization errors.
* **Chores**
  * Added two packages to the publish/setup filters: @mastra/evals and @mastra/observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->