### PR TITLE
moved observability config to zod to provide better validation

### DIFF
--- a/.changeset/hungry-poems-post.md
+++ b/.changeset/hungry-poems-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+moved observability config to zod to provide better validation

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -41,7 +41,9 @@
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4",
-    "@internal/types-builder": "workspace:*",
+    "@internal/types-builder": "workspace:*"
+  },
+  "dependencies": {
     "zod": "^3.25.76"
   },
   "peerDependencies": {

--- a/observability/mastra/src/config.test.ts
+++ b/observability/mastra/src/config.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import { Observability } from './default';
+import { SamplingStrategyType } from './config';
+
+describe('Observability Config Validation', () => {
+  describe('ObservabilityRegistryConfig validation', () => {
+    it('should accept empty config', () => {
+      expect(() => {
+        new Observability({});
+      }).not.toThrow();
+    });
+
+    it('should accept config with only default', () => {
+      expect(() => {
+        new Observability({
+          default: {
+            enabled: true,
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('should accept config with only configs', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.ALWAYS },
+            },
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('should reject config with both default and configs', () => {
+      expect(() => {
+        new Observability({
+          default: {
+            enabled: true,
+          },
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.ALWAYS },
+            },
+          },
+        });
+      }).toThrow('Cannot specify both "default" and "configs"');
+    });
+
+    it('should accept config with default disabled and configs', () => {
+      // Even if default.enabled is false, having default present counts as having default
+      expect(() => {
+        new Observability({
+          default: {
+            enabled: false,
+          },
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.ALWAYS },
+            },
+          },
+        });
+      }).toThrow('Cannot specify both "default" and "configs"');
+    });
+
+    it('should accept config with empty configs object', () => {
+      // Empty configs object should not trigger the validation error
+      expect(() => {
+        new Observability({
+          default: {
+            enabled: true,
+          },
+          configs: {},
+        });
+      }).not.toThrow();
+    });
+
+    it('should accept config with only configSelector', () => {
+      expect(() => {
+        new Observability({
+          configSelector: () => 'default',
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('SamplingStrategy validation', () => {
+    it('should accept valid RATIO probability', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.RATIO, probability: 0.5 },
+            },
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('should reject RATIO with probability > 1', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.RATIO, probability: 1.5 },
+            },
+          },
+        });
+      }).toThrow('Probability must be between 0 and 1');
+    });
+
+    it('should reject RATIO with negative probability', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.RATIO, probability: -0.5 },
+            },
+          },
+        });
+      }).toThrow('Probability must be between 0 and 1');
+    });
+
+    it('should accept ALWAYS sampling strategy', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.ALWAYS },
+            },
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('should accept NEVER sampling strategy', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.NEVER },
+            },
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('should accept CUSTOM sampling strategy with function', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: {
+                type: SamplingStrategyType.CUSTOM,
+                sampler: () => true,
+              },
+            },
+          },
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('ObservabilityInstanceConfig validation', () => {
+    it('should accept valid instance config', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              serviceName: 'my-service',
+              sampling: { type: SamplingStrategyType.ALWAYS },
+              includeInternalSpans: true,
+              requestContextKeys: ['userId', 'sessionId'],
+            },
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('should reject config without serviceName', () => {
+      expect(() => {
+        new Observability({
+          configs: {
+            myTracing: {
+              // @ts-expect-error - testing invalid config
+              sampling: { type: SamplingStrategyType.ALWAYS },
+            },
+          },
+        });
+      }).toThrow();
+    });
+  });
+});

--- a/observability/mastra/src/config.ts
+++ b/observability/mastra/src/config.ts
@@ -5,6 +5,7 @@
  * including tracing configs, sampling strategies, and registry setup.
  */
 
