### PR TITLE
fix: remove full width so modal can be closed by clicking outside

### DIFF
--- a/docs/src/theme/Navbar/Search/index.tsx
+++ b/docs/src/theme/Navbar/Search/index.tsx
@@ -116,9 +116,9 @@ export default function SearchContainer({ locale }: { locale: string }) {
         </DialogTrigger>
         <DialogPortal>
           <DialogOverlay className="fixed inset-0 transition-opacity z-250 bg-black/40" />
-          <DialogContent className="dialog-panel z-260 fixed left-1/2 top-[100px] -translate-x-1/2  w-full">
+          <DialogContent className="dialog-panel z-260 fixed left-1/2 top-[100px] -translate-x-1/2">
             <div className="flex relative top-1/2 justify-center items-start p-4 min-h-full">
-              <div className="w-full ring ring-neutral-200 dark:ring-(--border) shadow-2xl duration-150 ease-out data-closed:transform-[scale(95%)] data-closed:opacity-0 dark:border-(--border) h-fit max-w-[660px] mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">
+              <div className="ring ring-neutral-200 dark:ring-(--border) shadow-2xl duration-150 ease-out data-closed:transform-[scale(95%)] data-closed:opacity-0 dark:border-(--border) h-fit w-[660px] mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">
                 <DialogTitle className="sr-only">Search docs...</DialogTitle>
                 <div className="w-full">
                   <CustomSearch

--- a/docs/src/theme/Navbar/index.tsx
+++ b/docs/src/theme/Navbar/index.tsx
@@ -16,7 +16,7 @@ function NavbarContentDesktop() {
   const { i18n } = useDocusaurusContext();
   const locale = i18n?.currentLocale;
   return (
-    <div className="flex px-4 border-b-[0.5px] h-[var(--ifm-navbar-height)] border-(--border-subtle) mx-auto w-full items-center justify-between @container">
+    <div className="flex px-4 border-b-[0.5px] h-(--ifm-navbar-height) border-(--border-subtle) mx-auto w-full items-center justify-between @container">
       <div className="flex gap-2 items-center">
         <Link href="/docs">
           <Logo />


### PR DESCRIPTION
## Description

Fix modal not closing when you click outside

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
