### PR TITLE
Ensure libsql storage has ids in the codebase

### DIFF
--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -112,10 +112,12 @@ if (process.env.MASTRA_STORAGE_URL && process.env.MASTRA_STORAGE_AUTH_TOKEN) {
   const { MastraStorage } = await import('@mastra/core/storage');
   logger.info('Using Mastra Cloud Storage: ' + process.env.MASTRA_STORAGE_URL)
   const storage = new LibSQLStore({
+    id: 'mastra-cloud-storage-libsql',
     url: process.env.MASTRA_STORAGE_URL,
     authToken: process.env.MASTRA_STORAGE_AUTH_TOKEN,
   })
   const vector = new LibSQLVector({
+    id: 'mastra-cloud-storage-libsql-vector',
     connectionUrl: process.env.MASTRA_STORAGE_URL,
     authToken: process.env.MASTRA_STORAGE_AUTH_TOKEN,
   })

--- a/deployers/cloud/src/server-runtime.test.ts
+++ b/deployers/cloud/src/server-runtime.test.ts
@@ -108,6 +108,7 @@ describe('CloudDeployer Server Runtime', () => {
 
       // Check LibSQL setup
       expect(entry).toContain('const storage = new LibSQLStore({');
+      expect(entry).toContain('id: "mastra-cloud-storage-libsql"');
       expect(entry).toContain('url: process.env.MASTRA_STORAGE_URL');
       expect(entry).toContain('authToken: process.env.MASTRA_STORAGE_AUTH_TOKEN');
 

--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -70,7 +70,7 @@ import { LibSQLStore } from "@mastra/libsql";
 export const mastra = new Mastra({
   // ..
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: ":memory:",
   }),
 });
@@ -98,7 +98,7 @@ export const memoryAgent = new Agent({
   // ...
   memory: new Memory({
     storage: new LibSQLStore({
-  id: 'mastra-storage',
+      id: 'mastra-storage',
       url: ":memory:",
     }),
   }),

--- a/docs/src/content/en/docs/agents/networks.mdx
+++ b/docs/src/content/en/docs/agents/networks.mdx
@@ -57,7 +57,7 @@ export const routingAgent = new Agent({
   },
   memory: new Memory({
     storage: new LibSQLStore({
-  id: 'mastra-storage',
+      id: 'mastra-storage',
       url: "file:../mastra.db",
     }),
   }),

--- a/docs/src/content/en/docs/deployment/cloud-providers/index.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/index.mdx
@@ -34,7 +34,7 @@ Specifically, ensure you've removed it from both `src/mastra/index.ts` and `src/
 export const mastra = new Mastra({
   // ...
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     // [!code --]
     // stores telemetry, scorer results, ... into memory storage, if it needs to persist, change to file:../mastra.db // [!code --]
     url: ":memory:", // [!code --]
@@ -49,7 +49,7 @@ export const weatherAgent = new Agent({
   memory: new Memory({
     // [!code --]
     storage: new LibSQLStore({
-  id: 'mastra-storage',
+      id: 'mastra-storage',
       // [!code --]
       url: "file:../mastra.db", // path is relative to the .mastra/output directory // [!code --]
     }), // [!code --]

--- a/docs/src/content/en/docs/deployment/serverless-platforms/index.mdx
+++ b/docs/src/content/en/docs/deployment/serverless-platforms/index.mdx
@@ -34,7 +34,7 @@ Specifically, ensure you've removed it from both `src/mastra/index.ts` and `src/
 export const mastra = new Mastra({
   // ...
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     // [!code --]
     // stores telemetry, scorer results, ... into memory storage, if it needs to persist, change to file:../mastra.db // [!code --]
     url: ":memory:", // [!code --]
@@ -49,7 +49,7 @@ export const weatherAgent = new Agent({
   memory: new Memory({
     // [!code --]
     storage: new LibSQLStore({
-  id: 'mastra-storage',
+      id: 'mastra-storage',
       // [!code --]
       url: "file:../mastra.db", // path is relative to the .mastra/output directory // [!code --]
     }), // [!code --]

--- a/docs/src/content/en/docs/observability/overview.mdx
+++ b/docs/src/content/en/docs/observability/overview.mdx
@@ -32,7 +32,7 @@ export const mastra = new Mastra({
   // ... other config
   logger: new PinoLogger(),
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: "file:./mastra.db", // Storage is required for tracing
   }),
   observability: new Observability({ // Enables Tracing

--- a/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
@@ -23,7 +23,7 @@ import { LibSQLStore } from "@mastra/libsql";
 
 export const mastra = new Mastra({
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: "file:./mastra.db", // Required for trace persistence
   }),
   observability: new Observability({
@@ -47,7 +47,7 @@ import { Observability } from "@mastra/observability";
 import { LibSQLStore } from "@mastra/libsql";
 export const mastra = new Mastra({
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: "file:./mastra.db",
   }),
   observability: new Observability({

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -31,7 +31,7 @@ export const mastra = new Mastra({
     default: { enabled: true }, // Enables DefaultExporter and CloudExporter
   }),
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: "file:./mastra.db", // Storage is required for tracing
   }),
 });
@@ -71,7 +71,7 @@ export const mastra = new Mastra({
     },
   }),
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: "file:./mastra.db", // Storage is required for tracing
   }),
 });

--- a/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
@@ -17,7 +17,7 @@ export const mastra = new Mastra({
     default: { enabled: true }, // Automatically includes SensitiveDataFilter
   }),
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: "file:./mastra.db",
   }),
 });

--- a/docs/src/content/en/docs/workflows/snapshots.mdx
+++ b/docs/src/content/en/docs/workflows/snapshots.mdx
@@ -138,7 +138,7 @@ import { LibSQLStore } from "@mastra/libsql";
 export const mastra = new Mastra({
   // ...
   storage: new LibSQLStore({
-  id: 'mastra-storage',
+    id: 'mastra-storage',
     url: ":memory:",
   }),
 });

--- a/docs/src/content/en/examples/agents/ai-sdk-v5-integration.mdx
+++ b/docs/src/content/en/examples/agents/ai-sdk-v5-integration.mdx
@@ -42,7 +42,7 @@ import { weatherTool } from "../tools";
 
 export const memory = new Memory({
   storage: new LibSQLStore({
-  id: 'agent-storage',
+    id: 'agent-storage',
     url: `file:./mastra.db`,
   }),
   options: {

--- a/docs/src/content/en/examples/agents/whatsapp-chat-bot.mdx
+++ b/docs/src/content/en/examples/agents/whatsapp-chat-bot.mdx
@@ -126,7 +126,7 @@ export const chatAgent = new Agent({
   model: anthropic("claude-4-sonnet-20250514"),
   memory: new Memory({
     storage: new LibSQLStore({
-  id: 'agent-storage',
+      id: 'agent-storage',
       url: "file:../mastra.db",
     }),
   }),
@@ -165,7 +165,7 @@ export const textMessageAgent = new Agent({
   model: anthropic("claude-4-sonnet-20250514"),
   memory: new Memory({
     storage: new LibSQLStore({
-  id: 'agent-storage',
+      id: 'agent-storage',
       url: "file:../mastra.db",
     }),
   }),
@@ -316,7 +316,7 @@ export const mastra = new Mastra({
   workflows: { chatWorkflow },
   agents: { textMessageAgent, chatAgent },
   storage: new LibSQLStore({
-  id: 'agent-storage',
+    id: 'agent-storage',
     url: ":memory:",
   }),
   logger: new PinoLogger({

--- a/docs/src/content/en/examples/memory/working-memory-schema.mdx
+++ b/docs/src/content/en/examples/memory/working-memory-schema.mdx
@@ -58,7 +58,7 @@ export const workingMemorySchemaAgent = new Agent({
   model: openai("gpt-4o"),
   memory: new Memory({
     storage: new LibSQLStore({
-  id: 'mastra-storage',
+      id: 'mastra-storage',
       url: "file:working-memory-schema.db",
     }),
     options: {

--- a/docs/src/content/en/examples/memory/working-memory-template.mdx
+++ b/docs/src/content/en/examples/memory/working-memory-template.mdx
@@ -57,7 +57,7 @@ export const workingMemoryTemplateAgent = new Agent({
   model: openai("gpt-4o"),
   memory: new Memory({
     storage: new LibSQLStore({
-  id: 'mastra-storage',
+      id: 'mastra-storage',
       url: "file:working-memory-template.db",
     }),
     options: {

--- a/docs/src/course/01-first-agent/08-exporting-your-agent.md
+++ b/docs/src/course/01-first-agent/08-exporting-your-agent.md
@@ -15,6 +15,7 @@ export const mastra = new Mastra({
     financialAgent,
   },
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: ":memory:",
   }),
   logger: new PinoLogger({

--- a/docs/src/course/01-first-agent/16-adding-memory-to-agent.md
+++ b/docs/src/course/01-first-agent/16-adding-memory-to-agent.md
@@ -24,6 +24,7 @@ export const financialAgent = new Agent({
   tools: { getTransactionsTool },
   memory: new Memory({
     storage: new LibSQLStore({
+      id: "learning-memory-storage",
       url: "file:../../memory.db", // local file-system database. Location is relative to the output directory `.mastra/output`
     }),
   }), // Add memory here

--- a/docs/src/course/02-agent-tools-mcp/31-enhancing-memory-configuration.md
+++ b/docs/src/course/02-agent-tools-mcp/31-enhancing-memory-configuration.md
@@ -7,9 +7,11 @@ import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db",
   }),
   vector: new LibSQLVector({
+    id: "learning-memory-vector",
     connectionUrl: "file:../../memory.db",
   }),
   embedder: openai.embedding("text-embedding-3-small"),

--- a/docs/src/course/03-agent-memory/04-creating-basic-memory-agent.md
+++ b/docs/src/course/03-agent-memory/04-creating-basic-memory-agent.md
@@ -13,6 +13,7 @@ import { openai } from "@ai-sdk/openai";
 // Create a basic memory instance
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }),
 });

--- a/docs/src/course/03-agent-memory/10-storage-configuration.md
+++ b/docs/src/course/03-agent-memory/10-storage-configuration.md
@@ -9,9 +9,8 @@ import { LibSQLStore } from "@mastra/libsql";
 const memory = new Memory({
   // Configure storage
   storage: new LibSQLStore({
-    config: {
-      url: "file:../../memory.db", // Local database. Relative to the output folder
-    },
+    id: "learning-memory-storage",
+    url: "file:../../memory.db", // Local database. Relative to the output folder
   }),
   options: {
     lastMessages: 20,

--- a/docs/src/course/03-agent-memory/13-vector-store-configuration.md
+++ b/docs/src/course/03-agent-memory/13-vector-store-configuration.md
@@ -8,9 +8,11 @@ import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }),
   vector: new LibSQLVector({
+    id: "learning-memory-vector",
     connectionUrl: "file:../../vector.db", // relative path from the `.mastra/output` directory
   }),
 });

--- a/docs/src/course/03-agent-memory/16-configuring-semantic-recall.md
+++ b/docs/src/course/03-agent-memory/16-configuring-semantic-recall.md
@@ -11,9 +11,11 @@ import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 // Create a memory instance with semantic recall configuration
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }), // Storage for message history
   vector: new LibSQLVector({
+    id: "learning-memory-vector",
     connectionUrl: "file:../../vector.db", // relative path from the `.mastra/output` directory
   }), // Vector database for semantic search
   embedder: openai.embedding("text-embedding-3-small"), // Embedder for message embeddings

--- a/docs/src/course/03-agent-memory/18-advanced-configuration-semantic-recall.md
+++ b/docs/src/course/03-agent-memory/18-advanced-configuration-semantic-recall.md
@@ -5,6 +5,7 @@ We can configure semantic recall in more detail by setting options for the `sema
 ```typescript
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }),
   vector: new LibSQLVector({

--- a/docs/src/course/03-agent-memory/21-configuring-working-memory.md
+++ b/docs/src/course/03-agent-memory/21-configuring-working-memory.md
@@ -11,9 +11,11 @@ import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 // Create a memory instance with working memory configuration
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }), // Storage for message history
   vector: new LibSQLVector({
+    id: "learning-memory-vector",
     connectionUrl: "file:../../vector.db", // relative path from the `.mastra/output` directory
   }), // Vector database for semantic search
   embedder: openai.embedding("text-embedding-3-small"), // Embedder for message embeddings

--- a/docs/src/course/03-agent-memory/22-custom-working-memory-templates.md
+++ b/docs/src/course/03-agent-memory/22-custom-working-memory-templates.md
@@ -12,6 +12,7 @@ import { openai } from "@ai-sdk/openai";
 // Create a memory instance with a custom working memory template
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }), // Storage for message history
   vector: new LibSQLVector({

--- a/docs/src/course/03-agent-memory/25-combining-memory-features.md
+++ b/docs/src/course/03-agent-memory/25-combining-memory-features.md
@@ -16,6 +16,7 @@ import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 // Create a comprehensive memory configuration
 const memory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }),
   vector: new LibSQLVector({

--- a/docs/src/course/03-agent-memory/27-creating-learning-assistant.md
+++ b/docs/src/course/03-agent-memory/27-creating-learning-assistant.md
@@ -12,6 +12,7 @@ import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
 // Create a specialized memory configuration for the learning assistant
 const learningMemory = new Memory({
   storage: new LibSQLStore({
+    id: "learning-memory-storage",
     url: "file:../../memory.db", // relative path from the `.mastra/output` directory
   }),
   vector: new LibSQLVector({

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -11,6 +11,7 @@ import { createScorer } from '@mastra/core/evals';
 import { myWorkflowX } from './workflows/other';
 
 const storage = new LibSQLStore({
+  id: 'mastra-storage',
   url: 'file:./mastra.db',
 });
 

--- a/examples/agui/src/mastra/agents/index.ts
+++ b/examples/agui/src/mastra/agents/index.ts
@@ -20,6 +20,7 @@ export const weatherAgent = new Agent({
 
   memory: new Memory({
     storage: new LibSQLStore({
+      id: 'agui-storage',
       url: 'file:../mastra.db', // path is relative to the .mastra/output directory
     }),
     options: {

--- a/examples/agui/src/mastra/index.ts
+++ b/examples/agui/src/mastra/index.ts
@@ -18,6 +18,7 @@ export const mastra = new Mastra({
     myNetwork,
   },
   storage: new LibSQLStore({
+    id: 'agui-storage',
     // stores observability, evals, ... into memory storage, if it needs to persist, change to file:../mastra.db
     url: ':memory:',
   }),

--- a/examples/ai-sdk-v5/app/lib/storage-instance.ts
+++ b/examples/ai-sdk-v5/app/lib/storage-instance.ts
@@ -5,6 +5,7 @@ let instance: LibSQLStore | null = null;
 export function getStorage() {
   if (!instance) {
     instance = new LibSQLStore({
+      id: "ai-sdk-v5-storage",
       url: `file:./mastra.db`,
     });
   }

--- a/examples/ai-sdk-v5/src/mastra/agents/index.ts
+++ b/examples/ai-sdk-v5/src/mastra/agents/index.ts
@@ -7,6 +7,7 @@ import { LibSQLStore } from "@mastra/libsql";
 
 export const memory = new Memory({
   storage: new LibSQLStore({
+    id: "ai-sdk-v5-storage",
     url: `file:./mastra.db`,
   }),
   options: {

--- a/examples/basics/scorers/custom-scorer/src/mastra/index.ts
+++ b/examples/basics/scorers/custom-scorer/src/mastra/index.ts
@@ -6,6 +6,7 @@ import { chefAgent } from './agents/chefAgent';
 export const mastra = new Mastra({
   agents: { chefAgent },
   storage: new LibSQLStore({
+    id: 'custom-scorer-storage',
     url: 'file:./mastra.db',
   }),
 });

--- a/examples/dane/src/mastra/index.ts
+++ b/examples/dane/src/mastra/index.ts
@@ -23,6 +23,7 @@ export const mastra: Mastra = new Mastra({
     daneNewContributor,
   },
   storage: new LibSQLStore({
+    id: 'dane-storage',
     url: ':memory:',
   }),
   workflows: {

--- a/examples/heads-up-game/src/mastra/index.ts
+++ b/examples/heads-up-game/src/mastra/index.ts
@@ -11,6 +11,7 @@ export const mastra = new Mastra({
   workflows: { headsUpWorkflow },
   agents: { famousPersonAgent, gameAgent, guessVerifierAgent },
   storage: new LibSQLStore({
+    id: 'heads-up-game-storage',
     // stores observability, evals, ... into file storage for persistence across playground refreshes
     url: 'file:../mastra.db',
   }),

--- a/examples/memory-per-resource-example/src/mastra/agents/index.ts
+++ b/examples/memory-per-resource-example/src/mastra/agents/index.ts
@@ -5,6 +5,7 @@ import { LibSQLStore } from '@mastra/libsql';
 
 // Create LibSQL storage for persistent per-resource working memory
 const storage = new LibSQLStore({
+  id: 'memory-demo-storage',
   url: 'file:./memory-demo.db',
 });
 

--- a/examples/travel-app/src/mastra/agents/storage.ts
+++ b/examples/travel-app/src/mastra/agents/storage.ts
@@ -1,5 +1,6 @@
 import { LibSQLStore } from "@mastra/libsql";
 
 export const storage = new LibSQLStore({
+  id: "travel-app-storage",
   url: "file:mastra.db",
 });

--- a/examples/weather-agent/src/mastra/agents/index.ts
+++ b/examples/weather-agent/src/mastra/agents/index.ts
@@ -12,6 +12,7 @@ import { weatherTool } from '../tools';
 
 // const memory = new Memory({
 //   storage: new LibSQLStore({
+//     id: 'weather-agent-storage',
 //     url: 'file:../mastra.db', // Or your database URL
 //   }),
 // });

--- a/examples/weather-agent/src/mastra/index.ts
+++ b/examples/weather-agent/src/mastra/index.ts
@@ -7,6 +7,7 @@ import { weatherWorkflow, weatherWorkflow2 } from './workflows/new-workflow';
 
 export const mastra = new Mastra({
   storage: new LibSQLStore({
+    id: 'weather-agent-storage',
     url: 'file:./mastra.db',
   }),
   agents: { weatherAgent, weatherReporterAgent },

--- a/examples/workflow-with-suspend-resume/src/mastra/index.ts
+++ b/examples/workflow-with-suspend-resume/src/mastra/index.ts
@@ -8,6 +8,7 @@ export const mastra = new Mastra({
     myWorkflow,
   },
   storage: new LibSQLStore({
+    id: 'workflow-snapshots-storage',
     url: 'file:./workflow-snapshots.db',
   }),
 });

--- a/packages/agent-builder/integration-tests/src/workflow-builder-integration.test.ts
+++ b/packages/agent-builder/integration-tests/src/workflow-builder-integration.test.ts
@@ -48,6 +48,7 @@ describe.skip('Workflow Builder Integration Tests', () => {
       },
       logger: false,
       storage: new LibSQLStore({
+        id: 'mastra-storage',
         url: 'file:mastra.db',
       }),
     });

--- a/packages/agent-builder/src/defaults.ts
+++ b/packages/agent-builder/src/defaults.ts
@@ -218,6 +218,7 @@ export const weatherAgent = new Agent({
   tools: { weatherTool },
   memory: new Memory({
     storage: new LibSQLStore({
+      id: 'mastra-memory-storage',
       url: 'file:../mastra.db', // ask user what database to use, use this as the default
     }),
   }),
@@ -385,6 +386,7 @@ export const mastra = new Mastra({
   workflows: { weatherWorkflow },
   agents: { weatherAgent },
   storage: new LibSQLStore({
+    id: 'mastra-storage',
     // stores observability, evals, ... into memory storage, if it needs to persist, change to file:../mastra.db
     url: ":memory:",
   }),

--- a/packages/agent-builder/src/workflows/workflow-builder/prompts.ts
+++ b/packages/agent-builder/src/workflows/workflow-builder/prompts.ts
@@ -174,7 +174,7 @@ export const mastra = new Mastra({
     sendEmailWorkflow,      // Use camelCase for keys
     dataProcessingWorkflow
   },
-  storage: new LibSQLStore({ url: 'file:./mastra.db' }), // Required for suspend/resume
+  storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }), // Required for suspend/resume
 });
 \`\`\`
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -653,19 +653,9 @@ export class Mastra<
     const agentKey = key || agent.id;
     const agents = this.#agents as Record<string, Agent<any>>;
     if (agents[agentKey]) {
-      const error = new MastraError({
-        id: 'MASTRA_ADD_AGENT_DUPLICATE_KEY',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `Agent with key ${agentKey} already exists`,
-        details: {
-          status: 409,
-          agentKey: agentKey,
-          existingAgents: Object.keys(agents).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      const logger = this.getLogger();
+      logger.debug(`Agent with key ${agentKey} already exists. Skipping addition.`);
+      return;
     }
 
     // Initialize the agent
@@ -836,19 +826,9 @@ export class Mastra<
     const vectorKey = key || vector.id;
     const vectors = this.#vectors as Record<string, MastraVector>;
     if (vectors[vectorKey]) {
-      const error = new MastraError({
-        id: 'MASTRA_ADD_VECTOR_DUPLICATE_KEY',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `Vector store with key ${vectorKey} already exists`,
-        details: {
-          status: 409,
-          vectorKey: vectorKey,
-          existingVectors: Object.keys(vectors).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      const logger = this.getLogger();
+      logger.debug(`Vector with key ${vectorKey} already exists. Skipping addition.`);
+      return;
     }
 
     // Initialize the vector with the logger
@@ -1085,19 +1065,9 @@ export class Mastra<
     const scorerKey = key || scorer.id;
     const scorers = this.#scorers as Record<string, MastraScorer<any, any, any, any>>;
     if (scorers[scorerKey]) {
-      const error = new MastraError({
-        id: 'MASTRA_ADD_SCORER_DUPLICATE_KEY',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `Scorer with key ${scorerKey} already exists`,
-        details: {
-          status: 409,
-          scorerKey: scorerKey,
-          existingScorers: Object.keys(scorers).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      const logger = this.getLogger();
+      logger.debug(`Scorer with key ${scorerKey} already exists. Skipping addition.`);
+      return;
     }
 
     scorers[scorerKey] = scorer;
@@ -1335,19 +1305,9 @@ export class Mastra<
     const toolKey = key || tool.id;
     const tools = this.#tools as Record<string, ToolAction<any, any, any, any>>;
     if (tools[toolKey]) {
-      const error = new MastraError({
-        id: 'MASTRA_ADD_TOOL_DUPLICATE_KEY',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `Tool with key ${toolKey} already exists`,
-        details: {
-          status: 409,
-          toolKey: toolKey,
-          existingTools: Object.keys(tools).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      const logger = this.getLogger();
+      logger.debug(`Tool with key ${toolKey} already exists. Skipping addition.`);
+      return;
     }
 
     tools[toolKey] = tool;
@@ -1491,19 +1451,9 @@ export class Mastra<
     const processorKey = key || processor.id;
     const processors = this.#processors as Record<string, Processor>;
     if (processors[processorKey]) {
-      const error = new MastraError({
-        id: 'MASTRA_ADD_PROCESSOR_DUPLICATE_KEY',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `Processor with key ${processorKey} already exists`,
-        details: {
-          status: 409,
-          processorKey: processorKey,
-          existingProcessors: Object.keys(processors).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      const logger = this.getLogger();
+      logger.debug(`Processor with key ${processorKey} already exists. Skipping addition.`);
+      return;
     }
 
     processors[processorKey] = processor;
@@ -1568,19 +1518,9 @@ export class Mastra<
     const workflowKey = key || workflow.id;
     const workflows = this.#workflows as Record<string, Workflow<any, any, any, any, any, any>>;
     if (workflows[workflowKey]) {
-      const error = new MastraError({
-        id: 'MASTRA_ADD_WORKFLOW_DUPLICATE_KEY',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `Workflow with key ${workflowKey} already exists`,
-        details: {
-          status: 409,
-          workflowKey: workflowKey,
-          existingWorkflows: Object.keys(workflows).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      const logger = this.getLogger();
+      logger.debug(`Workflow with key ${workflowKey} already exists. Skipping addition.`);
+      return;
     }
 
     // Initialize the workflow with Mastra and primitives
@@ -1941,19 +1881,9 @@ export class Mastra<
     const serverKey = key ?? resolvedId;
     const servers = this.#mcpServers as Record<string, MCPServerBase>;
     if (servers[serverKey]) {
-      const error = new MastraError({
-        id: 'MASTRA_ADD_MCP_SERVER_DUPLICATE_KEY',
-        domain: ErrorDomain.MASTRA,
-        category: ErrorCategory.USER,
-        text: `MCP server with key ${serverKey} already exists`,
-        details: {
-          status: 409,
-          mcpServerKey: serverKey,
-          existingServers: Object.keys(servers).join(', '),
-        },
-      });
-      this.#logger?.trackException(error);
-      throw error;
+      const logger = this.getLogger();
+      logger.debug(`MCP server with key ${serverKey} already exists. Skipping addition.`);
+      return;
     }
 
     // Initialize the server

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -53,7 +53,7 @@ import { createOnScorerHook } from './hooks';
  *       model: 'openai/gpt-5'
  *     })
  *   },
- *   storage: new LibSQLStore({ url: ':memory:' }),
+ *   storage: new LibSQLStore({ id: 'mastra-storage', url: ':memory:' }),
  *   logger: new PinoLogger({ name: 'MyApp' })
  * });
  * ```
@@ -210,7 +210,7 @@ export interface Config<
  *     })
  *   },
  *   workflows: { dataWorkflow },
- *   storage: new LibSQLStore({ url: ':memory:' }),
+ *   storage: new LibSQLStore({ id: 'mastra-storage', url: ':memory:' }),
  *   logger: new PinoLogger({ name: 'MyApp' })
  * });
  * ```
@@ -1646,7 +1646,7 @@ export class Mastra<
    * @example
    * ```typescript
    * const mastra = new Mastra({
-   *   storage: new LibSQLStore({ url: 'file:./data.db' })
+   *   storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./data.db' })
    * });
    *
    * // Use the storage in agent memory

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -358,7 +358,7 @@ export type SharedMemoryConfig = {
    *
    * @example
    * ```typescript
-   * storage: new LibSQLStore({ url: "file:./agent-memory.db" })
+   * storage: new LibSQLStore({ id: 'agent-memory-storage', url: "file:./agent-memory.db" })
    * ```
    */
   storage?: MastraStorage;

--- a/stores/libsql/README.md
+++ b/stores/libsql/README.md
@@ -50,6 +50,7 @@ const results = await vectorStore.query({
 import { LibSQLStore } from '@mastra/libsql';
 
 const store = new LibSQLStore({
+  id: 'libsql-storage',
   url: 'file:./my-db.db',
 });
 


### PR DESCRIPTION
- Fix addMethods so they dont throw an error
- Ensure libsql has ids

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `id` field to storage instance configurations, enabling explicit identification of storage backends in your application.

* **Documentation**
  * Updated all course materials and examples to demonstrate the new `id` field in storage configurations for improved clarity and best practices.

* **Bug Fixes**
  * Improved handling of duplicate storage configurations—now logs gracefully instead of throwing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->