### PR TITLE
Add `braintrustLogger` as an optional parameter to `BraintrustExporter`

### DIFF
--- a/.changeset/witty-tips-deny.md
+++ b/.changeset/witty-tips-deny.md
@@ -2,4 +2,4 @@
 '@mastra/braintrust': patch
 ---
 
-Add braintrustLogger as a parameter to BraintrustExporter
+Add braintrustLogger as an optional parameter to BraintrustExporter

--- a/.changeset/witty-tips-deny.md
+++ b/.changeset/witty-tips-deny.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': patch
+---
+
+Add braintrustLogger as a parameter to BraintrustExporter

--- a/observability/braintrust/eslint.config.js
+++ b/observability/braintrust/eslint.config.js
@@ -3,4 +3,9 @@ import { createConfig } from '@internal/lint/eslint';
 const config = await createConfig();
 
 /** @type {import("eslint").Linter.Config[]} */
-export default config;
+export default [
+  ...config,
+  {
+    ignores: ['examples/**'],
+  },
+];

--- a/observability/braintrust/examples/basic.ts
+++ b/observability/braintrust/examples/basic.ts
@@ -1,0 +1,96 @@
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { BraintrustExporter } from '../src/tracing';
+import { initLogger } from 'braintrust';
+import { Observability } from '@mastra/observability';
+
+/**
+ * Basic usage example showing both approaches.
+ *
+ * Environment variables required:
+ * - BRAINTRUST_API_KEY: Your Braintrust API key
+ * - OPENAI_API_KEY: Your OpenAI API key (for the model)
+ */
+
+async function exampleStandardApproach() {
+  console.log('\n=== Standard Approach: Pass apiKey, exporter creates loggers per trace ===\n');
+
+  // Pass apiKey and projectName to the exporter config
+  const exporter = new BraintrustExporter({
+    apiKey: process.env.BRAINTRUST_API_KEY,
+    projectName: 'mastra-demo',
+  });
+
+  const mastra = new Mastra({
+    agents: {
+      demo: new Agent({
+        name: 'Assistant',
+        instructions: 'Be helpful and concise.',
+        model: 'openai/gpt-4o',
+      }),
+    },
+    observability: new Observability({
+      configs: {
+        braintrust: {
+          serviceName: 'demo',
+          exporters: [exporter],
+        },
+      },
+    }),
+  });
+
+  const agent = mastra.getAgent('demo');
+  const response = await agent.generate('What is 2+2?');
+  console.log('Response:', response.text);
+  console.log("✓ Check your Braintrust project 'mastra-demo' for the trace");
+}
+
+async function exampleContextAwareApproach() {
+  console.log('\n=== Context-Aware Approach: Pass logger instance for Braintrust context integration ===\n');
+
+  // Initialize logger yourself and pass it to the exporter
+  const logger = initLogger({
+    projectName: 'mastra-demo',
+    apiKey: process.env.BRAINTRUST_API_KEY,
+    appUrl: process.env.BRAINTRUST_API_URL,
+  });
+
+  const exporter = new BraintrustExporter({
+    braintrustLogger: logger, // Enables integration with Braintrust contexts
+  });
+
+  const mastra = new Mastra({
+    agents: {
+      demo: new Agent({
+        name: 'Assistant',
+        instructions: 'Be helpful and concise.',
+        model: 'openai/gpt-4o',
+      }),
+    },
+    observability: new Observability({
+      configs: {
+        braintrust: {
+          serviceName: 'demo',
+          exporters: [exporter],
+        },
+      },
+    }),
+  });
+
+  const agent = mastra.getAgent('demo');
+  const response = await agent.generate('What is 2+2?');
+  console.log('Response:', response.text);
+  console.log("✓ Check your Braintrust project 'mastra-demo' for the trace");
+}
+
+async function main() {
+  // Run both approaches to demonstrate the difference
+  await exampleStandardApproach();
+  await exampleContextAwareApproach();
+
+  console.log('\n✨ Done! Both approaches work.');
+  console.log('   Passing a logger enables integration with Braintrust contexts (Evals, logger.traced()).');
+  console.log('   See with-logger-traced.ts and with-eval.ts for examples.\n');
+}
+
+main().catch(console.error);

