### PR TITLE
fix(mcp): allow disabling session management when sessionIdGenerator is undefined

### DIFF
--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -1412,17 +1412,9 @@ describe('MCPServer', () => {
         tools: minimalTestTool,
       });
 
-      let serverlessModeCalled = false;
-
       sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
         const url = new URL(req.url || '', `http://localhost:${SESSION_TEST_PORT}`);
-
-        // Spy on the handleServerlessRequest method to verify it's called
-        const originalHandleServerlessRequest = (sessionServer as any).handleServerlessRequest.bind(sessionServer);
-        (sessionServer as any).handleServerlessRequest = async (...args: any[]) => {
-          serverlessModeCalled = true;
-          return originalHandleServerlessRequest(...args);
-        };
+        
 
         await sessionServer.startHTTP({
           url,

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -923,13 +923,13 @@ describe('MCPServer', () => {
       if (reader) {
         try {
           await reader.cancel();
-        } catch {}
+        } catch { }
         reader = undefined;
       }
       if (sseRes && 'body' in sseRes && sseRes.body) {
         try {
           await sseRes.body.cancel();
-        } catch {}
+        } catch { }
         sseRes = undefined;
       }
     });
@@ -1219,6 +1219,245 @@ describe('MCPServer', () => {
       expect(toolResult).toHaveProperty('conditions');
       expect(toolResult).toHaveProperty('windSpeed');
       expect(toolResult).toHaveProperty('windGust');
+    });
+  });
+
+  describe('MCPServer Session Management', () => {
+    let sessionServer: MCPServer;
+    let sessionHttpServer: http.Server;
+    const SESSION_TEST_PORT = 9600 + Math.floor(Math.random() * 1000);
+
+    afterEach(async () => {
+      if (sessionHttpServer) {
+        sessionHttpServer.closeAllConnections?.();
+        await new Promise<void>((resolve, reject) => {
+          sessionHttpServer.close(err => {
+            if (err) return reject(err);
+            resolve();
+          });
+        });
+      }
+      if (sessionServer) {
+        await sessionServer.close();
+      }
+    });
+
+    it('should generate sessions by default when no sessionIdGenerator option is provided', async () => {
+      sessionServer = new MCPServer({
+        name: 'DefaultSessionServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${SESSION_TEST_PORT}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          // No options provided - should use default sessionIdGenerator
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(SESSION_TEST_PORT, () => resolve()));
+
+      const client = new InternalMastraMCPClient({
+        name: 'default-session-client',
+        server: {
+          url: new URL(`http://localhost:${SESSION_TEST_PORT}/http`),
+        },
+      });
+
+      await client.connect();
+
+      // Verify that a session was created by checking if we can list tools
+      const tools = await client.listTools();
+      expect(tools).toBeDefined();
+      expect(tools.tools).toBeInstanceOf(Array);
+
+      await client.disconnect();
+    });
+
+    it('should disable sessions when sessionIdGenerator is explicitly set to undefined', async () => {
+      sessionServer = new MCPServer({
+        name: 'NoSessionServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${SESSION_TEST_PORT}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: {
+            sessionIdGenerator: undefined, // Explicitly disable sessions
+          },
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(SESSION_TEST_PORT, () => resolve()));
+
+      const client = new InternalMastraMCPClient({
+        name: 'no-session-client',
+        server: {
+          url: new URL(`http://localhost:${SESSION_TEST_PORT}/http`),
+        },
+      });
+
+      await client.connect();
+
+      // Should work in stateless mode
+      const tools = await client.listTools();
+      expect(tools).toBeDefined();
+      expect(tools.tools).toBeInstanceOf(Array);
+
+      await client.disconnect();
+    });
+
+    it('should run in serverless mode when serverless option is true', async () => {
+      sessionServer = new MCPServer({
+        name: 'ServerlessServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${SESSION_TEST_PORT}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: {
+            serverless: true, // Enable serverless mode
+          },
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(SESSION_TEST_PORT, () => resolve()));
+
+      const client = new InternalMastraMCPClient({
+        name: 'serverless-client',
+        server: {
+          url: new URL(`http://localhost:${SESSION_TEST_PORT}/http`),
+        },
+      });
+
+      await client.connect();
+
+      // Should work in stateless serverless mode
+      const tools = await client.listTools();
+      expect(tools).toBeDefined();
+      expect(tools.tools).toBeInstanceOf(Array);
+
+      await client.disconnect();
+    });
+
+    it('should use custom sessionIdGenerator when provided', async () => {
+      const customSessionIds: string[] = [];
+      let sessionIdCounter = 0;
+
+      const customSessionIdGenerator = () => {
+        const customId = `custom-session-${sessionIdCounter++}`;
+        customSessionIds.push(customId);
+        return customId;
+      };
+
+      sessionServer = new MCPServer({
+        name: 'CustomSessionServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${SESSION_TEST_PORT}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: {
+            sessionIdGenerator: customSessionIdGenerator,
+          },
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(SESSION_TEST_PORT, () => resolve()));
+
+      const client = new InternalMastraMCPClient({
+        name: 'custom-session-client',
+        server: {
+          url: new URL(`http://localhost:${SESSION_TEST_PORT}/http`),
+        },
+      });
+
+      await client.connect();
+
+      // Verify that the custom session ID generator was called
+      expect(customSessionIds.length).toBeGreaterThan(0);
+      expect(customSessionIds[0]).toMatch(/^custom-session-\d+$/);
+
+      await client.disconnect();
+    });
+
+    it('should allow user options to override default sessionIdGenerator', async () => {
+      // This test verifies the core fix: user-provided options override defaults
+      sessionServer = new MCPServer({
+        name: 'OverrideTestServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+      });
+
+      let serverlessModeCalled = false;
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${SESSION_TEST_PORT}`);
+
+        // Spy on the handleServerlessRequest method to verify it's called
+        const originalHandleServerlessRequest = (sessionServer as any).handleServerlessRequest.bind(sessionServer);
+        (sessionServer as any).handleServerlessRequest = async (...args: any[]) => {
+          serverlessModeCalled = true;
+          return originalHandleServerlessRequest(...args);
+        };
+
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+          options: {
+            sessionIdGenerator: undefined, // User explicitly disables sessions
+            // The default is sessionIdGenerator: () => randomUUID()
+            // This test verifies that the user's undefined overrides the default
+          },
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(SESSION_TEST_PORT, () => resolve()));
+
+      const client = new InternalMastraMCPClient({
+        name: 'override-test-client',
+        server: {
+          url: new URL(`http://localhost:${SESSION_TEST_PORT}/http`),
+        },
+      });
+
+      await client.connect();
+
+      // Should work with sessions disabled
+      const tools = await client.listTools();
+      expect(tools).toBeDefined();
+      expect(tools.tools).toBeInstanceOf(Array);
+
+      await client.disconnect();
+
+      // Note: serverlessModeCalled check is removed because sessionIdGenerator: undefined
+      // doesn't automatically trigger serverless mode - it just disables session tracking
+      // Serverless mode is only triggered by options.serverless: true
     });
   });
 });

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1247,7 +1247,7 @@ export class MCPServer extends MCPServerBase {
       return;
     }
     const mergedOptions = {
-      sessionIdGenerator: undefined, // default: disabled
+      sessionIdGenerator: () => randomUUID(), // default: enabled
       ...options,                    // user-provided overrides default
     };
 
