### PR TITLE
tool call hooks and docs

### DIFF
--- a/.changeset/clever-forks-listen.md
+++ b/.changeset/clever-forks-listen.md
@@ -1,5 +1,5 @@
 ---
-"@mastra/core": minor
+"@mastra/core": patch
 ---
 
 Add `onOutput` hook for tools

--- a/.changeset/clever-forks-listen.md
+++ b/.changeset/clever-forks-listen.md
@@ -1,0 +1,43 @@
+---
+"@mastra/core": minor
+---
+
+Add `onOutput` hook for tools
+
+Tools now support an `onOutput` lifecycle hook that is invoked after successful tool execution. This complements the existing `onInputStart`, `onInputDelta`, and `onInputAvailable` hooks to provide complete visibility into the tool execution lifecycle.
+
+The `onOutput` hook receives:
+- `output`: The tool's return value (typed according to `outputSchema`)
+- `toolCallId`: Unique identifier for the tool call
+- `toolName`: The name of the tool that was executed
+- `abortSignal`: Signal for detecting if the operation should be cancelled
+
+Example usage:
+
+```typescript
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const weatherTool = createTool({
+  id: "weather-tool",
+  description: "Get weather information",
+  outputSchema: z.object({
+    temperature: z.number(),
+    conditions: z.string(),
+  }),
+  execute: async (input) => {
+    return { temperature: 72, conditions: "sunny" };
+  },
+  onOutput: ({ output, toolCallId, toolName }) => {
+    console.log(`${toolName} completed:`, output);
+    // output is fully typed based on outputSchema
+  },
+});
+```
+
+Hook execution order:
+1. `onInputStart` - Input streaming begins
+2. `onInputDelta` - Input chunks arrive (called multiple times)
+3. `onInputAvailable` - Complete input parsed and validated
+4. Tool's `execute` function runs
+5. `onOutput` - Tool completed successfully (NEW)

--- a/docs/src/content/en/docs/streaming/tool-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/tool-streaming.mdx
@@ -145,8 +145,8 @@ export const weatherTool = createTool({
     return weather;
   },
   // Called after successful execution
-  onOutput: ({ output, toolCallId }) => {
-    console.log(`Weather result: ${output.temperature}°F, ${output.conditions}`);
+  onOutput: ({ output, toolName }) => {
+    console.log(`${toolName} result: ${output.temperature}°F, ${output.conditions}`);
   },
 });
 ```

--- a/docs/src/content/en/docs/streaming/tool-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/tool-streaming.mdx
@@ -116,9 +116,53 @@ for await (const chunk of stream) {
 }
 ```
 
