### PR TITLE
[Fix] Scorer list filtering on Span Scorring

### DIFF
--- a/.changeset/smooth-moons-tease.md
+++ b/.changeset/smooth-moons-tease.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Fix scorer filtering for SpanScoring, add error and info message for user

--- a/packages/playground-ui/src/components/ui/elements/notification/notification.tsx
+++ b/packages/playground-ui/src/components/ui/elements/notification/notification.tsx
@@ -10,13 +10,23 @@ type Notification = {
   isVisible?: boolean;
   autoDismiss?: boolean;
   dismissTime?: number;
+  dismissible?: boolean;
+  type?: 'info' | 'error';
 };
 
-export function Notification({ children, className, isVisible, autoDismiss = true, dismissTime = 5000 }: Notification) {
+export function Notification({
+  children,
+  className,
+  isVisible,
+  autoDismiss = true,
+  dismissTime = 5000,
+  dismissible = true,
+  type = 'info',
+}: Notification) {
   const [localIsVisible, setLocalIsVisible] = useState(isVisible);
 
   useEffect(() => {
-    if (autoDismiss && isVisible) {
+    if (dismissible && autoDismiss && isVisible) {
       const timer = setTimeout(() => {
         setLocalIsVisible(false);
       }, dismissTime);
@@ -33,16 +43,30 @@ export function Notification({ children, className, isVisible, autoDismiss = tru
   return (
     <div
       className={cn(
-        'grid grid-cols-[1fr_auto] gap-[0.5rem] rounded-l bg-white/5 p-[1.5rem] py-[1rem] text-[0.875rem] text-icon3 items-center',
-        '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:opacity-50',
+        'grid grid-cols-[1fr_auto] gap-[0.5rem] rounded-lg bg-white/5 p-[1.5rem] py-[1rem] text-[0.875rem] text-icon3 items-center',
+        {
+          'bg-red-900/10 border border-red-900': type === 'error',
+        },
         className,
       )}
     >
-      <div className="flex gap-[0.5rem] items-center">{children}</div>
-      <Button variant="ghost" onClick={() => setLocalIsVisible(false)}>
-        <XIcon />
-        <VisuallyHidden>Dismiss</VisuallyHidden>
-      </Button>
+      <div
+        className={cn(
+          'flex gap-[0.5rem] items-start',
+          '[&>svg]:w-[1.2em] [&>svg]:h-[1.2em] [&>svg]:opacity-70 [&>svg]:translate-y-[0.2em]',
+          {
+            '[&>svg]:text-red-400': type === 'error',
+          },
+        )}
+      >
+        {children}
+      </div>
+      {dismissible && (
+        <Button variant="ghost" onClick={() => setLocalIsVisible(false)}>
+          <XIcon />
+          <VisuallyHidden>Dismiss</VisuallyHidden>
+        </Button>
+      )}
     </div>
   );
 }

--- a/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
@@ -69,7 +69,12 @@ export function SpanTabs({
                 <CircleGaugeIcon /> Scoring
               </Section.Heading>
             </Section.Header>
-            <SpanScoring traceId={trace?.traceId} spanId={span?.spanId} entityType={entityType} />
+            <SpanScoring
+              traceId={trace?.traceId}
+              isTopLevelSpan={span?.parentSpanId === null}
+              spanId={span?.spanId}
+              entityType={entityType}
+            />
           </Section>
           <Section>
             <Section.Header>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- explicitly provide `isTopLevelSpan` value to SpanScorring
- add Notification to inform a user that there is no Scorers and it's not an error
- add Notification to inform a user something went wrong while querying for scorers

<img width="1438" height="699" alt="CleanShot 2025-11-17 at 10 41 04" src="https://github.com/user-attachments/assets/087cc8ab-ed02-4976-b4fc-8f507f008f20" />

<img width="1438" height="490" alt="CleanShot 2025-11-17 at 11 46 50" src="https://github.com/user-attachments/assets/6e1effa2-5a45-4460-92ba-b94a61945361" />



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

https://linear.app/kepler-crm/issue/CLOUD-589/unable-to-select-scorers-in-observability-tab

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected scorer filtering so span scoring correctly distinguishes top-level vs nested spans.

* **New Features**
  * Shows an error notification when scorer errors occur.
  * Displays an info notification when no eligible scorers are defined.

* **UI Improvements**
  * Notification component now supports info/error types and optional dismissible behavior with adjusted styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->