### PR TITLE
fix: remove full width so modal can be closed by clicking outside

### DIFF
--- a/docs/src/theme/Navbar/Search/index.tsx
+++ b/docs/src/theme/Navbar/Search/index.tsx
@@ -114,9 +114,9 @@ export default function SearchContainer({ locale }: { locale: string }) {
       </DialogTrigger>
       <DialogPortal>
         <DialogOverlay className="fixed inset-0 transition-opacity z-250 bg-black/40" />
-        <DialogContent className="dialog-panel z-260 fixed left-1/2 top-[100px] -translate-x-1/2  w-full">
+        <DialogContent className="dialog-panel z-260 fixed left-1/2 top-[100px] -translate-x-1/2">
           <div className="flex relative top-1/2 justify-center items-start p-4 min-h-full">
-            <div className="w-full ring ring-neutral-200 dark:ring-(--border) shadow-2xl duration-150 ease-out data-closed:transform-[scale(95%)] data-closed:opacity-0 dark:border-(--border) h-fit max-w-[660px] mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">
+            <div className="ring ring-neutral-200 dark:ring-(--border) shadow-2xl duration-150 ease-out data-closed:transform-[scale(95%)] data-closed:opacity-0 dark:border-(--border) h-fit w-[660px] mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">
               <DialogTitle className="sr-only">Search docs...</DialogTitle>
               <div className="w-full">
                 <CustomSearch


### PR DESCRIPTION
## Description

Make search modal closable on clicking outside

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved search dialog layout with optimized width constraints for better visual consistency and refined presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->