### PR TITLE
fix: message-list conversion issues for tool suspension persistence (0.x)

### DIFF
--- a/.changeset/tall-bats-stare.md
+++ b/.changeset/tall-bats-stare.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix message-list conversion issues when persisting messages before tool suspension: filter internal metadata fields (`__originalContent`) from UI messages, keep reasoning field empty for consistent cache keys during message deduplication, and only include providerMetadata on parts when defined.

--- a/packages/core/src/agent/__tests__/stream.test.ts
+++ b/packages/core/src/agent/__tests__/stream.test.ts
@@ -438,7 +438,12 @@ function runStreamTest(version: 'v1' | 'v2') {
         // [{ type: 'text', text: 'Hello' }, { type: 'text', text: ' world' }]
         // Instead of: [{ role: 'assistant', content: [{ type: 'text', text: 'Hello world' }] }]
         // should only have a single text part of combined text delta chunks
-        expect(firstMessage.content?.filter(p => p.type === `text`)).toHaveLength(1);
+        if (firstMessage.content && Array.isArray(firstMessage.content)) {
+          expect(firstMessage.content.filter(p => p.type === `text`)).toHaveLength(1);
+        } else {
+          expect(firstMessage.content).toBeDefined();
+          expect(firstMessage.content).toBe('Hello world');
+        }
       }
     });
 

