### PR TITLE
fix(core): use getMemory to set storage

### DIFF
--- a/.changeset/fuzzy-glasses-lie.md
+++ b/.changeset/fuzzy-glasses-lie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+use `agent.getMemory` to fetch the memory instance on the Agent class to make sure that storage gets set if memory doesn't set it itself.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -334,10 +334,8 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
       : [];
 
     // Get memory output processors (with deduplication)
-    const memory =
-      typeof this.#memory === 'function'
-        ? await this.#memory({ requestContext: requestContext || new RequestContext() })
-        : this.#memory;
+    // Use getMemory() to ensure storage is injected from Mastra if not explicitly configured
+    const memory = await this.getMemory({ requestContext: requestContext || new RequestContext() });
 
     const memoryProcessors = memory ? memory.getOutputProcessors(configuredProcessors, requestContext) : [];
 
@@ -358,10 +356,8 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
       : [];
 
     // Get memory input processors (with deduplication)
-    const memory =
-      typeof this.#memory === 'function'
-        ? await this.#memory({ requestContext: requestContext || new RequestContext() })
-        : this.#memory;
+    // Use getMemory() to ensure storage is injected from Mastra if not explicitly configured
+    const memory = await this.getMemory({ requestContext: requestContext || new RequestContext() });
 
     const memoryProcessors = memory ? memory.getInputProcessors(configuredProcessors, requestContext) : [];
 

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -74,6 +74,20 @@ const filterSchema = z.preprocess(
 );
 
 /**
+ * Memory config schema - handles JSON parsing from query strings
+ */
+const memoryConfigSchema = z.preprocess(val => {
+  if (typeof val === 'string') {
+    try {
+      return JSON.parse(val);
+    } catch {
+      return undefined;
+    }
+  }
+  return val;
+}, z.record(z.string(), z.unknown()).optional());
+
+/**
  * Thread object structure
  */
 const threadSchema = z.object({
@@ -142,7 +156,7 @@ export const listMessagesQuerySchema = createPagePaginationSchema(40).extend({
 export const getWorkingMemoryQuerySchema = z.object({
   agentId: z.string(),
   resourceId: z.string().optional(),
-  memoryConfig: z.record(z.string(), z.unknown()).optional(), // Complex config object
+  memoryConfig: memoryConfigSchema,
 });
 
 // ============================================================================
@@ -318,7 +332,7 @@ export const searchMemoryQuerySchema = z.object({
   resourceId: z.string(),
   threadId: z.string().optional(),
   limit: z.coerce.number().optional().default(20),
-  memoryConfig: z.record(z.string(), z.unknown()).optional(),
+  memoryConfig: memoryConfigSchema,
 });
 
 /**


### PR DESCRIPTION
## Description

use `agent.getMemory` to fetch the memory instance on the Agent class to make sure that storage gets set if memory doesn't set it itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory initialization in agents to ensure consistent storage integration and lifecycle.
* **Behavior Improvements**
  * Memory recall now uses a consistent index naming and includes both user and assistant messages when creating embeddings, improving relevance and recall.
* **Tests**
  * Added coverage verifying embeddings include both message types.
* **Chores**
  * Centralized parsing for memory configuration in server request schemas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->