### PR TITLE
fix: broken link to mastra cloud docs

### DIFF
--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -112,4 +112,4 @@ CloudExporter uses intelligent batching to optimize network usage. Traces are bu
 
 - [Tracing Overview](/docs/v1/observability/tracing/overview)
 - [DefaultExporter](/docs/v1/observability/tracing/exporters/default)
-- [Mastra Cloud Documentation](https://cloud.mastra.ai/docs)
+- [Mastra Cloud Documentation](/docs/v1/deployment/mastra-cloud/overview)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloud Exporter documentation link to use internal documentation paths instead of external URLs for improved navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->