### PR TITLE
docs: fix pnpm init command (remove -y flag)

### DIFF
--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -9086,7 +9086,7 @@ npm install @mastra/core@beta zod@^4
 <TabItem value="pnpm" label="pnpm">
 
 ```bash copy
-pnpm init -y
+pnpm init
 pnpm add -D typescript @types/node mastra@beta
 pnpm add @mastra/core@beta zod@^4
 ```

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -9086,7 +9086,7 @@ npm install @mastra/core@beta zod@^4
 <TabItem value="pnpm" label="pnpm">
 
 ```bash copy
-pnpm init
+pnpm init -y
 pnpm add -D typescript @types/node mastra@beta
 pnpm add @mastra/core@beta zod@^4
 ```

--- a/docs/src/content/en/docs/getting-started/installation.mdx
+++ b/docs/src/content/en/docs/getting-started/installation.mdx
@@ -115,7 +115,7 @@ npm install @mastra/core@beta zod@^4
 <TabItem value="pnpm" label="pnpm">
 
 ```bash copy
-pnpm init -y
+pnpm init
 pnpm add -D typescript @types/node mastra@beta
 pnpm add @mastra/core@beta zod@^4
 ```


### PR DESCRIPTION
## Description

Remove `-y` flag from `pnpm init` command in documentation

```console
$ pnpm init -y
 ERROR  Unknown option: 'y'
For help, run: pnpm help init

$ pnpm help init
Version 10.14.0 (compiled to binary; bundled Node.js v20.19.5)
Usage: pnpm init

Create a package.json file

Options:
      --init-package-manager         Pin the project to the current pnpm version by adding a "packageManager" field to package.json
      --init-type <commonjs|module>  Set the module system for the package. Defaults to "commonjs".

Visit https://pnpm.io/10.x/cli/init for documentation about this command.
```

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Modernized API with streamlined method names for improved clarity and usability.
  * Enhanced structured output support with new configuration options.
  * Reorganized voice capabilities into a dedicated namespace for better organization.

* **Improvements**
  * Updated memory management configuration for explicit control.
  * Refined error handling with improved type safety.

* **Documentation**
  * Updated installation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->