### PR TITLE
feat(qdrant): add support for querying using named vectors using param

### DIFF
--- a/stores/qdrant/src/vector/index.test.ts
+++ b/stores/qdrant/src/vector/index.test.ts
@@ -59,6 +59,33 @@ describe('QdrantVector', () => {
       expect(vectorIds).toHaveLength(3);
     }, 50000);
 
+    it('should query using a named vector when `using` is provided', async () => {
+      const queryVector = [1, 2, 3];
+      const results = await qdrant.query({
+        indexName: testCollectionName,
+        queryVector,
+        topK: 2,
+        includeVector: true,
+        using: 'text',
+      });
+
+      expect(results).toBeDefined();
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('should fallback to default vector when `using` is not provided', async () => {
+      const queryVector = [1, 2, 3];
+      const results = await qdrant.query({
+        indexName: testCollectionName,
+        queryVector,
+        topK: 2,
+        includeVector: true,
+      });
+
+      expect(results).toBeDefined();
+      expect(results.length).toBeGreaterThan(0);
+    });
+
     it('should query vectors and return nearest neighbors', async () => {
       const queryVector = [1.0, 0.1, 0.1];
       const results = await qdrant.query({ indexName: testCollectionName, queryVector, topK: 3 });

--- a/stores/qdrant/src/vector/index.test.ts
+++ b/stores/qdrant/src/vector/index.test.ts
@@ -39,13 +39,13 @@ describe('QdrantVector', () => {
   describe('Vector Operations', () => {
     beforeAll(async () => {
       qdrant = new QdrantVector({ url: 'http://localhost:6333/', id: 'qdrant-test' });
-      await qdrant.createIndex({ 
-        indexName: testCollectionName, 
+      await qdrant.createIndex({
+        indexName: testCollectionName,
         dimension,
         namedVectors: {
           text: { size: dimension, distance: 'cosine' },
-          image: { size: dimension, distance: 'cosine' }
-        }
+          image: { size: dimension, distance: 'cosine' },
+        },
       });
     });
 
@@ -62,11 +62,11 @@ describe('QdrantVector', () => {
     let vectorIds: string[];
 
     it('should upsert vectors with metadata', async () => {
-      vectorIds = await qdrant.upsert({ 
-        indexName: testCollectionName, 
-        vectors: testVectors, 
+      vectorIds = await qdrant.upsert({
+        indexName: testCollectionName,
+        vectors: testVectors,
         metadata: testMetadata,
-        vectorName: 'text'
+        vectorName: 'text',
       });
       expect(vectorIds).toHaveLength(3);
     }, 50000);
@@ -98,11 +98,11 @@ describe('QdrantVector', () => {
         [0.0, 0.5, 0.5],
       ];
       const imageMetadata = [{ type: 'image1' }, { type: 'image2' }];
-      await qdrant.upsert({ 
-        indexName: testCollectionName, 
-        vectors: imageVectors, 
+      await qdrant.upsert({
+        indexName: testCollectionName,
+        vectors: imageVectors,
         metadata: imageMetadata,
-        vectorName: 'image'
+        vectorName: 'image',
       });
 
       const queryVector = [0.5, 0.5, 0.0];
@@ -122,11 +122,11 @@ describe('QdrantVector', () => {
 
     it('should query vectors and return nearest neighbors', async () => {
       const queryVector = [1.0, 0.1, 0.1];
-      const results = await qdrant.query({ 
-        indexName: testCollectionName, 
-        queryVector, 
+      const results = await qdrant.query({
+        indexName: testCollectionName,
+        queryVector,
         topK: 3,
-        using: 'text'
+        using: 'text',
       });
 
       expect(results).toHaveLength(3);
@@ -136,12 +136,12 @@ describe('QdrantVector', () => {
 
     it('should query vectors and return vector in results', async () => {
       const queryVector = [1.0, 0.1, 0.1];
-      const results = await qdrant.query({ 
-        indexName: testCollectionName, 
-        queryVector, 
-        topK: 3, 
+      const results = await qdrant.query({
+        indexName: testCollectionName,
+        queryVector,
+        topK: 3,
         includeVector: true,
-        using: 'text'
+        using: 'text',
       });
 
       expect(results).toHaveLength(3);
@@ -155,12 +155,12 @@ describe('QdrantVector', () => {
         label: 'y-axis',
       };
 
-      const results = await qdrant.query({ 
-        indexName: testCollectionName, 
-        queryVector, 
-        topK: 1, 
+      const results = await qdrant.query({
+        indexName: testCollectionName,
+        queryVector,
+        topK: 1,
         filter,
-        using: 'text'
+        using: 'text',
       });
 
       expect(results).toHaveLength(1);
@@ -174,13 +174,13 @@ describe('QdrantVector', () => {
     beforeAll(async () => {
       qdrant = new QdrantVector({ url: 'http://localhost:6333/', id: 'qdrant-test' });
       // Create collection with multiple named vector spaces
-      await qdrant.createIndex({ 
-        indexName: namedVectorCollectionName, 
+      await qdrant.createIndex({
+        indexName: namedVectorCollectionName,
         dimension,
         namedVectors: {
           text: { size: dimension, distance: 'cosine' },
-          image: { size: dimension, distance: 'euclidean' }
-        }
+          image: { size: dimension, distance: 'euclidean' },
+        },
       });
     });
 
@@ -200,11 +200,11 @@ describe('QdrantVector', () => {
         { type: 'text', content: 'doc2' },
         { type: 'text', content: 'doc3' },
       ];
-      const textIds = await qdrant.upsert({ 
-        indexName: namedVectorCollectionName, 
-        vectors: textVectors, 
+      const textIds = await qdrant.upsert({
+        indexName: namedVectorCollectionName,
+        vectors: textVectors,
         metadata: textMetadata,
-        vectorName: 'text'
+        vectorName: 'text',
       });
       expect(textIds).toHaveLength(3);
 
@@ -219,12 +219,12 @@ describe('QdrantVector', () => {
         { type: 'image', content: 'img2' },
         { type: 'image', content: 'img3' },
       ];
-      const imageIds = await qdrant.upsert({ 
-        indexName: namedVectorCollectionName, 
-        vectors: imageVectors, 
+      const imageIds = await qdrant.upsert({
+        indexName: namedVectorCollectionName,
+        vectors: imageVectors,
         metadata: imageMetadata,
         vectorName: 'image',
-        ids: textIds // Reuse same IDs to test that named vectors are independent
+        ids: textIds, // Reuse same IDs to test that named vectors are independent
       });
       expect(imageIds).toHaveLength(3);
       expect(imageIds).toEqual(textIds);
@@ -252,11 +252,11 @@ describe('QdrantVector', () => {
       // Assert results differ
       expect(textResults).toHaveLength(3);
       expect(imageResults).toHaveLength(3);
-      
+
       // Text results should have text metadata
       expect(textResults[0]?.metadata?.type).toBe('text');
       expect(textResults[0]?.metadata?.content).toMatch(/doc/);
-      
+
       // Image results should have image metadata
       expect(imageResults[0]?.metadata?.type).toBe('image');
       expect(imageResults[0]?.metadata?.content).toMatch(/img/);
@@ -281,20 +281,20 @@ describe('QdrantVector', () => {
       // Clear and set up fresh data
       const textVec = [[0.7, 0.7, 0.0]];
       const imageVec = [[0.0, 0.7, 0.7]];
-      
-      const textId = await qdrant.upsert({ 
-        indexName: namedVectorCollectionName, 
-        vectors: textVec, 
+
+      const textId = await qdrant.upsert({
+        indexName: namedVectorCollectionName,
+        vectors: textVec,
         metadata: [{ space: 'text-only' }],
-        vectorName: 'text'
+        vectorName: 'text',
       });
 
-      const imageId = await qdrant.upsert({ 
-        indexName: namedVectorCollectionName, 
-        vectors: imageVec, 
+      const imageId = await qdrant.upsert({
+        indexName: namedVectorCollectionName,
+        vectors: imageVec,
         metadata: [{ space: 'image-only' }],
         vectorName: 'image',
-        ids: textId // Same ID, different vector space
+        ids: textId, // Same ID, different vector space
       });
 
       // Query text space with includeVector
@@ -304,7 +304,7 @@ describe('QdrantVector', () => {
         topK: 1,
         includeVector: true,
         using: 'text',
-        filter: { space: 'text-only' }
+        filter: { space: 'text-only' },
       });
 
       // Query image space with includeVector
@@ -314,14 +314,14 @@ describe('QdrantVector', () => {
         topK: 1,
         includeVector: true,
         using: 'image',
-        filter: { space: 'image-only' }
+        filter: { space: 'image-only' },
       });
 
       // Assert vectors are returned and are from correct space
       expect(textResults).toHaveLength(1);
       expect(textResults[0]?.vector).toBeDefined();
       expect(textResults[0]?.vector).toHaveLength(dimension);
-      
+
       expect(imageResults).toHaveLength(1);
       expect(imageResults[0]?.vector).toBeDefined();
       expect(imageResults[0]?.vector).toHaveLength(dimension);
@@ -332,11 +332,11 @@ describe('QdrantVector', () => {
       // Verify vector values match what we inserted (approximately, due to normalization)
       const textReturnedVec = textResults[0]?.vector || [];
       const imageReturnedVec = imageResults[0]?.vector || [];
-      
+
       // Text vector should have high values in first two dimensions
       expect(textReturnedVec[0]).toBeGreaterThan(0.4);
       expect(textReturnedVec[1]).toBeGreaterThan(0.4);
-      
+
       // Image vector should have high values in last two dimensions
       expect(imageReturnedVec[1]).toBeGreaterThan(0.4);
       expect(imageReturnedVec[2]).toBeGreaterThan(0.4);
@@ -344,11 +344,11 @@ describe('QdrantVector', () => {
 
     it('should handle querying a non-existent named vector appropriately', async () => {
       // Insert some data
-      await qdrant.upsert({ 
-        indexName: namedVectorCollectionName, 
-        vectors: [[1.0, 0.0, 0.0]], 
+      await qdrant.upsert({
+        indexName: namedVectorCollectionName,
+        vectors: [[1.0, 0.0, 0.0]],
         metadata: [{ test: 'data' }],
-        vectorName: 'text'
+        vectorName: 'text',
       });
 
       // Try to query with a non-existent named vector
@@ -375,7 +375,7 @@ describe('QdrantVector', () => {
         { category: 'B', priority: 2, source: 'text' },
         { category: 'A', priority: 3, source: 'text' },
       ];
-      
+
       const imageVectors = [
         [0.0, 0.0, 1.0],
         [0.0, 0.1, 0.9],
@@ -387,18 +387,18 @@ describe('QdrantVector', () => {
         { category: 'A', priority: 3, source: 'image' },
       ];
 
-      await qdrant.upsert({ 
-        indexName: namedVectorCollectionName, 
-        vectors: textVectors, 
+      await qdrant.upsert({
+        indexName: namedVectorCollectionName,
+        vectors: textVectors,
         metadata: textMetadata,
-        vectorName: 'text'
+        vectorName: 'text',
       });
 
-      await qdrant.upsert({ 
-        indexName: namedVectorCollectionName, 
-        vectors: imageVectors, 
+      await qdrant.upsert({
+        indexName: namedVectorCollectionName,
+        vectors: imageVectors,
         metadata: imageMetadata,
-        vectorName: 'image'
+        vectorName: 'image',
       });
 
       // Query text space with filter for category A
@@ -447,9 +447,9 @@ describe('QdrantVector', () => {
         queryVector: [1.0, 0.0, 0.0],
         topK: 10,
         using: 'text',
-        filter: { 
+        filter: {
           category: 'A',
-          priority: { $gt: 1 }
+          priority: { $gt: 1 },
         },
         includeVector: true,
       });
@@ -496,12 +496,12 @@ describe('QdrantVector', () => {
         [0.0, 1.0, 0.0],
       ];
       const testMetadata = [{ label: 'default-x' }, { label: 'default-y' }];
-      
+
       // Upsert without vectorName parameter
-      const vectorIds = await qdrant.upsert({ 
-        indexName: defaultCollectionName, 
-        vectors: testVectors, 
-        metadata: testMetadata
+      const vectorIds = await qdrant.upsert({
+        indexName: defaultCollectionName,
+        vectors: testVectors,
+        metadata: testMetadata,
       });
       expect(vectorIds).toHaveLength(2);
 

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -27,7 +27,7 @@ const DISTANCE_MAPPING: Record<string, Schemas['Distance']> = {
 type QdrantQueryVectorParams = QueryVectorParams<QdrantVectorFilter>;
 
 export class QdrantVector extends MastraVector {
-  private client: QdrantClient;
+  protected client: QdrantClient;
 
   /**
    * Creates a new QdrantVector client.
@@ -133,7 +133,8 @@ export class QdrantVector extends MastraVector {
     topK = 10,
     filter,
     includeVector = false,
-  }: QdrantQueryVectorParams): Promise<QueryResult[]> {
+    using,
+  }: QdrantQueryVectorParams & {using ? : string}): Promise<QueryResult[]> {
     const translatedFilter = this.transformFilter(filter) ?? {};
 
     try {
@@ -144,6 +145,7 @@ export class QdrantVector extends MastraVector {
           filter: translatedFilter,
           with_payload: true,
           with_vector: includeVector,
+          ...(using ? {using} : {}),
         })
       ).points;
 

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -51,6 +51,15 @@ export class QdrantVector extends MastraVector {
   }: UpsertVectorParams & { vectorName?: string }): Promise<string[]> {
     const pointIds = ids || vectors.map(() => crypto.randomUUID());
 
+    if (vectorName) {
+      const { config } = await this.client.getCollection(indexName);
+      const vectorsConfig = config.params.vectors;
+      const isNamedVectors = vectorsConfig && typeof vectorsConfig === 'object' && !('size' in vectorsConfig);
+
+      if (!isNamedVectors || !(vectorName in vectorsConfig)) {
+        throw new Error(`Vector name "${vectorName}" does not exist in collection "${indexName}"`);
+      }
+    }
     const records = vectors.map((vector, i) => ({
       id: pointIds[i],
       vector: vectorName ? { [vectorName]: vector } : vector,

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -300,16 +300,19 @@ export class QdrantVector extends MastraVector {
         return {
           dimension: firstVector?.size as number,
           count: points_count || 0,
-          // @ts-expect-error
-          metric: Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance),
+          metric: (
+            Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance) || 'cosine'
+          ) as 'cosine' | 'euclidean' | 'dotproduct',
         };
       } else {
         const distance = (vectors as any)?.distance as Schemas['Distance'];
         return {
           dimension: (vectors as any)?.size as number,
           count: points_count || 0,
-          // @ts-expect-error
-          metric: Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance),
+          metric: (
+            Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance) || 'cosine'
+          ) as 'cosine' | 'euclidean' | 'dotproduct',
+
         };
       }
     } catch (error) {

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -300,19 +300,20 @@ export class QdrantVector extends MastraVector {
         return {
           dimension: firstVector?.size as number,
           count: points_count || 0,
-          metric: (
-            Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance) || 'cosine'
-          ) as 'cosine' | 'euclidean' | 'dotproduct',
+          metric: (Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance) || 'cosine') as
+            | 'cosine'
+            | 'euclidean'
+            | 'dotproduct',
         };
       } else {
         const distance = (vectors as any)?.distance as Schemas['Distance'];
         return {
           dimension: (vectors as any)?.size as number,
           count: points_count || 0,
-          metric: (
-            Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance) || 'cosine'
-          ) as 'cosine' | 'euclidean' | 'dotproduct',
-
+          metric: (Object.keys(DISTANCE_MAPPING).find(key => DISTANCE_MAPPING[key] === distance) || 'cosine') as
+            | 'cosine'
+            | 'euclidean'
+            | 'dotproduct',
         };
       }
     } catch (error) {

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -96,7 +96,9 @@ export class QdrantVector extends MastraVector {
             throw new Error(`Named vector "${name}": size must be a positive integer`);
           }
           if (!DISTANCE_MAPPING[config.distance]) {
-            throw new Error(`Named vector "${name}": invalid distance "${config.distance}". Must be one of: cosine, euclidean, dotproduct`);
+            throw new Error(
+              `Named vector "${name}": invalid distance "${config.distance}". Must be one of: cosine, euclidean, dotproduct`,
+            );
           }
         }
       } else {

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -348,7 +348,7 @@ export class QdrantVector extends MastraVector {
         const { config } = await this.client.getCollection(indexName);
         const vectorsConfig = config.params.vectors;
         const isNamedVectors = vectorsConfig && typeof vectorsConfig === 'object' && !('size' in vectorsConfig);
-        
+
         if (!isNamedVectors || !(vectorName in vectorsConfig)) {
           throw new Error(`Vector name "${vectorName}" does not exist in collection "${indexName}"`);
         }

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -155,13 +155,15 @@ export class QdrantVector extends MastraVector {
         if (includeVector && match.vector != null) {
           if (Array.isArray(match.vector)) {
             vector = match.vector as number[];
-          } else if (typeof match.vector === 'object') {
+          } else if (typeof match.vector === 'object' && match.vector !== null) {
             const named = match.vector as Record<string, unknown>;
-            const maybeNamed = using && Array.isArray(named[using]) ? (named[using] as unknown[]) : undefined;
-            if (maybeNamed) {
-              vector = maybeNamed.filter((v): v is number => typeof v === 'number');
-            } else {
-              vector = Object.values(named).filter((v): v is number => typeof v === 'number');
+            const sourceArray: unknown[] | undefined =
+             using && Array.isArray(named[using])
+              ? (named[using] as unknown[])
+              : (Object.values(named).find(v => Array.isArray(v)) as unknown[] | undefined);
+
+            if (sourceArray) {
+              vector = sourceArray.filter((v): v is number => typeof v === 'number');
             }
           }
         }

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -146,7 +146,7 @@ export class QdrantVector extends MastraVector {
           filter: translatedFilter,
           with_payload: true,
           with_vector: includeVector,
-          ...(using ? {using} : {}),
+          ...(using ? { using } : {}),
         })
       ).points;
 
@@ -158,9 +158,9 @@ export class QdrantVector extends MastraVector {
           } else if (typeof match.vector === 'object' && match.vector !== null) {
             const named = match.vector as Record<string, unknown>;
             const sourceArray: unknown[] | undefined =
-             using && Array.isArray(named[using])
-              ? (named[using] as unknown[])
-              : (Object.values(named).find(v => Array.isArray(v)) as unknown[] | undefined);
+              using && Array.isArray(named[using])
+                ? (named[using] as unknown[])
+                : (Object.values(named).find(v => Array.isArray(v)) as unknown[] | undefined);
 
             if (sourceArray) {
               vector = sourceArray.filter((v): v is number => typeof v === 'number');

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -344,6 +344,15 @@ export class QdrantVector extends MastraVector {
       if (!update.vector && !update.metadata) {
         throw new Error('No updates provided');
       }
+      if (vectorName) {
+        const { config } = await this.client.getCollection(indexName);
+        const vectorsConfig = config.params.vectors;
+        const isNamedVectors = vectorsConfig && typeof vectorsConfig === 'object' && !('size' in vectorsConfig);
+        
+        if (!isNamedVectors || !(vectorName in vectorsConfig)) {
+          throw new Error(`Vector name "${vectorName}" does not exist in collection "${indexName}"`);
+        }
+      }
     } catch (validationError) {
       throw new MastraError(
         {

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -62,8 +62,21 @@ export class QdrantVector extends MastraVector {
     const pointIds = ids || vectors.map(() => crypto.randomUUID());
 
     if (vectorName) {
-      await this.validateVectorName(indexName, vectorName);
+      try {
+        await this.validateVectorName(indexName, vectorName);
+      } catch (validationError) {
+        throw new MastraError(
+          {
+            id: 'STORAGE_QDRANT_VECTOR_UPSERT_INVALID_ARGS',
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            details: { indexName, vectorName },
+          },
+          validationError,
+        );
+      }
     }
+
     const records = vectors.map((vector, i) => ({
       id: pointIds[i],
       vector: vectorName ? { [vectorName]: vector } : vector,


### PR DESCRIPTION
## Description

This PR adds support for querying Qdrant collections using **named vectors** by introducing an optional `using` parameter to the `query` method of `QdrantVector`.

Qdrant supports multiple named vector spaces per collection (e.g., `text`, `image`, `embedding`).  
Previously, Mastra's Qdrant integration did not expose the `using` field, making it impossible to query a specific named vector.

This PR:
- Extends query parameters to include `using?: string`
- Adds conditional spread (`...(using ? { using } : {})`) to ensure backward compatibility
- **Makes the underlying Qdrant client `protected` instead of `private` to allow subclass extension when needed**

## Related Issue(s)

- Closes #4660

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Named vector spaces: create indexes with multiple named vectors; upsert/update into a specific named vector; query a named vector via an optional "using" selector; includeVector returns vectors from the requested space.

* **Bug Fixes**
  * Improved validation and clearer errors for missing/invalid named vectors; conditional validation when named vectors are present to avoid false failures; correct wrapping/unwrapping of named-vector payloads.

* **Tests**
  * Expanded comprehensive tests for named-vector creation, upsert/update, queries, isolation, filters, backward compatibility, updates, and many edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->