--- a/packages/core/src/agent/__tests__/tool-suspension.test.ts
+++ b/packages/core/src/agent/__tests__/tool-suspension.test.ts
@@ -110,13 +110,11 @@ describe('Tool suspension memory persistence', () => {
 
     // Assert 2: User message should be saved
     const messagesAfterSuspension = await mockMemory.query();
-
-    const userMessages = messagesAfterSuspension.messages.filter(m => m.role === 'user');
+    const userMessages = messagesAfterSuspension.messagesV2.filter(m => m.role === 'user');
     expect(userMessages.length).toBeGreaterThan(0);
 
     const userMessage = userMessages.find(m => {
       const content = m.content;
-      if (typeof content === 'string') return content.includes('software engineer job');
       if (typeof content === 'object' && 'parts' in content) {
         return content.parts.some(p => p.type === 'text' && p.text.includes('software engineer job'));
       }
@@ -125,7 +123,7 @@ describe('Tool suspension memory persistence', () => {
     expect(userMessage).toBeDefined();
 
     // Assert 3: Assistant message with tool call should be saved
-    const assistantMessages = messagesAfterSuspension.messages.filter(m => m.role === 'assistant');
+    const assistantMessages = messagesAfterSuspension.messagesV2.filter(m => m.role === 'assistant');
     expect(assistantMessages.length).toBeGreaterThan(0);
 
     const assistantWithToolCall = assistantMessages.find(m => {
@@ -227,18 +225,14 @@ Always follow this order.`,
     expect(threadAfterSuspension?.resourceId).toBe(resourceId);
 
     // Assert: All messages should be saved
-    const messagesAfterSuspension = await mockMemory.recall({
-      threadId,
-      resourceId,
-    });
+    const messagesAfterSuspension = await mockMemory.query();
 
     // Assert: User message should be saved
-    const userMessages = messagesAfterSuspension.messages.filter(m => m.role === 'user');
+    const userMessages = messagesAfterSuspension.messagesV2.filter(m => m.role === 'user');
     expect(userMessages.length).toBeGreaterThan(0);
 
     const userMessage = userMessages.find(m => {
       const content = m.content;
-      if (typeof content === 'string') return content.includes('process');
       if (typeof content === 'object' && 'parts' in content) {
         return content.parts.some(p => p.type === 'text' && p.text.includes('process'));
       }
@@ -247,7 +241,7 @@ Always follow this order.`,
     expect(userMessage).toBeDefined();
 
     // Assert: Assistant messages with tool call should be saved
-    const assistantMessages = messagesAfterSuspension.messages.filter(m => m.role === 'assistant');
+    const assistantMessages = messagesAfterSuspension.messagesV2.filter(m => m.role === 'assistant');
     expect(assistantMessages.length).toBeGreaterThan(0);
 
     // Verify both tool calls are saved - validation tool and suspending tool

--- a/packages/core/src/agent/__tests__/tool-suspension.test.ts
+++ b/packages/core/src/agent/__tests__/tool-suspension.test.ts
@@ -1,10 +1,10 @@
 import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { MockMemory } from '../test-utils';
 import { createTool } from '../../tools';
 import { delay } from '../../utils';
 import { Agent } from '../agent';
+import { MockMemory } from '../test-utils';
 
 describe('Tool suspension memory persistence', () => {
   it('should save thread and messages to memory before suspension when tool requires approval', async () => {

--- a/packages/core/src/agent/__tests__/tool-suspension.test.ts
+++ b/packages/core/src/agent/__tests__/tool-suspension.test.ts
@@ -1,7 +1,7 @@
 import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { MockMemory } from '../../memory/mock';
+import { MockMemory } from '../test-utils';
 import { createTool } from '../../tools';
 import { delay } from '../../utils';
 import { Agent } from '../agent';
@@ -109,10 +109,7 @@ describe('Tool suspension memory persistence', () => {
     expect(threadAfterSuspension?.resourceId).toBe(resourceId);
 
     // Assert 2: User message should be saved
-    const messagesAfterSuspension = await mockMemory.recall({
-      threadId,
-      resourceId,
-    });
+    const messagesAfterSuspension = await mockMemory.query();
 
     const userMessages = messagesAfterSuspension.messages.filter(m => m.role === 'user');
     expect(userMessages.length).toBeGreaterThan(0);

--- a/packages/core/src/agent/test-utils.ts
+++ b/packages/core/src/agent/test-utils.ts
@@ -1,9 +1,9 @@
 import { expect } from 'vitest';
+import type { CoreMessage } from '../llm';
 import { MastraMemory } from '../memory';
 import type { StorageThreadType, MastraMessageV1, MastraMessageV2, MemoryConfig } from '../memory';
 import type { StorageGetMessagesArg } from '../storage';
 import { MessageList } from './message-list';
-import type { CoreMessage } from '../llm';
 
 export class MockMemory extends MastraMemory {
   threads: Record<string, StorageThreadType> = {};

--- a/packages/core/src/agent/test-utils.ts
+++ b/packages/core/src/agent/test-utils.ts
@@ -3,6 +3,7 @@ import { MastraMemory } from '../memory';
 import type { StorageThreadType, MastraMessageV1, MastraMessageV2, MemoryConfig } from '../memory';
 import type { StorageGetMessagesArg } from '../storage';
 import { MessageList } from './message-list';
+import type { CoreMessage } from '../llm';
 
 export class MockMemory extends MastraMemory {
   threads: Record<string, StorageThreadType> = {};
@@ -117,7 +118,12 @@ export class MockMemory extends MastraMemory {
     };
   }
   async query() {
-    return { messages: [], uiMessages: [], messagesV2: [] };
+    const list = new MessageList().add(Array.from(this.messages.values()), `memory`);
+    return {
+      messages: list.get.all.v1() as CoreMessage[],
+      uiMessages: list.get.all.ui(),
+      messagesV2: list.get.all.v2(),
+    };
   }
   async deleteThread(threadId: string) {
     delete this.threads[threadId];

--- a/packages/core/src/loop/test-utils/resultObject.ts
+++ b/packages/core/src/loop/test-utils/resultObject.ts
@@ -759,12 +759,11 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                 {
                   "id": "msg-0",
                   "metadata": {
-                    "createdAt": 2024-01-01T00:00:00.002Z,
+                    "createdAt": 2024-01-01T00:00:00.003Z,
                   },
                   "parts": [
                     {
                       "mediaType": "text/plain",
-                      "providerMetadata": undefined,
                       "type": "file",
                       "url": "data:text/plain;base64,Hello World",
                     },
@@ -774,7 +773,6 @@ export function resultObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     },
                     {
                       "mediaType": "image/jpeg",
-                      "providerMetadata": undefined,
                       "type": "file",
                       "url": "data:image/jpeg;base64,QkFVRw==",
                     },

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -57,6 +57,19 @@ export function createAgenticExecutionWorkflow<
     .map(
       async ({ inputData }) => {
         const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
+        // Add assistant response messages to messageList BEFORE processing tool calls
+        // This ensures messages are available for persistence before suspension
+        const responseMessages = typedInputData.messages.nonUser;
+        if (responseMessages && responseMessages.length > 0) {
+          rest.messageList.add(responseMessages, 'response');
+        }
+        return typedInputData;
+      },
+      { id: 'add-response-to-messagelist' },
+    )
+    .map(
+      async ({ inputData }) => {
+        const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
         if (modelStreamSpan && telemetry_settings?.recordOutputs !== false && typedInputData.output.toolCalls?.length) {
           modelStreamSpan.setAttribute(
             'stream.response.toolCalls',
@@ -72,19 +85,6 @@ export function createAgenticExecutionWorkflow<
             ),
           );
         }
-        // Add assistant response messages to messageList BEFORE processing tool calls
-        // This ensures messages are available for persistence before suspension
-        const responseMessages = typedInputData.messages.nonUser;
-        if (responseMessages && responseMessages.length > 0) {
-          rest.messageList.add(responseMessages, 'response');
-        }
-        return typedInputData;
-      },
-      { id: 'add-response-to-messagelist' },
-    )
-    .map(
-      async ({ inputData }) => {
-        const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
         return typedInputData.output.toolCalls || [];
       },
       { id: 'map-tool-calls' },

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -76,10 +76,10 @@ describe('createToolCallStep tool approval workflow', () => {
           },
         },
         response: {
-          db: () => [],
+          v2: () => [],
         },
         all: {
-          db: () => [],
+          v2: () => [],
         },
       },
     } as unknown as MessageList;

--- a/packages/core/src/workflows/__tests__/parallel-writer.test.ts
+++ b/packages/core/src/workflows/__tests__/parallel-writer.test.ts
@@ -34,7 +34,7 @@ describe('Parallel Steps with Writer', () => {
       ])
       .commit();
 
-    const run = await workflow.createRun({
+    const run = await workflow.createRunAsync({
       runId: 'test-parallel-writer',
     });
 
@@ -92,7 +92,7 @@ describe('Parallel Steps with Writer', () => {
       ])
       .commit();
 
-    const run = await workflow.createRun({
+    const run = await workflow.createRunAsync({
       runId: 'test-multi-parallel-writer',
     });
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
- Filter internal metadata fields (`__originalContent`) from UI messages during V3→UIMessage conversion
- Keep reasoning field empty in V3→V2 conversion for consistent cache keys during message deduplication
- Only include `providerMetadata` on parts when defined (avoids `providerMetadata: undefined`)

Fixes 0.x-specific message format conversion issues introduced after backporting #10369.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
