### PR TITLE
fix(deployer): Disable treeshake in analyzeEntry

### DIFF
--- a/.changeset/plain-hornets-open.md
+++ b/.changeset/plain-hornets-open.md
@@ -2,4 +2,4 @@
 '@mastra/deployer': patch
 ---
 
-Fix a bug where unused imports (that we not imported into the main entry point) were being tree-shaken away during analysis, causing errors during bundling. Tree-shaking only happens during bundling now.
+Fixed a bug where imports that were not used in the main entry point were tree-shaken during analysis, causing bundling errors. Tree-shaking now only runs during the bundling step.

--- a/.changeset/plain-hornets-open.md
+++ b/.changeset/plain-hornets-open.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix a bug where unused imports (that we not imported into the main entry point) were being tree-shaken away during analysis, causing errors during bundling. Tree-shaking only happens during bundling now.

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -151,4 +151,4 @@ export type LLMStreamObjectOptions<Z extends ZodSchema | JSONSchema7 | undefined
 export type { ProviderConfig } from './model/gateways/base';
 export { MastraModelGateway, NetlifyGateway, ModelsDevGateway } from './model/gateways';
 
-export { ModelRouterEmbeddingModel, type EmbeddingModelId } from './model';
+export { ModelRouterEmbeddingModel, type EmbeddingModelId } from './model/embedding-router';

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -151,4 +151,4 @@ export type LLMStreamObjectOptions<Z extends ZodSchema | JSONSchema7 | undefined
 export type { ProviderConfig } from './model/gateways/base';
 export { MastraModelGateway, NetlifyGateway, ModelsDevGateway } from './model/gateways';
 
-export { ModelRouterEmbeddingModel, type EmbeddingModelId } from './model/embedding-router';
+export { ModelRouterEmbeddingModel, type EmbeddingModelId } from './model';

--- a/packages/deployer/src/build/analyze/__snapshots__/analyzeEntry.test.ts.snap
+++ b/packages/deployer/src/build/analyze/__snapshots__/analyzeEntry.test.ts.snap
@@ -7,6 +7,7 @@ import { Mastra } from '@mastra/core/mastra';
 import { Agent } from '@mastra/core/agent';
 import { openai } from '@ai-sdk/openai';
 
+"use strict";
 const testAgent = new Agent({
   id: "test-agent",
   name: "test-agent",

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -247,7 +247,7 @@ export async function analyzeEntry(
   const optimizerBundler = await rollup({
     logLevel: process.env.MASTRA_BUNDLER_DEBUG === 'true' ? 'debug' : 'silent',
     input: isVirtualFile ? '#entry' : entry,
-    treeshake: 'smallest',
+    treeshake: false,
     preserveSymlinks: true,
     plugins: getInputPlugins({ entry, isVirtualFile }, mastraEntry, { sourcemapEnabled }),
     external: DEPS_TO_IGNORE,


### PR DESCRIPTION
## Description

Fix bundling failure when imports are declared but never used

### Problem

Users encountered build errors when importing multiple exports from a package but only using some of them:

```ts
import { ModelRouterEmbeddingModel, ModelRouterLanguageModel } from '@mastra/core/llm';

// Only ModelRouterLanguageModel is used
export function getLanguageModel() {
  return new ModelRouterLanguageModel(...);
}

// getEmbeddingModel is never called anywhere
export function getEmbeddingModel() {
  return new ModelRouterEmbeddingModel(...);
}
```

This caused errors like:

```shell
"ModelRouterEmbeddingModel" is not exported by ".mastra/.build/@mastra-core-llm.mjs"
```

### Root Cause

The dependency analysis stage used treeshake: 'smallest' which removed unused functions before capturing which imports were needed. When getEmbeddingModel() was tree-shaken away, ModelRouterEmbeddingModel wasn't captured as a required export,
but the source file still had the import statement.

### Solution

Changed the analysis stage in analyzeEntry.ts from treeshake: 'smallest' to treeshake: false. This ensures all imports from source files are preserved during analysis. The final bundle stage still uses treeshake: 'safest', so the output remains
optimized.

### Trade-offs

• ✅ Fixes import errors for unused but declared imports
• ✅ Final bundle size unaffected (still tree-shaken in bundling stage)
• ⚠️ Slightly slower analysis (~100-500ms) due to analyzing more code
• ⚠️ Dead/commented code with problematic imports may trigger externals warnings

## Related Issue(s)

Fixes #9845

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bundling errors caused by premature removal of imports during build analysis. Tree‑shaking is now deferred to the bundling step so all necessary code is preserved during analysis and final bundles assemble correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->