### PR TITLE
Fix Chroma test dimension from 4 to 1536

### DIFF
--- a/stores/chroma/src/vector/index.test.ts
+++ b/stores/chroma/src/vector/index.test.ts
@@ -1568,8 +1568,8 @@ describe('Chroma Metadata Filtering', () => {
   createVectorTestSuite({
     vector: chromaVector,
     createIndex: async (indexName: string) => {
-      // Using dimension 4 as required by the metadata filtering test vectors
-      await chromaVector.createIndex({ indexName, dimension: 4 });
+      // Using dimension 1536 as required by the metadata filtering test vectors
+      await chromaVector.createIndex({ indexName, dimension: 1536 });
     },
     deleteIndex: async (indexName: string) => {
       await chromaVector.deleteIndex({ indexName });


### PR DESCRIPTION
Fixes the dimension configuration in Chroma metadata filtering tests.

## Problem
The metadata filtering test suite was using dimension 4, but the test vectors are 1536 dimensions (standard embedding size). This caused 12 test failures with the error:
```
Vector at index 0 has invalid dimension 1536. Expected 4 dimensions.
```

## Solution
Updated the `createIndex` call in the metadata filtering test suite to use dimension 1536 instead of 4.

## Test Results
✅ All 141 tests now pass (previously 12 failures)

## Files Changed
- `stores/chroma/src/vector/index.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated vector indexing test configuration to use appropriate embedding dimensions, ensuring tests accurately validate vector database operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->