### PR TITLE
rename playground to studio (1.x)

### DIFF
--- a/docs/src/content/en/docs/getting-started/studio.mdx
+++ b/docs/src/content/en/docs/getting-started/studio.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Playground | Getting Started | Mastra Docs"
+title: "Studio | Getting Started | Mastra Docs"
 description: Guide on installing Mastra and setting up the necessary prerequisites for running it with various LLM providers.
 ---
 
@@ -8,17 +8,17 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { VideoPlayer } from "@site/src/components/video-player";
 
-# Playground
+# Studio
 
-Playground provides an interactive UI for building and testing your agents, along with a REST API that exposes your Mastra application as a local service. This lets you start building without worrying about integration right away.
+Studio provides an interactive UI for building and testing your agents, along with a REST API that exposes your Mastra application as a local service. This lets you start building without worrying about integration right away.
 
-As your project evolves, Playground's development environment helps you iterate on your agent quickly. Meanwhile, Observability and Scorer features give you visibility into performance at every stage.
+As your project evolves, Studio's development environment helps you iterate on your agent quickly. Meanwhile, Observability and Scorer features give you visibility into performance at every stage.
 
-To get started, run Playground locally using the instructions below, or [deploy to Mastra Cloud](https://mastra.ai/docs/mastra-cloud/setting-up) to collaborate with your team.
+To get started, run Studio locally using the instructions below, or [create a project in Mastra Cloud](https://mastra.ai/docs/mastra-cloud/setting-up) to collaborate with your team.
 
-<YouTube id="spGlcTEjuXY" startTime={126} />
+<YouTube id="ojGu6Bi4wYk" />
 
-## Start Playground
+## Start Studio
 
 If you created your application with `create mastra`, start the local development server using the `dev` script. You can also run it directly with `mastra dev`.
 
@@ -52,12 +52,12 @@ If you created your application with `create mastra`, start the local developmen
 
 Once the server's running, you can:
 
-- Open the Playground UI at http://localhost:4111/ to test your agent interactively.
+- Open the Studio UI at http://localhost:4111/ to test your agent interactively.
 - Visit http://localhost:4111/swagger-ui to discover and interact with the underlying REST API.
 
-## Playground UI
+## Studio UI
 
-The Playground UI provides an interactive development environment for you to test your agents, workflows, and tools, observe exactly what happens under the hood with each interaction, and tweak things as you go.
+The Studio UI provides an interactive development environment for you to test your agents, workflows, and tools, observe exactly what happens under the hood with each interaction, and tweak things as you go.
 
 ### Agents
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -29,7 +29,7 @@ const sidebars = {
         {
           type: "doc",
           id: "getting-started/studio",
-          label: "Playground",
+          label: "Studio",
         },
         {
           type: "doc",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed "Playground" to "Studio" throughout getting-started documentation.
  * Updated sidebar navigation label and all related instructional content.
  * Updated embedded video reference and UI descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->