### PR TITLE
fix(client-js): added agentId to listMessages API call

### DIFF
--- a/.changeset/funny-views-fall.md
+++ b/.changeset/funny-views-fall.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Include agentId parameter in listMessages API call

--- a/client-sdks/client-js/src/resources/memory-thread.test.ts
+++ b/client-sdks/client-js/src/resources/memory-thread.test.ts
@@ -129,7 +129,7 @@ describe('MemoryThread', () => {
       const result = await thread.listMessages();
 
       expect(global.fetch).toHaveBeenCalledWith(
-        `http://localhost:4111/api/memory/threads/${threadId}/messages`,
+        `http://localhost:4111/api/memory/threads/${threadId}/messages?agentId=${agentId}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer test-key',
@@ -150,7 +150,7 @@ describe('MemoryThread', () => {
       const result = await thread.listMessages({ perPage: 5 });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        `http://localhost:4111/api/memory/threads/${threadId}/messages?perPage=5`,
+        `http://localhost:4111/api/memory/threads/${threadId}/messages?agentId=${agentId}&perPage=5`,
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer test-key',

--- a/client-sdks/client-js/src/resources/memory-thread.ts
+++ b/client-sdks/client-js/src/resources/memory-thread.ts
@@ -82,7 +82,7 @@ export class MemoryThread extends BaseResource {
 
     const query = new URLSearchParams(queryParams);
     const queryString = query.toString();
-    const url = `/api/memory/threads/${this.threadId}/messages${queryString ? `?${queryString}` : ''}${requestContextQueryString(requestContext, queryString ? '&' : '?')}`;
+    const url = `/api/memory/threads/${this.threadId}/messages?agentId=${this.agentId}${queryString ? `&${queryString}` : ''}${requestContextQueryString(requestContext, '&')}`;
     return this.request(url);
   }
 


### PR DESCRIPTION
## Description

Fixed listMessages API call to include agentId.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the message listing API always includes the agentId parameter, fixing inconsistent requests.
  * Stabilizes query parameter ordering so filters and pagination are applied reliably across calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->