+import { z } from 'zod';
 import type { RequestContext } from '@mastra/core/di';
 import type {
   ObservabilityInstance,
@@ -85,3 +86,86 @@ export interface ObservabilityRegistryConfig {
   /** Optional selector function to choose which tracing instance to use */
   configSelector?: ConfigSelector;
 }
+
+// ============================================================================
+// Zod Schemas for Validation
+// ============================================================================
+
+/**
+ * Zod schema for SamplingStrategy
+ */
+export const samplingStrategySchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal(SamplingStrategyType.ALWAYS),
+  }),
+  z.object({
+    type: z.literal(SamplingStrategyType.NEVER),
+  }),
+  z.object({
+    type: z.literal(SamplingStrategyType.RATIO),
+    probability: z.number().min(0, 'Probability must be between 0 and 1').max(1, 'Probability must be between 0 and 1'),
+  }),
+  z.object({
+    type: z.literal(SamplingStrategyType.CUSTOM),
+    sampler: z.function().args(z.any().optional()).returns(z.boolean()),
+  }),
+]);
+
+/**
+ * Zod schema for ObservabilityInstanceConfig
+ * Note: exporters, spanOutputProcessors, and configSelector are validated as any
+ * since they're complex runtime objects
+ */
+export const observabilityInstanceConfigSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  serviceName: z.string().min(1, 'Service name is required'),
+  sampling: samplingStrategySchema.optional(),
+  exporters: z.array(z.any()).optional(),
+  spanOutputProcessors: z.array(z.any()).optional(),
+  includeInternalSpans: z.boolean().optional(),
+  requestContextKeys: z.array(z.string()).optional(),
+});
+
+/**
+ * Zod schema for config values in the configs map
+ * This is the config object without the name field
+ */
+export const observabilityConfigValueSchema = z.object({
+  serviceName: z.string().min(1, 'Service name is required'),
+  sampling: samplingStrategySchema.optional(),
+  exporters: z.array(z.any()).optional(),
+  spanOutputProcessors: z.array(z.any()).optional(),
+  includeInternalSpans: z.boolean().optional(),
+  requestContextKeys: z.array(z.string()).optional(),
+});
+
+/**
+ * Zod schema for ObservabilityRegistryConfig
+ * Validates that either 'default' OR 'configs' is set, but not both
+ * Note: Individual configs are validated separately in the constructor to allow for
+ * both plain config objects and pre-instantiated ObservabilityInstance objects
+ */
+export const observabilityRegistryConfigSchema = z
+  .object({
+    default: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .optional(),
+    configs: z.record(z.string(), z.any()).optional(),
+    configSelector: z.function().optional(),
+  })
+  .refine(
+    data => {
+      // Either default or configs can be set, but not both
+      const hasDefault = data.default !== undefined;
+      const hasConfigs = data.configs !== undefined && Object.keys(data.configs).length > 0;
+
+      // It's ok to have neither, or just one, but not both
+      return !(hasDefault && hasConfigs);
+    },
+    {
+      message:
+        'Cannot specify both "default" and "configs". Use either default configuration or custom configs, but not both.',
+    },
+  );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,6 +950,10 @@ importers:
         version: 3.25.76
 
   observability/mastra:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -984,9 +988,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.23)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.11.6(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.1)
-      zod:
-        specifier: ^3.25.76
-        version: 3.25.76
 
   observability/otel-exporter:
     dependencies:


### PR DESCRIPTION
## Description

moved observability config to zod to provide better validation

for example, only 'default' or 'configs' is allowed in a config... not both. 

## Related Issue(s)

#6773

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced observability configuration validation with schema-based checks and clearer aggregated error reporting.
  * Validation now runs early to surface all config issues before initialization.
* **New Features**
  * Support for multiple named observability configs with a selector to route to the appropriate config.
  * Exposed validation schemas for sampling strategies and instance/config shapes.
* **Tests**
  * Added comprehensive tests covering config shapes, selector behavior, sampling strategies, and instance validation.
* **Chores**
  * Added a changeset declaring a patch release for observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->