### PR TITLE
fix: workflow resolution by id (fix broken trace link)

### DIFF
--- a/.changeset/free-doors-sniff.md
+++ b/.changeset/free-doors-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix the link issue in observability

--- a/.changeset/tiny-pumas-enter.md
+++ b/.changeset/tiny-pumas-enter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix the link from traces to workflow

--- a/packages/playground-ui/src/domains/observability/components/helpers.tsx
+++ b/packages/playground-ui/src/domains/observability/components/helpers.tsx
@@ -11,7 +11,7 @@ export function useTraceInfo(trace: SpanRecord | undefined) {
   const agentsLink = paths.agentsLink();
   const workflowsLink = paths.workflowsLink();
   const agentLink = paths.agentLink(trace?.metadata?.resourceId!);
-  const workflowLink = paths.workflowLink(trace?.metadata?.resourceId!);
+  const workflowLink = paths.workflowLink(trace?.attributes?.workflowId!);
 
   return [
     {

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -40,7 +40,7 @@ async function listWorkflowsFromSystem({ mastra, workflowId }: WorkflowContext) 
 
   if (!workflow) {
     try {
-      workflow = mastra.getWorkflow(workflowId);
+      workflow = mastra.getWorkflowById(workflowId);
     } catch (error) {
       logger.debug('Error getting workflow, searching agents for workflow', error);
     }


### PR DESCRIPTION
## Description

Fixes the broken trace link in the right pane by making sure to get the workflow by id. getWorkflowById does check by key AND by id, while getWorkflow only checks for the key.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed observability trace links so workflows are identified from the correct trace attribute.
  * Improved workflow lookup when listing workflows so the system falls back to an alternate retrieval method if not found in the registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->