### PR TITLE
refactor: delete Memory.rememberMessages and rename query to recall

### DIFF
--- a/.changeset/free-laws-study.md
+++ b/.changeset/free-laws-study.md
@@ -1,0 +1,26 @@
+---
+'@mastra/memory': major
+'@mastra/server': major
+'@mastra/core': major
+---
+
+This simplifies the Memory API by removing the confusing rememberMessages method and renaming query to recall for better clarity.
+
+The rememberMessages method name implied it might persist data when it was actually just retrieving messages, same as query. Having two methods that did essentially the same thing was unnecessary.
+
+Before:
+
+```typescript
+// Two methods that did the same thing
+memory.rememberMessages({ threadId, resourceId, config, vectorMessageSearch });
+memory.query({ threadId, resourceId, perPage, vectorSearchString });
+```
+
+After:
+
+```typescript
+// Single unified method with clear purpose
+memory.recall({ threadId, resourceId, perPage, vectorMessageSearch, threadConfig });
+```
+
+All usages have been updated across the codebase including tests. The agent now calls recall directly with the appropriate parameters.

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1.mdx
@@ -19,6 +19,57 @@ All Mastra packages have a peer dependency on `@mastra/core` so your package man
 
 ## Migrate to v1.0.0-beta
 
+### Removed: Memory.rememberMessages() and Renamed: Memory.query() to Memory.recall()
+
+**Breaking Changes:**
+
+1. `Memory.rememberMessages()` method has been removed
+2. `Memory.query()` has been renamed to `Memory.recall()`
+3. Parameter `vectorMessageSearch` is now `vectorSearchString`
+
+**Why these changes?**
+
+- "Remember" could imply persisting data, not just retrieving, which was confusing
+- `query` and `rememberMessages` performed the same function - consolidating to one method simplifies the API
+- `recall` better describes the action of retrieving messages from memory
+- `vectorSearchString` is more consistent with the rest of the codebase
+
+**Migration:**
+
+If you were using `rememberMessages()`, switch to `recall()`:
+
+```typescript
+// Before
+const { messages } = await memory.rememberMessages({
+  threadId,
+  resourceId,
+});
+
+// After
+const { messages } = await memory.recall({
+  threadId,
+  resourceId,
+});
+```
+
+If you were using `query()`, rename it to `recall()`:
+
+```typescript
+// Before
+const { messages } = await memory.query({
+  threadId,
+  vectorMessageSearch: "What did we discuss?",
+  threadConfig: { semanticRecall: true },
+});
+
+// After
+const { messages } = await memory.recall({
+  threadId,
+  vectorSearchString: "What did we discuss?",
+  threadConfig: { semanticRecall: true },
+});
+```
+
 ### Changed: Thread Title Generation Location and Default
 
 **Breaking Changes:**
@@ -187,7 +238,7 @@ The storage format (`MastraMessageV2`) and all public APIs remain unchanged.
 - `agent.speak()` → `agent.voice.speak()`
 - `agent.getSpeakers()` → `agent.voice.getSpeakers()`
 - `agent.listen` → `agent.voice.listen()`
-- `agent.fetchMemory` → `(await agent.getMemory()).query()`
+- `agent.fetchMemory` → `(await agent.getMemory()).recall()`
 - `agent.toStep` → Add agent directly to the step, workflows handle the transformation
 - `getDefaultGenerateOptions()` → `getDefaultGenerateOptionsLegacy()`
 - `getDefaultStreamOptions()` → `getDefaultStreamOptionsLegacy()`
@@ -602,14 +653,14 @@ function yourCustomFunction(input: MastraDBMessage) {}
 
 #### 2. Update Memory Method Return Types
 
-The `rememberMessages` method now returns an object wrapper for consistency between all methods:
+The `recall` method (previously `rememberMessages`) now returns an object wrapper for consistency between all methods:
 
 ```typescript
 // Before
 const messages = await memory.rememberMessages({ threadId, resourceId });
 
 // After
-const { messages } = await memory.rememberMessages({ threadId, resourceId });
+const { messages } = await memory.recall({ threadId, resourceId });
 ```
 
 #### 4. Update AI SDK Format Conversion
@@ -641,7 +692,7 @@ const messages = await memory.getMessages({ threadId, format: "v2" });
 const uiMessages = await memory.getMessages({ threadId, format: "ui" });
 
 // After
-const result = await memory.query({ threadId });
+const result = await memory.recall({ threadId });
 const messages = result.messages; // Always MastraDBMessage[]
 
 // Use conversion functions for AI SDK formats

--- a/docs/src/content/en/reference/memory/deleteMessages.mdx
+++ b/docs/src/content/en/reference/memory/deleteMessages.mdx
@@ -47,7 +47,7 @@ import { MastraDBMessage } from "@mastra/core";
 const agent = mastra.getAgent("agent");
 const memory = await agent.getMemory();
 
