### PR TITLE
fix(core): Correct peerDep on observability

### DIFF
--- a/.changeset/brown-clubs-lick.md
+++ b/.changeset/brown-clubs-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Set correct peer dependency range for `@mastra/observability`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -218,7 +218,7 @@
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0",
-    "@mastra/observability": ">=0.0.0"
+    "@mastra/observability": ">=1.0.0-0 <2.0.0-0"
   },
   "peerDependenciesMeta": {
     "@mastra/observability": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1535,8 +1535,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       '@mastra/observability':
-        specifier: '>=0.0.0'
-        version: 0.0.4(@mastra/core@1.0.0-beta.0)
+        specifier: '>=1.0.0-0 <2.0.0-0'
+        version: 1.0.0-beta.0(@mastra/core@1.0.0-beta.0)
       '@mastra/schema-compat':
         specifier: workspace:*
         version: link:../schema-compat
@@ -7146,10 +7146,11 @@ packages:
       '@mastra/observability':
         optional: true
 
-  '@mastra/observability@0.0.4':
-    resolution: {integrity: sha512-FPOL/hSAE/3vwXniZpDbCpj15IkEDTofpppEC5wMHQzbJ29Stt/1UqGH4IVuzWVdPGFgBP66F7cCDjn1J+awjA==}
+  '@mastra/observability@1.0.0-beta.0':
+    resolution: {integrity: sha512-oqplDogM6WeulQ3GbNx24QVW8sk4SvxaGxCSSZW572Vpnhula7VVy+wFC4z1LKLR96H3VKmmXiCHD9mSRHMz4Q==}
+    engines: {node: '>=22.13.0'}
     peerDependencies:
-      '@mastra/core': '>=0.18.1-0 <0.24.0-0'
+      '@mastra/core': '>=1.0.0-0 <2.0.0-0'
 
   '@mastra/rag@1.3.1':
     resolution: {integrity: sha512-vcnKO0cSCNj92ucWCcfYyCW1LYMoeNfLuJlzYLZ72FpGeTlUEfDwTh/nsQZIuEd3lTZvWXfRsenmv3v6M7WYmQ==}
@@ -19901,7 +19902,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mastra/core@1.0.0-beta.0(@mastra/observability@0.0.4)(ai@5.0.76(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)':
+  '@mastra/core@1.0.0-beta.0(@mastra/observability@1.0.0-beta.0)(ai@5.0.76(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.12(zod@3.25.76)'
@@ -19931,7 +19932,7 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
     optionalDependencies:
-      '@mastra/observability': 0.0.4(@mastra/core@1.0.0-beta.0)
+      '@mastra/observability': 1.0.0-beta.0(@mastra/core@1.0.0-beta.0)
     transitivePeerDependencies:
       - '@hono/arktype-validator'
       - '@hono/effect-validator'
@@ -19948,9 +19949,10 @@ snapshots:
       - valibot
       - zod-openapi
 
-  '@mastra/observability@0.0.4(@mastra/core@1.0.0-beta.0)':
+  '@mastra/observability@1.0.0-beta.0(@mastra/core@1.0.0-beta.0)':
     dependencies:
-      '@mastra/core': 1.0.0-beta.0(@mastra/observability@0.0.4)(ai@5.0.76(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)
+      '@mastra/core': 1.0.0-beta.0(@mastra/observability@1.0.0-beta.0)(ai@5.0.76(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)
+      zod: 3.25.76
 
   '@mastra/rag@1.3.1(@mastra/core@packages+core)(ai@4.3.19(react@19.2.0)(zod@3.25.76))(encoding@0.1.13)(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
## Description

Current peerDep on `@mastra/observability` doesn't include pre-release versions.

```shell
$ echo "Testing >=0.0.0 (current/broken):" && npx semver 0.5.0-alpha 0.9.0 1.0.0-beta.0 1.0.0 1.5.0 2.0.0-beta.0 2.0.0 -r '>=0.0.0'
Testing >=0.0.0 (current/broken):
0.9.0
1.0.0
1.5.0
2.0.0
```

Fixed:

```shell
$ echo "Testing >=1.0.0-0 <2.0.0-0:" && npx semver 0.5.0-alpha 0.9.0 1.0.0-beta.0 1.0.0 1.5.0 2.0.0-beta.0 2.0.0 -r '>=1.0.0-0 <2.0.0-0'
Testing >=1.0.0-0 <2.0.0-0:
1.0.0-beta.0
1.0.0
1.5.0
```

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/9844

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated peer dependency requirements for the observability component to specify version 1.x compatibility
  * Released patch version bump for the core package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->