### PR TITLE
docs: move memory examples (1.0)

### DIFF
--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -377,6 +377,6 @@ await memory.updateWorkingMemory({
 
 ## Examples
 
-- [Working memory with template](/examples/v1/memory/working-memory-template)
-- [Working memory with schema](/examples/v1/memory/working-memory-schema)
+- [Working memory with template](https://github.com/mastra-ai/mastra/tree/main/examples/memory-with-template)
+- [Working memory with schema](https://github.com/mastra-ai/mastra/tree/main/examples/memory-with-schema)
 - [Per-resource working memory](https://github.com/mastra-ai/mastra/tree/main/examples/memory-per-resource-example) - Complete example showing resource-scoped memory persistence

--- a/docs/src/content/en/examples/index.mdx
+++ b/docs/src/content/en/examples/index.mdx
@@ -56,16 +56,6 @@ The Examples section is a short list of example projects demonstrating basic AI 
         href: "/examples/v1/processors/response-validator",
       },
     ],
-    Memory: [
-      {
-        title: "Memory with Template",
-        href: "/examples/v1/memory/working-memory-template",
-      },
-      {
-        title: "Memory with Schema",
-        href: "/examples/v1/memory/working-memory-schema",
-      },
-    ],
     RAG: [
       { title: "Chunk Text", href: "/examples/v1/rag/chunking/chunk-text" },
       {

--- a/docs/src/content/en/examples/sidebars.js
+++ b/docs/src/content/en/examples/sidebars.js
@@ -67,23 +67,6 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Memory",
-      collapsed: true,
-      items: [
-        {
-          type: "doc",
-          id: "memory/working-memory-template",
-          label: "Memory with Template",
-        },
-        {
-          type: "doc",
-          id: "memory/working-memory-schema",
-          label: "Memory with Schema",
-        },
-      ],
-    },
-    {
-      type: "category",
       label: "RAG",
       collapsed: true,
       items: [

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -84,6 +84,16 @@
       "source": "/examples/v1/agents/system-prompt",
       "destination": "/docs/v1/agents/overview",
       "permanent": true
+    },
+    {
+      "source": "/examples/v1/memory/working-memory-schema",
+      "destination": "https://github.com/mastra-ai/mastra/tree/main/examples/memory-with-schema",
+      "permanent": true
+    },
+    {
+      "source": "/examples/v1/memory/working-memory-template",
+      "destination": "https://github.com/mastra-ai/mastra/tree/main/examples/memory-with-template",
+      "permanent": true
     }
   ]
 }

--- a/examples/memory-with-schema/index.md
+++ b/examples/memory-with-schema/index.md
@@ -1,27 +1,22 @@
----
-title: "Example: Working Memory with Template | Memory"
-description: Example showing how to use Markdown template to structure working memory data.
----
+# Working Memory with Schema
 
-# Working Memory with Template
-
-Use template to define the structure of information stored in working memory. Template helps agents extract and persist consistent, structured data across conversations.
+Use Zod schema to define the structure of information stored in working memory. Schema provides type safety and validation for the data that agents extract and persist across conversations.
 
 It works with both streamed responses using `.stream()` and generated responses using `.generate()`, and requires a storage provider such as PostgreSQL, LibSQL, or Redis to persist data between sessions.
 
-This example shows how to manage a todo list using a working memory template.
+This example shows how to manage a todo list using a working memory schema.
 
 ## Prerequisites
 
 This example uses the `openai` model. Make sure to add `OPENAI_API_KEY` to your `.env` file.
 
-```bash title=".env" copy
+```bash
 OPENAI_API_KEY=<your-api-key>
 ```
 
 And install the following package:
 
-```bash copy
+```bash
 npm install @mastra/libsql@beta
 ```
 
@@ -29,21 +24,22 @@ npm install @mastra/libsql@beta
 
 To add LibSQL memory to an agent, use the `Memory` class and pass a `storage` instance using `LibSQLStore`. The `url` can point to a remote location or local file.
 
-### Working memory with `template`
+### Working memory with `schema`
 
 Enable working memory by setting `workingMemory.enabled` to `true`. This allows the agent to remember structured information between interactions.
 
-Providing a `template` helps define the structure of what should be remembered. In this example, the template organizes tasks into active and completed items using Markdown formatting.
+Providing a `schema` defines the shape in which the agent should remember information. In this example, it separates tasks into active and completed lists.
 
 Threads group related messages into conversations. When `generateTitle` is enabled, each thread is automatically given a descriptive name based on its content.
 
-```typescript title="src/mastra/agents/example-working-memory-template-agent.ts" showLineNumbers copy
+```typescript
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore } from "@mastra/libsql";
+import { z } from "zod";
 
-export const workingMemoryTemplateAgent = new Agent({
-  name: "working-memory-template-agent",
+export const workingMemorySchemaAgent = new Agent({
+  name: "working-memory-schema-agent",
   instructions: `
     You are a todo list AI agent.
     Always show the current list when starting a conversation.
@@ -55,22 +51,22 @@ export const workingMemoryTemplateAgent = new Agent({
   model: "openai/gpt-5.1",
   memory: new Memory({
     storage: new LibSQLStore({
-      url: "file:working-memory-template.db",
+      url: "file:working-memory-schema.db",
     }),
     options: {
       workingMemory: {
         enabled: true,
-        template: `
-          # Todo List
-          ## Active Items
-          - Task 1: Example task
-            - Due: Feb 7 2028
-            - Description: This is an example task
-            - Status: Not Started
-            - Estimated Time: 2 hours
-
-          ## Completed Items
-          - None yet`,
+        schema: z.object({
+          items: z.array(
+            z.object({
+              title: z.string(),
+              due: z.string().optional(),
+              description: z.string(),
+              status: z.enum(["active", "completed"]).default("active"),
+              estimatedTime: z.string().optional(),
+            }),
+          ),
+        }),
       },
       threads: {
         generateTitle: true,
@@ -82,13 +78,13 @@ export const workingMemoryTemplateAgent = new Agent({
 
 ## Usage examples
 
-This example shows how to interact with an agent that uses a working memory template to manage structured information. The agent updates and persists the todo list across multiple interactions within the same thread.
+This example shows how to interact with an agent that uses a working memory schema to manage structured information. The agent updates and persists the todo list across multiple interactions within the same thread.
 
 ### Streaming a response using `.stream()`
 
 This example sends a message to the agent with a new task. The response is streamed and includes the updated todo list.
 
-```typescript title="src/test-working-memory-template-agent.ts" showLineNumbers copy
+```typescript
 import "dotenv/config";
 
 import { mastra } from "./mastra";
@@ -96,7 +92,7 @@ import { mastra } from "./mastra";
 const threadId = "123";
 const resourceId = "user-456";
 
-const agent = mastra.getAgent("workingMemoryTemplateAgent");
+const agent = mastra.getAgent("workingMemorySchemaAgent");
 
 const stream = await agent.stream(
   "Add a task: Build a new feature for our app. It should take about 2 hours and needs to be done by next Friday.",
@@ -117,7 +113,7 @@ for await (const chunk of stream.textStream) {
 
 This example sends a message to the agent with a new task. The response is returned as a single message and includes the updated todo list.
 
-```typescript title="src/test-working-memory-template-agent.ts" showLineNumbers copy
+```typescript
 import "dotenv/config";
 
 import { mastra } from "./mastra";
@@ -125,7 +121,7 @@ import { mastra } from "./mastra";
 const threadId = "123";
 const resourceId = "user-456";
 
-const agent = mastra.getAgent("workingMemoryTemplateAgent");
+const agent = mastra.getAgent("workingMemorySchemaAgent");
 
 const response = await agent.generate(
   "Add a task: Build a new feature for our app. It should take about 2 hours and needs to be done by next Friday.",
@@ -142,7 +138,7 @@ console.log(response.text);
 
 ## Example output
 
-The output demonstrates how the agent formats and returns the updated todo list using the structure defined in the working memory template.
+The output demonstrates how the agent formats and returns the updated todo list using the structure defined by the zod schema.
 
 ```text
 # Todo List
@@ -168,7 +164,17 @@ Working memory stores data in `.json` format, which would look similar to the be
     {
       // ...
       "args": {
-        "memory": "# Todo List\n## Active Items\n- Task 1: Build a new feature for our app\n  - Due: Next Friday\n  - Description: Build a new feature for our app\n  - Status: Not Started\n  - Estimated Time: 2 hours\n\n## Completed Items\n- None yet"
+        "memory": {
+          "items": [
+            {
+              "title": "Build a new feature for our app",
+              "due": "Next Friday",
+              "description": "",
+              "status": "active",
+              "estimatedTime": "2 hours"
+            }
+          ]
+        }
       }
     }
   ]
@@ -177,6 +183,7 @@ Working memory stores data in `.json` format, which would look similar to the be
 
 ## Related
 
-- [Calling Agents](/docs/v1/agents/overview#referencing-an-agent)
-- [Agent Memory](/docs/v1/agents/agent-memory)
-- [Serverless Deployment](/reference/v1/storage/libsql)
+- [Calling Agents](https://mastra.ai/docs/v1/agents/overview#referencing-an-agent)
+- [Agent Memory](https://mastra.ai/docs/v1/agents/agent-memory)
+- [Serverless Deployment](https://mastra.ai/reference/v1/storage/libsql)
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized memory examples documentation to reference external GitHub repositories instead of internal documentation paths
  * Removed memory examples from documentation navigation sidebar and main examples index
  * Updated working memory documentation links to point to corresponding GitHub repository locations
  * Applied formatting standardization to example documentation, including link updates and removal of metadata

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->