-const { messages } = await memory!.query({ threadId: "thread-123" });
+const { messages } = await memory!.recall({ threadId: "thread-123" });
 
 const messageIds = messages.map(
   (message: MastraDBMessage) => message.id,
@@ -58,5 +58,5 @@ await memory?.deleteMessages([...messageIds]);
 ## Related
 
 - [Memory Class Reference](/reference/memory/memory-class)
-- [query](/reference/memory/query)
+- [recall](/reference/memory/recall)
 - [Getting Started with Memory](/docs/memory/overview)

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -208,7 +208,7 @@ export const agent = new Agent({
 - [Working Memory](/docs/memory/working-memory)
 - [Memory Processors](/docs/memory/memory-processors)
 - [createThread](/reference/memory/createThread)
-- [query](/reference/memory/query)
+- [recall](/reference/memory/recall)
 - [getThreadById](/reference/memory/getThreadById)
 - [listThreadsByResourceId](/reference/memory/listThreadsByResourceId)
 - [deleteMessages](/reference/memory/deleteMessages)

--- a/docs/src/content/en/reference/memory/recall.mdx
+++ b/docs/src/content/en/reference/memory/recall.mdx
@@ -1,20 +1,16 @@
 ---
-title: "Reference: Memory.query() | Memory | Mastra Docs"
-description: "Documentation for the `Memory.query()` method in Mastra, which retrieves messages from a specific thread with support for pagination, filtering options, and semantic search."
+title: "Reference: Memory.recall() | Memory | Mastra Docs"
+description: "Documentation for the `Memory.recall()` method in Mastra, which retrieves messages from a specific thread with support for pagination, filtering options, and semantic search."
 ---
 
-# Memory.query()
+# Memory.recall()
 
-:::warning[Deprecated]
-The `Memory.query()` method has been renamed to [`Memory.recall()`](/reference/memory/recall). This page is kept for reference, but please use `recall()` in new code. See the [migration guide](/guides/migrations/upgrade-to-v1#removed-memoryremembermessages-and-renamed-memoryquery-to-memoryrecall) for details.
-:::
-
-the `.query()` method retrieves messages from a specific thread, with support for pagination, filtering options, and semantic search.
+the `.recall()` method retrieves messages from a specific thread, with support for pagination, filtering options, and semantic search.
 
 ## Usage Example
 
 ```typescript copy
-await memory?.query({ threadId: "user-123" });
+await memory?.recall({ threadId: "user-123" });
 ```
 
 ## Parameters
@@ -46,7 +42,7 @@ await memory?.query({ threadId: "user-123" });
       name: "perPage",
       type: "number | false",
       description:
-        "Number of messages to retrieve per page. Set to false to fetch all messages without pagination.",
+        "Number of messages to retrieve per page. Set to false to fetch all messages without pagination. If not provided, defaults to threadConfig.lastMessages.",
       isOptional: true,
     },
     {
@@ -96,7 +92,7 @@ await memory?.query({ threadId: "user-123" });
       name: "lastMessages",
       type: "number | false",
       description:
-        "Number of most recent messages to retrieve. Set to false to disable.",
+        "Number of most recent messages to retrieve. Set to false to disable. When perPage is not explicitly provided, this value is used as the default.",
       isOptional: true,
       defaultValue: "10",
     },
@@ -149,7 +145,7 @@ const agent = mastra.getAgent("agent");
 const memory = await agent.getMemory();
 
 // Retrieve messages with pagination
-const { messages } = await memory!.query({
+const { messages } = await memory!.recall({
   threadId: "thread-123",
   perPage: 50,
   vectorSearchString: "What messages are there?",
@@ -171,7 +167,7 @@ const { messages } = await memory!.query({
 console.log(messages); // MastraDBMessage[]
 
 // Fetch all messages without pagination
-const allMessages = await memory!.query({
+const allMessages = await memory!.recall({
   threadId: "thread-123",
   perPage: false, // Fetch all
 });

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -301,7 +301,8 @@ const sidebars = {
       items: [
         { type: "doc", id: "memory/memory-class", label: "Memory Class" },
         { type: "doc", id: "memory/createThread", label: ".createThread()" },
-        { type: "doc", id: "memory/query", label: ".query()" },
+        { type: "doc", id: "memory/recall", label: ".recall()" },
+        { type: "doc", id: "memory/query", label: ".query() (Deprecated)" },
         { type: "doc", id: "memory/getThreadById", label: ".getThreadById()" },
         {
           type: "doc",

--- a/examples/ai-sdk-v5/app/api/initial-chat/route.ts
+++ b/examples/ai-sdk-v5/app/api/initial-chat/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 const myAgent = mastra.getAgent("weatherAgent");
 export async function GET() {
   const memory = await myAgent.getMemory();
-  const result = await memory?.query({
+  const result = await memory?.recall({
     threadId: "2",
   });
 

--- a/examples/crypto-chatbot/app/(chat)/chat/[id]/page.tsx
+++ b/examples/crypto-chatbot/app/(chat)/chat/[id]/page.tsx
@@ -42,7 +42,7 @@ export default async function Page(props: { params: Promise<any> }) {
     return notFound();
   }
 
-  const memoryMessages = await mastra.memory?.query({
+  const memoryMessages = await mastra.memory?.recall({
     threadId: id,
   });
 

--- a/packages/core/src/agent/__tests__/stream.test.ts
+++ b/packages/core/src/agent/__tests__/stream.test.ts
@@ -681,7 +681,7 @@ function runStreamTest(version: 'v1' | 'v2') {
       const threadId = '1';
       const resourceId = '2';
       // @ts-ignore
-      mockMemory.rememberMessages = async function rememberMessages() {
+      mockMemory.recall = async function recall() {
         const list = new MessageList({ threadId, resourceId }).add(
           [
             { role: `user`, content: `hello!`, threadId, resourceId },

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1406,7 +1406,7 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
       perPage: threadConfig.lastMessages,
       threadConfig: memoryConfig,
       // The new user messages aren't in the list yet cause we add memory messages first to try to make sure ordering is correct (memory comes before new user messages)
-      vectorMessageSearch: threadConfig.semanticRecall && vectorMessageSearch ? vectorMessageSearch : undefined,
+      vectorSearchString: threadConfig.semanticRecall && vectorMessageSearch ? vectorMessageSearch : undefined,
     });
   }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1394,12 +1394,19 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
     if (!memory) {
       return { messages: [] };
     }
-    return memory.rememberMessages({
+
+    const threadConfig = memory.getMergedThreadConfig(memoryConfig || {});
+    if (!threadConfig.lastMessages && !threadConfig.semanticRecall) {
+      return { messages: [] };
+    }
+
+    return memory.recall({
       threadId,
       resourceId,
-      config: memoryConfig,
+      perPage: threadConfig.lastMessages,
+      threadConfig: memoryConfig,
       // The new user messages aren't in the list yet cause we add memory messages first to try to make sure ordering is correct (memory comes before new user messages)
-      vectorMessageSearch,
+      vectorMessageSearch: threadConfig.semanticRecall && vectorMessageSearch ? vectorMessageSearch : undefined,
     });
   }
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -327,14 +327,14 @@ export abstract class MastraMemory extends MastraBase {
    * Retrieves messages for a specific thread with optional semantic recall
    * @param threadId - The unique identifier of the thread
    * @param resourceId - Optional resource ID for validation
-   * @param vectorMessageSearch - Optional search string for semantic recall
+   * @param vectorSearchString - Optional search string for semantic recall
    * @param config - Optional memory configuration
    * @returns Promise resolving to array of messages in mastra-db format
    */
   abstract recall(
     args: StorageListMessagesInput & {
       threadConfig?: MemoryConfig;
-      vectorMessageSearch?: string;
+      vectorSearchString?: string;
     },
   ): Promise<{ messages: MastraDBMessage[] }>;
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -8,6 +8,7 @@ import type { Mastra } from '../mastra';
 import type {
   MastraStorage,
   StorageGetMessagesArg,
+  StorageListMessagesInput,
   StorageListThreadsByResourceIdInput,
   StorageListThreadsByResourceIdOutput,
 } from '../storage';
@@ -274,13 +275,6 @@ export abstract class MastraMemory extends MastraBase {
     return this.applyProcessors(messages, { processors: processors || this.processors, ...opts });
   }
 
-  abstract rememberMessages(args: {
-    threadId: string;
-    resourceId?: string;
-    vectorMessageSearch?: string;
-    config?: MemoryConfig;
-  }): Promise<{ messages: MastraDBMessage[] }>;
-
   estimateTokens(text: string): number {
     return Math.ceil(text.split(' ').length * 1.3);
   }
@@ -331,13 +325,17 @@ export abstract class MastraMemory extends MastraBase {
   }): Promise<{ messages: MastraDBMessage[] }>;
 
   /**
-   * Retrieves all messages for a specific thread
+   * Retrieves messages for a specific thread with optional semantic recall
    * @param threadId - The unique identifier of the thread
+   * @param resourceId - Optional resource ID for validation
+   * @param vectorMessageSearch - Optional search string for semantic recall
+   * @param config - Optional memory configuration
    * @returns Promise resolving to array of messages in mastra-db format
    */
-  abstract query(
-    args: StorageGetMessagesArg & {
+  abstract recall(
+    args: StorageListMessagesInput & {
       threadConfig?: MemoryConfig;
+      vectorMessageSearch?: string;
     },
   ): Promise<{ messages: MastraDBMessage[] }>;
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -7,7 +7,6 @@ import { ModelRouterEmbeddingModel } from '../llm/model/index.js';
 import type { Mastra } from '../mastra';
 import type {
   MastraStorage,
-  StorageGetMessagesArg,
   StorageListMessagesInput,
   StorageListThreadsByResourceIdInput,
   StorageListThreadsByResourceIdOutput,

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -3,7 +3,6 @@ import { MastraMemory } from '../memory';
 import type { StorageThreadType, MastraDBMessage, MemoryConfig, MessageDeleteInput } from '../memory';
 import { InMemoryStore } from '../storage';
 import type {
-  StorageGetMessagesArg,
   StorageListMessagesInput,
   StorageListThreadsByResourceIdInput,
   StorageListThreadsByResourceIdOutput,
@@ -25,7 +24,7 @@ export class MockMemory extends MastraMemory {
     return this.storage.saveThread({ thread });
   }
 
-  async getMessages(args: StorageGetMessagesArg): Promise<{ messages: MastraDBMessage[] }> {
+  async getMessages(args: StorageListMessagesInput): Promise<{ messages: MastraDBMessage[] }> {
     return this.storage.getMessages(args);
   }
 

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -45,35 +45,22 @@ export class MockMemory extends MastraMemory {
     return this.storage.saveMessages({ messages: dbMessages });
   }
 
-  async rememberMessages(args: {
-    threadId: string;
-    resourceId?: string;
-    vectorMessageSearch?: string;
-    config?: MemoryConfig;
-  }): Promise<{ messages: MastraDBMessage[] }> {
-    // Query all messages from storage and return them
-    const getMessagesArgs: StorageListMessagesInput = { threadId: args.threadId };
-    if (args.resourceId !== undefined) {
-      getMessagesArgs.resourceId = args.resourceId;
-    }
-    const result = await this.storage.getMessages(getMessagesArgs);
-    return { messages: result.messages };
-  }
-
   async listThreadsByResourceId(
     args: StorageListThreadsByResourceIdInput,
   ): Promise<StorageListThreadsByResourceIdOutput> {
     return this.storage.listThreadsByResourceId(args);
   }
 
-  async query(args: StorageGetMessagesArg & { threadConfig?: MemoryConfig }): Promise<{
+  async recall(
+    args: StorageListMessagesInput & { threadConfig?: MemoryConfig; vectorMessageSearch?: string },
+  ): Promise<{
     messages: MastraDBMessage[];
   }> {
     // Get raw messages from storage
     const result = await this.storage.getMessages({
       threadId: args.threadId,
       resourceId: args.resourceId,
-      selectBy: args.selectBy,
+      selectBy: args.perPage ? { last: args.perPage } : undefined,
     });
 
     return result;

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -50,9 +50,7 @@ export class MockMemory extends MastraMemory {
     return this.storage.listThreadsByResourceId(args);
   }
 
-  async recall(
-    args: StorageListMessagesInput & { threadConfig?: MemoryConfig; vectorMessageSearch?: string },
-  ): Promise<{
+  async recall(args: StorageListMessagesInput & { threadConfig?: MemoryConfig; vectorSearchString?: string }): Promise<{
     messages: MastraDBMessage[];
   }> {
     // Get raw messages from storage

--- a/packages/core/src/storage/mock.test.ts
+++ b/packages/core/src/storage/mock.test.ts
@@ -202,12 +202,10 @@ describe('InMemoryStore - Message Fetching', () => {
     expect(result2.messages).toHaveLength(0);
   });
 
-  it('listMessages should return empty array if threadId is an empty string or whitespace only', async () => {
-    const result = await store.listMessages({ threadId: '' });
-    expect(result.messages).toHaveLength(0);
+  it('listMessages should throw error if threadId is an empty string or whitespace only', async () => {
+    await expect(store.listMessages({ threadId: '' })).rejects.toThrow('threadId must be a non-empty string');
 
-    const result2 = await store.listMessages({ threadId: '   ' });
-    expect(result2.messages).toHaveLength(0);
+    await expect(store.listMessages({ threadId: '   ' })).rejects.toThrow('threadId must be a non-empty string');
   });
 });
 

--- a/packages/memory/integration-tests-v5/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests-v5/src/agent-memory.test.ts
@@ -66,9 +66,9 @@ describe('Agent Memory Tests', () => {
       }),
     });
     const agentMemory = (await mastra.getAgent('agent').getMemory())!;
-    await expect(agentMemory.query({ threadId: '1' })).resolves.not.toThrow();
+    await expect(agentMemory.recall({ threadId: '1' })).resolves.not.toThrow();
     const agentMemory2 = (await agent.getMemory())!;
-    await expect(agentMemory2.query({ threadId: '1' })).resolves.not.toThrow();
+    await expect(agentMemory2.recall({ threadId: '1' })).resolves.not.toThrow();
   });
 
   it('should inherit storage from Mastra instance when workingMemory is enabled', async () => {
@@ -302,7 +302,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
       const userMessages = messages.filter((m: any) => m.role === 'user').map((m: any) => getTextContent(m));
 
       expect(userMessages).toEqual(expect.arrayContaining(['First message', 'Second message']));
@@ -336,7 +336,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
       const userMessages = messages.filter((m: any) => m.role === 'user').map((m: any) => getTextContent(m));
       const assistantMessages = messages.filter((m: any) => m.role === 'assistant').map((m: any) => getTextContent(m));
       expect(userMessages).toEqual(expect.arrayContaining(['What is 2+2?', 'Give me JSON']));
@@ -371,7 +371,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
 
       // Assert that the context messages are NOT saved
       const savedContextMessages = messages.filter(
@@ -423,7 +423,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
 
       // Check that all user messages were saved
       const savedUserMessages = messages.filter((m: any) => m.role === 'user');
@@ -476,7 +476,7 @@ describe('Agent Memory Tests', () => {
       const originalReasoningText = result.reasoningText;
 
       const agentMemory = (await reasoningAgent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
 
       const assistantMessage = messages.find(
         m => m.role === 'assistant' && m.content.parts?.find(p => p.type === 'reasoning'),
@@ -640,7 +640,7 @@ describe('Agent with message processors', () => {
 
     // Check that tool calls were saved to memory
     const agentMemory = (await memoryProcessorAgent.getMemory())!;
-    const { messages: messagesFromMemory } = await agentMemory.query({ threadId });
+    const { messages: messagesFromMemory } = await agentMemory.recall({ threadId });
     const toolMessages = messagesFromMemory.filter(
       m => m.role === 'tool' || (m.role === 'assistant' && typeof m.content !== 'string'),
     );

--- a/packages/memory/integration-tests-v5/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests-v5/src/agent-memory.test.ts
@@ -219,7 +219,7 @@ describe('Agent Memory Tests', () => {
     });
 
     // Verify first thread has messages
-    const thread1Messages = await memory.query({ threadId: thread1Id, resourceId });
+    const thread1Messages = await memory.recall({ threadId: thread1Id, resourceId });
     expect(thread1Messages.messages.length).toBeGreaterThan(0);
 
     // Now create a second thread - this should be able to access memory from thread1

--- a/packages/memory/integration-tests-v5/src/processors.test.ts
+++ b/packages/memory/integration-tests-v5/src/processors.test.ts
@@ -76,7 +76,7 @@ describe('Memory with Processors', () => {
     await memory.saveMessages({ messages: messagesV2 });
 
     // Get messages with a token limit of 250 (should get ~2.5 messages)
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -102,7 +102,7 @@ describe('Memory with Processors', () => {
     });
 
     // Now query with a very high token limit that should return all messages
-    const allMessagesQuery = await memory.query({
+    const allMessagesQuery = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -148,7 +148,7 @@ describe('Memory with Processors', () => {
     await memory.saveMessages({ messages: messagesV2 });
 
     // filter weather tool calls
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -164,7 +164,7 @@ describe('Memory with Processors', () => {
     expect(filterToolResultsByName(result, 'calculator')).toHaveLength(1);
 
     // make another query with no processors to make sure memory messages in DB were not altered and were only filtered from results
-    const queryResult2 = await memory.query({
+    const queryResult2 = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -180,7 +180,7 @@ describe('Memory with Processors', () => {
     expect(filterToolResultsByName(result2, 'calculator')).toHaveLength(1);
 
     // filter all by name
-    const queryResult3 = await memory.query({
+    const queryResult3 = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -195,7 +195,7 @@ describe('Memory with Processors', () => {
     expect(filterToolResultsByName(result3, 'calculator')).toHaveLength(0);
 
     // filter all by default
-    const queryResult4 = await memory.query({
+    const queryResult4 = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -230,7 +230,7 @@ describe('Memory with Processors', () => {
     await memory.saveMessages({ messages: messagesV2 });
 
     // Apply multiple processors: first remove weather tool calls, then limit to 250 tokens
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -340,7 +340,7 @@ describe('Memory with Processors', () => {
     const allUserMessages = requestInputMessages2.filter((m: CoreMessage) => m.role === 'user');
     expect(allUserMessages.length).toBe(2);
 
-    const remembered = await memory.query({
+    const remembered = await memory.recall({
       threadId: thread.id,
       resourceId,
       perPage: 20,
@@ -419,7 +419,7 @@ describe('Memory with Processors', () => {
     });
 
     // Query with no processors to verify baseline message count
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -442,7 +442,7 @@ describe('Memory with Processors', () => {
     expect(calculatorToolCalls.length).toBeGreaterThan(0);
 
     // Test filtering weather tool calls
-    const weatherQueryResult = await memory.query({
+    const weatherQueryResult = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -463,7 +463,7 @@ describe('Memory with Processors', () => {
     expect(filterToolCallsByName(weatherFilteredResult, 'calculator').length).toBeGreaterThan(0);
 
     // Test token limiting
-    const tokenLimitQuery = await memory.query({
+    const tokenLimitQuery = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -477,7 +477,7 @@ describe('Memory with Processors', () => {
     expect(tokenLimitedResult.length).toBeLessThan(baselineResult.length);
 
     // Test combining processors
-    const combinedQuery = await memory.query({
+    const combinedQuery = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -529,7 +529,7 @@ describe('Memory with Processors', () => {
     });
 
     // Query the message back
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 1,
     });

--- a/packages/memory/integration-tests-v5/src/streaming-memory.test.ts
+++ b/packages/memory/integration-tests-v5/src/streaming-memory.test.ts
@@ -129,7 +129,7 @@ describe('Memory Streaming Tests', () => {
     });
 
     const agentMemory = (await agent.getMemory())!;
-    const { messages } = await agentMemory.query({ threadId });
+    const { messages } = await agentMemory.recall({ threadId });
 
     console.log('Custom IDs: ', customIds);
     console.log('Messages: ', messages);
@@ -267,7 +267,7 @@ describe('Memory Streaming Tests', () => {
       });
 
       const agentMemory = (await weatherAgent.getMemory())!;
-      const dbMessages = (await agentMemory.query({ threadId })).messages;
+      const dbMessages = (await agentMemory.recall({ threadId })).messages;
       const initialMessages = dbMessages.map(m => MessageList.mastraDBMessageToAIV5UIMessage(m));
       const state = { clipboard: '' };
       const { result } = renderHook(() => {
@@ -376,7 +376,7 @@ describe('Memory Streaming Tests', () => {
         responseContains: [state.clipboard],
       });
 
-      const messagesResult = await agentMemory.query({ threadId, resourceId });
+      const messagesResult = await agentMemory.recall({ threadId, resourceId });
 
       const clipboardToolInvocation = messagesResult.messages.filter(
         m =>

--- a/packages/memory/integration-tests-v5/src/working-memory.test.ts
+++ b/packages/memory/integration-tests-v5/src/working-memory.test.ts
@@ -197,9 +197,9 @@ describe('Working Memory Tests', () => {
 
       await memory.saveMessages({ messages });
 
-      const remembered = await memory.rememberMessages({
+      const remembered = await memory.recall({
         threadId: thread.id,
-        config: { lastMessages: 10 },
+        perPage: 10,
       });
 
       // Working memory tags should be stripped from the messages
@@ -343,7 +343,7 @@ describe('Working Memory Tests', () => {
         expect(workingMemory).toContain('**Location**: Vancouver Island');
       }
 
-      const history = await memory.query({
+      const history = await memory.recall({
         threadId: thread.id,
         resourceId,
         perPage: 20,

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -192,7 +192,7 @@ describe('Agent Memory Tests', () => {
     });
 
     // Verify first thread has messages
-    const thread1Messages = await memory.query({ threadId: thread1Id, resourceId });
+    const thread1Messages = await memory.recall({ threadId: thread1Id, resourceId });
     expect(thread1Messages.messages.length).toBeGreaterThan(0);
 
     // Now create a second thread - this should be able to access memory from thread1

--- a/packages/memory/integration-tests/src/agent-memory.test.ts
+++ b/packages/memory/integration-tests/src/agent-memory.test.ts
@@ -39,9 +39,9 @@ describe('Agent Memory Tests', () => {
       }),
     });
     const agentMemory = (await mastra.getAgent('agent').getMemory())!;
-    await expect(agentMemory.query({ threadId: '1' })).resolves.not.toThrow();
+    await expect(agentMemory.recall({ threadId: '1' })).resolves.not.toThrow();
     const agentMemory2 = (await agent.getMemory())!;
-    await expect(agentMemory2.query({ threadId: '1' })).resolves.not.toThrow();
+    await expect(agentMemory2.recall({ threadId: '1' })).resolves.not.toThrow();
   });
 
   it('should inherit storage from Mastra instance when workingMemory is enabled', async () => {
@@ -279,7 +279,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
       const userMessages = messages
         .filter((m: any) => m.role === 'user')
         .map((m: any) => {
@@ -311,7 +311,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
       const userMessages = messages
         .filter((m: any) => m.role === 'user')
         .map((m: any) => m.content.parts?.find((p: any) => p.type === 'text')?.text || '');
@@ -344,7 +344,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
 
       // Assert that the context messages are NOT saved
       const savedContextMessages = messages.filter((m: any) => {
@@ -398,7 +398,7 @@ describe('Agent Memory Tests', () => {
 
       // Fetch messages from memory
       const agentMemory = (await agent.getMemory())!;
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
 
       // Check that all user messages were saved
       const savedUserMessages = messages.filter((m: any) => m.role === 'user');
@@ -591,7 +591,7 @@ describe('Agent with message processors', () => {
 
     // Check that tool calls were saved to memory
     const agentMemory = (await memoryProcessorAgent.getMemory())!;
-    const { messages: messagesFromMemory } = await agentMemory.query({ threadId });
+    const { messages: messagesFromMemory } = await agentMemory.recall({ threadId });
     const toolMessages = messagesFromMemory.filter(
       m => m.role === 'tool' || (m.role === 'assistant' && typeof m.content !== 'string'),
     );

--- a/packages/memory/integration-tests/src/performance-testing/performance-tests.ts
+++ b/packages/memory/integration-tests/src/performance-testing/performance-tests.ts
@@ -133,10 +133,10 @@ export function getPerformanceTests(memory: Memory) {
 
         for (const thread of threads) {
           const start = performance.now();
-          await memory.rememberMessages({
+          await memory.recall({
             threadId: thread.id,
-            vectorMessageSearch: searchQuery,
-            config: {
+            vectorSearchString: searchQuery,
+            threadConfig: {
               semanticRecall: {
                 topK: 50,
                 messageRange: { before: 5, after: 5 },

--- a/packages/memory/integration-tests/src/processors.test.ts
+++ b/packages/memory/integration-tests/src/processors.test.ts
@@ -93,7 +93,7 @@ describe('Memory with Processors', () => {
     await memory.saveMessages({ messages: messagesV2 });
 
     // Get messages with a token limit of 250 (should get ~2.5 messages)
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -123,7 +123,7 @@ describe('Memory with Processors', () => {
     });
 
     // Now query with a very high token limit that should return all messages
-    const allMessagesQuery = await memory.query({
+    const allMessagesQuery = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -169,7 +169,7 @@ describe('Memory with Processors', () => {
     await memory.saveMessages({ messages: messagesV2 });
 
     // filter weather tool calls
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -185,7 +185,7 @@ describe('Memory with Processors', () => {
     expect(filterToolResultsByName(result, 'calculator')).toHaveLength(1);
 
     // make another query with no processors to make sure memory messages in DB were not altered and were only filtered from results
-    const queryResult2 = await memory.query({
+    const queryResult2 = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -201,7 +201,7 @@ describe('Memory with Processors', () => {
     expect(filterToolResultsByName(result2, 'calculator')).toHaveLength(1);
 
     // filter all by name
-    const queryResult3 = await memory.query({
+    const queryResult3 = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -216,7 +216,7 @@ describe('Memory with Processors', () => {
     expect(filterToolResultsByName(result3, 'calculator')).toHaveLength(0);
 
     // filter all by default
-    const queryResult4 = await memory.query({
+    const queryResult4 = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -251,7 +251,7 @@ describe('Memory with Processors', () => {
     await memory.saveMessages({ messages });
 
     // Apply multiple processors: first remove weather tool calls, then limit to 250 tokens
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 20,
     });
@@ -358,7 +358,7 @@ describe('Memory with Processors', () => {
     const allUserMessages = responseMessages2.filter((m: CoreMessage) => m.role === 'user');
     expect(allUserMessages.length).toBe(2);
 
-    const remembered = await memory.query({
+    const remembered = await memory.recall({
       threadId: thread.id,
       resourceId,
       perPage: 20,
@@ -431,7 +431,7 @@ describe('Memory with Processors', () => {
     });
 
     // Query with no processors to verify baseline message count
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -454,7 +454,7 @@ describe('Memory with Processors', () => {
     expect(calculatorToolCalls.length).toBeGreaterThan(0);
 
     // Test filtering weather tool calls
-    const weatherQueryResult = await memory.query({
+    const weatherQueryResult = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -475,7 +475,7 @@ describe('Memory with Processors', () => {
     expect(filterToolCallsByName(weatherFilteredResult, 'calculator').length).toBeGreaterThan(0);
 
     // Test token limiting
-    const tokenLimitQuery = await memory.query({
+    const tokenLimitQuery = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -489,7 +489,7 @@ describe('Memory with Processors', () => {
     expect(tokenLimitedResult.length).toBeLessThan(baselineResult.length);
 
     // Test combining processors
-    const combinedQuery = await memory.query({
+    const combinedQuery = await memory.recall({
       threadId,
       perPage: 20,
     });
@@ -541,7 +541,7 @@ describe('Memory with Processors', () => {
     });
 
     // Query the message back
-    const queryResult = await memory.query({
+    const queryResult = await memory.recall({
       threadId: thread.id,
       perPage: 1,
     });

--- a/packages/memory/integration-tests/src/reusable-tests.ts
+++ b/packages/memory/integration-tests/src/reusable-tests.ts
@@ -231,7 +231,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const weatherQuery = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: "How's the temperature outside?",
           threadConfig: {
             lastMessages: 0,
@@ -248,7 +247,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const locationQuery = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'Tell me about cities in France',
           threadConfig: {
             semanticRecall: {
@@ -268,7 +266,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const locationQuery2 = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'Tell me about cities in France',
           threadConfig: {
             semanticRecall: {
@@ -288,7 +285,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const locationQuery3 = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'Tell me about cities in France',
           threadConfig: {
             semanticRecall: {
@@ -322,7 +318,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'topic X',
           threadConfig: {
             lastMessages: 0,
@@ -387,7 +382,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const resultProgramming = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'JavaScript',
           threadConfig: {
             lastMessages: 0,
@@ -402,7 +396,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const resultWeather = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'rainy',
           threadConfig: {
             lastMessages: 0,
@@ -430,7 +423,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'world',
           threadConfig: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
         });
@@ -455,7 +447,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: 'assistant',
           threadConfig: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
         });
@@ -492,7 +483,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const threadScopeResult = await memory.recall({
           threadId: thread1.id,
           resourceId, // resourceId is defined globally in this file
-          perPage: 0,
           vectorSearchString: searchQuery,
           threadConfig: {
             lastMessages: 0,
@@ -514,7 +504,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const resourceScopeResult = await memory.recall({
           threadId: thread1.id, // Still need a threadId, but scope overrides
           resourceId,
-          perPage: 0,
           vectorSearchString: searchQuery,
           threadConfig: {
             lastMessages: 0,
@@ -550,7 +539,6 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const defaultScopeResult = await memory.recall({
           threadId: thread1.id,
           resourceId,
-          perPage: 0,
           vectorSearchString: searchQuery,
           threadConfig: {
             lastMessages: 0,

--- a/packages/memory/integration-tests/src/reusable-tests.ts
+++ b/packages/memory/integration-tests/src/reusable-tests.ts
@@ -231,6 +231,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const weatherQuery = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: "How's the temperature outside?",
           threadConfig: {
             lastMessages: 0,
@@ -247,6 +248,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const locationQuery = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'Tell me about cities in France',
           threadConfig: {
             semanticRecall: {
@@ -266,6 +268,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const locationQuery2 = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'Tell me about cities in France',
           threadConfig: {
             semanticRecall: {
@@ -285,6 +288,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const locationQuery3 = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'Tell me about cities in France',
           threadConfig: {
             semanticRecall: {
@@ -318,6 +322,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const result = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'topic X',
           threadConfig: {
             lastMessages: 0,
@@ -382,6 +387,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const resultProgramming = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'JavaScript',
           threadConfig: {
             lastMessages: 0,
@@ -396,6 +402,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const resultWeather = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'rainy',
           threadConfig: {
             lastMessages: 0,
@@ -423,6 +430,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const result = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'world',
           threadConfig: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
         });
@@ -447,6 +455,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const result = await memory.recall({
           threadId: thread.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: 'assistant',
           threadConfig: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
         });
@@ -483,6 +492,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const threadScopeResult = await memory.recall({
           threadId: thread1.id,
           resourceId, // resourceId is defined globally in this file
+          perPage: 0,
           vectorSearchString: searchQuery,
           threadConfig: {
             lastMessages: 0,
@@ -504,6 +514,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const resourceScopeResult = await memory.recall({
           threadId: thread1.id, // Still need a threadId, but scope overrides
           resourceId,
+          perPage: 0,
           vectorSearchString: searchQuery,
           threadConfig: {
             lastMessages: 0,
@@ -539,6 +550,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const defaultScopeResult = await memory.recall({
           threadId: thread1.id,
           resourceId,
+          perPage: 0,
           vectorSearchString: searchQuery,
           threadConfig: {
             lastMessages: 0,

--- a/packages/memory/integration-tests/src/reusable-tests.ts
+++ b/packages/memory/integration-tests/src/reusable-tests.ts
@@ -136,21 +136,19 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const messages = Array.from({ length: 15 }, (_, i) => createTestMessage(thread.id, `Message ${i + 1}`));
         await memory.saveMessages({ messages });
 
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 10 },
+          perPage: 10,
         });
         expect(result.messages).toHaveLength(10); // lastMessages is set to 10
         expect(getTextContent(result.messages[0])).toBe('Message 6'); // First message
         expect(getTextContent(result.messages[9])).toBe('Message 15'); // Last message
 
-        const result2 = await memory.rememberMessages({
+        const result2 = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: {
-            lastMessages: 15,
-          },
+          perPage: 15,
         });
         expect(result2.messages).toHaveLength(15); // lastMessages is set to 10
         expect(getTextContent(result2.messages[0])).toBe('Message 1'); // First message
@@ -166,10 +164,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         ];
 
         await memory.saveMessages({ messages: conversation });
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 10 },
+          perPage: 10,
         });
 
         // Verify conversation flow is maintained
@@ -204,7 +202,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
           }),
         ).resolves.not.toThrow();
 
-        const { messages } = await memory.query({
+        const { messages } = await memory.recall({
           threadId,
           resourceId,
           vectorSearchString: content,
@@ -230,11 +228,14 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         await memory.saveMessages({ messages });
 
         // Search for weather-related messages
-        const weatherQuery = await memory.rememberMessages({
+        const weatherQuery = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 0, semanticRecall: { messageRange: 1, topK: 1 } },
-          vectorMessageSearch: "How's the temperature outside?",
+          vectorSearchString: "How's the temperature outside?",
+          threadConfig: {
+            lastMessages: 0,
+            semanticRecall: { messageRange: 1, topK: 1 },
+          },
         });
 
         // Should find the weather-related messages due to semantic similarity
@@ -243,11 +244,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         expect(getTextContent(weatherQuery.messages[1])).toBe("Yes, it's sunny and warm");
 
         // Search for location-related messages
-        const locationQuery = await memory.rememberMessages({
+        const locationQuery = await memory.recall({
           threadId: thread.id,
           resourceId,
-          vectorMessageSearch: 'Tell me about cities in France',
-          config: {
+          vectorSearchString: 'Tell me about cities in France',
+          threadConfig: {
             semanticRecall: {
               topK: 1,
               messageRange: { after: 1, before: 0 },
@@ -262,11 +263,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         expect(getTextContent(locationQuery.messages[1])).toBe('The capital of France is Paris');
 
         // Search for location-related messages
-        const locationQuery2 = await memory.rememberMessages({
+        const locationQuery2 = await memory.recall({
           threadId: thread.id,
           resourceId,
-          vectorMessageSearch: 'Tell me about cities in France',
-          config: {
+          vectorSearchString: 'Tell me about cities in France',
+          threadConfig: {
             semanticRecall: {
               topK: 1,
               messageRange: { after: 0, before: 1 },
@@ -281,11 +282,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         expect(getTextContent(locationQuery2.messages[1])).toBe("What's the capital of France?");
 
         // Search for location-related messages
-        const locationQuery3 = await memory.rememberMessages({
+        const locationQuery3 = await memory.recall({
           threadId: thread.id,
           resourceId,
-          vectorMessageSearch: 'Tell me about cities in France',
-          config: {
+          vectorSearchString: 'Tell me about cities in France',
+          threadConfig: {
             semanticRecall: {
               topK: 1,
               messageRange: { after: 1, before: 1 },
@@ -314,11 +315,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         ];
         await memory.saveMessages({ messages });
 
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          vectorMessageSearch: 'topic X',
-          config: {
+          vectorSearchString: 'topic X',
+          threadConfig: {
             lastMessages: 0,
             semanticRecall: {
               topK: 1,
@@ -378,28 +379,28 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         });
 
         // Semantic search for a TextPart topic
-        const resultProgramming = await memory.rememberMessages({
+        const resultProgramming = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: {
+          vectorSearchString: 'JavaScript',
+          threadConfig: {
             lastMessages: 0,
             semanticRecall: { messageRange: 0, topK: 1 },
           },
-          vectorMessageSearch: 'JavaScript',
         });
         const programmingContents = resultProgramming.messages.map(m => getTextContent(m));
         expect(programmingContents).toContain('JavaScript is a versatile language.');
         expect(programmingContents).not.toContain('The weather is rainy and cold.');
 
         // Semantic search for a string topic
-        const resultWeather = await memory.rememberMessages({
+        const resultWeather = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: {
+          vectorSearchString: 'rainy',
+          threadConfig: {
             lastMessages: 0,
             semanticRecall: { messageRange: 0, topK: 1 },
           },
-          vectorMessageSearch: 'rainy',
         });
         const weatherContents = resultWeather.messages.map(m => getTextContent(m));
         expect(weatherContents).toContain('The weather is rainy and cold.');
@@ -419,11 +420,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         );
         await memory.saveMessages({ messages: [multiTextParts] });
 
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
-          vectorMessageSearch: 'world',
+          vectorSearchString: 'world',
+          threadConfig: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
         });
         const contents = result.messages.map(m => getTextContent(m));
         expect(contents[0]).toContain('world');
@@ -443,11 +444,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         );
         await memory.saveMessages({ messages: [assistantTextParts] });
 
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
-          vectorMessageSearch: 'assistant',
+          vectorSearchString: 'assistant',
+          threadConfig: { lastMessages: 0, semanticRecall: { messageRange: 0, topK: 1, scope: 'thread' } },
         });
         const contents = result.messages.map(m => getTextContent(m));
         expect(contents[0]).toContain('Assistant says hello.');
@@ -479,11 +480,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const searchQuery = 'Tell me about the color blue';
 
         // 1. Test thread scope (explicitly set)
-        const threadScopeResult = await memory.rememberMessages({
+        const threadScopeResult = await memory.recall({
           threadId: thread1.id,
           resourceId, // resourceId is defined globally in this file
-          vectorMessageSearch: searchQuery,
-          config: {
+          vectorSearchString: searchQuery,
+          threadConfig: {
             lastMessages: 0,
             semanticRecall: {
               topK: 1,
@@ -500,11 +501,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         expect(getTextContent(threadScopeResult.messages[1])).toBe('Yes, very clear skies');
 
         // 2. Test resource scope (explicitly set)
-        const resourceScopeResult = await memory.rememberMessages({
+        const resourceScopeResult = await memory.recall({
           threadId: thread1.id, // Still need a threadId, but scope overrides
           resourceId,
-          vectorMessageSearch: searchQuery,
-          config: {
+          vectorSearchString: searchQuery,
+          threadConfig: {
             lastMessages: 0,
             semanticRecall: {
               topK: 5, // Increase topK to potentially get both matches
@@ -535,11 +536,11 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         ).toBe(true);
 
         // 3. Test default scope (should be resource now)
-        const defaultScopeResult = await memory.rememberMessages({
+        const defaultScopeResult = await memory.recall({
           threadId: thread1.id,
           resourceId,
-          vectorMessageSearch: searchQuery,
-          config: {
+          vectorSearchString: searchQuery,
+          threadConfig: {
             lastMessages: 0,
             semanticRecall: {
               topK: 5,
@@ -586,12 +587,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const messages = messageList.get.all.db();
 
         await memory.saveMessages({ messages });
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: {
-            lastMessages: 10,
-          },
+          perPage: 10,
         });
 
         expect(result.messages).toHaveLength(3);
@@ -610,10 +609,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
           createTestMessage(thread.id, [assistantPart], 'assistant', 'text'),
         ];
         await memory.saveMessages({ messages });
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 10 },
+          perPage: 10,
         });
         expect(result.messages).toHaveLength(2);
         expect(result.messages[0]).toMatchObject({
@@ -645,12 +644,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
           messages: [createTestMessage(thread.id, complexMessage, 'assistant')],
         });
 
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: {
-            lastMessages: 10,
-          },
+          perPage: 10,
         });
         expect(result.messages[0].content.parts).toEqual(complexMessage);
       });
@@ -670,7 +667,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         await memory.deleteMessages([messageToDelete.id]);
 
         // Verify message is deleted
-        const remainingMessages = await memory.query({
+        const remainingMessages = await memory.recall({
           threadId: thread.id,
           perPage: 10,
         });
@@ -723,7 +720,7 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         // Delete the complex message
         await memory.deleteMessages([savedMessages.messages[1].id]);
 
-        const remainingMessages = await memory.query({
+        const remainingMessages = await memory.recall({
           threadId: thread.id,
           perPage: 10,
         });
@@ -748,14 +745,14 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         await memory.deleteMessages([message1.id]);
 
         // Verify first thread has no messages
-        const thread1Messages = await memory.query({
+        const thread1Messages = await memory.recall({
           threadId: thread.id,
           perPage: 10,
         });
         expect(thread1Messages.messages).toHaveLength(0);
 
         // Verify second thread still has its message
-        const thread2Messages = await memory.query({
+        const thread2Messages = await memory.recall({
           threadId: otherThread.id,
           perPage: 10,
         });
@@ -773,10 +770,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const messages = [createTestMessage(thread.id, 'Test message')];
         await memory.saveMessages({ messages });
 
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 10 },
+          perPage: 10,
         });
 
         expect(result.messages).toHaveLength(1);
@@ -789,10 +786,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         await memory.saveMessages({ messages });
 
         await expect(
-          memory.rememberMessages({
+          memory.recall({
             threadId: thread.id,
             resourceId: 'wrong-resource',
-            config: { lastMessages: 10 },
+            perPage: 10,
           }),
         ).rejects.toThrow(
           `Thread with id ${thread.id} is for resource with id ${resourceId} but resource wrong-resource was queried`,
@@ -803,9 +800,9 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         const messages = [createTestMessage(thread.id, 'Test message')];
         await memory.saveMessages({ messages });
 
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
-          config: { lastMessages: 10 },
+          perPage: 10,
         });
 
         expect(result.messages).toHaveLength(1);
@@ -834,10 +831,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
         await expect(Promise.all(promises)).resolves.not.toThrow();
 
         // Verify all messages were saved
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: thread.id,
           resourceId,
-          config: { lastMessages: 20 },
+          perPage: 20,
         });
         expect(result.messages).toHaveLength(messagesBatches.flat().length);
       });
@@ -1039,10 +1036,10 @@ export function getResuableTests(memory: Memory, workerTestConfig?: WorkerTestCo
           console.error('Error during reusable worker execution:', error);
           throw error;
         }
-        const result = await memory.rememberMessages({
+        const result = await memory.recall({
           threadId: mainThread.id,
           resourceId,
-          config: { lastMessages: totalMessages },
+          perPage: totalMessages,
         });
         expect(result.messages).toHaveLength(totalMessages);
 

--- a/packages/memory/integration-tests/src/streaming-memory.test.ts
+++ b/packages/memory/integration-tests/src/streaming-memory.test.ts
@@ -120,7 +120,7 @@ describe('Memory Streaming Tests', () => {
     });
 
     const agentMemory = (await agent.getMemory())!;
-    const { messages } = await agentMemory.query({ threadId });
+    const { messages } = await agentMemory.recall({ threadId });
 
     console.log('Custom IDs: ', customIds);
     console.log('Messages: ', messages);
@@ -254,7 +254,7 @@ describe('Memory Streaming Tests', () => {
 
       const agentMemory = (await weatherAgent.getMemory())!;
       // Get initial messages from memory and convert to AI SDK v4 format
-      const { messages } = await agentMemory.query({ threadId });
+      const { messages } = await agentMemory.recall({ threadId });
       const initialMessages = messages.map(m => MessageList.mastraDBMessageToAIV4UIMessage(m)) as Message[];
       const state = { clipboard: '' };
       const { result } = renderHook(() => {

--- a/packages/memory/integration-tests/src/with-pg-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-pg-storage.test.ts
@@ -107,7 +107,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test 1: Query with pagination - page 0, perPage 3
       console.log('Testing pagination: page 0, perPage 3');
-      const result1 = await memory.query({
+      const result1 = await memory.recall({
         threadId,
         resourceId,
         page: 0,
@@ -123,7 +123,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test 2: Query with pagination - page 1, perPage 3
       console.log('Testing pagination: page 1, perPage 3');
-      const result2 = await memory.query({
+      const result2 = await memory.recall({
         threadId,
         resourceId,
         page: 1,
@@ -137,7 +137,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test 3: Query with pagination - page 0, perPage 1
       console.log('Testing pagination: page 0, perPage 1 (original bug report)');
-      const result3 = await memory.query({
+      const result3 = await memory.recall({
         threadId,
         resourceId,
         page: 0,
@@ -149,7 +149,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test 4: Query with pagination - page 9, perPage 1 (last page)
       console.log('Testing pagination: page 9, perPage 1 (last page)');
-      const result4 = await memory.query({
+      const result4 = await memory.recall({
         threadId,
         resourceId,
         page: 9,
@@ -161,7 +161,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test 5: Query with pagination - page 1, perPage 5 (partial last page)
       console.log('Testing pagination: page 1, perPage 5 (partial last page)');
-      const result5 = await memory.query({
+      const result5 = await memory.recall({
         threadId,
         resourceId,
         page: 1,
@@ -174,7 +174,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test 6: Query without pagination should still work
       console.log('Testing query without pagination (backward compatibility)');
-      const result6 = await memory.query({
+      const result6 = await memory.recall({
         threadId,
         resourceId,
         perPage: 5,
@@ -204,7 +204,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test: Page beyond available data
       console.log('Testing pagination beyond available data');
-      const result1 = await memory.query({
+      const result1 = await memory.recall({
         threadId,
         resourceId,
         page: 5,
@@ -215,7 +215,7 @@ describe('Memory with PostgresStore Integration', () => {
 
       // Test: perPage larger than total messages
       console.log('Testing perPage larger than total messages');
-      const result2 = await memory.query({
+      const result2 = await memory.recall({
         threadId,
         resourceId,
         page: 0,

--- a/packages/memory/integration-tests/src/with-pg-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-pg-storage.test.ts
@@ -274,7 +274,7 @@ describe('Memory with PostgresStore Integration', () => {
       });
 
       // Query to verify the index works
-      const result = await hnswMemory.query({
+      const result = await hnswMemory.recall({
         threadId,
         resourceId,
         vectorSearchString: 'HNSW test',
@@ -329,7 +329,7 @@ describe('Memory with PostgresStore Integration', () => {
       });
 
       // Query to verify the index works
-      const result = await ivfflatMemory.query({
+      const result = await ivfflatMemory.recall({
         threadId,
         resourceId,
         vectorSearchString: 'IVFFlat test',
@@ -381,7 +381,7 @@ describe('Memory with PostgresStore Integration', () => {
       });
 
       // Query to verify the index works
-      const result = await flatMemory.query({
+      const result = await flatMemory.recall({
         threadId,
         resourceId,
         vectorSearchString: 'flat scan test',
@@ -457,7 +457,7 @@ describe('Memory with PostgresStore Integration', () => {
       });
 
       // Query should work with new index
-      const result = await memory2.query({
+      const result = await memory2.recall({
         threadId,
         resourceId,
       });
@@ -528,7 +528,7 @@ describe('Memory with PostgresStore Integration', () => {
       });
 
       // Query should work with preserved HNSW index
-      const result = await memory2.query({
+      const result = await memory2.recall({
         threadId,
         resourceId,
       });

--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -244,9 +244,9 @@ describe('Working Memory Tests', () => {
 
       await memory.saveMessages({ messages });
 
-      const remembered = await memory.rememberMessages({
+      const remembered = await memory.recall({
         threadId: thread.id,
-        config: { lastMessages: 10 },
+        perPage: 10,
       });
 
       // Working memory tags should be stripped from the messages
@@ -391,7 +391,7 @@ describe('Working Memory Tests', () => {
         expect(workingMemory).toContain('**Location**: Vancouver Island');
       }
 
-      const history = await memory.query({
+      const history = await memory.recall({
         threadId: thread.id,
         resourceId,
         perPage: 20,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -99,13 +99,14 @@ export class Memory extends MastraMemory {
     }
   }
 
-  async query(
+  async recall(
     args: StorageListMessagesInput & {
       threadConfig?: MemoryConfig;
-      vectorSearchString?: string;
+      vectorMessageSearch?: string;
     },
   ): Promise<{ messages: MastraDBMessage[] }> {
-    const { threadId, resourceId, perPage, page, orderBy, threadConfig, vectorSearchString, filter } = args;
+    const { threadId, resourceId, perPage, page, orderBy, threadConfig, vectorMessageSearch, filter } = args;
+    const vectorSearchString = vectorMessageSearch; // For backward compatibility with internal logic
     const config = this.getMergedThreadConfig(threadConfig || {});
     if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, config);
 
@@ -116,7 +117,7 @@ export class Memory extends MastraMemory {
       vector?: number[];
     }[] = [];
 
-    this.logger.debug(`Memory query() with:`, {
+    this.logger.debug(`Memory recall() with:`, {
       threadId,
       perPage,
       page,
@@ -215,34 +216,6 @@ export class Memory extends MastraMemory {
     const messages = list.get.all.db();
 
     return { messages };
-  }
-
-  async rememberMessages(args: {
-    threadId: string;
-    resourceId?: string;
-    vectorMessageSearch?: string;
-    config?: MemoryConfig;
-  }): Promise<{ messages: MastraDBMessage[] }> {
-    const { threadId, resourceId, vectorMessageSearch, config } = args;
-
-    const threadConfig = this.getMergedThreadConfig(config || {});
-    if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, threadConfig);
-
-    if (!threadConfig.lastMessages && !threadConfig.semanticRecall) {
-      return { messages: [] };
-    }
-
-    const messagesResult = await this.query({
-      resourceId,
-      threadId,
-      perPage: threadConfig.lastMessages,
-      vectorSearchString: threadConfig.semanticRecall && vectorMessageSearch ? vectorMessageSearch : undefined,
-      threadConfig: config,
-    });
-
-    // Always return mastra-db format (V2) in object wrapper for consistency
-    this.logger.debug(`Remembered message history includes ${messagesResult.messages.length} messages.`);
-    return messagesResult;
   }
 
   async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -102,25 +102,12 @@ export class Memory extends MastraMemory {
   async recall(
     args: StorageListMessagesInput & {
       threadConfig?: MemoryConfig;
-      vectorMessageSearch?: string;
+      vectorSearchString?: string;
     },
   ): Promise<{ messages: MastraDBMessage[] }> {
-    const {
-      threadId,
-      resourceId,
-      perPage: perPageArg,
-      page,
-      orderBy,
-      threadConfig,
-      vectorMessageSearch,
-      filter,
-    } = args;
-    const vectorSearchString = vectorMessageSearch; // For backward compatibility with internal logic
+    const { threadId, resourceId, perPage, page, orderBy, threadConfig, vectorSearchString, filter } = args;
     const config = this.getMergedThreadConfig(threadConfig || {});
     if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, config);
-
-    // Use perPage from args if provided, otherwise derive from threadConfig.lastMessages
-    const perPage = perPageArg !== undefined ? perPageArg : config.lastMessages;
 
     const vectorResults: {
       id: string;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -105,10 +105,22 @@ export class Memory extends MastraMemory {
       vectorMessageSearch?: string;
     },
   ): Promise<{ messages: MastraDBMessage[] }> {
-    const { threadId, resourceId, perPage, page, orderBy, threadConfig, vectorMessageSearch, filter } = args;
+    const {
+      threadId,
+      resourceId,
+      perPage: perPageArg,
+      page,
+      orderBy,
+      threadConfig,
+      vectorMessageSearch,
+      filter,
+    } = args;
     const vectorSearchString = vectorMessageSearch; // For backward compatibility with internal logic
     const config = this.getMergedThreadConfig(threadConfig || {});
     if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, config);
+
+    // Use perPage from args if provided, otherwise derive from threadConfig.lastMessages
+    const perPage = perPageArg !== undefined ? perPageArg : config.lastMessages;
 
     const vectorResults: {
       id: string;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -105,9 +105,12 @@ export class Memory extends MastraMemory {
       vectorSearchString?: string;
     },
   ): Promise<{ messages: MastraDBMessage[] }> {
-    const { threadId, resourceId, perPage, page, orderBy, threadConfig, vectorSearchString, filter } = args;
+    const { threadId, resourceId, perPage: perPageArg, page, orderBy, threadConfig, vectorSearchString, filter } = args;
     const config = this.getMergedThreadConfig(threadConfig || {});
     if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, config);
+
+    // Use perPage from args if provided, otherwise use threadConfig.lastMessages
+    const perPage = perPageArg !== undefined ? perPageArg : config.lastMessages;
 
     const vectorResults: {
       id: string;

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -448,7 +448,7 @@ describe('Memory Handlers', () => {
 
       const saveSpy = vi.spyOn(mockMemory, 'saveMessages');
       vi.spyOn(mockMemory, 'getThreadById');
-      vi.spyOn(mockMemory, 'query');
+      vi.spyOn(mockMemory, 'recall');
 
       // Save both messages
       const saveResponse = await saveMessagesHandler({
@@ -779,7 +779,7 @@ describe('Memory Handlers', () => {
       });
 
       vi.spyOn(mockMemory, 'getThreadById');
-      vi.spyOn(mockMemory, 'query');
+      vi.spyOn(mockMemory, 'recall');
 
       const result = await getMessagesHandler({ mastra, threadId, agentId: 'test-agent' });
 
@@ -854,7 +854,7 @@ describe('Memory Handlers', () => {
       });
 
       vi.spyOn(mockMemory, 'getThreadById');
-      vi.spyOn(mockMemory, 'query');
+      vi.spyOn(mockMemory, 'recall');
 
       const result = await getMessagesHandler({ mastra, threadId, agentId: 'test-agent' });
 
@@ -905,7 +905,7 @@ describe('Memory Handlers', () => {
       });
 
       vi.spyOn(mockMemory, 'getThreadById');
-      vi.spyOn(mockMemory, 'query');
+      vi.spyOn(mockMemory, 'recall');
 
       const result = await getMessagesHandler({ mastra, threadId, agentId: 'test-agent' });
 
@@ -981,7 +981,7 @@ describe('Memory Handlers', () => {
       });
 
       vi.spyOn(mockMemory, 'getThreadById');
-      vi.spyOn(mockMemory, 'query');
+      vi.spyOn(mockMemory, 'recall');
 
       const result = await getMessagesHandler({ mastra, threadId, agentId: 'test-agent' });
 

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -379,7 +379,7 @@ export async function getMessagesHandler({
 
     const result = await memory.recall({
       threadId: threadId,
-      ...(limit && { selectBy: { last: limit } }),
+      ...(limit && { perPage: limit }),
     });
     const uiMessages = convertMessages(result.messages).to('AIV5.UI');
     return { messages: result.messages, uiMessages };

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -625,7 +625,7 @@ export async function searchMemoryHandler({
     // The Memory class handles scope (thread vs resource) internally
     const threadConfig = memory.getMergedThreadConfig(config || {});
     if (!threadConfig.lastMessages && !threadConfig.semanticRecall) {
-      return { messages: [] };
+      return { results: [], count: 0, query: searchQuery };
     }
 
     const result = await memory.recall({

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -633,7 +633,7 @@ export async function searchMemoryHandler({
       resourceId,
       perPage: threadConfig.lastMessages,
       threadConfig: config,
-      vectorMessageSearch: threadConfig.semanticRecall && searchQuery ? searchQuery : undefined,
+      vectorSearchString: threadConfig.semanticRecall && searchQuery ? searchQuery : undefined,
     });
 
     // Get all threads to build context and show which thread each message is from

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -377,7 +377,7 @@ export async function getMessagesHandler({
       throw new HTTPException(404, { message: 'Thread not found' });
     }
 
-    const result = await memory.query({
+    const result = await memory.recall({
       threadId: threadId,
       ...(limit && { selectBy: { last: limit } }),
     });
@@ -621,13 +621,19 @@ export async function searchMemoryHandler({
           : { ...config.semanticRecall, messageRange: 0 };
     }
 
-    // Single call to rememberMessages - just like the agent does
+    // Single call to recall - just like the agent does
     // The Memory class handles scope (thread vs resource) internally
-    const result = await memory.rememberMessages({
+    const threadConfig = memory.getMergedThreadConfig(config || {});
+    if (!threadConfig.lastMessages && !threadConfig.semanticRecall) {
+      return { messages: [] };
+    }
+
+    const result = await memory.recall({
       threadId,
       resourceId,
-      vectorMessageSearch: searchQuery,
-      config,
+      perPage: threadConfig.lastMessages,
+      threadConfig: config,
+      vectorMessageSearch: threadConfig.semanticRecall && searchQuery ? searchQuery : undefined,
     });
 
     // Get all threads to build context and show which thread each message is from
@@ -649,7 +655,7 @@ export async function searchMemoryHandler({
       const thread = threadMap.get(msgThreadId);
 
       // Get thread messages for context
-      const threadMessages = (await memory.query({ threadId: msgThreadId })).messages;
+      const threadMessages = (await memory.recall({ threadId: msgThreadId })).messages;
       const messageIndex = threadMessages.findIndex(m => m.id === msg.id);
 
       const searchResult: SearchResult = {


### PR DESCRIPTION
This simplifies the Memory API by removing the confusing rememberMessages method and renaming query to recall for better clarity.

The rememberMessages method name implied it might persist data when it was actually just retrieving messages, same as query. Having two methods that did essentially the same thing was unnecessary.

Before:
```typescript
// Two methods that did the same thing
memory.rememberMessages({ threadId, resourceId, config, vectorMessageSearch })
memory.query({ threadId, resourceId, perPage, vectorSearchString })
```

After:
```typescript
// Single unified method with clear purpose
memory.recall({ threadId, resourceId, perPage, vectorMessageSearch, threadConfig })
```

All usages have been updated across the codebase including tests. The agent now calls recall directly with the appropriate parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Message retrieval unified under a single recall API with renamed parameters (perPage, vectorSearchString) and threadConfig-driven per-thread settings; handlers now skip work when no recall criteria exist.

* **Bug Fixes**
  * Storage now rejects empty thread IDs instead of returning an empty list.

* **Tests**
  * Test suite updated to use the recall API and adjusted input shapes across integration and unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->