--- a/observability/braintrust/examples/with-eval.ts
+++ b/observability/braintrust/examples/with-eval.ts
@@ -1,0 +1,78 @@
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { BraintrustExporter } from '../src/tracing';
+import { Eval } from 'braintrust';
+import { initLogger } from 'braintrust';
+import { Observability } from '@mastra/observability';
+
+/**
+ * Evaluation example using Braintrust's Eval framework.
+ *
+ * This demonstrates how Mastra agent traces automatically nest inside
+ * Braintrust eval task spans. The exporter detects the eval context and
+ * attaches Mastra spans to the appropriate eval task.
+ *
+ * Environment variables required:
+ * - BRAINTRUST_API_KEY: Your Braintrust API key
+ * - OPENAI_API_KEY: Your OpenAI API key (for the model)
+ */
+
+async function main() {
+  // Initialize logger
+  const logger = initLogger({
+    projectName: 'mastra-demo',
+    apiKey: process.env.BRAINTRUST_API_KEY,
+    appUrl: process.env.BRAINTRUST_API_URL,
+  });
+
+  // Pass logger to exporter for context-awareness
+  const exporter = new BraintrustExporter({
+    braintrustLogger: logger,
+  });
+
+  const mastra = new Mastra({
+    agents: {
+      assistant: new Agent({
+        name: 'Assistant',
+        instructions: 'Be concise.',
+        model: 'openai/gpt-4o-mini',
+      }),
+    },
+    observability: new Observability({
+      configs: {
+        braintrust: {
+          serviceName: 'demo',
+          exporters: [exporter],
+        },
+      },
+    }),
+  });
+
+  console.log('\n--- Running evaluation ---\n');
+
+  // Run evaluation with Mastra agent
+  // Agent traces will automatically nest inside each eval task span
+  await Eval('mastra-demo', {
+    data: () => [
+      { input: 'What is the capital of France?', expected: 'Paris' },
+      { input: 'What is 2+2?', expected: '4' },
+    ],
+    task: async (input: string) => {
+      const agent = mastra.getAgent('assistant');
+      return (await agent.generate(input)).text;
+    },
+    scores: [
+      (args: any) => ({
+        name: 'contains_answer',
+        score: String(args.output).toLowerCase().includes(String(args.expected).toLowerCase()) ? 1 : 0,
+      }),
+    ],
+  });
+
+  console.log("\n✓ Check your Braintrust project 'mastra-demo' to see:");
+  console.log('  - Eval results with scores');
+  console.log('  - Mastra agent traces nested inside each eval task');
+  console.log('  - Full trace of model calls and tool usage\n');
+}
+
+main().catch(console.error);

--- a/observability/braintrust/examples/with-logger-traced.ts
+++ b/observability/braintrust/examples/with-logger-traced.ts
@@ -1,0 +1,75 @@
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { BraintrustExporter } from '../src/tracing';
+import { initLogger } from 'braintrust';
+import { Observability } from '@mastra/observability';
+
+/**
+ * Context-aware example using logger.traced().
+ *
+ * This demonstrates how Mastra agent traces automatically nest inside
+ * Braintrust spans when using logger.traced(). The exporter detects the
+ * external Braintrust span and attaches Mastra spans to it.
+ *
+ * Environment variables required:
+ * - BRAINTRUST_API_KEY: Your Braintrust API key
+ * - OPENAI_API_KEY: Your OpenAI API key (for the model)
+ */
+
+async function main() {
+  // Initialize logger
+  const logger = initLogger({
+    projectName: 'mastra-demo',
+    apiKey: process.env.BRAINTRUST_API_KEY,
+    appUrl: process.env.BRAINTRUST_API_URL,
+  });
+
+  // Pass logger to exporter for context-awareness
+  const exporter = new BraintrustExporter({
+    braintrustLogger: logger,
+  });
+
+  const mastra = new Mastra({
+    agents: {
+      demo: new Agent({
+        name: 'Assistant',
+        instructions: 'Be concise.',
+        model: 'openai/gpt-4o-mini',
+      }),
+    },
+    observability: new Observability({
+      configs: {
+        braintrust: {
+          serviceName: 'demo',
+          exporters: [exporter],
+        },
+      },
+    }),
+  });
+
+  // Use logger.traced() to create parent spans with tags and metadata
+  // Mastra agent calls will automatically nest inside these spans
+  for (const env of ['production', 'staging', 'development']) {
+    await logger.traced(async span => {
+      // Add tags and metadata to the parent span
+      span.log({
+        tags: [`environment:${env}`],
+        metadata: { environment: env },
+      });
+
+      console.log(`\n--- Running in ${env} environment ---`);
+
+      // Agent call will be automatically nested inside the logger.traced() span
+      const agent = mastra.getAgent('demo');
+      const response = await agent.generate('Say hi');
+      console.log(`${env}: ${response.text}`);
+    });
+  }
+
+  console.log("\n✓ Check your Braintrust project 'mastra-demo' to see:");
+  console.log('  - 3 top-level spans (one per environment)');
+  console.log('  - Each with environment tags and metadata');
+  console.log('  - Mastra agent traces nested inside each span\n');
+}
+
+main().catch(console.error);

