### PR TITLE
fix: combine assistant messages in stream() calls

### DIFF
--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1-reasoning.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1-reasoning.test.ts
@@ -233,35 +233,33 @@ describe('convertToV1Messages - reasoning and file support', () => {
 
     const result = convertToV1Messages(messages);
 
-    // Should split at tool invocation
-    // 1. Text + file + reasoning + text
-    // 2. Tool call
-    // 3. Tool result
-    // 4. Final text
-    expect(result.length).toBe(4);
+    // With combined assistant messages, content before tool result stays together
+    // 1. Text + file + reasoning + text (all combined, no tool-call since it's a result)
+    // 2. Tool result
+    // 3. Final text
+    expect(result.length).toBe(3);
 
-    // First message: combined content before tool
+    // First message: combined content with tool-call
     expect(result[0].role).toBe('assistant');
-    expect(result[0].type).toBe('text');
+    // With our change, assistant messages are combined, including tool-calls
+    // The type will be 'tool-call' if there's at least one tool-call part
+    expect(result[0].type).toBe('tool-call');
     if (Array.isArray(result[0].content)) {
-      expect(result[0].content.length).toBe(4);
+      expect(result[0].content.length).toBe(5); // text, file, reasoning, text, tool-call
       expect(result[0].content[0].type).toBe('text');
       expect(result[0].content[1].type).toBe('file');
       expect(result[0].content[2].type).toBe('reasoning');
       expect(result[0].content[3].type).toBe('text');
+      expect(result[0].content[4].type).toBe('tool-call');
     }
 
-    // Second message: tool call
-    expect(result[1].role).toBe('assistant');
-    expect(result[1].type).toBe('tool-call');
+    // Second message: tool result
+    expect(result[1].role).toBe('tool');
+    expect(result[1].type).toBe('tool-result');
 
-    // Third message: tool result
-    expect(result[2].role).toBe('tool');
-    expect(result[2].type).toBe('tool-result');
-
-    // Fourth message: text after tool
-    expect(result[3].role).toBe('assistant');
-    expect(result[3].type).toBe('text');
+    // Third message: text after tool
+    expect(result[2].role).toBe('assistant');
+    expect(result[2].type).toBe('text');
   });
 
   it('should handle file attachments in experimental_attachments', () => {

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -3426,14 +3426,13 @@ describe('MessageList', () => {
       // Now convert back to v1 and see what happens
       const v1Again = newList.get.all.v1();
 
-      // With our improved suffix pattern, messages with __split- suffix should NOT get double-suffixed
-      // Note: v1 tool messages get converted to v2 assistant messages, then split again when converting back
-      expect(v1Again.length).toBe(5); // 5 messages because tool message gets split
+      // With our improved suffix pattern AND combined assistant messages,
+      // assistant tool-call and subsequent text are now combined into one message
+      expect(v1Again.length).toBe(4); // 4 messages because assistant parts are combined
       expect(v1Again[0].id).toBe('user-1');
-      expect(v1Again[1].id).toBe('msg-1');
-      expect(v1Again[2].id).toBe('msg-1__split-1'); // assistant tool-call (preserved)
-      expect(v1Again[3].id).toBe('msg-1__split-1'); // tool result (preserved - no double suffix!)
-      expect(v1Again[4].id).toBe('msg-1__split-2'); // assistant text (preserved)
+      expect(v1Again[1].id).toBe('msg-1'); // assistant with tool-call now combined with text
+      expect(v1Again[2].id).toBe('msg-1__split-1'); // tool result
+      expect(v1Again[3].id).toBe('msg-1__split-2'); // assistant text (now combined with previous assistant)
 
       // Now if we try to convert these v2 messages that came from suffixed v1s
       // We need to check if we get double-suffixed IDs
@@ -3480,7 +3479,8 @@ describe('MessageList', () => {
       const finalV1 = newList.get.all.v1();
 
       // The test shows our fix works! Messages with __split- suffix are not getting double-suffixed
-      expect(finalV1.length).toBeGreaterThanOrEqual(8); // At least 5 existing + 3 new split messages
+      // With combined assistant messages, we now have fewer total messages
+      expect(finalV1.length).toBeGreaterThanOrEqual(5); // At least 4 existing + 1 new message (tool-result and text combined)
 
       // Verify that messages with __split- suffix are preserved (no double-suffixing)
       const splitMessages = finalV1.filter(m => m.id.includes('__split-'));


### PR DESCRIPTION
This fixes the message splitting behavior in stream() calls by combining consecutive assistant messages into a single message with multiple parts.

Previously, assistant messages with different content types (text, tool-calls) were split into separate messages for backwards compatibility. Since we no longer need v1 message compatibility inside stream(), we can now combine them.

The main change is removing the tool-call exception that prevented assistant messages from being combined, and adding logic to recalculate the message type when combining messages.

Before:
- Assistant message with text
- Assistant message with tool-call (separate)
- Tool result
- Assistant message with text (separate)

After:
- Assistant message with text + tool-call (combined)
- Tool result
- Assistant message with text

This results in cleaner message handling and fewer split messages with __split-N suffixes.