### PR TITLE
fix(server): fix memory endpoints to return and handle data properly

### DIFF
--- a/.changeset/blue-taxis-spend.md
+++ b/.changeset/blue-taxis-spend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix semantic search endpoint to return results in the correct format. Also fix the delete messages endpoint to properly normalize ids in the expected format.

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -13,6 +13,7 @@ import {
   createThreadHandler,
   listMessagesHandler,
   deleteMessagesHandler,
+  getTextContent,
 } from './memory';
 
 function createThread(overrides?: Partial<StorageThreadType>): StorageThreadType {
@@ -25,17 +26,6 @@ function createThread(overrides?: Partial<StorageThreadType>): StorageThreadType
     updatedAt: now,
     ...overrides,
   };
-}
-
-function getTextContent(message: MastraDBMessage): string {
-  if (typeof message.content === 'string') {
-    return message.content;
-  }
-  if (message.content && typeof message.content === 'object' && 'parts' in message.content) {
-    const textPart = message.content.parts.find((p: any) => p.type === 'text');
-    return textPart?.text || '';
-  }
-  return '';
 }
 
 describe('Memory Handlers', () => {

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1080,7 +1080,8 @@ describe('Memory Handlers', () => {
       });
 
       expect(result).toEqual({ success: true, message: '1 message deleted successfully' });
-      expect(mockMemory.deleteMessages).toHaveBeenCalledWith('test-message-id');
+      // Single string should be normalized to array
+      expect(mockMemory.deleteMessages).toHaveBeenCalledWith(['test-message-id']);
     });
 
     it('should delete multiple messages successfully', async () => {
@@ -1120,7 +1121,8 @@ describe('Memory Handlers', () => {
       });
 
       expect(result).toEqual({ success: true, message: '1 message deleted successfully' });
-      expect(mockMemory.deleteMessages).toHaveBeenCalledWith({ id: 'test-message-id' });
+      // Single object should be normalized to array
+      expect(mockMemory.deleteMessages).toHaveBeenCalledWith([{ id: 'test-message-id' }]);
     });
 
     it('should accept array of message objects', async () => {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -426,7 +426,7 @@ export async function updateWorkingMemoryHandler({
 interface SearchResult {
   id: string;
   role: string;
-  content: any;
+  content: string;
   createdAt: Date;
   threadId?: string;
   threadTitle?: string;
@@ -467,14 +467,25 @@ export async function deleteMessagesHandler({
       throw new HTTPException(400, { message: 'Memory is not initialized' });
     }
 
-    // Delete the messages - let the memory method handle validation
-    await memory.deleteMessages(messageIds as any);
+    // Normalize messageIds to the format expected by deleteMessages
+    // Convert single values to arrays and extract IDs from objects
+    let normalizedIds: string[] | { id: string }[];
+
+    if (Array.isArray(messageIds)) {
+      // Already an array - keep as is (could be string[] or { id: string }[])
+      normalizedIds = messageIds;
+    } else if (typeof messageIds === 'string') {
+      // Single string ID - wrap in array
+      normalizedIds = [messageIds];
+    } else {
+      // Single object with id property - wrap in array
+      normalizedIds = [messageIds];
+    }
+
+    await memory.deleteMessages(normalizedIds);
 
     // Count messages for response
-    let count = 1;
-    if (Array.isArray(messageIds)) {
-      count = messageIds.length;
-    }
+    const count = Array.isArray(messageIds) ? messageIds.length : 1;
 
     return { success: true, message: `${count} message${count === 1 ? '' : 's'} deleted successfully` };
   } catch (error) {
@@ -608,12 +619,15 @@ export async function searchMemoryHandler({
     const fetched = await Promise.all(threadIds.map((id: string) => memory.getThreadById({ threadId: id })));
     const threadMap = new Map(fetched.filter(Boolean).map(t => [t!.id, t!]));
 
+    const getContent = (message: MastraDBMessage): string => {
+      if (typeof message.content === 'string') {
+        return message.content;
+      }
+      return message.content.parts?.map(p => (p.type === 'text' ? p.text : '')).join(' ') || '';
+    };
     // Process each message in the results
     for (const msg of result.messages) {
-      const content =
-        typeof msg.content.content === `string`
-          ? msg.content.content
-          : msg.content.parts?.map((p: any) => (p.type === 'text' ? p.text : '')).join(' ') || '';
+      const content = getContent(msg);
 
       const msgThreadId = msg.threadId || threadId;
       const thread = threadMap.get(msgThreadId);
@@ -636,13 +650,13 @@ export async function searchMemoryHandler({
           before: threadMessages.slice(Math.max(0, messageIndex - beforeRange), messageIndex).map(m => ({
             id: m.id,
             role: m.role,
-            content: m.content,
+            content: getContent(m),
             createdAt: m.createdAt || new Date(),
           })),
           after: threadMessages.slice(messageIndex + 1, messageIndex + afterRange + 1).map(m => ({
             id: m.id,
             role: m.role,
-            content: m.content,
+            content: getContent(m),
             createdAt: m.createdAt || new Date(),
           })),
         };


### PR DESCRIPTION
## Description

There were a coupe "any"'s in the code which was leading to incorrect assumptions of what the data should be. this fixes the delete messages endpoint to properly handle messageIds as well as the semantic recall search endpoint to return data in the correct format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Semantic search endpoint now returns results in the correct format.
  * Delete messages endpoint normalizes message IDs consistently, handling single and multiple deletions reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->