### PR TITLE
fix(mssql): traces json double stringify issue fixed (#9901)

### DIFF
--- a/.changeset/salty-teeth-see.md
+++ b/.changeset/salty-teeth-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mssql': patch
+---
+
+Prevents double stringification for MSSQL jsonb columns by reusing incoming strings that already contain valid JSON while still stringifying other inputs as needed.

--- a/stores/mssql/src/storage/domains/operations/index.ts
+++ b/stores/mssql/src/storage/domains/operations/index.ts
@@ -496,6 +496,19 @@ export class StoreOperationsMSSQL extends StoreOperations {
 
     // If the column is JSONB, stringify the value
     if (columnSchema?.type === 'jsonb') {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed.length > 0) {
+          try {
+            JSON.parse(trimmed);
+            return trimmed;
+          } catch {}
+        }
+        return JSON.stringify(value);
+      }
+      if (typeof value === 'bigint') {
+        return value.toString();
+      }
       return JSON.stringify(value);
     }
 


### PR DESCRIPTION
## Description

Prevents double stringification for MSSQL jsonb columns by reusing incoming strings that already contain valid JSON while still stringifying other inputs as needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Optimized JSON data handling in MSSQL storage by preventing redundant serialization, resulting in cleaner data storage and improved efficiency for JSON-formatted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit f70a37c754f97d8aec55b8ecbee6ecf2b46854bc)

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
