### PR TITLE
model fallback exploration

### DIFF
--- a/.changeset/tender-teams-make.md
+++ b/.changeset/tender-teams-make.md
@@ -1,0 +1,11 @@
+---
+"@mastra/core": patch
+---
+
+Fix model fallback not triggering on mid-stream errors (like quota exceeded or rate limit)
+
+Previously, when a model returned an error mid-stream (after the connection was established), the fallback mechanism would not trigger. This was because error chunks were being processed but not thrown, so the fallback logic in `executeStreamWithFallbackModels` never caught them.
+
+This fix ensures that mid-stream errors are properly thrown from `processOutputStream`, allowing the fallback mechanism to catch them and try the next model in the chain. The error is only enqueued to the output stream when it's the last model in the fallback chain.
+
+Fixes #9306

--- a/packages/core/src/agent/__tests__/model-list.test.ts
+++ b/packages/core/src/agent/__tests__/model-list.test.ts
@@ -1172,4 +1172,316 @@ describe('model fallback - mid-stream errors', () => {
     expect(usedModelName).toBe('fallback');
     expect(result.text).toBe('Fallback generate response');
   });
+
+  it('should fallback through multiple models until one succeeds', async () => {
+    /**
+     * Tests that fallback works through a chain of models - if the first two
+     * models fail with mid-stream errors, it should eventually reach the third.
+     */
+    const modelCallOrder: string[] = [];
+
+    // First model - fails with quota error
+    const model1 = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw new Error('Model 1 quota exceeded');
+      },
+      doStream: async () => {
+        modelCallOrder.push('model1');
+        const stream = new ReadableStream({
+          async start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'error',
+              error: new Error('Model 1 quota exceeded'),
+            });
+            controller.close();
+          },
+        });
+        return { rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [], stream };
+      },
+    });
+
+    // Second model - also fails with rate limit error
+    const model2 = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw new Error('Model 2 rate limited');
+      },
+      doStream: async () => {
+        modelCallOrder.push('model2');
+        const stream = new ReadableStream({
+          async start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'error',
+              error: new Error('Model 2 rate limited'),
+            });
+            controller.close();
+          },
+        });
+        return { rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [], stream };
+      },
+    });
+
+    // Third model - succeeds
+    const model3 = new MockLanguageModelV2({
+      doGenerate: async () => {
+        modelCallOrder.push('model3');
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Third model success',
+          content: [{ type: 'text', text: 'Third model success' }],
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        modelCallOrder.push('model3');
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'model3', timestamp: new Date(0) },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Third model success' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-chain-fallback',
+      name: 'Test Chain Fallback',
+      instructions: 'test agent',
+      model: [
+        { model: model1, maxRetries: 0 },
+        { model: model2, maxRetries: 0 },
+        { model: model3, maxRetries: 0 },
+      ],
+    });
+
+    const streamResult = await agent.stream('Test message');
+    const fullText = await streamResult.text;
+
+    expect(modelCallOrder).toEqual(['model1', 'model2', 'model3']);
+    expect(fullText).toBe('Third model success');
+  });
+
+  it('should throw error when all models fail with mid-stream errors', async () => {
+    /**
+     * When all models in the fallback chain fail with mid-stream errors,
+     * the final error should be propagated to the caller.
+     */
+    const model1 = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw new Error('Model 1 failed');
+      },
+      doStream: async () => {
+        const stream = new ReadableStream({
+          async start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'error',
+              error: new Error('Model 1 quota exceeded'),
+            });
+            controller.close();
+          },
+        });
+        return { rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [], stream };
+      },
+    });
+
+    const model2 = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw new Error('Model 2 failed');
+      },
+      doStream: async () => {
+        const stream = new ReadableStream({
+          async start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'error',
+              error: new Error('Model 2 also failed'),
+            });
+            controller.close();
+          },
+        });
+        return { rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [], stream };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-all-fail',
+      name: 'Test All Models Fail',
+      instructions: 'test agent',
+      model: [
+        { model: model1, maxRetries: 0 },
+        { model: model2, maxRetries: 0 },
+      ],
+    });
+
+    const streamResult = await agent.stream('Test message');
+
+    // Consume the stream to get the final result with error
+    // The text promise will reject or return empty when there's an error
+    try {
+      await streamResult.text;
+    } catch {
+      // Expected - the stream has an error
+    }
+
+    // After consuming, the error should be available
+    expect(streamResult.error).toBeDefined();
+    expect(streamResult.error?.message).toContain('Model 2 also failed');
+  });
+
+  it('should retry mid-stream errors before falling back to next model', async () => {
+    /**
+     * When maxRetries > 0, mid-stream errors should trigger retries
+     * before falling back to the next model.
+     */
+    let model1Attempts = 0;
+    let usedModelName = '';
+
+    const model1 = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw new Error('Model 1 failed');
+      },
+      doStream: async () => {
+        model1Attempts++;
+        const stream = new ReadableStream({
+          async start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'error',
+              error: new Error(`Model 1 failed attempt ${model1Attempts}`),
+            });
+            controller.close();
+          },
+        });
+        return { rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [], stream };
+      },
+    });
+
+    const model2 = new MockLanguageModelV2({
+      doGenerate: async () => {
+        usedModelName = 'model2';
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Model 2 success',
+          content: [{ type: 'text', text: 'Model 2 success' }],
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        usedModelName = 'model2';
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'model2', timestamp: new Date(0) },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Model 2 success' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-retry-then-fallback',
+      name: 'Test Retry Then Fallback',
+      instructions: 'test agent',
+      model: [
+        { model: model1, maxRetries: 2 }, // Should try 3 times (1 initial + 2 retries)
+        { model: model2, maxRetries: 0 },
+      ],
+    });
+
+    const streamResult = await agent.stream('Test message');
+    const fullText = await streamResult.text;
+
+    // Model 1 should be tried 3 times (initial + 2 retries)
+    expect(model1Attempts).toBe(3);
+    expect(usedModelName).toBe('model2');
+    expect(fullText).toBe('Model 2 success');
+  });
+
+  it('should call onError callback for mid-stream errors', async () => {
+    /**
+     * Verifies that the onError callback is invoked when a mid-stream error occurs.
+     */
+    const errors: Error[] = [];
+
+    const failingModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw new Error('Generate failed');
+      },
+      doStream: async () => {
+        const stream = new ReadableStream({
+          async start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'error',
+              error: new Error('Mid-stream quota error'),
+            });
+            controller.close();
+          },
+        });
+        return { rawCall: { rawPrompt: null, rawSettings: {} }, warnings: [], stream };
+      },
+    });
+
+    const successModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        text: 'Success',
+        content: [{ type: 'text', text: 'Success' }],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'success', timestamp: new Date(0) },
+          { type: 'text-start', id: '1' },
+          { type: 'text-delta', id: '1', delta: 'Success' },
+          { type: 'text-end', id: '1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+        ]),
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'test-onerror-callback',
+      name: 'Test onError Callback',
+      instructions: 'test agent',
+      model: [
+        { model: failingModel, maxRetries: 0 },
+        { model: successModel, maxRetries: 0 },
+      ],
+    });
+
+    const streamResult = await agent.stream('Test message', {
+      onError: ({ error }) => {
+        errors.push(error);
+      },
+    });
+
+    await streamResult.text;
+
+    // onError should have been called with the mid-stream error
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.message).toContain('Mid-stream quota error');
+  });
 });


### PR DESCRIPTION
Fix model fallback not triggering on mid-stream errors (like quota exceeded or rate limit)

Previously, when a model returned an error mid-stream (after the connection was established), the fallback mechanism would not trigger. This was because error chunks were being processed but not thrown, so the fallback logic in `executeStreamWithFallbackModels` never caught them.

This fix ensures that mid-stream errors are properly thrown from `processOutputStream`, allowing the fallback mechanism to catch them and try the next model in the chain. The error is only enqueued to the output stream when it's the last model in the fallback chain.

Fixes #9306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mid-stream errors from models (such as quota exceeded or rate limit errors) now properly trigger the fallback mechanism to switch to the next model in the chain instead of terminating execution.

* **Tests**
  * Added comprehensive test coverage for model fallback behavior during mid-stream errors, including partial content preservation, multi-model chains, error propagation, and proper handling of disabled models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->