### PR TITLE
Fix/nested embedding path

### DIFF
--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -66,7 +66,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
 
   private static setNestedField(obj: any, path: string, value: any) {
     if (!path || path.trim() === '') {
-      throw new Error('Path cannot be empty')
+      throw new Error('Path cannot be empty');
     }
     const keys = path.split('.');
     let o: any = obj;
@@ -570,8 +570,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
         await this.validateVectorDimensions([update.vector], stats.dimension);
         const effectivePath = embeddingPath || this.embeddingFieldName;
         MongoDBVector.setNestedField(updateDoc, effectivePath, update.vector);
-    }
-    
+      }
+
       if (update.metadata) {
         // Normalize metadata in updates too
         const normalizedMeta = Object.keys(update.metadata).reduce(

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -305,11 +305,12 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
           {} as Record<string, any>,
         );
 
-        const updateDoc: Partial<MongoDBDocument> = {};
-        const effectiveEmbeddingPath = embeddingPath || this.embeddingFieldName;
         if (embeddingPath && embeddingPath !== this.embeddingFieldName) {
           throw new Error(`embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`);
         }
+        const updateDoc: Partial<MongoDBDocument> = {};
+        const effectiveEmbeddingPath = embeddingPath || this.embeddingFieldName;
+
         MongoDBVector.setNestedField(updateDoc, effectiveEmbeddingPath, vector);
         MongoDBVector.setNestedField(updateDoc, this.metadataFieldName, normalizedMeta);
 
@@ -576,6 +577,9 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
       if (update.vector) {
         const stats = await this.describeIndex({ indexName });
         await this.validateVectorDimensions([update.vector], stats.dimension);
+        if (embeddingPath && embeddingPath !== this.embeddingFieldName) {
+          throw new Error(`embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`);
+        }
         const effectivePath = embeddingPath || this.embeddingFieldName;
         MongoDBVector.setNestedField(updateDoc, effectivePath, update.vector);
       }

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -307,6 +307,11 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
 
         const updateDoc: Partial<MongoDBDocument> = {};
         const effectiveEmbeddingPath = embeddingPath || this.embeddingFieldName;
+        if (embeddingPath && embeddingPath !== this.embeddingFieldName) {
+          throw new Error(
+            `embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`
+          );
+        }
         MongoDBVector.setNestedField(updateDoc, effectiveEmbeddingPath, vector);
         MongoDBVector.setNestedField(updateDoc, this.metadataFieldName, normalizedMeta);
 
@@ -371,6 +376,11 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
       }
 
       const vectorPath = embeddingPath || this.embeddingFieldName;
+      if (embeddingPath && embeddingPath !== this.embeddingFieldName) {
+        throw new Error(
+          `embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`
+        );
+      }
       const vectorSearch: Document = {
         index: indexNameInternal,
         queryVector: queryVector,
@@ -585,7 +595,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
           {} as Record<string, any>,
         );
 
-        updateDoc[this.metadataFieldName] = normalizedMeta;
+        MongoDBVector.setNestedField(updateDoc, this.metadataFieldName, normalizedMeta);
       }
 
       // Type narrowing: check if updating by id or by filter

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -308,9 +308,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
         const updateDoc: Partial<MongoDBDocument> = {};
         const effectiveEmbeddingPath = embeddingPath || this.embeddingFieldName;
         if (embeddingPath && embeddingPath !== this.embeddingFieldName) {
-          throw new Error(
-            `embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`
-          );
+          throw new Error(`embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`);
         }
         MongoDBVector.setNestedField(updateDoc, effectiveEmbeddingPath, vector);
         MongoDBVector.setNestedField(updateDoc, this.metadataFieldName, normalizedMeta);
@@ -377,9 +375,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
 
       const vectorPath = embeddingPath || this.embeddingFieldName;
       if (embeddingPath && embeddingPath !== this.embeddingFieldName) {
-        throw new Error(
-          `embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`
-        );
+        throw new Error(`embeddingPath "${embeddingPath}" must match the indexed path "${this.embeddingFieldName}"`);
       }
       const vectorSearch: Document = {
         index: indexNameInternal,

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -69,15 +69,17 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
       throw new Error('Path cannot be empty');
     }
     const keys = path.split('.');
+    if (keys.some(k => !k)) {
+      throw new Error(`Invalid path: "${path}" contains empty segments`);
+    }
     let o: any = obj;
     for (let i = 0; i < keys.length - 1; i++) {
       const key = keys[i];
-      if (!key) continue;
       if (!o[key]) o[key] = {};
       o = o[key] as any;
     }
     const lastKey = keys[keys.length - 1];
-    if (lastKey) o[lastKey] = value;
+    o[lastKey] = value;
   }
 
   constructor({

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -541,8 +541,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
    * @returns A promise that resolves when the update is complete.
    * @throws Will throw an error if no updates are provided or if the update operation fails.
    */
-  async updateVector(params: UpdateVectorParams<MongoDBVectorFilter>): Promise<void> {
-    const { indexName, update } = params;
+  async updateVector(params: MongoDBUpdateVectorParams): Promise<void> {
+    const { indexName, update,embeddingPath } = params;
 
     // Validate that both id and filter are not provided at the same time
     if ('id' in params && params.id && 'filter' in params && params.filter) {

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -78,7 +78,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     uri,
     dbName,
     options,
-    embeddingField = "embedding",
+    embeddingField = 'embedding',
   }: {
     id: string;
     uri: string;
@@ -260,7 +260,14 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     throw new Error(`Index "${indexNameInternal}" did not become ready within timeout`);
   }
 
-  async upsert({ indexName, vectors, metadata, ids, documents, embeddingPath}: MongoDBUpsertVectorParams): Promise<string[]> {
+  async upsert({
+    indexName,
+    vectors,
+    metadata,
+    ids,
+    documents,
+    embeddingPath,
+  }: MongoDBUpsertVectorParams): Promise<string[]> {
     try {
       const collection = await this.getCollection(indexName);
 
@@ -410,7 +417,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
         id: result._id,
         score: result.score,
         metadata: result.metadata,
-         vector: includeVector ? (result.vector as number[]) : undefined,
+        vector: includeVector ? (result.vector as number[]) : undefined,
         document: result.document,
       }));
     } catch (error) {


### PR DESCRIPTION
## Description

Added support for upserting and querying vectors stored at nested paths in `MongoDBVector`. Previously, only flat embedding fields were supported, which caused issues when using deeply nested embeddings. This update allows specifying a custom `embeddingPath` for both `upsert` and `query` operations. The change also updates tests to ensure nested embedding functionality works correctly.

## Related Issue(s)
Closed: #6563

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for nested embedding paths when storing, updating, and querying vectors — embeddings and metadata can be placed under nested object fields.
  * Embedding field name can be customized.

* **Tests**
  * Added tests validating nested embedding-path upsert and query behavior.
  * Identical duplicate test suite was also added (cleanup recommended).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->