### PR TITLE
Add readable-streams to global externals, not compatible with CJS compilation

### DIFF
--- a/.changeset/some-rivers-jog.md
+++ b/.changeset/some-rivers-jog.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Add readable-streams to global externals, not compatible with CJS compilation

--- a/packages/deployer/src/build/analyze/constants.ts
+++ b/packages/deployer/src/build/analyze/constants.ts
@@ -9,5 +9,6 @@ export const GLOBAL_EXTERNALS = [
   '#tools',
   'typescript',
   'undici',
+  'readable-stream',
 ];
 export const DEPRECATED_EXTERNALS = ['fastembed', 'nodemailer', 'jsdom', 'sqlite3'];


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Add readable-streams to global externals, not compatible with CJS compilation

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated global external dependencies configuration to address CommonJS compilation compatibility. This change ensures proper handling of stream dependencies in deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->