@@ -1324,8 +1324,7 @@ export class MCPServer extends MCPServerBase {
             // Create a new transport for the new session
            transport = new StreamableHTTPServerTransport({
             ...mergedOptions,
-            sessionIdGenerator:
-              mergedOptions.sessionIdGenerator ?? (() => randomUUID()),
+            sessionIdGenerator: mergedOptions.sessionIdGenerator,
             onsessioninitialized: id => {
               this.streamableHTTPTransports.set(id, transport!);
             },

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1248,7 +1248,7 @@ export class MCPServer extends MCPServerBase {
     }
     const mergedOptions = {
       sessionIdGenerator: () => randomUUID(), // default: enabled
-      ...options,                    // user-provided overrides default
+      ...options, // user-provided overrides default
     };
 
     // Serverless mode: stateless, single request/response
@@ -1322,14 +1322,14 @@ export class MCPServer extends MCPServerBase {
             this.logger.debug('startHTTP: Received Streamable HTTP initialize request, creating new transport.');
 
             // Create a new transport for the new session
-           transport = new StreamableHTTPServerTransport({
-            ...mergedOptions,
-            sessionIdGenerator: mergedOptions.sessionIdGenerator,
-            onsessioninitialized: id => {
-              this.streamableHTTPTransports.set(id, transport!);
-            },
-          });
-          
+            transport = new StreamableHTTPServerTransport({
+              ...mergedOptions,
+              sessionIdGenerator: mergedOptions.sessionIdGenerator,
+              onsessioninitialized: id => {
+                this.streamableHTTPTransports.set(id, transport!);
+              },
+            });
+
             // Set up onclose handler to clean up transport when closed
             transport.onclose = () => {
               const closedSessionId = transport?.sessionId;


### PR DESCRIPTION
## Description

This PR fixes the inability to disable session management in the Mastra MCP server.

Previously:
- Passing `sessionIdGenerator: undefined` was impossible because the Mastra MCP wrapper always overwrote it.
- The internal HTTP transport forcibly generated sessions even when the user wanted a stateless MCP server.
- Developers deploying MCP servers on **Mastra Cloud** (stateless environment) were forced to switch to the raw Anthropic SDK.

## Related Issue(s)

- Fixes #8526

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that verify disabling session management works correctly
- [x] I confirmed the server behaves correctly in both stateful and stateless MCP modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * HTTP initialization no longer generates session IDs by default; provide an explicit sessionIdGenerator in options when needed.

* **Behavior**
  * Transport initialization now consistently uses merged options so session behavior follows provided configuration.

* **Tests**
  * Added end-to-end session-management tests covering default, stateless, serverless, and custom session scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->