### PR TITLE
feat(auth): add public/protected route options to MastraAuthProvider

### DIFF
--- a/.changeset/pretty-ghosts-doubt.md
+++ b/.changeset/pretty-ghosts-doubt.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+'@mastra/auth-clerk': patch
+'@mastra/auth-auth0': patch
+'@mastra/auth-firebase': patch
+'@mastra/auth-supabase': patch
+'@mastra/auth-workos': patch
+'@mastra/auth': patch
+---
+
+Allow provider to pass through options to the auth config

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -123,4 +123,40 @@ describe('MastraAuthClerk', () => {
     const noPermissionsUser = { sub: 'user789' };
     expect(await clerk.authorizeUser(noPermissionsUser)).toBe(false);
   });
+
+  describe('route configuration options', () => {
+    it('should store public routes configuration when provided', () => {
+      const publicRoutes = ['/health', '/api/status'];
+      const clerk = new MastraAuthClerk({
+        ...mockOptions,
+        public: publicRoutes,
+      });
+
+      expect(clerk.public).toEqual(publicRoutes);
+    });
+
+    it('should store protected routes configuration when provided', () => {
+      const protectedRoutes = ['/api/*', '/admin/*'];
+      const clerk = new MastraAuthClerk({
+        ...mockOptions,
+        protected: protectedRoutes,
+      });
+
+      expect(clerk.protected).toEqual(protectedRoutes);
+    });
+
+    it('should handle both public and protected routes together', () => {
+      const publicRoutes = ['/health', '/api/status'];
+      const protectedRoutes = ['/api/*', '/admin/*'];
+
+      const clerk = new MastraAuthClerk({
+        ...mockOptions,
+        public: publicRoutes,
+        protected: protectedRoutes,
+      });
+
+      expect(clerk.public).toEqual(publicRoutes);
+      expect(clerk.protected).toEqual(protectedRoutes);
+    });
+  });
 });

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1,18 +1,33 @@
 import type { HonoRequest } from 'hono';
 import { MastraBase } from '../base';
+import type { MastraAuthConfig } from './types';
 
 export interface MastraAuthProviderOptions<TUser = unknown> {
   name?: string;
   authorizeUser?: (user: TUser, request: HonoRequest) => Promise<boolean> | boolean;
+  /**
+   * Protected paths for the auth provider
+   */
+  protected?: MastraAuthConfig['protected'];
+  /**
+   * Public paths for the auth provider
+   */
+  public?: MastraAuthConfig['public'];
 }
 
 export abstract class MastraAuthProvider<TUser = unknown> extends MastraBase {
+  public protected?: MastraAuthConfig['protected'];
+  public public?: MastraAuthConfig['public'];
+
   constructor(options?: MastraAuthProviderOptions<TUser>) {
     super({ component: 'AUTH', name: options?.name });
 
     if (options?.authorizeUser) {
       this.authorizeUser = options.authorizeUser.bind(this);
     }
+
+    this.protected = options?.protected;
+    this.public = options?.public;
   }
 
   /**
@@ -34,6 +49,12 @@ export abstract class MastraAuthProvider<TUser = unknown> extends MastraBase {
   protected registerOptions(opts?: MastraAuthProviderOptions<TUser>) {
     if (opts?.authorizeUser) {
       this.authorizeUser = opts.authorizeUser.bind(this);
+    }
+    if (opts?.protected) {
+      this.protected = opts.protected;
+    }
+    if (opts?.public) {
+      this.public = opts.public;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `public` and `protected` route configuration options to `MastraAuthProviderOptions`
- Updates `MastraAuthProvider` base class to store and register these route options
- Enables auth providers like `MastraAuthClerk` to configure public routes directly via constructor options
- Adds tests to verify route configuration options are properly stored

## Changes
- Extended `MastraAuthProviderOptions` interface with `public` and `protected` fields
- Updated `MastraAuthProvider` base class to handle route configuration storage
- Added comprehensive tests for route configuration in `MastraAuthClerk`

## Usage Example
```typescript
const authProvider = new MastraAuthClerk({
  public: ['/health', '/api/status'],
  protected: ['/api/*'],
  // ... other options
});
```

## Test plan
- [x] Unit tests verify route options are stored correctly
- [x] Integration tests already exist in `auth-integration.test.ts` that cover the middleware behavior
- [x] TypeScript compilation passes
- [x] Lint checks pass

Closes #10273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication providers now support passing public and protected route options through their configuration, enabling flexible route-level access control setup.

* **Tests**
  * Added test coverage for authentication provider route configuration options to ensure routes are properly stored and configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->