### PR TITLE
fix(pg): listThreadsByResourceId validation

### DIFF
--- a/.changeset/better-schools-behave.md
+++ b/.changeset/better-schools-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fix pg listThreadsByResourceId page number validation

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -111,6 +111,21 @@ export class MemoryPG extends MemoryStorage {
     args: StorageListThreadsByResourceIdInput,
   ): Promise<StorageListThreadsByResourceIdOutput> {
     const { resourceId, page = 0, perPage: perPageInput, orderBy } = args;
+
+    // Validate page parameter
+    if (page < 0) {
+      throw new MastraError({
+        id: 'MASTRA_STORAGE_PG_STORE_INVALID_PAGE',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Page number must be non-negative',
+        details: {
+          resourceId,
+          page,
+        },
+      });
+    }
+
     const { field, direction } = this.parseOrderBy(orderBy);
     const perPage = normalizePerPage(perPageInput, 100);
     try {
@@ -542,6 +557,20 @@ export class MemoryPG extends MemoryStorage {
         },
         new Error('threadId must be a non-empty string'),
       );
+    }
+
+    // Validate page parameter
+    if (page < 0) {
+      throw new MastraError({
+        id: 'MASTRA_STORAGE_PG_STORE_INVALID_PAGE',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Page number must be non-negative',
+        details: {
+          threadId,
+          page,
+        },
+      });
     }
 
     const perPage = normalizePerPage(perPageInput, 40);


### PR DESCRIPTION
This was missed when we shipped this validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed page number validation for pagination queries. Invalid page numbers (negative values) now properly trigger error handling before processing, preventing unexpected behavior in paginated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->