### PR TITLE
fix(agent): persist messages before tool suspension (#10369)

### DIFF
--- a/.changeset/huge-moles-watch.md
+++ b/.changeset/huge-moles-watch.md
@@ -1,0 +1,28 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/react': patch
+'@mastra/core': patch
+---
+
+fix(agent): persist messages before tool suspension
+
+Fixes issues where thread and messages were not saved before suspension when tools require approval or call suspend() during execution. This caused conversation history to be lost if users refreshed during tool approval or suspension.
+
+**Backend changes (@mastra/core):**
+- Add assistant messages to messageList immediately after LLM execution
+- Flush messages synchronously before suspension to persist state
+- Create thread if it doesn't exist before flushing
+- Add metadata helpers to persist and remove tool approval state
+- Pass saveQueueManager and memory context through workflow for immediate persistence
+
+**Frontend changes (@mastra/react):**
+- Extract runId from pending approvals to enable resumption after refresh
+- Convert `pendingToolApprovals` (DB format) to `requireApprovalMetadata` (runtime format)
+- Handle both `dynamic-tool` and `tool-{NAME}` part types for approval state
+- Change runId from hardcoded `agentId` to unique `uuid()`
+
+**UI changes (@mastra/playground-ui):**
+- Handle tool calls awaiting approval in message initialization
+- Convert approval metadata format when loading initial messages
+
+Fixes #9745, #9906

--- a/.changeset/little-beans-work.md
+++ b/.changeset/little-beans-work.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Remove unneeded console warning when flushing messages and no threadId or saveQueueManager is found.

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -316,7 +316,7 @@ export type GetMemoryThreadMessagesPaginatedParams = Omit<StorageGetMessagesArg,
 
 export interface GetMemoryThreadMessagesResponse {
   messages: CoreMessage[];
-  legacyMessages: AiMessageType[];
+  legacyMessages: UIMessageWithMetadata[];
   uiMessages: UIMessage[];
 }
 

--- a/client-sdks/react/package.json
+++ b/client-sdks/react/package.json
@@ -44,6 +44,7 @@
   ],
   "dependencies": {
     "@mastra/client-js": "workspace:*",
+    "@lukeed/uuid": "^2.0.1",
     "@radix-ui/react-tooltip": "^1.2.7",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "lucide-react": "^0.522.0",

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -1,7 +1,7 @@
 import { ModelSettings } from './types';
 import { useMastraClient } from '@/mastra-client-context';
 import { UIMessage } from '@ai-sdk/react';
-import { MastraUIMessage } from '../lib/ai-sdk';
+import { ExtendedMastraUIMessage, MastraUIMessage } from '../lib/ai-sdk';
 import { MastraClient } from '@mastra/client-js';
 import { CoreUserMessage } from '@mastra/core/llm';
 import { RuntimeContext } from '@mastra/core/runtime-context';
@@ -10,6 +10,7 @@ import { useRef, useState } from 'react';
 import { toUIMessage } from '@/lib/ai-sdk';
 import { AISdkNetworkTransformer } from '@/lib/ai-sdk/transformers/AISdkNetworkTransformer';
 import { resolveInitialMessages } from '@/lib/ai-sdk/memory/resolveInitialMessages';
+import { v4 as uuid } from '@lukeed/uuid';
 
 export interface MastraChatProps {
   agentId: string;
@@ -42,11 +43,26 @@ export type NetworkArgs = SharedArgs & {
 };
 
 export const useChat = ({ agentId, initializeMessages }: MastraChatProps) => {
-  const _currentRunId = useRef<string | undefined>(undefined);
+  // Extract runId from any pending suspensions in initial messages
+  const extractRunIdFromMessages = (messages: ExtendedMastraUIMessage[]): string | undefined => {
+    for (const message of messages) {
+      const pendingToolApprovals = message.metadata?.pendingToolApprovals as Record<string, any> | undefined;
+      if (pendingToolApprovals && typeof pendingToolApprovals === 'object') {
+        const suspensionData = Object.values(pendingToolApprovals)[0];
+        if (suspensionData?.runId) {
+          return suspensionData.runId;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  const initialMessages = initializeMessages?.() || [];
+  const initialRunId = extractRunIdFromMessages(initialMessages);
+
+  const _currentRunId = useRef<string | undefined>(initialRunId);
   const _onChunk = useRef<((chunk: ChunkType) => Promise<void>) | undefined>(undefined);
-  const [messages, setMessages] = useState<MastraUIMessage[]>(() =>
-    resolveInitialMessages(initializeMessages?.() || []),
-  );
+  const [messages, setMessages] = useState<MastraUIMessage[]>(() => resolveInitialMessages(initialMessages));
   const [toolCallApprovals, setToolCallApprovals] = useState<{
     [toolCallId: string]: { status: 'approved' | 'declined' };
   }>({});
@@ -87,7 +103,7 @@ export const useChat = ({ agentId, initializeMessages }: MastraChatProps) => {
 
     const response = await agent.generate({
       messages: coreUserMessages,
-      runId: agentId,
+      runId: uuid(),
       maxSteps,
       modelSettings: {
         frequencyPenalty,
@@ -145,7 +161,7 @@ export const useChat = ({ agentId, initializeMessages }: MastraChatProps) => {
 
     const agent = clientWithAbort.getAgent(agentId);
 
-    const runId = agentId;
+    const runId = uuid();
 
     const response = await agent.stream({
       messages: coreUserMessages,
@@ -205,6 +221,8 @@ export const useChat = ({ agentId, initializeMessages }: MastraChatProps) => {
 
     const agent = clientWithAbort.getAgent(agentId);
 
+    const runId = uuid();
+
     const response = await agent.network({
       messages: coreUserMessages,
       maxSteps,
@@ -217,7 +235,7 @@ export const useChat = ({ agentId, initializeMessages }: MastraChatProps) => {
         topK,
         topP,
       },
-      runId: agentId,
+      runId,
       runtimeContext,
       ...(threadId ? { thread: threadId, resourceId: agentId } : {}),
     });

--- a/client-sdks/react/src/lib/ai-sdk/memory/resolveInitialMessages.test.ts
+++ b/client-sdks/react/src/lib/ai-sdk/memory/resolveInitialMessages.test.ts
@@ -559,34 +559,35 @@ describe('resolveInitialMessages', () => {
       ]);
     });
 
-    it('should log the parsed JSON', () => {
-      const networkData = {
-        isNetwork: true,
-        primitiveType: 'agent',
-        primitiveId: 'agent-8',
-        input: 'test',
-        finalResult: {
-          text: 'Result',
-        },
-      };
+    // Note: Do we still need this test? Leaving it here for now in case we need to log the parsed JSON again.
+    // it('should log the parsed JSON', () => {
+    //   const networkData = {
+    //     isNetwork: true,
+    //     primitiveType: 'agent',
+    //     primitiveId: 'agent-8',
+    //     input: 'test',
+    //     finalResult: {
+    //       text: 'Result',
+    //     },
+    //   };
 
-      const messages: MastraUIMessage[] = [
-        {
-          id: 'msg-13',
-          role: 'assistant',
-          parts: [
-            {
-              type: 'text',
-              text: JSON.stringify(networkData),
-            },
-          ],
-        },
-      ];
+    //   const messages: MastraUIMessage[] = [
+    //     {
+    //       id: 'msg-13',
+    //       role: 'assistant',
+    //       parts: [
+    //         {
+    //           type: 'text',
+    //           text: JSON.stringify(networkData),
+    //         },
+    //       ],
+    //     },
+    //   ];
 
-      resolveInitialMessages(messages);
+    //   resolveInitialMessages(messages);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('json', networkData);
-    });
+    //   expect(consoleLogSpy).toHaveBeenCalledWith('json', networkData);
+    // });
   });
 
   describe('Non-network messages', () => {

--- a/client-sdks/react/src/lib/ai-sdk/memory/resolveInitialMessages.ts
+++ b/client-sdks/react/src/lib/ai-sdk/memory/resolveInitialMessages.ts
@@ -1,4 +1,4 @@
-import { MastraUIMessage } from '../types';
+import { ExtendedMastraUIMessage, MastraUIMessage } from '../types';
 
 // Type definitions for parsing network execution data
 interface ToolCallPayload {
@@ -121,9 +121,6 @@ export const resolveInitialMessages = (messages: MastraUIMessage[]): MastraUIMes
           };
 
           // Return the transformed message with dynamic-tool part
-
-          console.log('json', json);
-
           const nextMessage = {
             role: 'assistant' as const,
             parts: [
@@ -152,6 +149,21 @@ export const resolveInitialMessages = (messages: MastraUIMessage[]): MastraUIMes
         // If parsing fails, return the original message
         return message;
       }
+    }
+
+    const extendedMessage = message as ExtendedMastraUIMessage;
+
+    // Convert pendingToolApprovals from DB format to stream format
+    const pendingToolApprovals = extendedMessage.metadata?.pendingToolApprovals as Record<string, any> | undefined;
+    if (pendingToolApprovals && typeof pendingToolApprovals === 'object') {
+      return {
+        ...message,
+        metadata: {
+          ...message.metadata,
+          mode: 'stream' as const,
+          requireApprovalMetadata: pendingToolApprovals,
+        },
+      };
     }
 
     // Return original message if it's not a network message

--- a/client-sdks/react/src/lib/ai-sdk/types.ts
+++ b/client-sdks/react/src/lib/ai-sdk/types.ts
@@ -1,4 +1,5 @@
 import { UIMessage } from '@ai-sdk/react';
+import { CompleteAttachment } from '@assistant-ui/react';
 
 export type MastraUIMessageMetadata = {
   status?: 'warning' | 'error';
@@ -25,3 +26,13 @@ export type MastraUIMessageMetadata = {
 );
 
 export type MastraUIMessage = UIMessage<MastraUIMessageMetadata, any, any>;
+
+/**
+ * Extended type for MastraUIMessage that may include additional properties
+ * from different sources (generate, toUIMessage, toNetworkUIMessage)
+ */
+export type ExtendedMastraUIMessage = MastraUIMessage & {
+  createdAt?: Date;
+  metadata?: Record<string, unknown>;
+  experimental_attachments?: readonly CompleteAttachment[];
+};

--- a/client-sdks/react/src/lib/ai-sdk/utils/toAssistantUIMessage.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toAssistantUIMessage.ts
@@ -1,16 +1,6 @@
-import { ThreadMessageLike, MessageStatus, CompleteAttachment } from '@assistant-ui/react';
-import { MastraUIMessage } from '../types';
+import { ThreadMessageLike, MessageStatus } from '@assistant-ui/react';
+import { ExtendedMastraUIMessage, MastraUIMessage } from '../types';
 import { ReadonlyJSONObject } from '@mastra/core/stream';
-
-/**
- * Extended type for MastraUIMessage that may include additional properties
- * from different sources (generate, toUIMessage, toNetworkUIMessage)
- */
-type ExtendedMastraUIMessage = MastraUIMessage & {
-  createdAt?: Date;
-  metadata?: Record<string, unknown>;
-  experimental_attachments?: readonly CompleteAttachment[];
-};
 
 type ContentPart = { metadata?: Record<string, unknown> } & (Exclude<
   ThreadMessageLike['content'],
@@ -133,6 +123,32 @@ export const toAssistantUIMessage = (message: MastraUIMessage): ThreadMessageLik
       }
 
       return baseToolCall;
+    }
+
+    // Extract requireApprovalMetadata from message metadata (if any)
+    const requireApprovalMetadata = extendedMessage.metadata?.requireApprovalMetadata as
+      | Record<string, any>
+      | undefined;
+
+    // Check if this part has a toolCallId that matches requireApprovalMetadata
+    const partToolCallId = 'toolCallId' in part && typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+    const suspensionData = partToolCallId ? requireApprovalMetadata?.[partToolCallId] : undefined;
+    if (suspensionData) {
+      const toolName =
+        'toolName' in part && typeof part.toolName === 'string'
+          ? part.toolName
+          : part.type.startsWith('tool-')
+            ? part.type.substring(5)
+            : '';
+
+      return {
+        type: 'tool-call' as const,
+        toolCallId: partToolCallId!,
+        toolName,
+        argsText: 'input' in part ? JSON.stringify(part.input) : '{}',
+        args: ('input' in part ? part.input : {}) as ReadonlyJSONObject,
+        metadata: extendedMessage.metadata,
+      };
     }
 
     // For any other part types, return a minimal text part

--- a/packages/core/src/agent/__tests__/tool-suspension.test.ts
+++ b/packages/core/src/agent/__tests__/tool-suspension.test.ts
@@ -1,0 +1,284 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { MockMemory } from '../../memory/mock';
+import { createTool } from '../../tools';
+import { delay } from '../../utils';
+import { Agent } from '../agent';
+
+describe('Tool suspension memory persistence', () => {
+  it('should save thread and messages to memory before suspension when tool requires approval', async () => {
+    // Create a mock memory instance with in-memory storage
+    const mockMemory = new MockMemory();
+
+    // Create a tool that requires approval
+    const findJobTool = createTool({
+      id: 'find-job-tool',
+      description: 'Use this tool to find job listings based on user criteria.',
+      inputSchema: z.object({
+        title: z.string().optional().describe('The job title to search for.'),
+      }),
+      requireApproval: true,
+      execute: async (inputData: { title?: string }) => {
+        const { title } = inputData;
+        return `Here are some job listings for the title: ${title || 'any position'}.`;
+      },
+    });
+
+    // Create a mock model that will generate a tool call
+    const mockModel = new MockLanguageModelV2({
+      doStream: async () => {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'test-id', modelId: 'test-model', timestamp: new Date() },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Let me find job listings for you.' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'tool-call-delta',
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'find-job-tool',
+              argsTextDelta: '{"title":"software engineer"}',
+            },
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'find-job-tool',
+              args: '{"title":"software engineer"}',
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ] as any),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    // Create agent with memory and the approval tool
+    const agent = new Agent({
+      id: 'require-tool-agent',
+      name: 'Require Tool Agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        findJobTool,
+      },
+      memory: mockMemory,
+    });
+
+    const threadId = 'test-thread-9745';
+    const resourceId = 'user-test-9745';
+
+    // Verify thread does not exist yet
+    const threadBefore = await mockMemory.getThreadById({ threadId });
+    expect(threadBefore).toBeNull();
+
+    // Start streaming
+    const stream = await agent.stream('find me a software engineer job', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+      },
+    });
+
+    // Consume stream until we hit the tool-call-approval event
+    let hitApprovalEvent = false;
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'tool-call-approval') {
+        hitApprovalEvent = true;
+        break; // Stop at suspension point
+      }
+    }
+
+    expect(hitApprovalEvent).toBe(true);
+
+    // Give the debounced save time to fire (if it exists)
+    // The debounce is 100ms, so 150ms should be enough
+    await delay(150);
+
+    // Assert 1: Thread should be created in database
+    const threadAfterSuspension = await mockMemory.getThreadById({ threadId });
+    expect(threadAfterSuspension).not.toBeNull();
+    expect(threadAfterSuspension?.resourceId).toBe(resourceId);
+
+    // Assert 2: User message should be saved
+    const messagesAfterSuspension = await mockMemory.recall({
+      threadId,
+      resourceId,
+    });
+
+    const userMessages = messagesAfterSuspension.messages.filter(m => m.role === 'user');
+    expect(userMessages.length).toBeGreaterThan(0);
+
+    const userMessage = userMessages.find(m => {
+      const content = m.content;
+      if (typeof content === 'string') return content.includes('software engineer job');
+      if (typeof content === 'object' && 'parts' in content) {
+        return content.parts.some(p => p.type === 'text' && p.text.includes('software engineer job'));
+      }
+      return false;
+    });
+    expect(userMessage).toBeDefined();
+
+    // Assert 3: Assistant message with tool call should be saved
+    const assistantMessages = messagesAfterSuspension.messages.filter(m => m.role === 'assistant');
+    expect(assistantMessages.length).toBeGreaterThan(0);
+
+    const assistantWithToolCall = assistantMessages.find(m => {
+      const content = m.content;
+      if (typeof content === 'object' && 'parts' in content) {
+        return content.parts.some(
+          (p: any) => p.type === 'tool-invocation' && p.toolInvocation?.toolName === 'find-job-tool',
+        );
+      }
+      return false;
+    });
+    expect(assistantWithToolCall).toBeDefined();
+  });
+
+  it('should save thread and messages to memory before suspension when tool calls suspend()', async () => {
+    const mockMemory = new MockMemory();
+
+    // Create a tool that validates data (doesn't suspend)
+    const validateTool = createTool({
+      id: 'validate-data',
+      description: 'Validates data format before processing',
+      inputSchema: z.object({
+        data: z.string().describe('The data to validate'),
+      }),
+      execute: async (inputData: { data: string }) => {
+        return { valid: true, message: `Data "${inputData.data}" is valid` };
+      },
+    });
+
+    // Create a tool that suspends during execution
+    const processDataTool = createTool({
+      id: 'process-data',
+      description: 'Processes validated data and may require manual approval',
+      inputSchema: z.object({
+        data: z.string().describe('The data to process'),
+      }),
+      execute: async (_inputData: { data: string }, context?: any) => {
+        const suspend = context?.agent?.suspend || context?.suspend;
+        if (!suspend) {
+          throw new Error('Expected suspend to be provided in context');
+        }
+        // Suspend to simulate waiting for manual approval/async work
+        await suspend({ reason: 'Waiting for manual approval' });
+        return { result: 'Data processed successfully' };
+      },
+    });
+
+    // Create agent with memory and both tools
+    const agent = new Agent({
+      id: 'suspending-tool-agent',
+      name: 'Suspending Tool Agent',
+      instructions: `You are a helpful assistant. When asked to process data:
+1. First, use the validate-data tool to validate the data
+2. Then, use the process-data tool to process the validated data
+Always follow this order.`,
+      model: 'openai/gpt-4o-mini',
+      tools: {
+        validateData: validateTool,
+        processData: processDataTool,
+      },
+      memory: mockMemory,
+    });
+
+    const threadId = 'test-thread-9906';
+    const resourceId = 'user-test-9906';
+
+    // Verify thread does not exist yet
+    const threadBefore = await mockMemory.getThreadById({ threadId });
+    expect(threadBefore).toBeNull();
+
+    // Start streaming with savePerStep
+    const stream = await agent.stream('Please process the data "test-data-123". First validate it, then process it.', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+      },
+      savePerStep: true,
+      maxSteps: 10,
+    });
+
+    let suspensionDetected = false;
+
+    // Consume stream until suspension - stop immediately at suspension point
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'tool-call-suspended') {
+        suspensionDetected = true;
+        break; // Stop at suspension point
+      }
+    }
+
+    expect(suspensionDetected).toBe(true);
+
+    // Give the debounced save time to fire (if it exists)
+    await delay(150);
+
+    // Assert: Thread should be created in database
+    const threadAfterSuspension = await mockMemory.getThreadById({ threadId });
+    expect(threadAfterSuspension).not.toBeNull();
+    expect(threadAfterSuspension?.resourceId).toBe(resourceId);
+
+    // Assert: All messages should be saved
+    const messagesAfterSuspension = await mockMemory.recall({
+      threadId,
+      resourceId,
+    });
+
+    // Assert: User message should be saved
+    const userMessages = messagesAfterSuspension.messages.filter(m => m.role === 'user');
+    expect(userMessages.length).toBeGreaterThan(0);
+
+    const userMessage = userMessages.find(m => {
+      const content = m.content;
+      if (typeof content === 'string') return content.includes('process');
+      if (typeof content === 'object' && 'parts' in content) {
+        return content.parts.some(p => p.type === 'text' && p.text.includes('process'));
+      }
+      return false;
+    });
+    expect(userMessage).toBeDefined();
+
+    // Assert: Assistant messages with tool call should be saved
+    const assistantMessages = messagesAfterSuspension.messages.filter(m => m.role === 'assistant');
+    expect(assistantMessages.length).toBeGreaterThan(0);
+
+    // Verify both tool calls are saved - validation tool and suspending tool
+    // Both tools should appear in the parts array (toolName can be validateData or validate-data)
+    const hasValidateTool = assistantMessages.some(m => {
+      const content = m.content;
+      if (typeof content === 'object' && 'parts' in content) {
+        return content.parts.some(
+          (p: any) =>
+            p.type === 'tool-invocation' &&
+            (p.toolInvocation?.toolName === 'validate-data' || p.toolInvocation?.toolName === 'validateData'),
+        );
+      }
+      return false;
+    });
+    expect(hasValidateTool).toBe(true);
+
+    const hasProcessTool = assistantMessages.some(m => {
+      const content = m.content;
+      if (typeof content === 'object' && 'parts' in content) {
+        return content.parts.some(
+          (p: any) =>
+            p.type === 'tool-invocation' &&
+            (p.toolInvocation?.toolName === 'process-data' || p.toolInvocation?.toolName === 'processData'),
+        );
+      }
+      return false;
+    });
+    expect(hasProcessTool).toBe(true);
+  });
+});

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -107,6 +107,10 @@ export function createPrepareStreamWorkflow<
     agentId,
     toolCallId,
     methodType,
+    saveQueueManager,
+    memoryConfig,
+    memory,
+    resourceId,
   });
 
   const mapResultsStep = createMapResultsStep({

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -2,9 +2,12 @@ import { z } from 'zod';
 import { getModelMethodFromAgentMethod } from '../../../llm/model/model-method-from-agent';
 import type { ModelLoopStreamArgs, ModelMethodType } from '../../../llm/model/model.loop.types';
 import { RuntimeContext } from '../../../runtime-context';
+import type { MastraMemory } from '../../../memory/memory';
+import type { MemoryConfig } from '../../../memory/types';
 import { AISDKV5OutputStream, MastraModelOutput } from '../../../stream';
 import type { OutputSchema } from '../../../stream/base/schema';
 import { createStep } from '../../../workflows';
+import type { SaveQueueManager } from '../../save-queue';
 import type { AgentMethodType } from '../../types';
 import type { AgentCapabilities } from './schema';
 
@@ -24,6 +27,10 @@ interface StreamStepOptions<FORMAT extends 'aisdk' | 'mastra' | undefined = unde
   agentId: string;
   toolCallId?: string;
   methodType: AgentMethodType;
+  saveQueueManager?: SaveQueueManager;
+  memoryConfig?: MemoryConfig;
+  memory?: MastraMemory;
+  resourceId?: string;
 }
 
 export function createStreamStep<
@@ -39,6 +46,10 @@ export function createStreamStep<
   agentId,
   toolCallId,
   methodType,
+  saveQueueManager,
+  memoryConfig,
+  memory,
+  resourceId,
 }: StreamStepOptions<FORMAT>) {
   return createStep({
     id: 'stream-text-step',
@@ -76,6 +87,11 @@ export function createStreamStep<
         resumeContext,
         _internal: {
           generateId: capabilities.generateMessageId,
+          saveQueueManager,
+          memoryConfig,
+          threadId: validatedInputData.threadId,
+          resourceId,
+          memory,
         },
         agentId,
         toolCallId,

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 import { getModelMethodFromAgentMethod } from '../../../llm/model/model-method-from-agent';
 import type { ModelLoopStreamArgs, ModelMethodType } from '../../../llm/model/model.loop.types';
-import { RuntimeContext } from '../../../runtime-context';
 import type { MastraMemory } from '../../../memory/memory';
 import type { MemoryConfig } from '../../../memory/types';
+import { RuntimeContext } from '../../../runtime-context';
 import { AISDKV5OutputStream, MastraModelOutput } from '../../../stream';
 import type { OutputSchema } from '../../../stream/base/schema';
 import { createStep } from '../../../workflows';

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -57,6 +57,12 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
     now: _internal?.now || (() => Date.now()),
     generateId: _internal?.generateId || (() => generateId()),
     currentDate: _internal?.currentDate || (() => new Date()),
+    saveQueueManager: _internal?.saveQueueManager,
+    memoryConfig: _internal?.memoryConfig,
+    threadId: _internal?.threadId,
+    resourceId: _internal?.resourceId,
+    memory: _internal?.memory,
+    threadExists: _internal?.threadExists,
   };
 
   let startTimestamp = internalToUse.now?.();

--- a/packages/core/src/loop/test-utils/generateText.ts
+++ b/packages/core/src/loop/test-utils/generateText.ts
@@ -745,12 +745,7 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
             "id": "test-id-from-model",
             "messages": [
               {
-                "content": [
-                  {
-                    "text": "Hello, world!",
-                    "type": "text",
-                  },
-                ],
+                "content": "Hello, world!",
                 "role": "assistant",
               },
             ],
@@ -767,7 +762,7 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
               {
                 "id": "1234",
                 "metadata": {
-                  "createdAt": 2024-01-01T00:00:00.000Z,
+                  "createdAt": 2024-01-01T00:00:00.001Z,
                 },
                 "parts": [
                   {
@@ -811,7 +806,7 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
               {
                 "id": "1234",
                 "metadata": {
-                  "createdAt": 2024-01-01T00:00:00.000Z,
+                  "createdAt": 2024-01-01T00:00:00.001Z,
                 },
                 "parts": [
                   {

--- a/packages/core/src/loop/test-utils/resultObject.ts
+++ b/packages/core/src/loop/test-utils/resultObject.ts
@@ -305,7 +305,7 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
             {
               "id": "msg-0",
               "metadata": {
-                "createdAt": 2024-01-01T00:00:00.000Z,
+                "createdAt": 2024-01-01T00:00:00.001Z,
               },
               "parts": [
                 {
@@ -672,6 +672,24 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                 },
                 "type": "file",
               },
+              {
+                "file": DefaultGeneratedFileWithType {
+                  "base64Data": "Hello World",
+                  "mediaType": "text/plain",
+                  "type": "file",
+                  "uint8ArrayData": undefined,
+                },
+                "type": "file",
+              },
+              {
+                "file": DefaultGeneratedFileWithType {
+                  "base64Data": "QkFVRw==",
+                  "mediaType": "image/jpeg",
+                  "type": "file",
+                  "uint8ArrayData": undefined,
+                },
+                "type": "file",
+              },
             ],
             "dynamicToolCalls": [],
             "dynamicToolResults": [],
@@ -757,6 +775,16 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     {
                       "mediaType": "image/jpeg",
                       "providerMetadata": undefined,
+                      "type": "file",
+                      "url": "data:image/jpeg;base64,QkFVRw==",
+                    },
+                    {
+                      "mediaType": "text/plain",
+                      "type": "file",
+                      "url": "data:text/plain;base64,Hello World",
+                    },
+                    {
+                      "mediaType": "image/jpeg",
                       "type": "file",
                       "url": "data:image/jpeg;base64,QkFVRw==",
                     },

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -992,7 +992,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                   {
                     "id": "1234",
                     "metadata": {
-                      "createdAt": 2024-01-01T00:00:00.000Z,
+                      "createdAt": 2024-01-01T00:00:00.001Z,
                       "structuredOutput": {
                         "content": "Hello, world!",
                       },
@@ -1035,12 +1035,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "id": "id-0",
                     "messages": [
                       {
-                        "content": [
-                          {
-                            "text": "{ "content": "Hello, world!" }",
-                            "type": "text",
-                          },
-                        ],
+                        "content": "{ "content": "Hello, world!" }",
                         "role": "assistant",
                       },
                     ],
@@ -1055,7 +1050,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                       {
                         "id": "1234",
                         "metadata": {
-                          "createdAt": 2024-01-01T00:00:00.000Z,
+                          "createdAt": 2024-01-01T00:00:00.001Z,
                           "structuredOutput": {
                             "content": "Hello, world!",
                           },
@@ -1213,7 +1208,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                   {
                     "id": "1234",
                     "metadata": {
-                      "createdAt": 2024-01-01T00:00:00.000Z,
+                      "createdAt": 2024-01-01T00:00:00.001Z,
                     },
                     "parts": [
                       {
@@ -1249,12 +1244,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "id": "id-0",
                     "messages": [
                       {
-                        "content": [
-                          {
-                            "text": "{ "invalid": "Hello, world!" }",
-                            "type": "text",
-                          },
-                        ],
+                        "content": "{ "invalid": "Hello, world!" }",
                         "role": "assistant",
                       },
                     ],
@@ -1269,7 +1259,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                       {
                         "id": "1234",
                         "metadata": {
-                          "createdAt": 2024-01-01T00:00:00.000Z,
+                          "createdAt": 2024-01-01T00:00:00.001Z,
                         },
                         "parts": [
                           {
@@ -1424,7 +1414,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                   {
                     "id": "1234",
                     "metadata": {
-                      "createdAt": 2024-01-01T00:00:00.000Z,
+                      "createdAt": 2024-01-01T00:00:00.001Z,
                     },
                     "parts": [
                       {
@@ -1460,12 +1450,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "id": "id-0",
                     "messages": [
                       {
-                        "content": [
-                          {
-                            "text": "{ "invalid": "Hello, world!" }",
-                            "type": "text",
-                          },
-                        ],
+                        "content": "{ "invalid": "Hello, world!" }",
                         "role": "assistant",
                       },
                     ],
@@ -1480,7 +1465,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                       {
                         "id": "1234",
                         "metadata": {
-                          "createdAt": 2024-01-01T00:00:00.000Z,
+                          "createdAt": 2024-01-01T00:00:00.001Z,
                         },
                         "parts": [
                           {

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -13,12 +13,14 @@ import type {
 } from 'ai-v5';
 import z from 'zod';
 import type { MessageList } from '../agent/message-list';
+import type { SaveQueueManager } from '../agent/save-queue';
 import type { StructuredOutputOptions } from '../agent/types';
 import type { ModelSpanTracker } from '../ai-tracing';
 import type { ModelMethodType } from '../llm/model/model.loop.types';
 import type { MastraLanguageModelV2 } from '../llm/model/shared.types';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
+import type { MastraMemory, MemoryConfig } from '../memory';
 import type { OutputProcessor, ProcessorState } from '../processors';
 import type { OutputSchema } from '../stream/base/schema';
 import type {
@@ -33,6 +35,12 @@ export type StreamInternal = {
   now?: () => number;
   generateId?: IdGenerator;
   currentDate?: () => Date;
+  saveQueueManager?: SaveQueueManager; // SaveQueueManager from agent/save-queue
+  memoryConfig?: MemoryConfig; // MemoryConfig from memory/types
+  threadId?: string;
+  resourceId?: string;
+  memory?: MastraMemory; // MastraMemory from memory/memory
+  threadExists?: boolean;
 };
 
 export type PrepareStepResult<TOOLS extends ToolSet = ToolSet> = {

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -72,6 +72,19 @@ export function createAgenticExecutionWorkflow<
             ),
           );
         }
+        // Add assistant response messages to messageList BEFORE processing tool calls
+        // This ensures messages are available for persistence before suspension
+        const responseMessages = typedInputData.messages.nonUser;
+        if (responseMessages && responseMessages.length > 0) {
+          rest.messageList.add(responseMessages, 'response');
+        }
+        return typedInputData;
+      },
+      { id: 'add-response-to-messagelist' },
+    )
+    .map(
+      async ({ inputData }) => {
+        const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
         return typedInputData.output.toolCalls || [];
       },
       { id: 'map-tool-calls' },

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -75,6 +75,12 @@ describe('createToolCallStep tool approval workflow', () => {
             model: () => [],
           },
         },
+        response: {
+          db: () => [],
+        },
+        all: {
+          db: () => [],
+        },
       },
     } as unknown as MessageList;
 
@@ -111,6 +117,9 @@ describe('createToolCallStep tool approval workflow', () => {
         args: { param: 'test' },
       },
     });
+
+    // Wait for flushMessagesBeforeSuspension to complete before suspend is called
+    await new Promise(resolve => setImmediate(resolve));
 
     expect(suspend).toHaveBeenCalledWith(
       {

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -107,7 +107,6 @@ export function createToolCallStep<
         const { saveQueueManager, memoryConfig, threadId, resourceId, memory } = _internal || {};
 
         if (!saveQueueManager || !threadId) {
-          console.warn('flushMessagesBeforeSuspension: saveQueueManager or threadId is missing');
           return;
         }
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -1,4 +1,5 @@
 import type { ToolSet } from 'ai-v5';
+import type { MastraMessageV2 } from '../../../memory';
 import type { OutputSchema } from '../../../stream/base/schema';
 import { ChunkFrom } from '../../../stream/types';
 import type { MastraToolInvocationOptions } from '../../../tools/types';
@@ -20,12 +21,118 @@ export function createToolCallStep<
   runId,
   streamState,
   modelSpanTracker,
+  _internal,
 }: OuterLLMRun<Tools, OUTPUT>) {
   return createStep({
     id: 'toolCallStep',
     inputSchema: toolCallInputSchema,
     outputSchema: toolCallOutputSchema,
     execute: async ({ inputData, suspend, resumeData, runtimeContext }) => {
+      // Helper function to add tool approval metadata to the assistant message
+      const addToolApprovalMetadata = (toolCallId: string, toolName: string, args: unknown) => {
+        // Find the last assistant message in the response (which should contain this tool call)
+        const responseMessages = messageList.get.response.v2();
+        const lastAssistantMessage = [...responseMessages].reverse().find(msg => msg.role === 'assistant');
+
+        if (lastAssistantMessage) {
+          const content = lastAssistantMessage.content;
+          if (!content) return;
+          // Add metadata to indicate this tool call is pending approval
+          const metadata =
+            typeof lastAssistantMessage.content.metadata === 'object' && lastAssistantMessage.content.metadata !== null
+              ? (lastAssistantMessage.content.metadata as Record<string, any>)
+              : {};
+          metadata.pendingToolApprovals = metadata.pendingToolApprovals || {};
+          metadata.pendingToolApprovals[toolCallId] = {
+            toolName,
+            args,
+            type: 'approval',
+            runId, // Store the runId so we can resume after page refresh
+          };
+          lastAssistantMessage.content.metadata = metadata;
+        }
+      };
+
+      // Helper function to remove tool approval metadata after approval/decline
+      const removeToolApprovalMetadata = async (toolCallId: string) => {
+        const { saveQueueManager, memoryConfig, threadId } = _internal || {};
+
+        if (!saveQueueManager || !threadId) {
+          return;
+        }
+
+        const getMetadata = (message: MastraMessageV2) => {
+          const content = message.content;
+          if (!content) return undefined;
+          const metadata =
+            typeof content.metadata === 'object' && content.metadata !== null
+              ? (content.metadata as Record<string, any>)
+              : undefined;
+          return metadata;
+        };
+
+        // Find and update the assistant message to remove approval metadata
+        // At this point, messages have been persisted, so we look in all messages
+        const allMessages = messageList.get.all.v2();
+        const lastAssistantMessage = [...allMessages].reverse().find(msg => {
+          const metadata = getMetadata(msg);
+          const pendingToolApprovals = metadata?.pendingToolApprovals as Record<string, any> | undefined;
+          return !!pendingToolApprovals?.[toolCallId];
+        });
+
+        if (lastAssistantMessage) {
+          const metadata = getMetadata(lastAssistantMessage);
+          const pendingToolApprovals = metadata?.pendingToolApprovals as Record<string, any> | undefined;
+
+          if (pendingToolApprovals && typeof pendingToolApprovals === 'object') {
+            delete pendingToolApprovals[toolCallId];
+
+            // If no more pending suspensions, remove the whole object
+            if (metadata && Object.keys(pendingToolApprovals).length === 0) {
+              delete metadata.pendingToolApprovals;
+            }
+
+            // Flush to persist the metadata removal
+            try {
+              await saveQueueManager.flushMessages(messageList, threadId, memoryConfig);
+            } catch (error) {
+              console.error('Error removing tool approval metadata:', error);
+            }
+          }
+        }
+      };
+
+      // Helper function to flush messages before suspension
+      const flushMessagesBeforeSuspension = async () => {
+        const { saveQueueManager, memoryConfig, threadId, resourceId, memory } = _internal || {};
+
+        if (!saveQueueManager || !threadId) {
+          console.warn('flushMessagesBeforeSuspension: saveQueueManager or threadId is missing');
+          return;
+        }
+
+        try {
+          // Ensure thread exists before flushing messages
+          if (memory && !_internal.threadExists && resourceId) {
+            const thread = await memory.getThreadById?.({ threadId });
+            if (!thread) {
+              // Thread doesn't exist yet, create it now
+              await memory.createThread?.({
+                threadId,
+                resourceId,
+                memoryConfig,
+              });
+            }
+            _internal.threadExists = true;
+          }
+
+          // Flush all pending messages immediately
+          await saveQueueManager.flushMessages(messageList, threadId, memoryConfig);
+        } catch (error) {
+          console.error('Error flushing messages before suspension:', error);
+        }
+      };
+
       // If the tool was already executed by the provider, skip execution
       if (inputData.providerExecuted) {
         // Still emit telemetry for provider-executed tools
@@ -114,6 +221,13 @@ export function createToolCallStep<
                 args: inputData.args,
               },
             });
+
+            // Add approval metadata to message before persisting
+            addToolApprovalMetadata(inputData.toolCallId, inputData.toolName, inputData.args);
+
+            // Flush messages before suspension to ensure they are persisted
+            await flushMessagesBeforeSuspension();
+
             return suspend(
               {
                 requireToolApproval: {
@@ -128,6 +242,9 @@ export function createToolCallStep<
               },
             );
           } else {
+            // Remove approval metadata since we're resuming (either approved or declined)
+            await removeToolApprovalMetadata(inputData.toolCallId);
+
             if (!resumeData.approved) {
               span.end();
               span.setAttributes({
@@ -155,6 +272,9 @@ export function createToolCallStep<
               from: ChunkFrom.AGENT,
               payload: { toolCallId: inputData.toolCallId, toolName: inputData.toolName, suspendPayload },
             });
+
+            // Flush messages before suspension to ensure they are persisted
+            await flushMessagesBeforeSuspension();
 
             return await suspend(
               {

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -13,7 +13,7 @@ import { CoreUserMessage } from '@mastra/core/llm';
 import { fileToBase64 } from '@/lib/file/toBase64';
 import { toAssistantUIMessage, useMastraClient } from '@mastra/react';
 import { useWorkingMemory } from '@/domains/agents/context/agent-working-memory-context';
-import { MastraClient } from '@mastra/client-js';
+import { MastraClient, UIMessageWithMetadata } from '@mastra/client-js';
 import { useAdapters } from '@/components/assistant-ui/hooks/use-adapters';
 
 import { ModelSettings, MastraUIMessage, useChat } from '@mastra/react';
@@ -74,10 +74,10 @@ const convertToAIAttachments = async (attachments: AppendMessage['attachments'])
   return Promise.all(promises);
 };
 
-const initializeMessageState = (initialMessages: Message[]) => {
+const initializeMessageState = (initialMessages: UIMessageWithMetadata[]) => {
   // @ts-expect-error - TODO: fix the ThreadMessageLike type, it's missing some properties like "data" from the role.
   const convertedMessages: ThreadMessageLike[] = initialMessages
-    ?.map((message: Message) => {
+    ?.map((message: UIMessageWithMetadata) => {
       const attachmentsAsContentParts = (message.experimental_attachments || []).map((image: any) => ({
         type: image.contentType.startsWith(`image/`)
           ? 'image'
@@ -110,6 +110,25 @@ const initializeMessageState = (initialMessages: Message[]) => {
                 args: part.toolInvocation.args,
                 result: part.toolInvocation.result,
               };
+            } else if (part.toolInvocation.state === 'call') {
+              // Only return pending tool calls that are legitimately awaiting approval
+              const toolCallId = part.toolInvocation.toolCallId;
+              const pendingToolApprovals = message.metadata?.pendingToolApprovals as Record<string, any> | undefined;
+              const suspensionData = pendingToolApprovals?.[toolCallId];
+              if (suspensionData) {
+                return {
+                  type: 'tool-call',
+                  toolCallId,
+                  toolName: part.toolInvocation.toolName,
+                  args: part.toolInvocation.args,
+                  metadata: {
+                    mode: 'stream',
+                    requireApprovalMetadata: {
+                      [toolCallId]: suspensionData,
+                    },
+                  },
+                };
+              }
             }
           }
 

--- a/packages/playground-ui/src/types.ts
+++ b/packages/playground-ui/src/types.ts
@@ -2,6 +2,7 @@ import { GetAgentResponse } from '@mastra/client-js';
 import type { AiMessageType } from '@mastra/core/memory';
 import type { LLMStepResult } from '@mastra/core/agent';
 import { MastraUIMessage } from '@mastra/react';
+import type { UIMessageWithMetadata } from '@mastra/client-js';
 
 export type Message = AiMessageType;
 
@@ -58,7 +59,7 @@ export interface ChatProps {
   modelVersion?: string;
   threadId?: string;
   initialMessages?: MastraUIMessage[];
-  initialLegacyMessages?: Message[];
+  initialLegacyMessages?: UIMessageWithMetadata[];
   memory?: boolean;
   refreshThreadList?: () => void;
   settings?: AgentSettingsType;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
 
   client-sdks/react:
     dependencies:
+      '@lukeed/uuid':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@mastra/client-js':
         specifier: workspace:*
         version: link:../client-js


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Backporting #10369 and #10498 to the 0.x branch

Fixes issues where thread and messages were not saved before suspension when tools require approval or call suspend() during execution. This caused conversation history to be lost if users refreshed during tool approval or suspension.

(cherry picked from commits fe3b897c2ccbcd2b10e81b099438c7337feddf89, 16785ced928f6f22638f4488cf8a125d99211799)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
