### PR TITLE
fix(core): preserve GPT-5 reasoning itemId for Responses API compatibility

### DIFF
--- a/.changeset/mighty-kings-sip.md
+++ b/.changeset/mighty-kings-sip.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixes GPT-5 reasoning which was failing on subsequent tool calls with the error:
+
+```
+Item 'fc_xxx' of type 'function_call' was provided without its required 'reasoning' item: 'rs_xxx'
+```

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -70,7 +70,7 @@ describe('Branch with Map Bug - Issue #10407', () => {
       .branch([[async ({ inputData }) => inputData.value > 10, workflowAWithMap]])
       .commit();
 
-    const run = await mainWorkflowWithMapBug.createRun();
+    const run = await mainWorkflowWithMapBug.createRunAsync();
     const result = await run.start({
       inputData: { value: 15 }, // Should trigger workflowA
     });


### PR DESCRIPTION
Fixes #9005

Fixes GPT-5 reasoning which was failing on subsequent tool calls with the error:
```
Item 'fc_xxx' of type 'function_call' was provided without its required 'reasoning' item: 'rs_xxx'
```

The issue was twofold:

1. GPT-5 often produces "empty" reasoning (reasoning-start/end events with providerMetadata but no content). We were skipping these, but OpenAI still requires them in the history.

2. When converting UI messages back to model messages, we weren't restoring `providerOptions` on reasoning parts (only on tool-call parts).

Now empty reasoning with providerMetadata gets stored, and reasoning parts get their `providerOptions.openai.itemId` restored through the round-trip:

```typescript
// Before: reasoning skipped if no deltas
if (runState.state.reasoningDeltas.length > 0) { ... }

// After: reasoning included if it has providerMetadata (contains itemId)
if (hasReasoningDeltas || hasProviderMetadata) { ... }
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures GPT-5 reasoning parts (with itemId) are stored and restored across stream, memory, and V5 UI↔Model conversions to prevent function_call/reasoning pairing errors.
> 
> - **AI V5 message handling**:
>   - Include `reasoning` parts when `providerMetadata` exists, even with empty text/details (`packages/core/src/agent/message-list/index.ts`).
>   - Restore `providerOptions` for `reasoning` parts (and keep for `tool-call`) during V5 UI → Model conversion to retain OpenAI `itemId`.
> - **Streaming/LLM execution**:
>   - On `reasoning-end`, always add a `reasoning` part if `providerMetadata` is present; conditionally include text from accumulated deltas (`packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`).
> - **Tests**:
>   - Add comprehensive GPT-5 compatibility tests verifying preservation of reasoning `itemId`, ordering before tool calls, and round-trips via memory (`message-list-v5.test.ts`, `agent-memory.test.ts`).
>   - Minor test fix: use `createRunAsync` (`packages/core/src/workflows/branch-map-bug.test.ts`).
> - **Release**:
>   - Patch changeset for `@mastra/core`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f78939fa9d81ff0abde46e80b000f606dbcf5cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->