### PR TITLE
fix(ai-sdk): chatRoute resumeStream for agents

### DIFF
--- a/.changeset/two-masks-pump.md
+++ b/.changeset/two-masks-pump.md
@@ -2,4 +2,4 @@
 '@mastra/ai-sdk': patch
 ---
 
-Add resumeData support to the AI SDK chat route for agents, enabling resuming streaming conversations.
+Added support for resuming agent streams in the chat route. You can now pass `resumeData` in the request body to continue a previous agent stream, enabling long-running conversations and multi-step agent workflows.

--- a/.changeset/two-masks-pump.md
+++ b/.changeset/two-masks-pump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+add resumeData support to chat route

--- a/.changeset/two-masks-pump.md
+++ b/.changeset/two-masks-pump.md
@@ -2,4 +2,4 @@
 '@mastra/ai-sdk': patch
 ---
 
-add resumeData support to chat route
+Add resumeData support to the AI SDK chat route for agents, enabling resuming streaming conversations.


### PR DESCRIPTION
## Description

Add support to resumeStream to chatRoute for agents. 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat route can resume interrupted streaming sessions using provided resume data and an associated run identifier, enabling continuation of long-running, multi-step conversations while preserving context.
  * Request options for resumed and new streams are merged with defaults and respect existing precedence/validation rules.

* **Chores**
  * Added a changeset entry marking a patch release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->