### PR TITLE
feat(ai-sdk): add runId and resourceId support to workflow route

### DIFF
--- a/.changeset/lovely-radios-clean.md
+++ b/.changeset/lovely-radios-clean.md
@@ -1,0 +1,11 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Extend the workflow route to accept optional runId and resourceId
+parameters, allowing clients to specify custom identifiers when
+creating workflow runs. These parameters are now properly validated
+in the OpenAPI schema and passed through to the createRun method.
+
+Also updates the OpenAPI schema to include previously undocumented
+resumeData and step fields.

--- a/client-sdks/ai-sdk/src/workflow-route.ts
+++ b/client-sdks/ai-sdk/src/workflow-route.ts
@@ -48,13 +48,13 @@ export function workflowRoute({
             schema: {
               type: 'object',
               properties: {
-                runId: { type: 'string', additionalProperties: true },
-                resourceId: { type: 'string', additionalProperties: true },
+                runId: { type: 'string' },
+                resourceId: { type: 'string' },
                 inputData: { type: 'object', additionalProperties: true },
                 resumeData: { type: 'object', additionalProperties: true },
                 requestContext: { type: 'object', additionalProperties: true },
                 tracingOptions: { type: 'object', additionalProperties: true },
-                step: { type: 'string', additionalProperties: true },
+                step: { type: 'string' },
               },
             },
           },


### PR DESCRIPTION
## Description

Extend the workflow route to accept optional runId and resourceId
parameters, allowing clients to specify custom identifiers when
creating workflow runs. These parameters are now properly validated
in the OpenAPI schema and passed through to the createRun method.

Also updates the OpenAPI schema to include previously undocumented
resumeData and step fields.

## Related Issue(s)

fixes https://github.com/mastra-ai/mastra/issues/9966

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow API routes now accept optional runId and resourceId parameters to allow explicit run targeting and better control over workflow executions.

* **Documentation**
  * OpenAPI schema updated to document resumeData and step fields and to clarify request payload structure for workflow invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->