### PR TITLE
base64 fixes for agent calls

### DIFF
--- a/.changeset/easy-squids-talk.md
+++ b/.changeset/easy-squids-talk.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': patch
+---
+
+Fix base64 encoded images with threads - issue #10480
+
+Fixed "Invalid URL" error when using base64 encoded images (without `data:` prefix) in agent calls with threads and resources. Raw base64 strings are now automatically converted to proper data URIs before being processed.
+
+**Changes:**
+- Updated `attachments-to-parts.ts` to detect and convert raw base64 strings to data URIs
+- Fixed `MessageList` image processing to handle raw base64 in two locations:
+  - Image part conversion in `aiV4CoreMessageToV1PromptMessage`
+  - File part to experimental_attachments conversion in `mastraDBMessageToAIV4UIMessage`
+- Added comprehensive tests for base64 images, data URIs, and HTTP URLs with threads
+
+**Breaking Change:** None - this is a bug fix that maintains backward compatibility while adding support for raw base64 strings.

--- a/examples/agent/src/mastra/agents/model-v2-agent.ts
+++ b/examples/agent/src/mastra/agents/model-v2-agent.ts
@@ -36,24 +36,20 @@ const memory = new Memory({
   },
 });
 
-const testAPICallError = new APICallError({
-  message: 'Test API error',
-  url: 'https://test.api.com',
-  requestBodyValues: { test: 'test' },
-  statusCode: 401,
-  isRetryable: false,
-  responseBody: 'Test API error response',
-});
+// const testAPICallError = new APICallError({
+//   message: 'Test API error',
+//   url: 'https://test.api.com',
+//   requestBodyValues: { test: 'test' },
+//   statusCode: 401,
+//   isRetryable: false,
+//   responseBody: 'Test API error response',
+// });
 
 export const errorAgent = new Agent({
   id: 'error-agent',
   name: 'Error Agent',
   instructions: 'You are an error agent that always errors',
-  model: new MockLanguageModelV2({
-    doStream: async () => {
-      throw testAPICallError;
-    },
-  }),
+  model: openai_v5('gpt-4o-mini'),
 });
 
 export const moderationProcessor = new ModerationProcessor({

--- a/packages/core/src/agent/__tests__/base64-images-with-threads.test.ts
+++ b/packages/core/src/agent/__tests__/base64-images-with-threads.test.ts
@@ -1,0 +1,412 @@
+import type { CoreMessage } from '@internal/ai-sdk-v4';
+import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai-v5/test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockMemory } from '../../memory/mock';
+import { InMemoryStore } from '../../storage';
+import { Agent } from '../agent';
+
+describe('Base64 Images with Threads - Issue #10480', () => {
+  let mockModel: MockLanguageModelV2;
+  let mockMemory: MockMemory;
+
+  beforeEach(() => {
+    mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'I can see the image' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    mockMemory = new MockMemory({
+      storage: new InMemoryStore(),
+    });
+  });
+
+  it('should handle raw base64 image strings (without data: prefix) with thread and resource', async () => {
+    // This is the exact scenario from issue #10480
+    // Raw base64 string without the "data:image/png;base64," prefix
+    const base64Image =
+      'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are a helpful assistant that can see images',
+      model: mockModel,
+      memory: mockMemory,
+    });
+
+    // Before the fix, this would throw: "Error executing step prepare-memory-step: Error: Invalid URL: iVBORw0KG..."
+    // After the fix, it should work correctly
+    const result = await agent.generate(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What do you see in this image?' },
+            {
+              type: 'image',
+              image: base64Image,
+              mimeType: 'image/png',
+            },
+          ],
+        },
+      ],
+      {
+        memory: {
+          thread: {
+            id: 'test-thread-1',
+          },
+          resource: 'test-user-1',
+        },
+      },
+    );
+
+    expect(result.text).toBe('I can see the image');
+
+    // Verify thread was created
+    const thread = await mockMemory.getThreadById({ threadId: 'test-thread-1' });
+    expect(thread).toBeDefined();
+    expect(thread?.resourceId).toBe('test-user-1');
+  });
+
+  it('should handle data URI format images with thread and resource', async () => {
+    const base64Image =
+      'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
+    const dataUri = `data:image/png;base64,${base64Image}`;
+
+    const agent = new Agent({
+      id: 'test-agent-2',
+      name: 'Test Agent 2',
+      instructions: 'You are a helpful assistant',
+      model: mockModel,
+      memory: mockMemory,
+    });
+
+    const result = await agent.generate(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Analyze this image' },
+            {
+              type: 'image',
+              image: dataUri,
+              mimeType: 'image/png',
+            },
+          ],
+        },
+      ],
+      {
+        memory: {
+          thread: {
+            id: 'test-thread-2',
+          },
+          resource: 'test-user-2',
+        },
+      },
+    );
+
+    expect(result.text).toBe('I can see the image');
+  });
+
+  it('should handle raw base64 images in stream mode with thread and resource', async () => {
+    const base64Image =
+      'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
+
+    const streamModel = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'text-delta', id: '1', delta: 'I see ' },
+          { type: 'text-delta', id: '2', delta: 'the image' },
+          {
+            type: 'finish',
+            id: '3',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'stream-agent',
+      name: 'Stream Agent',
+      instructions: 'You are a helpful assistant',
+      model: streamModel,
+      memory: mockMemory,
+    });
+
+    const stream = await agent.stream(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            {
+              type: 'image',
+              image: base64Image,
+              mimeType: 'image/png',
+            },
+          ],
+        },
+      ],
+      {
+        memory: {
+          thread: {
+            id: 'test-thread-stream',
+          },
+          resource: 'test-user-stream',
+        },
+      },
+    );
+
+    let fullText = '';
+    for await (const textPart of stream.textStream) {
+      fullText += textPart;
+    }
+
+    expect(fullText).toBe('I see the image');
+
+    // Verify thread was created
+    const thread = await mockMemory.getThreadById({ threadId: 'test-thread-stream' });
+    expect(thread).toBeDefined();
+    expect(thread?.resourceId).toBe('test-user-stream');
+  });
+
+  it('should handle multiple images with mixed formats (raw base64 and data URIs)', async () => {
+    const rawBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+    const dataUri = `data:image/jpeg;base64,${rawBase64}`;
+
+    const agent = new Agent({
+      id: 'multi-image-agent',
+      name: 'Multi Image Agent',
+      instructions: 'You are a helpful assistant',
+      model: mockModel,
+      memory: mockMemory,
+    });
+
+    const result = await agent.generate(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Compare these two images' },
+            {
+              type: 'image',
+              image: rawBase64, // Raw base64
+              mimeType: 'image/png',
+            },
+            {
+              type: 'image',
+              image: dataUri, // Data URI
+              mimeType: 'image/jpeg',
+            },
+          ],
+        },
+      ],
+      {
+        memory: {
+          thread: {
+            id: 'multi-image-thread',
+          },
+          resource: 'multi-image-user',
+        },
+      },
+    );
+
+    expect(result.text).toBe('I can see the image');
+  });
+
+  it('should handle experimental_attachments with raw base64', async () => {
+    const rawBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
+
+    const agent = new Agent({
+      id: 'attachment-agent',
+      name: 'Attachment Agent',
+      instructions: 'You are a helpful assistant',
+      model: mockModel,
+      memory: mockMemory,
+    });
+
+    // Test with experimental_attachments format
+    const messages: CoreMessage[] = [
+      {
+        role: 'user',
+        content: 'Describe the attachment',
+        experimental_attachments: [
+          {
+            url: rawBase64, // Raw base64 without data: prefix
+            contentType: 'image/png',
+            name: 'test-image.png',
+          },
+        ],
+      } as CoreMessage,
+    ];
+
+    // This should not throw "Invalid URL" error
+    const result = await agent.generate(messages, {
+      memory: {
+        thread: {
+          id: 'attachment-thread',
+        },
+        resource: 'attachment-user',
+      },
+    });
+
+    expect(result.text).toBe('I can see the image');
+  });
+
+  it('should handle HTTP image URLs with thread and resource', async () => {
+    // Use a real placeholder image service that actually works
+    const imageUrl = 'https://placehold.co/600x400/png';
+
+    const urlModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'I can see the image' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'url-agent',
+      name: 'URL Agent',
+      instructions: 'You are a helpful assistant',
+      model: urlModel,
+      memory: mockMemory,
+    });
+
+    const result = await agent.generate(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image from the URL?' },
+            {
+              type: 'image',
+              image: imageUrl,
+              mimeType: 'image/png',
+            },
+          ],
+        },
+      ],
+      {
+        memory: {
+          thread: {
+            id: 'url-thread',
+          },
+          resource: 'url-user',
+        },
+      },
+    );
+
+    expect(result.text).toBe('I can see the image');
+
+    // Verify thread was created
+    const thread = await mockMemory.getThreadById({ threadId: 'url-thread' });
+    expect(thread).toBeDefined();
+    expect(thread?.resourceId).toBe('url-user');
+  }, 10000);
+
+  it('should handle mixed URL and base64 images with thread and resource', async () => {
+    const placeholderUrl = 'https://placehold.co/400x300/png';
+    const rawBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+    const mixedModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'I can see the image' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'mixed-agent',
+      name: 'Mixed Agent',
+      instructions: 'You are a helpful assistant',
+      model: mixedModel,
+      memory: mockMemory,
+    });
+
+    const result = await agent.generate(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Compare these images' },
+            {
+              type: 'image',
+              image: placeholderUrl,
+              mimeType: 'image/png',
+            },
+            {
+              type: 'image',
+              image: rawBase64,
+              mimeType: 'image/png',
+            },
+          ],
+        },
+      ],
+      {
+        memory: {
+          thread: {
+            id: 'mixed-thread',
+          },
+          resource: 'mixed-user',
+        },
+      },
+    );
+
+    expect(result.text).toBe('I can see the image');
+  }, 10000);
+
+  it('should handle experimental_attachments with HTTP URLs', async () => {
+    const imageUrl = 'https://placehold.co/800x600/png';
+
+    const agent = new Agent({
+      id: 'url-attachment-agent',
+      name: 'URL Attachment Agent',
+      instructions: 'You are a helpful assistant',
+      model: mockModel,
+      memory: mockMemory,
+    });
+
+    const messages: CoreMessage[] = [
+      {
+        role: 'user',
+        content: 'Describe this product image',
+        experimental_attachments: [
+          {
+            url: imageUrl,
+            contentType: 'image/png',
+            name: 'product.png',
+          },
+        ],
+      } as CoreMessage,
+    ];
+
+    const result = await agent.generate(messages, {
+      memory: {
+        thread: {
+          id: 'url-attachment-thread',
+        },
+        resource: 'url-attachment-user',
+      },
+    });
+
+    expect(result.text).toBe('I can see the image');
+  });
+});

