### PR TITLE
feat(@mastra/ai-sdk): add configurable stream conversion options to `toAISdkV5Stream`

### DIFF
--- a/.changeset/slimy-gifts-invent.md
+++ b/.changeset/slimy-gifts-invent.md
@@ -5,3 +5,7 @@
 Add sendStart, sendFinish, sendReasoning, and sendSources options to toAISdkV5Stream function, allowing fine-grained control over which message chunks are included in the converted stream. Previously, these values were hardcoded in the transformer.
 
 BREAKING CHANGE: AgentStreamToAISDKTransformer now accepts an options object instead of a single lastMessageId parameter
+
+Also, add sendStart, sendFinish, sendReasoning, and sendSources parameters to
+chatRoute function, enabling fine-grained control over which chunks are
+included in the AI SDK stream output.

--- a/.changeset/slimy-gifts-invent.md
+++ b/.changeset/slimy-gifts-invent.md
@@ -1,0 +1,7 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Add sendStart, sendFinish, sendReasoning, and sendSources options to toAISdkV5Stream function, allowing fine-grained control over which message chunks are included in the converted stream. Previously, these values were hardcoded in the transformer.
+
+BREAKING CHANGE: AgentStreamToAISDKTransformer now accepts an options object instead of a single lastMessageId parameter

--- a/.changeset/slimy-gifts-invent.md
+++ b/.changeset/slimy-gifts-invent.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/ai-sdk': patch
+'@mastra/ai-sdk': major
 ---
 
 Add sendStart, sendFinish, sendReasoning, and sendSources options to toAISdkV5Stream function, allowing fine-grained control over which message chunks are included in the converted stream. Previously, these values were hardcoded in the transformer.

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -16,12 +16,66 @@ export type chatRouteOptions<OUTPUT extends OutputSchema = undefined> = {
       path: string;
       agent: string;
     }
-);
+) & {
+    sendStart?: boolean;
+    sendFinish?: boolean;
+    sendReasoning?: boolean;
+    sendSources?: boolean;
+  };
 
