### PR TITLE
fix(core): prevent step-start insertion between parallel tool calls for Gemini

### DIFF
--- a/.changeset/brave-foxes-smile.md
+++ b/.changeset/brave-foxes-smile.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+---
+
+Fix parallel tool call handling for Gemini models
+
+- Fix addStartStepPartsForAIV5 to prevent step-start parts from being inserted between consecutive tool parts (parallel tool calls)
+- This ensures parallel tool calls maintain correct order and preserve thought_signature metadata on the first tool call as required by Gemini API

--- a/packages/core/src/agent/agent-gemini.test.ts
+++ b/packages/core/src/agent/agent-gemini.test.ts
@@ -650,7 +650,7 @@ describe('Gemini Model Compatibility Tests', () => {
       expect(result2.error).toBeUndefined();
     }, 30000);
 
-    it.skip('should handle multi-step tool calls with gemini 3 pro', async () => {
+    it('should handle multi-step tool calls with gemini 3 pro', async () => {
       const weatherTool = createTool({
         id: 'get-weather-multi',
         description: 'Gets the current weather for a location',

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -2655,9 +2655,11 @@ export class MessageList {
       if (message.role !== `assistant`) continue;
       for (const [index, part] of message.parts.entries()) {
         if (!AIV5.isToolUIPart(part)) continue;
+        const nextPart = message.parts.at(index + 1);
         // If we don't insert step-start between tools and other parts, AIV5.convertToModelMessages will incorrectly add extra tool parts in the wrong order
         // ex: ui message with parts: [tool-result, text] becomes [assistant-message-with-both-parts, tool-result-message], when it should become [tool-call-message, tool-result-message, text-message]
-        if (message.parts.at(index + 1)?.type !== `step-start`) {
+        // However, we should NOT add step-start between consecutive tool parts (parallel tool calls)
+        if (nextPart && nextPart.type !== `step-start` && !AIV5.isToolUIPart(nextPart)) {
           message.parts.splice(index + 1, 0, { type: 'step-start' });
         }
       }


### PR DESCRIPTION
Fixes parallel tool call handling for Gemini models by preventing step-start parts from being inserted between consecutive tool parts in addStartStepPartsForAIV5. Previously when Gemini returned parallel tool calls we were incorrectly inserting step-start parts between them. This caused the AI SDK convertToModelMessages to drop or reorder tool calls which lost the thought_signature metadata that Gemini requires on the first tool call. Now we check if the next part is also a tool part before inserting step-start preserving the correct order and metadata for parallel tool calls. The previously skipped parallel tool call test for Gemini 3 Pro now passes.

fixes https://github.com/mastra-ai/mastra/issues/10319