### PR TITLE
feat(ai-sdk): Support streaming agent text chunks from workflow-step-output

### DIFF
--- a/.changeset/dark-insects-act.md
+++ b/.changeset/dark-insects-act.md
@@ -1,0 +1,15 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Support streaming agent text chunks from workflow-step-output
+
+Adds support for streaming text and tool call chunks from agents running inside workflows via the workflow-step-output event. Workflows can now include agent stream chunks that are properly converted to UI messages.
+
+Features:
+
+- Added includeTextStreamParts option to WorkflowStreamToAISDKTransformer
+- Added isMastraTextStreamChunk type guard to identify Mastra chunks
+- Support for text-start, text-delta, text-end chunks
+- Support for tool-call and tool-result chunks
+- Comprehensive test coverage in transformers.test.ts

--- a/.changeset/dark-insects-act.md
+++ b/.changeset/dark-insects-act.md
@@ -4,12 +4,28 @@
 
 Support streaming agent text chunks from workflow-step-output
 
-Adds support for streaming text and tool call chunks from agents running inside workflows via the workflow-step-output event. Workflows can now include agent stream chunks that are properly converted to UI messages.
+Adds support for streaming text and tool call chunks from agents running inside workflows via the workflow-step-output event. When you pipe an agent's stream into a workflow step's writer, the text chunks, tool calls, and other streaming events are automatically included in the workflow stream and converted to UI messages.
 
-Features:
+**Features:**
+- Added `includeTextStreamParts` option to `WorkflowStreamToAISDKTransformer` (defaults to `true`)
+- Added `isMastraTextStreamChunk` type guard to identify Mastra chunks with text streaming data
+- Support for streaming text chunks: `text-start`, `text-delta`, `text-end`
+- Support for streaming tool calls: `tool-call`, `tool-result`
+- Comprehensive test coverage in `transformers.test.ts`
+- Updated documentation for workflow streaming and `workflowRoute()`
 
