### PR TITLE
fix: broken image prompts with asset handling

### DIFF
--- a/.changeset/vast-banks-drive.md
+++ b/.changeset/vast-banks-drive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixes assets not being downloaded when available

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -311,36 +311,34 @@ export class MessageList {
 
         let messages = [...systemMessages, ...modelMessages];
 
-        if (Object.keys(downloadedAssets || {}).length > 0) {
-          messages = messages.map(message => {
-            if (message.role === 'user') {
-              if (typeof message.content === 'string') {
-                return {
-                  role: 'user' as const,
-                  content: [{ type: 'text' as const, text: message.content }],
-                  providerOptions: message.providerOptions,
-                } as AIV5Type.ModelMessage;
-              }
-
-              const convertedContent = message.content
-                .map(part => {
-                  if (part.type === 'image' || part.type === 'file') {
-                    return convertImageFilePart(part, downloadedAssets);
-                  }
-                  return part;
-                })
-                .filter(part => part.type !== 'text' || part.text !== '');
-
+        messages = messages.map(message => {
+          if (message.role === 'user') {
+            if (typeof message.content === 'string') {
               return {
                 role: 'user' as const,
-                content: convertedContent,
+                content: [{ type: 'text' as const, text: message.content }],
                 providerOptions: message.providerOptions,
               } as AIV5Type.ModelMessage;
             }
 
-            return message;
-          });
-        }
+            const convertedContent = message.content
+              .map(part => {
+                if (part.type === 'image' || part.type === 'file') {
+                  return convertImageFilePart(part, downloadedAssets);
+                }
+                return part;
+              })
+              .filter(part => part.type !== 'text' || part.text !== '');
+
+            return {
+              role: 'user' as const,
+              content: convertedContent,
+              providerOptions: message.providerOptions,
+            } as AIV5Type.ModelMessage;
+          }
+
+          return message;
+        });
 
         messages = ensureGeminiCompatibleMessages(messages);
 


### PR DESCRIPTION
Fixes an issue where assets weren't being properly handled in image prompts, causing them to fail when they should have been downloaded and processed correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing assets from downloading when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->