### PR TITLE
Fix Azure Foundry rate limit handling for -1 values

### DIFF
--- a/.changeset/grumpy-dogs-sparkle.md
+++ b/.changeset/grumpy-dogs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix Azure Foundry rate limit handling for -1 values

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -263,10 +263,8 @@ export class MastraLLMVNext extends MastraBase {
               runId,
             });
 
-            if (
-              props?.response?.headers?.['x-ratelimit-remaining-tokens'] &&
-              parseInt(props?.response?.headers?.['x-ratelimit-remaining-tokens'], 10) < 2000
-            ) {
+            const remainingTokens = parseInt(props?.response?.headers?.['x-ratelimit-remaining-tokens'] ?? '', 10);
+            if (!isNaN(remainingTokens) && remainingTokens > 0 && remainingTokens < 2000) {
               this.logger.warn('Rate limit approaching, waiting 10 seconds', { runId });
               await delay(10 * 1000);
             }

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -235,10 +235,8 @@ export class MastraLLMV1 extends MastraBase {
           runId,
         });
 
-        if (
-          props?.response?.headers?.['x-ratelimit-remaining-tokens'] &&
-          parseInt(props?.response?.headers?.['x-ratelimit-remaining-tokens'], 10) < 2000
-        ) {
+        const remainingTokens = parseInt(props?.response?.headers?.['x-ratelimit-remaining-tokens'] ?? '', 10);
+        if (!isNaN(remainingTokens) && remainingTokens > 0 && remainingTokens < 2000) {
           this.logger.warn('Rate limit approaching, waiting 10 seconds', { runId });
           await delay(10 * 1000);
         }
@@ -531,10 +529,8 @@ export class MastraLLMV1 extends MastraBase {
           runId,
         });
 
-        if (
-          props?.response?.headers?.['x-ratelimit-remaining-tokens'] &&
-          parseInt(props?.response?.headers?.['x-ratelimit-remaining-tokens'], 10) < 2000
-        ) {
+        const remainingTokens = parseInt(props?.response?.headers?.['x-ratelimit-remaining-tokens'] ?? '', 10);
+        if (!isNaN(remainingTokens) && remainingTokens > 0 && remainingTokens < 2000) {
           this.logger.warn('Rate limit approaching, waiting 10 seconds', { runId });
           await delay(10 * 1000);
         }


### PR DESCRIPTION
Fixes rate limit check to properly handle -1 values returned by Azure Foundry.

## Changes
- Added proper NaN check for parsed rate limit values
- Added check to ensure remainingTokens > 0 before triggering rate limit warning
- Prevents false positives when Azure Foundry returns -1 for unlimited rate limits

## Files Changed
- `packages/core/src/llm/model/model.loop.ts`
- `packages/core/src/llm/model/model.ts`

This ensures the rate limit warning only triggers for valid, low token counts rather than treating -1 as a low value.