### PR TITLE
feat: move position of theme switcher to bottom left

### DIFF
--- a/docs/src/theme/DocSidebar/Desktop/CollapseButton/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/CollapseButton/index.tsx
@@ -1,0 +1,32 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import { translate } from "@docusaurus/Translate";
+import IconArrow from "@theme/Icon/Arrow";
+import type { Props } from "@theme/DocSidebar/Desktop/CollapseButton";
+
+import styles from "./styles.module.css";
+
+export default function CollapseButton({ onClick }: Props): ReactNode {
+  return (
+    <button
+      type="button"
+      title={translate({
+        id: "theme.docs.sidebar.collapseButtonTitle",
+        message: "Collapse sidebar",
+        description: "The title attribute for collapse button of doc sidebar",
+      })}
+      aria-label={translate({
+        id: "theme.docs.sidebar.collapseButtonAriaLabel",
+        message: "Collapse sidebar",
+        description: "The title attribute for collapse button of doc sidebar",
+      })}
+      className={clsx(
+        "button button--secondary button--outline",
+        styles.collapseSidebarButton,
+      )}
+      onClick={onClick}
+    >
+      <IconArrow className={styles.collapseSidebarButtonIcon} />
+    </button>
+  );
+}

--- a/docs/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
+++ b/docs/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
@@ -1,0 +1,40 @@
+:root {
+  --docusaurus-collapse-button-bg: transparent;
+  --docusaurus-collapse-button-bg-hover: rgb(0 0 0 / 10%);
+}
+
+[data-theme="dark"]:root {
+  --docusaurus-collapse-button-bg: rgb(255 255 255 / 5%);
+  --docusaurus-collapse-button-bg-hover: rgb(255 255 255 / 10%);
+}
+
+@media (min-width: 997px) {
+  .collapseSidebarButton {
+    display: block !important;
+    background-color: var(--docusaurus-collapse-button-bg);
+    height: 40px;
+    position: sticky;
+    bottom: 0;
+    border-radius: 0;
+    border: 1px solid var(--ifm-toc-border-color);
+  }
+
+  .collapseSidebarButtonIcon {
+    transform: rotate(180deg);
+    margin-top: 4px;
+  }
+
+  [dir="rtl"] .collapseSidebarButtonIcon {
+    transform: rotate(0);
+  }
+
+  .collapseSidebarButton:hover,
+  .collapseSidebarButton:focus {
+    background-color: var(--docusaurus-collapse-button-bg-hover);
+  }
+}
+
+.collapseSidebarButton {
+  display: none;
+  margin: 0;
+}

--- a/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -1,0 +1,55 @@
+import React, { type ReactNode, useState } from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import {
+  useAnnouncementBar,
+  useScrollPosition,
+} from "@docusaurus/theme-common/internal";
+import { translate } from "@docusaurus/Translate";
+import DocSidebarItems from "@theme/DocSidebarItems";
+import type { Props } from "@theme/DocSidebar/Desktop/Content";
+
+import styles from "./styles.module.css";
+
+function useShowAnnouncementBar() {
+  const { isActive } = useAnnouncementBar();
+  const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive);
+
+  useScrollPosition(
+    ({ scrollY }) => {
+      if (isActive) {
+        setShowAnnouncementBar(scrollY === 0);
+      }
+    },
+    [isActive],
+  );
+  return isActive && showAnnouncementBar;
+}
+
+export default function DocSidebarDesktopContent({
+  path,
+  sidebar,
+  className,
+}: Props): ReactNode {
+  const showAnnouncementBar = useShowAnnouncementBar();
+
+  return (
+    <nav
+      aria-label={translate({
+        id: "theme.docs.sidebar.navAriaLabel",
+        message: "Docs sidebar",
+        description: "The ARIA label for the sidebar navigation",
+      })}
+      className={clsx(
+        "menu thin-scrollbar",
+        styles.menu,
+        showAnnouncementBar && styles.menuWithAnnouncementBar,
+        className,
+      )}
+    >
+      <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, "menu__list")}>
+        <DocSidebarItems items={sidebar} activePath={path} level={1} />
+      </ul>
+    </nav>
+  );
+}

--- a/docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -1,0 +1,16 @@
+@media (min-width: 997px) {
+  .menu {
+    flex-grow: 1;
+    padding: 0.5rem;
+  }
+  @supports (scrollbar-gutter: stable) {
+    .menu {
+      padding: 0.5rem 0 0.5rem 0.5rem;
+      scrollbar-gutter: stable;
+    }
+  }
+
+  .menuWithAnnouncementBar {
+    margin-bottom: var(--docusaurus-announcement-bar-height);
+  }
+}

