### PR TITLE
Added Observability init to the default template.

### DIFF
--- a/.changeset/rich-onions-stand.md
+++ b/.changeset/rich-onions-stand.md
@@ -1,0 +1,7 @@
+---
+'@mastra/observability': major
+'@mastra/core': major
+'mastra': major
+---
+
+Added Observability init to the default template.

--- a/observability/_test-without-config/mastra.test.ts
+++ b/observability/_test-without-config/mastra.test.ts
@@ -1,0 +1,31 @@
+import { Mastra } from '@mastra/core';
+import { MockStore } from '@mastra/core/storage';
+import type { IMastraLogger } from '@mastra/core/logger';
+import { describe, it, expect, vi } from 'vitest';
+import '@mastra/observability/init';
+
+describe('Observability init without observablity config', () => {
+  it('should log an error providing helpful info', async () => {
+    const mockLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as any as IMastraLogger;
+
+    new Mastra({
+      storage: new MockStore(),
+      logger: mockLogger,
+      // This tests the absence of this config, disabling Observability
+      //
+      // observability: {
+      //   default: { enabled: true },
+      // },
+    });
+
+    // Check if warn was called with the expected message
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[Mastra Observability] Observability init registered but no config provided'),
+    );
+  });
+});

--- a/observability/_test-without-config/package.json
+++ b/observability/_test-without-config/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@observability/_test-utils",
+  "name": "@observability/_test-without-config",
   "version": "0.0.1",
-  "description": "Test utilities for observability exporters",
+  "description": "Tests observability init without an observability config",
   "type": "module",
   "private": true,
   "files": [],
@@ -9,7 +9,8 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@mastra/core": "workspace:*"
+    "@mastra/core": "workspace:*",
+    "@mastra/observability": "workspace:*"
   },
   "peerDependencies": {
     "@mastra/core": ">=0.18.1-0 <2.0.0-0"

--- a/observability/_test-without-config/vitest.config.ts
+++ b/observability/_test-without-config/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['*.test.ts'],
+  },
+});

--- a/observability/_test-without-init/mastra.test.ts
+++ b/observability/_test-without-init/mastra.test.ts
@@ -1,0 +1,31 @@
+import { Mastra } from '@mastra/core';
+import { MockStore } from '@mastra/core/storage';
+import type { IMastraLogger } from '@mastra/core/logger';
+import { describe, it, expect, vi } from 'vitest';
+
+// This tests the absence of this init, disabling Observability
+// import '@mastra/observability/init';
+
+describe('Observability init without observablity config', () => {
+  it('should log an error providing helpful info', async () => {
+    const mockLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as any as IMastraLogger;
+
+    new Mastra({
+      storage: new MockStore(),
+      logger: mockLogger,
+      observability: {
+        default: { enabled: true },
+      },
+    });
+
+    // Check if warn was called with the expected message
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[Mastra Observability] Observability config provided but no init registered'),
+    );
+  });
+});

--- a/observability/_test-without-init/package.json
+++ b/observability/_test-without-init/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@observability/_test-utils",
+  "name": "@observability/_test-without-init",
   "version": "0.0.1",
-  "description": "Test utilities for observability exporters",
+  "description": "Tests an observability config without init",
   "type": "module",
   "private": true,
   "files": [],
@@ -9,7 +9,8 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@mastra/core": "workspace:*"
+    "@mastra/core": "workspace:*",
+    "@mastra/observability": "workspace:*"
   },
   "peerDependencies": {
     "@mastra/core": ">=0.18.1-0 <2.0.0-0"

--- a/observability/_test-without-init/vitest.config.ts
+++ b/observability/_test-without-init/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['*.test.ts'],
+  },
+});

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -20,6 +20,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./init": {
+      "import": {
+        "types": "./dist/init.d.ts",
+        "default": "./dist/init.js"
+      },
+      "require": {
+        "types": "./dist/init.d.ts",
+        "default": "./dist/init.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/observability/mastra/src/init.ts
+++ b/observability/mastra/src/init.ts
@@ -1,8 +1,9 @@
 import { NoOpEntrypoint, registerObservabilityInit } from '@mastra/core/observability';
-import type { InitObservabilityOptions, ObservabilityEntrypoint } from '@mastra/core/observability';
+import type { InitObservabilityOptions } from '@mastra/core/observability';
 import { DefaultEntrypoint } from './default-entrypoint';
 
-function initObservability(options: InitObservabilityOptions): ObservabilityEntrypoint {
+// Side-effect: called once when this module is imported.
+registerObservabilityInit((options: InitObservabilityOptions) => {
   if (!options.config) {
     options.logger?.warn?.(
       '[Mastra Observability] Observability init registered but no config provided. ' +
@@ -12,7 +13,4 @@ function initObservability(options: InitObservabilityOptions): ObservabilityEntr
     return new NoOpEntrypoint();
   }
   return new DefaultEntrypoint(options.config);
-}
-
-// Side-effect: called once when this module is imported.
-registerObservabilityInit(initObservability);
+});

--- a/observability/mastra/tsup.config.ts
+++ b/observability/mastra/tsup.config.ts
@@ -2,7 +2,7 @@ import { generateTypes } from '@internal/types-builder';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/init.ts'],
   format: ['esm', 'cjs'],
   clean: true,
   dts: false,

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -84,6 +84,7 @@ import { Memory } from '@mastra/memory';
 import { LibSQLStore } from '@mastra/libsql';
 ${addExampleTool ? `import { weatherTool } from '../tools/weather-tool';` : ''}
 ${addScorers ? `import { scorers } from '../scorers/weather-scorer';` : ''}
+import '@mastra/observability/init';
 
 export const weatherAgent = new Agent({
   id: 'weather-agent',

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -23,19 +23,15 @@ export function getObservabilityInit(): InitObservabilityFunction | undefined {
 }
 
 export function initObservability(options: InitObservabilityOptions): ObservabilityEntrypoint {
-  if (!options.config) {
+  const init = getObservabilityInit();
+  if (!init) {
+    options.logger?.warn?.(
+      '[Mastra Observability] Observability config provided but no init registered. ' +
+        "To enable observability install '@mastra/observability' and " +
+        "import '@mastra/observability/init' at startup. Falling back to No-Op.",
+    );
     return new NoOpEntrypoint();
   } else {
-    const init = getObservabilityInit();
-    if (!init) {
-      options.logger?.warn?.(
-        '[Mastra Observability] Observability config provided but no init registered. ' +
-          "To enable observability install '@mastra/observability' and " +
-          "import '@mastra/observability/init' at startup. Falling back to No-Op.",
-      );
-      return new NoOpEntrypoint();
-    } else {
-      return init(options);
-    }
+    return init(options);
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -777,6 +777,24 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
 
+  observability/_test-without-config:
+    devDependencies:
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@mastra/observability':
+        specifier: workspace:*
+        version: link:../mastra
+
+  observability/_test-without-init:
+    devDependencies:
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@mastra/observability':
+        specifier: workspace:*
+        version: link:../mastra
+
   observability/arize:
     dependencies:
       '@arizeai/openinference-genai':


### PR DESCRIPTION
## Description

Also updated the `@mastra/observability` build to export the `init` file on its own.

And added tests of the error conditions.

## Related Issue(s)

#6773 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observability initialization is now included in the default project template, enabling automatic setup for new projects created via the CLI.

* **Chores**
  * Major version bump for @mastra/observability, @mastra/core, and mastra packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->