### PR TITLE
[Fix] Add explicit click action to SideDialog Overlay 

### DIFF
--- a/.changeset/cute-corners-behave.md
+++ b/.changeset/cute-corners-behave.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Explicitly add onClose to SideDialog Overlay

--- a/packages/playground-ui/src/components/ui/elements/side-dialog/side-dialog-root.tsx
+++ b/packages/playground-ui/src/components/ui/elements/side-dialog/side-dialog-root.tsx
@@ -31,7 +31,10 @@ export function SideDialogRoot({
     <Dialog.Root open={isOpen} onOpenChange={onClose}>
       <Dialog.Portal>
         {!isConfirmation && (
-          <Dialog.Overlay className={cn('bg-black top-0 bottom-0 right-0 left-0 fixed z-50 opacity-40')} />
+          <Dialog.Overlay
+            className={cn('bg-black top-0 bottom-0 right-0 left-0 fixed z-50 opacity-40')}
+            onClick={onClose}
+          />
         )}
         <Dialog.Content
           className={cn(


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

I noticed the outside-content, click on Overlay of SideDialog stopped working, does not close the dialog, This is a quick fix. It will require further investigation what has changed, what caused the default behaviour fails now. 

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SideDialog usability: users can now close dialogs by clicking outside the content area on the backdrop, providing a more intuitive interaction pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->