### PR TITLE
Pass headers from router to underlying models

### DIFF
--- a/.changeset/heavy-onions-buy.md
+++ b/.changeset/heavy-onions-buy.md
@@ -1,0 +1,49 @@
+---
+'@mastra/core': patch
+---
+
+Fix model headers not being passed through gateway system
+
+Previously, custom headers specified in `MastraModelConfig` were not being passed through the gateway system to model providers. This affected:
+- OpenRouter (preventing activity tracking with `HTTP-Referer` and `X-Title`)
+- Custom providers using custom URLs (headers not passed to `createOpenAICompatible`)
+- Custom gateway implementations (headers not available in `resolveLanguageModel`)
+
+Now headers are correctly passed through the entire gateway system:
+- Base `MastraModelGateway` interface updated to accept headers
+- `ModelRouterLanguageModel` passes headers from config to all gateways
+- OpenRouter receives headers for activity tracking
+- Custom URL providers receive headers via `createOpenAICompatible`
+- Custom gateways can access headers in their `resolveLanguageModel` implementation
+
+Example usage:
+```typescript
+// Works with OpenRouter
+const agent = new Agent({
+  name: 'my-agent',
+  instructions: 'You are a helpful assistant.',
+  model: {
+    id: 'openrouter/anthropic/claude-3-5-sonnet',
+    headers: {
+      'HTTP-Referer': 'https://myapp.com',
+      'X-Title': 'My Application',
+    },
+  },
+});
+
+// Also works with custom providers
+const customAgent = new Agent({
+  name: 'custom-agent',
+  instructions: 'You are a helpful assistant.',
+  model: {
+    id: 'custom-provider/model',
+    url: 'https://api.custom.com/v1',
+    apiKey: 'key',
+    headers: {
+      'X-Custom-Header': 'custom-value',
+    },
+  },
+});
+```
+
+Fixes https://github.com/mastra-ai/mastra/issues/9760

--- a/packages/core/src/llm/model/gateways/base.ts
+++ b/packages/core/src/llm/model/gateways/base.ts
@@ -55,5 +55,6 @@ export abstract class MastraModelGateway {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> | LanguageModelV2;
 }

--- a/packages/core/src/llm/model/gateways/custom-gateway.test.ts
+++ b/packages/core/src/llm/model/gateways/custom-gateway.test.ts
@@ -40,16 +40,19 @@ class TestCustomGateway extends MastraModelGateway {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     const baseURL = this.buildUrl(`${providerId}/${modelId}`);
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL,
+      headers,
       supportsStructuredOutputs: true,
     }).chatModel(modelId);
   }