-- Added includeTextStreamParts option to WorkflowStreamToAISDKTransformer
-- Added isMastraTextStreamChunk type guard to identify Mastra chunks
-- Support for text-start, text-delta, text-end chunks
-- Support for tool-call and tool-result chunks
-- Comprehensive test coverage in transformers.test.ts
+**Example:**
+```typescript
+const planActivities = createStep({
+  execute: async ({ mastra, writer }) => {
+    const agent = mastra?.getAgent('weatherAgent');
+    const response = await agent.stream('Plan activities');
+    await response.fullStream.pipeTo(writer);
+    
+    return { activities: await response.text };
+  }
+});
+```
+
+When served via `workflowRoute()`, the UI receives incremental text updates as the agent generates its response, providing a smooth streaming experience.
+

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -1,0 +1,493 @@
+import { ChunkFrom } from '@mastra/core/stream';
+import type { ChunkType } from '@mastra/core/stream';
+import { describe, expect, it } from 'vitest';
+import { WorkflowStreamToAISDKTransformer } from '../transformers';
+
+describe('WorkflowStreamToAISDKTransformer', () => {
+  describe('basic workflow stream', () => {
+    it('should transform basic workflow events', async () => {
+      const mockStream = new ReadableStream<ChunkType>({
+        async start(controller) {
+          // Workflow starts
+          controller.enqueue({
+            type: 'workflow-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              workflowId: 'test-workflow',
+            },
+          });
+
+          // Step starts
+          controller.enqueue({
+            id: 'step-1',
+            type: 'workflow-step-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'step-1',
+              stepCallId: 'call-1',
+              status: 'running',
+              payload: {},
+            },
+          });
+
+          // Step result
+          controller.enqueue({
+            type: 'workflow-step-result',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'step-1',
+              stepCallId: 'call-1',
+              status: 'success',
+              output: {},
+            },
+          });
+
+          // Workflow finish
+          controller.enqueue({
+            type: 'workflow-finish',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              metadata: {},
+              workflowStatus: 'success',
+              output: { usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 } },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const transformedStream = mockStream.pipeThrough(WorkflowStreamToAISDKTransformer());
+
+      const chunks: any[] = [];
+      for await (const chunk of transformedStream) {
+        chunks.push(chunk);
+      }
+
+      // Should have start, workflow data chunks, and finish
+      expect(chunks[0]).toEqual({ type: 'start' });
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'finish' });
+
+      // Check workflow data chunks
+      const workflowDataChunks = chunks.filter(chunk => chunk.type === 'data-workflow');
+      expect(workflowDataChunks.length).toBeGreaterThan(0);
+
+      // First workflow chunk should show running status
+      const firstWorkflowChunk = workflowDataChunks[0];
+      expect(firstWorkflowChunk.data.name).toBe('test-workflow');
+      expect(firstWorkflowChunk.data.status).toBe('running');
+
+      // Last workflow chunk should show success status
+      const lastWorkflowChunk = workflowDataChunks[workflowDataChunks.length - 1];
+      expect(lastWorkflowChunk.data.status).toBe('success');
+      expect(lastWorkflowChunk.data.output).toMatchObject({
+        usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+      });
+    });
+  });
+
+  describe('workflow-step-output with text stream chunks', () => {
+    it('should transform text-delta chunks from workflow-step-output', async () => {
+      const mockStream = new ReadableStream<ChunkType>({
+        async start(controller) {
+          // Workflow starts
+          controller.enqueue({
+            type: 'workflow-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              workflowId: 'test-workflow',
+            },
+          });
+
+          // Step starts
+          controller.enqueue({
+            id: 'agent-step',
+            type: 'workflow-step-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'agent-step',
+              stepCallId: 'call-1',
+              status: 'running',
+            },
+          });
+
+          // Agent streaming text chunks as workflow-step-output (Mastra chunk format)
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'text-start',
+                from: ChunkFrom.USER,
+                runId: 'agent-run-id',
+                payload: {
+                  id: 'msg-1',
+                },
+              },
+            },
+          });
+
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'text-delta',
+                from: ChunkFrom.USER,
+                runId: 'agent-run-id',
+                payload: {
+                  id: 'msg-1',
+                  text: 'Hello',
+                },
+              },
+            },
+          });
+
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'text-delta',
+                from: ChunkFrom.USER,
+                runId: 'agent-run-id',
+                payload: {
+                  id: 'msg-1',
+                  text: ' World',
+                },
+              },
+            },
+          });
+
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'text-end',
+                from: ChunkFrom.USER,
+                runId: 'agent-run-id',
+                payload: {
+                  id: 'msg-1',
+                },
+              },
+            },
+          });
+
+          // Step result
+          controller.enqueue({
+            type: 'workflow-step-result',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'agent-step',
+              stepCallId: 'call-1',
+              status: 'success',
+              output: {},
+            },
+          });
+
+          // Workflow finish
+          controller.enqueue({
+            type: 'workflow-finish',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              metadata: {},
+              workflowStatus: 'success',
+              output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const transformedStream = mockStream.pipeThrough(
+        WorkflowStreamToAISDKTransformer({ includeTextStreamParts: true }),
+      );
+
+      const chunks: any[] = [];
+      for await (const chunk of transformedStream) {
+        chunks.push(chunk);
+      }
+
+      // Find text stream chunks
+      const textStartChunk = chunks.find(chunk => chunk.type === 'text-start');
+      const textDeltaChunks = chunks.filter(chunk => chunk.type === 'text-delta');
+      const textEndChunk = chunks.find(chunk => chunk.type === 'text-end');
+
+      // Verify text-start chunk
+      expect(textStartChunk).toBeDefined();
+      expect(textStartChunk.id).toBe('msg-1');
+
+      // Verify text-delta chunks
+      expect(textDeltaChunks.length).toBe(2);
+      expect(textDeltaChunks[0].delta).toBe('Hello');
+      expect(textDeltaChunks[1].delta).toBe(' World');
+
+      // Verify text-end chunk
+      expect(textEndChunk).toBeDefined();
+      expect(textEndChunk.id).toBe('msg-1');
+    });
+
+    it('should transform tool-call chunks from workflow-step-output', async () => {
+      const mockStream = new ReadableStream<ChunkType>({
+        async start(controller) {
+          // Workflow starts
+          controller.enqueue({
+            type: 'workflow-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              workflowId: 'test-workflow',
+            },
+          });
+
+          // Step starts
+          controller.enqueue({
+            id: 'agent-step',
+            type: 'workflow-step-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'agent-step',
+              stepCallId: 'call-1',
+              status: 'running',
+            },
+          });
+
+          // Tool call chunks (Mastra chunk format)
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'tool-call',
+                from: ChunkFrom.USER,
+                runId: 'agent-run-id',
+                payload: {
+                  toolCallId: 'tool-call-1',
+                  toolName: 'search',
+                  args: { query: 'test query' },
+                },
+              },
+            },
+          });
+
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'tool-result',
+                from: ChunkFrom.USER,
+                runId: 'agent-run-id',
+                payload: {
+                  toolCallId: 'tool-call-1',
+                  toolName: 'search',
+                  result: { results: ['result 1', 'result 2'] },
+                },
+              },
+            },
+          });
+
+          // Step result
+          controller.enqueue({
+            type: 'workflow-step-result',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'agent-step',
+              stepCallId: 'call-1',
+              status: 'success',
+              output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+            },
+          });
+
+          // Workflow finish
+          controller.enqueue({
+            type: 'workflow-finish',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              metadata: {},
+              workflowStatus: 'success',
+              output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const transformedStream = mockStream.pipeThrough(
+        WorkflowStreamToAISDKTransformer({ includeTextStreamParts: true }),
+      );
+
+      const chunks: any[] = [];
+      for await (const chunk of transformedStream) {
+        chunks.push(chunk);
+      }
+
+      // Find tool-related chunks
+      const toolInputAvailableChunk = chunks.find(chunk => chunk.type === 'tool-input-available');
+      const toolOutputAvailableChunk = chunks.find(chunk => chunk.type === 'tool-output-available');
+
+      // Verify tool-input-available (converted from tool-call)
+      expect(toolInputAvailableChunk).toBeDefined();
+      expect(toolInputAvailableChunk.toolCallId).toBe('tool-call-1');
+      expect(toolInputAvailableChunk.toolName).toBe('search');
+      expect(toolInputAvailableChunk.input).toEqual({ query: 'test query' });
+
+      // Verify tool-output-available (converted from tool-result)
+      expect(toolOutputAvailableChunk).toBeDefined();
+      expect(toolOutputAvailableChunk.toolCallId).toBe('tool-call-1');
+      expect(toolOutputAvailableChunk.output).toEqual({ results: ['result 1', 'result 2'] });
+    });
+
+    it('should not include text stream chunks when includeTextStreamParts is false', async () => {
+      const mockStream = new ReadableStream<ChunkType>({
+        async start(controller) {
+          // Workflow starts
+          controller.enqueue({
+            type: 'workflow-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              workflowId: 'test-workflow',
+            },
+          });
+
+          // Text chunks that should be filtered out (Mastra chunk format)
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'text-delta',
+                from: ChunkFrom.USER,
+                runId: 'agent-run-id',
+                payload: {
+                  id: 'msg-1',
+                  text: 'Hello World',
+                },
+              },
+            },
+          });
+
+          // Workflow finish
+          controller.enqueue({
+            type: 'workflow-finish',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              metadata: {},
+              workflowStatus: 'success',
+              output: { usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 } },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const transformedStream = mockStream.pipeThrough(
+        WorkflowStreamToAISDKTransformer({ includeTextStreamParts: false }),
+      );
+
+      const chunks: any[] = [];
+      for await (const chunk of transformedStream) {
+        chunks.push(chunk);
+      }
+
+      // Should not have any text-delta chunks
+      const textDeltaChunks = chunks.filter(chunk => chunk.type === 'text-delta');
+      expect(textDeltaChunks.length).toBe(0);
+
+      // Should still have start, workflow data, and finish
+      expect(chunks[0]).toEqual({ type: 'start' });
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'finish' });
+    });
+  });
+
+  describe('workflow-step-output with custom data chunks', () => {
+    it('should pass through custom data chunks from workflow-step-output', async () => {
+      const mockStream = new ReadableStream<ChunkType>({
+        async start(controller) {
+          // Workflow starts
+          controller.enqueue({
+            type: 'workflow-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              workflowId: 'test-workflow',
+            },
+          });
+
+          // Custom data chunk
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'data-custom-event',
+                from: ChunkFrom.USER,
+                runId: 'test-run-id',
+                data: {
+                  message: 'Custom data from workflow step',
+                  value: 42,
+                },
+              },
+            },
+          });
+
+          // Workflow finish
+          controller.enqueue({
+            type: 'workflow-finish',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              metadata: {},
+              workflowStatus: 'success',
+              output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const transformedStream = mockStream.pipeThrough(WorkflowStreamToAISDKTransformer());
+
+      const chunks: any[] = [];
+      for await (const chunk of transformedStream) {
+        chunks.push(chunk);
+      }
+
+      // Find the custom data chunk
+      const customDataChunk = chunks.find(chunk => chunk.type === 'data-custom-event');
+
+      expect(customDataChunk).toBeDefined();
+      expect(customDataChunk.type).toBe('data-custom-event');
+      expect(customDataChunk.data).toEqual({
+        message: 'Custom data from workflow step',
+        value: 42,
+      });
+    });
+  });
+});

