### PR TITLE
fix: Filter incomplete client-side tool calls when sending messages to LLM

### DIFF
--- a/.changeset/wicked-lemons-listen.md
+++ b/.changeset/wicked-lemons-listen.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Fix message conversion and Gemini API compatibility for tool-call messages
+
+Two related fixes for handling messages with tool-calls:
+
+1. **Stop filtering out input-available tool states in sanitizeV5UIMessages()**: Previously, `input-available` states (completed tool-calls) were being filtered out, causing assistant messages with only tool-calls to be dropped entirely. This broke loop tests with prepareStep. Now only `input-streaming` states are filtered, preserving completed tool-call messages.
+
+2. **Filter problematic patterns before sending to Gemini**: When passing historical conversation messages with tool-calls to agent.network(), the AI SDK's convertToModelMessages creates empty tool messages and duplicate assistant messages. Added filterGeminiIncompatibleMessages() helper that removes these patterns before sending to Gemini, while preserving complete message history in response.messages for internal use and testing.

--- a/packages/core/src/agent/agent-gemini.test.ts
+++ b/packages/core/src/agent/agent-gemini.test.ts
@@ -232,7 +232,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 15000);
 
     it('should handle empty user message with system context in network', async () => {
@@ -269,7 +269,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 60000);
 
     it('should handle single turn with maxSteps=1 and messages ending with assistant in network', async () => {
@@ -306,7 +306,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 15000);
 
     it('should handle conversation ending with tool result in network (with follow-up user message)', async () => {
@@ -366,7 +366,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 15000);
 
     it('should handle conversation ending with tool result in network (agentic loop pattern)', async () => {
@@ -425,7 +425,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 15000);
 
     it('should handle messages starting with assistant-with-tool-call in network', async () => {
@@ -484,7 +484,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 15000);
 
     it('should handle network with workflow execution', async () => {
@@ -540,7 +540,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 20000);
 
     it('should handle simple conversation ending with assistant in network', async () => {
@@ -569,7 +569,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 15000);
 
     it('should handle messages with only assistant role in network', async () => {
@@ -600,7 +600,7 @@ describe('Gemini Model Compatibility Tests', () => {
       }
 
       expect(chunks).toBeDefined();
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.length).toBeGreaterThan(1);
     }, 15000);
   });
 });

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -279,7 +279,7 @@ export class MessageList {
         // Filter incomplete tool calls when sending messages TO the LLM
         const modelMessages = this.aiV5UIMessagesToAIV5ModelMessages(this.all.aiV5.ui(), true);
 
-        let messages = [...systemMessages, ...modelMessages];
+        const messages = [...systemMessages, ...modelMessages];
 
         return ensureGeminiCompatibleMessages(messages);
       },
@@ -361,7 +361,7 @@ export class MessageList {
       // Used when calling AI SDK streamText/generateText
       prompt: () => {
         const coreMessages = this.all.aiV4.core();
-        let messages = [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat(), ...coreMessages];
+        const messages = [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat(), ...coreMessages];
 
         return ensureGeminiCompatibleMessages(messages);
       },

--- a/packages/core/src/agent/message-list/utils/ai-v5/gemini-compatibility.ts
+++ b/packages/core/src/agent/message-list/utils/ai-v5/gemini-compatibility.ts
@@ -5,6 +5,52 @@ import { ErrorCategory, ErrorDomain, MastraError } from '../../../../error';
 type GeminiCompatibleMessage = ModelMessage | CoreMessage;
 
 /**
+ * Filters out problematic message patterns that Gemini rejects.
+ *
+ * This removes:
+ * 1. Empty tool messages (messages with role='tool' but no content)
+ * 2. Duplicate assistant messages with only tool-calls (artifacts from convertToModelMessages)
+ *
+ * These patterns can occur when historical conversation messages with tool-calls
+ * are passed through the AI SDK's convertToModelMessages function, which splits
+ * them in ways that create invalid message structures for Gemini.
+ *
+ * @param messages - Array of model messages to filter
+ * @returns Filtered messages array without problematic patterns
+ */
+export function filterGeminiIncompatibleMessages<T extends GeminiCompatibleMessage>(messages: T[]): T[] {
+  return messages.filter((msg, idx) => {
+    // Remove empty tool messages
+    if (msg.role === 'tool' && Array.isArray(msg.content) && msg.content.length === 0) {
+      return false;
+    }
+
+    // Remove duplicate assistant messages with only tool-calls
+    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+      const hasOnlyToolCalls = msg.content.every(p => p.type === 'tool-call');
+      if (hasOnlyToolCalls && msg.content.length > 0) {
+        const toolCallIds = msg.content.filter(p => p.type === 'tool-call').map(p => p.toolCallId);
+
+        // Check if there's another assistant message later with the same tool-call IDs
+        const hasDuplicateLater = messages.slice(idx + 1).some(laterMsg => {
+          if (laterMsg.role !== 'assistant' || !Array.isArray(laterMsg.content)) return false;
+
+          const laterToolCallIds = laterMsg.content.filter(p => p.type === 'tool-call').map(p => p.toolCallId);
+
+          return toolCallIds.some(id => laterToolCallIds.includes(id));
+        });
+
+        if (hasDuplicateLater) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  });
+}
+
+/**
  * Ensures message array is compatible with Gemini API requirements.
  *
  * Gemini requires that the first non-system message must be from the user role.

--- a/packages/core/src/agent/message-list/utils/ai-v5/gemini-compatibility.ts
+++ b/packages/core/src/agent/message-list/utils/ai-v5/gemini-compatibility.ts
@@ -5,52 +5,6 @@ import { ErrorCategory, ErrorDomain, MastraError } from '../../../../error';
 type GeminiCompatibleMessage = ModelMessage | CoreMessage;
 
 /**
- * Filters out problematic message patterns that Gemini rejects.
- *
- * This removes:
- * 1. Empty tool messages (messages with role='tool' but no content)
- * 2. Duplicate assistant messages with only tool-calls (artifacts from convertToModelMessages)
- *
- * These patterns can occur when historical conversation messages with tool-calls
- * are passed through the AI SDK's convertToModelMessages function, which splits
- * them in ways that create invalid message structures for Gemini.
- *
- * @param messages - Array of model messages to filter
- * @returns Filtered messages array without problematic patterns
- */
-export function filterGeminiIncompatibleMessages<T extends GeminiCompatibleMessage>(messages: T[]): T[] {
-  return messages.filter((msg, idx) => {
-    // Remove empty tool messages
-    if (msg.role === 'tool' && Array.isArray(msg.content) && msg.content.length === 0) {
-      return false;
-    }
-
-    // Remove duplicate assistant messages with only tool-calls
-    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-      const hasOnlyToolCalls = msg.content.every(p => p.type === 'tool-call');
-      if (hasOnlyToolCalls && msg.content.length > 0) {
-        const toolCallIds = msg.content.filter(p => p.type === 'tool-call').map(p => p.toolCallId);
-
-        // Check if there's another assistant message later with the same tool-call IDs
-        const hasDuplicateLater = messages.slice(idx + 1).some(laterMsg => {
-          if (laterMsg.role !== 'assistant' || !Array.isArray(laterMsg.content)) return false;
-
-          const laterToolCallIds = laterMsg.content.filter(p => p.type === 'tool-call').map(p => p.toolCallId);
-
-          return toolCallIds.some(id => laterToolCallIds.includes(id));
-        });
-
-        if (hasDuplicateLater) {
-          return false;
-        }
-      }
-    }
-
-    return true;
-  });
-}
-
-/**
  * Ensures message array is compatible with Gemini API requirements.
  *
  * Gemini requires that the first non-system message must be from the user role.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Description

Fixed handling of `input-available` tool state to differentiate between response messages FROM the LLM versus prompt messages TO the LLM. This fixes streaming memory tests with client-side tool calls while preserving loop test behavior with prepareStep.

## Root Cause

The `sanitizeV5UIMessages()` function was being used for two different purposes with conflicting requirements:

1. **Response messages FROM the LLM** (`response.messages`): Should include `input-available` states (tool calls waiting for client-side execution) to show what the LLM requested
2. **Prompt messages TO the LLM** (`prompt()`, `llmPrompt()`): Should filter out `input-available` states (incomplete tool calls without results) to avoid OpenAI Responses API errors like "No tool output found for function call"

The previous approach either:
- Kept `input-available` → broke streaming memory tests (incomplete client-side tool calls sent to LLM)
- Filtered `input-available` → broke loop tests (tool-call requests missing from `response.messages`)

## Solution

Added a `filterIncompleteToolCalls` parameter to `sanitizeV5UIMessages()` and `aiV5UIMessagesToAIV5ModelMessages()`:

- **When `false` (default)**: Keep `input-available` states, only filter `input-streaming`. Used for `response.messages` to preserve what the LLM returned.
- **When `true`**: Filter both `input-available` and `input-streaming`, only keep `output-available` and `output-error`. Used in `prompt()` and `llmPrompt()` when sending messages TO the LLM.

This ensures:
- ✅ Loop tests pass: `response.messages` includes tool-call requests from prepareStep
- ✅ Streaming memory tests pass: Incomplete client-side tool calls are filtered out when sending to LLM
- ✅ Gemini tests pass: No invalid message patterns sent to API

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed message handling for incomplete tool calls, preventing OpenAI API errors
  * Improved message filtering logic to correctly distinguish between messages received from and sent to the LLM, ensuring incomplete tool calls are handled appropriately based on message direction

* **Tests**
  * Updated Gemini agent test assertions for enhanced coverage validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->