@@ -88,16 +91,19 @@ class AnotherCustomGateway extends MastraModelGateway {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     const baseURL = this.buildUrl(`${providerId}/${modelId}`);
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL,
+      headers,
       supportsStructuredOutputs: true,
     }).chatModel(modelId);
   }

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -177,10 +177,12 @@ export class ModelsDevGateway extends MastraModelGateway {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     const baseURL = this.buildUrl(`${providerId}/${modelId}`);
 
@@ -197,7 +199,7 @@ export class ModelsDevGateway extends MastraModelGateway {
       case 'mistral':
         return createMistral({ apiKey })(modelId);
       case 'openrouter':
-        return createOpenRouter({ apiKey })(modelId);
+        return createOpenRouter({ apiKey, headers })(modelId);
       case 'xai':
         return createXai({
           apiKey,

--- a/packages/core/src/llm/model/gateways/netlify.ts
+++ b/packages/core/src/llm/model/gateways/netlify.ts
@@ -189,13 +189,14 @@ export class NetlifyGateway extends MastraModelGateway {
 
     switch (providerId) {
       case 'openai':
-        return createOpenAI({ apiKey, baseURL }).responses(modelId);
+        return createOpenAI({ apiKey, baseURL, headers }).responses(modelId);
       case 'gemini':
         return createGoogleGenerativeAI({
           baseURL: `${baseURL}/v1beta/`,
           apiKey,
           headers: {
             'user-agent': 'google-genai-sdk/',
+            ...(headers ? headers : {}),
           },
         }).chat(modelId);
       case 'anthropic':
@@ -205,6 +206,7 @@ export class NetlifyGateway extends MastraModelGateway {
           headers: {
             'anthropic-version': '2023-06-01',
             'user-agent': 'anthropic/',
+            ...(headers ? headers : {}),
           },
         })(modelId);
       default:

--- a/packages/core/src/llm/model/gateways/netlify.ts
+++ b/packages/core/src/llm/model/gateways/netlify.ts
@@ -178,10 +178,12 @@ export class NetlifyGateway extends MastraModelGateway {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     const baseURL = await this.buildUrl(`${providerId}/${modelId}`);
 

--- a/packages/core/src/llm/model/router-openrouter-headers.test.ts
+++ b/packages/core/src/llm/model/router-openrouter-headers.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from '../../agent/index.js';
+import { createMockModel } from '../../test-utils/llm-mock.js';
+
+// Mock the @openrouter/ai-sdk-provider-v5 module BEFORE importing it
+vi.mock('@openrouter/ai-sdk-provider-v5', async () => {
+  return {
+    createOpenRouter: vi.fn(),
+  };
+});
+
+// Now import the mocked module
+const { createOpenRouter } = await import('@openrouter/ai-sdk-provider-v5');
+
+describe('ModelRouter - OpenRouter Headers Support', () => {
+  beforeEach(() => {
+    // Set up environment variable for OpenRouter
+    process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
+
+    // Setup mock implementation to return a provider with chatModel
+    vi.mocked(createOpenRouter).mockReturnValue(
+      vi.fn((_modelId: string) => {
+        // Return a mock LanguageModelV2 instance
+        return createMockModel({
+          mockText: 'Hello from OpenRouter!',
+        });
+      }) as any,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OPENROUTER_API_KEY;
+  });
+
+  describe('Headers passing', () => {
+    it('should pass headers to createOpenRouter when using string model id', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: {
+          id: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+          headers: {
+            'HTTP-Referer': 'http://my-service/',
+            'X-Title': 'my-application-name',
+          },
+        },
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      // Verify createOpenRouter was called with the headers
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: 'test-openrouter-key',
+        headers: {
+          'HTTP-Referer': 'http://my-service/',
+          'X-Title': 'my-application-name',
+        },
+      });
+
+      // Verify the returned function was called with the model ID
+      const mockProviderFn = vi.mocked(createOpenRouter).mock.results[0].value;
+      expect(mockProviderFn).toHaveBeenCalledWith('anthropic/claude-3-5-sonnet-20241022');
+    });
+
+    it('should pass headers when using providerId/modelId format', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: {
+          providerId: 'openrouter/openai',
+          modelId: 'gpt-4o',
+          headers: {
+            'HTTP-Referer': 'https://myapp.com',
+            'X-Title': 'MyApp',
+          },
+        },
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      // Verify createOpenRouter was called with the headers
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: 'test-openrouter-key',
+        headers: {
+          'HTTP-Referer': 'https://myapp.com',
+          'X-Title': 'MyApp',
+        },
+      });
+    });
+
+    it('should work without headers (backward compatibility)', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      // Verify createOpenRouter was called without headers
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: 'test-openrouter-key',
+        headers: undefined,
+      });
+    });
+
+    it('should pass custom API key along with headers', async () => {
+      const customApiKey = 'custom-openrouter-key-123';
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: {
+          id: 'openrouter/meta-llama/llama-3.1-8b-instruct',
+          apiKey: customApiKey,
+          headers: {
+            'HTTP-Referer': 'https://example.com',
+            'X-Title': 'Example App',
+          },
+        },
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      // Verify createOpenRouter was called with custom API key and headers
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: customApiKey,
+        headers: {
+          'HTTP-Referer': 'https://example.com',
+          'X-Title': 'Example App',
+        },
+      });
+    });
+
+    it('should handle multiple header fields', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: {
+          id: 'openrouter/google/gemini-pro',
+          headers: {
+            'HTTP-Referer': 'https://myapp.com',
+            'X-Title': 'My Application',
+            'X-Custom-Header': 'custom-value',
+            'X-User-ID': 'user-123',
+          },
+        },
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      // Verify all headers were passed
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: 'test-openrouter-key',
+        headers: {
+          'HTTP-Referer': 'https://myapp.com',
+          'X-Title': 'My Application',
+          'X-Custom-Header': 'custom-value',
+          'X-User-ID': 'user-123',
+        },
+      });
+    });
+
+    it('should support dynamic model config function with headers', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: () => ({
+          id: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+          headers: {
+            'HTTP-Referer': 'https://dynamic.com',
+            'X-Title': 'Dynamic App',
+          },
+        }),
+      });
+
+      await agent.generate('test', { maxSteps: 1 });
+
+      // Verify headers were passed from dynamic config
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: 'test-openrouter-key',
+        headers: {
+          'HTTP-Referer': 'https://dynamic.com',
+          'X-Title': 'Dynamic App',
+        },
+      });
+    });
+  });
+
+  describe('Model caching with headers', () => {
+    it('should create different model instances for different headers', async () => {
+      const agent1 = new Agent({
+        id: 'agent-1',
+        name: 'agent-1',
+        instructions: 'Agent 1',
+        model: {
+          id: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+          headers: {
+            'X-Title': 'App1',
+          },
+        },
+      });
+
+      const agent2 = new Agent({
+        id: 'agent-2',
+        name: 'agent-2',
+        instructions: 'Agent 2',
+        model: {
+          id: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+          headers: {
+            'X-Title': 'App2',
+          },
+        },
+      });
+
+      await agent1.generate('test', { maxSteps: 1 });
+      await agent2.generate('test', { maxSteps: 1 });
+
+      // Both should have been called with different headers
+      expect(createOpenRouter).toHaveBeenCalledTimes(2);
+      expect(createOpenRouter).toHaveBeenNthCalledWith(1, {
+        apiKey: 'test-openrouter-key',
+        headers: {
+          'X-Title': 'App1',
+        },
+      });
+      expect(createOpenRouter).toHaveBeenNthCalledWith(2, {
+        apiKey: 'test-openrouter-key',
+        headers: {
+          'X-Title': 'App2',
+        },
+      });
+    });
+
+    it('should reuse model instance for same headers', async () => {
+      const sharedHeaders = {
+        'HTTP-Referer': 'https://shared.com',
+        'X-Title': 'Shared App',
+      };
+
+      const agent1 = new Agent({
+        id: 'agent-1',
+        name: 'agent-1',
+        instructions: 'Agent 1',
+        model: {
+          id: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+          headers: sharedHeaders,
+        },
+      });
+
+      const agent2 = new Agent({
+        id: 'agent-2',
+        name: 'agent-2',
+        instructions: 'Agent 2',
+        model: {
+          id: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+          headers: sharedHeaders,
+        },
+      });
+
+      await agent1.generate('test', { maxSteps: 1 });
+      await agent2.generate('test', { maxSteps: 1 });
+
+      // Should only be called once since headers are the same
+      expect(createOpenRouter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should pass headers even when using custom API key (no env var needed)', async () => {
+      delete process.env.OPENROUTER_API_KEY;
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'You are a helpful assistant.',
+        model: {
+          id: 'openrouter/anthropic/claude-3-5-sonnet-20241022',
+          apiKey: 'custom-key-no-env',
+          headers: {
+            'HTTP-Referer': 'http://my-service/',
+            'X-Title': 'my-application-name',
+          },
+        },
+      });
+
+      // Should not throw during agent creation
+      expect(agent).toBeDefined();
+
+      // Should work with custom API key
+      await agent.generate('test', { maxSteps: 1 });
+
+      // Verify headers were passed even without env var
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: 'custom-key-no-env',
+        headers: {
+          'HTTP-Referer': 'http://my-service/',
+          'X-Title': 'my-application-name',
+        },
+      });
+    });
+  });
+});

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -123,6 +123,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     const gatewayPrefix = this.gateway.id === 'models.dev' ? undefined : this.gateway.id;
     const model = await this.resolveLanguageModel({
       apiKey,
+      headers: this.config.headers,
       ...parseModelRouterId(this.config.routerId, gatewayPrefix),
     });
 
