### PR TITLE
fix(core): preserve providerOptions in reasoning message parts

### DIFF
--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -1547,13 +1547,21 @@ export class MessageList {
             toolInvocations.push(invocation);
             break;
 
-          case 'reasoning':
+          case 'reasoning': {
+            // Merge part-level and message-level providerOptions for reasoning
+            // part-level takes precedence over message-level
+            const providerMetadata = {
+              ...(coreMessage.providerOptions ?? {}),
+              ...(part.providerOptions ?? {}),
+            };
             parts.push({
               type: 'reasoning',
               reasoning: '', // leave this blank so we aren't double storing it in the db along with details
               details: [{ type: 'text', text: part.text, signature: part.signature }],
+              ...(Object.keys(providerMetadata).length && { providerMetadata }),
             });
             break;
+          }
           case 'redacted-reasoning':
             parts.push({
               type: 'reasoning',


### PR DESCRIPTION
## Description

This PR fixes a critical bug where `providerOptions` metadata was being lost when processing reasoning-type message parts in AI SDK V4 CoreMessage format. 

When Claude's extended thinking feature returns reasoning blocks with Bedrock-specific metadata (such as signatures), this metadata was dropped during the conversion from CoreMessage to MastraMessageV2 in the `aiV4CoreMessageToMastraMessageV2` method. As a result, `@ai-sdk/amazon-bedrock` could not recognize these reasoning blocks as valid Bedrock content and removed them from outgoing messages, causing the API to reject requests with: "Expected thinking or redacted_thinking, but found text".

The fix preserves `providerOptions` as `providerMetadata` in reasoning message parts, following the same pattern already used for text-type parts.

## Related Issue(s)

Fixes #7799

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider metadata from message and part levels is now correctly merged, with part-level options taking precedence.
  * Provider metadata on reasoning parts within assistant messages is now preserved during storage and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->