### PR TITLE
fix: throw on invalid filter instead of silently skipping filtering (#10141)

### DIFF
--- a/packages/rag/src/tools/graph-rag.ts
+++ b/packages/rag/src/tools/graph-rag.ts
@@ -75,11 +75,10 @@ export const createGraphRAGTool = (options: GraphRagToolOptions) => {
             try {
               return typeof filter === 'string' ? JSON.parse(filter) : filter;
             } catch (error) {
-              // Log the error and use empty object
               if (logger) {
-                logger.warn('Failed to parse filter as JSON, using empty filter', { filter, error });
+                logger.error('Invalid filter', { filter, error });
               }
-              return {};
+              throw new Error(`Invalid filter format: ${error instanceof Error ? error.message : String(error)}`);
             }
           })();
         }

--- a/packages/rag/src/tools/vector-query.test.ts
+++ b/packages/rag/src/tools/vector-query.test.ts
@@ -244,8 +244,8 @@ describe('createVectorQueryTool', () => {
 
       const stringFilter = 'string-filter';
 
-      // Execute with string filter
-      await tool.execute?.({
+      // Execute with string filter - should throw an error for invalid JSON
+      const result = await tool.execute?.({
         context: {
           queryText: 'test query',
           topK: 5,
@@ -255,12 +255,9 @@ describe('createVectorQueryTool', () => {
         runtimeContext,
       });
 
-      // Since this is not a valid filter, it should be ignored
-      expect(vectorQuerySearch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          queryFilter: undefined,
-        }),
-      );
+      // Since this is not a valid JSON filter, the error is caught and returns empty results
+      expect(result).toEqual({ relevantContext: [], sources: [] });
+      expect(vectorQuerySearch).not.toHaveBeenCalled();
     });
 
     it('Returns early when no Mastra server or vector store is provided', async () => {

--- a/packages/rag/src/tools/vector-query.ts
+++ b/packages/rag/src/tools/vector-query.ts
@@ -78,11 +78,10 @@ export const createVectorQueryTool = (options: VectorQueryToolOptions) => {
             try {
               return typeof filter === 'string' ? JSON.parse(filter) : filter;
             } catch (error) {
-              // Log the error and use empty object
               if (logger) {
-                logger.warn('Failed to parse filter as JSON, using empty filter', { filter, error });
+                logger.error('Invalid filter', { filter, error });
               }
-              return {};
+              throw new Error(`Invalid filter format: ${error instanceof Error ? error.message : String(error)}`);
             }
           })();
         }


### PR DESCRIPTION
Backporting #10141 to the 0.x branch

(cherry picked from commit dd2535c12dfb5b9d2f61dbdc2ea05a313709722c)