@@ -159,6 +160,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     const gatewayPrefix = this.gateway.id === 'models.dev' ? undefined : this.gateway.id;
     const model = await this.resolveLanguageModel({
       apiKey,
+      headers: this.config.headers,
       ...parseModelRouterId(this.config.routerId, gatewayPrefix),
     });
 
@@ -170,13 +172,22 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     const key = createHash('sha256')
-      .update(this.gateway.id + modelId + providerId + apiKey + (this.config.url || ''))
+      .update(
+        this.gateway.id +
+          modelId +
+          providerId +
+          apiKey +
+          (this.config.url || '') +
+          (headers ? JSON.stringify(headers) : ''),
+      )
       .digest('hex');
     if (ModelRouterLanguageModel.modelInstances.has(key)) return ModelRouterLanguageModel.modelInstances.get(key)!;
 
@@ -193,7 +204,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
       return modelInstance;
     }
 
-    const modelInstance = await this.gateway.resolveLanguageModel({ modelId, providerId, apiKey });
+    const modelInstance = await this.gateway.resolveLanguageModel({ modelId, providerId, apiKey, headers });
     ModelRouterLanguageModel.modelInstances.set(key, modelInstance);
     return modelInstance;
   }

--- a/packages/core/src/mastra/custom-gateway-integration.test.ts
+++ b/packages/core/src/mastra/custom-gateway-integration.test.ts
@@ -32,15 +32,18 @@ class Gateway1 extends MastraModelGateway {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL: this.buildUrl(`${providerId}/${modelId}`),
+      headers,
       supportsStructuredOutputs: true,
     }).chatModel(modelId);
   }
