### PR TITLE
fix: ci to run when its supposed to

### DIFF
--- a/.github/workflows/secrets.test-agent-builder.yml
+++ b/.github/workflows/secrets.test-agent-builder.yml
@@ -40,8 +40,8 @@ jobs:
           predicate-quantifier: 'every'
           filters: |
             agent-builder:
-              - 'packages/agent-builder/**'
-              - '!**/*.md'
+              - '!(**/*.md)packages/**'
+              - '!(**/*.md)stores/**'
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-deployer.yml
+++ b/.github/workflows/secrets.test-deployer.yml
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             deployer:
-              - '!(**/*.md)packages/{deployer,core}/**' # Deployer depends on core
+              - '!(**/*.md)packages/{deployer,server,core}/**' # Deployer depends on server and core
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-mcp.yml
+++ b/.github/workflows/secrets.test-mcp.yml
@@ -39,7 +39,8 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             mcp:
-              - '!(**/*.md)packages/{mcp,core}/**' # MCP depends on core
+              - '!(**/*.md)packages/**'
+              - '!(**/*.md)stores/**'
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-memory-ai5.yml
+++ b/.github/workflows/secrets.test-memory-ai5.yml
@@ -39,9 +39,9 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             memory:
-              - '!(**/*.md)packages/{memory,core,deployer,server}/**'
+              - '!(**/*.md)packages/**'
               - '!(**/*.md)stores/**'
-              - '!(**/*.md)client-sdks/client-js/**'
+              - '!(**/*.md)client-sdks/**'
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -39,9 +39,9 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             memory:
-              - '!(**/*.md)packages/{memory,core,deployer,server}/**'
+              - '!(**/*.md)packages/**'
               - '!(**/*.md)stores/**'
-              - '!(**/*.md)client-sdks/client-js/**'
+              - '!(**/*.md)client-sdks/**'
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/secrets.test-observability.yml
+++ b/.github/workflows/secrets.test-observability.yml
@@ -40,9 +40,9 @@ jobs:
           predicate-quantifier: 'every'
           filters: |
             observability:
-              - 'observability/**'
-              - 'packages/core/src/observability/**'
-              - '!**/*.md'
+              - '!(**/*.md)observability/**'
+              - '!(**/*.md)packages/**'
+              - '!(**/*.md)stores/**'
 
   skip-tests:
     needs: check-changes

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, 0.x]
     paths:
       - 'packages/cli/**'
+      - 'packages/core/**'
+      - 'packages/deployer/**'
+      - 'packages/loggers/**'
       - '.github/workflows/test-cli.yml'
 
 jobs:

--- a/.github/workflows/test-client-react.yml
+++ b/.github/workflows/test-client-react.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, 0.x]
     paths:
       - 'client-sdks/react/**'
+      - 'client-sdks/client-js/**'
       - 'packages/core/**'
       - 'packages/server/**'
       - 'packages/deployer/**'

--- a/.github/workflows/test-docs-mcp.yml
+++ b/.github/workflows/test-docs-mcp.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'packages/mcp/**'
       - 'packages/mcp-docs-server/**'
+      - 'packages/core/**'
+      - 'docs/**'
       - '.github/workflows/test-docs-mcp.yml'
 
 jobs:

--- a/.github/workflows/test-evals.yml
+++ b/.github/workflows/test-evals.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, 0.x]
     paths:
       - 'packages/evals/**'
+      - 'packages/core/**'
       - '.github/workflows/test-evals.yml'
 
 jobs:


### PR DESCRIPTION
Lots of tests haven't been running when they were supposed to.

I did an audit of all the packages and their dependencies and when their tests run. There were a lot of missing cases where tests should be running

Now:
- Every package that has a mastra fixture will run ALWAYS, this is because it tests multiple mastra packages and it's easier to do that than to whitelist 8 different packages and then also have to remember to go in and update the CI workflows everytime we add a new package to the integration tests
- Every package that has a mastra dependency but not integration tests, will run when that dependency changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test automation trigger conditions across multiple workflows to improve test coverage and execution efficiency by adjusting package-level path filtering patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->