### PR TITLE
add table support to markdown transformer

### DIFF
--- a/.changeset/add-markdown-table-support.md
+++ b/.changeset/add-markdown-table-support.md
@@ -1,0 +1,46 @@
+---
+'@mastra/rag': patch
+---
+
+Add table support to markdown transformer
+
+Added support for markdown tables in the `MarkdownHeaderTransformer` to prevent tables from being split in the middle during document chunking. Tables are now treated as semantic units similar to code blocks.
+
+**Changes:**
+- Updated `MarkdownHeaderTransformer` to detect and preserve markdown tables during chunking
+- Tables are identified by lines containing pipe characters (`|`)
+- Tables are kept together as a single block, preventing splits that would break table structure
+- Added comprehensive test coverage for table handling in various scenarios
+- Works with both simple and complex tables, including multi-row tables and tables with different formatting
+
+**Usage:**
+```typescript
+import { MDocument } from '@mastra/rag';
+
+const doc = MDocument.fromMarkdown(`
+# Data Report
+
+## Results
+
+| Name | Score | Status |
+|------|-------|--------|
+| Alice | 95   | Pass   |
+| Bob   | 87   | Pass   |
+| Carol | 78   | Pass   |
+
+## Summary
+
+The results show...
+`);
+
+const chunks = await doc.chunk({
+  strategy: 'markdown',
+  headers: [
+    ['#', 'title'],
+    ['##', 'section'],
+  ],
+});
+
+// Tables will now be preserved intact within chunks
+```
+

--- a/packages/rag/src/document/transformers/markdown.test.ts
+++ b/packages/rag/src/document/transformers/markdown.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { MarkdownHeaderTransformer, MarkdownTransformer } from './markdown';
+
+describe('MarkdownHeaderTransformer', () => {
+  describe('table support', () => {
+    it('should keep tables together when splitting markdown', () => {
+      const transformer = new MarkdownHeaderTransformer([
+        ['#', 'Header 1'],
+        ['##', 'Header 2'],
+      ]);
+
+      const markdown = `# Introduction
+
+This is some intro text.
+
+## Data Table
+
+Here is a table:
+
+| Name | Age | City |
+|------|-----|------|
+| John | 30  | NYC  |
+| Jane | 25  | LA   |
+| Bob  | 35  | SF   |
+
+## Conclusion
+
+This is the conclusion.`;
+
+      const result = transformer.splitText({ text: markdown });
+
+      // Find the chunk with the table
+      const tableChunk = result.find(doc => doc.text.includes('| Name | Age | City |'));
+
+      expect(tableChunk).toBeDefined();
+      // Verify the entire table is in one chunk
+      expect(tableChunk?.text).toContain('| Name | Age | City |');
+      expect(tableChunk?.text).toContain('|------|-----|------|');
+      expect(tableChunk?.text).toContain('| John | 30  | NYC  |');
+      expect(tableChunk?.text).toContain('| Jane | 25  | LA   |');
+      expect(tableChunk?.text).toContain('| Bob  | 35  | SF   |');
+    });
+
+    it('should handle tables without surrounding text', () => {
+      const transformer = new MarkdownHeaderTransformer([['##', 'Header']]);
+
+      const markdown = `## Table Section
+
+| Col1 | Col2 |
+|------|------|
+| A    | B    |`;
+
+      const result = transformer.splitText({ text: markdown });
+
+      expect(result.length).toBeGreaterThan(0);
+      const chunk = result[0];
+      expect(chunk?.text).toContain('| Col1 | Col2 |');
+      expect(chunk?.text).toContain('| A    | B    |');
+    });
+
+    it('should handle multiple tables in different sections', () => {
+      const transformer = new MarkdownHeaderTransformer([['##', 'Section']]);
+
+      const markdown = `## First Section
+
+| A | B |
+|---|---|
+| 1 | 2 |
+
+## Second Section
+
+| C | D |
+|---|---|
+| 3 | 4 |`;
+
+      const result = transformer.splitText({ text: markdown });
+
+      expect(result.length).toBe(2);
+      expect(result[0]?.text).toContain('| A | B |');
+      expect(result[0]?.text).toContain('| 1 | 2 |');
+      expect(result[1]?.text).toContain('| C | D |');
+      expect(result[1]?.text).toContain('| 3 | 4 |');
+    });
+
+    it('should not split tables across chunks', () => {
+      const transformer = new MarkdownHeaderTransformer([['#', 'Header']]);
+
+      const markdown = `# Section
+
+Before table text.
+
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Row 1 A  | Row 1 B  | Row 1 C  |
+| Row 2 A  | Row 2 B  | Row 2 C  |
+| Row 3 A  | Row 3 B  | Row 3 C  |
+
+After table text.`;
+
+      const result = transformer.splitText({ text: markdown });
+
+      // All table rows should be in the same chunk
+      const chunkWithTable = result.find(doc => doc.text.includes('| Header 1 | Header 2 | Header 3 |'));
+      expect(chunkWithTable).toBeDefined();
+      expect(chunkWithTable?.text).toContain('| Row 1 A  | Row 1 B  | Row 1 C  |');
+      expect(chunkWithTable?.text).toContain('| Row 2 A  | Row 2 B  | Row 2 C  |');
+      expect(chunkWithTable?.text).toContain('| Row 3 A  | Row 3 B  | Row 3 C  |');
+    });
+
+    it('should handle tables within code blocks correctly', () => {
+      const transformer = new MarkdownHeaderTransformer([['##', 'Section']]);
+
+      const markdown = `## Code Example
+
+\`\`\`markdown
+| Fake | Table |
+|------|-------|
+| In   | Code  |
+\`\`\`
+
+## Real Table
+
+| Real | Table |
+|------|-------|
+| With | Data  |`;
+
+      const result = transformer.splitText({ text: markdown });
+
+      // The code block should be treated as code, not as a table
+      const codeChunk = result.find(doc => doc.text.includes('```markdown'));
+      expect(codeChunk).toBeDefined();
+      expect(codeChunk?.text).toContain('| Fake | Table |');
+
+      // The real table should also be present
+      const tableChunk = result.find(doc => doc.text.includes('| Real | Table |') && !doc.text.includes('```'));
+      expect(tableChunk).toBeDefined();
+      expect(tableChunk?.text).toContain('| With | Data  |');
+    });
+
+    it('should handle empty lines within table context', () => {
+      const transformer = new MarkdownHeaderTransformer([['#', 'Header']]);
+
+      const markdown = `# Data
+
+| Col1 | Col2 |
+|------|------|
+| A    | B    |
+| C    | D    |
+
+After the table.`;
+
+      const result = transformer.splitText({ text: markdown });
+
+      const tableChunk = result.find(doc => doc.text.includes('| Col1 | Col2 |'));
+      expect(tableChunk).toBeDefined();
+      expect(tableChunk?.text).toContain('| A    | B    |');
+      expect(tableChunk?.text).toContain('| C    | D    |');
+      // The "After the table" should be in the same chunk since it's under the same header
+      expect(tableChunk?.text).toContain('After the table.');
+    });
+  });
+
+  describe('metadata', () => {
+    it('should preserve header metadata for chunks with tables', () => {
+      const transformer = new MarkdownHeaderTransformer([
+        ['#', 'Title'],
+        ['##', 'Section'],
+      ]);
+
+      const markdown = `# My Document
+
+## Introduction
+
+| Feature | Status |
+|---------|--------|
+| Tables  | Added  |`;
+
+      const result = transformer.splitText({ text: markdown });
+
+      const tableChunk = result.find(doc => doc.text.includes('| Feature | Status |'));
+      expect(tableChunk).toBeDefined();
+      expect(tableChunk?.metadata).toEqual({
+        Title: 'My Document',
+        Section: 'Introduction',
+      });
+    });
+  });
+});
+
+describe('MarkdownTransformer', () => {
+  it('should handle markdown with tables using recursive character splitting', () => {
+    const transformer = new MarkdownTransformer({ maxSize: 1000 });
+
+    const markdown = `# Introduction
+
+Some text before the table.
+
+| Name | Value |
+|------|-------|
+| A    | 1     |
+| B    | 2     |
+
+Some text after the table.`;
+
+    const docs = transformer.createDocuments([markdown]);
+
+    expect(docs.length).toBeGreaterThan(0);
+    // At least one document should contain table content
+    const hasTableContent = docs.some(doc => doc.text.includes('|') && doc.text.includes('Name'));
+    expect(hasTableContent).toBe(true);
+  });
+});