--- a/packages/core/src/agent/message-list/prompt/attachments-to-parts.test.ts
+++ b/packages/core/src/agent/message-list/prompt/attachments-to-parts.test.ts
@@ -1,0 +1,286 @@
+import type { Attachment } from '@ai-sdk/ui-utils-v5';
+import type { FilePart, ImagePart } from 'ai-v5';
+import { describe, it, expect } from 'vitest';
+import { attachmentsToParts } from './attachments-to-parts';
+
+describe('attachmentsToParts', () => {
+  it('should handle regular HTTP URLs', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 'https://example.com/image.png',
+        contentType: 'image/png',
+        name: 'image.png',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toMatchObject({
+      type: 'image',
+      image: 'https://example.com/image.png',
+      mimeType: 'image/png',
+    });
+  });
+
+  it('should handle data URIs', () => {
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+    const dataUri = `data:image/png;base64,${base64Data}`;
+
+    const attachments: Attachment[] = [
+      {
+        url: dataUri,
+        contentType: 'image/png',
+        name: 'pixel.png',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+    });
+    expect((parts[0] as ImagePart).image).toContain('data:image/png;base64,');
+  });
+
+  it('should handle raw base64 strings by converting them to data URIs', () => {
+    // This is the bug from issue #10480
+    // Raw base64 string without the data: prefix should be automatically converted
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
+
+    const attachments: Attachment[] = [
+      {
+        url: base64Data,
+        contentType: 'image/png',
+        name: 'test.png',
+      },
+    ];
+
+    // This should NOT throw "Invalid URL" error anymore
+    expect(() => attachmentsToParts(attachments)).not.toThrow();
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+
+    const imagePart = parts[0] as ImagePart;
+
+    expect(imagePart).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+    });
+    // The raw base64 should be converted to a proper data URI
+    expect(imagePart.image).toContain('data:image/png;base64,');
+    expect(imagePart.image).toContain(base64Data);
+  });
+
+  it('should handle raw base64 strings for non-image files', () => {
+    const base64Data = 'SGVsbG8gV29ybGQh'; // "Hello World!" in base64
+
+    const attachments: Attachment[] = [
+      {
+        url: base64Data,
+        contentType: 'text/plain',
+        name: 'hello.txt',
+      },
+    ];
+
+    expect(() => attachmentsToParts(attachments)).not.toThrow();
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+
+    const filePart = parts[0] as unknown as FilePart;
+
+    expect(filePart).toMatchObject({
+      type: 'file',
+      mimeType: 'text/plain',
+    });
+    expect(filePart.data).toContain('data:text/plain;base64,');
+    expect(filePart.data).toContain(base64Data);
+  });
+
+  it('should handle multiple attachments with mixed formats', () => {
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+    const dataUri = `data:image/jpeg;base64,${base64Data}`;
+    const httpUrl = 'https://example.com/image.png';
+
+    const attachments: Attachment[] = [
+      {
+        url: httpUrl,
+        contentType: 'image/png',
+        name: 'remote.png',
+      },
+      {
+        url: dataUri,
+        contentType: 'image/jpeg',
+        name: 'data-uri.jpg',
+      },
+      {
+        url: base64Data,
+        contentType: 'image/gif',
+        name: 'raw-base64.gif',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(3);
+
+    const imagePart0 = parts[0] as unknown as ImagePart;
+
+    // First: HTTP URL
+    expect(imagePart0).toMatchObject({
+      type: 'image',
+      image: httpUrl,
+      mimeType: 'image/png',
+    });
+
+    const imagePart1 = parts[1] as unknown as ImagePart;
+
+    // Second: Data URI
+    expect(imagePart1).toMatchObject({
+      type: 'image',
+      mimeType: 'image/jpeg',
+    });
+    expect(imagePart1.image).toContain('data:image/jpeg;base64,');
+
+    const imagePart2 = parts[2] as unknown as ImagePart;
+
+    // Third: Raw base64 (should be converted to data URI)
+    expect(imagePart2).toMatchObject({
+      type: 'image',
+      mimeType: 'image/gif',
+    });
+    expect(imagePart2.image).toContain('data:image/gif;base64,');
+  });
+
+  it('should throw error for raw base64 without contentType', () => {
+    const base64Data = 'SGVsbG8gV29ybGQh';
+
+    const attachments: Attachment[] = [
+      {
+        url: base64Data,
+        contentType: undefined as any, // Simulating missing contentType
+        name: 'unknown.bin',
+      },
+    ];
+
+    // Without contentType for non-image/text files, it should throw an error
+    expect(() => attachmentsToParts(attachments)).toThrow(
+      'If the attachment is not an image or text, it must specify a content type',
+    );
+  });
+
+  it('should handle HTTPS URLs with query parameters', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 'https://example.com/image.png?size=large&format=webp',
+        contentType: 'image/png',
+        name: 'image.png',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const imagePart = parts[0] as ImagePart;
+    expect(imagePart).toMatchObject({
+      type: 'image',
+      image: 'https://example.com/image.png?size=large&format=webp',
+      mimeType: 'image/png',
+    });
+  });
+
+  it('should handle HTTP URLs (not just HTTPS)', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 'http://example.com/photo.jpg',
+        contentType: 'image/jpeg',
+        name: 'photo.jpg',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const imagePart = parts[0] as ImagePart;
+    expect(imagePart).toMatchObject({
+      type: 'image',
+      image: 'http://example.com/photo.jpg',
+      mimeType: 'image/jpeg',
+    });
+  });
+
+  it('should handle non-image file URLs', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 'https://example.com/document.pdf',
+        contentType: 'application/pdf',
+        name: 'document.pdf',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const filePart = parts[0] as unknown as FilePart;
+    expect(filePart).toMatchObject({
+      type: 'file',
+      data: 'https://example.com/document.pdf',
+      mimeType: 'application/pdf',
+    });
+  });
+
+  it('should handle URLs with various image formats', () => {
+    const imageFormats = [
+      { url: 'https://example.com/image.webp', contentType: 'image/webp', name: 'image.webp' },
+      { url: 'https://example.com/image.gif', contentType: 'image/gif', name: 'image.gif' },
+      { url: 'https://example.com/image.svg', contentType: 'image/svg+xml', name: 'image.svg' },
+      { url: 'https://example.com/image.bmp', contentType: 'image/bmp', name: 'image.bmp' },
+    ];
+
+    const parts = attachmentsToParts(imageFormats);
+    expect(parts).toHaveLength(4);
+
+    imageFormats.forEach((format, index) => {
+      const imagePart = parts[index] as ImagePart;
+      expect(imagePart).toMatchObject({
+        type: 'image',
+        image: format.url,
+        mimeType: format.contentType,
+      });
+    });
+  });
+
+  it('should handle URLs with special characters', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 'https://example.com/images/my%20image%20(1).png',
+        contentType: 'image/png',
+        name: 'my image (1).png',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const imagePart = parts[0] as ImagePart;
+    expect(imagePart.image).toBe('https://example.com/images/my%20image%20(1).png');
+  });
+
+  it('should not convert URLs to data URIs', () => {
+    // URLs should remain as URLs, not be converted to data URIs
+    const attachments: Attachment[] = [
+      {
+        url: 'https://example.com/image.png',
+        contentType: 'image/png',
+        name: 'image.png',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    const imagePart = parts[0] as ImagePart;
+
+    // Should still be a URL, not a data URI
+    expect(imagePart.image).toMatch(/^https?:\/\//);
+    expect(imagePart.image).not.toContain('data:');
+  });
+});

--- a/packages/core/src/agent/message-list/prompt/attachments-to-parts.ts
+++ b/packages/core/src/agent/message-list/prompt/attachments-to-parts.ts
@@ -1,5 +1,6 @@
 import type { Attachment } from '@ai-sdk/ui-utils-v5';
 import type { FilePart, ImagePart, TextPart } from '@internal/ai-sdk-v4';
+import { categorizeFileData, createDataUri } from './image-utils';
 
 type ContentPart = TextPart | ImagePart | FilePart;
 
@@ -12,10 +13,18 @@ export function attachmentsToParts(attachments: Attachment[]): ContentPart[] {
   const parts: ContentPart[] = [];
 
   for (const attachment of attachments) {
-    let url;
+    // Categorize the attachment URL to determine if it's a URL, data URI, or raw base64
+    const categorized = categorizeFileData(attachment.url, attachment.contentType);
 
+    // If it's raw data (base64), convert it to a data URI
+    let urlString = attachment.url;
+    if (categorized.type === 'raw') {
+      urlString = createDataUri(attachment.url, attachment.contentType || 'application/octet-stream');
+    }
+
+    let url;
     try {
-      url = new URL(attachment.url);
+      url = new URL(urlString);
     } catch {
       throw new Error(`Invalid URL: ${attachment.url}`);
     }
@@ -43,13 +52,13 @@ export function attachmentsToParts(attachments: Attachment[]): ContentPart[] {
         if (attachment.contentType?.startsWith('image/')) {
           parts.push({
             type: 'image',
-            image: attachment.url,
+            image: urlString,
             mimeType: attachment.contentType,
           });
         } else if (attachment.contentType?.startsWith('text/')) {
           parts.push({
             type: 'file',
-            data: attachment.url,
+            data: urlString,
             mimeType: attachment.contentType,
           });
         } else {
@@ -59,7 +68,7 @@ export function attachmentsToParts(attachments: Attachment[]): ContentPart[] {
 
           parts.push({
             type: 'file',
-            data: attachment.url,
+            data: urlString,
             mimeType: attachment.contentType,
           });
         }


### PR DESCRIPTION
base64 encoded images

Fixes #10480

Fixed "Invalid URL" error when using base64 encoded images (without `data:` prefix) in agent calls with threads and resources. Raw base64 strings are now automatically converted to proper data URIs before being processed.

**Changes:**
- Updated `attachments-to-parts.ts` to detect and convert raw base64 strings to data URIs
- Fixed `MessageList` image processing to handle raw base64 in two locations:
  - Image part conversion in `aiV4CoreMessageToV1PromptMessage`
  - File part to experimental_attachments conversion in `mastraDBMessageToAIV4UIMessage`
- Added comprehensive tests for base64 images, data URIs, and HTTP URLs with threads

**Breaking Change:** None - this is a bug fix that maintains backward compatibility while adding support for raw base64 strings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved attachment handling: agents now accept raw base64, data URIs, and HTTP/HTTPS URLs consistently, preserving mime types.

* **Bug Fixes**
  * Fixed "Invalid URL" errors when sending raw base64 images in threaded conversations by auto-converting to valid data URIs.

* **Tests**
  * Added broad test coverage for image/file attachments, mixed formats, streaming, and thread/resource handling.

* **Chores**
  * Added changelog entry for the patch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->