### PR TITLE
Fix mcp client resource clean up

### DIFF
--- a/.changeset/clear-lands-cross.md
+++ b/.changeset/clear-lands-cross.md
@@ -1,0 +1,15 @@
+---
+'@mastra/mcp': patch
+---
+
+Fix MCPClient resource leak causing MaxListenersExceededWarning
+
+Fixes an issue where `InternalMastraMCPClient` registered event listeners to the `process` object for graceful shutdown but failed to remove them upon disconnection. This caused a memory leak after multiple connect/disconnect cycles, triggering the warning:
+
+```
+MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTERM listeners added to [process].
+```
+
+The fix stores references to the exit hook unsubscribe function and SIGTERM handler, then properly cleans them up in `disconnect()`.
+
+Fixes #10499

--- a/.changeset/clear-lands-cross.md
+++ b/.changeset/clear-lands-cross.md
@@ -12,4 +12,6 @@ MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGT
 
 The fix stores references to the exit hook unsubscribe function and SIGTERM handler, then properly cleans them up in `disconnect()`.
 
-Fixes #10499
+Additionally, users can now disable session management by passing `sessionIdGenerator: undefined` in `startHTTP()` options. This enables stateless MCP server deployments, which is useful for serverless environments.
+
+Fixes #10499, #8526

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsup --silent --config tsup.config.ts",
     "build:watch": "pnpm build --watch",
+    "test:client": "vitest run ./src/client/client.test.ts",
     "test:integration": "cd integration-tests && pnpm test:mcp",
     "test": "pnpm test:integration && vitest run",
     "lint": "eslint ."

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,6 +26,7 @@
     "build": "tsup --silent --config tsup.config.ts",
     "build:watch": "pnpm build --watch",
     "test:client": "vitest run ./src/client/client.test.ts",
+    "test:server": "vitest run ./src/server/server.test.ts",
     "test:integration": "cd integration-tests && pnpm test:mcp",
     "test": "pnpm test:integration && vitest run",
     "lint": "eslint ."

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,7 +28,7 @@
     "test:client": "vitest run ./src/client/client.test.ts",
     "test:server": "vitest run ./src/server/server.test.ts",
     "test:integration": "cd integration-tests && pnpm test:mcp",
-    "test": "pnpm test:integration && vitest run",
+    "test": "pnpm test:server && pnpm test:client && pnpm test:integration",
     "lint": "eslint ."
   },
   "keywords": [],

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -566,3 +566,94 @@ describe('MastraMCPClient - AuthProvider Tests', () => {
     expect(tools).toHaveProperty('greet');
   });
 });
