### PR TITLE
fix(voice): Fix Vertex AI WebSocket connection failures in GeminiLiveVoice 

### DIFF
--- a/.changeset/metal-masks-divide.md
+++ b/.changeset/metal-masks-divide.md
@@ -1,0 +1,5 @@
+---
+"@mastra/voice-google-gemini-live": patch
+---
+
+fix(voice): Fix Vertex AI WebSocket connection failures in GeminiLiveVoice 

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -130,11 +130,13 @@ describe('GeminiLiveVoice', () => {
   });
 
   describe('Vertex AI configuration', () => {
-    it('should send fully-qualified Vertex AI model paths when needed', async () => {
+    it('should preserve fully-qualified Vertex AI model paths when provided', async () => {
+      const fullModelPath =
+        'projects/test-project/locations/us-central1/publishers/google/models/gemini-2.0-flash-live-001';
       const vertexVoice = new GeminiLiveVoice({
         vertexAI: true,
         project: 'test-project',
-        model: 'gemini-2.0-flash-live-001',
+        model: fullModelPath,
       });
 
       vi.spyOn((vertexVoice as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
@@ -145,9 +147,7 @@ describe('GeminiLiveVoice', () => {
       const wsSent = ((vertexVoice as any).connectionManager.getWebSocket() as any).send as any;
       const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
       const setupMsg = payloads.find((p: any) => p.setup);
-      expect(setupMsg.setup.model).toBe(
-        'projects/test-project/locations/us-central1/publishers/google/models/gemini-2.0-flash-live-001',
-      );
+      expect(setupMsg.setup.model).toBe(fullModelPath);
 
       await vertexVoice.disconnect();
     });

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -130,13 +130,11 @@ describe('GeminiLiveVoice', () => {
   });
 
   describe('Vertex AI configuration', () => {
-    it('should preserve fully-qualified Vertex AI model paths when provided', async () => {
-      const fullModelPath =
-        'projects/test-project/locations/us-central1/publishers/google/models/gemini-2.0-flash-live-001';
+    it('should build fully-qualified Vertex AI model path for bare model names', async () => {
       const vertexVoice = new GeminiLiveVoice({
         vertexAI: true,
         project: 'test-project',
-        model: fullModelPath,
+        model: 'gemini-2.0-flash-live-001',
       });
 
       vi.spyOn((vertexVoice as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
@@ -147,7 +145,9 @@ describe('GeminiLiveVoice', () => {
       const wsSent = ((vertexVoice as any).connectionManager.getWebSocket() as any).send as any;
       const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
       const setupMsg = payloads.find((p: any) => p.setup);
-      expect(setupMsg.setup.model).toBe(fullModelPath);
+      expect(setupMsg.setup.model).toBe(
+        'projects/test-project/locations/us-central1/publishers/google/models/gemini-2.0-flash-live-001',
+      );
 
       await vertexVoice.disconnect();
     });

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -130,16 +130,6 @@ describe('GeminiLiveVoice', () => {
   });
 
   describe('Vertex AI configuration', () => {
-    it('should fall back to default location when not provided', () => {
-      const vertexVoice = new GeminiLiveVoice({
-        vertexAI: true,
-        project: 'test-project',
-        model: 'gemini-2.0-flash-live-001',
-      });
-
-      expect((vertexVoice as any).getVertexLocation()).toBe('us-central1');
-    });
-
     it('should send fully-qualified Vertex AI model paths when needed', async () => {
       const vertexVoice = new GeminiLiveVoice({
         vertexAI: true,

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -427,8 +427,8 @@ export class GeminiLiveVoice extends MastraVoice<
       let headers: WebSocket.ClientOptions = {};
 
       if (this.options.vertexAI) {
-        // Vertex AI endpoint
-        wsUrl = `wss://${this.options.location}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1beta1.PredictionService.ServerStreamingPredict`;
+        // Vertex AI endpoint - using correct LlmBidiService endpoint
+        wsUrl = `wss://${this.options.location}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent`;
         // Initialize auth and get token
         await this.authManager.initialize();
         const accessToken = await this.authManager.getAccessToken();
@@ -1738,7 +1738,7 @@ export class GeminiLiveVoice extends MastraVoice<
     // Build the Live API setup message
     const setupMessage: { setup: LiveGenerateContentSetup } = {
       setup: {
-        model: `models/${this.options.model}`,
+        model: this.options.vertexAI ? this.options.model : `models/${this.options.model}`,
       },
     };
 

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -1735,6 +1735,7 @@ export class GeminiLiveVoice extends MastraVoice<
         }>;
       }>;
     }
+
     // Build the Live API setup message
     const setupMessage: { setup: LiveGenerateContentSetup } = {
       setup: {

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -427,7 +427,7 @@ export class GeminiLiveVoice extends MastraVoice<
       let headers: WebSocket.ClientOptions = {};
 
       if (this.options.vertexAI) {
-        const location = this.getVertexLocation();
+        const location = this.options.location?.trim() || 'us-central1';
         // Vertex AI endpoint - using correct LlmBidiService endpoint
         wsUrl = `wss://${location}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent`;
         // Initialize auth and get token
@@ -1695,40 +1695,6 @@ export class GeminiLiveVoice extends MastraVoice<
   }
 
   /**
-   * Get Vertex AI location with fallback to default region
-   * @private
-   */
-  private getVertexLocation(): string {
-    return this.options.location?.trim() || 'us-central1';
-  }
-
-  /**
-   * Resolve the proper model identifier for each API mode
-   * @private
-   */
-  private resolveModelIdentifier(): string {
-    const model = this.options.model ?? DEFAULT_MODEL;
-
-    if (!this.options.vertexAI) {
-      return `models/${model}`;
-    }
-
-    if (model.startsWith('projects/')) {
-      return model;
-    }
-
-    if (!this.options.project) {
-      throw this.createAndEmitError(
-        GeminiLiveErrorCode.PROJECT_ID_MISSING,
-        'Google Cloud project ID is required when using Vertex AI.',
-      );
-    }
-
-    const location = this.getVertexLocation();
-    return `projects/${this.options.project}/locations/${location}/publishers/google/models/${model}`;
-  }
-
-  /**
    * Send initial configuration to Gemini Live API
    * @private
    */
@@ -1769,11 +1735,10 @@ export class GeminiLiveVoice extends MastraVoice<
         }>;
       }>;
     }
-
     // Build the Live API setup message
     const setupMessage: { setup: LiveGenerateContentSetup } = {
       setup: {
-        model: this.resolveModelIdentifier(),
+        model: `models/${this.options.model}`,
       },
     };
 


### PR DESCRIPTION
## Description

Fix incomplete Vertex AI WebSocket support in @mastra/voice-google-gemini-live. The package was using Live API endpoints and model formats even when `vertexAI: true` was configured, causing HTTP 400 errors and WebSocket connection failures.

https://mastra.ai/reference/voice/google-gemini-live

**Changes:**
- Updated WebSocket endpoint selection to use correct Vertex AI endpoint (`LlmBidiService/BidiGenerateContent`)
   - [LlmBidiService](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rpc/google.cloud.aiplatform.v1beta1#llmbidiservice)
- Fixed model path formatting to avoid `models/` prefix duplication for Vertex AI full paths
- Maintained backward compatibility with Live API mode

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/10256

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Technical Details

### Before Fix
```
❌ HTTP 400 Bad Request - Vertex AI doesn't recognize Live API endpoint
❌ WebSocket Error 1007: Invalid resource field value - Model path duplication
```

### After Fix
```
✅ WebSocket connection opened
✅ OAuth authentication successful
✅ Setup message sent successfully
```

### Code Changes

**1. WebSocket Endpoint Selection** (`connect` method):
```typescript
if (this.options.vertexAI) {
  // Vertex AI endpoint - using correct LlmBidiService endpoint
  wsUrl = `wss://${this.options.location}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent`;
} else {
  // Live API endpoint
  wsUrl = `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent`;
}
```

**2. Model Path Formatting** (`sendInitialConfig` method):
```typescript
const setupMessage = {
  setup: {
    model: this.options.vertexAI ? this.options.model : `models/${this.options.model}`,
  },
};
```

## Testing

Tested with:
- **Vertex AI mode**: `vertexAI: true` with full model path `projects/{project}/locations/{location}/publishers/google/models/gemini-2.0-flash-live-001`
- **Live API mode**: `vertexAI: false` with simple model name `gemini-2.0-flash-live-001`

Both modes now work correctly without breaking existing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vertex AI voice connection to use the bi-directional streaming endpoint and preserve fully-qualified model identifiers.
  * Normalize model location input (trim, default to us-central1) and enforce project ID when Vertex AI is enabled to prevent misrouting.
* **Tests**
  * Added a test verifying the full Vertex AI model path and streaming endpoint are used and the connection URL is correct.
* **Chores**
  * Bumped package patch version for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->