### PR TITLE
fixed observability dependency linking

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -215,7 +215,7 @@
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0",
-    "@mastra/observability": ">=0.0.2"
+    "@mastra/observability": ">=0.0.0"
   },
   "peerDependenciesMeta": {
     "@mastra/observability": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1523,7 +1523,7 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       '@mastra/observability':
-        specifier: '>=0.0.2'
+        specifier: '>=0.0.0'
         version: 0.0.4(@mastra/core@0.22.2(openapi-types@12.1.3)(react@19.2.0)(zod@3.25.76))
       '@mastra/schema-compat':
         specifier: workspace:*


### PR DESCRIPTION
## Description

The snapshot builds are failing to install observability when using `npx create-mastra@snapshot-....`, due to version incompatiblity.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to support a wider range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->