### PR TITLE
fix(core): Improve tool validation errors

### DIFF
--- a/.changeset/five-mice-serve.md
+++ b/.changeset/five-mice-serve.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Adjust the tool validation error messages to directly show the errors provided by Zod without extra logging context.
+Fixed tool validation error messages so logs show Zod validation errors directly instead of hiding them inside structured JSON.

--- a/.changeset/five-mice-serve.md
+++ b/.changeset/five-mice-serve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Adjust the tool validation error messages to directly show the errors provided by Zod without extra logging context.

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -868,7 +868,7 @@ describe('Tool Input Validation', () => {
 
     expect(result).toHaveProperty('error', true);
     expect(result).toHaveProperty('message');
-    expect(result.message).toContain('Tool validation failed');
+    expect(result.message).toContain('Tool input validation failed');
     expect(result.message).toContain('Name must be at least 3 characters');
     expect(result.message).toContain('- name:');
   });
@@ -882,7 +882,7 @@ describe('Tool Input Validation', () => {
 
     expect(result).toHaveProperty('error', true);
     expect(result).toHaveProperty('message');
-    expect(result.message).toContain('Tool validation failed');
+    expect(result.message).toContain('Tool input validation failed');
     expect(result.message).toContain('Age must be positive');
     expect(result.message).toContain('- age:');
   });
@@ -897,7 +897,7 @@ describe('Tool Input Validation', () => {
 
     expect(result).toHaveProperty('error', true);
     expect(result).toHaveProperty('message');
-    expect(result.message).toContain('Tool validation failed');
+    expect(result.message).toContain('Tool input validation failed');
     expect(result.message).toContain('Invalid email format');
     expect(result.message).toContain('- email:');
   });
@@ -912,7 +912,7 @@ describe('Tool Input Validation', () => {
 
     expect(result).toHaveProperty('error', true);
     expect(result).toHaveProperty('message');
-    expect(result.message).toContain('Tool validation failed');
+    expect(result.message).toContain('Tool input validation failed');
     expect(result.message).toContain('Required');
     expect(result.message).toContain('- name:');
   });
@@ -927,7 +927,7 @@ describe('Tool Input Validation', () => {
 
     expect(result).toHaveProperty('error', true);
     expect(result).toHaveProperty('message');
-    expect(result.message).toContain('Tool validation failed');
+    expect(result.message).toContain('Tool input validation failed');
     expect(result.message).toContain('At least one tag required');
     expect(result.message).toContain('- tags:');
   });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -415,10 +415,7 @@ export class CoreToolBuilder extends MastraBase {
         const parameters = processedSchema || this.getParameters();
         const { data, error } = validateToolInput(parameters, args, options.name);
         if (error) {
-          logger.warn(error.message, {
-            toolName: options.name,
-            args,
-          });
+          logger.warn(error.message);
           return error;
         }
         // Use validated/transformed data

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -367,11 +367,7 @@ export class CoreToolBuilder extends MastraBase {
             const resumeSchema = this.getResumeSchema();
             const resumeValidation = validateToolInput(resumeSchema, resumeData, options.name);
             if (resumeValidation.error) {
-              logger?.warn(`Tool resume data validation failed for '${options.name}'`, {
-                toolName: options.name,
-                errors: resumeValidation.error.validationErrors,
-                resumeData,
-              });
+              logger?.warn(resumeValidation.error.message);
               toolSpan?.end({ output: resumeValidation.error });
               return resumeValidation.error as any;
             }
@@ -384,11 +380,7 @@ export class CoreToolBuilder extends MastraBase {
           const suspendSchema = this.getSuspendSchema();
           const suspendValidation = validateToolSuspendData(suspendSchema, suspendData, options.name);
           if (suspendValidation.error) {
-            logger?.warn(`Tool suspend data validation failed for '${options.name}'`, {
-              toolName: options.name,
-              errors: suspendValidation.error.validationErrors,
-              suspendData,
-            });
+            logger?.warn(suspendValidation.error.message);
             toolSpan?.end({ output: suspendValidation.error });
             return suspendValidation.error as any;
           }
@@ -400,11 +392,7 @@ export class CoreToolBuilder extends MastraBase {
         const outputSchema = this.getOutputSchema();
         const outputValidation = validateToolOutput(outputSchema, result, options.name, skiptOutputValidation);
         if (outputValidation.error) {
-          logger?.warn(`Tool output validation failed for '${options.name}'`, {
-            toolName: options.name,
-            errors: outputValidation.error.validationErrors,
-            output: result,
-          });
+          logger?.warn(outputValidation.error.message);
           toolSpan?.end({ output: outputValidation.error });
           return outputValidation.error;
         }
@@ -427,9 +415,8 @@ export class CoreToolBuilder extends MastraBase {
         const parameters = processedSchema || this.getParameters();
         const { data, error } = validateToolInput(parameters, args, options.name);
         if (error) {
-          logger.warn(`Tool input validation failed for '${options.name}'`, {
+          logger.warn(error.message, {
             toolName: options.name,
-            errors: error.validationErrors,
             args,
           });
           return error;

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -21,7 +21,7 @@ describe('Tool Input Validation Integration Tests', () => {
       // Test missing required fields - pass raw data as first arg
       const result = await tool.execute({} as any);
       expect(result.error).toBe(true);
-      expect(result.message).toContain('Tool validation failed');
+      expect(result.message).toContain('Tool input validation failed');
       expect(result.message).toContain('- name: Required');
       expect(result.message).toContain('- age: Required');
     });
@@ -45,7 +45,7 @@ describe('Tool Input Validation Integration Tests', () => {
       } as any);
 
       expect(result.error).toBe(true);
-      expect(result.message).toContain('Tool validation failed');
+      expect(result.message).toContain('Tool input validation failed');
       expect(result.validationErrors).toBeDefined();
     });
 
@@ -202,7 +202,7 @@ describe('Tool Input Validation Integration Tests', () => {
       const result = await tool.execute({ username: 'ab' });
 
       expect(result.error).toBe(true);
-      expect(result.message).toContain('Tool validation failed for user-registration');
+      expect(result.message).toContain('Tool input validation failed for user-registration');
     });
   });
 
@@ -376,7 +376,7 @@ describe('Tool Input Validation Integration Tests', () => {
       });
 
       expect(result.error).toBe(true);
-      expect(result.message).toContain('Tool validation failed');
+      expect(result.message).toContain('Tool input validation failed');
       expect(result.message).toContain('Expected string, received number');
     });
 
@@ -401,7 +401,7 @@ describe('Tool Input Validation Integration Tests', () => {
       });
 
       expect(result.error).toBe(true);
-      expect(result.message).toContain('Tool validation failed');
+      expect(result.message).toContain('Tool input validation failed');
       expect(result.message).toContain('Expected object, received string');
     });
   });
