### PR TITLE
feat(workflows,storage,pg): distributed run locks (exactly-once) + heartbeats; init-time DDL

### DIFF
--- a/packages/core/src/storage/LOCKS.md
+++ b/packages/core/src/storage/LOCKS.md
@@ -1,0 +1,67 @@
+Distributed Run Locks
+
+Goal: ensure only one worker instance resumes/restarts a given workflow run at a time.
+
+Interface
+- tryAcquireWorkflowRunLock({ workflowName, runId }): boolean
+- renewWorkflowRunLock({ workflowName, runId, ttlMs? }): boolean
+- getWorkflowRunLock({ workflowName, runId }): { holder?: string; expiresAt?: number; backend?: string } | null
+- releaseWorkflowRunLock({ workflowName, runId }): void
+
+The core workflow engine calls these hooks around Run.resume() and Run.restart().
+
+Supported backends
+
+- Postgres: Fully implemented (advisory locks + metadata for TTL/heartbeat and fencing token CAS)
+- InMemory: Best-effort single-process locks for tests and local runs
+
+Other backends
+
+The following patterns are provided for reference only; current code paths do not enforce locking or CAS on these backends. For production multi-instance deployments, use Postgres (recommended) or run a single instance.
+
+Backend patterns
+
+PostgreSQL (advisory locks)
+- Acquire: SELECT pg_try_advisory_lock(hashtext($1), hashtext($2)) AS ok
+- Release: SELECT pg_advisory_unlock(hashtext($1), hashtext($2))
+- Keep the same client (session) checked out for the duration of the lock.
+- For isometric TTL/heartbeat, a metadata table `${schema}.mastra_run_locks` tracks `holder` + `expires_at`.
+
+LibSQL/SQLite
+- Create a table mastra_run_locks(workflow_name TEXT, run_id TEXT, holder TEXT, expires_at INTEGER, PRIMARY KEY(workflow_name, run_id))
+- Acquire: INSERT OR IGNORE; treat success as acquired. Optionally clear expired rows.
+- Release: DELETE WHERE workflow_name/run_id/holder match.
+- Renew: UPDATE expires_at
+- Inspect: SELECT holder, expires_at
+
+Upstash/Redis
+- Key: mastra:runlock:{workflowName}:{runId}
+- Acquire: SET key token NX PX ttl
+- Release: Lua script to delete only if value == token.
+- Renew: Lua script to PEXPIRE only if value == token
+- Inspect: GET token + PTTL
+
+MongoDB
+- Collection: mastra_run_locks with unique index on (workflowName, runId); TTL index on expiresAt
+- Acquire: insertOne({ workflowName, runId, holder, expiresAt }) catching duplicate key
+- Release: deleteOne({ workflowName, runId, holder })
+- Renew: updateOne to set expiresAt (holder match)
+- Inspect: findOne
+
+DynamoDB
+- PK: WORKFLOW#{workflowName} SK: RUN#{runId}
+- Acquire: PutItem with ConditionExpression attribute_not_exists(PK)
+- Release: DeleteItem with ConditionExpression holder = :holder
+- Renew: UpdateItem to set expiresAt; optional ConditionExpression on holder
+- Inspect: GetItem
+
+MSSQL
+- sp_getapplock @Resource = 'workflowName:runId', @LockMode = 'Exclusive', @LockOwner='Session', @LockTimeout = 0
+- sp_releaseapplock @Resource = 'workflowName:runId', @LockOwner='Session'
+- For isometric TTL/heartbeat, a table `${schema}.mastra_run_locks` tracks `holder` + `expires_at`.
+
+Notes
+- Always include a TTL/expiry to avoid deadlocks on crashes.
+- For session-scoped locks (PG advisory, MSSQL applock), hold the same connection until release.
+- For value-based locks (Redis, SQL rows), store a random holder token and only release if the token matches.
+- Engine sends automatic heartbeats every 10 minutes to extend locks to ~30 minutes by default.

