### PR TITLE
fix(clerk): remove organization requirement from default authorization

### DIFF
--- a/.changeset/modern-cats-grow.md
+++ b/.changeset/modern-cats-grow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/auth-clerk': major
+---
+
+remove organization requirement from default authorization

--- a/.changeset/modern-cats-grow.md
+++ b/.changeset/modern-cats-grow.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/auth-clerk': major
+'@mastra/auth-clerk': minor
 ---
 
 remove organization requirement from default authorization

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -73,55 +73,93 @@ describe('MastraAuthClerk', () => {
       const result = await auth.authorizeUser({ email: 'test@example.com' });
 
       expect(result).toBe(false);
-      expect(mockClerkClient.users.getOrganizationMembershipList).not.toHaveBeenCalled();
     });
 
-    it('should return true when user has organization memberships', async () => {
-      mockClerkClient.users.getOrganizationMembershipList.mockResolvedValue({
-        data: [{ id: 'org1' }],
-      });
-
+    it('should return true when user has valid sub', async () => {
       const auth = new MastraAuthClerk(mockOptions);
       const result = await auth.authorizeUser({ sub: 'user123' });
 
-      expect(mockClerkClient.users.getOrganizationMembershipList).toHaveBeenCalledWith({
-        userId: 'user123',
-      });
       expect(result).toBe(true);
     });
 
-    it('should return false when user has no organization memberships', async () => {
-      mockClerkClient.users.getOrganizationMembershipList.mockResolvedValue({
-        data: [],
-      });
-
+    it('should return false when user sub is empty string', async () => {
       const auth = new MastraAuthClerk(mockOptions);
-      const result = await auth.authorizeUser({ sub: 'user123' });
+      const result = await auth.authorizeUser({ sub: '' });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when user sub is undefined', async () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      const result = await auth.authorizeUser({ sub: undefined });
 
       expect(result).toBe(false);
     });
   });
 
-  it('can be overridden with custom authorization logic', async () => {
-    const clerk = new MastraAuthClerk({
-      ...mockOptions,
-      async authorizeUser(user: any): Promise<boolean> {
-        // Custom authorization logic that checks for specific permissions
-        return user?.permissions?.includes('admin') ?? false;
-      },
+  describe('custom authorization', () => {
+    it('can be overridden with custom authorization logic', async () => {
+      const clerk = new MastraAuthClerk({
+        ...mockOptions,
+        async authorizeUser(user: any): Promise<boolean> {
+          // Custom authorization logic that checks for specific permissions
+          return user?.permissions?.includes('admin') ?? false;
+        },
+      });
+
+      // Test with admin user
+      const adminUser = { sub: 'user123', permissions: ['admin'] };
+      expect(await clerk.authorizeUser(adminUser)).toBe(true);
+
+      // Test with non-admin user
+      const regularUser = { sub: 'user456', permissions: ['read'] };
+      expect(await clerk.authorizeUser(regularUser)).toBe(false);
+
+      // Test with user without permissions
+      const noPermissionsUser = { sub: 'user789' };
+      expect(await clerk.authorizeUser(noPermissionsUser)).toBe(false);
     });
 
-    // Test with admin user
-    const adminUser = { sub: 'user123', permissions: ['admin'] };
-    expect(await clerk.authorizeUser(adminUser)).toBe(true);
+    it('can use organization-based authorization when organizations are enabled', async () => {
+      // Mock the organization membership API call for this test
+      const mockOrgClerkClient = {
+        users: {
+          getOrganizationMembershipList: vi.fn(),
+        },
+      };
+      (createClerkClient as any).mockReturnValue(mockOrgClerkClient);
 
-    // Test with non-admin user
-    const regularUser = { sub: 'user456', permissions: ['read'] };
-    expect(await clerk.authorizeUser(regularUser)).toBe(false);
+      const clerk = new MastraAuthClerk({
+        ...mockOptions,
+        async authorizeUser(user: any): Promise<boolean> {
+          if (!user.sub) return false;
 
-    // Test with user without permissions
-    const noPermissionsUser = { sub: 'user789' };
-    expect(await clerk.authorizeUser(noPermissionsUser)).toBe(false);
+          try {
+            const orgs = await mockOrgClerkClient.users.getOrganizationMembershipList({
+              userId: user.sub,
+            });
+            return orgs.data.length > 0;
+          } catch {
+            // Fallback if organizations are not enabled
+            return true;
+          }
+        },
+      });
+
+      // Test with user who has organization membership
+      mockOrgClerkClient.users.getOrganizationMembershipList.mockResolvedValue({
+        data: [{ id: 'org1' }],
+      });
+      const userWithOrg = { sub: 'user123' };
+      expect(await clerk.authorizeUser(userWithOrg)).toBe(true);
+
+      // Test with user who has no organization memberships
+      mockOrgClerkClient.users.getOrganizationMembershipList.mockResolvedValue({
+        data: [],
+      });
+      const userWithoutOrg = { sub: 'user456' };
+      expect(await clerk.authorizeUser(userWithoutOrg)).toBe(false);
+    });
   });
 
   describe('route configuration options', () => {

--- a/auth/clerk/src/index.ts
+++ b/auth/clerk/src/index.ts
@@ -45,14 +45,6 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> {
   }
 
   async authorizeUser(user: ClerkUser) {
-    if (!user.sub) {
-      return false;
-    }
-
-    const orgs = await this.clerk.users.getOrganizationMembershipList({
-      userId: user.sub,
-    });
-
-    return orgs.data.length > 0;
+    return !!user.sub;
   }
 }


### PR DESCRIPTION
## Summary
- Fixes `organization_not_enabled_in_instance` error for Clerk instances without organizations enabled
- Changes default `authorizeUser` implementation to accept any authenticated user with valid `sub`
- **BREAKING CHANGE**: Removes organization membership requirement from default authorization

## Problem
The default `authorizeUser` method in `MastraAuthClerk` was calling Clerk's organization API, which fails with `organization_not_enabled_in_instance` error when the organizations feature is not enabled in the Clerk instance.

## Solution
Changed the default authorization logic to simply check if the user has a valid `sub` (user ID), removing the organization dependency entirely.

## Breaking Change Details
**Before**: Default authorization required organization membership (would reject users not in organizations)
**After**: Default authorization accepts any authenticated user with a valid `sub`

To maintain the previous behavior, provide a custom `authorizeUser` function:

```typescript
new MastraAuthClerk({
  async authorizeUser(user) {
    if (\!user.sub) return false;
    const orgs = await this.clerk.users.getOrganizationMembershipList({
      userId: user.sub,
    });
    return orgs.data.length > 0;
  }
});
```

## Test plan
- [x] Updated tests to reflect new default behavior
- [x] Added example test showing how to implement organization-based authorization
- [x] All tests pass
- [x] Verified changeset is included for major version bump

Closes #9939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Default authorization now grants access based on a user's authentication status (presence of a user identifier) rather than requiring organization membership.

* **Tests**
  * Test suite updated to match the simplified authorization behavior and to add coverage for custom authorization paths and optional organization-based authorization scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->