### PR TITLE
fix: agent network deprecation warning when executing workflows

### DIFF
--- a/.changeset/quiet-dragons-win.md
+++ b/.changeset/quiet-dragons-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix deprecation warning when agent network executes workflows by using `.fullStream` instead of iterating `WorkflowRunOutput` directly

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -253,7 +253,7 @@ const result = await run.stream({
   }
 });
 
-for await (const chunk of result.stream) {
+for await (const chunk of result.fullStream) {
   console.log(chunk);
 }
 ```

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -239,6 +239,34 @@ describe('Agent - network', () => {
     await checkIterations(anStream);
   });
 
+  it('LOOP - should not trigger WorkflowRunOutput deprecation warning when executing workflows', async () => {
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (message: string) => {
+      warnings.push(message);
+    };
+
+    try {
+      const anStream = await network.network('Execute workflow1 on Paris', {
+        requestContext,
+      });
+
+      // Consume the stream
+      for await (const _chunk of anStream) {
+        // Just iterate through
+      }
+
+      // Verify no deprecation warnings about WorkflowRunOutput[Symbol.asyncIterator]
+      const deprecationWarnings = warnings.filter(
+        w => w.includes('WorkflowRunOutput[Symbol.asyncIterator]') && w.includes('deprecated'),
+      );
+
+      expect(deprecationWarnings).toHaveLength(0);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('LOOP - should track usage data from workflow with agent stream agent.network()', async () => {
     const anStream = await networkWithWflowAgentStream.network('Research dolphins', {
       requestContext,

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -738,7 +738,7 @@ export async function createNetworkLoop({
       // let result: any;
       // let stepResults: Record<string, any> = {};
       let chunks: ChunkType[] = [];
-      for await (const chunk of stream) {
+      for await (const chunk of stream.fullStream) {
         chunks.push(chunk);
         await writer?.write({
           type: `workflow-execution-event-${chunk.type}`,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fixes deprecation warning `WorkflowRunOutput[Symbol.asyncIterator]() is deprecated. Use fullStream[Symbol.asyncIterator]() instead.` that appears when using agent network with attached workflows.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a deprecation warning during agent network workflow execution by changing how streamed workflow results are consumed.

* **Tests**
  * Added a test to ensure no deprecation warnings are emitted when executing workflow streams.

* **Documentation**
  * Updated workflow docs to reflect the adjusted stream consumption approach.

* **Chores**
  * Added a changelog entry marking a patch release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->