+
+describe('MastraMCPClient - Resource Cleanup Tests', () => {
+  let testServer: {
+    httpServer: HttpServer;
+    mcpServer: McpServer;
+    serverTransport: StreamableHTTPServerTransport;
+    baseUrl: URL;
+  };
+
+  beforeEach(async () => {
+    testServer = await setupTestServer(false);
+  });
+
+  afterEach(async () => {
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it('should not accumulate SIGTERM listeners across multiple connect/disconnect cycles', async () => {
+    const initialListenerCount = process.listenerCount('SIGTERM');
+
+    // Perform multiple connect/disconnect cycles
+    for (let i = 0; i < 15; i++) {
+      const client = new InternalMastraMCPClient({
+        name: `cleanup-test-client-${i}`,
+        server: {
+          url: testServer.baseUrl,
+        },
+      });
+
+      await client.connect();
+      await client.disconnect();
+    }
+
+    const finalListenerCount = process.listenerCount('SIGTERM');
+
+    // The listener count should not have increased significantly
+    // (allowing for some tolerance in case other parts of the test framework add listeners)
+    expect(finalListenerCount).toBeLessThanOrEqual(initialListenerCount + 1);
+  });
+
+  it('should clean up exit hooks and SIGTERM listeners on disconnect', async () => {
+    const initialListenerCount = process.listenerCount('SIGTERM');
+
+    const client = new InternalMastraMCPClient({
+      name: 'cleanup-single-test-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+
+    await client.connect();
+
+    // After connect, there should be at most one additional SIGTERM listener
+    const afterConnectCount = process.listenerCount('SIGTERM');
+    expect(afterConnectCount).toBeLessThanOrEqual(initialListenerCount + 1);
+
+    await client.disconnect();
+
+    // After disconnect, the listener count should return to the initial value
+    const afterDisconnectCount = process.listenerCount('SIGTERM');
+    expect(afterDisconnectCount).toBe(initialListenerCount);
+  });
+
+  it('should not add duplicate listeners when connect is called multiple times on the same client', async () => {
+    const initialListenerCount = process.listenerCount('SIGTERM');
+
+    const client = new InternalMastraMCPClient({
+      name: 'duplicate-connect-test-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+
+    // Connect multiple times on the same client
+    await client.connect();
+    await client.connect();
+    await client.connect();
+
+    const afterMultipleConnects = process.listenerCount('SIGTERM');
+
+    // Should only have added one listener, not three
+    expect(afterMultipleConnects).toBeLessThanOrEqual(initialListenerCount + 1);
+
+    await client.disconnect();
+
+    const afterDisconnectCount = process.listenerCount('SIGTERM');
+    expect(afterDisconnectCount).toBe(initialListenerCount);
+  });
+});

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -229,6 +229,8 @@ export class InternalMastraMCPClient extends MastraBase {
   private serverConfig: MastraMCPServerDefinition;
   private transport?: Transport;
   private currentOperationContext: RequestContext | null = null;
+  private exitHookUnsubscribe?: () => void;
+  private sigTermHandler?: () => void;
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
   public readonly resources: ResourceClientActions;
@@ -355,7 +357,7 @@ export class InternalMastraMCPClient extends MastraBase {
           authProvider: authProvider,
         });
         await this.client.connect(streamableTransport, {
-          timeout: 
+          timeout:
             connectTimeout ?? DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC,
         });
         this.transport = streamableTransport;
@@ -433,15 +435,22 @@ export class InternalMastraMCPClient extends MastraBase {
       }
     });
 
-    asyncExitHook(
-      async () => {
-        this.log('debug', `Disconnecting MCP server during exit`);
-        await this.disconnect();
-      },
-      { wait: 5000 },
-    );
+    // Only register exit hooks if not already registered
+    if (!this.exitHookUnsubscribe) {
+      this.exitHookUnsubscribe = asyncExitHook(
+        async () => {
+          this.log('debug', `Disconnecting MCP server during exit`);
+          await this.disconnect();
+        },
+        { wait: 5000 },
+      );
+    }
 
-    process.on('SIGTERM', () => gracefulExit());
+    if (!this.sigTermHandler) {
+      this.sigTermHandler = () => gracefulExit();
+      process.on('SIGTERM', this.sigTermHandler);
+    }
+
     this.log('debug', `Successfully connected to MCP server`);
     return this.isConnected;
   }
@@ -479,6 +488,16 @@ export class InternalMastraMCPClient extends MastraBase {
     } finally {
       this.transport = undefined;
       this.isConnected = Promise.resolve(false);
+
+      // Clean up exit hooks to prevent memory leaks
+      if (this.exitHookUnsubscribe) {
+        this.exitHookUnsubscribe();
+        this.exitHookUnsubscribe = undefined;
+      }
+      if (this.sigTermHandler) {
+        process.off('SIGTERM', this.sigTermHandler);
+        this.sigTermHandler = undefined;
+      }
     }
   }
 
@@ -699,13 +718,13 @@ export class InternalMastraMCPClient extends MastraBase {
               );
 
               this.log('debug', `Tool executed successfully: ${tool.name}`);
-              
+
               // When a tool has an outputSchema, return the structuredContent directly
               // so that output validation works correctly
               if (res.structuredContent !== undefined) {
                 return res.structuredContent;
               }
-              
+
               return res;
             } catch (e) {
               this.log('error', `Error calling tool: ${tool.name}`, {


### PR DESCRIPTION

Fix MCPClient resource leak causing MaxListenersExceededWarning

Fixes an issue where `InternalMastraMCPClient` registered event listeners to the `process` object for graceful shutdown but failed to remove them upon disconnection. This caused a memory leak after multiple connect/disconnect cycles, triggering the warning:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTERM listeners added to [process].
```

The fix stores references to the exit hook unsubscribe function and SIGTERM handler, then properly cleans them up in `disconnect()`.

Fixes #10499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a stateless/serverless mode and an option to disable session management for server deployments.

* **Tests**
  * Added resource-cleanup tests to verify lifecycle handlers are managed across connect/disconnect cycles.
  * Expanded server/client tests to cover session and tooling behaviors.

* **Bug Fixes**
  * Fixed cleanup of process lifecycle handlers to prevent listener leaks and related warnings.

* **Chores**
  * Added/updated test scripts to run server, client, and integration tests in sequence.

* **Documentation**
  * Changelog entry describing the resource-leak fix and stateless mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->