### PR TITLE
Fix model types

### DIFF
--- a/.changeset/fix-generate-title-model-type.md
+++ b/.changeset/fix-generate-title-model-type.md
@@ -1,0 +1,13 @@
+---
+"@mastra/core": patch
+---
+
+Fix generateTitle model type to accept AI SDK LanguageModelV2
+
+Updated the `generateTitle.model` config option to accept `MastraModelConfig` instead of `MastraLanguageModel`. This allows users to pass raw AI SDK `LanguageModelV2` models (e.g., `anthropic.languageModel('claude-3-5-haiku-20241022')`) directly without type errors.
+
+Previously, passing a standard `LanguageModelV2` would fail because `MastraLanguageModelV2` has different `doGenerate`/`doStream` return types. Now `MastraModelConfig` is used consistently across:
+- `memory/types.ts` - `generateTitle.model` config
+- `agent.ts` - `genTitle`, `generateTitleFromUserMessage`, `resolveTitleGenerationConfig`
+- `agent-legacy.ts` - `AgentLegacyCapabilities` interface
+

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -17,7 +17,7 @@ import type {
   StreamTextWithMessagesArgs,
   StreamObjectWithMessagesArgs,
 } from '../llm/model/base.types';
-import type { MastraLanguageModel, TripwireProperties } from '../llm/model/shared.types';
+import type { MastraModelConfig, TripwireProperties } from '../llm/model/shared.types';
 import type { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfig, StorageThreadType } from '../memory/types';
@@ -116,18 +116,18 @@ export interface AgentLegacyCapabilities {
     userMessage: UIMessage | UIMessageWithMetadata,
     requestContext: RequestContext,
     tracingContext: TracingContext,
-    titleModel?: DynamicArgument<MastraLanguageModel>,
+    titleModel?: DynamicArgument<MastraModelConfig>,
     titleInstructions?: DynamicArgument<string>,
   ): Promise<string | undefined>;
   /** Resolve title generation config */
   resolveTitleGenerationConfig(
     generateTitleConfig:
       | boolean
-      | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> }
+      | { model: DynamicArgument<MastraModelConfig>; instructions?: DynamicArgument<string> }
       | undefined,
   ): {
     shouldGenerate: boolean;
-    model?: DynamicArgument<MastraLanguageModel>;
+    model?: DynamicArgument<MastraModelConfig>;
     instructions?: DynamicArgument<string>;
   };
   /** Save step messages */

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1138,7 +1138,7 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
     message: string | MessageInput;
     requestContext?: RequestContext;
     tracingContext: TracingContext;
-    model?: DynamicArgument<MastraLanguageModel>;
+    model?: DynamicArgument<MastraModelConfig>;
     instructions?: DynamicArgument<string>;
   }) {
     // need to use text, not object output or it will error for models that don't support structured output (eg Deepseek R1)
@@ -1233,7 +1233,7 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
     userMessage: string | MessageInput | undefined,
     requestContext: RequestContext,
     tracingContext: TracingContext,
-    model?: DynamicArgument<MastraLanguageModel>,
+    model?: DynamicArgument<MastraModelConfig>,
     instructions?: DynamicArgument<string>,
   ) {
     try {
@@ -3135,11 +3135,11 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
   resolveTitleGenerationConfig(
     generateTitleConfig:
       | boolean
-      | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> }
+      | { model: DynamicArgument<MastraModelConfig>; instructions?: DynamicArgument<string> }
       | undefined,
   ): {
     shouldGenerate: boolean;
-    model?: DynamicArgument<MastraLanguageModel>;
+    model?: DynamicArgument<MastraModelConfig>;
     instructions?: DynamicArgument<string>;
   } {
     if (typeof generateTitleConfig === 'boolean') {

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -5,7 +5,7 @@ import type { JSONSchema7 } from 'json-schema';
 export type { MastraDBMessage } from '../agent';
 import type { ZodObject } from 'zod';
 import type { EmbeddingModelId } from '../llm/model/index.js';
-import type { MastraLanguageModel } from '../llm/model/shared.types';
+import type { MastraLanguageModel, MastraModelConfig } from '../llm/model/shared.types';
 import type { MastraStorage } from '../storage';
 import type { DynamicArgument } from '../types';
 import type { MastraVector } from '../vector';
@@ -316,8 +316,9 @@ export type MemoryConfig = {
         /**
          * Language model to use for title generation.
          * Can be static or a function that receives request context for dynamic selection.
+         * Accepts both Mastra models and standard AI SDK LanguageModelV1/V2.
          */
-        model: DynamicArgument<MastraLanguageModel>;
+        model: DynamicArgument<MastraModelConfig>;
         /**
          * Custom instructions for title generation.
          * Can be static or a function that receives request context for dynamic customization.
@@ -336,7 +337,7 @@ export type MemoryConfig = {
     generateTitle?:
       | boolean
       | {
-          model: DynamicArgument<MastraLanguageModel>;
+          model: DynamicArgument<MastraModelConfig>;
           instructions?: DynamicArgument<string>;
         };
   };


### PR DESCRIPTION
Fix generateTitle model type to accept AI SDK LanguageModelV2

Updated the `generateTitle.model` config option to accept `MastraModelConfig` instead of `MastraLanguageModel`. This allows users to pass raw AI SDK `LanguageModelV2` models (e.g., `anthropic.languageModel('claude-3-5-haiku-20241022')`) directly without type errors.

Previously, passing a standard `LanguageModelV2` would fail because `MastraLanguageModelV2` has different `doGenerate`/`doStream` return types. Now `MastraModelConfig` is used consistently across:
- `memory/types.ts` - `generateTitle.model` config
- `agent.ts` - `genTitle`, `generateTitleFromUserMessage`, `resolveTitleGenerationConfig`
- `agent-legacy.ts` - `AgentLegacyCapabilities` interface

Fixes https://github.com/mastra-ai/mastra/issues/10519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed type compatibility to allow using AI SDK language models directly for title generation without type errors. Title generation now accepts a broader range of model configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->