--- a/packages/core/src/storage/LOCKS.md
+++ b/packages/core/src/storage/LOCKS.md
@@ -15,50 +15,13 @@ Supported backends
 - Postgres: Fully implemented (advisory locks + metadata for TTL/heartbeat and fencing token CAS)
 - InMemory: Best-effort single-process locks for tests and local runs
 
-Other backends
-
-The following patterns are provided for reference only; current code paths do not enforce locking or CAS on these backends. For production multi-instance deployments, use Postgres (recommended) or run a single instance.
-
-Backend patterns
+Supported backends
 
 PostgreSQL (advisory locks)
 - Acquire: SELECT pg_try_advisory_lock(hashtext($1), hashtext($2)) AS ok
 - Release: SELECT pg_advisory_unlock(hashtext($1), hashtext($2))
 - Keep the same client (session) checked out for the duration of the lock.
 - For isometric TTL/heartbeat, a metadata table `${schema}.mastra_run_locks` tracks `holder` + `expires_at`.
-
-LibSQL/SQLite
-- Create a table mastra_run_locks(workflow_name TEXT, run_id TEXT, holder TEXT, expires_at INTEGER, PRIMARY KEY(workflow_name, run_id))
-- Acquire: INSERT OR IGNORE; treat success as acquired. Optionally clear expired rows.
-- Release: DELETE WHERE workflow_name/run_id/holder match.
-- Renew: UPDATE expires_at
-- Inspect: SELECT holder, expires_at
-
-Upstash/Redis
-- Key: mastra:runlock:{workflowName}:{runId}
-- Acquire: SET key token NX PX ttl
-- Release: Lua script to delete only if value == token.
-- Renew: Lua script to PEXPIRE only if value == token
-- Inspect: GET token + PTTL
-
-MongoDB
-- Collection: mastra_run_locks with unique index on (workflowName, runId); TTL index on expiresAt
-- Acquire: insertOne({ workflowName, runId, holder, expiresAt }) catching duplicate key
-- Release: deleteOne({ workflowName, runId, holder })
-- Renew: updateOne to set expiresAt (holder match)
-- Inspect: findOne
-
-DynamoDB
-- PK: WORKFLOW#{workflowName} SK: RUN#{runId}
-- Acquire: PutItem with ConditionExpression attribute_not_exists(PK)
-- Release: DeleteItem with ConditionExpression holder = :holder
-- Renew: UpdateItem to set expiresAt; optional ConditionExpression on holder
-- Inspect: GetItem
-
-MSSQL
-- sp_getapplock @Resource = 'workflowName:runId', @LockMode = 'Exclusive', @LockOwner='Session', @LockTimeout = 0
-- sp_releaseapplock @Resource = 'workflowName:runId', @LockOwner='Session'
-- For isometric TTL/heartbeat, a table `${schema}.mastra_run_locks` tracks `holder` + `expires_at`.
 
 Notes
 - Always include a TTL/expiry to avoid deadlocks on crashes.

--- a/packages/core/src/storage/domains/workflows/base.ts
+++ b/packages/core/src/storage/domains/workflows/base.ts
@@ -10,6 +10,43 @@ export abstract class WorkflowsStorage extends MastraBase {
     });
   }
 
+  /**
+   * Optional: Acquire a distributed lock for a workflow run to prevent
+   * concurrent execution across multiple app instances.
+   *
+   * Default implementation is a no-op that returns true. Storage backends
+   * that support locking (e.g., Postgres advisory locks) should override.
+   */
+  async tryAcquireRunLock(_args: { workflowName: string; runId: string }): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Optional: Release a previously acquired lock. Default is a no-op.
+   */
+  async releaseRunLock(_args: { workflowName: string; runId: string }): Promise<void> {
+    return;
+  }
+
+  /**
+   * Optional: Renew/heartbeat a lock extending its expiry. Default is a no-op
+   * that returns true. Backends without TTL can update metadata for observability.
+   */
+  async renewRunLock(_args: { workflowName: string; runId: string; ttlMs?: number }): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Optional: Get lock info for debugging/observability. Default is null.
+   */
+  async getRunLock(_args: { workflowName: string; runId: string }): Promise<{
+    holder?: string;
+    expiresAt?: number;
+    backend?: string;
+  } | null> {
+    return null;
+  }
+
   abstract updateWorkflowResults({
     workflowName,
     runId,

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -79,6 +79,7 @@ export class InMemoryStore extends MastraStorage {
       observabilityInstance: true,
       indexManagement: false,
       listScoresBySpan: true,
+      locking: true,
     };
   }
 

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -1920,6 +1920,16 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       requestContextObj[key] = value;
     });
 
