### PR TITLE
fix(core): prevent step-start insertion between parallel tool calls for Gemini (v1)

### DIFF
--- a/.changeset/v1-gemini-parallel-fix.md
+++ b/.changeset/v1-gemini-parallel-fix.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixes parallel tool call issue with Gemini 3 Pro by preventing step-start parts from being inserted between consecutive tool parts in the `addStartStepPartsForAIV5` function. This ensures that the AI SDK's `convertToModelMessages` correctly preserves the order of parallel tool calls and maintains the `thought_signature` on the first tool call as required by Gemini's API.

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -2860,9 +2860,11 @@ export class MessageList {
       if (message.role !== `assistant`) continue;
       for (const [index, part] of message.parts.entries()) {
         if (!AIV5.isToolUIPart(part)) continue;
+        const nextPart = message.parts.at(index + 1);
         // If we don't insert step-start between tools and other parts, AIV5.convertToModelMessages will incorrectly add extra tool parts in the wrong order
         // ex: ui message with parts: [tool-result, text] becomes [assistant-message-with-both-parts, tool-result-message], when it should become [tool-call-message, tool-result-message, text-message]
-        if (message.parts.at(index + 1)?.type !== `step-start`) {
+        // However, we should NOT add step-start between consecutive tool parts (parallel tool calls)
+        if (nextPart && nextPart.type !== `step-start` && !AIV5.isToolUIPart(nextPart)) {
           message.parts.splice(index + 1, 0, { type: 'step-start' });
         }
       }


### PR DESCRIPTION
This backports the parallel tool call fix from 0.x to main (v1 beta).

The issue was that `step-start` parts were being inserted between consecutive tool parts in parallel tool call responses from Gemini. This caused the AI SDK's `convertToModelMessages` to drop or reorder tool calls, resulting in the loss of the `thought_signature` on the first tool call (which Gemini requires to be sent back in multi-turn conversations).

The fix modifies `addStartStepPartsForAIV5` to skip inserting `step-start` parts when the next part is also a tool part:

```typescript
// Before: step-start parts inserted between parallel tool calls
if (nextPart?.type !== 'step-start') {
  // insert step-start
}

// After: skip step-start between consecutive tool parts
if (nextPart && nextPart.type !== 'step-start' && !AIV5.isToolUIPart(nextPart)) {
  // insert step-start
}
```

Also includes a test case for parallel tool calls with Gemini 3 Pro to verify the fix works correctly.

fixes https://github.com/mastra-ai/mastra/issues/10319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gemini 3 Pro integration to properly handle parallel tool invocations, ensuring correct execution order while maintaining all required API metadata.

* **Tests**
  * Added comprehensive test coverage for Gemini 3 Pro supporting multi-step parallel tool-calling workflows with extended execution time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->