### PR TITLE
chore: add retries for flakey image test

### DIFF
--- a/packages/core/src/agent/__tests__/image-prompt.test.ts
+++ b/packages/core/src/agent/__tests__/image-prompt.test.ts
@@ -10,54 +10,61 @@ export function imagePromptTest({ version }: { version: 'v1' | 'v2' }) {
   const openaiModel = version === 'v1' ? openai('gpt-4o') : openaiV5('gpt-4o');
 
   describe('image prompt test', () => {
-    it('should download assets from messages', async () => {
-      const agent = new Agent({
-        id: 'llmPrompt-agent',
-        name: 'LLM Prompt Agent',
-        instructions: 'test agent',
-        model: openaiModel,
-      });
+    it(
+      'should download assets from messages',
+      {
+        timeout: 100000,
+        retry: 3,
+      },
+      async () => {
+        const agent = new Agent({
+          id: 'llmPrompt-agent',
+          name: 'LLM Prompt Agent',
+          instructions: 'test agent',
+          model: openaiModel,
+        });
 
-      let result;
+        let result;
 
-      if (version === 'v1') {
-        result = await agent.generateLegacy([
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'image',
-                image: 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png',
-                mimeType: 'image/png',
-              },
-              {
-                type: 'text',
-                text: 'What is the photo?',
-              },
-            ],
-          },
-        ]);
-      } else {
-        result = await agent.generate([
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'image',
-                image: 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png',
-                mimeType: 'image/png',
-              },
-              {
-                type: 'text',
-                text: 'What is the photo?',
-              },
-            ],
-          },
-        ]);
-      }
+        if (version === 'v1') {
+          result = await agent.generateLegacy([
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'image',
+                  image: 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png',
+                  mimeType: 'image/png',
+                },
+                {
+                  type: 'text',
+                  text: 'What is the photo?',
+                },
+              ],
+            },
+          ]);
+        } else {
+          result = await agent.generate([
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'image',
+                  image: 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png',
+                  mimeType: 'image/png',
+                },
+                {
+                  type: 'text',
+                  text: 'What is the photo?',
+                },
+              ],
+            },
+          ]);
+        }
 
-      expect(result.text.toLowerCase()).toContain('google');
-    }, 10000);
+        expect(result.text.toLowerCase()).toContain('google');
+      },
+    );
   });
 }
 

--- a/packages/core/src/agent/message-list/tests/message-list-url-handling.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-url-handling.test.ts
@@ -205,45 +205,52 @@ describe('MessageList - File URL Handling', () => {
     }
   });
 
-  it('should download URLs for providers that do not support them', async () => {
-    const messageList = new MessageList();
-    const imageUrl = 'https://httpbin.org/image/png';
+  it(
+    'should download URLs for providers that do not support them',
+    {
+      timeout: 100000,
+      retry: 3,
+    },
+    async () => {
+      const messageList = new MessageList();
+      const imageUrl = 'https://httpbin.org/image/png';
 
-    // Add message with URL
-    const v2Message: MastraDBMessage = {
-      id: 'test-msg-2',
-      role: 'user',
-      content: {
-        format: 2,
-        parts: [
-          { type: 'text', text: 'Analyze this image' },
-          { type: 'file', mimeType: 'image/png', data: imageUrl },
-        ],
-      },
-      createdAt: new Date(),
-      resourceId: 'test-resource',
-      threadId: 'test-thread',
-    };
+      // Add message with URL
+      const v2Message: MastraDBMessage = {
+        id: 'test-msg-2',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text', text: 'Analyze this image' },
+            { type: 'file', mimeType: 'image/png', data: imageUrl },
+          ],
+        },
+        createdAt: new Date(),
+        resourceId: 'test-resource',
+        threadId: 'test-thread',
+      };
 
-    messageList.add(v2Message, 'user');
+      messageList.add(v2Message, 'user');
 
-    // Test with provider that does NOT support URLs (empty supportedUrls)
-    const llmPrompt = await messageList.get.all.aiV5.llmPrompt({
-      downloadConcurrency: 1,
-      downloadRetries: 1,
-      supportedUrls: {}, // No URL support
-    });
+      // Test with provider that does NOT support URLs (empty supportedUrls)
+      const llmPrompt = await messageList.get.all.aiV5.llmPrompt({
+        downloadConcurrency: 1,
+        downloadRetries: 1,
+        supportedUrls: {}, // No URL support
+      });
 
-    const userMessage = llmPrompt.find((msg: any) => msg.role === 'user');
-    expect(userMessage).toBeDefined();
+      const userMessage = llmPrompt.find((msg: any) => msg.role === 'user');
+      expect(userMessage).toBeDefined();
 
-    if (userMessage && Array.isArray(userMessage.content)) {
-      const filePart = userMessage.content.find((part: any) => part.type === 'file');
-      expect(filePart).toBeDefined();
-      expect(filePart?.type).toBe('file');
-      // URL should be downloaded and converted to binary data
-      expect((filePart as any)?.data).toBeInstanceOf(Uint8Array);
-      expect((filePart as any)?.data).not.toBe(imageUrl);
-    }
-  });
+      if (userMessage && Array.isArray(userMessage.content)) {
+        const filePart = userMessage.content.find((part: any) => part.type === 'file');
+        expect(filePart).toBeDefined();
+        expect(filePart?.type).toBe('file');
+        // URL should be downloaded and converted to binary data
+        expect((filePart as any)?.data).toBeInstanceOf(Uint8Array);
+        expect((filePart as any)?.data).not.toBe(imageUrl);
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Description

This test is really flakey and occasionally fails, often we have to run Core tests multiple times to make this pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved image asset download test reliability with extended timeout (100s) and automatic retry (3 attempts).
  * Applied the same per-test timeout and retry enhancements to the URL download test to reduce flaky failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->