### PR TITLE
Fix vector definition to fix pinecone

### DIFF
--- a/.changeset/fluffy-plums-drive.md
+++ b/.changeset/fluffy-plums-drive.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix vector definition to fix pinecone

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -64,7 +64,7 @@ export interface Config<
     string,
     Workflow<any, any, any, any, any, any>
   >,
-  TVectors extends Record<string, MastraVector> = Record<string, MastraVector>,
+  TVectors extends Record<string, MastraVector<any>> = Record<string, MastraVector<any>>,
   TTTS extends Record<string, MastraTTS> = Record<string, MastraTTS>,
   TLogger extends IMastraLogger = IMastraLogger,
   TMCPServers extends Record<string, MCPServerBase> = Record<string, MCPServerBase>,
@@ -221,7 +221,7 @@ export class Mastra<
     string,
     Workflow<any, any, any, any, any, any>
   >,
-  TVectors extends Record<string, MastraVector> = Record<string, MastraVector>,
+  TVectors extends Record<string, MastraVector<any>> = Record<string, MastraVector<any>>,
   TTTS extends Record<string, MastraTTS> = Record<string, MastraTTS>,
   TLogger extends IMastraLogger = IMastraLogger,
   TMCPServers extends Record<string, MCPServerBase> = Record<string, MCPServerBase>,


### PR DESCRIPTION
Fixes: https://github.com/mastra-ai/mastra/issues/10144

MastraVector should take any filter type since they may change between providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced type flexibility for vector store configurations, enabling support for a broader range of vector store implementations and improving configuration compatibility.
* **Chores**
  * Added a changeset entry to record a patch release for the core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->