### PR TITLE
message metadata

### DIFF
--- a/.changeset/four-turkeys-win.md
+++ b/.changeset/four-turkeys-win.md
@@ -1,0 +1,12 @@
+---
+'@mastra/core': patch
+---
+
+Fix message metadata not persisting when using simple message format. Previously, custom metadata passed in messages (e.g., `{role: 'user', content: 'text', metadata: {userId: '123'}}`) was not being saved to the database. This occurred because the CoreMessage conversion path didn't preserve metadata fields.
+
+Now metadata is properly preserved for all message input formats:
+- Simple CoreMessage format: `{role, content, metadata}`
+- Full UIMessage format: `{role, content, parts, metadata}`
+- AI SDK v5 ModelMessage format with metadata
+
+Fixes #8556

--- a/packages/core/src/agent/__tests__/uimessage.test.ts
+++ b/packages/core/src/agent/__tests__/uimessage.test.ts
@@ -298,7 +298,7 @@ function uiMessageTest(version: 'v1' | 'v2') {
 
     it('should handle content as string', async () => {
       const agent = new Agent({
-        name: 'mixed-metadata-agent',
+        name: 'simple-content-agent',
         instructions: 'You are a helpful assistant',
         model: dummyModel,
         memory: mockMemory,
@@ -317,9 +317,9 @@ function uiMessageTest(version: 'v1' | 'v2') {
           ],
           {
             memory: {
-              resource: 'mixed-user',
+              resource: 'simple-content-user',
               thread: {
-                id: 'mixed-thread',
+                id: 'simple-content-thread',
               },
             },
           },
@@ -337,9 +337,9 @@ function uiMessageTest(version: 'v1' | 'v2') {
           ],
           {
             memory: {
-              resource: 'mixed-user',
+              resource: 'simple-content-user',
               thread: {
-                id: 'mixed-thread',
+                id: 'simple-content-thread',
               },
             },
           },
@@ -347,12 +347,30 @@ function uiMessageTest(version: 'v1' | 'v2') {
       }
 
       const result = await mockMemory.recall({
-        threadId: 'mixed-thread',
-        resourceId: 'mixed-user',
+        threadId: 'simple-content-thread',
+        resourceId: 'simple-content-user',
         perPage: 10,
       });
 
       expect(result?.messages.length).toBeGreaterThan(0);
+
+      // Find the user message
+      const userMessage = result.messages.find(m => m.role === 'user');
+      expect(userMessage).toBeDefined();
+
+      // Verify metadata was preserved in the simple content-only format
+      if (
+        userMessage &&
+        'content' in userMessage &&
+        typeof userMessage.content === 'object' &&
+        'metadata' in userMessage.content
+      ) {
+        expect(userMessage.content.metadata).toEqual({
+          foo: 'bar',
+        });
+      } else {
+        throw new Error('Expected user message to have content.metadata field');
+      }
     });
   });
 }

