### PR TITLE
Fix documentation on threads & resources

### DIFF
--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -112,13 +112,13 @@ Include a `memory` object with both `resource` and `thread` to track conversatio
 
 These fields tell the agent where to store and retrieve context, enabling persistent, thread-aware memory across a conversation.
 
-```typescript {3-4}
+```typescript {5-6}
 const response = await memoryAgent.generate(
   "Remember my favorite color is blue.",
   {
     memory: {
-      thread: "user-123",
-      resource: "test-123",
+      resource: "user-123",
+      thread: "conversation-123",
     },
   },
 );
@@ -129,8 +129,8 @@ To recall information stored in memory, call the agent with the same `resource` 
 ```typescript {3-4}
 const response = await memoryAgent.generate("What's my favorite color?", {
   memory: {
-    thread: "user-123",
-    resource: "test-123",
+    resource: "user-123",
+    thread: "conversation-123",
   },
 });
 ```

--- a/docs/src/content/en/docs/memory/threads-and-resources.mdx
+++ b/docs/src/content/en/docs/memory/threads-and-resources.mdx
@@ -15,8 +15,8 @@ The `resource` is especially important for [resource-scoped memory](./working-me
 ```typescript {4} showLineNumbers
 const stream = await agent.stream("message for agent", {
   memory: {
-    thread: "user-123",
-    resource: "test-123",
+    thread: "conversation-123",
+    resource: "user-123",
   },
 });
 ```


### PR DESCRIPTION
## Description

This PR fixes the examples for resources and threads, which originally contradicted with the documentation (resources are for users/orgs/etc, yet it said `thread: 'user-123'` which seemed confusing/contradictory.).

Also fixed some code highlighting:

<img width="790" height="492" alt="CleanShot 2025-11-05 at 09 06 27@2x" src="https://github.com/user-attachments/assets/81e2e668-4a64-4bbf-9598-85d29cdb7458" />

## Related Issue(s)

None

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ (N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in memory and thread documentation to clarify field ordering conventions
  * Refined example values for improved consistency and clarity in memory usage documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->