### PR TITLE
fix(agents-server-handler): correct memory parameter access

### DIFF
--- a/.changeset/tidy-suns-slide.md
+++ b/.changeset/tidy-suns-slide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Network handler now accesses thread and resource parameters from the nested memory object instead of directly from request body.

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -757,10 +757,7 @@ export async function streamNetworkHandler({
 }: Context & {
   requestContext: RequestContext;
   agentId: string;
-  body: GetBody<'network'> & {
-    thread?: string;
-    resourceId?: string;
-  };
+  body: GetBody<'network'>;
   // abortSignal?: AbortSignal;
 }): ReturnType<Agent['network']> {
   try {
@@ -781,8 +778,8 @@ export async function streamNetworkHandler({
     const streamResult = agent.network(messages, {
       ...rest,
       memory: {
-        thread: rest.thread ?? '',
-        resource: rest.resourceId ?? '',
+        thread: rest.memory?.thread ?? '',
+        resource: rest.memory?.resource ?? '',
         options: rest.memory?.options ?? {},
       },
       requestContext: finalRequestContext,


### PR DESCRIPTION
## Description

Network handler now accesses thread and resource parameters from the nested memory object instead of directly from request body.

## Related Issue(s)

fixes #9723 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network handler now reads thread and resource parameters from memory configuration instead of request body.

* **Refactor**
  * Network handler API signature simplified for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->