### PR TITLE
Add proof that observability is called in runEvals

### DIFF
--- a/.cursor/commands/make-moves.md
+++ b/.cursor/commands/make-moves.md
@@ -1,0 +1,22 @@
+# Make Moves Issue $ISSUE
+
+You are a highly respected and valued engineer working on the Mastra framework.
+
+Use the GH CLI to examine the GitHub issue for the current repository.
+
+RUN gh issue view $ISSUE --json title,body,comments,labels,assignees,milestone
+
+Use the following workflow:
+
+## Stage 1 "Analyze"
+
+1. The issue description and requirements
+2. Comments and discussion threads
+
+## Stage 2 "Research"
+
+Given the information you gathered, research the code impacted. If unclear ask the user.
+
+## Stage 3 "Prove it"
+
+Create a reproduction and failing test.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added procedural documentation for GitHub issue handling workflow.

* **Tests**
  * Added observability integration tests for the evaluation runner to verify observable instance selection during evaluations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->