### PR TITLE
   feat(tools): add dynamic tool description support

### DIFF
--- a/.changeset/dynamic-tool-descriptions.md
+++ b/.changeset/dynamic-tool-descriptions.md
@@ -1,0 +1,35 @@
+---
+"@mastra/core": minor
+"@mastra/mcp": patch
+---
+
+Add support for dynamic tool descriptions that can access `requestContext` and the Mastra instance.
+
+Tool descriptions may now be plain strings or resolver functions that receive `{ requestContext, mastra }`, matching the existing `DynamicArgument<T>` pattern used for instructions and models. This unlocks multi-tenancy, localization, and feature-flag scenarios without rebuilding tool definitions per request.
+
+**Usage**
+
+```ts
+const sqlTool = createTool({
+  id: 'tenant-sql',
+  description: ({ requestContext }) => {
+    const tenant = requestContext.get('tenant');
+    return `Query the ${tenant} schema`;
+  },
+  execute: async (input, { mastra }) => { /* ... */ },
+});
+```
+
+**Highlights**
+- `ToolAction.description` now uses `DynamicToolDescription` (`string | ({ requestContext, mastra }) => string | Promise<string>`).
+- `Tool#getDescription()` resolves dynamic descriptions with shared `resolveMaybePromise`.
+- Agents resolve descriptions centrally before calling `makeCoreTool`, covering assigned, memory, toolset, and client tools.
+- Workflows keep static descriptions and safely skip dynamic ones at build time.
+- CoreToolBuilder, MCP server, and workflow helpers all guard against accessing dynamic getters directly.
+- Comprehensive tests (14) cover static/dynamic/async cases, raw `ToolAction`s, CoreToolBuilder fallbacks, and empty-string descriptions.
+
+**Bug Fixes**
+- Prevented `CoreToolBuilder.getResolvedDescription()` and MCP server registration from throwing when a tool exposes a dynamic description.
+- Ensured Agent resolves descriptions for both `Tool` instances and raw `ToolAction` objects, keeping type safety across adapters.
+- Treat empty-string descriptions as intentional values instead of falsy fallbacks.
+

