### PR TITLE
Inngest stream error

### DIFF
--- a/.changeset/fancy-showers-lick.md
+++ b/.changeset/fancy-showers-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Fixes an issue where workflow step failures weren't emitting `workflow-step-result` events in the catch block, preventing proper failure tracking. Also improved error details by including full stack traces instead of just error messages.


### PR DESCRIPTION
## Fix workflow step failure event emission and improve error reporting

### Summary

This PR fixes an issue in `@mastra/inngest` where workflow step failures were not properly emitting events, and improves error reporting by including full stack traces.

### Changes

**1. Add missing failure event emission**

When a workflow step fails in the catch block, the code was not emitting a `workflow-step-result` event. This prevented proper failure tracking and observability through the watch API.

```typescript
// Added in catch block
await emitter.emit('watch', {
  type: 'workflow-step-result',
  payload: {
    id: step.id,
    ...stepFailure,
  },
});
```

**2. Include full stack traces in error reporting**

Changed error reporting from using just `e.message` to `e?.stack ?? e?.message` in multiple locations, providing better debugging information when steps fail.

### Why

- **Observability**: Without the failure event emission, subscribers watching workflow runs wouldn't receive notifications when steps failed
- **Debugging**: Stack traces provide much more useful information than just the error message when diagnosing issues

### Testing

- Existing workflow tests continue to pass
- Failure events are now properly emitted and can be observed through the watch API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow-step-result event emission when workflow steps fail within catch blocks, enabling proper failure tracking.
  * Enhanced error reporting to include full stack traces instead of only error messages, improving troubleshooting and debugging capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->