### PR TITLE
SEO: Avoid title and description duplication

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ Frontmatter looks like this. title and description are mandatory.
 
 ```bash
 ---
-title: "Introduction | Mastra Docs"
+title: "Introduction"
 description: "Mastra is a TypeScript agent framework. It helps you build AI applications and features quickly. It gives you the set of primitives you need: workflows, agents, RAG, integrations, syncs and evals."
 ---
 ```

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -30,7 +30,7 @@ const config = {
     },
     parseFrontMatter: async (params) => {
       const result = await params.defaultParseFrontMatter(params);
-      result.frontMatter.description = `Mastra v1 BETA: ${result.frontMatter.description}`
+      result.frontMatter.description = `Mastra v1 BETA: ${result.frontMatter.description}`;
       return result;
     },
   },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,7 +11,7 @@ import "dotenv/config";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Mastra Documentation",
+  title: "Mastra v1 BETA Documentation",
   tagline: "TypeScript agent framework",
   favicon: "/favicon.ico",
 
@@ -27,6 +27,11 @@ const config = {
   markdown: {
     hooks: {
       onBrokenMarkdownLinks: "warn",
+    },
+    parseFrontMatter: async (params) => {
+      const result = await params.defaultParseFrontMatter(params);
+      result.frontMatter.description = `Mastra v1 BETA: ${result.frontMatter.description}`
+      return result;
     },
   },
   // Enable v4 features in prod

--- a/docs/src/content/en/docs/agents/adding-voice.mdx
+++ b/docs/src/content/en/docs/agents/adding-voice.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Adding Voice to Agents | Agents | Mastra Docs"
+title: "Adding Voice to Agents | Agents"
 ---
 
 # Adding Voice to Agents

--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agent Memory | Agents | Mastra Docs"
+title: "Agent Memory | Agents"
 description: Learn how to add memory to agents to store conversation history and maintain context across interactions.
 ---
 

--- a/docs/src/content/en/docs/agents/guardrails.mdx
+++ b/docs/src/content/en/docs/agents/guardrails.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Guardrails | Agents | Mastra Docs"
+title: "Guardrails | Agents"
 description: "Learn how to implement guardrails using input and output processors to secure and control AI interactions."
 ---
 

--- a/docs/src/content/en/docs/agents/networks.mdx
+++ b/docs/src/content/en/docs/agents/networks.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agent Networks | Agents | Mastra Docs"
+title: "Agent Networks | Agents"
 description: Learn how to coordinate multiple agents, workflows, and tools using agent networks for complex, non-deterministic task execution.
 ---
 

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Using Agents | Agents | Mastra Docs"
+title: "Using Agents | Agents"
 description: Overview of agents in Mastra, detailing their capabilities and how they interact with tools, workflows, and external systems.
 ---
 

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Using Tools | Agents | Mastra Docs"
+title: "Using Tools | Agents"
 description: Learn how to create tools and add them to agents to extend capabilities beyond text generation.
 ---
 

--- a/docs/src/content/en/docs/auth/auth0.mdx
+++ b/docs/src/content/en/docs/auth/auth0.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MastraAuthAuth0 Class | Auth | Mastra Docs"
+title: "MastraAuthAuth0 Class | Auth"
 description: "Documentation for the MastraAuthAuth0 class, which authenticates Mastra applications using Auth0 authentication."
 ---
 

--- a/docs/src/content/en/docs/auth/clerk.mdx
+++ b/docs/src/content/en/docs/auth/clerk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MastraAuthClerk Class | Auth | Mastra Docs"
+title: "MastraAuthClerk Class | Auth"
 description: "Documentation for the MastraAuthClerk class, which authenticates Mastra applications using Clerk authentication."
 ---
 

--- a/docs/src/content/en/docs/auth/firebase.mdx
+++ b/docs/src/content/en/docs/auth/firebase.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MastraAuthFirebase Class | Auth | Mastra Docs"
+title: "MastraAuthFirebase Class | Auth"
 description: "Documentation for the MastraAuthFirebase class, which authenticates Mastra applications using Firebase Authentication."
 ---
 

--- a/docs/src/content/en/docs/auth/index.mdx
+++ b/docs/src/content/en/docs/auth/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Auth Overview | Auth | Mastra Docs"
+title: "Auth Overview | Auth"
 description: Learn about different Auth options for your Mastra applications
 ---
 

--- a/docs/src/content/en/docs/auth/jwt.mdx
+++ b/docs/src/content/en/docs/auth/jwt.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MastraJwtAuth Class | Auth | Mastra Docs"
+title: "MastraJwtAuth Class | Auth"
 description: "Documentation for the MastraJwtAuth class, which authenticates Mastra applications using JSON Web Tokens."
 ---
 

--- a/docs/src/content/en/docs/auth/supabase.mdx
+++ b/docs/src/content/en/docs/auth/supabase.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MastraAuthSupabase Class | Auth | Mastra Docs"
+title: "MastraAuthSupabase Class | Auth"
 description: "Documentation for the MastraAuthSupabase class, which authenticates Mastra applications using Supabase Auth."
 ---
 

--- a/docs/src/content/en/docs/auth/workos.mdx
+++ b/docs/src/content/en/docs/auth/workos.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MastraAuthWorkos Class | Auth | Mastra Docs"
+title: "MastraAuthWorkos Class | Auth"
 description: "Documentation for the MastraAuthWorkos class, which authenticates Mastra applications using WorkOS authentication."
 ---
 

--- a/docs/src/content/en/docs/community/contributing-templates.mdx
+++ b/docs/src/content/en/docs/community/contributing-templates.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Contributing Templates | Community | Mastra Docs"
+title: "Contributing Templates | Community"
 description: "How to contribute your own templates to the Mastra ecosystem"
 ---
 

--- a/docs/src/content/en/docs/community/discord.mdx
+++ b/docs/src/content/en/docs/community/discord.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Discord Community | Community | Mastra Docs"
+title: "Discord Community | Community"
 description: Information about the Mastra Discord community and MCP bot.
 ---
 

--- a/docs/src/content/en/docs/community/licensing.mdx
+++ b/docs/src/content/en/docs/community/licensing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "License | Community | Mastra Docs"
+title: "License | Community"
 description: "Mastra License"
 ---
 

--- a/docs/src/content/en/docs/deployment/building-mastra.mdx
+++ b/docs/src/content/en/docs/deployment/building-mastra.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Building Mastra | Deployment | Mastra Docs"
+title: "Building Mastra | Deployment"
 description: "Learn how to build a Mastra server with build settings and deployment options."
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/amazon-ec2.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/amazon-ec2.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Amazon EC2 | Deployment | Mastra Docs"
+title: "Amazon EC2 | Deployment"
 description: "Deploy your Mastra applications to Amazon EC2."
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/aws-lambda.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/aws-lambda.mdx
@@ -1,5 +1,5 @@
 ---
-title: "AWS Lambda | Deployment | Mastra Docs"
+title: "AWS Lambda | Deployment"
 description: "Deploy your Mastra applications to AWS Lambda using Docker containers and the AWS Lambda Web Adapter."
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/azure-app-services.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/azure-app-services.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Azure App Services | Deployment | Mastra Docs"
+title: "Azure App Services | Deployment"
 description: "Deploy your Mastra applications to Azure App Services."
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/cloudflare-deployer.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/cloudflare-deployer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CloudflareDeployer | Deployment | Mastra Docs"
+title: "CloudflareDeployer | Deployment"
 description: "Learn how to deploy a Mastra application to Cloudflare using the Mastra CloudflareDeployer"
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/digital-ocean.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/digital-ocean.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Digital Ocean | Deployment | Mastra Docs"
+title: "Digital Ocean | Deployment"
 description: "Deploy your Mastra applications to Digital Ocean."
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/index.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Cloud Providers | Deployment | Mastra Docs"
+title: "Cloud Providers | Deployment"
 description: "Deploy your Mastra applications to popular cloud providers."
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/netlify-deployer.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/netlify-deployer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "NetlifyDeployer | Deployment | Mastra Docs"
+title: "NetlifyDeployer | Deployment"
 description: "Learn how to deploy a Mastra application to Netlify using the Mastra NetlifyDeployer"
 ---
 

--- a/docs/src/content/en/docs/deployment/cloud-providers/vercel-deployer.mdx
+++ b/docs/src/content/en/docs/deployment/cloud-providers/vercel-deployer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "VercelDeployer | Deployment | Mastra Docs"
+title: "VercelDeployer | Deployment"
 description: "Learn how to deploy a Mastra application to Vercel using the Mastra VercelDeployer"
 ---
 

--- a/docs/src/content/en/docs/deployment/mastra-cloud/dashboard.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-cloud/dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Navigating the Dashboard | Mastra Cloud | Mastra Docs"
+title: "Navigating the Dashboard | Mastra Cloud"
 description: Details of each feature available in Mastra Cloud
 ---
 

--- a/docs/src/content/en/docs/deployment/mastra-cloud/observability.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-cloud/observability.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Understanding Tracing and Logs | Mastra Cloud | Mastra Docs"
+title: "Understanding Tracing and Logs | Mastra Cloud"
 description: Monitoring and debugging tools for Mastra Cloud deployments
 ---
 

--- a/docs/src/content/en/docs/deployment/mastra-cloud/overview.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-cloud/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Mastra Cloud | Mastra Cloud | Mastra Docs"
+title: "Mastra Cloud | Mastra Cloud"
 description: Deployment and monitoring service for Mastra applications
 ---
 

--- a/docs/src/content/en/docs/deployment/mastra-cloud/setting-up.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-cloud/setting-up.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting Up and Deploying | Mastra Cloud | Mastra Docs"
+title: "Setting Up and Deploying | Mastra Cloud"
 description: Configuration steps for Mastra Cloud projects
 ---
 

--- a/docs/src/content/en/docs/deployment/monorepo.mdx
+++ b/docs/src/content/en/docs/deployment/monorepo.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Monorepo Deployment | Deployment | Mastra Docs"
+title: "Monorepo Deployment | Deployment"
 description: Learn how to deploy Mastra applications that are part of a monorepo setup
 ---
 

--- a/docs/src/content/en/docs/deployment/overview.mdx
+++ b/docs/src/content/en/docs/deployment/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Deployment Overview | Deployment | Mastra Docs"
+title: "Deployment Overview | Deployment"
 description: Learn about different deployment options for your Mastra applications
 ---
 

--- a/docs/src/content/en/docs/deployment/web-framework.mdx
+++ b/docs/src/content/en/docs/deployment/web-framework.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Web Framework Integration | Deployment | Mastra Docs"
+title: "Web Framework Integration | Deployment"
 description: "Learn how Mastra can be deployed when integrated with a Web Framework"
 ---
 

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom Scorers | Evals | Mastra Docs"
+title: "Custom Scorers | Evals"
 ---
 
 # Custom scorers

--- a/docs/src/content/en/docs/evals/off-the-shelf-scorers.mdx
+++ b/docs/src/content/en/docs/evals/off-the-shelf-scorers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Built-in Scorers | Evals | Mastra Docs"
+title: "Built-in Scorers | Evals"
 description: "Overview of Mastra's ready-to-use scorers for evaluating AI outputs across quality, safety, and performance dimensions."
 ---
 

--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Scorers overview | Evals | Mastra Docs"
+title: "Scorers overview | Evals"
 description: Overview of scorers in Mastra, detailing their capabilities for evaluating AI outputs and measuring performance.
 ---
 

--- a/docs/src/content/en/docs/evals/running-in-ci.mdx
+++ b/docs/src/content/en/docs/evals/running-in-ci.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Running Scorers in CI | Evals | Mastra Docs"
+title: "Running Scorers in CI | Evals"
 description: "Learn how to run scorer experiments in your CI/CD pipeline using the runEvals function."
 ---
 

--- a/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/ai-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Using Vercel AI SDK | Frameworks | Mastra Docs"
+title: "Using Vercel AI SDK | Frameworks"
 description: "Learn how Mastra leverages the Vercel AI SDK library and how you can leverage it further with Mastra"
 ---
 

--- a/docs/src/content/en/docs/frameworks/agentic-uis/assistant-ui.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/assistant-ui.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Using with Assistant UI | Frameworks | Mastra Docs"
+title: "Using with Assistant UI | Frameworks"
 description: "Learn how to integrate Assistant UI with Mastra"
 ---
 

--- a/docs/src/content/en/docs/frameworks/agentic-uis/cedar-os.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/cedar-os.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrate Cedar-OS with Mastra | Frameworks | Mastra Docs"
+title: "Integrate Cedar-OS with Mastra | Frameworks"
 description: "Build AI-native frontends for your Mastra agents with Cedar-OS"
 ---
 

--- a/docs/src/content/en/docs/frameworks/agentic-uis/copilotkit.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/copilotkit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrate CopilotKit with Mastra | Frameworks | Mastra Docs"
+title: "Integrate CopilotKit with Mastra | Frameworks"
 description: "Learn how Mastra leverages the CopilotKit's AGUI library and how you can leverage it to build user experiences"
 ---
 

--- a/docs/src/content/en/docs/frameworks/agentic-uis/openrouter.mdx
+++ b/docs/src/content/en/docs/frameworks/agentic-uis/openrouter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Use OpenRouter with Mastra | Frameworks | Mastra Docs"
+title: "Use OpenRouter with Mastra | Frameworks"
 description: "Learn how to integrate OpenRouter with Mastra"
 ---
 

--- a/docs/src/content/en/docs/frameworks/servers/express.mdx
+++ b/docs/src/content/en/docs/frameworks/servers/express.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrate Mastra in your Express project | Frameworks | Mastra Docs"
+title: "Integrate Mastra in your Express project | Frameworks"
 description: A step-by-step guide to integrating Mastra with an Express backend.
 ---
 

--- a/docs/src/content/en/docs/frameworks/web-frameworks/astro.mdx
+++ b/docs/src/content/en/docs/frameworks/web-frameworks/astro.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrate Mastra in your Astro project | Frameworks | Mastra Docs"
+title: "Integrate Mastra in your Astro project | Frameworks"
 description: A step-by-step guide to integrating Mastra with Astro.
 ---
 

--- a/docs/src/content/en/docs/frameworks/web-frameworks/next-js.mdx
+++ b/docs/src/content/en/docs/frameworks/web-frameworks/next-js.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrate Mastra in your Next.js project | Frameworks | Mastra Docs"
+title: "Integrate Mastra in your Next.js project | Frameworks"
 description: A step-by-step guide to integrating Mastra with Next.js.
 ---
 

--- a/docs/src/content/en/docs/frameworks/web-frameworks/sveltekit.mdx
+++ b/docs/src/content/en/docs/frameworks/web-frameworks/sveltekit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrate Mastra in your SvelteKit project | Frameworks | Mastra Docs"
+title: "Integrate Mastra in your SvelteKit project | Frameworks"
 description: A step-by-step guide to integrating Mastra with SvelteKit.
 ---
 

--- a/docs/src/content/en/docs/frameworks/web-frameworks/vite-react.mdx
+++ b/docs/src/content/en/docs/frameworks/web-frameworks/vite-react.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrate Mastra in your Vite/React project | Frameworks | Mastra Docs"
+title: "Integrate Mastra in your Vite/React project | Frameworks"
 description: A step-by-step guide to integrating Mastra with Vite and React.
 ---
 

--- a/docs/src/content/en/docs/getting-started/installation.mdx
+++ b/docs/src/content/en/docs/getting-started/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Install Mastra | Getting Started | Mastra Docs"
+title: "Install Mastra | Getting Started"
 description: Guide on installing Mastra and setting up the necessary prerequisites for running it with various LLM providers.
 ---
 

--- a/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Mastra Docs Server | Getting Started | Mastra Docs"
+title: "Mastra Docs Server | Getting Started"
 description: "Learn how to use the Mastra MCP documentation server in your IDE to turn it into an agentic Mastra expert."
 ---
 

--- a/docs/src/content/en/docs/getting-started/project-structure.mdx
+++ b/docs/src/content/en/docs/getting-started/project-structure.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Project Structure | Getting Started | Mastra Docs"
+title: "Project Structure | Getting Started"
 description: Guide on organizing folders and files in Mastra, including best practices and recommended structures.
 ---
 

--- a/docs/src/content/en/docs/getting-started/studio.mdx
+++ b/docs/src/content/en/docs/getting-started/studio.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Studio | Getting Started | Mastra Docs"
+title: "Studio | Getting Started"
 description: Guide on installing Mastra and setting up the necessary prerequisites for running it with various LLM providers.
 ---
 

--- a/docs/src/content/en/docs/getting-started/templates.mdx
+++ b/docs/src/content/en/docs/getting-started/templates.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Templates | Getting Started | Mastra Docs"
+title: "Templates | Getting Started"
 description: Pre-built project structures that demonstrate common Mastra use cases and patterns
 ---
 

--- a/docs/src/content/en/docs/index.mdx
+++ b/docs/src/content/en/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "About Mastra | Mastra Docs"
+title: "About Mastra"
 sidebar_position: 2
 sidebar_label: "Introduction"
 description: "Mastra is an all-in-one framework for building AI-powered applications and agents with a modern TypeScript stack."

--- a/docs/src/content/en/docs/logging.mdx
+++ b/docs/src/content/en/docs/logging.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Logging | Observability | Mastra Docs"
+title: "Logging | Observability"
 description: Learn how to use logging in Mastra to monitor execution, capture application behavior, and improve the accuracy of AI applications.
 ---
 

--- a/docs/src/content/en/docs/memory/conversation-history.mdx
+++ b/docs/src/content/en/docs/memory/conversation-history.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Conversation History | Memory | Mastra Docs"
+title: "Conversation History | Memory"
 description: "Learn how to configure conversation history in Mastra to store recent messages from the current conversation."
 ---
 

--- a/docs/src/content/en/docs/memory/memory-processors.mdx
+++ b/docs/src/content/en/docs/memory/memory-processors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Memory Processors | Memory | Mastra Docs"
+title: "Memory Processors | Memory"
 description: "Learn how to use memory processors in Mastra to filter, trim, and transform messages before they're sent to the language model to manage context window limits."
 ---
 

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Memory overview | Memory | Mastra Docs"
+title: "Memory overview | Memory"
 description: "Learn how Mastra's memory system works with working memory, conversation history, and semantic recall."
 ---
 

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Semantic Recall | Memory | Mastra Docs"
+title: "Semantic Recall | Memory"
 description: "Learn how to use semantic recall in Mastra to retrieve relevant messages from past conversations using vector search and embeddings."
 ---
 

--- a/docs/src/content/en/docs/memory/storage/memory-with-libsql.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-libsql.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Memory with LibSQL | Memory | Mastra Docs"
+title: "Memory with LibSQL | Memory"
 description: Example for how to use Mastra's memory system with LibSQL storage and vector database backend.
 ---
 

--- a/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Memory with MongoDB | Memory | Mastra Docs"
+title: "Example: Memory with MongoDB | Memory"
 description: Example for how to use Mastra's memory system with MongoDB storage and vector capabilities.
 ---
 

--- a/docs/src/content/en/docs/memory/storage/memory-with-pg.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-pg.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Memory with Postgres | Memory | Mastra Docs"
+title: "Memory with Postgres | Memory"
 description: Example for how to use Mastra's memory system with PostgreSQL storage and vector capabilities.
 ---
 

--- a/docs/src/content/en/docs/memory/storage/memory-with-upstash.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-upstash.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Memory with Upstash | Memory | Mastra Docs"
+title: "Memory with Upstash | Memory"
 description: Example for how to use Mastra's memory system with Upstash Redis storage and vector capabilities.
 ---
 

--- a/docs/src/content/en/docs/memory/threads-and-resources.mdx
+++ b/docs/src/content/en/docs/memory/threads-and-resources.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Memory threads and resources | Memory | Mastra Docs"
+title: "Memory threads and resources | Memory"
 description: "Learn how Mastra's memory system works with working memory, conversation history, and semantic recall."
 ---
 

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Working Memory | Memory | Mastra Docs"
+title: "Working Memory | Memory"
 description: "Learn how to configure working memory in Mastra to store persistent user data, preferences."
 ---
 

--- a/docs/src/content/en/docs/observability/overview.mdx
+++ b/docs/src/content/en/docs/observability/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Observability Overview | Observability | Mastra Docs"
+title: "Observability Overview | Observability"
 description: Monitor and debug applications with Mastra's Observability features.
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/arize.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/arize.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Arize Exporter | Tracing | Observability | Mastra Docs"
+title: "Arize Exporter | Tracing | Observability"
 description: "Send traces to Arize Phoenix or Arize AX using OpenTelemetry and OpenInference"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Braintrust Exporter | Tracing | Observability | Mastra Docs"
+title: "Braintrust Exporter | Tracing | Observability"
 description: "Send traces to Braintrust for evaluation and monitoring"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Cloud Exporter | Tracing | Observability | Mastra Docs"
+title: "Cloud Exporter | Tracing | Observability"
 description: "Send traces to Mastra Cloud for production monitoring"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Default Exporter | Tracing | Observability | Mastra Docs"
+title: "Default Exporter | Tracing | Observability"
 description: "Store traces locally for development and debugging"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/langfuse.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/langfuse.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Langfuse Exporter | Tracing | Observability | Mastra Docs"
+title: "Langfuse Exporter | Tracing | Observability"
 description: "Send traces to Langfuse for LLM observability and analytics"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/langsmith.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/langsmith.mdx
@@ -1,5 +1,5 @@
 ---
-title: "LangSmith Exporter | Tracing | Observability | Mastra Docs"
+title: "LangSmith Exporter | Tracing | Observability"
 description: "Send traces to LangSmith for LLM observability and evaluation"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/otel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "OpenTelemetry Exporter | Tracing | Observability | Mastra Docs"
+title: "OpenTelemetry Exporter | Tracing | Observability"
 description: "Send traces to any OpenTelemetry-compatible observability platform"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Tracing | Observability | Mastra Docs"
+title: "Tracing | Observability"
 description: "Set up Tracing for Mastra applications"
 ---
 

--- a/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Sensitive Data Filter | Processors | Observability | Mastra Docs"
+title: "Sensitive Data Filter | Processors | Observability"
 description: "Protect sensitive information in your traces with automatic data redaction"
 ---
 

--- a/docs/src/content/en/docs/rag/overview.mdx
+++ b/docs/src/content/en/docs/rag/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "RAG (Retrieval-Augmented Generation) in Mastra | RAG | Mastra Docs"
+title: "RAG (Retrieval-Augmented Generation) in Mastra | RAG"
 description: Overview of Retrieval-Augmented Generation (RAG) in Mastra, detailing its capabilities for enhancing LLM outputs with relevant context.
 ---
 

--- a/docs/src/content/en/docs/rag/retrieval.mdx
+++ b/docs/src/content/en/docs/rag/retrieval.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Retrieval, Semantic Search, Reranking | RAG | Mastra Docs"
+title: "Retrieval, Semantic Search, Reranking | RAG"
 description: Guide on retrieval processes in Mastra's RAG systems, including semantic search, filtering, and re-ranking.
 ---
 

--- a/docs/src/content/en/docs/rag/vector-databases.mdx
+++ b/docs/src/content/en/docs/rag/vector-databases.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Storing Embeddings in A Vector Database | RAG | Mastra Docs"
+title: "Storing Embeddings in A Vector Database | RAG"
 description: Guide on vector storage options in Mastra, including embedded and dedicated vector databases for similarity search.
 ---
 

--- a/docs/src/content/en/docs/server-db/custom-api-routes.mdx
+++ b/docs/src/content/en/docs/server-db/custom-api-routes.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom API Routes | Server & DB | Mastra Docs"
+title: "Custom API Routes | Server & DB"
 description: "Expose additional HTTP endpoints from your Mastra server."
 ---
 

--- a/docs/src/content/en/docs/server-db/mastra-client.mdx
+++ b/docs/src/content/en/docs/server-db/mastra-client.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Mastra Client SDK | Server & DB | Mastra Docs"
+title: "Mastra Client SDK | Server & DB"
 description: "Learn how to set up and use the Mastra Client SDK"
 ---
 

--- a/docs/src/content/en/docs/server-db/mastra-server.mdx
+++ b/docs/src/content/en/docs/server-db/mastra-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Mastra Server | Server & DB | Mastra Docs"
+title: "Mastra Server | Server & DB"
 description: "Learn how to configure and deploy a production-ready Mastra server with custom settings for APIs, CORS, and more"
 ---
 

--- a/docs/src/content/en/docs/server-db/middleware.mdx
+++ b/docs/src/content/en/docs/server-db/middleware.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Middleware | Server & DB | Mastra Docs"
+title: "Middleware | Server & DB"
 description: "Apply custom middleware functions to intercept requests."
 ---
 

--- a/docs/src/content/en/docs/server-db/request-context.mdx
+++ b/docs/src/content/en/docs/server-db/request-context.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Request Context | Server & DB | Mastra Docs"
+title: "Request Context | Server & DB"
 description: Learn how to use Mastra's RequestContext to provide dynamic, request-specific configuration to agents.
 ---
 

--- a/docs/src/content/en/docs/server-db/storage.mdx
+++ b/docs/src/content/en/docs/server-db/storage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MastraStorage | Server & DB | Mastra Docs"
+title: "MastraStorage | Server & DB"
 description: Overview of Mastra's storage system and data persistence capabilities.
 ---
 

--- a/docs/src/content/en/docs/streaming/events.mdx
+++ b/docs/src/content/en/docs/streaming/events.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Streaming Events | Streaming | Mastra Docs"
+title: "Streaming Events | Streaming"
 description: "Learn about the different types of streaming events in Mastra, including text deltas, tool calls, step events, and how to handle them in your applications."
 ---
 

--- a/docs/src/content/en/docs/streaming/overview.mdx
+++ b/docs/src/content/en/docs/streaming/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Streaming Overview | Streaming | Mastra Docs"
+title: "Streaming Overview | Streaming"
 description: "Streaming in Mastra enables real-time, incremental responses from both agents and workflows, providing immediate feedback as AI-generated content is produced."
 ---
 

--- a/docs/src/content/en/docs/streaming/tool-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/tool-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Tool streaming | Streaming | Mastra Docs"
+title: "Tool streaming | Streaming"
 description: "Learn how to use tool streaming in Mastra, including handling tool calls, tool results, and tool execution events during streaming."
 ---
 

--- a/docs/src/content/en/docs/streaming/workflow-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/workflow-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Workflow streaming | Streaming | Mastra Docs"
+title: "Workflow streaming | Streaming"
 description: "Learn how to use workflow streaming in Mastra, including handling workflow execution events, step streaming, and workflow integration with agents and tools."
 ---
 

--- a/docs/src/content/en/docs/tools-mcp/advanced-usage.mdx
+++ b/docs/src/content/en/docs/tools-mcp/advanced-usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Advanced Tool Usage | Tools & MCP | Mastra Docs"
+title: "Advanced Tool Usage | Tools & MCP"
 description: This page covers advanced features for Mastra tools, including abort signals and compatibility with the Vercel AI SDK tool format.
 ---
 

--- a/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MCP Overview | Tools & MCP | Mastra Docs"
+title: "MCP Overview | Tools & MCP"
 description: Learn about the Model Context Protocol (MCP), how to use third-party tools via MCPClient, connect to registries, and share your own tools using MCPServer.
 ---
 

--- a/docs/src/content/en/docs/tools-mcp/overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Using Tools | Tools & MCP | Mastra Docs"
+title: "Using Tools | Tools & MCP"
 description: Understand what tools are in Mastra, how to add them to agents, and best practices for designing effective tools.
 ---
 

--- a/docs/src/content/en/docs/voice/overview.mdx
+++ b/docs/src/content/en/docs/voice/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Voice in Mastra | Voice | Mastra Docs"
+title: "Voice in Mastra | Voice"
 description: Overview of voice capabilities in Mastra, including text-to-speech, speech-to-text, and real-time speech-to-speech interactions.
 ---
 

--- a/docs/src/content/en/docs/voice/speech-to-speech.mdx
+++ b/docs/src/content/en/docs/voice/speech-to-speech.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Speech-to-Speech Capabilities in Mastra | Voice | Mastra Docs"
+title: "Speech-to-Speech Capabilities in Mastra | Voice"
 description: Overview of speech-to-speech capabilities in Mastra, including real-time interactions and event-driven architecture.
 ---
 

--- a/docs/src/content/en/docs/voice/speech-to-text.mdx
+++ b/docs/src/content/en/docs/voice/speech-to-text.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Speech-to-Text (STT) | Voice | Mastra Docs"
+title: "Speech-to-Text (STT) | Voice"
 description: Overview of Speech-to-Text capabilities in Mastra, including configuration, usage, and integration with voice providers.
 ---
 

--- a/docs/src/content/en/docs/voice/text-to-speech.mdx
+++ b/docs/src/content/en/docs/voice/text-to-speech.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Text-to-Speech (TTS) | Voice | Mastra Docs"
+title: "Text-to-Speech (TTS) | Voice"
 description: Overview of Text-to-Speech capabilities in Mastra, including configuration, usage, and integration with voice providers.
 ---
 

--- a/docs/src/content/en/docs/workflows/agents-and-tools.mdx
+++ b/docs/src/content/en/docs/workflows/agents-and-tools.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agents and Tools | Workflows | Mastra Docs"
+title: "Agents and Tools | Workflows"
 description: "Learn how to call agents and tools from workflow steps and choose between execute functions and step composition."
 ---
 

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Control Flow | Workflows | Mastra Docs"
+title: "Control Flow | Workflows"
 description: "Control flow in Mastra workflows allows you to manage branching, merging, and conditions to construct workflows that meet your logic requirements."
 ---
 

--- a/docs/src/content/en/docs/workflows/error-handling.mdx
+++ b/docs/src/content/en/docs/workflows/error-handling.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Error Handling | Workflows | Mastra Docs"
+title: "Error Handling | Workflows"
 description: "Learn how to handle errors in Mastra workflows using step retries, conditional branching, and monitoring."
 ---
 

--- a/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
+++ b/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Human-in-the-loop | Workflows | Mastra Docs"
+title: "Human-in-the-loop | Workflows"
 description: Example of using Mastra to create workflows with multi-turn human/agent interaction points using suspend/resume and dountil methods.
 ---
 

--- a/docs/src/content/en/docs/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/docs/workflows/inngest-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Inngest Workflow | Workflows | Mastra Docs"
+title: "Inngest Workflow | Workflows"
 description: "Inngest workflow allows you to run Mastra workflows with Inngest"
 ---
 

--- a/docs/src/content/en/docs/workflows/input-data-mapping.mdx
+++ b/docs/src/content/en/docs/workflows/input-data-mapping.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Input Data Mapping | Workflows | Mastra Docs"
+title: "Input Data Mapping | Workflows"
 description: "Learn how to use workflow input mapping to create more dynamic data flows in your Mastra workflows."
 ---
 

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Workflows overview | Workflows | Mastra Docs"
+title: "Workflows overview | Workflows"
 description: "Workflows in Mastra help you orchestrate complex sequences of tasks with features like branching, parallel execution, resource suspension, and more."
 ---
 

--- a/docs/src/content/en/docs/workflows/snapshots.mdx
+++ b/docs/src/content/en/docs/workflows/snapshots.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Snapshots | Workflows | Mastra Docs"
+title: "Snapshots | Workflows"
 description: "Learn how to save and resume workflow execution state with snapshots in Mastra"
 ---
 

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Suspend & Resume | Workflows | Mastra Docs"
+title: "Suspend & Resume | Workflows"
 description: "Suspend and resume in Mastra workflows allows you to pause execution while waiting for external input or resources."
 ---
 

--- a/docs/src/content/en/examples/agents/ai-sdk-v5-integration.mdx
+++ b/docs/src/content/en/examples/agents/ai-sdk-v5-integration.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: AI SDK v5 Integration | Agents | Mastra Docs"
+title: "Example: AI SDK v5 Integration | Agents"
 description: Example of integrating Mastra agents with AI SDK v5 for streaming chat interfaces with memory and tool integration.
 ---
 

--- a/docs/src/content/en/examples/agents/calling-agents.mdx
+++ b/docs/src/content/en/examples/agents/calling-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Calling Agents | Agents | Mastra Docs"
+title: "Example: Calling Agents | Agents"
 description: Example for how to call agents.
 ---
 

--- a/docs/src/content/en/examples/agents/deploying-mcp-server.mdx
+++ b/docs/src/content/en/examples/agents/deploying-mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Deploying an MCPServer | Agents | Mastra Docs"
+title: "Example: Deploying an MCPServer | Agents"
 description: Example of setting up, building, and deploying a Mastra MCPServer using the stdio transport and publishing it to NPM.
 ---
 

--- a/docs/src/content/en/examples/agents/image-analysis.mdx
+++ b/docs/src/content/en/examples/agents/image-analysis.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Image Analysis | Agents | Mastra Docs"
+title: "Example: Image Analysis | Agents"
 description: Example of using a Mastra AI Agent to analyze images from Unsplash to identify objects, determine species, and describe locations.
 ---
 

--- a/docs/src/content/en/examples/agents/request-context.mdx
+++ b/docs/src/content/en/examples/agents/request-context.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Request Context | Agents | Mastra Docs"
+title: "Example: Request Context | Agents"
 description: Learn how to create and configure dynamic agents using request context to adapt behavior based on user subscription tiers.
 ---
 

--- a/docs/src/content/en/examples/agents/supervisor-agent.mdx
+++ b/docs/src/content/en/examples/agents/supervisor-agent.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Supervisor Agent | Agents | Mastra Docs"
+title: "Example: Supervisor Agent | Agents"
 description: Example of creating a supervisor agent using Mastra, where agents interact through tool functions.
 ---
 

--- a/docs/src/content/en/examples/agents/system-prompt.mdx
+++ b/docs/src/content/en/examples/agents/system-prompt.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Changing the System Prompt | Agents | Mastra Docs"
+title: "Example: Changing the System Prompt | Agents"
 description: Example of creating an AI agent in Mastra with a system prompt to define its personality and capabilities.
 ---
 

--- a/docs/src/content/en/examples/agents/whatsapp-chat-bot.mdx
+++ b/docs/src/content/en/examples/agents/whatsapp-chat-bot.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: WhatsApp Chat Bot | Agents | Mastra Docs"
+title: "Example: WhatsApp Chat Bot | Agents"
 description: Example of creating a WhatsApp chat bot using Mastra agents and workflows to handle incoming messages and respond naturally via text messages.
 ---
 

--- a/docs/src/content/en/examples/evals/running-in-ci.mdx
+++ b/docs/src/content/en/examples/evals/running-in-ci.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Running Scorers in CI | Evals | Mastra Docs"
+title: "Example: Running Scorers in CI | Evals"
 description: Example of using runEvals to test agents in a CI/CD pipeline with Vitest.
 ---
 

--- a/docs/src/content/en/examples/index.mdx
+++ b/docs/src/content/en/examples/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Examples List: Workflows, Agents, RAG | Mastra Docs"
+title: "Examples List: Workflows, Agents, RAG"
 description: "Explore practical examples of AI development with Mastra, including text generation, RAG implementations, structured outputs, and multi-modal interactions. Learn how to build AI applications using OpenAI, Anthropic, and Google Gemini."
 ---
 

--- a/docs/src/content/en/examples/memory/working-memory-schema.mdx
+++ b/docs/src/content/en/examples/memory/working-memory-schema.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Working Memory with Schema | Memory | Mastra Docs"
+title: "Example: Working Memory with Schema | Memory"
 description: Example showing how to use Zod schema to structure and validate working memory data.
 ---
 

--- a/docs/src/content/en/examples/memory/working-memory-template.mdx
+++ b/docs/src/content/en/examples/memory/working-memory-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Working Memory with Template | Memory | Mastra Docs"
+title: "Example: Working Memory with Template | Memory"
 description: Example showing how to use Markdown template to structure working memory data.
 ---
 

--- a/docs/src/content/en/examples/observability/basic-tracing.mdx
+++ b/docs/src/content/en/examples/observability/basic-tracing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Basic Tracing Example | Observability | Mastra Docs"
+title: "Example: Basic Tracing Example | Observability"
 description: Get started with Tracing in your Mastra application
 ---
 

--- a/docs/src/content/en/examples/processors/message-length-limiter.mdx
+++ b/docs/src/content/en/examples/processors/message-length-limiter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Message Length Limiter | Processors | Mastra Docs"
+title: "Example: Message Length Limiter | Processors"
 description: Example of creating a custom input processor that limits message length before sending to the language model.
 ---
 

--- a/docs/src/content/en/examples/processors/response-length-limiter.mdx
+++ b/docs/src/content/en/examples/processors/response-length-limiter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Response Length Limiter | Processors | Mastra Docs"
+title: "Example: Response Length Limiter | Processors"
 description: Example of creating a custom output processor that limits AI response length during streaming to prevent excessively long outputs.
 ---
 

--- a/docs/src/content/en/examples/processors/response-validator.mdx
+++ b/docs/src/content/en/examples/processors/response-validator.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Response Validator | Processors | Mastra Docs"
+title: "Example: Response Validator | Processors"
 description: Example of creating a custom output processor that validates AI responses contain required keywords before returning them to users.
 ---
 

--- a/docs/src/content/en/examples/rag/chunking/adjust-chunk-delimiters.mdx
+++ b/docs/src/content/en/examples/rag/chunking/adjust-chunk-delimiters.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Adjust Chunk Delimiters | RAG | Mastra Docs"
+title: "Example: Adjust Chunk Delimiters | RAG"
 description: Adjust chunk delimiters in Mastra to better match your content structure.
 ---
 

--- a/docs/src/content/en/examples/rag/chunking/adjust-chunk-size.mdx
+++ b/docs/src/content/en/examples/rag/chunking/adjust-chunk-size.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Adjust Chunk Size | RAG | Mastra Docs"
+title: "Example: Adjust Chunk Size | RAG"
 description: Adjust chunk size in Mastra to better match your content and memory requirements.
 ---
 

--- a/docs/src/content/en/examples/rag/chunking/chunk-html.mdx
+++ b/docs/src/content/en/examples/rag/chunking/chunk-html.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Semantically Chunking HTML | RAG | Mastra Docs"
+title: "Example: Semantically Chunking HTML | RAG"
 description: Chunk HTML content in Mastra to semantically chunk the document.
 ---
 

--- a/docs/src/content/en/examples/rag/chunking/chunk-json.mdx
+++ b/docs/src/content/en/examples/rag/chunking/chunk-json.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Semantically Chunking JSON | RAG | Mastra Docs"
+title: "Example: Semantically Chunking JSON | RAG"
 description: Chunk JSON data in Mastra to semantically chunk the document.
 ---
 

--- a/docs/src/content/en/examples/rag/chunking/chunk-markdown.mdx
+++ b/docs/src/content/en/examples/rag/chunking/chunk-markdown.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Chunk Markdown | RAG | Mastra Docs"
+title: "Example: Chunk Markdown | RAG"
 description: Example of using Mastra to chunk markdown documents for search or retrieval purposes.
 ---
 

--- a/docs/src/content/en/examples/rag/chunking/chunk-text.mdx
+++ b/docs/src/content/en/examples/rag/chunking/chunk-text.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Chunk Text | RAG | Mastra Docs"
+title: "Example: Chunk Text | RAG"
 description: Example of using Mastra to split large text documents into smaller chunks for processing.
 ---
 

--- a/docs/src/content/en/examples/rag/embedding/embed-chunk-array.mdx
+++ b/docs/src/content/en/examples/rag/embedding/embed-chunk-array.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Embed Chunk Array | RAG | Mastra Docs"
+title: "Example: Embed Chunk Array | RAG"
 description: Example of using Mastra to generate embeddings for an array of text chunks for similarity search.
 ---
 

--- a/docs/src/content/en/examples/rag/embedding/embed-text-chunk.mdx
+++ b/docs/src/content/en/examples/rag/embedding/embed-text-chunk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Embed Text Chunk | RAG | Mastra Docs"
+title: "Example: Embed Text Chunk | RAG"
 description: Example of using Mastra to generate an embedding for a single text chunk for similarity search.
 ---
 

--- a/docs/src/content/en/examples/rag/embedding/embed-text-with-cohere.mdx
+++ b/docs/src/content/en/examples/rag/embedding/embed-text-with-cohere.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Embed Text with Cohere | RAG | Mastra Docs"
+title: "Example: Embed Text with Cohere | RAG"
 description: Example of using Mastra to generate embeddings using Cohere's embedding model.
 ---
 

--- a/docs/src/content/en/examples/rag/embedding/metadata-extraction.mdx
+++ b/docs/src/content/en/examples/rag/embedding/metadata-extraction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Metadata Extraction | RAG | Mastra Docs"
+title: "Example: Metadata Extraction | RAG"
 description: Example of extracting and utilizing metadata from documents in Mastra for enhanced document processing and retrieval.
 ---
 

--- a/docs/src/content/en/examples/rag/query/hybrid-vector-search.mdx
+++ b/docs/src/content/en/examples/rag/query/hybrid-vector-search.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Hybrid Vector Search | RAG | Mastra Docs"
+title: "Example: Hybrid Vector Search | RAG"
 description: Example of using metadata filters with PGVector to enhance vector search results in Mastra.
 ---
 

--- a/docs/src/content/en/examples/rag/query/retrieve-results.mdx
+++ b/docs/src/content/en/examples/rag/query/retrieve-results.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Retrieving Top-K Results | RAG | Mastra Docs"
+title: "Example: Retrieving Top-K Results | RAG"
 description: Example of using Mastra to query a vector database and retrieve semantically similar chunks.
 ---
 

--- a/docs/src/content/en/examples/rag/rerank/rerank-rag.mdx
+++ b/docs/src/content/en/examples/rag/rerank/rerank-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Re-ranking Results with Tools | RAG | Mastra Docs"
+title: "Example: Re-ranking Results with Tools | RAG"
 description: Example of implementing a RAG system with re-ranking in Mastra using OpenAI embeddings and PGVector for vector storage.
 ---
 

--- a/docs/src/content/en/examples/rag/rerank/rerank.mdx
+++ b/docs/src/content/en/examples/rag/rerank/rerank.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Re-ranking Results | RAG | Mastra Docs"
+title: "Example: Re-ranking Results | RAG"
 description: Example of implementing semantic re-ranking in Mastra using OpenAI embeddings and PGVector for vector storage.
 ---
 

--- a/docs/src/content/en/examples/rag/rerank/reranking-with-cohere.mdx
+++ b/docs/src/content/en/examples/rag/rerank/reranking-with-cohere.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Reranking with Cohere | RAG | Mastra Docs"
+title: "Example: Reranking with Cohere | RAG"
 description: Example of using Mastra to improve document retrieval relevance with Cohere's reranking service.
 ---
 

--- a/docs/src/content/en/examples/rag/rerank/reranking-with-zeroentropy.mdx
+++ b/docs/src/content/en/examples/rag/rerank/reranking-with-zeroentropy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Reranking with ZeroEntropy | RAG | Mastra Docs"
+title: "Example: Reranking with ZeroEntropy | RAG"
 description: Example of using Mastra to improve document retrieval relevance with ZeroEntropy's reranking service.
 ---
 

--- a/docs/src/content/en/examples/rag/upsert/upsert-embeddings.mdx
+++ b/docs/src/content/en/examples/rag/upsert/upsert-embeddings.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Upsert Embeddings | RAG | Mastra Docs"
+title: "Example: Upsert Embeddings | RAG"
 description: Examples of using Mastra to store embeddings in various vector databases for similarity search.
 ---
 

--- a/docs/src/content/en/examples/rag/usage/basic-rag.mdx
+++ b/docs/src/content/en/examples/rag/usage/basic-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Using the Vector Query Tool | RAG | Mastra Docs"
+title: "Example: Using the Vector Query Tool | RAG"
 description: Example of implementing a basic RAG system in Mastra using OpenAI embeddings and PGVector for vector storage.
 ---
 

--- a/docs/src/content/en/examples/rag/usage/cleanup-rag.mdx
+++ b/docs/src/content/en/examples/rag/usage/cleanup-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Optimizing Information Density | RAG | Mastra Docs"
+title: "Example: Optimizing Information Density | RAG"
 description: Example of implementing a RAG system in Mastra to optimize information density and deduplicate data using LLM-based processing.
 ---
 

--- a/docs/src/content/en/examples/rag/usage/cot-rag.mdx
+++ b/docs/src/content/en/examples/rag/usage/cot-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Chain of Thought Prompting | RAG | Mastra Docs"
+title: "Example: Chain of Thought Prompting | RAG"
 description: Example of implementing a RAG system in Mastra with chain-of-thought reasoning using OpenAI and PGVector.
 ---
 

--- a/docs/src/content/en/examples/rag/usage/cot-workflow-rag.mdx
+++ b/docs/src/content/en/examples/rag/usage/cot-workflow-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Structured Reasoning with Workflows | RAG | Mastra Docs"
+title: "Example: Structured Reasoning with Workflows | RAG"
 description: Example of implementing structured reasoning in a RAG system using Mastra's workflow capabilities.
 ---
 

--- a/docs/src/content/en/examples/rag/usage/database-specific-config.mdx
+++ b/docs/src/content/en/examples/rag/usage/database-specific-config.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Database-Specific Configurations | RAG | Mastra Docs"
+title: "Example: Database-Specific Configurations | RAG"
 description: Learn how to use database-specific configurations to optimize vector search performance and leverage unique features of different vector stores.
 ---
 

--- a/docs/src/content/en/examples/rag/usage/filter-rag.mdx
+++ b/docs/src/content/en/examples/rag/usage/filter-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Agent-Driven Metadata Filtering | RAG | Mastra Docs"
+title: "Example: Agent-Driven Metadata Filtering | RAG"
 description: Example of using a Mastra agent in a RAG system to construct and apply metadata filters for document retrieval.
 ---
 

--- a/docs/src/content/en/examples/rag/usage/graph-rag.mdx
+++ b/docs/src/content/en/examples/rag/usage/graph-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Graph RAG | RAG | Mastra Docs"
+title: "Example: Graph RAG | RAG"
 description: Example of implementing a Graph RAG system in Mastra using OpenAI embeddings and PGVector for vector storage.
 ---
 

--- a/docs/src/content/en/examples/voice/speech-to-speech.mdx
+++ b/docs/src/content/en/examples/voice/speech-to-speech.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Call Analysis with Mastra | Voice | Mastra Docs"
+title: "Example: Call Analysis with Mastra | Voice"
 description: Example of using Mastra to create a speech to speech application.
 ---
 

--- a/docs/src/content/en/examples/voice/speech-to-text.mdx
+++ b/docs/src/content/en/examples/voice/speech-to-text.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Smart Voice Memo App | Voice | Mastra Docs"
+title: "Example: Smart Voice Memo App | Voice"
 description: Example of using Mastra to create a speech to text application.
 ---
 

--- a/docs/src/content/en/examples/voice/text-to-speech.mdx
+++ b/docs/src/content/en/examples/voice/text-to-speech.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Interactive Story Generator | Voice | Mastra Docs"
+title: "Example: Interactive Story Generator | Voice"
 description: Example of using Mastra to create a text to speech application.
 ---
 

--- a/docs/src/content/en/examples/voice/turn-taking.mdx
+++ b/docs/src/content/en/examples/voice/turn-taking.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: AI Debate with Turn Taking | Voice | Mastra Docs"
+title: "Example: AI Debate with Turn Taking | Voice"
 description: Example of using Mastra to create a multi-agent debate with turn-taking conversation flow.
 ---
 

--- a/docs/src/content/en/examples/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/examples/workflows/inngest-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example: Inngest Workflow | Workflows | Mastra Docs"
+title: "Example: Inngest Workflow | Workflows"
 description: Example of building an inngest workflow with Mastra
 ---
 

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent Class | Agents | Mastra Docs"
+title: "Reference: Agent Class | Agents"
 description: "Documentation for the `Agent` class in Mastra, which provides the foundation for creating AI agents with various capabilities."
 ---
 

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.generate() | Agents | Mastra Docs"
+title: "Reference: Agent.generate() | Agents"
 description: "Documentation for the `Agent.generate()` method in Mastra agents, which enables non-streaming generation of responses with enhanced capabilities."
 ---
 

--- a/docs/src/content/en/reference/agents/generateLegacy.mdx
+++ b/docs/src/content/en/reference/agents/generateLegacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.generateLegacy() (Legacy) | Agents | Mastra Docs"
+title: "Reference: Agent.generateLegacy() (Legacy) | Agents"
 description: "Documentation for the legacy `Agent.generateLegacy()` method in Mastra agents. This method is deprecated and will be removed in a future version."
 ---
 

--- a/docs/src/content/en/reference/agents/getDefaultGenerateOptions.mdx
+++ b/docs/src/content/en/reference/agents/getDefaultGenerateOptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getDefaultGenerateOptionsLegacy() | Agents | Mastra Docs"
+title: "Reference: Agent.getDefaultGenerateOptionsLegacy() | Agents"
 description: "Documentation for the `Agent.getDefaultGenerateOptionsLegacy()` method in Mastra agents, which retrieves the default options used for generateLegacy calls."
 ---
 

--- a/docs/src/content/en/reference/agents/getDefaultOptions.mdx
+++ b/docs/src/content/en/reference/agents/getDefaultOptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getDefaultOptions() | Agents | Mastra Docs"
+title: "Reference: Agent.getDefaultOptions() | Agents"
 description: "Documentation for the `Agent.getDefaultOptions()` method in Mastra agents, which retrieves the default options used for stream and generate calls."
 ---
 

--- a/docs/src/content/en/reference/agents/getDefaultStreamOptions.mdx
+++ b/docs/src/content/en/reference/agents/getDefaultStreamOptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getDefaultStreamOptionsLegacy() | Agents | Mastra Docs"
+title: "Reference: Agent.getDefaultStreamOptionsLegacy() | Agents"
 description: "Documentation for the `Agent.getDefaultStreamOptionsLegacy()` method in Mastra agents, which retrieves the default options used for streamLegacy calls."
 ---
 

--- a/docs/src/content/en/reference/agents/getDescription.mdx
+++ b/docs/src/content/en/reference/agents/getDescription.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getDescription() | Agents | Mastra Docs"
+title: "Reference: Agent.getDescription() | Agents"
 description: "Documentation for the `Agent.getDescription()` method in Mastra agents, which retrieves the agent's description."
 ---
 

--- a/docs/src/content/en/reference/agents/getInstructions.mdx
+++ b/docs/src/content/en/reference/agents/getInstructions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getInstructions() | Agents | Mastra Docs"
+title: "Reference: Agent.getInstructions() | Agents"
 description: "Documentation for the `Agent.getInstructions()` method in Mastra agents, which retrieves the instructions that guide the agent's behavior."
 ---
 

--- a/docs/src/content/en/reference/agents/getLLM.mdx
+++ b/docs/src/content/en/reference/agents/getLLM.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getLLM() | Agents | Mastra Docs"
+title: "Reference: Agent.getLLM() | Agents"
 description: "Documentation for the `Agent.getLLM()` method in Mastra agents, which retrieves the language model instance."
 ---
 

--- a/docs/src/content/en/reference/agents/getMemory.mdx
+++ b/docs/src/content/en/reference/agents/getMemory.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getMemory() | Agents | Mastra Docs"
+title: "Reference: Agent.getMemory() | Agents"
 description: "Documentation for the `Agent.getMemory()` method in Mastra agents, which retrieves the memory system associated with the agent."
 ---
 

--- a/docs/src/content/en/reference/agents/getModel.mdx
+++ b/docs/src/content/en/reference/agents/getModel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getModel() | Agents | Mastra Docs"
+title: "Reference: Agent.getModel() | Agents"
 description: "Documentation for the `Agent.getModel()` method in Mastra agents, which retrieves the language model that powers the agent."
 ---
 

--- a/docs/src/content/en/reference/agents/getVoice.mdx
+++ b/docs/src/content/en/reference/agents/getVoice.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.getVoice() | Agents | Mastra Docs"
+title: "Reference: Agent.getVoice() | Agents"
 description: "Documentation for the `Agent.getVoice()` method in Mastra agents, which retrieves the voice provider for speech capabilities."
 ---
 

--- a/docs/src/content/en/reference/agents/listAgents.mdx
+++ b/docs/src/content/en/reference/agents/listAgents.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.listAgents() | Agents | Mastra Docs"
+title: "Reference: Agent.listAgents() | Agents"
 description: "Documentation for the `Agent.listAgents()` method in Mastra agents, which retrieves the sub-agents that the agent can access."
 ---
 

--- a/docs/src/content/en/reference/agents/listScorers.mdx
+++ b/docs/src/content/en/reference/agents/listScorers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.listScorers() | Agents | Mastra Docs"
+title: "Reference: Agent.listScorers() | Agents"
 description: "Documentation for the `Agent.listScorers()` method in Mastra agents, which retrieves the scoring configuration."
 ---
 

--- a/docs/src/content/en/reference/agents/listTools.mdx
+++ b/docs/src/content/en/reference/agents/listTools.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.listTools() | Agents | Mastra Docs"
+title: "Reference: Agent.listTools() | Agents"
 description: "Documentation for the `Agent.listTools()` method in Mastra agents, which retrieves the tools that the agent can use."
 ---
 

--- a/docs/src/content/en/reference/agents/listWorkflows.mdx
+++ b/docs/src/content/en/reference/agents/listWorkflows.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.listWorkflows() | Agents | Mastra Docs"
+title: "Reference: Agent.listWorkflows() | Agents"
 description: "Documentation for the `Agent.listWorkflows()` method in Mastra agents, which retrieves the workflows that the agent can execute."
 ---
 

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.network() | Agents | Mastra Docs"
+title: "Reference: Agent.network() | Agents"
 description: "Documentation for the `Agent.network()` method in Mastra agents, which enables multi-agent collaboration and routing."
 ---
 

--- a/docs/src/content/en/reference/auth/auth0.mdx
+++ b/docs/src/content/en/reference/auth/auth0.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraAuthAuth0 Class | Auth | Mastra Docs"
+title: "Reference: MastraAuthAuth0 Class | Auth"
 description: "API reference for the MastraAuthAuth0 class, which authenticates Mastra applications using Auth0 authentication."
 ---
 

--- a/docs/src/content/en/reference/auth/clerk.mdx
+++ b/docs/src/content/en/reference/auth/clerk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraAuthClerk Class | Auth | Mastra Docs"
+title: "Reference: MastraAuthClerk Class | Auth"
 description: "API reference for the MastraAuthClerk class, which authenticates Mastra applications using Clerk authentication."
 ---
 

--- a/docs/src/content/en/reference/auth/firebase.mdx
+++ b/docs/src/content/en/reference/auth/firebase.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraAuthFirebase Class | Auth | Mastra Docs"
+title: "Reference: MastraAuthFirebase Class | Auth"
 description: "API reference for the MastraAuthFirebase class, which authenticates Mastra applications using Firebase Authentication."
 ---
 

--- a/docs/src/content/en/reference/auth/jwt.mdx
+++ b/docs/src/content/en/reference/auth/jwt.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraJwtAuth Class | Auth | Mastra Docs"
+title: "Reference: MastraJwtAuth Class | Auth"
 description: "API reference for the MastraJwtAuth class, which authenticates Mastra applications using JSON Web Tokens."
 ---
 

--- a/docs/src/content/en/reference/auth/supabase.mdx
+++ b/docs/src/content/en/reference/auth/supabase.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraAuthSupabase Class | Auth | Mastra Docs"
+title: "Reference: MastraAuthSupabase Class | Auth"
 description: "API reference for the MastraAuthSupabase class, which authenticates Mastra applications using Supabase Auth."
 ---
 

--- a/docs/src/content/en/reference/auth/workos.mdx
+++ b/docs/src/content/en/reference/auth/workos.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraAuthWorkos Class | Auth | Mastra Docs"
+title: "Reference: MastraAuthWorkos Class | Auth"
 description: "API reference for the MastraAuthWorkos class, which authenticates Mastra applications using WorkOS authentication."
 ---
 

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: create-mastra | CLI | Mastra Docs"
+title: "Reference: create-mastra | CLI"
 description: Documentation for the create-mastra command, which creates a new Mastra project with interactive setup options.
 ---
 

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: CLI Commands | CLI | Mastra Docs"
+title: "Reference: CLI Commands | CLI"
 description: Documentation for the Mastra CLI to develop, build, and start your project.
 ---
 

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agents API | Client SDK | Mastra Docs"
+title: "Reference: Agents API | Client SDK"
 description: Learn how to interact with Mastra AI agents, including generating responses, streaming interactions, and managing agent tools using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/error-handling.mdx
+++ b/docs/src/content/en/reference/client-js/error-handling.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Error Handling | Client SDK | Mastra Docs"
+title: "Reference: Error Handling | Client SDK"
 description: Learn about the built-in retry mechanism and error handling capabilities in the Mastra client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/logs.mdx
+++ b/docs/src/content/en/reference/client-js/logs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Logs API | Client SDK | Mastra Docs"
+title: "Reference: Logs API | Client SDK"
 description: Learn how to access and query system logs and debugging information in Mastra using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra Client SDK | Client SDK | Mastra Docs"
+title: "Reference: Mastra Client SDK | Client SDK"
 description: Learn how to interact with Mastra using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/memory.mdx
+++ b/docs/src/content/en/reference/client-js/memory.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory API | Client SDK | Mastra Docs"
+title: "Reference: Memory API | Client SDK"
 description: Learn how to manage conversation threads and message history in Mastra using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/observability.mdx
+++ b/docs/src/content/en/reference/client-js/observability.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Observability API | Client SDK | Mastra Docs"
+title: "Reference: Observability API | Client SDK"
 description: Learn how to retrieve traces, monitor application performance, and score traces using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/telemetry.mdx
+++ b/docs/src/content/en/reference/client-js/telemetry.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Telemetry API | Client SDK | Mastra Docs"
+title: "Reference: Telemetry API | Client SDK"
 description: Learn how to retrieve and analyze traces from your Mastra application for monitoring and debugging using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/tools.mdx
+++ b/docs/src/content/en/reference/client-js/tools.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Tools API | Client SDK | Mastra Docs"
+title: "Reference: Tools API | Client SDK"
 description: Learn how to interact with and execute tools available in the Mastra platform using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/vectors.mdx
+++ b/docs/src/content/en/reference/client-js/vectors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Vectors API | Client SDK | Mastra Docs"
+title: "Reference: Vectors API | Client SDK"
 description: Learn how to work with vector embeddings for semantic search and similarity matching in Mastra using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflows API | Client SDK | Mastra Docs"
+title: "Reference: Workflows API | Client SDK"
 description: Learn how to interact with and execute automated workflows in Mastra using the client-js SDK.
 ---
 

--- a/docs/src/content/en/reference/core/getAgent.mdx
+++ b/docs/src/content/en/reference/core/getAgent.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getAgent() | Core | Mastra Docs"
+title: "Reference: Mastra.getAgent() | Core"
 description: "Documentation for the `Agent.getAgent()` method in Mastra, which retrieves an agent by name."
 ---
 

--- a/docs/src/content/en/reference/core/getAgentById.mdx
+++ b/docs/src/content/en/reference/core/getAgentById.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getAgentById() | Core | Mastra Docs"
+title: "Reference: Mastra.getAgentById() | Core"
 description: "Documentation for the `Mastra.getAgentById()` method in Mastra, which retrieves an agent by its ID."
 ---
 

--- a/docs/src/content/en/reference/core/getDeployer.mdx
+++ b/docs/src/content/en/reference/core/getDeployer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getDeployer() | Core | Mastra Docs"
+title: "Reference: Mastra.getDeployer() | Core"
 description: "Documentation for the `Mastra.getDeployer()` method in Mastra, which retrieves the configured deployer instance."
 ---
 

--- a/docs/src/content/en/reference/core/getLogger.mdx
+++ b/docs/src/content/en/reference/core/getLogger.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getLogger() | Core | Mastra Docs"
+title: "Reference: Mastra.getLogger() | Core"
 description: "Documentation for the `Mastra.getLogger()` method in Mastra, which retrieves the configured logger instance."
 ---
 

--- a/docs/src/content/en/reference/core/getMCPServer.mdx
+++ b/docs/src/content/en/reference/core/getMCPServer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getMCPServer() | Core | Mastra Docs"
+title: "Reference: Mastra.getMCPServer() | Core"
 description: "Documentation for the `Mastra.getMCPServer()` method in Mastra, which retrieves a specific MCP server instance by ID and optional version."
 ---
 

--- a/docs/src/content/en/reference/core/getMCPServerById.mdx
+++ b/docs/src/content/en/reference/core/getMCPServerById.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getMCPServerById() | Core | Mastra Docs"
+title: "Reference: Mastra.getMCPServerById() | Core"
 description: "Documentation for the `Mastra.getMCPServerById()` method in Mastra, which retrieves a specific MCP server instance by its intrinsic id property."
 ---
 

--- a/docs/src/content/en/reference/core/getScorer.mdx
+++ b/docs/src/content/en/reference/core/getScorer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: getScorer() | Core | Mastra Docs"
+title: "Reference: getScorer() | Core"
 description: "Documentation for the `getScorer()` method in Mastra, which retrieves a specific scorer by its registration key."
 ---
 

--- a/docs/src/content/en/reference/core/getScorerById.mdx
+++ b/docs/src/content/en/reference/core/getScorerById.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: getScorerById() | Core | Mastra Docs"
+title: "Reference: getScorerById() | Core"
 description: "Documentation for the `getScorerById()` method in Mastra, which retrieves a scorer by its id property rather than registration key."
 ---
 

--- a/docs/src/content/en/reference/core/getServer.mdx
+++ b/docs/src/content/en/reference/core/getServer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getServer() | Core | Mastra Docs"
+title: "Reference: Mastra.getServer() | Core"
 description: "Documentation for the `Mastra.getServer()` method in Mastra, which retrieves the configured server configuration."
 ---
 

--- a/docs/src/content/en/reference/core/getStorage.mdx
+++ b/docs/src/content/en/reference/core/getStorage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getStorage() | Core | Mastra Docs"
+title: "Reference: Mastra.getStorage() | Core"
 description: "Documentation for the `Mastra.getStorage()` method in Mastra, which retrieves the configured storage instance."
 ---
 

--- a/docs/src/content/en/reference/core/getTelemetry.mdx
+++ b/docs/src/content/en/reference/core/getTelemetry.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getTelemetry() | Core | Mastra Docs"
+title: "Reference: Mastra.getTelemetry() | Core"
 description: "Documentation for the `Mastra.getTelemetry()` method in Mastra, which retrieves the configured telemetry instance."
 ---
 

--- a/docs/src/content/en/reference/core/getVector.mdx
+++ b/docs/src/content/en/reference/core/getVector.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getVector() | Core | Mastra Docs"
+title: "Reference: Mastra.getVector() | Core"
 description: "Documentation for the `Mastra.getVector()` method in Mastra, which retrieves a vector store by name."
 ---
 

--- a/docs/src/content/en/reference/core/getWorkflow.mdx
+++ b/docs/src/content/en/reference/core/getWorkflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.getWorkflow() | Core | Mastra Docs"
+title: "Reference: Mastra.getWorkflow() | Core"
 description: "Documentation for the `Mastra.getWorkflow()` method in Mastra, which retrieves a workflow by ID."
 ---
 

--- a/docs/src/content/en/reference/core/listAgents.mdx
+++ b/docs/src/content/en/reference/core/listAgents.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.listAgents() | Core | Mastra Docs"
+title: "Reference: Mastra.listAgents() | Core"
 description: "Documentation for the `Mastra.listAgents()` method in Mastra, which retrieves all configured agents."
 ---
 

--- a/docs/src/content/en/reference/core/listLogs.mdx
+++ b/docs/src/content/en/reference/core/listLogs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.listLogs() | Core | Mastra Docs"
+title: "Reference: Mastra.listLogs() | Core"
 description: "Documentation for the `Mastra.listLogs()` method in Mastra, which retrieves all logs for a specific transport ID."
 ---
 

--- a/docs/src/content/en/reference/core/listLogsByRunId.mdx
+++ b/docs/src/content/en/reference/core/listLogsByRunId.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.listLogsByRunId() | Core | Mastra Docs"
+title: "Reference: Mastra.listLogsByRunId() | Core"
 description: "Documentation for the `Mastra.listLogsByRunId()` method in Mastra, which retrieves logs for a specific run ID and transport ID."
 ---
 

--- a/docs/src/content/en/reference/core/listMCPServers.mdx
+++ b/docs/src/content/en/reference/core/listMCPServers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.listMCPServers() | Core | Mastra Docs"
+title: "Reference: Mastra.listMCPServers() | Core"
 description: "Documentation for the `Mastra.listMCPServers()` method in Mastra, which retrieves all registered MCP server instances."
 ---
 

--- a/docs/src/content/en/reference/core/listScorers.mdx
+++ b/docs/src/content/en/reference/core/listScorers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: listScorers() | Core | Mastra Docs"
+title: "Reference: listScorers() | Core"
 description: "Documentation for the `listScorers()` method in Mastra, which returns all registered scorers for evaluating AI outputs."
 ---
 

--- a/docs/src/content/en/reference/core/listVectors.mdx
+++ b/docs/src/content/en/reference/core/listVectors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.listVectors() | Core | Mastra Docs"
+title: "Reference: Mastra.listVectors() | Core"
 description: "Documentation for the `Mastra.listVectors()` method in Mastra, which retrieves all configured vector stores."
 ---
 

--- a/docs/src/content/en/reference/core/listWorkflows.mdx
+++ b/docs/src/content/en/reference/core/listWorkflows.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.listWorkflows() | Core | Mastra Docs"
+title: "Reference: Mastra.listWorkflows() | Core"
 description: "Documentation for the `Mastra.listWorkflows()` method in Mastra, which retrieves all configured workflows."
 ---
 

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra Class | Core | Mastra Docs"
+title: "Reference: Mastra Class | Core"
 description: "Documentation for the `Mastra` class in Mastra, the core entry point for managing agents, workflows, MCP servers, and server endpoints."
 ---
 

--- a/docs/src/content/en/reference/core/setLogger.mdx
+++ b/docs/src/content/en/reference/core/setLogger.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.setLogger() | Core | Mastra Docs"
+title: "Reference: Mastra.setLogger() | Core"
 description: "Documentation for the `Mastra.setLogger()` method in Mastra, which sets the logger for all components (agents, workflows, etc.)."
 ---
 

--- a/docs/src/content/en/reference/core/setStorage.mdx
+++ b/docs/src/content/en/reference/core/setStorage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.setStorage() | Core | Mastra Docs"
+title: "Reference: Mastra.setStorage() | Core"
 description: "Documentation for the `Mastra.setStorage()` method in Mastra, which sets the storage instance for the Mastra instance."
 ---
 

--- a/docs/src/content/en/reference/core/setTelemetry.mdx
+++ b/docs/src/content/en/reference/core/setTelemetry.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Mastra.setTelemetry() | Core | Mastra Docs"
+title: "Reference: Mastra.setTelemetry() | Core"
 description: "Documentation for the `Mastra.setTelemetry()` method in Mastra, which sets the telemetry configuration for all components."
 ---
 

--- a/docs/src/content/en/reference/deployer/cloudflare.mdx
+++ b/docs/src/content/en/reference/deployer/cloudflare.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: CloudflareDeployer | Deployer | Mastra Docs"
+title: "Reference: CloudflareDeployer | Deployer"
 description: "Documentation for the CloudflareDeployer class, which deploys Mastra applications to Cloudflare Workers."
 ---
 

--- a/docs/src/content/en/reference/deployer/deployer.mdx
+++ b/docs/src/content/en/reference/deployer/deployer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Deployer | Deployer | Mastra Docs"
+title: "Reference: Deployer | Deployer"
 description: Documentation for the Deployer abstract class, which handles packaging and deployment of Mastra applications.
 asIndexPage: true
 ---

--- a/docs/src/content/en/reference/deployer/netlify.mdx
+++ b/docs/src/content/en/reference/deployer/netlify.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: NetlifyDeployer | Deployer | Mastra Docs"
+title: "Reference: NetlifyDeployer | Deployer"
 description: "Documentation for the NetlifyDeployer class, which deploys Mastra applications to Netlify Functions."
 ---
 

--- a/docs/src/content/en/reference/deployer/vercel.mdx
+++ b/docs/src/content/en/reference/deployer/vercel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: VercelDeployer | Deployer | Mastra Docs"
+title: "Reference: VercelDeployer | Deployer"
 description: "Documentation for the VercelDeployer class, which deploys Mastra applications to Vercel."
 ---
 

--- a/docs/src/content/en/reference/evals/answer-relevancy.mdx
+++ b/docs/src/content/en/reference/evals/answer-relevancy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Answer Relevancy Scorer | Evals | Mastra Docs"
+title: "Reference: Answer Relevancy Scorer | Evals"
 description: Documentation for the Answer Relevancy Scorer in Mastra, which evaluates how well LLM outputs address the input query.
 ---
 

--- a/docs/src/content/en/reference/evals/answer-similarity.mdx
+++ b/docs/src/content/en/reference/evals/answer-similarity.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Answer Similarity Scorer | Evals | Mastra Docs"
+title: "Reference: Answer Similarity Scorer | Evals"
 description: Documentation for the Answer Similarity Scorer in Mastra, which compares agent outputs against ground truth answers for CI/CD testing.
 ---
 

--- a/docs/src/content/en/reference/evals/bias.mdx
+++ b/docs/src/content/en/reference/evals/bias.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Bias Scorer | Evals | Mastra Docs"
+title: "Reference: Bias Scorer | Evals"
 description: Documentation for the Bias Scorer in Mastra, which evaluates LLM outputs for various forms of bias, including gender, political, racial/ethnic, or geographical bias.
 ---
 

--- a/docs/src/content/en/reference/evals/completeness.mdx
+++ b/docs/src/content/en/reference/evals/completeness.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Completeness Scorer | Evals | Mastra Docs"
+title: "Reference: Completeness Scorer | Evals"
 description: Documentation for the Completeness Scorer in Mastra, which evaluates how thoroughly LLM outputs cover key elements present in the input.
 ---
 

--- a/docs/src/content/en/reference/evals/content-similarity.mdx
+++ b/docs/src/content/en/reference/evals/content-similarity.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Content Similarity Scorer | Evals | Mastra Docs"
+title: "Reference: Content Similarity Scorer | Evals"
 description: Documentation for the Content Similarity Scorer in Mastra, which measures textual similarity between strings and provides a matching score.
 ---
 

--- a/docs/src/content/en/reference/evals/context-precision.mdx
+++ b/docs/src/content/en/reference/evals/context-precision.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Context Precision Scorer | Evals | Mastra Docs"
+title: "Reference: Context Precision Scorer | Evals"
 description: Documentation for the Context Precision Scorer in Mastra. Evaluates the relevance and precision of retrieved context for generating expected outputs using Mean Average Precision.
 ---
 

--- a/docs/src/content/en/reference/evals/context-relevance.mdx
+++ b/docs/src/content/en/reference/evals/context-relevance.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Context Relevance Scorer | Evals | Mastra Docs"
+title: "Reference: Context Relevance Scorer | Evals"
 description: Documentation for the Context Relevance Scorer in Mastra. Evaluates the relevance and utility of provided context for generating agent responses using weighted relevance scoring.
 ---
 

--- a/docs/src/content/en/reference/evals/create-scorer.mdx
+++ b/docs/src/content/en/reference/evals/create-scorer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createScorer | Evals | Mastra Docs"
+title: "Reference: createScorer | Evals"
 description: Documentation for creating custom scorers in Mastra, allowing users to define their own evaluation logic using either JavaScript functions or LLM-based prompts.
 ---
 

--- a/docs/src/content/en/reference/evals/faithfulness.mdx
+++ b/docs/src/content/en/reference/evals/faithfulness.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Faithfulness Scorer | Evals | Mastra Docs"
+title: "Reference: Faithfulness Scorer | Evals"
 description: Documentation for the Faithfulness Scorer in Mastra, which evaluates the factual accuracy of LLM outputs compared to the provided context.
 ---
 

--- a/docs/src/content/en/reference/evals/hallucination.mdx
+++ b/docs/src/content/en/reference/evals/hallucination.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Hallucination Scorer | Evals | Mastra Docs"
+title: "Reference: Hallucination Scorer | Evals"
 description: Documentation for the Hallucination Scorer in Mastra, which evaluates the factual correctness of LLM outputs by identifying contradictions with provided context.
 ---
 

--- a/docs/src/content/en/reference/evals/keyword-coverage.mdx
+++ b/docs/src/content/en/reference/evals/keyword-coverage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Keyword Coverage Scorer | Evals | Mastra Docs"
+title: "Reference: Keyword Coverage Scorer | Evals"
 description: Documentation for the Keyword Coverage Scorer in Mastra, which evaluates how well LLM outputs cover important keywords from the input.
 ---
 

--- a/docs/src/content/en/reference/evals/mastra-scorer.mdx
+++ b/docs/src/content/en/reference/evals/mastra-scorer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraScorer | Evals | Mastra Docs"
+title: "Reference: MastraScorer | Evals"
 description: Documentation for the MastraScorer base class in Mastra, which provides the foundation for all custom and built-in scorers.
 ---
 

--- a/docs/src/content/en/reference/evals/noise-sensitivity.mdx
+++ b/docs/src/content/en/reference/evals/noise-sensitivity.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Noise Sensitivity Scorer | Evals | Mastra Docs"
+title: "Reference: Noise Sensitivity Scorer | Evals"
 description: Documentation for the Noise Sensitivity Scorer in Mastra. A CI/testing scorer that evaluates agent robustness by comparing responses between clean and noisy inputs in controlled test environments.
 ---
 

--- a/docs/src/content/en/reference/evals/prompt-alignment.mdx
+++ b/docs/src/content/en/reference/evals/prompt-alignment.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Prompt Alignment Scorer | Evals | Mastra Docs"
+title: "Reference: Prompt Alignment Scorer | Evals"
 description: Documentation for the Prompt Alignment Scorer in Mastra. Evaluates how well agent responses align with user prompt intent, requirements, completeness, and appropriateness using multi-dimensional analysis.
 ---
 

--- a/docs/src/content/en/reference/evals/run-evals.mdx
+++ b/docs/src/content/en/reference/evals/run-evals.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: runEvals | Evals | Mastra Docs"
+title: "Reference: runEvals | Evals"
 description: "Documentation for the runEvals function in Mastra, which enables batch evaluation of agents and workflows using multiple scorers."
 ---
 

--- a/docs/src/content/en/reference/evals/textual-difference.mdx
+++ b/docs/src/content/en/reference/evals/textual-difference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Textual Difference Scorer | Evals | Mastra Docs"
+title: "Reference: Textual Difference Scorer | Evals"
 description: Documentation for the Textual Difference Scorer in Mastra, which measures textual differences between strings using sequence matching.
 ---
 

--- a/docs/src/content/en/reference/evals/tone-consistency.mdx
+++ b/docs/src/content/en/reference/evals/tone-consistency.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Tone Consistency Scorer | Evals | Mastra Docs"
+title: "Reference: Tone Consistency Scorer | Evals"
 description: Documentation for the Tone Consistency Scorer in Mastra, which evaluates emotional tone and sentiment consistency in text.
 ---
 

--- a/docs/src/content/en/reference/evals/tool-call-accuracy.mdx
+++ b/docs/src/content/en/reference/evals/tool-call-accuracy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Tool Call Accuracy Scorers | Evals | Mastra Docs"
+title: "Reference: Tool Call Accuracy Scorers | Evals"
 description: Documentation for the Tool Call Accuracy Scorers in Mastra, which evaluate whether LLM outputs call the correct tools from available options.
 ---
 

--- a/docs/src/content/en/reference/evals/toxicity.mdx
+++ b/docs/src/content/en/reference/evals/toxicity.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Toxicity Scorer | Evals | Mastra Docs"
+title: "Reference: Toxicity Scorer | Evals"
 description: Documentation for the Toxicity Scorer in Mastra, which evaluates LLM outputs for racist, biased, or toxic elements.
 ---
 

--- a/docs/src/content/en/reference/logging/pino-logger.mdx
+++ b/docs/src/content/en/reference/logging/pino-logger.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: PinoLogger | Observability | Mastra Docs"
+title: "Reference: PinoLogger | Observability"
 description: Documentation for PinoLogger, which provides methods to record events at various severity levels.
 ---
 

--- a/docs/src/content/en/reference/memory/createThread.mdx
+++ b/docs/src/content/en/reference/memory/createThread.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory.createThread() | Memory | Mastra Docs"
+title: "Reference: Memory.createThread() | Memory"
 description: "Documentation for the `Memory.createThread()` method in Mastra, which creates a new conversation thread in the memory system."
 ---
 

--- a/docs/src/content/en/reference/memory/deleteMessages.mdx
+++ b/docs/src/content/en/reference/memory/deleteMessages.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory.deleteMessages() | Memory | Mastra Docs"
+title: "Reference: Memory.deleteMessages() | Memory"
 description: "Documentation for the `Memory.deleteMessages()` method in Mastra, which deletes multiple messages by their IDs."
 ---
 

--- a/docs/src/content/en/reference/memory/getThreadById.mdx
+++ b/docs/src/content/en/reference/memory/getThreadById.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory.getThreadById() | Memory | Mastra Docs"
+title: "Reference: Memory.getThreadById() | Memory"
 description: "Documentation for the `Memory.getThreadById()` method in Mastra, which retrieves a specific thread by its ID."
 ---
 

--- a/docs/src/content/en/reference/memory/listThreadsByResourceId.mdx
+++ b/docs/src/content/en/reference/memory/listThreadsByResourceId.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory.listThreadsByResourceId() | Memory | Mastra Docs"
+title: "Reference: Memory.listThreadsByResourceId() | Memory"
 description: "Documentation for the `Memory.listThreadsByResourceId()` method in Mastra, which retrieves threads associated with a specific resource ID with pagination support."
 ---
 

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory Class | Memory | Mastra Docs"
+title: "Reference: Memory Class | Memory"
 description: "Documentation for the `Memory` class in Mastra, which provides a robust system for managing conversation history and thread-based message storage."
 ---
 

--- a/docs/src/content/en/reference/memory/query.mdx
+++ b/docs/src/content/en/reference/memory/query.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory.query() | Memory | Mastra Docs"
+title: "Reference: Memory.query() | Memory"
 description: "Documentation for the `Memory.query()` method in Mastra, which retrieves messages from a specific thread with support for pagination, filtering options, and semantic search."
 ---
 

--- a/docs/src/content/en/reference/memory/recall.mdx
+++ b/docs/src/content/en/reference/memory/recall.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Memory.recall() | Memory | Mastra Docs"
+title: "Reference: Memory.recall() | Memory"
 description: "Documentation for the `Memory.recall()` method in Mastra, which retrieves messages from a specific thread with support for pagination, filtering options, and semantic search."
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/configuration.mdx
+++ b/docs/src/content/en/reference/observability/tracing/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Configuration | Observability | Mastra Docs"
+title: "Reference: Configuration | Observability"
 description: Tracing configuration types and registry functions
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: ArizeExporter | Observability | Mastra Docs"
+title: "Reference: ArizeExporter | Observability"
 description: Arize exporter for Tracing using OpenInference
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/braintrust.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: BraintrustExporter | Observability | Mastra Docs"
+title: "Reference: BraintrustExporter | Observability"
 description: Braintrust exporter for Tracing
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: CloudExporter | Observability | Mastra Docs"
+title: "Reference: CloudExporter | Observability"
 description: API reference for the CloudExporter
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/console-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/console-exporter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: ConsoleExporter | Observability | Mastra Docs"
+title: "Reference: ConsoleExporter | Observability"
 description: API reference for the ConsoleExporter
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: DefaultExporter | Observability | Mastra Docs"
+title: "Reference: DefaultExporter | Observability"
 description: API reference for the DefaultExporter
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: LangfuseExporter | Observability | Mastra Docs"
+title: "Reference: LangfuseExporter | Observability"
 description: Langfuse exporter for Tracing
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/langsmith.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/langsmith.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: LangSmithExporter | Observability | Mastra Docs"
+title: "Reference: LangSmithExporter | Observability"
 description: LangSmith exporter for Tracing
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: OtelExporter | Observability | Mastra Docs"
+title: "Reference: OtelExporter | Observability"
 description: OpenTelemetry exporter for Tracing
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/instances.mdx
+++ b/docs/src/content/en/reference/observability/tracing/instances.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Tracing | Observability | Mastra Docs"
+title: "Reference: Tracing | Observability"
 description: Core Tracing classes and methods
 asIndexPage: true
 ---

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Interfaces | Observability | Mastra Docs"
+title: "Reference: Interfaces | Observability"
 description: Tracing type definitions and interfaces
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/processors/sensitive-data-filter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: SensitiveDataFilter | Observability | Mastra Docs"
+title: "Reference: SensitiveDataFilter | Observability"
 description: API reference for the SensitiveDataFilter processor
 ---
 

--- a/docs/src/content/en/reference/observability/tracing/spans.mdx
+++ b/docs/src/content/en/reference/observability/tracing/spans.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Spans | Observability | Mastra Docs"
+title: "Reference: Spans | Observability"
 description: Span interfaces, methods, and lifecycle events
 ---
 

--- a/docs/src/content/en/reference/processors/batch-parts-processor.mdx
+++ b/docs/src/content/en/reference/processors/batch-parts-processor.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Batch Parts Processor | Processors | Mastra Docs"
+title: "Reference: Batch Parts Processor | Processors"
 description: "Documentation for the BatchPartsProcessor in Mastra, which batches multiple stream parts together to reduce frequency of emissions."
 ---
 

--- a/docs/src/content/en/reference/processors/language-detector.mdx
+++ b/docs/src/content/en/reference/processors/language-detector.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Language Detector | Processors | Mastra Docs"
+title: "Reference: Language Detector | Processors"
 description: "Documentation for the LanguageDetector in Mastra, which detects language and can translate content in AI responses."
 ---
 

--- a/docs/src/content/en/reference/processors/moderation-processor.mdx
+++ b/docs/src/content/en/reference/processors/moderation-processor.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Moderation Processor | Processors | Mastra Docs"
+title: "Reference: Moderation Processor | Processors"
 description: "Documentation for the ModerationProcessor in Mastra, which provides content moderation using LLM to detect inappropriate content across multiple categories."
 ---
 

--- a/docs/src/content/en/reference/processors/pii-detector.mdx
+++ b/docs/src/content/en/reference/processors/pii-detector.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: PII Detector | Processors | Mastra Docs"
+title: "Reference: PII Detector | Processors"
 description: "Documentation for the PIIDetector in Mastra, which detects and redacts personally identifiable information (PII) from AI responses."
 ---
 

--- a/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
+++ b/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Prompt Injection Detector | Processors | Mastra Docs"
+title: "Reference: Prompt Injection Detector | Processors"
 description: "Documentation for the PromptInjectionDetector in Mastra, which detects prompt injection attempts in user input."
 ---
 

--- a/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
+++ b/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: System Prompt Scrubber | Processors | Mastra Docs"
+title: "Reference: System Prompt Scrubber | Processors"
 description: "Documentation for the SystemPromptScrubber in Mastra, which detects and redacts system prompts from AI responses."
 ---
 

--- a/docs/src/content/en/reference/processors/token-limiter-processor.mdx
+++ b/docs/src/content/en/reference/processors/token-limiter-processor.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Token Limiter Processor | Processors | Mastra Docs"
+title: "Reference: Token Limiter Processor | Processors"
 description: "Documentation for the TokenLimiterProcessor in Mastra, which limits the number of tokens in AI responses."
 ---
 

--- a/docs/src/content/en/reference/processors/unicode-normalizer.mdx
+++ b/docs/src/content/en/reference/processors/unicode-normalizer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Unicode Normalizer | Processors | Mastra Docs"
+title: "Reference: Unicode Normalizer | Processors"
 description: "Documentation for the UnicodeNormalizer in Mastra, which normalizes Unicode text to ensure consistent formatting and remove potentially problematic characters."
 ---
 

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Reference: .chunk() | RAG | Mastra Docs"
+title: "Reference: Reference: .chunk() | RAG"
 description: Documentation for the chunk function in Mastra, which splits documents into smaller segments using various strategies.
 ---
 

--- a/docs/src/content/en/reference/rag/database-config.mdx
+++ b/docs/src/content/en/reference/rag/database-config.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: DatabaseConfig | RAG | Mastra Docs"
+title: "Reference: DatabaseConfig | RAG"
 description: API reference for database-specific configuration types used with vector query tools in Mastra RAG systems.
 ---
 

--- a/docs/src/content/en/reference/rag/document.mdx
+++ b/docs/src/content/en/reference/rag/document.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MDocument | Document Processing | RAG | Mastra Docs"
+title: "Reference: MDocument | Document Processing | RAG"
 description: Documentation for the MDocument class in Mastra, which handles document processing and chunking.
 ---
 

--- a/docs/src/content/en/reference/rag/embeddings.mdx
+++ b/docs/src/content/en/reference/rag/embeddings.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Embed | RAG | Mastra Docs"
+title: "Reference: Embed | RAG"
 description: Documentation for embedding functionality in Mastra using the AI SDK.
 ---
 

--- a/docs/src/content/en/reference/rag/extract-params.mdx
+++ b/docs/src/content/en/reference/rag/extract-params.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: ExtractParams | RAG | Mastra Docs"
+title: "Reference: ExtractParams | RAG"
 description: Documentation for metadata extraction configuration in Mastra.
 ---
 

--- a/docs/src/content/en/reference/rag/graph-rag.mdx
+++ b/docs/src/content/en/reference/rag/graph-rag.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: GraphRAG | RAG | Mastra Docs"
+title: "Reference: GraphRAG | RAG"
 description: Documentation for the GraphRAG class in Mastra, which implements a graph-based approach to retrieval augmented generation.
 ---
 

--- a/docs/src/content/en/reference/rag/metadata-filters.mdx
+++ b/docs/src/content/en/reference/rag/metadata-filters.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Metadata Filters | RAG | Mastra Docs"
+title: "Reference: Metadata Filters | RAG"
 description: Documentation for metadata filtering capabilities in Mastra, which allow for precise querying of vector search results across different vector stores.
 ---
 

--- a/docs/src/content/en/reference/rag/rerank.mdx
+++ b/docs/src/content/en/reference/rag/rerank.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: rerank() | RAG | Mastra Docs"
+title: "Reference: rerank() | RAG"
 description: Documentation for the rerank function in Mastra, which provides advanced reranking capabilities for vector search results.
 ---
 

--- a/docs/src/content/en/reference/rag/rerankWithScorer.mdx
+++ b/docs/src/content/en/reference/rag/rerankWithScorer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: rerankWithScorer() | RAG | Mastra Docs"
+title: "Reference: rerankWithScorer() | RAG"
 description: Documentation for the rerank function in Mastra, which provides advanced reranking capabilities for vector search results.
 ---
 

--- a/docs/src/content/en/reference/storage/cloudflare-d1.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare-d1.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Cloudflare D1 Storage | Storage | Mastra Docs"
+title: "Reference: Cloudflare D1 Storage | Storage"
 description: Documentation for the Cloudflare D1 SQL storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/storage/cloudflare.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Cloudflare Storage | Storage | Mastra Docs"
+title: "Reference: Cloudflare Storage | Storage"
 description: Documentation for the Cloudflare KV storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/storage/dynamodb.mdx
+++ b/docs/src/content/en/reference/storage/dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: DynamoDB Storage | Storage | Mastra Docs"
+title: "Reference: DynamoDB Storage | Storage"
 description: "Documentation for the DynamoDB storage implementation in Mastra, using a single-table design with ElectroDB."
 ---
 

--- a/docs/src/content/en/reference/storage/lance.mdx
+++ b/docs/src/content/en/reference/storage/lance.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: LanceDB Storage | Storage | Mastra Docs"
+title: "Reference: LanceDB Storage | Storage"
 description: Documentation for the LanceDB storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/storage/libsql.mdx
+++ b/docs/src/content/en/reference/storage/libsql.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: LibSQL Storage | Storage | Mastra Docs"
+title: "Reference: LibSQL Storage | Storage"
 description: Documentation for the LibSQL storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/storage/mongodb.mdx
+++ b/docs/src/content/en/reference/storage/mongodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MongoDB Storage | Storage | Mastra Docs"
+title: "Reference: MongoDB Storage | Storage"
 description: Documentation for the MongoDB storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/storage/mssql.mdx
+++ b/docs/src/content/en/reference/storage/mssql.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MSSQL Storage | Storage | Mastra Docs"
+title: "Reference: MSSQL Storage | Storage"
 description: Documentation for the MSSQL storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: PostgreSQL Storage | Storage | Mastra Docs"
+title: "Reference: PostgreSQL Storage | Storage"
 description: Documentation for the PostgreSQL storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/storage/upstash.mdx
+++ b/docs/src/content/en/reference/storage/upstash.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Upstash Storage | Storage | Mastra Docs"
+title: "Reference: Upstash Storage | Storage"
 description: Documentation for the Upstash storage implementation in Mastra.
 ---
 

--- a/docs/src/content/en/reference/streaming/ChunkType.mdx
+++ b/docs/src/content/en/reference/streaming/ChunkType.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: ChunkType | Streaming | Mastra Docs"
+title: "Reference: ChunkType | Streaming"
 description: "Documentation for the ChunkType type used in Mastra streaming responses, defining all possible chunk types and their payloads."
 ---
 

--- a/docs/src/content/en/reference/streaming/agents/MastraModelOutput.mdx
+++ b/docs/src/content/en/reference/streaming/agents/MastraModelOutput.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraModelOutput | Streaming | Mastra Docs"
+title: "Reference: MastraModelOutput | Streaming"
 description: "Complete reference for MastraModelOutput - the stream object returned by agent.stream() with streaming and promise-based access to model outputs."
 ---
 

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.stream() | Streaming | Mastra Docs"
+title: "Reference: Agent.stream() | Streaming"
 description: "Documentation for the `Agent.stream()` method in Mastra agents, which enables real-time streaming of responses with enhanced capabilities."
 ---
 

--- a/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
+++ b/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Agent.streamLegacy() (Legacy) | Streaming | Mastra Docs"
+title: "Reference: Agent.streamLegacy() (Legacy) | Streaming"
 description: "Documentation for the legacy `Agent.streamLegacy()` method in Mastra agents. This method is deprecated and will be removed in a future version."
 ---
 

--- a/docs/src/content/en/reference/streaming/workflows/observeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/observeStream.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.observeStream() | Streaming | Mastra Docs"
+title: "Reference: Run.observeStream() | Streaming"
 description: Documentation for the `Run.observeStream()` method in workflows, which enables reopening the stream of an already active workflow run.
 ---
 

--- a/docs/src/content/en/reference/streaming/workflows/observeStreamVNext.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/observeStreamVNext.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.observeStreamVNext() (Experimental) | Streaming | Mastra Docs"
+title: "Reference: Run.observeStreamVNext() (Experimental) | Streaming"
 description: Documentation for the `Run.observeStreamVNext()` method in workflows, which enables reopening the stream of an already active workflow run.
 ---
 

--- a/docs/src/content/en/reference/streaming/workflows/resumeStreamVNext.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/resumeStreamVNext.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.resumeStreamVNext() (Experimental) | Streaming | Mastra Docs"
+title: "Reference: Run.resumeStreamVNext() (Experimental) | Streaming"
 description: Documentation for the `Run.resumeStreamVNext()` method in workflows, which enables real-time resumption and streaming of suspended workflow runs.
 ---
 

--- a/docs/src/content/en/reference/streaming/workflows/stream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/stream.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.stream() | Streaming | Mastra Docs"
+title: "Reference: Run.stream() | Streaming"
 description: Documentation for the `Run.stream()` method in workflows, which allows you to monitor the execution of a workflow run as a stream.
 ---
 

--- a/docs/src/content/en/reference/streaming/workflows/streamVNext.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/streamVNext.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.streamVNext() (Experimental) | Streaming | Mastra Docs"
+title: "Reference: Run.streamVNext() (Experimental) | Streaming"
 description: Documentation for the `Run.streamVNext()` method in workflows, which enables real-time streaming of responses.
 ---
 

--- a/docs/src/content/en/reference/templates/overview.mdx
+++ b/docs/src/content/en/reference/templates/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: LLM provider API keys (choose one or more) | Templates | Mastra Docs"
+title: "Reference: LLM provider API keys (choose one or more) | Templates"
 description: "Complete guide to creating, using, and contributing Mastra templates"
 ---
 

--- a/docs/src/content/en/reference/tools/client.mdx
+++ b/docs/src/content/en/reference/tools/client.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraMCPClient (Deprecated) | Tools & MCP | Mastra Docs"
+title: "Reference: MastraMCPClient (Deprecated) | Tools & MCP"
 description: API Reference for MastraMCPClient - A client implementation for the Model Context Protocol.
 ---
 

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createTool() | Tools & MCP | Mastra Docs"
+title: "Reference: createTool() | Tools & MCP"
 description: Documentation for the `createTool()` function in Mastra, used to define custom tools for agents.
 ---
 

--- a/docs/src/content/en/reference/tools/document-chunker-tool.mdx
+++ b/docs/src/content/en/reference/tools/document-chunker-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createDocumentChunkerTool() | Tools & MCP | Mastra Docs"
+title: "Reference: createDocumentChunkerTool() | Tools & MCP"
 description: Documentation for the Document Chunker Tool in Mastra, which splits documents into smaller chunks for efficient processing and retrieval.
 ---
 

--- a/docs/src/content/en/reference/tools/graph-rag-tool.mdx
+++ b/docs/src/content/en/reference/tools/graph-rag-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createGraphRAGTool() | Tools & MCP | Mastra Docs"
+title: "Reference: createGraphRAGTool() | Tools & MCP"
 description: Documentation for the Graph RAG Tool in Mastra, which enhances RAG by building a graph of semantic relationships between documents.
 ---
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MCPClient | Tools & MCP | Mastra Docs"
+title: "Reference: MCPClient | Tools & MCP"
 description: API Reference for MCPClient - A class for managing multiple Model Context Protocol servers and their tools.
 ---
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MCPServer | Tools & MCP | Mastra Docs"
+title: "Reference: MCPServer | Tools & MCP"
 description: API Reference for MCPServer - A class for exposing Mastra tools and capabilities as a Model Context Protocol server.
 ---
 

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: createVectorQueryTool() | Tools & MCP | Mastra Docs"
+title: "Reference: createVectorQueryTool() | Tools & MCP"
 description: Documentation for the Vector Query Tool in Mastra, which facilitates semantic search over vector stores with filtering and reranking capabilities.
 ---
 

--- a/docs/src/content/en/reference/vectors/astra.mdx
+++ b/docs/src/content/en/reference/vectors/astra.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Astra Vector Store | Vectors | Mastra Docs"
+title: "Reference: Astra Vector Store | Vectors"
 description: Documentation for the AstraVector class in Mastra, which provides vector search using DataStax Astra DB.
 ---
 

--- a/docs/src/content/en/reference/vectors/chroma.mdx
+++ b/docs/src/content/en/reference/vectors/chroma.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Chroma Vector Store | Vectors | Mastra Docs"
+title: "Reference: Chroma Vector Store | Vectors"
 description: Documentation for the ChromaVector class in Mastra, which provides vector search using ChromaDB.
 ---
 

--- a/docs/src/content/en/reference/vectors/couchbase.mdx
+++ b/docs/src/content/en/reference/vectors/couchbase.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Couchbase Vector Store | Vectors | Mastra Docs"
+title: "Reference: Couchbase Vector Store | Vectors"
 description: Documentation for the CouchbaseVector class in Mastra, which provides vector search using Couchbase Vector Search.
 ---
 

--- a/docs/src/content/en/reference/vectors/lance.mdx
+++ b/docs/src/content/en/reference/vectors/lance.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Lance Vector Store | Vectors | Mastra Docs"
+title: "Reference: Lance Vector Store | Vectors"
 description: "Documentation for the LanceVectorStore class in Mastra, which provides vector search using LanceDB, an embedded vector database based on the Lance columnar format."
 ---
 

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: LibSQLVector Store | Vectors | Mastra Docs"
+title: "Reference: LibSQLVector Store | Vectors"
 description: Documentation for the LibSQLVector class in Mastra, which provides vector search using LibSQL with vector extensions.
 ---
 

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MongoDB Vector Store | Vectors | Mastra Docs"
+title: "Reference: MongoDB Vector Store | Vectors"
 description: Documentation for the MongoDBVector class in Mastra, which provides vector search using MongoDB Atlas and Atlas Vector Search.
 ---
 

--- a/docs/src/content/en/reference/vectors/opensearch.mdx
+++ b/docs/src/content/en/reference/vectors/opensearch.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: OpenSearch Vector Store | Vectors | Mastra Docs"
+title: "Reference: OpenSearch Vector Store | Vectors"
 description: Documentation for the OpenSearchVector class in Mastra, which provides vector search using OpenSearch.
 ---
 

--- a/docs/src/content/en/reference/vectors/pg.mdx
+++ b/docs/src/content/en/reference/vectors/pg.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: PG Vector Store | Vectors | Mastra Docs"
+title: "Reference: PG Vector Store | Vectors"
 description: Documentation for the PgVector class in Mastra, which provides vector search using PostgreSQL with pgvector extension.
 ---
 

--- a/docs/src/content/en/reference/vectors/pinecone.mdx
+++ b/docs/src/content/en/reference/vectors/pinecone.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Pinecone Vector Store | Vectors | Mastra Docs"
+title: "Reference: Pinecone Vector Store | Vectors"
 description: Documentation for the PineconeVector class in Mastra, which provides an interface to Pinecone's vector database.
 ---
 

--- a/docs/src/content/en/reference/vectors/qdrant.mdx
+++ b/docs/src/content/en/reference/vectors/qdrant.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Qdrant Vector Store | Vectors | Mastra Docs"
+title: "Reference: Qdrant Vector Store | Vectors"
 description: Documentation for integrating Qdrant with Mastra, a vector similarity search engine for managing vectors and payloads.
 ---
 

--- a/docs/src/content/en/reference/vectors/s3vectors.mdx
+++ b/docs/src/content/en/reference/vectors/s3vectors.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Amazon S3 Vectors Store | Vectors | Mastra Docs"
+title: "Reference: Amazon S3 Vectors Store | Vectors"
 description: Documentation for the S3Vectors class in Mastra, which provides vector search using Amazon S3 Vectors (Preview).
 ---
 

--- a/docs/src/content/en/reference/vectors/turbopuffer.mdx
+++ b/docs/src/content/en/reference/vectors/turbopuffer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Turbopuffer Vector Store | Vectors | Mastra Docs"
+title: "Reference: Turbopuffer Vector Store | Vectors"
 description: Documentation for integrating Turbopuffer with Mastra, a high-performance vector database for efficient similarity search.
 ---
 

--- a/docs/src/content/en/reference/vectors/upstash.mdx
+++ b/docs/src/content/en/reference/vectors/upstash.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Upstash Vector Store | Vectors | Mastra Docs"
+title: "Reference: Upstash Vector Store | Vectors"
 description: Documentation for the UpstashVector class in Mastra, which provides vector search using Upstash Vector.
 ---
 

--- a/docs/src/content/en/reference/vectors/vectorize.mdx
+++ b/docs/src/content/en/reference/vectors/vectorize.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Cloudflare Vector Store | Vectors | Mastra Docs"
+title: "Reference: Cloudflare Vector Store | Vectors"
 description: Documentation for the CloudflareVector class in Mastra, which provides vector search using Cloudflare Vectorize.
 ---
 

--- a/docs/src/content/en/reference/voice/azure.mdx
+++ b/docs/src/content/en/reference/voice/azure.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Azure | Voice | Mastra Docs"
+title: "Reference: Azure | Voice"
 description: "Documentation for the AzureVoice class, providing text-to-speech and speech-to-text capabilities using Azure Cognitive Services."
 ---
 

--- a/docs/src/content/en/reference/voice/cloudflare.mdx
+++ b/docs/src/content/en/reference/voice/cloudflare.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Cloudflare | Voice | Mastra Docs"
+title: "Reference: Cloudflare | Voice"
 description: "Documentation for the CloudflareVoice class, providing text-to-speech capabilities using Cloudflare Workers AI."
 ---
 

--- a/docs/src/content/en/reference/voice/composite-voice.mdx
+++ b/docs/src/content/en/reference/voice/composite-voice.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: CompositeVoice | Voice | Mastra Docs"
+title: "Reference: CompositeVoice | Voice"
 description: "Documentation for the CompositeVoice class, which enables combining multiple voice providers for flexible text-to-speech and speech-to-text operations."
 ---
 

--- a/docs/src/content/en/reference/voice/deepgram.mdx
+++ b/docs/src/content/en/reference/voice/deepgram.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Deepgram | Voice | Mastra Docs"
+title: "Reference: Deepgram | Voice"
 description: "Documentation for the Deepgram voice implementation, providing text-to-speech and speech-to-text capabilities with multiple voice models and languages."
 ---
 

--- a/docs/src/content/en/reference/voice/elevenlabs.mdx
+++ b/docs/src/content/en/reference/voice/elevenlabs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: ElevenLabs | Voice | Mastra Docs"
+title: "Reference: ElevenLabs | Voice"
 description: "Documentation for the ElevenLabs voice implementation, offering high-quality text-to-speech capabilities with multiple voice models and natural-sounding synthesis."
 ---
 

--- a/docs/src/content/en/reference/voice/google-gemini-live.mdx
+++ b/docs/src/content/en/reference/voice/google-gemini-live.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Google Gemini Live Voice | Voice | Mastra Docs"
+title: "Reference: Google Gemini Live Voice | Voice"
 description: "Documentation for the GeminiLiveVoice class, providing real-time multimodal voice interactions using Google's Gemini Live API with support for both Gemini API and Vertex AI."
 ---
 

--- a/docs/src/content/en/reference/voice/google.mdx
+++ b/docs/src/content/en/reference/voice/google.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Google | Voice | Mastra Docs"
+title: "Reference: Google | Voice"
 description: "Documentation for the Google Voice implementation, providing text-to-speech and speech-to-text capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/mastra-voice.mdx
+++ b/docs/src/content/en/reference/voice/mastra-voice.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: MastraVoice | Voice | Mastra Docs"
+title: "Reference: MastraVoice | Voice"
 description: "Documentation for the MastraVoice abstract base class, which defines the core interface for all voice services in Mastra, including speech-to-speech capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/murf.mdx
+++ b/docs/src/content/en/reference/voice/murf.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Murf | Voice | Mastra Docs"
+title: "Reference: Murf | Voice"
 description: "Documentation for the Murf voice implementation, providing text-to-speech capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/openai-realtime.mdx
+++ b/docs/src/content/en/reference/voice/openai-realtime.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: OpenAI Realtime Voice | Voice | Mastra Docs"
+title: "Reference: OpenAI Realtime Voice | Voice"
 description: "Documentation for the OpenAIRealtimeVoice class, providing real-time text-to-speech and speech-to-text capabilities via WebSockets."
 ---
 

--- a/docs/src/content/en/reference/voice/openai.mdx
+++ b/docs/src/content/en/reference/voice/openai.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: OpenAI | Voice | Mastra Docs"
+title: "Reference: OpenAI | Voice"
 description: "Documentation for the OpenAIVoice class, providing text-to-speech and speech-to-text capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/playai.mdx
+++ b/docs/src/content/en/reference/voice/playai.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: PlayAI | Voice | Mastra Docs"
+title: "Reference: PlayAI | Voice"
 description: "Documentation for the PlayAI voice implementation, providing text-to-speech capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/sarvam.mdx
+++ b/docs/src/content/en/reference/voice/sarvam.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Sarvam | Voice | Mastra Docs"
+title: "Reference: Sarvam | Voice"
 description: "Documentation for the Sarvam class, providing text-to-speech and speech-to-text capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/speechify.mdx
+++ b/docs/src/content/en/reference/voice/speechify.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Speechify | Voice | Mastra Docs"
+title: "Reference: Speechify | Voice"
 description: "Documentation for the Speechify voice implementation, providing text-to-speech capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.addInstructions.mdx
+++ b/docs/src/content/en/reference/voice/voice.addInstructions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.addInstructions() | Voice | Mastra Docs"
+title: "Reference: voice.addInstructions() | Voice"
 description: "Documentation for the addInstructions() method available in voice providers, which adds instructions to guide the voice model's behavior."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.addTools.mdx
+++ b/docs/src/content/en/reference/voice/voice.addTools.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.addTools() | Voice | Mastra Docs"
+title: "Reference: voice.addTools() | Voice"
 description: "Documentation for the addTools() method available in voice providers, which equips voice models with function calling capabilities."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.answer.mdx
+++ b/docs/src/content/en/reference/voice/voice.answer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.answer() | Voice | Mastra Docs"
+title: "Reference: voice.answer() | Voice"
 description: "Documentation for the answer() method available in real-time voice providers, which triggers the voice provider to generate a response."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.close.mdx
+++ b/docs/src/content/en/reference/voice/voice.close.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.close() | Voice | Mastra Docs"
+title: "Reference: voice.close() | Voice"
 description: "Documentation for the close() method available in voice providers, which disconnects from real-time voice services."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.connect.mdx
+++ b/docs/src/content/en/reference/voice/voice.connect.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.connect() | Voice | Mastra Docs"
+title: "Reference: voice.connect() | Voice"
 description: "Documentation for the connect() method available in real-time voice providers, which establishes a connection for speech-to-speech communication."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.events.mdx
+++ b/docs/src/content/en/reference/voice/voice.events.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Voice Events | Voice | Mastra Docs"
+title: "Reference: Voice Events | Voice"
 description: "Documentation for events emitted by voice providers, particularly for real-time voice interactions."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.getSpeakers.mdx
+++ b/docs/src/content/en/reference/voice/voice.getSpeakers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.getSpeakers() | Voice Providers | Mastra Docs"
+title: "Reference: voice.getSpeakers() | Voice Providers"
 description: "Documentation for the getSpeakers() method available in voice providers, which retrieves available voice options."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.listen.mdx
+++ b/docs/src/content/en/reference/voice/voice.listen.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.listen() | Voice | Mastra Docs"
+title: "Reference: voice.listen() | Voice"
 description: "Documentation for the listen() method available in all Mastra voice providers, which converts speech to text."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.off.mdx
+++ b/docs/src/content/en/reference/voice/voice.off.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.off() | Voice | Mastra Docs"
+title: "Reference: voice.off() | Voice"
 description: "Documentation for the off() method available in voice providers, which removes event listeners for voice events."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.on.mdx
+++ b/docs/src/content/en/reference/voice/voice.on.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.on() | Voice | Mastra Docs"
+title: "Reference: voice.on() | Voice"
 description: "Documentation for the on() method available in voice providers, which registers event listeners for voice events."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.send.mdx
+++ b/docs/src/content/en/reference/voice/voice.send.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.send() | Voice | Mastra Docs"
+title: "Reference: voice.send() | Voice"
 description: "Documentation for the send() method available in real-time voice providers, which streams audio data for continuous processing."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.speak.mdx
+++ b/docs/src/content/en/reference/voice/voice.speak.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.speak() | Voice | Mastra Docs"
+title: "Reference: voice.speak() | Voice"
 description: "Documentation for the speak() method available in all Mastra voice providers, which converts text to speech."
 ---
 

--- a/docs/src/content/en/reference/voice/voice.updateConfig.mdx
+++ b/docs/src/content/en/reference/voice/voice.updateConfig.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: voice.updateConfig() | Voice | Mastra Docs"
+title: "Reference: voice.updateConfig() | Voice"
 description: "Documentation for the updateConfig() method available in voice providers, which updates the configuration of a voice provider at runtime."
 ---
 

--- a/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.cancel() | Workflows | Mastra Docs"
+title: "Reference: Run.cancel() | Workflows"
 description: Documentation for the `Run.cancel()` method in workflows, which cancels a workflow run.
 ---
 

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.resume() | Workflows | Mastra Docs"
+title: "Reference: Run.resume() | Workflows"
 description: Documentation for the `Run.resume()` method in workflows, which resumes a suspended workflow run with new data.
 ---
 

--- a/docs/src/content/en/reference/workflows/run-methods/start.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run.start() | Workflows | Mastra Docs"
+title: "Reference: Run.start() | Workflows"
 description: Documentation for the `Run.start()` method in workflows, which starts a workflow run with input data.
 ---
 

--- a/docs/src/content/en/reference/workflows/run.mdx
+++ b/docs/src/content/en/reference/workflows/run.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Run Class | Workflows | Mastra Docs"
+title: "Reference: Run Class | Workflows"
 description: Documentation for the Run class in Mastra, which represents a workflow execution instance.
 ---
 

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Step Class | Workflows | Mastra Docs"
+title: "Reference: Step Class | Workflows"
 description: Documentation for the Step class in Mastra, which defines individual units of work within a workflow.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/branch.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/branch.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.branch() | Workflows | Mastra Docs"
+title: "Reference: Workflow.branch() | Workflows"
 description: Documentation for the `Workflow.branch()` method in workflows, which creates conditional branches between steps.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/commit.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/commit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.commit() | Workflows | Mastra Docs"
+title: "Reference: Workflow.commit() | Workflows"
 description: Documentation for the `Workflow.commit()` method in workflows, which finalizes the workflow and returns the final result.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/create-run.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/create-run.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.createRun() | Workflows | Mastra Docs"
+title: "Reference: Workflow.createRun() | Workflows"
 description: Documentation for the `Workflow.createRun()` method in workflows, which creates a new workflow run instance.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/dountil.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/dountil.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.dountil() | Workflows | Mastra Docs"
+title: "Reference: Workflow.dountil() | Workflows"
 description: Documentation for the `Workflow.dountil()` method in workflows, which creates a loop that executes a step until a condition is met.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/dowhile.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/dowhile.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.dowhile() | Workflows | Mastra Docs"
+title: "Reference: Workflow.dowhile() | Workflows"
 description: Documentation for the `Workflow.dowhile()` method in workflows, which creates a loop that executes a step while a condition is met.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.foreach() | Workflows | Mastra Docs"
+title: "Reference: Workflow.foreach() | Workflows"
 description: Documentation for the `Workflow.foreach()` method in workflows, which creates a loop that executes a step for each item in an array.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.map() | Workflows | Mastra Docs"
+title: "Reference: Workflow.map() | Workflows"
 description: Documentation for the `Workflow.map()` method in workflows, which maps output data from a previous step to the input of a subsequent step.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/parallel.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/parallel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.parallel() | Workflows | Mastra Docs"
+title: "Reference: Workflow.parallel() | Workflows"
 description: Documentation for the `Workflow.parallel()` method in workflows, which executes multiple steps in parallel.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/sendEvent.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sendEvent.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.sendEvent() | Workflows | Mastra Docs"
+title: "Reference: Workflow.sendEvent() | Workflows"
 description: Documentation for the `Workflow.sendEvent()` method in workflows, which resumes execution when an event is sent.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.sleep() | Workflows | Mastra Docs"
+title: "Reference: Workflow.sleep() | Workflows"
 description: Documentation for the `Workflow.sleep()` method in workflows, which pauses execution for a specified number of milliseconds.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.sleepUntil() | Workflows | Mastra Docs"
+title: "Reference: Workflow.sleepUntil() | Workflows"
 description: Documentation for the `Workflow.sleepUntil()` method in workflows, which pauses execution until a specified date.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/then.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/then.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.then() | Workflows | Mastra Docs"
+title: "Reference: Workflow.then() | Workflows"
 description: Documentation for the `Workflow.then()` method in workflows, which creates sequential dependencies between steps.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/waitForEvent.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/waitForEvent.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow.waitForEvent() | Workflows | Mastra Docs"
+title: "Reference: Workflow.waitForEvent() | Workflows"
 description: Documentation for the `Workflow.waitForEvent()` method in workflows, which pauses execution until an event is received.
 ---
 

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Workflow Class | Workflows | Mastra Docs"
+title: "Reference: Workflow Class | Workflows"
 description: Documentation for the `Workflow` class in Mastra, which enables you to create state machines for complex sequences of operations with conditional branching and data validation.
 ---
 


### PR DESCRIPTION
This marks our v1 docs clearly as v1 docs, to avoid confusion for Google and the user