### PR TITLE
fix(core): Correct iteration count

### DIFF
--- a/.changeset/kind-bees-unite.md
+++ b/.changeset/kind-bees-unite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix a bug where streaming didn't output the final chunk

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -271,7 +271,7 @@ export async function createNetworkLoop({
 
       let completionResult;
 
-      let iterationCount = (inputData.iteration ? inputData.iteration : -1) + 1;
+      let iterationCount = inputData.iteration === 0 ? 0 : inputData.iteration + 1;
 
       await writer.write({
         type: 'routing-agent-start',

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -271,7 +271,7 @@ export async function createNetworkLoop({
 
       let completionResult;
 
-      let iterationCount = inputData.iteration === 0 ? 0 : inputData.iteration + 1;
+      let iterationCount = (inputData.iteration ? inputData.iteration : -1) + 1;
 
       await writer.write({
         type: 'routing-agent-start',

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -271,7 +271,7 @@ export async function createNetworkLoop({
 
       let completionResult;
 
-      let iterationCount = (inputData.iteration ?? -1) + 1;
+      let iterationCount = (inputData.iteration ? inputData.iteration : -1) + 1;
 
       await writer.write({
         type: 'routing-agent-start',


### PR DESCRIPTION
## Description

Fix a bug where during streaming the last chunk was not displayed because the iteration count was incorrect.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming output now reliably includes the final chunk, preventing truncated responses and ensuring complete data delivery.
  * Iteration handling preserves an explicit zero value (no unintended increment), stabilizing behavior when iteration is intentionally set to 0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->