### PR TITLE
Do not initialize local storage in cloud deployer

### DIFF
--- a/.changeset/itchy-icons-move.md
+++ b/.changeset/itchy-icons-move.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-cloud': patch
+---
+
+Do not initialize local storage

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -107,10 +107,6 @@ const combinedLogger = existingLogger ? new MultiLogger([logger, existingLogger]
 
 mastra.setLogger({ logger: combinedLogger });
 
-if (mastra?.storage) {
-  mastra.storage.init()
-}
-
 if (process.env.MASTRA_STORAGE_URL && process.env.MASTRA_STORAGE_AUTH_TOKEN) {
   const { MastraStorage } = await import('@mastra/core/storage');
   logger.info('Using Mastra Cloud Storage: ' + process.env.MASTRA_STORAGE_URL)
@@ -127,6 +123,8 @@ if (process.env.MASTRA_STORAGE_URL && process.env.MASTRA_STORAGE_AUTH_TOKEN) {
 
   await storage.init()
   mastra?.setStorage(storage)
+} else if (mastra?.storage) {
+  mastra.storage.init()
 }
 
 if (mastra?.getStorage()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed storage initialization to prevent unnecessary local storage setup when external storage is properly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->