@@ -69,15 +72,18 @@ class Gateway2 extends MastraModelGateway {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL: this.buildUrl(`${providerId}/${modelId}`),
+      headers,
       supportsStructuredOutputs: true,
     }).chatModel(modelId);
   }
@@ -113,16 +119,19 @@ class TestGateway extends MastraModelGateway {
     modelId,
     providerId,
     apiKey,
+    headers,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
+    headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     const baseURL = this.buildUrl(`${providerId}/${modelId}`);
     return createOpenAICompatible({
       name: providerId,
       apiKey,
       baseURL,
+      headers,
       supportsStructuredOutputs: true,
     }).chatModel(modelId);
   }
@@ -229,15 +238,18 @@ describe('Mastra Custom Gateway Integration', () => {
           modelId,
           providerId,
           apiKey,
+          headers,
         }: {
           modelId: string;
           providerId: string;
           apiKey: string;
+          headers?: Record<string, string>;
         }) {
           return createOpenAICompatible({
             name: providerId,
             apiKey,
             baseURL: this.buildUrl(`${providerId}/${modelId}`),
+            headers,
             supportsStructuredOutputs: true,
           }).chatModel(modelId);
         }


### PR DESCRIPTION
Fix model headers not being passed through gateway system

Previously, custom headers specified in `MastraModelConfig` were not being passed through the gateway system to model providers. This affected:
- OpenRouter (preventing activity tracking with `HTTP-Referer` and `X-Title`)
- Custom providers using custom URLs (headers not passed to `createOpenAICompatible`)
- Custom gateway implementations (headers not available in `resolveLanguageModel`)

Now headers are correctly passed through the entire gateway system:
- Base `MastraModelGateway` interface updated to accept headers
- `ModelRouterLanguageModel` passes headers from config to all gateways
- OpenRouter receives headers for activity tracking
- Custom URL providers receive headers via `createOpenAICompatible`
- Custom gateways can access headers in their `resolveLanguageModel` implementation

Example usage:
```typescript
// Works with OpenRouter
const agent = new Agent({
  name: 'my-agent',
  instructions: 'You are a helpful assistant.',
  model: {
    id: 'openrouter/anthropic/claude-3-5-sonnet',
    headers: {
      'HTTP-Referer': 'https://myapp.com',
      'X-Title': 'My Application',
    },
  },
});

// Also works with custom providers
const customAgent = new Agent({
  name: 'custom-agent',
  instructions: 'You are a helpful assistant.',
  model: {
    id: 'custom-provider/model',
    url: 'https://api.custom.com/v1',
    apiKey: 'key',
    headers: {
      'X-Custom-Header': 'custom-value',
    },
  },
});
```

Fixes https://github.com/mastra-ai/mastra/issues/9760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-request custom headers are now supported and propagated to model providers and custom gateways (including OpenRouter and custom URL providers).
  * Headers are included in model instance resolution so different headers can yield distinct model instances.

* **Tests**
  * Added tests covering header propagation, caching behavior with varied headers, API key/header combinations, and dynamic model configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->