@@ -436,7 +436,7 @@ describe('Tool Input Validation Integration Tests', () => {
 
       const result = await tool.execute({} as any);
       expect(result.error).toBe(true);
-      expect(result.message).toContain('Tool validation failed');
+      expect(result.message).toContain('Tool input validation failed');
       expect(result.message).toContain('Required');
     });
 
@@ -716,7 +716,7 @@ describe('Tool Output Validation Tests', () => {
     const invalidInputResult = await tool.execute({ email: 'not-an-email' });
     if ('error' in invalidInputResult) {
       expect(invalidInputResult.error).toBe(true);
-      expect(invalidInputResult.message).toContain('Tool validation failed');
+      expect(invalidInputResult.message).toContain('Tool input validation failed');
     } else {
       throw new Error('Result is not a validation error');
     }

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -96,7 +96,7 @@ export function validateToolInput<T = any>(
 
   const error: ValidationError<T> = {
     error: true,
-    message: `Tool validation failed${toolId ? ` for ${toolId}` : ''}. Please fix the following errors and try again:\n${errorMessages}\n\nProvided arguments: ${truncateForLogging(input)}`,
+    message: `Tool input validation failed${toolId ? ` for ${toolId}` : ''}. Please fix the following errors and try again:\n${errorMessages}\n\nProvided arguments: ${truncateForLogging(input)}`,
     validationErrors: validation.error.format() as z.ZodFormattedError<T>,
   };
 

--- a/packages/mcp-docs-server/src/tools/__tests__/course.test.ts
+++ b/packages/mcp-docs-server/src/tools/__tests__/course.test.ts
@@ -236,7 +236,7 @@ describe('Course Tools', () => {
 
       test('should handle missing required arguments with an error', async () => {
         const result = await callTool(tools.mastra_startMastraCourseLesson, {});
-        expect(result.toLowerCase()).toContain('tool validation failed');
+        expect(result.toLowerCase()).toContain('tool input validation failed');
       });
       test('should handle corrupted state file gracefully', async () => {
         const statePath = path.join(os.homedir(), '.cache', 'mastra', 'course', 'state.json');


### PR DESCRIPTION
## Description

We're using `validateToolInput` to validate the tool input Zod schema and then run it through `schema.safeParse`. But the errors we were throwing didn't actually return this and instead just returned a static error message and the rest in a JSON. That JSON was always collapsed in most logging systems, making it hard to debug what exactly was wrong with the input.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation error messages now surface Zod validation messages directly and use clearer wording ("Tool input validation failed") so issues are easier to read.

* **Chores**
  * Reduced verbose logging for validation failures so logs show concise error text.

* **Tests**
  * Updated test expectations to reflect the new validation message wording.

* **Documentation**
  * Added a changeset entry describing the patch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->