### PR TITLE
backport: 10206

### DIFF
--- a/.changeset/pretty-cameras-kneel.md
+++ b/.changeset/pretty-cameras-kneel.md
@@ -1,0 +1,5 @@
+---
+"@mastra/voice-deepgram": patch
+---
+
+feat(voice-deepgram): add speaker diarization support for STT

--- a/voice/deepgram/README.md
+++ b/voice/deepgram/README.md
@@ -1,6 +1,6 @@
 # @mastra/voice-deepgram
 
-Deepgram voice integration for Mastra, providing both Text-to-Speech (TTS) and Speech-to-Text (STT) capabilities using Deepgram's advanced AI models.
+Deepgram voice integration for Mastra, providing both Text-to-Speech (TTS) and Speech-to-Text (STT) using Deepgram's Aura (TTS) and Nova (STT) families.
 
 ## Installation
 
@@ -24,14 +24,14 @@ import { DeepgramVoice } from '@mastra/voice-deepgram';
 // Create voice with both speech and listening capabilities
 const voice = new DeepgramVoice({
   speechModel: {
-    name: 'aura-asteria-en', // Default voice
+    name: 'aura', // TTS family
     apiKey: 'your-api-key', // Optional, can use DEEPGRAM_API_KEY env var
   },
   listeningModel: {
-    name: 'nova', // Optional, specify a listening model
+    name: 'nova', // STT family
     apiKey: 'your-api-key', // Optional, can use DEEPGRAM_API_KEY env var
   },
-  speaker: 'aura-athena-en', // Optional, specify a speaker voice
+  speaker: 'asteria-en', // default voiceId (see voice.ts)
 });
 
 // List available voices
@@ -39,12 +39,15 @@ const voices = await voice.getSpeakers();
 
 // Generate speech
 const audioStream = await voice.speak('Hello from Mastra!', {
-  speaker: 'aura-athena-en', // Optional: override default speaker
-  speed: 1.0, // Optional: adjust speech speed
+  speaker: 'hera-en', // override speaker voice
 });
 
 // Convert speech to text
