### PR TITLE
fix(e2e): add doGenerate method and optimize streaming delays in kitchen-sink tests

### DIFF
--- a/e2e-tests/kitchen-sink/template/src/mastra/agents/index.ts
+++ b/e2e-tests/kitchen-sink/template/src/mastra/agents/index.ts
@@ -3,7 +3,6 @@ import { Memory } from '@mastra/memory';
 import { LibSQLStore } from '@mastra/libsql';
 
 import { weatherInfo } from '../tools';
-import { simulateReadableStream } from 'ai';
 import * as aiTest from 'ai/test';
 import { fixtures } from '../../../fixtures';
 import { Fixtures } from '../../../types';
@@ -19,6 +18,23 @@ const memory = new Memory({
 });
 
 let count = 0;
+
+// Helper function to create a delayed readable stream
+function createDelayedStream(chunks: Array<any>, delayMs: number = 10) {
+  return new ReadableStream({
+    async start(controller) {
+      for (let i = 0; i < chunks.length; i++) {
+        controller.enqueue(chunks[i]);
+        // Add delay only for text-delta chunks to show progressive text streaming
+        // Skip delay for other chunk types to speed up tool/workflow execution
+        if (delayMs > 0 && chunks[i]?.type === 'text-delta' && i < chunks.length - 1) {
+          await new Promise(resolve => setTimeout(resolve, delayMs));
+        }
+      }
+      controller.close();
+    },
+  });
+}
 
 export const subAgent = new Agent({
   name: 'Sub Agent',
@@ -43,20 +59,43 @@ export const weatherAgent = new Agent({
     const fixtureData = fixtures[fixture];
 
     return new aiTest.MockLanguageModelV2({
-      doStream: async () => {
+      doGenerate: async () => {
+        const chunk = fixtureData[count] as Array<any>;
+
         count++;
+        if (count >= fixtureData.length) {
+          count = 0;
+        }
 
-        const chunk = fixtureData[count - 1] as Array<any>;
+        // Extract text from fixture chunks
+        const textChunks = chunk.filter((item: any) => item.type === 'text-delta').map((item: any) => item.delta);
+        const text = textChunks.join('');
 
-        if (count === fixtureData.length) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [
+            {
+              type: 'text',
+              text,
+            },
+          ],
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        const chunk = fixtureData[count] as Array<any>;
+
+        count++;
+        if (count >= fixtureData.length) {
           count = 0;
         }
 
         return {
-          stream: simulateReadableStream({
-            chunks: chunk,
-            delay: 500,
-          }),
+          stream: createDelayedStream(chunk, 20),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
         };
       },
     });


### PR DESCRIPTION
Backporting #10298 to the 0.x branch to fix E2E test failures.

This adds the missing `doGenerate` method to the mock language model in E2E tests, which is needed after recent changes that call `generate()` in addition to `stream()`.

(cherry picked from commit 9a6d94064094af9ae3dadd746f256ff3885120ca)