--- a/.changeset/dynamic-tool-descriptions.md
+++ b/.changeset/dynamic-tool-descriptions.md
@@ -24,12 +24,15 @@ const sqlTool = createTool({
 - `ToolAction.description` now uses `DynamicToolDescription` (`string | ({ requestContext, mastra }) => string | Promise<string>`).
 - `Tool#getDescription()` resolves dynamic descriptions with shared `resolveMaybePromise`.
 - Agents resolve descriptions centrally before calling `makeCoreTool`, covering assigned, memory, toolset, and client tools.
+- Agent networks resolve dynamic descriptions for routing decisions.
 - Workflows keep static descriptions and safely skip dynamic ones at build time.
 - CoreToolBuilder, MCP server, and workflow helpers all guard against accessing dynamic getters directly.
-- Comprehensive tests (14) cover static/dynamic/async cases, raw `ToolAction`s, CoreToolBuilder fallbacks, and empty-string descriptions.
+- 18 comprehensive tests (14 unit + 4 integration) cover static/dynamic/async cases, raw `ToolAction`s, CoreToolBuilder fallbacks, and empty-string descriptions.
 
 **Bug Fixes**
 - Prevented `CoreToolBuilder.getResolvedDescription()` and MCP server registration from throwing when a tool exposes a dynamic description.
+- Fixed client tools spread-order bug where `getDescription()` method was lost before resolution.
+- Prevented agent network crashes when encountering tools with dynamic descriptions.
 - Ensured Agent resolves descriptions for both `Tool` instances and raw `ToolAction` objects, keeping type safety across adapters.
 - Treat empty-string descriptions as intentional values instead of falsy fallbacks.
 

--- a/packages/core/src/loop/network/index.test.ts
+++ b/packages/core/src/loop/network/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { RequestContext } from '../../request-context';
+import { createTool } from '../../tools';
+import type { ToolAction } from '../../tools/types';
+import { resolveToolDescriptionForNetwork } from './index';
+
+describe('resolveToolDescriptionForNetwork', () => {
+  it('resolves descriptions for Tool instances with dynamic description', async () => {
+    const tool = createTool({
+      id: 'dynamic-tool',
+      description: ({ requestContext }) => `Tenant: ${requestContext.get('tenant')}`,
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('tenant', 'acme');
+
+    const description = await resolveToolDescriptionForNetwork(tool, requestContext);
+
+    expect(description).toBe('Tenant: acme');
+  });
+
+  it('resolves descriptions for raw ToolAction objects with dynamic description', async () => {
+    const tool: ToolAction = {
+      id: 'raw-dynamic-tool',
+      description: ({ requestContext }) => `Org: ${requestContext.get('org')}`,
+      execute: async () => ({}),
+    };
+
+    const requestContext = new RequestContext();
+    requestContext.set('org', 'mastra');
+
+    const description = await resolveToolDescriptionForNetwork(tool, requestContext);
+
+    expect(description).toBe('Org: mastra');
+  });
+
+  it('returns undefined when description resolver throws', async () => {
+    const tool = createTool({
+      id: 'throwing-tool',
+      description: () => {
+        throw new Error('boom');
+      },
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+
+    const description = await resolveToolDescriptionForNetwork(tool, requestContext);
+
+    expect(description).toBeUndefined();
+  });
+});

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -176,12 +176,12 @@ export class CoreToolBuilder extends MastraBase {
         type: 'provider-defined' as const,
         id: tool.id as `${string}.${string}`,
         args: ('args' in this.originalTool ? this.originalTool.args : {}) as Record<string, unknown>,
-        description: tool.description,
+        description: this.getResolvedDescription(),
         parameters: processedParameters,
         execute: this.originalTool.execute
           ? this.createExecute(
               this.originalTool,
-              { ...this.options, description: this.originalTool.description },
+              { ...this.options, description: this.getResolvedDescription() },
               this.logType,
             )
           : undefined,
@@ -466,6 +466,20 @@ export class CoreToolBuilder extends MastraBase {
     };
   }
 
+  private getResolvedDescription(): string | undefined {
+    if (this.options.description !== undefined) {
+      return this.options.description;
+    }
+
+    try {
+      const desc = this.originalTool.description;
+      return typeof desc === 'string' ? desc : undefined;
+    } catch (error) {
+      // Tool.description throws for dynamic resolvers; fall back to undefined.
+      return undefined;
+    }
+  }
+
   buildV5() {
     const builtTool = this.build();
 
@@ -574,12 +588,12 @@ export class CoreToolBuilder extends MastraBase {
 
     const definition = {
       type: 'function' as const,
-      description: this.originalTool.description,
+      description: this.getResolvedDescription(),
       requireApproval: this.options.requireApproval,
       execute: this.originalTool.execute
         ? this.createExecute(
             this.originalTool,
-            { ...this.options, description: this.originalTool.description },
+            { ...this.options, description: this.getResolvedDescription() },
             this.logType,
             processedZodSchema, // Pass the processed Zod schema for validation
           )

--- a/packages/core/src/tools/tools.test.ts
+++ b/packages/core/src/tools/tools.test.ts
@@ -75,3 +75,202 @@ describe('createTool', () => {
     expect(user).toStrictEqual({ message: 'User not found' });
   });
 });
+
+describe('dynamic tool description', () => {
+  it('should support static description (backward compatibility)', async () => {
+    const tool = createTool({
+      id: 'test',
+      description: 'Static description',
+      execute: async () => ({}),
+    });
+
+    const desc = await tool.getDescription();
+    expect(desc).toBe('Static description');
+  });
+
+  it('should support dynamic description with requestContext', async () => {
+    const tool = createTool({
+      id: 'test',
+      description: ({ requestContext }) => {
+        return `Tool for ${requestContext.get('tenant')}`;
+      },
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('tenant', 'acme');
+
+    const desc = await tool.getDescription({ requestContext });
+    expect(desc).toBe('Tool for acme');
+  });
+
+  it('should support async dynamic description', async () => {
+    const tool = createTool({
+      id: 'test',
+      description: async ({ requestContext }) => {
+        // Simulate async lookup
+        await new Promise(r => setTimeout(r, 10));
+        return `Async: ${requestContext.get('value')}`;
+      },
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('value', 'test');
+
+    const desc = await tool.getDescription({ requestContext });
+    expect(desc).toBe('Async: test');
+  });
+
+  it('should have access to mastra instance', async () => {
+    const tool = createTool({
+      id: 'test',
+      description: ({ mastra }) => {
+        return mastra ? 'Has mastra' : 'No mastra';
+      },
+      execute: async () => ({}),
+    });
+
+    const mockMastra = {} as any;
+    const desc = await tool.getDescription({ mastra: mockMastra });
+    expect(desc).toBe('Has mastra');
+  });
+
+  it('should throw error when accessing description getter on dynamic tool', () => {
+    const tool = createTool({
+      id: 'test',
+      description: () => 'Dynamic',
+      execute: async () => ({}),
+    });
+
+    expect(() => tool.description).toThrow('Dynamic description requires requestContext. Use getDescription()');
+  });
+
+  it('should allow accessing description getter on static tool', () => {
+    const tool = createTool({
+      id: 'test',
+      description: 'Static description',
+      execute: async () => ({}),
+    });
+
+    expect(tool.description).toBe('Static description');
+  });
+
+  it('should handle requestContext values correctly', async () => {
+    const tool = createTool({
+      id: 'test',
+      description: ({ requestContext }) => {
+        const org = requestContext.get('org');
+        const user = requestContext.get('user');
+        return `${org}/${user} tool`;
+      },
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('org', 'mastra');
+    requestContext.set('user', 'ash');
+
+    const desc = await tool.getDescription({ requestContext });
+    expect(desc).toBe('mastra/ash tool');
+  });
+
+  it('should handle dynamic description in CoreToolBuilder without throwing', async () => {
+    // Regression test for issue where CoreToolBuilder.getResolvedDescription()
+    // would throw when accessing .description getter on a Tool with dynamic description
+    const tool = createTool({
+      id: 'test',
+      description: ({ requestContext }) => `Dynamic: ${requestContext.get('value')}`,
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('value', 'test123');
+
+    // Resolve the description first (as Agent does)
+    const resolvedDescription = await tool.getDescription({ requestContext });
+
+    // Now pass it to makeCoreTool with resolved description in options
+    const { makeCoreTool } = await import('../utils');
+    const coreTool = makeCoreTool(tool, {
+      name: 'test-tool',
+      requestContext,
+      tracingContext: {},
+      description: resolvedDescription,
+    });
+
+    expect(coreTool.description).toBe('Dynamic: test123');
+  });
+
+  it('should handle dynamic description in CoreToolBuilder with missing options.description gracefully', async () => {
+    // Test the fallback path in CoreToolBuilder.getResolvedDescription()
+    // where options.description is undefined and it needs to safely access originalTool.description
+    const tool = createTool({
+      id: 'test',
+      description: ({ requestContext }) => `Dynamic: ${requestContext.get('value')}`,
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('value', 'test123');
+
+    // Call makeCoreTool WITHOUT providing description in options
+    // This tests the fallback behavior - should return undefined gracefully
+    const { makeCoreTool } = await import('../utils');
+    const coreTool = makeCoreTool(tool, {
+      name: 'test-tool',
+      requestContext,
+      tracingContext: {},
+      // description is NOT provided - triggers fallback path
+    });
+
+    // When description is not resolved, it should be undefined (not throw)
+    expect(coreTool.description).toBeUndefined();
+  });
+
+  it('should handle dynamic description on raw ToolAction object (not Tool class)', async () => {
+    // Regression test: raw ToolAction objects (not wrapped in Tool class) can have dynamic descriptions
+    // These should be resolved by resolveToolDescription in Agent
+    const rawToolAction = {
+      id: 'raw-tool',
+      description: ({ requestContext }: { requestContext: any; mastra?: any }) =>
+        `Raw ToolAction: ${requestContext.get('tenant')}`,
+      execute: async () => ({ success: true }),
+    };
+
+    const requestContext = new RequestContext();
+    requestContext.set('tenant', 'acme-corp');
+
+    // Simulate what Agent.resolveToolDescription does with raw ToolAction objects
+    let resolvedDescription: string | undefined;
+    if (typeof rawToolAction.description === 'function') {
+      resolvedDescription = await rawToolAction.description({ requestContext });
+    }
+
+    expect(resolvedDescription).toBe('Raw ToolAction: acme-corp');
+  });
+
+  it('should handle empty string descriptions correctly', async () => {
+    // Regression test: empty strings are valid descriptions (meaning "no description")
+    // and should not be treated as falsy, falling through to originalTool.description
+    const tool = createTool({
+      id: 'test',
+      description: 'Original description',
+      execute: async () => ({}),
+    });
+
+    const requestContext = new RequestContext();
+
+    // Pass empty string explicitly via options
+    const { makeCoreTool } = await import('../utils');
+    const coreTool = makeCoreTool(tool, {
+      name: 'test-tool',
+      requestContext,
+      tracingContext: {},
+      description: '', // Intentional empty string
+    });
+
+    // Should use the empty string from options, not fall back to "Original description"
+    expect(coreTool.description).toBe('');
+  });
+});

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -17,11 +17,13 @@ import type { RequestContext } from '../request-context';
 import type { ZodLikeSchema, InferZodLikeSchema } from '../types/zod-compat';
 import type { ToolStream } from './stream';
 import type { ValidationError } from './validation';
+import type { DynamicArgument } from '../types';
 
 export type VercelTool = Tool;
 export type VercelToolV5 = ToolV5;
 
 export type ToolInvocationOptions = ToolExecutionOptions | ToolCallOptions;
+export type DynamicToolDescription = DynamicArgument<string>;
 
 /**
  * MCP-specific context properties available during tool execution in MCP environments.
@@ -215,7 +217,7 @@ export interface ToolAction<
   TId extends string = string,
 > {
   id: TId;
-  description: string;
+  description: DynamicToolDescription;
   inputSchema?: TSchemaIn;
   outputSchema?: TSchemaOut;
   suspendSchema?: TSuspendSchema;

--- a/packages/core/src/utils/resolve-maybe-promise.ts
+++ b/packages/core/src/utils/resolve-maybe-promise.ts
@@ -1,0 +1,10 @@
+export function resolveMaybePromise<T, R = void>(
+  value: T | Promise<T> | PromiseLike<T>,
+  cb: (value: T) => R,
+): R | Promise<R> {
+  if (value instanceof Promise || (value != null && typeof (value as PromiseLike<T>).then === 'function')) {
+    return Promise.resolve(value).then(cb);
+  }
+
+  return cb(value as T);
+}

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -244,9 +244,11 @@ export function createStep<
       throw new Error('Tool must have input and output schemas defined');
     }
 
+    const description = getStaticDescriptionFromTool(params);
+
     return {
       id: params.id as TStepId,
-      description: params.description,
+      description,
       inputSchema: params.inputSchema,
       outputSchema: params.outputSchema,
       suspendSchema: params.suspendSchema,
@@ -291,13 +293,24 @@ export function createStep<
 
   return {
     id: params.id as TStepId,
-    description: params.description,
+    description: ('description' in params && typeof params.description === 'string'
+      ? params.description
+      : undefined) as string | undefined,
     inputSchema: params.inputSchema,
     outputSchema: params.outputSchema,
     resumeSchema: params.resumeSchema,
     suspendSchema: params.suspendSchema,
     execute: params.execute,
   };
+}
+
+function getStaticDescriptionFromTool(tool: Tool<any, any, any, any, any>): string | undefined {
+  try {
+    const desc = tool.description;
+    return typeof desc === 'string' ? desc : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function createWorkflow<

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -259,11 +259,14 @@ export function createStep<
       throw new Error('Tool must have input and output schemas defined');
     }
 
+    const description = getStaticDescriptionFromTool(params);
+
     return {
       // TODO: tool probably should have strong id type
       // @ts-ignore
       id: params.id,
-      description: params.description,
+      // Workflows cannot resolve dynamic descriptions at build time, so we keep static ones if available.
+      description,
       inputSchema: params.inputSchema,
       outputSchema: params.outputSchema,
       resumeSchema: params.resumeSchema,
@@ -350,6 +353,15 @@ export function createWorkflow<
   >[],
 >(params: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps>) {
   return new Workflow<DefaultEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput>(params);
+}
+
+function getStaticDescriptionFromTool(tool: Tool<any, any, any, any, any>): string | undefined {
+  try {
+    const desc = tool.description;
+    return typeof desc === 'string' ? desc : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function cloneWorkflow<

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -914,18 +914,12 @@ export class MCPServer extends MCPServerBase {
         continue;
       }
 
-      // Safely get description - avoid triggering Tool's dynamic description getter
-      // Note: For dynamic descriptions, the description will be undefined at MCP server
-      // registration time. Dynamic descriptions need requestContext which is not available
-      // during server initialization. They will be resolved when the tool is actually used.
+      // Resolve description without triggering Tool's dynamic getter.
       let description: string | undefined;
       try {
-        // Try to access description - will throw if it's a dynamic description
         const desc = toolInstance.description;
         description = typeof desc === 'string' ? desc : undefined;
       } catch (error) {
-        // If accessing description throws, it's a dynamic description
-        // We can't resolve it without requestContext, so log a warning
         this.logger.warn(
           `Tool '${toolName}' has a dynamic description that cannot be resolved at server initialization. ` +
             `The description will be undefined in the MCP tool listing.`,


### PR DESCRIPTION
## Description

Tool descriptions can now be dynamic functions that access `requestContext` and the Mastra instance, matching the same pattern used for agent instructions and models (`DynamicArgument<T>`). This enables multi-tenancy, localization, and feature flags without rebuilding tool definitions per request.

**Example:**

```ts
const sqlTool = createTool({
  id: 'tenant-sql',
  description: ({ requestContext }) => {
    const tenant = requestContext.get('tenant');
    return `Query the ${tenant} schema`;
  },
  execute: async (input, { mastra }) => { /* ... */ },
});
```

## What Changed

- Added `DynamicToolDescription` type and `Tool.getDescription()` async method
- Added `Agent.resolveToolDescription()` helper to resolve descriptions for all tool types (assigned, memory, toolset, client)
- Added `resolveToolDescriptionForNetwork()` to handle agent networks safely
- Updated `CoreToolBuilder` to handle dynamic descriptions without throwing
- Extracted `resolveMaybePromise` to shared utility
- Updated MCP server and workflows to handle dynamic descriptions gracefully

## Bug Fixes

After the initial PR, CodeRabbit found two critical bugs that are now fixed:

- Fixed client tools losing `getDescription()` method due to incorrect spread order
- Fixed agent network crashes when tools have dynamic descriptions
- Fixed `CoreToolBuilder` throwing when accessing dynamic description getter
- Fixed MCP server crashing during initialization with dynamic tools
- Fixed Agent ignoring dynamic descriptions on raw `ToolAction` objects
- Fixed empty strings being treated as falsy instead of valid values

## Tests

Added 18 tests total (14 unit + 4 integration) across 3 test files:

- Backward compatibility with static descriptions
- Dynamic descriptions with `requestContext` and `mastra` access
- Async dynamic descriptions
- Error handling (throwing descriptions, missing context)
- CoreToolBuilder edge cases
- Raw `ToolAction` objects vs `Tool` class instances
- Empty string handling
- Agent integration with client tools
- Agent network integration

All tests pass locally.

## Known Issues (Out of Scope)

Found a few other places that will have issues with dynamic descriptions, but they're in separate packages outside `@mastra/core`:

1. `packages/server/src/server/handlers/a2a.ts` - will expose function objects to serialization
2. `packages/evals/src/scorers/llm/tool-call-accuracy/index.ts` - will crash when comparing tools with dynamic descriptions
3. Voice adapters - will emit `[object Function]` when serializing:
   - `voice/google-gemini-live-api/src/index.ts` (4 occurrences)
   - `voice/openai-realtime-api/src/utils.ts` (1 occurrence)
   - `voice/openai-realtime-api/src/index.ts` (2 occurrences)

I kept this PR focused on `@mastra/core` and `@mastra/mcp` to keep the scope manageable. Happy to file follow-up issues for these packages if that works better than including them here.

## Related Issue(s)

Resolves #9334

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation
  - Added comprehensive changeset documenting the feature, usage, highlights, and bug fixes
- [x] I have added tests that prove my fix is effective or that my feature works
  - Added 18 comprehensive tests (14 unit + 4 integration) covering all scenarios
- [x] All new and existing tests pass locally
- [x] Code follows the project's style guidelines (lint-staged passed)
- [x] TypeScript checks pass without errors
- [x] No breaking changes introduced



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for dynamic tool descriptions that can be plain strings or functions accessing request context and instance data.

* **Bug Fixes**
  * Prevented crashes and registration errors when tools expose dynamic descriptions.
  * Restored correct description handling for client tools and preserved empty-string descriptions as intentional.

* **Tests**
  * Added comprehensive unit and integration tests covering static, dynamic, async, and edge-case description behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->