-const text = await voice.listen(audioStream);
+const result = await voice.listen(audioStream, {
+  diarize: true,
+  diarize_speaker_count: 2,
+});
+console.log(result.transcript);
 ```
 
 ## Features

--- a/voice/deepgram/src/index.ts
+++ b/voice/deepgram/src/index.ts
@@ -13,9 +13,20 @@ interface DeepgramVoiceConfig {
   language?: string;
 }
 
+interface DeepgramWord {
+  word: string;
+  start?: number;
+  end?: number;
+  confidence?: number;
+  speaker?: number;
+}
+
 export class DeepgramVoice extends MastraVoice {
   private speechClient?: ReturnType<typeof createClient>;
   private listeningClient?: ReturnType<typeof createClient>;
+  private storedSpeechModel?: { name: DeepgramModel; apiKey?: string };
+  private storedListeningModel?: { name: DeepgramModel; apiKey?: string };
+  private storedSpeaker?: DeepgramVoiceId;
 
   constructor({
     speechModel,
@@ -24,12 +35,12 @@ export class DeepgramVoice extends MastraVoice {
   }: { speechModel?: DeepgramVoiceConfig; listeningModel?: DeepgramVoiceConfig; speaker?: DeepgramVoiceId } = {}) {
     const defaultApiKey = process.env.DEEPGRAM_API_KEY;
 
-    const defaultSpeechModel = {
+    const defaultSpeechModel: { name: DeepgramModel; apiKey?: string } = {
       name: 'aura',
       apiKey: defaultApiKey,
     };
 
-    const defaultListeningModel = {
+    const defaultListeningModel: { name: DeepgramModel; apiKey?: string } = {
       name: 'nova',
       apiKey: defaultApiKey,
     };
@@ -46,6 +57,15 @@ export class DeepgramVoice extends MastraVoice {
       speaker,
     });
 
+    this.storedSpeechModel = {
+      name: speechModel?.name ?? defaultSpeechModel.name,
+      apiKey: speechModel?.apiKey ?? defaultSpeechModel.apiKey,
+    };
+    this.storedListeningModel = {
+      name: listeningModel?.name ?? defaultListeningModel.name,
+      apiKey: listeningModel?.apiKey ?? defaultListeningModel.apiKey,
+    };
+
     const speechApiKey = speechModel?.apiKey || defaultApiKey;
     const listeningApiKey = listeningModel?.apiKey || defaultApiKey;
 
@@ -60,7 +80,7 @@ export class DeepgramVoice extends MastraVoice {
       this.listeningClient = createClient(listeningApiKey);
     }
 
-    this.speaker = speaker || 'asteria-en';
+    this.storedSpeaker = speaker || 'asteria-en';
   }
 
   async getSpeakers() {
@@ -106,19 +126,22 @@ export class DeepgramVoice extends MastraVoice {
         throw new Error('No speech client configured');
       }
 
-      let model;
-      if (options?.speaker) {
-        model = this.speechModel?.name + '-' + options.speaker;
-      } else if (this.speaker) {
-        model = this.speechModel?.name + '-' + this.speaker;
-      }
+      const baseModel = this.storedSpeechModel?.name;
+      const speakerId = options?.speaker || this.storedSpeaker;
+
+      const modelName =
+        baseModel && speakerId
+          ? speakerId.startsWith(`${baseModel}-`)
+            ? speakerId
+            : `${baseModel}-${speakerId}`
+          : baseModel || speakerId;
 
       const speakClient = this.speechClient.speak;
       const response = await speakClient.request(
         { text },
         {
-          model,
-          ...options,
+          model: modelName,
+          ...Object.fromEntries(Object.entries(options ?? {}).filter(([k]) => k !== 'speaker')),
         },
       );
 
@@ -161,12 +184,24 @@ export class DeepgramVoice extends MastraVoice {
     return { enabled: true };
   }
 
+  /**
+   * Transcribes audio with optional speaker diarization.
+   *
+   * @param audioStream - Audio input stream
+   * @param options - Transcription options (diarize, language, etc.)
+   * @returns Promise resolving to:
+   *   - transcript: Full transcript string
+   *   - words: Array of word objects with timing and confidence
+   *   - raw: Complete Deepgram API response
+   *   - speakerSegments: (when diarize=true) Array of {word, speaker, start, end}
+   */
   async listen(
     audioStream: NodeJS.ReadableStream,
     options?: {
+      diarize?: boolean;
       [key: string]: any;
     },
-  ): Promise<string> {
+  ): Promise<any> {
     if (!this.listeningClient) {
       throw new Error('Deepgram listening client not configured');
     }
@@ -185,21 +220,50 @@ export class DeepgramVoice extends MastraVoice {
       if (!this.listeningClient) {
         throw new Error('No listening client configured');
       }
+
+      const { diarize, diarize_speaker_count: _, ...restOptions } = options ?? {};
       const { result, error } = await this.listeningClient.listen.prerecorded.transcribeFile(buffer, {
-        model: this.listeningModel?.name,
-        ...options,
+        ...restOptions,
+        model: this.storedListeningModel?.name,
+        diarize,
       });
 
       if (error) {
         throw error;
       }
 
-      const transcript = result.results?.channels?.[0]?.alternatives?.[0]?.transcript;
-      if (!transcript) {
-        throw new Error('No transcript found in Deepgram response');
+      const channel = result.results?.channels?.[0];
+      const alt:
+        | {
+            transcript?: string;
+            words?: DeepgramWord[];
+          }
+        | undefined = channel?.alternatives?.[0];
+
+      if (!alt) {
+        return {
+          transcript: '',
+          words: [],
+          raw: result,
+        };
       }
 
-      return transcript;
+      const response: any = {
+        transcript: alt.transcript,
+        words: alt.words,
+        raw: result,
+      };
+
+      if (diarize && alt.words) {
+        response.speakerSegments = alt.words.map((w: DeepgramWord) => ({
+          word: w.word,
+          speaker: w.speaker,
+          start: w.start,
+          end: w.end,
+        }));
+      }
+
+      return response;
     }, 'voice.deepgram.listen')();
   }
 }


### PR DESCRIPTION
## Description

Backports #10206 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds speaker diarization to Deepgram STT with a structured listen() response and refines TTS speaker/model handling; updates docs and changeset.
> 
> - **Voice Deepgram**:
>   - **STT (listen)**:
>     - Add `diarize` support and optional `speakerSegments` in result.
>     - Return structured object `{ transcript, words, raw, speakerSegments? }` instead of plain string.
>     - Preserve/forward options while setting `model` from stored config.
>   - **TTS (speak)**:
>     - Refine model name composition using stored `speechModel` and `speaker`; filter `speaker` from API options payload.
>     - Store model/speaker config internally (`storedSpeechModel`, `storedListeningModel`, `storedSpeaker`).
>   - **Types**: Introduce `DeepgramWord` for word-level timing/confidence/speaker.
> - **Docs**: Update README usage/examples (model families, speaker defaults, diarization options) and description.
> - **Release**: Add changeset for `@mastra/voice-deepgram` patch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96a6c750aa9dc1a1715bb7b7ca3daba1da72cfc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->