### PR TITLE
fix/10430  mcp tool output schema

### DIFF
--- a/.changeset/pink-crabs-flow.md
+++ b/.changeset/pink-crabs-flow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fix MCP client to return structuredContent directly when tools define an outputSchema, ensuring output validation works correctly instead of failing with "expected X, received undefined" errors.

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -699,6 +699,13 @@ export class InternalMastraMCPClient extends MastraBase {
               );
 
               this.log('debug', `Tool executed successfully: ${tool.name}`);
+              
+              // When a tool has an outputSchema, return the structuredContent directly
+              // so that output validation works correctly
+              if (res.structuredContent !== undefined) {
+                return res.structuredContent;
+              }
+              
               return res;
             } catch (e) {
               this.log('error', `Error calling tool: ${tool.name}`, {

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -2067,13 +2067,10 @@ describe('MCPServer with Tool Output Schema', () => {
     const result = await tool.execute!({ input: 'hello' });
 
     expect(result).toBeDefined();
-    expect(result.structuredContent).toBeDefined();
-    expect(result.structuredContent.processedInput).toBe('processed: hello');
-    expect(result.structuredContent.timestamp).toBe(mockDateISO);
-
-    expect(result.content).toBeDefined();
-    expect(result.content[0].type).toBe('text');
-    expect(JSON.parse(result.content[0].text)).toEqual(result.structuredContent);
+    // When a tool has outputSchema, the MCP client returns structuredContent directly
+    // so output validation can work correctly
+    expect(result.processedInput).toBe('processed: hello');
+    expect(result.timestamp).toBe(mockDateISO);
   });
 });
 


### PR DESCRIPTION
## Description

Fixed MCP client to correctly handle tools with `outputSchema` by returning the `structuredContent` field directly instead of the entire `CallToolResult` object. This ensures that output validation works correctly against the defined schema. Previously, validation would fail with errors like "expected number, received undefined" because it was trying to validate the wrong object structure.

The fix checks if `res.structuredContent` exists and returns only that when present, maintaining backward compatibility for tools without `outputSchema` that still receive the full `CallToolResult`.

## Related Issue(s)

#10430

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP client to return structured content correctly when tools define an outputSchema, resolving validation errors that resulted in "expected X, received undefined" messages.

* **Breaking Changes**
  * Tool output structure has been updated to expose top-level fields instead of a nested structuredContent wrapper.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->