### PR TITLE
feat(agent): add includeRawChunks option to agent stream 

### DIFF
--- a/.changeset/moody-lies-lose.md
+++ b/.changeset/moody-lies-lose.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Add optional includeRawChunks parameter to agent execution options,
+allowing users to include raw chunks in stream output where supported
+by the model provider.

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -255,6 +255,13 @@ const aiSdkStream = await agent.stream("message for agent", {
         "Overrides the output processors set on the agent. Output processors that can modify or validate messages from the agent before they are returned to the user. Must implement either (or both) of the `processOutputResult` and `processOutputStream` functions.",
     },
     {
+      name: "includeRawChunks",
+      type: "boolean",
+      isOptional: true,
+      description:
+        "Whether to include raw chunks in the stream output (not available on all model providers).",
+    },
+    {
       name: "inputProcessors",
       type: "Processor[]",
       isOptional: true,

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -122,6 +122,9 @@ export type AgentExecutionOptions<
 
   /** Structured output generation with enhanced developer experience  */
   structuredOutput?: StructuredOutputOptions<OUTPUT extends OutputSchema ? OUTPUT : never>;
+
+  /** Whether to include raw chunks in the stream output (not available on all model providers) */
+  includeRawChunks?: boolean;
 };
 
 export type InnerAgentExecutionOptions<

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -156,6 +156,7 @@ export function createMapResultsStep<
       stopWhen: result.stopWhen,
       maxSteps: result.maxSteps,
       providerOptions: result.providerOptions,
+      includeRawChunks: options.includeRawChunks,
       options: {
         ...(options.prepareStep && { prepareStep: options.prepareStep }),
         onFinish: async (payload: any) => {

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -160,6 +160,7 @@ export class MastraLLMVNext extends MastraBase {
     agentId,
     toolCallId,
     methodType,
+    includeRawChunks,
   }: ModelLoopStreamArgs<Tools, OUTPUT>): MastraModelOutput<OUTPUT> {
     let stopWhenToUse;
 
@@ -224,6 +225,7 @@ export class MastraLLMVNext extends MastraBase {
         requireToolApproval,
         agentId,
         methodType,
+        includeRawChunks,
         options: {
           ...options,
           onStepFinish: async props => {


### PR DESCRIPTION
## Description

Add optional includeRawChunks parameter to agent execution options,
allowing users to include raw chunks in stream output where supported
by the model provider.

## Related Issue(s)

fix slack
fix #9698

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `includeRawChunks` option to Agent.stream() to optionally include raw chunks in stream output when supported by the model provider.

* **Documentation**
  * Updated streaming documentation to reflect the new configuration option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->