### PR TITLE
feat!(mcp): remove remaining deprecated mcp items

### DIFF
--- a/.changeset/yellow-islands-rescue.md
+++ b/.changeset/yellow-islands-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': major
+---
+
+Remove deprecated `mcpClient.getResources()`, `MCPConfiguration` class and `MCPConfigurationOptions`

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -322,7 +322,7 @@ const mcp = new MCPClient({
 });
 
 // Get resources from all connected MCP servers
-const resources = await mcp.getResources();
+const resources = await mcp.resources.get();
 
 // Resources are grouped by server name
 console.log(Object.keys(resources)); // ['weather', 'dataService']
@@ -558,5 +558,4 @@ The client includes comprehensive error handling:
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/specification)
 - [@modelcontextprotocol/sdk Documentation](https://github.com/modelcontextprotocol/typescript-sdk)
 - [Mastra Docs: Using MCP With Mastra](/docs/agents/mcp-guide)
-- [Mastra Docs: MCPConfiguration Reference](/reference/tools/mcp-configuration)
 - [Mastra Docs: MastraMCPClient Reference](/reference/tools/client)

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -720,21 +720,3 @@ export class InternalMastraMCPClient extends MastraBase {
     return toolsRes;
   }
 }
-
-/**
- * @deprecated MastraMCPClient is deprecated and will be removed in a future release. Please use MCPClient instead.
- */
-
-export class MastraMCPClient extends InternalMastraMCPClient {
-  constructor(args: InternalMastraMCPClientOptions) {
-    super(args);
-    throw new MastraError(
-      {
-        id: 'MASTRA_MCP_CLIENT_DEPRECATED',
-        domain: ErrorDomain.MCP,
-        category: ErrorCategory.USER,
-        text: '[DEPRECATION] MastraMCPClient is deprecated and will be removed in a future release. Please use MCPClient instead.',
-      },
-    );
-  }
-}

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -765,13 +765,6 @@ To fix this you have three different options:
   }
 
   /**
-   * @deprecated all resource actions have been moved to the this.resources object. Use this.resources.list() instead.
-   */
-  public async getResources() {
-    return this.resources.list();
-  }
-
-  /**
    * Gets current session IDs for all connected MCP clients using Streamable HTTP transport.
    *
    * Returns an object mapping server names to their session IDs. Only includes servers
@@ -874,56 +867,6 @@ To fix this you have three different options:
         const tools = await client.tools();
         await cb({ serverName, tools, client });
       }),
-    );
-  }
-}
-
-/**
- * @deprecated MCPConfigurationOptions is deprecated and will be removed in a future release. Use {@link MCPClientOptions} instead.
- *
- * This interface has been renamed to MCPClientOptions. The API is identical.
- */
-export interface MCPConfigurationOptions {
-  /** @deprecated Use MCPClientOptions.id instead */
-  id?: string;
-  /** @deprecated Use MCPClientOptions.servers instead */
-  servers: Record<string, MastraMCPServerDefinition>;
-  /** @deprecated Use MCPClientOptions.timeout instead */
-  timeout?: number;
-}
-
-/**
- * @deprecated MCPConfiguration is deprecated and will be removed in a future release. Use {@link MCPClient} instead.
- *
- * This class has been renamed to MCPClient. The API is identical but the class name changed
- * for clarity and consistency.
- *
- * @example
- * ```typescript
- * // Old way (deprecated)
- * const config = new MCPConfiguration({
- *   servers: { myServer: { command: 'npx', args: ['tsx', 'server.ts'] } }
- * });
- *
- * // New way (recommended)
- * const client = new MCPClient({
- *   servers: { myServer: { command: 'npx', args: ['tsx', 'server.ts'] } }
- * });
- * ```
- */
-export class MCPConfiguration extends MCPClient {
-  /**
-   * @deprecated Use MCPClient constructor instead
-   */
-  constructor(args: MCPClientOptions) {
-    super(args);
-    throw new MastraError(
-      {
-        id: 'MCP_CLIENT_CONFIGURATION_DEPRECATED',
-        domain: ErrorDomain.MCP,
-        category: ErrorCategory.USER,
-        text: '[DEPRECATION] MCPConfiguration has been renamed to MCPClient and MCPConfiguration is deprecated. The API is identical but the MCPConfiguration export will be removed in the future. Update your imports now to prevent future errors.',
-      },
     );
   }
 }

--- a/packages/mcp/src/client/index.ts
+++ b/packages/mcp/src/client/index.ts
@@ -1,3 +1,2 @@
 export type { LoggingLevel, LogMessage, LogHandler, MastraMCPServerDefinition, ElicitationHandler } from './client';
-export { MastraMCPClient } from './client';
 export * from './configuration';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Major version bump for @mastra/mcp.
  * Removed deprecated public APIs: legacy client wrapper, MCPConfiguration class, MCPConfigurationOptions type, and the legacy getResources() method.
  * Callers must migrate to the new MCPClient surface (resources accessor and MCPClient options).

* **Documentation**
  * README updated to reflect the new resource access pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->