--- a/client-sdks/ai-sdk/src/convert-streams.ts
+++ b/client-sdks/ai-sdk/src/convert-streams.ts
@@ -79,7 +79,7 @@ export function toAISdkV5Stream<
   TState extends ZodObject<any>,
 >(
   stream: MastraWorkflowStream<TState, TInput, TOutput, TSteps>,
-  options: { from: 'workflow' },
+  options: { from: 'workflow'; includeTextStreamParts?: boolean },
 ): ReadableStream<InferUIMessageChunk<UIMessage>>;
 export function toAISdkV5Stream<
   TOutput extends ZodType<any>,
@@ -88,7 +88,7 @@ export function toAISdkV5Stream<
   TState extends ZodObject<any>,
 >(
   stream: WorkflowRunOutput<WorkflowResult<TState, TInput, TOutput, TSteps>>,
-  options: { from: 'workflow' },
+  options: { from: 'workflow'; includeTextStreamParts?: boolean },
 ): ReadableStream<InferUIMessageChunk<UIMessage>>;
 export function toAISdkV5Stream(
   stream: MastraAgentNetworkStream,
@@ -115,6 +115,7 @@ export function toAISdkV5Stream(
     | WorkflowRunOutput<WorkflowResult<any, any, any, any>>,
   options: {
     from: ToAISDKFrom;
+    includeTextStreamParts?: boolean;
     lastMessageId?: string;
     sendStart?: boolean;
     sendFinish?: boolean;
@@ -131,9 +132,11 @@ export function toAISdkV5Stream(
   const from = options?.from;
 
   if (from === 'workflow') {
-    return (stream as ReadableStream<ChunkType>).pipeThrough(WorkflowStreamToAISDKTransformer()) as ReadableStream<
-      InferUIMessageChunk<UIMessage>
-    >;
+    const includeTextStreamParts = options?.includeTextStreamParts ?? true;
+
+    return (stream as ReadableStream<ChunkType>).pipeThrough(
+      WorkflowStreamToAISDKTransformer({ includeTextStreamParts }),
+    ) as ReadableStream<InferUIMessageChunk<UIMessage>>;
   }
 
   if (from === 'network') {

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -4,11 +4,13 @@ import type { WorkflowRunStatus, WorkflowStepStatus, WorkflowStreamEvent } from 
 import type { InferUIMessageChunk, TextStreamPart, ToolSet, UIMessage, UIMessageStreamOptions } from 'ai';
 import type { ZodType } from 'zod';
 import { convertMastraChunkToAISDKv5, convertFullStreamChunkToUIMessageStream } from './helpers';
+import type { ToolAgentChunkType, ToolWorkflowChunkType, ToolNetworkChunkType } from './helpers';
 import {
   isAgentExecutionDataChunkType,
   isDataChunkType,
   isWorkflowExecutionDataChunkType,
   safeParseErrorObject,
+  isMastraTextStreamChunk,
 } from './utils';
 
 type LanguageModelV2Usage = {
@@ -83,7 +85,9 @@ export type AgentDataPart = {
 // used so it's not serialized to JSON
 const PRIMITIVE_CACHE_SYMBOL = Symbol('primitive-cache');
 
-export function WorkflowStreamToAISDKTransformer() {
+export function WorkflowStreamToAISDKTransformer({
+  includeTextStreamParts,
+}: { includeTextStreamParts?: boolean } = {}) {
   const bufferedWorkflows = new Map<
     string,
     {
@@ -97,8 +101,12 @@ export function WorkflowStreamToAISDKTransformer() {
         data?: string;
         type?: 'start' | 'finish';
       }
+    | InferUIMessageChunk<UIMessage>
     | WorkflowDataPart
     | ChunkType
+    | ToolAgentChunkType
+    | ToolWorkflowChunkType
+    | ToolNetworkChunkType
   >({
     start(controller) {
       controller.enqueue({
@@ -111,8 +119,7 @@ export function WorkflowStreamToAISDKTransformer() {
       });
     },
     transform(chunk, controller) {
-      const transformed = transformWorkflow<any>(chunk, bufferedWorkflows);
-
+      const transformed = transformWorkflow<any>(chunk, bufferedWorkflows, false, includeTextStreamParts);
       if (transformed) controller.enqueue(transformed);
     },
   });
@@ -404,6 +411,7 @@ export function transformWorkflow<TOutput extends ZodType<any>>(
     }
   >,
   isNested?: boolean,
+  includeTextStreamParts?: boolean,
 ) {
   switch (payload.type) {
     case 'workflow-start':
@@ -499,6 +507,20 @@ export function transformWorkflow<TOutput extends ZodType<any>>(
     }
     case 'workflow-step-output': {
       const output = payload.payload.output;
+
+      if (includeTextStreamParts && output && isMastraTextStreamChunk(output)) {
+        const part = convertMastraChunkToAISDKv5({ chunk: output, mode: 'stream' });
+
+        const transformedChunk = convertFullStreamChunkToUIMessageStream<any>({
+          part: part as any,
+          onError(error) {
+            return safeParseErrorObject(error);
+          },
+        });
+
+        return transformedChunk;
+      }
+
       if (output && isDataChunkType(output)) {
         if (!('data' in output)) {
           throw new Error(
@@ -845,7 +867,7 @@ export function transformNetwork(
 
         step[PRIMITIVE_CACHE_SYMBOL] = step[PRIMITIVE_CACHE_SYMBOL] || new Map();
         const result = transformWorkflow(payload.payload as WorkflowStreamEvent, step[PRIMITIVE_CACHE_SYMBOL]);
-        if (result) {
+        if (result && 'data' in result) {
           const data = result.data;
           step.task = data;
 

--- a/client-sdks/ai-sdk/src/utils.ts
+++ b/client-sdks/ai-sdk/src/utils.ts
@@ -1,7 +1,39 @@
-import type { DataChunkType, NetworkChunkType } from '@mastra/core/stream';
+import type { ChunkType, DataChunkType, NetworkChunkType, OutputSchema } from '@mastra/core/stream';
 
 export const isDataChunkType = (chunk: any): chunk is DataChunkType => {
   return chunk && typeof chunk === 'object' && 'type' in chunk && chunk.type?.startsWith('data-');
+};
+
+export const isMastraTextStreamChunk = (chunk: any): chunk is ChunkType<OutputSchema> => {
+  return (
+    chunk &&
+    typeof chunk === 'object' &&
+    'type' in chunk &&
+    typeof chunk.type === 'string' &&
+    [
+      'text-start',
+      'text-delta',
+      'text-end',
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-end',
+      'file',
+      'source',
+      'tool-input-start',
+      'tool-input-delta',
+      'tool-call',
+      'tool-result',
+      'tool-error',
+      'error',
+      'start-step',
+      'finish-step',
+      'start',
+      'finish',
+      'abort',
+      'tool-input-end',
+      'raw',
+    ].includes(chunk.type)
+  );
 };
 
 export function safeParseErrorObject(obj: unknown): string {

--- a/client-sdks/ai-sdk/src/workflow-route.ts
+++ b/client-sdks/ai-sdk/src/workflow-route.ts
@@ -15,12 +15,13 @@ type WorkflowRouteBody = {
 };
 
 export type WorkflowRouteOptions =
-  | { path: `${string}:workflowId${string}`; workflow?: never }
-  | { path: string; workflow: string };
+  | { path: `${string}:workflowId${string}`; workflow?: never; includeTextStreamParts?: boolean }
+  | { path: string; workflow: string; includeTextStreamParts?: boolean };
 
 export function workflowRoute({
   path = '/api/workflows/:workflowId/stream',
   workflow,
+  includeTextStreamParts = true,
 }: WorkflowRouteOptions): ReturnType<typeof registerApiRoute> {
   if (!workflow && !path.includes('/:workflowId')) {
     throw new Error('Path must include :workflowId to route to the correct workflow or pass the workflow explicitly');
@@ -114,7 +115,7 @@ export function workflowRoute({
 
       const uiMessageStream = createUIMessageStream({
         execute: async ({ writer }) => {
-          for await (const part of toAISdkV5Stream(stream, { from: 'workflow' })) {
+          for await (const part of toAISdkV5Stream(stream, { from: 'workflow', includeTextStreamParts })) {
             writer.write(part);
           }
         },

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -142,6 +142,12 @@ const { error, status, sendMessage, messages, regenerate, stop } = useChat({
 });
 ```
 
+:::tip Agent streaming in workflows
+When a workflow step pipes an agent's stream to the workflow writer (e.g., `await response.fullStream.pipeTo(writer)`), the agent's text chunks and tool calls are automatically streamed to the UI in real-time. This provides a seamless streaming experience even when agents are running inside workflow steps.
+
+Learn more in [Workflow Streaming](/docs/v1/streaming/workflow-streaming#streaming-agent-text-chunks-to-ui).
+:::
+
 ### `networkRoute()`
 
 Use the `networkRoute()` utility to create a route handler that automatically formats the agent network stream into an AI SDK-compatible format.


### PR DESCRIPTION
- **feat(ai-sdk): Support streaming agent text chunks from workflow-step-output**
- **changeset**

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)
Fixes #9114
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now stream text and tool-call outputs in real-time within workflows
  * New `includeTextStreamParts` option controls streaming behavior (defaults to true)
  * New `isMastraTextStreamChunk` type guard identifies Mastra streaming chunks

* **Tests**
  * Added comprehensive test coverage for workflow streaming scenarios

* **Documentation**
  * Updated workflow streaming and `workflowRoute()` usage documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->