+    // Retrieve lock info to attach fencing token for exactly-once guarantees
+    let fencingToken: string | undefined = undefined;
+    try {
+      const lockInfo = await this.mastra?.getStorage()?.getWorkflowRunLock({
+        workflowName: workflowId,
+        runId,
+      });
+      fencingToken = lockInfo?.holder;
+    } catch {}
+
     await this.mastra?.getStorage()?.persistWorkflowSnapshot({
       workflowName: workflowId,
       runId,
@@ -1938,6 +1948,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
         result,
         error,
         requestContext: requestContextObj,
+        fencingToken,
         // @ts-ignore
         timestamp: Date.now(),
       },

--- a/packages/core/src/workflows/exactly-once.pg.test.ts
+++ b/packages/core/src/workflows/exactly-once.pg.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { z } from 'zod';
+import { Mastra } from '../mastra';
+import { createStep, createWorkflow } from './workflow';
+import { PostgresStore } from '../../../../stores/pg/src/storage';
+
+const PG_URL = process.env.PG_TEST_URL || process.env.POSTGRES_URL || process.env.DATABASE_URL;
+
+// Only run when a Postgres URL is provided
+const maybe = PG_URL ? describe : describe.skip;
+
+maybe('Exactly-once with Postgres', () => {
+  let store: PostgresStore;
+  let mastra: Mastra;
+
+  beforeAll(async () => {
+    store = new PostgresStore({ id: 'pg-test', connectionString: PG_URL! });
+    await store.init();
+  }, 30000);
+
+  afterAll(async () => {
+    // nothing specific to close for pg-promise
+  });
+
+  it('acquires exclusive lock on restart (second caller blocked)', async () => {
+    const wf = createWorkflow({
+      id: 'xo-wf-lock',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.boolean() }),
+    });
+    const step = createStep({
+      id: 'one',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    });
+    wf.then(step).commit();
+
+    mastra = new Mastra({ storage: store, workflows: { 'xo-wf-lock': wf } });
+
+    const runId = 'xo-lock-run';
+    // Seed a running snapshot to allow restart
+    await store.persistWorkflowSnapshot({
+      workflowName: wf.id,
+      runId,
+      snapshot: {
+        runId,
+        status: 'running',
+        value: {},
+        context: { input: {} },
+        activePaths: [0],
+        activeStepsPath: { one: [0] },
+        serializedStepGraph: [],
+        suspendedPaths: {},
+        waitingPaths: {},
+        resumeLabels: {},
+        timestamp: Date.now(),
+      } as any,
+    });
+
+    const run1 = await wf.createRun({ runId });
+    const run2 = await wf.createRun({ runId });
+
+    const p1 = run1.restart();
+    const p2 = run2.restart();
+
+    let failed = 0;
+    try {
+      await p1;
+    } catch {
+      failed++;
+    }
+    try {
+      await p2;
+    } catch {
+      failed++;
+    }
+    // Exactly one should fail to acquire lock
+    expect(failed).toBe(1);
+  }, 30000);
+
+  it('CAS fencing rejects writes with mismatched token', async () => {
+    const wfName = 'xo-wf-cas';
+    const runId = 'xo-cas-run';
+
+    // Acquire lock to register metadata (token)
+    const ok = await store.tryAcquireWorkflowRunLock({ workflowName: wfName, runId });
+    expect(ok).toBe(true);
+    const info = await store.getWorkflowRunLock({ workflowName: wfName, runId });
+    expect(info?.holder).toBeTruthy();
+
+    // Attempt to persist with wrong fencingToken
+    await expect(
+      store.persistWorkflowSnapshot({
+        workflowName: wfName,
+        runId,
+        snapshot: {
+          runId,
+          status: 'running',
+          value: {},
+          context: { input: {} },
+          activePaths: [],
+          activeStepsPath: {},
+          serializedStepGraph: [],
+          suspendedPaths: {},
+          waitingPaths: {},
+          resumeLabels: {},
+          fencingToken: 'not-the-token',
+          timestamp: Date.now(),
+        } as any,
+      }),
+    ).rejects.toThrowError(/CAS_MISMATCH/i);
+
+    // Cleanup
+    await store.releaseWorkflowRunLock({ workflowName: wfName, runId });
+  }, 30000);
+});
+

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -245,6 +245,8 @@ export interface WorkflowRunState {
   result?: Record<string, any>;
   error?: string | Error;
   requestContext?: Record<string, any>;
+  // Fencing: token of the current lock holder to ensure exactly-once writes
+  fencingToken?: string;
   value: Record<string, string>;
   context: { input?: Record<string, any> } & Record<string, StepResult<any, any, any, any>>;
   serializedStepGraph: SerializedStepFlowEntry[];


### PR DESCRIPTION
Feature: Distributed run locks for workflows with exactly-once behavior

Overview
- Add optional distributed run locks for workflow resume/restart, gated by `storage.supports.locking`.
- Introduce periodic heartbeats to extend lock TTL while processing.
- Attach a fencing token (current lock holder) on snapshot persistence; Postgres enforces CAS on snapshots using this token.
- Move Postgres run-locks metadata DDL to `PostgresStore.init()` to follow existing init patterns.
- Clean up duplicate heartbeat logic and ensure heartbeat lifecycle + lock release in `finally` blocks.
- Documentation: remove non-implemented backend locking patterns to avoid confusion; keep supported backends (Postgres, InMemory).

Motivation
- Prevent concurrent resume/restart across multiple instances and improve exactly-once guarantees for workflow state writes.
- Align PG initialization with other tables/indexes; avoid runtime DDL during lock acquire.

Behavior & Compatibility
- Backends without locking are unaffected; engine gates acquire/heartbeat/release by `storage.supports.locking`.
- InMemory implements best-effort single-process locks for tests/local runs.
- Postgres implements advisory locks held on a dedicated connection + metadata table for TTL/fencing.
- If a locking backend errors during acquire, resume/restart fails early (safer than proceeding without a lock).

Postgres Details
- Advisory locks via `pg_try_advisory_lock(hashtext($1), hashtext($2))` and `pg_advisory_unlock(...)`.
- Metadata table `${schema}.mastra_run_locks` created during `PostgresStore.init()`; used for heartbeat TTL and fencing token.
- Snapshot persistence performs CAS check when `fencingToken` is present; rejects on mismatch.

Operational Notes
- For multi-instance deployments, use Postgres storage to enable locks; otherwise, run a single instance.
- Heartbeat interval: 10m; TTL: 30m (defaults). These are internal defaults; no public config surface added here.
- `supports.locking` advertises capability (PG, InMemory true; others false by default).

Tests
- Added `exactly-once.pg.test.ts` for lock exclusivity and CAS fencing on snapshots.
- Existing tests updated where necessary; resumptions use a single heartbeat timer and clean up reliably.

Diff Summary
- workflows: `_start` cleanup; lock acquire/heartbeat/release wrapping resume/restart; no duplicate timers; gated by `supports.locking`.
- storage(base): safer acquire fallback (`false` on error) to avoid proceeding without a lock on locking backends.
- storage(pg): advisory unlock call fix; init-time creation of `mastra_run_locks`.
- docs: remove non-implemented locking backends from LOCKS.md.

Follow-ups (optional)
- Consider enforcing CAS on additional write paths (e.g., `updateWorkflowResults`) if we want wider exactly-once guarantees.
- Optionally switch advisory lock key derivation to a more robust/stable hashing approach in a dedicated change.
