### PR TITLE
paul/grwth-996-auth-tab-order-1.x

### DIFF
--- a/docs/src/content/en/docs/auth/jwt.mdx
+++ b/docs/src/content/en/docs/auth/jwt.mdx
@@ -58,7 +58,7 @@ export const mastraClient = new MastraClient({
 Once `MastraClient` is configured, you can send authenticated requests from your frontend application, or use `curl` for quick local testing:
 
 <Tabs>
-  <TabItem value="curl" label="cURL">
+  <TabItem value="react" label="React">
     ```tsx title="src/components/test-agent.tsx" showLineNumbers copy
     import { mastraClient } from "../../lib/mastra-client";
 
@@ -78,7 +78,7 @@ Once `MastraClient` is configured, you can send authenticated requests from your
     ```
 
   </TabItem>
-  <TabItem value="react" label="React">
+  <TabItem value="curl" label="cURL">
     ```bash copy
     curl -X POST http://localhost:4111/api/agents/weatherAgent/generate \
       -H "Content-Type: application/json" \

--- a/docs/src/content/en/docs/auth/supabase.mdx
+++ b/docs/src/content/en/docs/auth/supabase.mdx
@@ -97,7 +97,7 @@ export const mastraClient = new MastraClient({
 Once `MastraClient` is configured with the Supabase access token, you can send authenticated requests:
 
 <Tabs>
-  <TabItem value="curl" label="cURL">
+    <TabItem value="react" label="React">
     ```tsx title="src/components/test-agent.tsx" showLineNumbers copy
     import { mastraClient } from "../../lib/mastra-client";
 
@@ -117,7 +117,7 @@ Once `MastraClient` is configured with the Supabase access token, you can send a
     ```
 
   </TabItem>
-  <TabItem value="react" label="React">
+  <TabItem value="curl" label="cURL">
     ```bash copy
     curl -X POST http://localhost:4111/api/agents/weatherAgent/generate \
       -H "Content-Type: application/json" \

--- a/docs/src/content/en/docs/auth/workos.mdx
+++ b/docs/src/content/en/docs/auth/workos.mdx
@@ -159,7 +159,7 @@ export const createMastraClient = (accessToken: string) => {
 Once `MastraClient` is configured with the WorkOS access token, you can send authenticated requests:
 
 <Tabs>
-  <TabItem value="curl" label="cURL">
+  <TabItem value="react" label="React">
     ```typescript title="src/api/agents.ts" showLineNumbers copy
     import { WorkOS } from '@workos-inc/node';
     import { MastraClient } from '@mastra/client-js';
@@ -191,7 +191,7 @@ Once `MastraClient` is configured with the WorkOS access token, you can send aut
     ```
 
   </TabItem>
-  <TabItem value="react" label="React">
+  <TabItem value="curl" label="cURL">
     ```bash copy
     curl -X POST http://localhost:4111/api/agents/weatherAgent/generate \
       -H "Content-Type: application/json" \


### PR DESCRIPTION
## Description

- docs: update tab order

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Reordered code example tabs in authentication documentation to display React examples first, followed by cURL examples for improved discoverability across JWT, Supabase, and WorkOS authentication guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->