--- a/observability/braintrust/package.json
+++ b/observability/braintrust/package.json
@@ -27,7 +27,10 @@
     "build:watch": "pnpm build --watch",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "example:basic": "tsx examples/basic.ts",
+    "example:traced": "tsx examples/with-logger-traced.ts",
+    "example:eval": "tsx examples/with-eval.ts"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -979,7 +979,6 @@ describe('BraintrustExporter', () => {
 describe('BraintrustExporter with braintrustLogger parameter', () => {
   let mockLogger: any;
   let mockExternalSpan: any;
-  let mockCurrentSpan: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -996,9 +995,6 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
       log: vi.fn(),
       end: vi.fn(),
     };
-
-    // Mock currentSpan to return NOOP_SPAN by default
-    mockCurrentSpan = vi.fn().mockReturnValue({ id: undefined });
   });
 
   it('should use provided logger when no external span exists', async () => {

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -18,7 +18,7 @@ import type {
 import { SpanType, TracingEventType } from '@mastra/core/observability';
 import { initLogger, _exportsForTestingOnly } from 'braintrust';
 import type { Logger } from 'braintrust';
-import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BraintrustExporter } from './tracing';
 import type { BraintrustExporterConfig } from './tracing';
 
@@ -979,7 +979,6 @@ describe('BraintrustExporter', () => {
 describe('BraintrustExporter with braintrustLogger parameter', () => {
   let mockLogger: any;
   let mockExternalSpan: any;
-  let mockCurrentSpan: any;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -16,8 +16,9 @@ import type {
   ToolCallAttributes,
 } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
-import { initLogger } from 'braintrust';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initLogger, _exportsForTestingOnly } from 'braintrust';
+import type { Logger } from 'braintrust';
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 import { BraintrustExporter } from './tracing';
 import type { BraintrustExporterConfig } from './tracing';
 
@@ -967,6 +968,251 @@ describe('BraintrustExporter', () => {
       await exporter.shutdown();
       expect(mockSpan.end).toHaveBeenCalledTimes(3);
     });
+  });
+});
+
+// ==============================================================================
+// Tests: braintrustLogger Parameter
+// ==============================================================================
+// These tests verify the braintrustLogger parameter integration works correctly.
+
+describe('BraintrustExporter with braintrustLogger parameter', () => {
+  let mockLogger: any;
+  let mockExternalSpan: any;
+  let mockCurrentSpan: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set up mock logger
+    mockLogger = {
+      startSpan: vi.fn(),
+    };
+
+    // Set up mock external span (simulating logger.traced() or Eval context)
+    mockExternalSpan = {
+      id: 'external-span-id',
+      startSpan: vi.fn(),
+      log: vi.fn(),
+      end: vi.fn(),
+    };
+
+    // Mock currentSpan to return NOOP_SPAN by default
+    mockCurrentSpan = vi.fn().mockReturnValue({ id: undefined });
+  });
+
+  it('should use provided logger when no external span exists', async () => {
+    // Set up mock span that will be returned
+    const mockSpan = {
+      startSpan: vi.fn(),
+      log: vi.fn(),
+      end: vi.fn(),
+    };
+    mockSpan.startSpan.mockReturnValue(mockSpan);
+    mockLogger.startSpan.mockReturnValue(mockSpan);
+
+    // Create exporter with braintrustLogger parameter
+    const config: BraintrustExporterConfig = {
+      braintrustLogger: mockLogger as Logger<true>,
+    };
+    const exporter = new BraintrustExporter(config);
+
+    // Verify initLogger was NOT called (because braintrustLogger is provided)
+    const mockInitLogger = vi.mocked(initLogger);
+    expect(mockInitLogger).not.toHaveBeenCalled();
+
+    // Create and export a root span
+    const rootSpan = createMockSpan({
+      id: 'root-span-id',
+      name: 'root-agent',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+      attributes: { agentId: 'test-agent' },
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: rootSpan,
+    });
+
+    // Verify the provided logger was used to create the span
+    expect(mockLogger.startSpan).toHaveBeenCalledWith({
+      spanId: 'root-span-id',
+      name: 'root-agent',
+      type: 'task',
+      parentSpanIds: {
+        spanId: rootSpan.traceId,
+        rootSpanId: rootSpan.traceId,
+      },
+      metadata: {
+        spanType: 'agent_run',
+        agentId: 'test-agent',
+      },
+    });
+
+    // Verify mastra-trace-id metadata was logged
+    expect(mockSpan.log).toHaveBeenCalledWith({
+      metadata: {
+        'mastra-trace-id': rootSpan.traceId,
+      },
+    });
+
+    // Verify the trace is NOT marked as external
+    const spanData = (exporter as any).traceMap.get(rootSpan.traceId);
+    expect(spanData).toBeDefined();
+    expect(spanData.isExternal).toBe(false);
+    expect(spanData.logger).toBe(mockLogger);
+  });
+
+  it('should attach to external span when detected via currentSpan()', async () => {
+    // Mock currentSpan to return an external span (simulating logger.traced() or Eval context)
+    const { currentSpan: realCurrentSpan } = await import('braintrust');
+    const mockedCurrentSpan = vi.mocked(realCurrentSpan);
+
+    // Set up mock external span
+    mockExternalSpan.startSpan.mockReturnValue(mockExternalSpan);
+    mockedCurrentSpan.mockReturnValue(mockExternalSpan);
+
+    // Create exporter with braintrustLogger parameter
+    const config: BraintrustExporterConfig = {
+      braintrustLogger: mockLogger as Logger<true>,
+    };
+    const exporter = new BraintrustExporter(config);
+
+    // Create a Mastra root span
+    const rootSpan = createMockSpan({
+      id: 'mastra-span-id',
+      name: 'mastra-agent',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+      attributes: { agentId: 'test-agent' },
+    });
+
+    // Export the span - should detect external span and attach to it
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: rootSpan,
+    });
+
+    // Verify currentSpan was called to detect external context
+    expect(mockedCurrentSpan).toHaveBeenCalled();
+
+    // Verify the external span was used (not the provided logger)
+    expect(mockExternalSpan.startSpan).toHaveBeenCalledWith({
+      spanId: 'mastra-span-id',
+      name: 'mastra-agent',
+      type: 'task',
+      // When attaching to external span, parentSpanIds should be omitted
+      // (checked by NOT having parentSpanIds in the call)
+      metadata: {
+        spanType: 'agent_run',
+        agentId: 'test-agent',
+      },
+    });
+
+    // Verify the trace IS marked as external
+    const spanData = (exporter as any).traceMap.get(rootSpan.traceId);
+    expect(spanData).toBeDefined();
+    expect(spanData.isExternal).toBe(true);
+    expect(spanData.logger).toBe(mockExternalSpan);
+
+    // Verify mastra-trace-id metadata was logged
+    expect(mockExternalSpan.log).toHaveBeenCalledWith({
+      metadata: {
+        'mastra-trace-id': rootSpan.traceId,
+      },
+    });
+  });
+
+  it('should nest child spans correctly with external parent', async () => {
+    // Mock currentSpan to return an external span
+    const { currentSpan: realCurrentSpan } = await import('braintrust');
+    const mockedCurrentSpan = vi.mocked(realCurrentSpan);
+
+    // Set up mock external span with child span support
+    const mockChildSpan = {
+      startSpan: vi.fn(),
+      log: vi.fn(),
+      end: vi.fn(),
+    };
+    mockChildSpan.startSpan.mockReturnValue(mockChildSpan); // Allow nested spans
+    mockExternalSpan.startSpan.mockReturnValue(mockChildSpan);
+    mockedCurrentSpan.mockReturnValue(mockExternalSpan);
+
+    // Create exporter with braintrustLogger parameter
+    const config: BraintrustExporterConfig = {
+      braintrustLogger: mockLogger as Logger<true>,
+    };
+    const exporter = new BraintrustExporter(config);
+
+    // Create parent and child Mastra spans
+    const parentSpan = createMockSpan({
+      id: 'parent-span-id',
+      name: 'parent-agent',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+      attributes: { agentId: 'parent-agent' },
+    });
+
+    const childSpan = createMockSpan({
+      id: 'child-span-id',
+      name: 'child-tool',
+      type: SpanType.TOOL_CALL,
+      isRoot: false,
+      attributes: { toolId: 'calculator' },
+    });
+    childSpan.traceId = parentSpan.traceId;
+    childSpan.parentSpanId = parentSpan.id;
+
+    // Export parent span (should attach to external span)
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: parentSpan,
+    });
+
+    // Export child span (should nest inside parent)
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: childSpan,
+    });
+
+    // Verify parent was attached to external span without parentSpanIds
+    expect(mockExternalSpan.startSpan).toHaveBeenCalledWith({
+      spanId: 'parent-span-id',
+      name: 'parent-agent',
+      type: 'task',
+      metadata: {
+        spanType: 'agent_run',
+        agentId: 'parent-agent',
+      },
+    });
+
+    // Verify child span was created with proper parent relationship
+    expect(mockChildSpan.startSpan).toHaveBeenCalledWith({
+      spanId: 'child-span-id',
+      name: 'child-tool',
+      type: 'tool',
+      parentSpanIds: {
+        spanId: parentSpan.id,
+        rootSpanId: parentSpan.traceId,
+      },
+      metadata: {
+        spanType: 'tool_call',
+        toolId: 'calculator',
+      },
+    });
+
+    // Verify both spans have mastra-trace-id metadata
+    expect(mockChildSpan.log).toHaveBeenCalledWith({
+      metadata: {
+        'mastra-trace-id': parentSpan.traceId,
+      },
+    });
+
+    // Verify trace is marked as external
+    const spanData = (exporter as any).traceMap.get(parentSpan.traceId);
+    expect(spanData).toBeDefined();
+    expect(spanData.isExternal).toBe(true);
   });
 });
 

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -979,6 +979,7 @@ describe('BraintrustExporter', () => {
 describe('BraintrustExporter with braintrustLogger parameter', () => {
   let mockLogger: any;
   let mockExternalSpan: any;
+  let mockCurrentSpan: any;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -147,7 +147,11 @@ export class BraintrustExporter extends BaseExporter {
       name: span.name,
       type: mapSpanType(span.type),
       ...(shouldOmitParentIds
-        ? {} // Let Braintrust auto-link to parent
+        ? {
+            metadata: {
+              traceId: span.traceId,
+            },
+          } // Let Braintrust auto-link to parent
         : {
             parentSpanIds: span.parentSpanId
               ? { spanId: span.parentSpanId, rootSpanId: span.traceId }

--- a/observability/braintrust/tsconfig.json
+++ b/observability/braintrust/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.node.json",
   "include": ["src/**/*", "tsup.config.ts"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "examples/**/*"]
 }


### PR DESCRIPTION
## Description

This PR adds `braintrustLogger` as a parameter to `BraintrustExporter` allowing developers to pass in their own braintrust logger. This enables:

* nesting Mastra traces inside parent spans  
* running braintrust evals on mastra agents

Note: this PR isn't intended to be a breaking change.

## Related Issue(s)

customer request


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

I've manually tested and checked the scripts ran into this repo.
braintrust eval:
<img width="1435" height="1262" alt="image" src="https://github.com/user-attachments/assets/5328f15d-fd75-44f7-b5cf-058ab4ea00ad" />

parent span:
<img width="1436" height="1194" alt="image" src="https://github.com/user-attachments/assets/91c4088a-2a62-46ba-90f8-d5c7af95255a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional braintrustLogger for context-aware Braintrust tracing.
  * New example demos: standard integration, logger-traced context, and Eval workflow.

* **Chores**
  * Runnable scripts to launch the examples.
  * Examples excluded from linting and TypeScript compilation.
  * Added changeset declaring a patch release.

* **Tests**
  * Added tests covering braintrustLogger integration, external-span attachment, and nested trace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->