### PR TITLE
feat/add description to list agents

### DIFF
--- a/.changeset/five-spiders-arrive.md
+++ b/.changeset/five-spiders-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Add the description field to listAgents

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -15,6 +15,8 @@ Retrieve a list of all available agents:
 const agents = await mastraClient.listAgents();
 ```
 
+Returns a record of agent IDs to their serialized agent configurations. See the [Agent class reference](/reference/agents/agent) for details on agent properties.
+
 ## Working with a Specific Agent
 
 Get an instance of a specific agent:
@@ -32,6 +34,8 @@ Retrieve detailed information about an agent:
 ```typescript
 const details = await agent.details();
 ```
+
+Returns the serialized agent configuration. See the [Agent class reference](/reference/agents/agent) for details on agent properties.
 
 ### Generate Response
 

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -46,6 +46,7 @@ class MockAgent extends Agent {
 const makeMockAgent = (config?: Partial<AgentConfig>) =>
   new MockAgent({
     name: 'test-agent',
+    description: 'A test agent for unit testing',
     instructions: 'test instructions',
     model: openai('gpt-4o'),
     ...(config || {}),
@@ -78,6 +79,7 @@ describe('Agent Handlers', () => {
 
     mockMultiModelAgent = makeMockAgent({
       name: 'test-multi-model-agent',
+      description: 'A test agent with multiple model configurations',
       model: [{ model: openaiV5('gpt-4o-mini') }, { model: openaiV5('gpt-4o') }, { model: openaiV5('gpt-4.1') }],
     });
 
@@ -96,6 +98,7 @@ describe('Agent Handlers', () => {
       expect(result).toEqual({
         'test-agent': {
           name: 'test-agent',
+          description: 'A test agent for unit testing',
           instructions: 'test instructions',
           tools: {},
           agents: {},
@@ -112,6 +115,7 @@ describe('Agent Handlers', () => {
         },
         'test-multi-model-agent': {
           name: 'test-multi-model-agent',
+          description: 'A test agent with multiple model configurations',
           instructions: 'test instructions',
           tools: {},
           agents: {},
@@ -154,6 +158,7 @@ describe('Agent Handlers', () => {
 
       const agentWithCoreProcessors = makeMockAgent({
         name: 'agent-with-core-processors',
+        description: 'A test agent with input and output processors',
         inputProcessors: [unicodeNormalizer],
         outputProcessors: [tokenLimiter],
       });
@@ -168,6 +173,7 @@ describe('Agent Handlers', () => {
 
       expect(result['agent-with-core-processors']).toMatchObject({
         name: 'agent-with-core-processors',
+        description: 'A test agent with input and output processors',
         inputProcessors: [
           {
             id: 'unicode-normalizer',
@@ -224,6 +230,7 @@ describe('Agent Handlers', () => {
 
       expect(result).toEqual({
         name: 'test-agent',
+        description: 'A test agent for unit testing',
         instructions: 'test instructions',
         tools: {},
         agents: {},

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -47,6 +47,7 @@ export interface SerializedWorkflow {
 
 export interface SerializedAgent {
   name: string;
+  description?: string;
   instructions?: SystemMessage;
   tools: Record<string, SerializedTool>;
   agents: Record<string, SerializedAgentDefinition>;
@@ -185,6 +186,7 @@ async function formatAgentList({
   agent: Agent;
   requestContext: RequestContext;
 }): Promise<SerializedAgentWithId> {
+  const description = agent.getDescription();
   const instructions = await agent.getInstructions({ requestContext });
   const tools = await agent.listTools({ requestContext });
   const llm = await agent.getLLM({ requestContext });
@@ -239,6 +241,7 @@ async function formatAgentList({
   return {
     id,
     name: agent.name,
+    description,
     instructions,
     agents: serializedAgentAgents,
     tools: serializedAgentTools,
@@ -334,6 +337,7 @@ async function formatAgent({
   requestContext: RequestContext;
   isPlayground: boolean;
 }): Promise<SerializedAgent> {
+  const description = agent.getDescription();
   const tools = await agent.listTools({ requestContext });
 
   const serializedAgentTools = await getSerializedAgentTools(tools);
@@ -419,6 +423,7 @@ async function formatAgent({
 
   return {
     name: agent.name,
+    description,
     instructions,
     tools: serializedAgentTools,
     agents: serializedAgentAgents,


### PR DESCRIPTION
## Description

The agent and listAgent API calls were missing the `description` field.  Added to the format handler.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ x] I have made corresponding changes to the documentation (if applicable)
- [ x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now support an optional description field for better documentation and metadata.
  * The listAgents endpoint now returns agent descriptions alongside existing agent information.

* **Documentation**
  * Updated Agents API reference with return value descriptions for listAgents and agent details endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->