+/**
+ * Creates a chat route handler for streaming agent conversations using the AI SDK format.
+ *
+ * This function registers an HTTP POST endpoint that accepts messages, executes an agent,
+ * and streams the response back to the client in AI SDK v5 compatible format.
+ * *
+ * @param {chatRouteOptions} options - Configuration options for the chat route
+ * @param {string} [options.path='/chat/:agentId'] - The route path. Include `:agentId` for dynamic routing
+ * @param {string} [options.agent] - Fixed agent ID when not using dynamic routing
+ * @param {AgentExecutionOptions} [options.defaultOptions] - Default options passed to agent execution
+ * @param {boolean} [options.sendStart=true] - Whether to send start events in the stream
+ * @param {boolean} [options.sendFinish=true] - Whether to send finish events in the stream
+ * @param {boolean} [options.sendReasoning=false] - Whether to include reasoning steps in the stream
+ * @param {boolean} [options.sendSources=false] - Whether to include source citations in the stream
+ *
+ * @returns {ReturnType<typeof registerApiRoute>} A registered API route handler
+ *
+ * @throws {Error} When path doesn't include `:agentId` and no fixed agent is specified
+ * @throws {Error} When agent ID is missing at runtime
+ * @throws {Error} When specified agent is not found in Mastra instance
+ *
+ * @example
+ * // Dynamic agent routing
+ * chatRoute({
+ *   path: '/chat/:agentId',
+ *   sendReasoning: true,
+ * });
+ *
+ * @example
+ * // Fixed agent with custom path
+ * chatRoute({
+ *   path: '/api/support-chat',
+ *   agent: 'support-agent',
+ *   defaultOptions: {
+ *     maxSteps: 5,
+ *   },
+ * });
+ *
+ * @remarks
+ * - The route handler expects a JSON body with a `messages` array
+ * - Messages should follow the format: `{ role: 'user' | 'assistant' | 'system', content: string }`
+ * - The response is a Server-Sent Events (SSE) stream compatible with AI SDK v5
+ * - If both `agent` and `:agentId` are present, a warning is logged and the fixed `agent` takes precedence
+ * - Request context from the incoming request overrides `defaultOptions.requestContext` if both are present
+ */
 export function chatRoute<OUTPUT extends OutputSchema = undefined>({
   path = '/chat/:agentId',
   agent,
   defaultOptions,
+  sendStart = true,
+  sendFinish = true,
+  sendReasoning = false,
+  sendSources = false,
 }: chatRouteOptions<OUTPUT>): ReturnType<typeof registerApiRoute> {
   if (!agent && !path.includes('/:agentId')) {
     throw new Error('Path must include :agentId to route to the correct agent or pass the agent explicitly');
@@ -168,7 +222,14 @@ export function chatRoute<OUTPUT extends OutputSchema = undefined>({
       const uiMessageStream = createUIMessageStream({
         originalMessages: messages,
         execute: async ({ writer }) => {
-          for await (const part of toAISdkV5Stream(result, { from: 'agent', lastMessageId })!) {
+          for await (const part of toAISdkV5Stream(result, {
+            from: 'agent',
+            lastMessageId,
+            sendStart,
+            sendFinish,
+            sendReasoning,
+            sendSources,
+          })!) {
             writer.write(part);
           }
         },

--- a/client-sdks/ai-sdk/src/convert-streams.ts
+++ b/client-sdks/ai-sdk/src/convert-streams.ts
@@ -16,6 +16,50 @@ import {
 
 type ToAISDKFrom = 'agent' | 'network' | 'workflow';
 
+/**
+ * Converts Mastra streams (workflow, agent network, or agent) to AI SDK v5 compatible streams.
+ *
+ * This function transforms various Mastra stream types into ReadableStream objects that are compatible
+ * with the AI SDK v5, enabling seamless integration with AI SDK's streaming capabilities.
+ *
+ *
+ * @param {MastraWorkflowStream | WorkflowRunOutput | MastraAgentNetworkStream | MastraModelOutput} stream
+ *   The Mastra stream to convert. Can be one of:
+ *   - MastraWorkflowStream: A workflow execution stream
+ *   - WorkflowRunOutput: The output of a workflow run
+ *   - MastraAgentNetworkStream: An agent network execution stream
+ *   - MastraModelOutput: An agent model output stream
+ *
+ * @param {Object} options - Conversion options
+ * @param {'workflow' | 'network' | 'agent'} options.from - The type of stream being converted. Defaults to 'agent'
+ * @param {string} [options.lastMessageId] - (Agent only) The ID of the last message in the conversation
+ * @param {boolean} [options.sendStart=true] - (Agent only) Whether to send start events. Defaults to true
+ * @param {boolean} [options.sendFinish=true] - (Agent only) Whether to send finish events. Defaults to true
+ * @param {boolean} [options.sendReasoning] - (Agent only) Whether to include reasoning in the output
+ * @param {boolean} [options.sendSources] - (Agent only) Whether to include sources in the output
+ *
+ * @returns {ReadableStream<InferUIMessageChunk<UIMessage>>} A ReadableStream compatible with AI SDK v5
+ *
+ * @example
+ * // Convert a workflow stream
+ * const workflowStream = await workflowRun.stream(...);
+ * const aiSDKStream = toAISdkV5Stream(workflowStream, { from: 'workflow' });
+ *
+ * @example
+ * // Convert an agent network stream
+ * const networkStream = await agentNetwork.network(...);
+ * const aiSDKStream = toAISdkV5Stream(networkStream, { from: 'network' });
+ *
+ * @example
+ * // Convert an agent stream with custom options
+ * const agentStream = await agent.stream(...);
+ * const aiSDKStream = toAISdkV5Stream(agentStream, {
+ *   from: 'agent',
+ *   lastMessageId: 'msg-123',
+ *   sendReasoning: true,
+ *   sendSources: true
+ * });
+ */
 export function toAISdkV5Stream<
   TOutput extends ZodType<any>,
   TInput extends ZodType<any>,

--- a/client-sdks/ai-sdk/src/convert-streams.ts
+++ b/client-sdks/ai-sdk/src/convert-streams.ts
@@ -40,7 +40,14 @@ export function toAISdkV5Stream(
 ): ReadableStream<InferUIMessageChunk<UIMessage>>;
 export function toAISdkV5Stream<TOutput extends OutputSchema>(
   stream: MastraModelOutput<TOutput>,
-  options: { from: 'agent'; lastMessageId?: string },
+  options: {
+    from: 'agent';
+    lastMessageId?: string;
+    sendStart?: boolean;
+    sendFinish?: boolean;
+    sendReasoning?: boolean;
+    sendSources?: boolean;
+  },
 ): ReadableStream<InferUIMessageChunk<UIMessage>>;
 export function toAISdkV5Stream(
   stream:
@@ -48,7 +55,18 @@ export function toAISdkV5Stream(
     | MastraWorkflowStream<any, any, any, any>
     | MastraModelOutput
     | WorkflowRunOutput<WorkflowResult<any, any, any, any>>,
-  options: { from: ToAISDKFrom; lastMessageId?: string } = { from: 'agent' },
+  options: {
+    from: ToAISDKFrom;
+    lastMessageId?: string;
+    sendStart?: boolean;
+    sendFinish?: boolean;
+    sendReasoning?: boolean;
+    sendSources?: boolean;
+  } = {
+    from: 'agent',
+    sendStart: true,
+    sendFinish: true,
+  },
 ): ReadableStream<InferUIMessageChunk<UIMessage>> {
   const from = options?.from;
 
@@ -66,7 +84,13 @@ export function toAISdkV5Stream(
 
   const agentReadable: ReadableStream<ChunkType> =
     'fullStream' in stream ? (stream as MastraModelOutput).fullStream : (stream as ReadableStream<ChunkType>);
-  return agentReadable.pipeThrough(AgentStreamToAISDKTransformer<any>(options?.lastMessageId)) as ReadableStream<
-    InferUIMessageChunk<UIMessage>
-  >;
+  return agentReadable.pipeThrough(
+    AgentStreamToAISDKTransformer<any>({
+      lastMessageId: options?.lastMessageId,
+      sendStart: options?.sendStart,
+      sendFinish: options?.sendFinish,
+      sendReasoning: options?.sendReasoning,
+      sendSources: options?.sendSources,
+    }),
+  ) as ReadableStream<InferUIMessageChunk<UIMessage>>;
 }

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -148,7 +148,19 @@ export function AgentNetworkToAISDKTransformer() {
   });
 }
 
-export function AgentStreamToAISDKTransformer<TOutput extends ZodType<any>>(lastMessageId?: string) {
+export function AgentStreamToAISDKTransformer<TOutput extends ZodType<any>>({
+  lastMessageId,
+  sendStart,
+  sendFinish,
+  sendReasoning,
+  sendSources,
+}: {
+  lastMessageId?: string;
+  sendStart?: boolean;
+  sendFinish?: boolean;
+  sendReasoning?: boolean;
+  sendSources?: boolean;
+}) {
   let bufferedSteps = new Map<string, any>();
 
   return new TransformStream<ChunkType<TOutput>, object>({
@@ -157,10 +169,10 @@ export function AgentStreamToAISDKTransformer<TOutput extends ZodType<any>>(last
 
       const transformedChunk = convertFullStreamChunkToUIMessageStream<any>({
         part: part as any,
-        sendReasoning: false,
-        sendSources: false,
-        sendStart: true,
-        sendFinish: true,
+        sendReasoning,
+        sendSources,
+        sendStart,
+        sendFinish,
         responseMessageId: lastMessageId,
         onError(error) {
           return safeParseErrorObject(error);


### PR DESCRIPTION
## Description

Add sendStart, sendFinish, sendReasoning, and sendSources options to toAISdkV5Stream function, allowing fine-grained control over which message chunks are included in the converted stream. Previously, these values were hardcoded in the transformer.

BREAKING CHANGE: This seems to be an ok breaking change as AgentStreamToAISDKTransformer is used internally only, but  AgentStreamToAISDKTransformer now accepts an options object instead of a single lastMessageId parameter

Also, add sendStart, sendFinish, sendReasoning, and sendSources parameters to
chatRoute function, enabling fine-grained control over which chunks are
included in the AI SDK stream output.

## Related Issue(s)

slack issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fine-grained streaming controls to opt in/out of start/finish events, reasoning steps, and source citations; chat stream defaults emit start and finish events.

* **Breaking Changes**
  * Public streaming APIs now accept a configuration object with these flags (replacing the prior single-parameter form); integrations must pass the options to control which stream chunks are emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->