### PR TITLE
fixed most observability tests

### DIFF
--- a/observability/arize/src/tracing.config.test.ts
+++ b/observability/arize/src/tracing.config.test.ts
@@ -3,10 +3,12 @@ import { ARIZE_AX_ENDPOINT, ArizeExporter } from './tracing';
 
 // Mock OtelExporter to spy on its constructor
 vi.mock('@mastra/otel-exporter', () => ({
-  OtelExporter: vi.fn().mockImplementation(() => ({
-    exportTracingEvent: vi.fn(),
-    shutdown: vi.fn(),
-  })),
+  OtelExporter: vi.fn().mockImplementation(function () {
+    return {
+      exportTracingEvent: vi.fn(),
+      shutdown: vi.fn(),
+    };
+  }),
 }));
 
 describe('ArizeExporterConfig', () => {

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -67,7 +67,9 @@ describe('LangfuseExporter', () => {
 
     // Get the mocked Langfuse constructor and configure it
     LangfuseMock = vi.mocked(Langfuse);
-    LangfuseMock.mockImplementation(() => mockLangfuseClient);
+    LangfuseMock.mockImplementation(function () {
+      return mockLangfuseClient;
+    });
 
     config = {
       publicKey: 'test-public-key',

--- a/observability/langsmith/src/tracing.test.ts
+++ b/observability/langsmith/src/tracing.test.ts
@@ -54,7 +54,9 @@ describe('LangSmithExporter', () => {
 
     // Mock RunTree constructor
     MockRunTreeClass = vi.mocked(RunTree);
-    MockRunTreeClass.mockImplementation(() => mockRunTree);
+    MockRunTreeClass.mockImplementation(function () {
+      return mockRunTree;
+    });
 
     // Set up mock for Client
     mockClient = {
@@ -63,7 +65,9 @@ describe('LangSmithExporter', () => {
     };
 
     MockClientClass = vi.mocked(Client);
-    MockClientClass.mockImplementation(() => mockClient);
+    MockClientClass.mockImplementation(function () {
+      return mockClient;
+    });
 
     config = {
       apiKey: 'test-api-key',

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -38,6 +38,8 @@
     "@types/node": "22.13.17",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
+    "ai": "^4.3.16",
+    "ai-v5": "npm:ai@5.0.97",
     "eslint": "^9.37.0",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/observability/mastra/src/registry.test.ts
+++ b/observability/mastra/src/registry.test.ts
@@ -768,9 +768,7 @@ describe('Observability Registry', () => {
           'mastra-cloud-observability-exporter disabled: MASTRA_CLOUD_ACCESS_TOKEN environment variable not set',
         ),
       );
-      expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Sign up for Mastra Cloud at https://cloud.mastra.ai'),
-      );
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Sign up at https://cloud.mastra.ai'));
 
       // Verify exporter is disabled but doesn't throw
       const event = {

--- a/observability/otel-exporter/src/tracing.test.ts
+++ b/observability/otel-exporter/src/tracing.test.ts
@@ -5,28 +5,34 @@ import { OtelExporter } from './tracing';
 
 // Mock the OpenTelemetry modules
 vi.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
-  OTLPTraceExporter: vi.fn().mockImplementation(() => ({
-    export: vi.fn().mockResolvedValue(undefined),
-    shutdown: vi.fn().mockResolvedValue(undefined),
-  })),
+  OTLPTraceExporter: vi.fn().mockImplementation(function () {
+    return {
+      export: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
 }));
 
 vi.mock('@opentelemetry/sdk-trace-base', () => ({
   SimpleSpanProcessor: vi.fn(),
-  BatchSpanProcessor: vi.fn().mockImplementation(() => ({
-    onEnd: vi.fn(),
-    onStart: vi.fn(),
-    shutdown: vi.fn().mockResolvedValue(undefined),
-    forceFlush: vi.fn().mockResolvedValue(undefined),
-  })),
+  BatchSpanProcessor: vi.fn().mockImplementation(function () {
+    return {
+      onEnd: vi.fn(),
+      onStart: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      forceFlush: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
 }));
 
 vi.mock('@opentelemetry/sdk-trace-node', () => ({
-  NodeTracerProvider: vi.fn().mockImplementation(() => ({
-    addSpanProcessor: vi.fn(),
-    register: vi.fn(),
-    shutdown: vi.fn().mockResolvedValue(undefined),
-  })),
+  NodeTracerProvider: vi.fn().mockImplementation(function () {
+    return {
+      addSpanProcessor: vi.fn(),
+      register: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
 }));
 
 vi.mock('@opentelemetry/resources', () => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1072,6 +1072,12 @@ importers:
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.12(vitest@4.0.12)
+      ai:
+        specifier: ^4.3.16
+        version: 4.3.19(react@19.2.0)(zod@3.25.76)
+      ai-v5:
+        specifier: npm:ai@5.0.97
+        version: ai@5.0.97(zod@3.25.76)
       eslint:
         specifier: ^9.37.0
         version: 9.38.0(jiti@2.6.1)
@@ -16879,7 +16885,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.10(zod@3.25.76)
-      '@vercel/oidc': 3.0.3
+      '@vercel/oidc': 3.0.5
       zod: 3.25.76
 
   '@ai-sdk/gateway@2.0.0(zod@3.25.76)':


### PR DESCRIPTION
## Description

Fixes most observability tests in main. I think the remaining failure could be an actual issue.

The primary changes are due to `vitest` updates and us now actually calling `generate` in VNext agents instead of just wrapping `stream`.

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [X] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mock implementations across observability module tests (Arize, Langfuse, Langsmith, OTel Exporter) for improved constructor semantics.
  * Enhanced integration tests with dynamic response assertions and updated tool-call handling structures for V2 mock generation paths.
  * Updated expected messages in registry tests for clarity.

* **Chores**
  * Internal test infrastructure refinements and development dependency updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->