### PR TITLE
fix(core): download assets

### DIFF
--- a/.changeset/busy-baths-buy.md
+++ b/.changeset/busy-baths-buy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Only handle download image asset transformation if needed

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -311,34 +311,44 @@ export class MessageList {
 
         let messages = [...systemMessages, ...modelMessages];
 
-        messages = messages.map(message => {
-          if (message.role === 'user') {
-            if (typeof message.content === 'string') {
+        // Check if any messages have image/file content that needs processing
+        const hasImageOrFileContent = modelMessages.some(
+          message =>
+            message.role === 'user' &&
+            typeof message.content !== 'string' &&
+            message.content.some(part => part.type === 'image' || part.type === 'file'),
+        );
+
+        if (hasImageOrFileContent) {
+          messages = messages.map(message => {
+            if (message.role === 'user') {
+              if (typeof message.content === 'string') {
+                return {
+                  role: 'user' as const,
+                  content: [{ type: 'text' as const, text: message.content }],
+                  providerOptions: message.providerOptions,
+                } as AIV5Type.ModelMessage;
+              }
+
+              const convertedContent = message.content
+                .map(part => {
+                  if (part.type === 'image' || part.type === 'file') {
+                    return convertImageFilePart(part, downloadedAssets);
+                  }
+                  return part;
+                })
+                .filter(part => part.type !== 'text' || part.text !== '');
+
               return {
                 role: 'user' as const,
-                content: [{ type: 'text' as const, text: message.content }],
+                content: convertedContent,
                 providerOptions: message.providerOptions,
               } as AIV5Type.ModelMessage;
             }
 
-            const convertedContent = message.content
-              .map(part => {
-                if (part.type === 'image' || part.type === 'file') {
-                  return convertImageFilePart(part, downloadedAssets);
-                }
-                return part;
-              })
-              .filter(part => part.type !== 'text' || part.text !== '');
-
-            return {
-              role: 'user' as const,
-              content: convertedContent,
-              providerOptions: message.providerOptions,
-            } as AIV5Type.ModelMessage;
-          }
-
-          return message;
-        });
+            return message;
+          });
+        }
 
         messages = ensureGeminiCompatibleMessages(messages);
 

--- a/packages/core/src/agent/message-list/prompt/convert-file.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-file.ts
@@ -4,7 +4,7 @@ import { convertToDataContent, detectMediaType, imageMediaTypeSignatures } from 
 
 export function convertImageFilePart(
   part: ImagePart | FilePart,
-  downloadedAssets: Record<string, { mediaType: string | undefined; data: Uint8Array }>,
+  downloadedAssets?: Record<string, { mediaType: string | undefined; data: Uint8Array }>,
 ): LanguageModelV2TextPart | LanguageModelV2FilePart {
   let originalData: DataContent | URL;
   const type = part.type;
@@ -26,7 +26,7 @@ export function convertImageFilePart(
   let data: Uint8Array | string | URL = convertedData; // binary | base64 | url
 
   // If the content is a URL, we check if it was downloaded:
-  if (data instanceof URL) {
+  if (data instanceof URL && downloadedAssets) {
     const downloadedFile = downloadedAssets[data.toString()];
     if (downloadedFile) {
       data = downloadedFile.data;

--- a/packages/core/src/llm/model/router.integration.test.ts
+++ b/packages/core/src/llm/model/router.integration.test.ts
@@ -182,34 +182,30 @@ describe('ModelRouter Integration Tests', () => {
       expect(hasPirateWord).toBe(true);
     });
 
-    it.skipIf(skipInCI)(
-      'should support streaming',
-      async () => {
-        if (!process.env[envVar]) {
-          throw new Error(`${envVar} not set - required for ${provider} integration tests`);
-        }
+    it.skipIf(skipInCI)('should support streaming', { timeout: 30000 }, async () => {
+      if (!process.env[envVar]) {
+        throw new Error(`${envVar} not set - required for ${provider} integration tests`);
+      }
 
-        const agent = new Agent({
-          id: 'test-agent',
-          name: 'test-agent',
-          instructions: 'You are a helpful assistant.',
-          model: modelId,
-        });
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: modelId,
+      });
 
-        const { textStream } = await agent.stream('Count from 1 to 3');
+      const { textStream } = await agent.stream('Count from 1 to 3');
 
-        const chunks: string[] = [];
-        for await (const chunk of textStream) {
-          chunks.push(chunk);
-        }
+      const chunks: string[] = [];
+      for await (const chunk of textStream) {
+        chunks.push(chunk);
+      }
 
-        expect(chunks.length).toBeGreaterThan(0);
-        const fullText = chunks.join('');
-        expect(fullText).toBeDefined();
-        expect(typeof fullText).toBe('string');
-      },
-      { timeout: 30000 },
-    );
+      expect(chunks.length).toBeGreaterThan(0);
+      const fullText = chunks.join('');
+      expect(fullText).toBeDefined();
+      expect(typeof fullText).toBe('string');
+    });
   });
 
   describe('Model ID Validation', () => {


### PR DESCRIPTION
## Description

We removed the check in a previous PR that would check if there were any assets to be downloaded. Instead of running this logic for all messages always, we only run it if there's an image that needs to be handled.

Also fixes a vitest upgrade issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized image and file asset transformation to only process when media is present in messages, improving efficiency while preserving behavior for text-only content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->