--- a/packages/core/src/agent/__tests__/uimessage.test.ts
+++ b/packages/core/src/agent/__tests__/uimessage.test.ts
@@ -309,7 +309,6 @@ function uiMessageTest(version: 'v1' | 'v2') {
             {
               role: 'user',
               content: 'First message with metadata',
-              parts: [{ type: 'text' as const, text: 'First message with metadata' }],
               metadata: {
                 foo: 'bar',
               },

--- a/packages/core/src/agent/__tests__/uimessage.test.ts
+++ b/packages/core/src/agent/__tests__/uimessage.test.ts
@@ -1,7 +1,8 @@
 import { simulateReadableStream, MockLanguageModelV1 } from '@internal/ai-sdk-v4';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { MastraDBMessage, MockMemory } from '../../memory';
+import type { MastraDBMessage } from '../../memory';
+import { MockMemory } from '../../memory';
 import { Agent } from '../agent';
 
 function uiMessageTest(version: 'v1' | 'v2') {

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -1707,6 +1707,11 @@ export class MessageList {
       content.providerMetadata = coreMessage.providerOptions;
     }
 
+    // Preserve metadata field if present (matches aiV4UIMessageToMastraDBMessage behavior)
+    if ('metadata' in coreMessage && coreMessage.metadata !== null && coreMessage.metadata !== undefined) {
+      content.metadata = coreMessage.metadata as Record<string, unknown>;
+    }
+
     return {
       id,
       role: MessageList.getRole(coreMessage),
@@ -2818,8 +2823,11 @@ export class MessageList {
       .map(p => p.text)
       .join('\n');
 
-    // Store original content in metadata for round-trip
-    const metadata: Record<string, unknown> = {};
+    // Preserve metadata from the input message if present
+    const metadata: Record<string, unknown> =
+      'metadata' in modelMsg && modelMsg.metadata !== null && modelMsg.metadata !== undefined
+        ? (modelMsg.metadata as Record<string, unknown>)
+        : {};
 
     // Generate ID from modelMsg if available, otherwise create a new one
     const id =
@@ -2838,7 +2846,7 @@ export class MessageList {
         reasoning: reasoningParts.length > 0 ? reasoningParts.join('\n') : undefined,
         experimental_attachments: experimental_attachments.length > 0 ? experimental_attachments : undefined,
         content: contentString || undefined,
-        metadata,
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
       },
     };
     // Add message-level providerOptions if present (AIV5 ModelMessage uses providerOptions)

--- a/packages/core/src/agent/message-list/tests/message-list-url-handling.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-url-handling.test.ts
@@ -5,7 +5,7 @@ import { MessageList } from '../index';
 describe('MessageList - File URL Handling', () => {
   it('should preserve external URLs through V2->V3->V2 message conversion', () => {
     const messageList = new MessageList();
-    const imageUrl = 'https://httpbin.org/image/png';
+    const imageUrl = 'https://placehold.co/10.png';
 
     // Create a V2 message with a file part containing a URL
     const v2Message: MastraDBMessage = {
@@ -51,7 +51,7 @@ describe('MessageList - File URL Handling', () => {
 
   it('should provide clean URLs to InputProcessors without data URI corruption', () => {
     const messageList = new MessageList();
-    const imageUrl = 'https://httpbin.org/image/png';
+    const imageUrl = 'https://placehold.co/10.png';
 
     // Simulate what happens when stream receives messages with file parts
     const inputMessage: MastraDBMessage = {
@@ -90,7 +90,7 @@ describe('MessageList - File URL Handling', () => {
   });
 
   it('should correctly differentiate between URLs and base64 data', () => {
-    const imageUrl = 'https://httpbin.org/image/png';
+    const imageUrl = 'https://placehold.co/10.png';
     const base64Data =
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
     const dataUri = `data:image/png;base64,${base64Data}`;
@@ -161,7 +161,7 @@ describe('MessageList - File URL Handling', () => {
 
   it('should preserve URLs for providers that support them natively', async () => {
     const messageList = new MessageList();
-    const imageUrl = 'https://httpbin.org/image/png';
+    const imageUrl = 'https://placehold.co/10.png';
 
     // Add message with URL
     const v2Message: MastraDBMessage = {
@@ -183,7 +183,7 @@ describe('MessageList - File URL Handling', () => {
 
     // Test with provider that supports URLs (like OpenAI)
     const supportedUrls = {
-      'image/png': [/^https:\/\/httpbin\.org\//],
+      'image/png': [/^https:\/\/placehold\.co\//],
     };
 
     const llmPrompt = await messageList.get.all.aiV5.llmPrompt({
@@ -213,7 +213,7 @@ describe('MessageList - File URL Handling', () => {
     },
     async () => {
       const messageList = new MessageList();
-      const imageUrl = 'https://httpbin.org/image/png';
+      const imageUrl = 'https://placehold.co/10.png';
 
       // Add message with URL
       const v2Message: MastraDBMessage = {


### PR DESCRIPTION
Fix message metadata not persisting when using simple message format. Previously, custom metadata passed in messages (e.g., `{role: 'user', content: 'text', metadata: {userId: '123'}}`) was not being saved to the database. This occurred because the CoreMessage conversion path didn't preserve metadata fields.

Now metadata is properly preserved for all message input formats:
- Simple CoreMessage format: `{role, content, metadata}`
- Full UIMessage format: `{role, content, parts, metadata}`
- AI SDK v5 ModelMessage format with metadata

Fixes #8556


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message metadata is now reliably persisted and preserved across all message format conversions and SDK versions.

* **Tests**
  * Added coverage for string-content messages preserving metadata.
  * Updated test fixtures and URL expectations to a new stable image source.

* **Documentation**
  * Added a changelog entry noting the metadata persistence fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->