+## Tool Lifecycle Hooks
+
+Tools support lifecycle hooks that allow you to monitor different stages of tool execution during streaming. These hooks are particularly useful for logging or analytics.
+
+### Example: Using onInputAvailable and onOutput
+
+```typescript showLineNumbers copy
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const weatherTool = createTool({
+  id: "weather-tool",
+  description: "Get weather information",
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  outputSchema: z.object({
+    temperature: z.number(),
+    conditions: z.string(),
+  }),
+  // Called when the complete input is available
+  onInputAvailable: ({ input, toolCallId }) => {
+    console.log(`Weather requested for: ${input.city}`);
+  },
+  execute: async (input) => {
+    const weather = await fetchWeather(input.city);
+    return weather;
+  },
+  // Called after successful execution
+  onOutput: ({ output, toolCallId }) => {
+    console.log(`Weather result: ${output.temperature}°F, ${output.conditions}`);
+  },
+});
+```
+
+### Available Hooks
+
+- **onInputStart**: Called when tool call input streaming begins
+- **onInputDelta**: Called for each chunk of input as it streams in
+- **onInputAvailable**: Called when complete input is parsed and validated
+- **onOutput**: Called after the tool successfully executes with the output
+
+For detailed documentation on all lifecycle hooks, see the [createTool() reference](/reference/v1/tools/create-tool#tool-lifecycle-hooks).
+
 ## Tool using an agent
 
-Pipe an agent’s `textStream` to the tool’s `writer`. This streams partial output, and Mastra automatically aggregates the agent’s usage into the tool run.
+Pipe an agent's `textStream` to the tool's `writer`. This streams partial output, and Mastra automatically aggregates the agent's usage into the tool run.
 
 ```typescript showLineNumbers copy
 import { createTool } from "@mastra/core/tools";

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -131,6 +131,34 @@ export const tool = createTool({
         },
       ],
     },
+    {
+      name: "onInputStart",
+      type: "function",
+      description:
+        "Optional callback invoked when the tool call input streaming begins. Receives `toolCallId`, `messages`, and `abortSignal`.",
+      isOptional: true,
+    },
+    {
+      name: "onInputDelta",
+      type: "function",
+      description:
+        "Optional callback invoked for each incremental chunk of input text as it streams in. Receives `inputTextDelta`, `toolCallId`, `messages`, and `abortSignal`.",
+      isOptional: true,
+    },
+    {
+      name: "onInputAvailable",
+      type: "function",
+      description:
+        "Optional callback invoked when the complete tool input is available and parsed. Receives the validated `input` object, `toolCallId`, `messages`, and `abortSignal`.",
+      isOptional: true,
+    },
+    {
+      name: "onOutput",
+      type: "function",
+      description:
+        "Optional callback invoked after the tool has successfully executed and returned output. Receives the tool's `output`, `toolCallId`, `messages`, and `abortSignal`.",
+      isOptional: true,
+    },
   ]}
 />
 
@@ -149,8 +177,112 @@ The `createTool()` function returns a `Tool` object.
   ]}
 />
 
+## Tool Lifecycle Hooks
+
+Tools support lifecycle hooks that allow you to monitor and react to different stages of tool execution. These hooks are particularly useful for logging, analytics, validation, and real-time updates during streaming.
+
+### Available Hooks
+
+#### onInputStart
+
+Called when tool call input streaming begins, before any input data is received.
+
+```typescript
+export const tool = createTool({
+  id: "example-tool",
+  description: "Example tool with hooks",
+  onInputStart: ({ toolCallId, messages, abortSignal }) => {
+    console.log(`Tool ${toolCallId} input streaming started`);
+  },
+  // ... other properties
+});
+```
+
+#### onInputDelta
+
+Called for each incremental chunk of input text as it streams in. Useful for showing real-time progress or parsing partial JSON.
+
+```typescript
+export const tool = createTool({
+  id: "example-tool",
+  description: "Example tool with hooks",
+  onInputDelta: ({ inputTextDelta, toolCallId, messages, abortSignal }) => {
+    console.log(`Received input chunk: ${inputTextDelta}`);
+  },
+  // ... other properties
+});
+```
+
+#### onInputAvailable
+
+Called when the complete tool input is available and has been parsed and validated against the `inputSchema`.
+
+```typescript
+export const tool = createTool({
+  id: "example-tool",
+  description: "Example tool with hooks",
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  onInputAvailable: ({ input, toolCallId, messages, abortSignal }) => {
+    console.log(`Tool received complete input:`, input);
+    // input is fully typed based on inputSchema
+  },
+  // ... other properties
+});
+```
+
+#### onOutput
+
+Called after the tool has successfully executed and returned output. Useful for logging results, triggering follow-up actions, or analytics.
+
+```typescript
+export const tool = createTool({
+  id: "example-tool",
+  description: "Example tool with hooks",
+  outputSchema: z.object({
+    result: z.string(),
+  }),
+  execute: async (input) => {
+    return { result: "Success" };
+  },
+  onOutput: ({ output, toolCallId, messages, abortSignal }) => {
+    console.log(`Tool execution completed:`, output);
+    // output is fully typed based on outputSchema
+  },
+});
+```
+
+### Hook Execution Order
+
+For a typical streaming tool call, the hooks are invoked in this order:
+
+1. **onInputStart** - Input streaming begins
+2. **onInputDelta** - Called multiple times as chunks arrive
+3. **onInputAvailable** - Complete input is parsed and validated
+4. Tool's **execute** function runs
+5. **onOutput** - Tool has completed successfully
+
+### Hook Parameters
+
+All hooks receive a parameter object with these common properties:
+
+- `toolCallId` (string): Unique identifier for this specific tool call
+- `messages` (array): The conversation messages at the time of the tool call
+- `abortSignal` (AbortSignal): Signal for detecting if the operation should be cancelled
+
+Additionally:
+- `onInputDelta` receives `inputTextDelta` (string): The incremental text chunk
+- `onInputAvailable` receives `input`: The validated input data (typed according to `inputSchema`)
+- `onOutput` receives `output`: The tool's return value (typed according to `outputSchema`)
+
+### Error Handling
+
+Hook errors are caught and logged automatically, but do not prevent tool execution from continuing. If a hook throws an error, it will be logged to the console but will not fail the tool call.
+
 ## Related
 
 - [MCP Overview](/docs/v1/mcp/overview)
 - [Using Tools with Agents](/docs/v1/agents/using-tools)
+- [Tool Streaming](/docs/v1/streaming/tool-streaming)
 - [Request Context](/docs/v1/server-db/request-context#accessing-values-with-tools)

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -246,8 +246,8 @@ export const tool = createTool({
   execute: async (input) => {
     return { result: "Success" };
   },
-  onOutput: ({ output, toolCallId, messages, abortSignal }) => {
-    console.log(`Tool execution completed:`, output);
+  onOutput: ({ output, toolCallId, toolName, abortSignal }) => {
+    console.log(`${toolName} execution completed:`, output);
     // output is fully typed based on outputSchema
   },
 });
@@ -268,13 +268,13 @@ For a typical streaming tool call, the hooks are invoked in this order:
 All hooks receive a parameter object with these common properties:
 
 - `toolCallId` (string): Unique identifier for this specific tool call
-- `messages` (array): The conversation messages at the time of the tool call
 - `abortSignal` (AbortSignal): Signal for detecting if the operation should be cancelled
 
 Additionally:
+- `onInputStart`, `onInputDelta`, and `onInputAvailable` receive `messages` (array): The conversation messages at the time of the tool call
 - `onInputDelta` receives `inputTextDelta` (string): The incremental text chunk
 - `onInputAvailable` receives `input`: The validated input data (typed according to `inputSchema`)
-- `onOutput` receives `output`: The tool's return value (typed according to `outputSchema`)
+- `onOutput` receives `output`: The tool's return value (typed according to `outputSchema`) and `toolName` (string): The name of the tool
 
 ### Error Handling
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -123,6 +123,21 @@ export function createToolCallStep<
         };
 
         const result = await tool.execute(inputData.args, toolOptions);
+
+        // Call onOutput hook after successful execution
+        if (tool && 'onOutput' in tool && typeof (tool as any).onOutput === 'function') {
+          try {
+            await (tool as any).onOutput({
+              toolCallId: inputData.toolCallId,
+              toolName: inputData.toolName,
+              output: result,
+              abortSignal: options?.abortSignal,
+            });
+          } catch (error) {
+            console.error('Error calling onOutput', error);
+          }
+        }
+
         return { result, ...inputData };
       } catch (error) {
         return {

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -479,6 +479,7 @@ export class CoreToolBuilder extends MastraBase {
       onInputStart: 'onInputStart' in this.originalTool ? this.originalTool.onInputStart : undefined,
       onInputDelta: 'onInputDelta' in this.originalTool ? this.originalTool.onInputDelta : undefined,
       onInputAvailable: 'onInputAvailable' in this.originalTool ? this.originalTool.onInputAvailable : undefined,
+      onOutput: 'onOutput' in this.originalTool ? this.originalTool.onOutput : undefined,
     };
 
     // For provider-defined tools, exclude execute and add name as per v5 spec

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -245,6 +245,7 @@ export interface ToolAction<
   onOutput?: (
     options: {
       output: TSchemaOut extends ZodLikeSchema ? InferZodLikeSchema<TSchemaOut> : any;
-    } & ToolCallOptions,
+      toolName: string;
+    } & Omit<ToolCallOptions, 'messages'>,
   ) => void | PromiseLike<void>;
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -242,4 +242,9 @@ export interface ToolAction<
       input: InferZodLikeSchema<TSchemaIn>;
     } & ToolCallOptions,
   ) => void | PromiseLike<void>;
+  onOutput?: (
+    options: {
+      output: TSchemaOut extends ZodLikeSchema ? InferZodLikeSchema<TSchemaOut> : any;
+    } & ToolCallOptions,
+  ) => void | PromiseLike<void>;
 }


### PR DESCRIPTION
- Document tool lifecycle and add onOutput
- type fixes

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `onOutput` lifecycle hook for tools that fires after successful execution, enabling post-execution side effects and logging with access to typed output data.
  * Tools now provide full visibility into their execution lifecycle with complementary hooks for input handling and output completion.

* **Documentation**
  * Updated documentation with comprehensive tool lifecycle hook examples and recommended invocation order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->