### PR TITLE
Fix network agent not getting `text-delta` from subAgent when `.stream` is used

### DIFF
--- a/.changeset/pretty-peaches-knock.md
+++ b/.changeset/pretty-peaches-knock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix network agent not getting `text-delta` from subAgent when `.stream` is used

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1672,7 +1672,9 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
           threadId: z.string().optional().describe('Thread ID for conversation continuity for memory messages'),
           resourceId: z.string().optional().describe('Resource/user identifier for memory messages'),
           instructions: z.string().optional().describe('Custom instructions to override agent defaults'),
-          maxSteps: z.number().optional().describe('Maximum number of execution steps for the sub-agent'),
+          maxSteps: z.number().min(3).optional().describe('Maximum number of execution steps for the sub-agent'),
+          // using minimum of 3 to ensure if the agent has a tool call, the llm gets executed again after the tool call step, using the tool call result
+          // to return a proper llm response
         });
 
         const agentOutputSchema = z.object({


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

`maxSteps` is down to the subAgent when used as tool, and the main/parent agent always send a `maxStep` of `1`, which will prevent the subAgent's llm from getting executed again after the tool call, since execution step is already 1 by then.
Added `min(3)` to the subAgent (used as tool) inputSchema , this ensures when maxStep is passed, it's at least 3, making sure the subAgent's llm is executed again with the tool results after tool calls

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network agents failing to receive text-delta updates from subagents when using the `.stream` option.
  * Added validation: Agent `maxSteps` now enforces a minimum value of 3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->