### PR TITLE
fix/9697  resume data types

### DIFF
--- a/.changeset/fruity-walls-strive.md
+++ b/.changeset/fruity-walls-strive.md
@@ -1,0 +1,6 @@
+---
+'@mastra/inngest': patch
+'@mastra/core': patch
+---
+
+fix resumeStream type to use resumeSchema

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -1024,7 +1024,7 @@ describe('Workflow', () => {
 
       const resumeData = { stepId: 'promptAgent', context: { userInput: 'test input for resumption' } };
 
-      output = await run.resumeStream({ resumeData: resumeData as any, step: promptAgent });
+      output = await run.resumeStream({ resumeData, step: promptAgent });
       for await (const _data of output.fullStream) {
       }
 

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1715,7 +1715,7 @@ describe('Workflow', () => {
       }
 
       const resumeData = { stepId: 'promptAgent', context: { userInput: 'test input for resumption' } };
-      const errStreamResult = run.resumeStreamVNext({ resumeData: resumeData as any, step: getUserInput });
+      const errStreamResult = run.resumeStreamVNext({ resumeData, step: getUserInput });
       for await (const _data of errStreamResult.fullStream) {
       }
 
@@ -1728,7 +1728,7 @@ describe('Workflow', () => {
         );
       }
 
-      streamResult = run.resumeStreamVNext({ resumeData: resumeData as any, step: promptAgent });
+      streamResult = run.resumeStreamVNext({ resumeData, step: promptAgent });
       console.log('created stream');
       for await (const _data of streamResult.fullStream) {
         console.log('data===', _data);
@@ -1993,7 +1993,7 @@ describe('Workflow', () => {
       let result = await streamResult.result;
 
       const resumeData = { userInput: 'test input for resumption' };
-      streamResult = run.resumeStreamVNext({ resumeData: resumeData as any, step: promptAgent });
+      streamResult = run.resumeStreamVNext({ resumeData, step: promptAgent });
       for await (const data of streamResult.fullStream) {
         if (data.type === 'workflow-step-output') {
           expect(data.payload.output).toMatchObject({

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2105,7 +2105,7 @@ export class Run<
    * @param input The input data for the workflow
    * @returns A promise that resolves to the workflow output
    */
-  resumeStream({
+  resumeStream<TResumeSchema extends z.ZodType<any>>({
     step,
     resumeData,
     requestContext,
@@ -2113,10 +2113,13 @@ export class Run<
     tracingOptions,
     outputOptions,
   }: {
-    resumeData?: z.input<TInput>;
+    resumeData?: z.input<TResumeSchema>;
     step?:
-      | Step<string, any, any, any, any, any, TEngineType>
-      | [...Step<string, any, any, any, any, any, TEngineType>[], Step<string, any, any, any, any, any, TEngineType>]
+      | Step<string, any, any, any, TResumeSchema, any, TEngineType>
+      | [
+          ...Step<string, any, any, any, any, any, TEngineType>[],
+          Step<string, any, any, any, TResumeSchema, any, TEngineType>,
+        ]
       | string
       | string[];
     requestContext?: RequestContext;
@@ -2142,7 +2145,7 @@ export class Run<
    * @param input The input data for the workflow
    * @returns A promise that resolves to the workflow output
    */
-  resumeStreamVNext({
+  resumeStreamVNext<TResumeSchema extends z.ZodType<any>>({
     step,
     resumeData,
     requestContext,
@@ -2151,10 +2154,13 @@ export class Run<
     forEachIndex,
     outputOptions,
   }: {
-    resumeData?: z.input<TInput>;
+    resumeData?: z.input<TResumeSchema>;
     step?:
-      | Step<string, any, any, any, any, any, TEngineType>
-      | [...Step<string, any, any, any, any, any, TEngineType>[], Step<string, any, any, any, any, any, TEngineType>]
+      | Step<string, any, any, any, TResumeSchema, any, TEngineType>
+      | [
+          ...Step<string, any, any, any, any, any, TEngineType>[],
+          Step<string, any, any, any, TResumeSchema, any, TEngineType>,
+        ]
       | string
       | string[];
     requestContext?: RequestContext;

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -10362,7 +10362,7 @@ describe('MastraInngestWorkflow', () => {
       for await (const _data of streamOutput.fullStream) {
       }
       const resumeData = { stepId: 'promptAgent', context: { userInput: 'test input for resumption' } };
-      const resumeStreamOutput = run.resumeStreamVNext({ resumeData: resumeData as any, step: promptAgent });
+      const resumeStreamOutput = run.resumeStreamVNext({ resumeData, step: promptAgent });
 
       for await (const _data of resumeStreamOutput.fullStream) {
       }


### PR DESCRIPTION
## Description

Fixed incorrect type definitions for `resumeStream()` and `resumeStreamVNext()` methods in workflow runs. The `resumeData` parameter was incorrectly typed as `z.input<TInput>` (workflow input schema) instead of `z.input<TResumeSchema>` (step's resume schema), causing type errors when passing valid resume data.

**Changes:**
- Added generic type parameter `<TResumeSchema>` to both methods
- Changed `resumeData` type to correctly match the step's resume schema
- Removed `as any` workarounds from tests that were working around this bug

## Related Issue(s)

#9697 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type handling for workflow resume operations to improve type safety and validation
  * Applied patch version updates to core and integration packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->