### PR TITLE
AI SDK tripwire data chunks

### DIFF
--- a/.changeset/cuddly-tires-hope.md
+++ b/.changeset/cuddly-tires-hope.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+AI SDK tripwire data chunks

--- a/.changeset/cuddly-tires-hope.md
+++ b/.changeset/cuddly-tires-hope.md
@@ -2,4 +2,23 @@
 '@mastra/ai-sdk': patch
 ---
 
-AI SDK tripwire data chunks
+Added support for tripwire data chunks in streaming responses.
+
+Tripwire chunks allow the AI SDK to emit special data events when certain conditions are triggered during stream processing. These chunks include a `tripwireReason` field explaining why the tripwire was activated.
+
+#### Usage
+
+When converting Mastra chunks to AI SDK v5 format, tripwire chunks are now automatically handled:
+
+```typescript
+// Tripwire chunks are converted to data-tripwire format
+const chunk = {
+  type: 'tripwire',
+  payload: { tripwireReason: 'Rate limit approaching' }
+};
+
+// Converts to:
+{
+  type: 'data-tripwire',
+  data: { tripwireReason: 'Rate limit approaching' }
+}

--- a/client-sdks/ai-sdk/src/__tests__/convert-messages.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/convert-messages.test.ts
@@ -105,4 +105,121 @@ describe('toAISdkFormat', () => {
       expect(errorChunk.errorText).toContain(errorMessage); // Should contain the actual error message
     });
   });
+
+  describe('toAISdkV5Stream tripwire handling', () => {
+    it('should send finish event with finishReason "other" when tripwire occurs and stream does not exit gracefully', async () => {
+      const tripwireReason = 'Content filter triggered';
+
+      // Create a mock stream with tripwire chunk but no finish event
+      const mockStream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({
+            type: 'start',
+            runId: 'test-run-id',
+            payload: { id: 'test-id' },
+          });
+
+          controller.enqueue({
+            type: 'tripwire',
+            runId: 'test-run-id',
+            payload: {
+              tripwireReason,
+            },
+          });
+
+          // Stream closes without a finish event (ungraceful exit)
+          controller.close();
+        },
+      });
+
+      const aiSdkStream = toAISdkV5Stream(mockStream as unknown as MastraModelOutput, {
+        from: 'agent',
+        sendFinish: true,
+      });
+
+      const chunks: any[] = [];
+      let finishChunk: any = null;
+      let tripwireChunk: any = null;
+
+      for await (const chunk of aiSdkStream) {
+        chunks.push(chunk);
+        if (chunk.type === 'finish') {
+          finishChunk = chunk;
+        }
+        if (chunk.type === 'data-tripwire') {
+          tripwireChunk = chunk;
+        }
+      }
+
+      // Verify tripwire chunk was received
+      expect(tripwireChunk).toBeDefined();
+      expect(tripwireChunk.type).toBe('data-tripwire');
+      expect(tripwireChunk.data.tripwireReason).toBe(tripwireReason);
+
+      // Verify finish event was sent with finishReason 'other'
+      expect(finishChunk).toBeDefined();
+      expect(finishChunk.type).toBe('finish');
+      expect(finishChunk.finishReason).toBe('other');
+    });
+
+    it('should not send additional finish event if finish already occurred after tripwire', async () => {
+      const tripwireReason = 'Content filter triggered';
+
+      // Create a mock stream with tripwire chunk followed by finish event
+      const mockStream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({
+            type: 'start',
+            runId: 'test-run-id',
+            payload: { id: 'test-id' },
+          });
+
+          controller.enqueue({
+            type: 'tripwire',
+            runId: 'test-run-id',
+            payload: {
+              tripwireReason,
+            },
+          });
+
+          controller.enqueue({
+            type: 'finish',
+            runId: 'test-run-id',
+            payload: {
+              stepResult: {
+                reason: 'stop',
+              },
+              output: {
+                usage: {
+                  inputTokens: 10,
+                  outputTokens: 20,
+                  totalTokens: 30,
+                },
+              },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const aiSdkStream = toAISdkV5Stream(mockStream as unknown as MastraModelOutput, {
+        from: 'agent',
+        sendFinish: true,
+      });
+
+      const chunks: any[] = [];
+      const finishChunks: any[] = [];
+
+      for await (const chunk of aiSdkStream) {
+        chunks.push(chunk);
+        if (chunk.type === 'finish') {
+          finishChunks.push(chunk);
+        }
+      }
+
+      // Should only have one finish event (the original one, not an additional one)
+      expect(finishChunks).toHaveLength(1);
+    });
+  });
 });

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -7,6 +7,7 @@ import { isDataChunkType } from './utils';
 export type OutputChunkType<OUTPUT extends OutputSchema = undefined> =
   | TextStreamPart<ToolSet>
   | ObjectStreamPart<PartialSchemaOutput<OUTPUT>>
+  | DataChunkType
   | undefined;
 
 export type ToolAgentChunkType = { type: 'tool-agent'; toolCallId: string; payload: any };
@@ -219,7 +220,13 @@ export function convertMastraChunkToAISDKv5<OUTPUT extends OutputSchema = undefi
         type: 'object',
         object: chunk.object,
       };
-
+    case 'tripwire':
+      return {
+        type: 'data-tripwire',
+        data: {
+          tripwireReason: chunk.payload.tripwireReason,
+        },
+      };
     default:
       if (chunk.type && 'payload' in chunk && chunk.payload) {
         return {


### PR DESCRIPTION
- **AI SDK tripwire data chunks**
- **changeset**

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)
Fixes #10075
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for tripwire data chunks in streaming responses so tripwire reasons are emitted as data-tripwire events.

* **Bug Fixes**
  * Streams that include tripwire events now ensure graceful completion: if no finish was emitted, a finish with reason "other" is emitted when appropriate.

* **Tests**
  * Added tests verifying tripwire-to-data conversion and finish-event emission/ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->