### PR TITLE
feat: setup easier access to chatbot

### DIFF
--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/context.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/context.tsx
@@ -52,8 +52,6 @@ export function ChatbotSidebarProvider({
 }: ChatbotSidebarProviderProps) {
   const [isHidden, setIsHidden] = useState(defaultHidden);
 
-  console.log("isHidden", isHidden);
-
   const toggle = useCallback(() => {
     setIsHidden((prev) => !prev);
   }, []);

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/context.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/context.tsx
@@ -1,0 +1,109 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+export interface ChatbotSidebarContextValue {
+  /**
+   * Whether the chatbot sidebar is hidden
+   */
+  isHidden: boolean;
+  /**
+   * Set the hidden state of the chatbot sidebar
+   */
+  setIsHidden: (value: boolean | ((prev: boolean) => boolean)) => void;
+  /**
+   * Toggle the chatbot sidebar open/closed
+   */
+  toggle: () => void;
+  /**
+   * Open the chatbot sidebar
+   */
+  open: () => void;
+  /**
+   * Close the chatbot sidebar
+   */
+  close: () => void;
+}
+
+const ChatbotSidebarContext = createContext<
+  ChatbotSidebarContextValue | undefined
+>(undefined);
+
+interface ChatbotSidebarProviderProps {
+  children: ReactNode;
+  /**
+   * Initial hidden state (defaults to true)
+   */
+  defaultHidden?: boolean;
+}
+
+/**
+ * Provider component for chatbot sidebar state management.
+ * Wrap your layout with this provider to enable chatbot sidebar state access
+ * from any child component.
+ */
+export function ChatbotSidebarProvider({
+  children,
+  defaultHidden = true,
+}: ChatbotSidebarProviderProps) {
+  const [isHidden, setIsHidden] = useState(defaultHidden);
+
+  console.log("isHidden", isHidden);
+
+  const toggle = useCallback(() => {
+    setIsHidden((prev) => !prev);
+  }, []);
+
+  const open = useCallback(() => {
+    setIsHidden(false);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsHidden(true);
+  }, []);
+
+  const value: ChatbotSidebarContextValue = {
+    isHidden,
+    setIsHidden,
+    toggle,
+    open,
+    close,
+  };
+
+  return (
+    <ChatbotSidebarContext.Provider value={value}>
+      {children}
+    </ChatbotSidebarContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the chatbot sidebar state and controls.
+ * Must be used within a ChatbotSidebarProvider.
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { isHidden, open, close, toggle } = useChatbotSidebar();
+ *
+ *   return (
+ *     <button onClick={toggle}>
+ *       {isHidden ? 'Open' : 'Close'} Chatbot
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export function useChatbotSidebar(): ChatbotSidebarContextValue {
+  const context = useContext(ChatbotSidebarContext);
+  if (context === undefined) {
+    throw new Error(
+      "useChatbotSidebar must be used within a ChatbotSidebarProvider",
+    );
+  }
+  return context;
+}

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
@@ -20,19 +20,11 @@ import {
   ThumbsDown,
   ThumbsUp,
 } from "lucide-react";
+import { useChatbotSidebar } from "./context";
 import styles from "./styles.module.css";
 
-interface ChatbotSidebarProps {
-  hiddenChatbotSidebar: boolean;
-  setHiddenChatbotSidebar: (
-    value: boolean | ((prev: boolean) => boolean),
-  ) => void;
-}
-
-export default function ChatbotSidebar({
-  hiddenChatbotSidebar,
-  setHiddenChatbotSidebar,
-}: ChatbotSidebarProps): ReactNode {
+export default function ChatbotSidebar(): ReactNode {
+  const { isHidden: hiddenChatbotSidebar, toggle } = useChatbotSidebar();
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
 
   const toggleSidebar = useCallback(() => {
@@ -44,8 +36,8 @@ export default function ChatbotSidebar({
     if (!hiddenSidebar && prefersReducedMotion()) {
       setHiddenSidebar(true);
     }
-    setHiddenChatbotSidebar((value) => !value);
-  }, [setHiddenChatbotSidebar, hiddenSidebar]);
+    toggle();
+  }, [toggle, hiddenSidebar]);
 
   const {
     conversation,

--- a/docs/src/theme/DocRoot/Layout/Main/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/Main/index.tsx
@@ -2,19 +2,17 @@ import React, { type ReactNode } from "react";
 import clsx from "clsx";
 import { useDocsSidebar } from "@docusaurus/plugin-content-docs/client";
 import type { Props } from "@theme/DocRoot/Layout/Main";
+import { useChatbotSidebar } from "../ChatbotSidebar/context";
 
 import styles from "./styles.module.css";
 
-interface ExtendedProps extends Props {
-  hiddenChatbotSidebar?: boolean;
-}
-
 export default function DocRootLayoutMain({
   hiddenSidebarContainer,
-  hiddenChatbotSidebar,
   children,
-}: ExtendedProps): ReactNode {
+}: Props): ReactNode {
   const sidebar = useDocsSidebar();
+  const { isHidden: hiddenChatbotSidebar } = useChatbotSidebar();
+
   return (
     <main
       className={clsx(

--- a/docs/src/theme/DocRoot/Layout/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/index.tsx
@@ -1,17 +1,16 @@
-import React, { type ReactNode, useState } from "react";
 import { useDocsSidebar } from "@docusaurus/plugin-content-docs/client";
 import BackToTopButton from "@theme/BackToTopButton";
-import DocRootLayoutSidebar from "@theme/DocRoot/Layout/Sidebar";
-import DocRootLayoutMain from "./Main";
 import type { Props } from "@theme/DocRoot/Layout";
+import DocRootLayoutSidebar from "@theme/DocRoot/Layout/Sidebar";
+import { type ReactNode, useState } from "react";
+import DocRootLayoutMain from "./Main";
 
-import styles from "./styles.module.css";
 import ChatbotSidebar from "./ChatbotSidebar";
+import styles from "./styles.module.css";
 
 export default function DocRootLayout({ children }: Props): ReactNode {
   const sidebar = useDocsSidebar();
   const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
-  const [hiddenChatbotSidebar, setHiddenChatbotSidebar] = useState(true);
 
   return (
     <div className={styles.docsWrapper}>
@@ -24,16 +23,10 @@ export default function DocRootLayout({ children }: Props): ReactNode {
             setHiddenSidebarContainer={setHiddenSidebarContainer}
           />
         )}
-        <DocRootLayoutMain
-          hiddenSidebarContainer={hiddenSidebarContainer}
-          hiddenChatbotSidebar={hiddenChatbotSidebar}
-        >
+        <DocRootLayoutMain hiddenSidebarContainer={hiddenSidebarContainer}>
           {children}
         </DocRootLayoutMain>
-        <ChatbotSidebar
-          hiddenChatbotSidebar={hiddenChatbotSidebar}
-          setHiddenChatbotSidebar={setHiddenChatbotSidebar}
-        />
+        <ChatbotSidebar />
       </div>
     </div>
   );

--- a/docs/src/theme/Navbar/Search/index.tsx
+++ b/docs/src/theme/Navbar/Search/index.tsx
@@ -10,6 +10,7 @@ import { CustomSearch } from "@site/src/components/custom-search";
 import { Button } from "@site/src/components/ui/button";
 import { useEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { useChatbotSidebar } from "../../DocRoot/Layout/ChatbotSidebar/context";
 
 const SHORTCUT_OS_KEY = "shortcut-os-preference";
 
@@ -31,7 +32,7 @@ function getInitialIsMac(): boolean {
   return false;
 }
 
-export function Shortcut() {
+export function Shortcut({ shortcut }: { shortcut: string }) {
   const [isMac, setIsMac] = useState(getInitialIsMac);
 
   useEffect(() => {
@@ -48,11 +49,11 @@ export function Shortcut() {
   return (
     <kbd className="flex items-center py-2 gap-1 text-xs font-medium text-(--mastra-icons-3)">
       {!isMac ? (
-        "CTRL K"
+        `CTRL ${shortcut}`
       ) : (
-        <span className="inline-flex text-sm gap-1 items-center">
+        <span className="inline-flex gap-1 items-center text-sm">
           <span className="text-xs">⌘</span>
-          <span className="text-xs">K</span>
+          <span className="text-xs">{shortcut}</span>
         </span>
       )}
     </kbd>
@@ -108,13 +109,13 @@ export default function SearchContainer({ locale }: { locale: string }) {
           className="md:flex hidden w-[200px]  items-center pr-[0.38rem] text-sm font-normal justify-between gap-6 cursor-pointer border-[0.5px] bg-(--mastra-surface-4) border-(--border)  text-(--mastra-icons-3)"
         >
           <span className="text-sm">Search docs...</span>
-          <Shortcut />
+          <Shortcut shortcut="K" />
         </Button>
       </DialogTrigger>
       <DialogPortal>
         <DialogOverlay className="fixed inset-0 transition-opacity z-250 bg-black/40" />
         <DialogContent className="dialog-panel z-260 fixed left-1/2 top-[100px] -translate-x-1/2  w-full">
-          <div className="flex items-start relative top-1/2 justify-center min-h-full p-4">
+          <div className="flex relative top-1/2 justify-center items-start p-4 min-h-full">
             <div className="w-full ring ring-neutral-200 dark:ring-(--border) shadow-2xl duration-150 ease-out data-closed:transform-[scale(95%)] data-closed:opacity-0 dark:border-(--border) h-fit max-w-[660px] mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">
               <DialogTitle className="sr-only">Search docs...</DialogTitle>
               <div className="w-full">
@@ -128,5 +129,23 @@ export default function SearchContainer({ locale }: { locale: string }) {
         </DialogContent>
       </DialogPortal>
     </Dialog>
+  );
+}
+
+export function AskAI() {
+  const { toggle } = useChatbotSidebar();
+
+  useHotkeys("meta+i", () => toggle());
+
+  return (
+    <Button
+      onClick={toggle}
+      size="sm"
+      variant="ghost"
+      className="md:flex hidden w-fit items-center pr-[0.38rem] text-sm font-normal justify-between gap-6 cursor-pointer border-[0.5px] bg-(--mastra-surface-4) border-(--border)  text-(--mastra-icons-3)"
+    >
+      <span className="text-sm">Ask AI</span>
+      <Shortcut shortcut="I" />
+    </Button>
   );
 }

--- a/docs/src/theme/Navbar/Search/index.tsx
+++ b/docs/src/theme/Navbar/Search/index.tsx
@@ -10,7 +10,7 @@ import { CustomSearch } from "@site/src/components/custom-search";
 import { Button } from "@site/src/components/ui/button";
 import { useEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { useChatbotSidebar } from "../../DocRoot/Layout/ChatbotSidebar/context";
+import { useChatbotSidebar } from "@site/src/theme/DocRoot/Layout/ChatbotSidebar/context";
 
 const SHORTCUT_OS_KEY = "shortcut-os-preference";
 

--- a/docs/src/theme/Navbar/index.tsx
+++ b/docs/src/theme/Navbar/index.tsx
@@ -6,7 +6,7 @@ import VersionControl from "@site/src/components/version-control";
 import NavbarLayout from "@theme/Navbar/Layout";
 import NavbarMobileSidebarToggle from "@theme/Navbar/MobileSidebar/Toggle";
 import { type ReactNode } from "react";
-import SearchContainer from "./Search";
+import SearchContainer, { AskAI } from "./Search";
 import { Logo } from "./logo";
 import { TabSwitcher } from "./tab-switcher";
 
@@ -39,7 +39,10 @@ function NavbarContentDesktop() {
         </div>
 
         <div className="hidden @[798px]:block">
-          <SearchContainer locale="en" />
+          <div className="flex gap-2 items-center">
+            <SearchContainer locale="en" />
+            <AskAI />
+          </div>
         </div>
         <NavbarMobileSidebarToggle />
       </div>

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -4,6 +4,7 @@ import { CookieConsent } from "@site/src/components/cookie/cookie-consent";
 import { Toaster } from "@site/src/components/ui/sonner";
 import { PostHogProvider } from "posthog-js/react";
 import React from "react";
+import { ChatbotSidebarProvider } from "./DocRoot/Layout/ChatbotSidebar/context";
 
 export default function Root({ children }: { children: React.ReactNode }) {
   const { siteConfig } = useDocusaurusContext();
@@ -23,7 +24,9 @@ export default function Root({ children }: { children: React.ReactNode }) {
       <KapaProvider integrationId={kapaIntegrationId || ""}>
         <Toaster />
         <CookieConsent />
-        {children}
+        <ChatbotSidebarProvider defaultHidden={true}>
+          {children}
+        </ChatbotSidebarProvider>
       </KapaProvider>
     </PostHogProvider>
   );


### PR DESCRIPTION
- Refactored ChatbotSidebar to use context for state management of the visibility state of the chatbot sidebar.
- Introduced AskAI button in the Navbar to toggle the chatbot sidebar using a keyboard shortcut.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Ask AI" button added to the navbar for quick chatbot access.
  * Keyboard shortcuts: Meta/Ctrl+I toggles the chatbot; Meta/Ctrl+K opens search.

* **Improvements**
  * Chatbot visibility is consistently integrated across the site layout.
  * Shortcut labels adapt to OS and persist user preference; chatbot remains hidden by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->