### PR TITLE
fix: avoid content duplication penality

### DIFF
--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -33,7 +33,9 @@ export default function Layout(props: Props): ReactNode {
 
   const location = useLocation();
   const { siteConfig } = useDocusaurusContext();
-  const cleanPath = location.pathname.replace(/^\/ja(\/|$)/, "/");
+  const cleanPath = location.pathname
+    .replace(/^\/ja(\/|$)/, "/")
+    .replace(/^\/([a-z]+)\/v1(\/|$)/, "/$1$2");
   const canonicalUrl = `${siteConfig.url}${cleanPath}`;
 
   return (
@@ -45,7 +47,7 @@ export default function Layout(props: Props): ReactNode {
         <link rel="alternate" hrefLang="en" href={canonicalUrl} />
         <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
         {/* IMPORTANT: Remove the next line when v1 gets stable and docs are moved to the url without `v1` prefix */}
-        <meta name="robots" content="noindex" />
+        <meta name="robots" content="noindex, follow" />
       </Head>
 
       <SkipToContent />

--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -44,6 +44,8 @@ export default function Layout(props: Props): ReactNode {
         <link rel="canonical" href={canonicalUrl} />
         <link rel="alternate" hrefLang="en" href={canonicalUrl} />
         <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
+        {/* IMPORTANT: Remove the next line when v1 gets stable and docs are moved to the url without `v1` prefix */}
+        <meta name="robots" content="noindex" />
       </Head>
 
       <SkipToContent />


### PR DESCRIPTION
Based on @bookercodes input, we gonna tell the machines to skip indexing our beta docs to avoid content duplication.

Important:

1. This no-index needs to be removed when the v1 docs become the officials table docs
2. This no-index must be added to the v0 docs as soon they are legacy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Canonical URLs are now normalized to correctly handle language and versioned (v1) URL patterns, improving link consistency.

* **Chores**
  * Temporarily disabled search engine indexing of documentation (robots: noindex, follow) until v1 is stabilized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->