### PR TITLE
fix: make github icon less prominent

### DIFF
--- a/docs/src/components/github-star-count.tsx
+++ b/docs/src/components/github-star-count.tsx
@@ -4,13 +4,13 @@ export const GithubStarCount = () => {
       href="https://github.com/mastra-ai/mastra"
       target="_blank"
       rel="noopener noreferrer"
-      className="font-medium hover:text-black  cursor-pointer w-fit text-(--mastra-text-quaternary) dark:text-white  rounded-md  transition-colors hover:opacity-100 flex items-center gap-2 justify-start px-2.5 py-2 h-8.5 text-sm"
+      className="font-medium hover:text-black  cursor-pointer w-fit text-(--mastra-text-tertiary)! dark:text-white!  rounded-md  transition-colors hover:opacity-100 flex items-center gap-2 justify-start px-2.5 py-2 h-8.5 text-sm"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         id="github"
         viewBox="0 0 24 24"
-        className="size-5 dark:text-white"
+        className="size-5"
       >
         <polygon
           fill="currentColor"


### PR DESCRIPTION
## Description

Make github icon less prominent.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the GitHub star count component's visual presentation with updated text coloring to improve hierarchy. Enhanced spacing adjustments and optimized styling consistency across light and dark theme modes for a more cohesive appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->