### PR TITLE
chore: add changeset for inspect flags host:port support

### DIFF
--- a/.changeset/add-inspect-host-port-support.md
+++ b/.changeset/add-inspect-host-port-support.md
@@ -1,0 +1,8 @@
+---
+'mastra': minor
+---
+
+Add host:port support to --inspect and --inspect-brk flags
+
+Enable optional host:port values for Docker debugging (e.g., `--inspect=0.0.0.0:9229`) while maintaining backward compatibility with boolean flags.
+


### PR DESCRIPTION
Adds changeset for the merged PR #9472 which added host:port support to --inspect and --inspect-brk flags.

This enables optional host:port values for Docker debugging (e.g., --inspect=0.0.0.0:9229) while maintaining backward compatibility with boolean flags.

Fixes #6464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced debug flags with optional host:port configuration, allowing custom debugging endpoints for containerized environments while preserving existing boolean flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->