### PR TITLE
fix(core): store empty reasoning for OpenAI item_reference

### DIFF
--- a/.changeset/fix-empty-reasoning-item-reference.md
+++ b/.changeset/fix-empty-reasoning-item-reference.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix GPT-5/o3 reasoning models failing with "required reasoning item" errors when using memory with tools. Empty reasoning is now stored with providerMetadata to preserve OpenAI's item_reference.


### PR DESCRIPTION
## Summary
- GPT-5/o3 reasoning models emit empty reasoning (no deltas between `reasoning-start` and `reasoning-end`) but still require the `providerMetadata` containing `itemId` to be preserved for OpenAI's `item_reference` system
- The previous check `if (reasoningDeltas.length > 0)` skipped storing empty reasoning, which caused "required reasoning item" errors when the model referenced the missing reasoning in subsequent tool calls
- Added test that verifies empty reasoning with `providerMetadata` is stored correctly

## Test plan
- [x] Added test `should store empty reasoning with providerMetadata for OpenAI item_reference`
- [x] All existing loop tests pass (134 passed)

Fixes #9005

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure reasoning entries are always recorded in conversation history with their associated provider metadata, even when no intermediate reasoning updates occur.

* **Tests**
  * Added tests verifying empty reasoning is persisted and that provider metadata is preserved in stored reasoning entries.

* **Documentation**
  * Added a changelog entry describing the patch addressing empty reasoning/item-reference preservation for reasoning models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->