--- a/docs/src/theme/DocSidebar/Desktop/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/index.tsx
@@ -1,0 +1,38 @@
+import { useThemeConfig } from "@docusaurus/theme-common";
+import type { Props } from "@theme/DocSidebar/Desktop";
+import CollapseButton from "@theme/DocSidebar/Desktop/CollapseButton";
+import Content from "@theme/DocSidebar/Desktop/Content";
+import Logo from "@theme/Logo";
+import clsx from "clsx";
+import React from "react";
+
+import { ThemeSwitcher } from "@site/src/components/theme-switcher";
+
+import styles from "./styles.module.css";
+
+function DocSidebarDesktop({ path, sidebar, onCollapse, isHidden }: Props) {
+  const {
+    navbar: { hideOnScroll },
+    docs: {
+      sidebar: { hideable },
+    },
+  } = useThemeConfig();
+  return (
+    <div
+      className={clsx(
+        styles.sidebar,
+        hideOnScroll && styles.sidebarWithHideableNavbar,
+        isHidden && styles.sidebarHidden,
+      )}
+    >
+      {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
+      <Content path={path} sidebar={sidebar} />
+      <footer className="py-4 pr-0.5 mr-4 flex justify-end border-t-[0.5px] border-(--border)">
+        <ThemeSwitcher />
+      </footer>
+      {hideable && <CollapseButton onClick={onCollapse} />}
+    </div>
+  );
+}
+
+export default React.memo(DocSidebarDesktop);

--- a/docs/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/docs/src/theme/DocSidebar/Desktop/styles.module.css
@@ -1,0 +1,37 @@
+@media (min-width: 997px) {
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding-top: var(--ifm-navbar-height);
+    width: var(--doc-sidebar-width);
+  }
+
+  .sidebarWithHideableNavbar {
+    padding-top: 0;
+  }
+
+  .sidebarHidden {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .sidebarLogo {
+    display: flex !important;
+    align-items: center;
+    margin: 0 var(--ifm-navbar-padding-horizontal);
+    min-height: var(--ifm-navbar-height);
+    max-height: var(--ifm-navbar-height);
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+
+  .sidebarLogo img {
+    margin-right: 0.5rem;
+    height: 2rem;
+  }
+}
+
+.sidebarLogo {
+  display: none;
+}

--- a/docs/src/theme/DocSidebar/Mobile/index.tsx
+++ b/docs/src/theme/DocSidebar/Mobile/index.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import clsx from "clsx";
+import {
+  NavbarSecondaryMenuFiller,
+  type NavbarSecondaryMenuComponent,
+  ThemeClassNames,
+} from "@docusaurus/theme-common";
+import { useNavbarMobileSidebar } from "@docusaurus/theme-common/internal";
+import DocSidebarItems from "@theme/DocSidebarItems";
+import type { Props } from "@theme/DocSidebar/Mobile";
+
+// eslint-disable-next-line react/function-component-definition
+const DocSidebarMobileSecondaryMenu: NavbarSecondaryMenuComponent<Props> = ({
+  sidebar,
+  path,
+}) => {
+  const mobileSidebar = useNavbarMobileSidebar();
+  return (
+    <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, "menu__list")}>
+      <DocSidebarItems
+        items={sidebar}
+        activePath={path}
+        onItemClick={(item) => {
+          // Mobile sidebar should only be closed if the category has a link
+          if (item.type === "category" && item.href) {
+            mobileSidebar.toggle();
+          }
+          if (item.type === "link") {
+            mobileSidebar.toggle();
+          }
+        }}
+        level={1}
+      />
+    </ul>
+  );
+};
+
+function DocSidebarMobile(props: Props) {
+  return (
+    <NavbarSecondaryMenuFiller
+      component={DocSidebarMobileSecondaryMenu}
+      props={props}
+    />
+  );
+}
+
+export default React.memo(DocSidebarMobile);

--- a/docs/src/theme/DocSidebar/index.tsx
+++ b/docs/src/theme/DocSidebar/index.tsx
@@ -1,0 +1,23 @@
+import React, { type ReactNode } from "react";
+import { useWindowSize } from "@docusaurus/theme-common";
+import DocSidebarDesktop from "@theme/DocSidebar/Desktop";
+import DocSidebarMobile from "@theme/DocSidebar/Mobile";
+import type { Props } from "@theme/DocSidebar";
+
+export default function DocSidebar(props: Props): ReactNode {
+  const windowSize = useWindowSize();
+
+  // Desktop sidebar visible on hydration: need SSR rendering
+  const shouldRenderSidebarDesktop =
+    windowSize === "desktop" || windowSize === "ssr";
+
+  // Mobile sidebar not visible on hydration: can avoid SSR rendering
+  const shouldRenderSidebarMobile = windowSize === "mobile";
+
+  return (
+    <>
+      {shouldRenderSidebarDesktop && <DocSidebarDesktop {...props} />}
+      {shouldRenderSidebarMobile && <DocSidebarMobile {...props} />}
+    </>
+  );
+}

--- a/docs/src/theme/Navbar/index.tsx
+++ b/docs/src/theme/Navbar/index.tsx
@@ -34,10 +34,6 @@ function NavbarContentDesktop() {
           />
         </div>
 
-        <div className="hidden lg:block">
-          <ThemeSwitcher />
-        </div>
-
         <div className="hidden @[798px]:block">
           <div className="flex gap-2 items-center">
             <SearchContainer locale="en" />


### PR DESCRIPTION
## Description

Move position of theme switcher to bottom left

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive sidebar that automatically adapts to desktop and mobile screen sizes
  * Desktop sidebar is now collapsible with a dedicated button for better content space management
  * Moved theme switcher from the navbar to the sidebar for improved UI organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->