### PR TITLE
fix(storage): sort messages by createdAt in Upstash and Cloudflare listMessages

### DIFF
--- a/.changeset/icy-moons-invite.md
+++ b/.changeset/icy-moons-invite.md
@@ -1,0 +1,6 @@
+---
+'@mastra/cloudflare': patch
+'@mastra/upstash': patch
+---
+
+Fix message sorting in listMessages when using semantic recall (include parameter). Messages are now always sorted by createdAt instead of storage order, ensuring correct chronological ordering of conversation history.

--- a/stores/_test-utils/src/domains/memory/messages-list.ts
+++ b/stores/_test-utils/src/domains/memory/messages-list.ts
@@ -569,5 +569,162 @@ export function createMessagesListTest({ storage }: { storage: MastraStorage }) 
         expect(resultNeg.perPage).toBe(40); // Verify fallback to default value
       });
     });
+
+    describe('include parameter with separate batch saves', () => {
+      it('should sort messages by createdAt when include adds messages saved in different batches', async () => {
+        const testThread = createSampleThread();
+        await storage.saveThread({ thread: testThread });
+
+        const now = Date.now();
+
+        // Save first batch: messages 1, 2, 3 (chronologically oldest)
+        const batch1 = [
+          createSampleMessageV2({
+            threadId: testThread.id,
+            resourceId: testThread.resourceId,
+            role: 'user',
+            content: { content: 'User message 1' },
+            createdAt: new Date(now + 1000),
+          }),
+          createSampleMessageV2({
+            threadId: testThread.id,
+            resourceId: testThread.resourceId,
+            role: 'assistant',
+            content: { content: 'Assistant message 1' },
+            createdAt: new Date(now + 2000),
+          }),
+          createSampleMessageV2({
+            threadId: testThread.id,
+            resourceId: testThread.resourceId,
+            role: 'user',
+            content: { content: 'User message 2' },
+            createdAt: new Date(now + 3000),
+          }),
+        ];
+        await storage.saveMessages({ messages: batch1 });
+
+        // Save second batch: messages 4, 5 (chronologically newer)
+        const batch2 = [
+          createSampleMessageV2({
+            threadId: testThread.id,
+            resourceId: testThread.resourceId,
+            role: 'assistant',
+            content: { content: 'Assistant message 2' },
+            createdAt: new Date(now + 4000),
+          }),
+          createSampleMessageV2({
+            threadId: testThread.id,
+            resourceId: testThread.resourceId,
+            role: 'user',
+            content: { content: 'User message 3' },
+            createdAt: new Date(now + 5000),
+          }),
+        ];
+        await storage.saveMessages({ messages: batch2 });
+
+        // Now retrieve with pagination (only get latest 2) and include an older message
+        // This simulates what semantic recall does
+        const result = await storage.listMessages({
+          threadId: testThread.id,
+          perPage: 2,
+          page: 0,
+          // Default orderBy (not specified) - should default to createdAt ASC
+          include: [
+            {
+              id: batch1[0]!.id, // Include oldest user message
+              withNextMessages: 1, // Also get the assistant response after it
+            },
+          ],
+        });
+
+        // Should have: paginated (2) + included (2, but 1 might overlap)
+        // The key assertion: messages MUST be sorted by createdAt ASC
+        const contents = result.messages.map((m: any) => m.content.content);
+        const timestamps = result.messages.map(m => new Date(m.createdAt).getTime());
+        const sortedTimestamps = [...timestamps].sort((a, b) => a - b);
+
+        // Messages should be in chronological order
+        expect(timestamps).toEqual(sortedTimestamps);
+
+        // Verify we got the expected messages
+        expect(contents).toContain('User message 1');
+        expect(contents).toContain('Assistant message 1');
+      });
+
+      it('should maintain chronological order when include brings in messages from a different thread', async () => {
+        // Create two threads
+        const mainThread = createSampleThread();
+        const otherThread = createSampleThread();
+        await storage.saveThread({ thread: mainThread });
+        await storage.saveThread({ thread: otherThread });
+
+        const now = Date.now();
+
+        // Save messages to main thread
+        const mainMessages = [
+          createSampleMessageV2({
+            threadId: mainThread.id,
+            resourceId: mainThread.resourceId,
+            role: 'user',
+            content: { content: 'Main thread user 1' },
+            createdAt: new Date(now + 1000),
+          }),
+          createSampleMessageV2({
+            threadId: mainThread.id,
+            resourceId: mainThread.resourceId,
+            role: 'assistant',
+            content: { content: 'Main thread assistant 1' },
+            createdAt: new Date(now + 3000),
+          }),
+          createSampleMessageV2({
+            threadId: mainThread.id,
+            resourceId: mainThread.resourceId,
+            role: 'user',
+            content: { content: 'Main thread user 2' },
+            createdAt: new Date(now + 5000),
+          }),
+        ];
+        await storage.saveMessages({ messages: mainMessages });
+
+        // Save messages to other thread (some with timestamps between main thread messages)
+        const otherMessages = [
+          createSampleMessageV2({
+            threadId: otherThread.id,
+            resourceId: otherThread.resourceId,
+            role: 'user',
+            content: { content: 'Other thread user' },
+            createdAt: new Date(now + 2000), // Between main thread messages 1 and 2
+          }),
+          createSampleMessageV2({
+            threadId: otherThread.id,
+            resourceId: otherThread.resourceId,
+            role: 'assistant',
+            content: { content: 'Other thread assistant' },
+            createdAt: new Date(now + 4000), // Between main thread messages 2 and 3
+          }),
+        ];
+        await storage.saveMessages({ messages: otherMessages });
+
+        // Retrieve from main thread, but include a message from other thread
+        const result = await storage.listMessages({
+          threadId: mainThread.id,
+          include: [
+            {
+              id: otherMessages[0]!.id,
+              threadId: otherThread.id,
+            },
+          ],
+        });
+
+        // All messages should be sorted by createdAt
+        const timestamps = result.messages.map(m => new Date(m.createdAt).getTime());
+        const sortedTimestamps = [...timestamps].sort((a, b) => a - b);
+        expect(timestamps).toEqual(sortedTimestamps);
+
+        // The other thread message should be interleaved correctly by timestamp
+        const contents = result.messages.map((m: any) => m.content.content);
+        expect(contents).toContain('Other thread user');
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
When using Upstash or Cloudflare storage with semantic recall (the include parameter), messages were being sorted by storage order instead of createdAt timestamp. This caused conversation history to appear out of order, with user messages missing or misplaced.

Upstash: Always sort messages by createdAt before pagination and after combining with included messages. 

Cloudflare: Refactored listMessages to:
- Fetch all thread messages first
- Sort by createdAt before pagination
- Fetch included messages separately (not subject to pagination)
- Combine and sort final output

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#9025

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message sorting to display conversations in chronological order by creation date, ensuring consistent ordering when using semantic recall.

* **New Features**
  * Added pagination metadata to message list responses, including total count, current page, items per page, and a flag indicating additional results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->