### PR TITLE
feat(auth): Expose requiresAuth on custom routes

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Add visual styles and labels for more workflow node types ([#9777](https://github.com/mastra-ai/mastra/pull/9777))
 
+- `registerApiRoute` now accepts a `requiresAuth` option, so custom endpoints can opt in/out of Mastra auth without mutating the returned route object.
+
 ## 1.0.0-beta.0
 
 ### Major Changes

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -41,6 +41,10 @@ type RegisterApiRouteOptions<P extends string> = {
     >
   >;
   middleware?: MiddlewareHandler | MiddlewareHandler[];
+  /**
+   * When false, skips Mastra auth for this route (defaults to true)
+   */
+  requiresAuth?: boolean;
 };
 
 function validateOptions<P extends string>(
@@ -99,6 +103,7 @@ export function registerApiRoute<P extends string>(
     createHandler: options.createHandler,
     openapi: options.openapi,
     middleware: options.middleware,
+    requiresAuth: options.requiresAuth,
   } as unknown as ValidatePath<P, ApiRoute>;
 }
 

--- a/packages/core/src/server/server.test.ts
+++ b/packages/core/src/server/server.test.ts
@@ -19,6 +19,7 @@ describe('registerApiRoute', () => {
       createHandler: undefined,
       openapi: undefined,
       middleware: undefined,
+      requiresAuth: undefined,
     });
 
     route = registerApiRoute('/test', {
@@ -33,7 +34,18 @@ describe('registerApiRoute', () => {
       handler: undefined,
       openapi: undefined,
       middleware: undefined,
+      requiresAuth: undefined,
     });
+  });
+
+  it('should set requiresAuth when provided', () => {
+    const route = registerApiRoute('/test', {
+      method: 'POST',
+      handler: mockHandler,
+      requiresAuth: false,
+    });
+
+    expect(route.requiresAuth).toBe(false);
   });
 
   it('should throw if path starts with /api', () => {

--- a/packages/deployer/CHANGELOG.md
+++ b/packages/deployer/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated dependencies [[`910db9e`](https://github.com/mastra-ai/mastra/commit/910db9e0312888495eb5617b567f247d03303814), [`e7266a2`](https://github.com/mastra-ai/mastra/commit/e7266a278db02035c97a5e9cd9d1669a6b7a535d)]:
   - @mastra/core@1.0.0-beta.1
   - @mastra/server@1.0.0-beta.1
+- Custom route handling now respects the `requiresAuth` flag emitted directly from `registerApiRoute`, so you can mark endpoints as public without mutating the returned object.
 
 ## 1.0.0-beta.0
 

--- a/packages/deployer/src/server/handlers/auth/auth-integration.test.ts
+++ b/packages/deployer/src/server/handlers/auth/auth-integration.test.ts
@@ -44,20 +44,16 @@ describe('auth middleware integration tests', () => {
   describe('Public Routes', () => {
     it('should allow access to explicitly public routes without authentication', async () => {
       const routes = [
-        {
-          ...registerApiRoute('/webhooks/github', {
-            method: 'POST',
-            handler: c => c.json({ received: true }),
-          }),
+        registerApiRoute('/webhooks/github', {
+          method: 'POST',
+          handler: c => c.json({ received: true }),
           requiresAuth: false,
-        },
-        {
-          ...registerApiRoute('/public/status', {
-            method: 'GET',
-            handler: c => c.json({ status: 'public' }),
-          }),
+        }),
+        registerApiRoute('/public/status', {
+          method: 'GET',
+          handler: c => c.json({ status: 'public' }),
           requiresAuth: false,
-        },
+        }),
       ];
 
       const mastra = createMastraWithRoutes(routes);
@@ -109,20 +105,14 @@ describe('auth middleware integration tests', () => {
   describe('Protected Routes', () => {
     it('should deny access to explicitly protected routes without authentication', async () => {
       const routes = [
-        {
-          ...registerApiRoute('/data/sensitive', {
-            method: 'GET',
-            handler: c => c.json({ data: 'sensitive information' }),
-          }),
-          requiresAuth: true,
-        },
-        {
-          ...registerApiRoute('/user/profile', {
-            method: 'GET',
-            handler: c => c.json({ profile: 'user data' }),
-          }),
-          requiresAuth: true,
-        },
+        registerApiRoute('/data/sensitive', {
+          method: 'GET',
+          handler: c => c.json({ data: 'sensitive information' }),
+        }),
+        registerApiRoute('/user/profile', {
+          method: 'GET',
+          handler: c => c.json({ profile: 'user data' }),
+        }),
       ];
 
       const mastra = createMastraWithRoutes(routes);
@@ -141,20 +131,14 @@ describe('auth middleware integration tests', () => {
 
     it('should allow access to protected routes with valid authentication', async () => {
       const routes = [
-        {
-          ...registerApiRoute('/data/sensitive', {
-            method: 'GET',
-            handler: c => c.json({ data: 'sensitive information' }),
-          }),
-          requiresAuth: true,
-        },
-        {
-          ...registerApiRoute('/user/profile', {
-            method: 'POST',
-            handler: c => c.json({ updated: true }),
-          }),
-          requiresAuth: true,
-        },
+        registerApiRoute('/data/sensitive', {
+          method: 'GET',
+          handler: c => c.json({ data: 'sensitive information' }),
+        }),
+        registerApiRoute('/user/profile', {
+          method: 'POST',
+          handler: c => c.json({ updated: true }),
+        }),
       ];
 
       const mastra = createMastraWithRoutes(routes);
@@ -186,13 +170,10 @@ describe('auth middleware integration tests', () => {
 
     it('should deny access with invalid authentication tokens', async () => {
       const routes = [
-        {
-          ...registerApiRoute('/data/sensitive', {
-            method: 'GET',
-            handler: c => c.json({ data: 'sensitive information' }),
-          }),
-          requiresAuth: true,
-        },
+        registerApiRoute('/data/sensitive', {
+          method: 'GET',
+          handler: c => c.json({ data: 'sensitive information' }),
+        }),
       ];
 
       const mastra = createMastraWithRoutes(routes);
@@ -215,22 +196,16 @@ describe('auth middleware integration tests', () => {
   });
 
   describe('Default Behavior', () => {
-    it('should default to requiring authentication when requiresAuth is not specified', async () => {
+    it('should default to requiring authentication when auth is not specified', async () => {
       const routes = [
-        {
-          ...registerApiRoute('/default/behavior', {
-            method: 'GET',
-            handler: c => c.json({ message: 'default behavior' }),
-          }),
-          // No requiresAuth specified - should default to true
-        },
-        {
-          ...registerApiRoute('/another/default', {
-            method: 'POST',
-            handler: c => c.json({ created: true }),
-          }),
-          // No requiresAuth specified - should default to true
-        },
+        registerApiRoute('/default/behavior', {
+          method: 'GET',
+          handler: c => c.json({ message: 'default behavior' }),
+        }),
+        registerApiRoute('/another/default', {
+          method: 'POST',
+          handler: c => c.json({ created: true }),
+        }),
       ];
 
       const mastra = createMastraWithRoutes(routes);
@@ -301,13 +276,11 @@ describe('auth middleware integration tests', () => {
 
     it('should override pattern protection with explicit route configuration', async () => {
       const routes = [
-        {
-          ...registerApiRoute('/custom/public-override', {
-            method: 'GET',
-            handler: c => c.json({ message: 'public override' }),
-          }),
+        registerApiRoute('/custom/public-override', {
+          method: 'GET',
+          handler: c => c.json({ message: 'public override' }),
           requiresAuth: false,
-        },
+        }),
       ];
 
       const mastra = createMastraWithRoutes(routes);
@@ -349,27 +322,19 @@ describe('auth middleware integration tests', () => {
   describe('HTTP Method Handling', () => {
     it('should handle different auth requirements for same path with different methods', async () => {
       const routes = [
-        {
-          ...registerApiRoute('/multi/endpoint', {
-            method: 'GET',
-            handler: c => c.json({ method: 'GET', data: 'public' }),
-          }),
+        registerApiRoute('/multi/endpoint', {
+          method: 'GET',
+          handler: c => c.json({ method: 'GET', data: 'public' }),
           requiresAuth: false,
-        },
-        {
-          ...registerApiRoute('/multi/endpoint', {
-            method: 'POST',
-            handler: c => c.json({ method: 'POST', data: 'protected' }),
-          }),
-          requiresAuth: true,
-        },
-        {
-          ...registerApiRoute('/multi/endpoint', {
-            method: 'PUT',
-            handler: c => c.json({ method: 'PUT', data: 'default' }),
-          }),
-          // No requiresAuth - should default to true
-        },
+        }),
+        registerApiRoute('/multi/endpoint', {
+          method: 'POST',
+          handler: c => c.json({ method: 'POST', data: 'protected' }),
+        }),
+        registerApiRoute('/multi/endpoint', {
+          method: 'PUT',
+          handler: c => c.json({ method: 'PUT', data: 'default' }),
+        }),
       ];
 
       const mastra = createMastraWithRoutes(routes);
@@ -419,6 +384,29 @@ describe('auth middleware integration tests', () => {
       });
       const putAuthRes = await app.request(putAuthReq);
       expect(putAuthRes.status).toBe(200);
+    });
+  });
+
+  describe('Legacy Compatibility', () => {
+    it('should still honor routes that manually set requiresAuth', async () => {
+      const routes = [
+        {
+          ...registerApiRoute('/legacy/public', {
+            method: 'GET',
+            handler: c => c.json({ ok: true }),
+          }),
+          requiresAuth: false,
+        },
+      ];
+
+      const mastra = createMastraWithRoutes(routes);
+      const app = await createHonoServer(mastra, { tools: {} });
+
+      const req = new Request('http://localhost/legacy/public');
+      const res = await app.request(req);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.ok).toBe(true);
     });
   });
 });

--- a/packages/deployer/src/server/handlers/auth/helpers.ts
+++ b/packages/deployer/src/server/handlers/auth/helpers.ts
@@ -18,7 +18,7 @@ export const isCustomRoutePublic = (
   // Check exact match first
   const routeKey = `${method}:${path}`;
   if (customRouteAuthConfig.has(routeKey)) {
-    return !customRouteAuthConfig.get(routeKey); // Return true if requiresAuth is false
+    return !customRouteAuthConfig.get(routeKey); // True when route opts out of auth
   }
 
   // Check ALL method


### PR DESCRIPTION
## Description
- allow `registerApiRoute` to accept/forward the existing `requiresAuth` flag so custom endpoints can opt out of MastraAuth without mutating the returned route config
- wire the deployer + auth helpers/tests to rely on that flag so `/livekit/mastra/access-token`-style bootstrapping routes can run before a Clerk token exists

## Related Issue(s)
- #9949

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

Fixes https://github.com/mastra-ai/mastra/issues/9949


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-route authentication control for custom API endpoints. The new `requiresAuth` configuration option allows each endpoint to independently specify whether it requires Mastra authentication, enabling fine-grained control over security policies across your API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->