### PR TITLE
[Backport] Fix: Don't download unsupported media (#9209)

### DIFF
--- a/.changeset/long-planes-drive.md
+++ b/.changeset/long-planes-drive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix: Don't download unsupported media

--- a/packages/core/src/agent/message-list/prompt/download-assets.ts
+++ b/packages/core/src/agent/message-list/prompt/download-assets.ts
@@ -87,7 +87,13 @@ export async function downloadAssetsFromMessages({
   const downloadedFiles = await pMap(
     filesToDownload,
     async fileItem => {
-      return downloadFromUrl({ url: fileItem.url, downloadRetries });
+      if (!fileItem.isUrlSupportedByModel) {
+        return null;
+      }
+      return {
+        url: fileItem.url.toString(),
+        ...(await downloadFromUrl({ url: fileItem.url, downloadRetries })),
+      };
     },
     {
       concurrency: downloadConcurrency,
@@ -99,11 +105,12 @@ export async function downloadAssetsFromMessages({
       (
         downloadedFile,
       ): downloadedFile is {
+        url: string;
         mediaType: string | undefined;
         data: Uint8Array<ArrayBuffer>;
       } => downloadedFile?.data != null,
     )
-    .map(({ data, mediaType }, index) => [filesToDownload?.[index]?.url.toString(), { data, mediaType }]);
+    .map(({ url, data, mediaType }) => [url, { data, mediaType }]);
 
   return Object.fromEntries(downloadFileList);
 }


### PR DESCRIPTION
## Description

Backport of https://github.com/mastra-ai/mastra/pull/9209

`isUrlSupportedByModel` is being calculated, however it is not being used.

If media is not supported, it is still being downloaded and resulting in errors.

Also fixes potential data corruption issues due to index misalignment.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Fixed an issue where unsupported media types were being unnecessarily downloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