--- a/packages/rag/src/document/transformers/markdown.ts
+++ b/packages/rag/src/document/transformers/markdown.ts
@@ -99,11 +99,13 @@ export class MarkdownHeaderTransformer {
 
     let inCodeBlock = false;
     let openingFence = '';
+    let inTable = false;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
       const strippedLine = line.trim();
 
+      // Handle code blocks
       if (!inCodeBlock) {
         if (
           (strippedLine.startsWith('```') && strippedLine.split('```').length === 2) ||
@@ -122,6 +124,21 @@ export class MarkdownHeaderTransformer {
       if (inCodeBlock) {
         currentContent.push(line);
         continue;
+      }
+
+      // Handle markdown tables
+      // A table line must contain at least one pipe character and not be empty
+      const isTableLine = strippedLine.includes('|') && strippedLine.length > 0;
+
+      if (isTableLine) {
+        if (!inTable) {
+          inTable = true;
+        }
+        currentContent.push(line);
+        continue;
+      } else if (inTable) {
+        // We were in a table but this line is not a table line, so the table has ended
+        inTable = false;
       }
 
       let headerMatched = false;


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/8294

add table support to markdown transformer

Added support for markdown tables in the `MarkdownHeaderTransformer` to prevent tables from being split in the middle during document chunking. Tables are now treated as semantic units similar to code blocks.

**Changes:**
- Updated `MarkdownHeaderTransformer` to detect and preserve markdown tables during chunking
- Tables are identified by lines containing pipe characters (`|`)
- Tables are kept together as a single block, preventing splits that would break table structure
- Added comprehensive test coverage for table handling in various scenarios
- Works with both simple and complex tables, including multi-row tables and tables with different formatting

**Usage:**
```typescript
import { MDocument } from '@mastra/rag';

const doc = MDocument.fromMarkdown(`
# Data Report
## Results
| Name | Score | Status |
|------|-------|--------|
| Alice | 95   | Pass   |
| Bob   | 87   | Pass   |
| Carol | 78   | Pass   |
## Summary
The results show...
`);

const chunks = await doc.chunk({
  strategy: 'markdown',
  headers: [
    ['#', 'title'],
    ['##', 'section'],
  ],
});

// Tables will now be preserved intact within chunks
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown table support. Tables are now recognized and preserved as complete units during document processing to prevent splits that would break table structure. Enhanced handling ensures tables within multiple sections and combined with surrounding content remain properly formatted and readable. Metadata is correctly maintained for all chunks containing tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->