### PR TITLE
change truncation to ensure at least two package versions

### DIFF
--- a/.changeset/fresh-ears-worry.md
+++ b/.changeset/fresh-ears-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-docs-server': patch
+---
+
+Ensure changelog truncation includes at least 2 versions before cutting off


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Increases MAX_LINES and adds checks to ensure at least 2 versions in changelog when truncating files for tests.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced changelog truncation to preserve at least the last two versions when displaying version history.
  * Increased maximum changelog display capacity from 300 to 500 lines.
  * Improved version header detection for accurate changelog formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->