### PR TITLE
Fixed bundling to correctly exclude subpath imports of external packages

### DIFF
--- a/.changeset/tall-guests-march.md
+++ b/.changeset/tall-guests-march.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed bundling to correctly exclude subpath imports of external packages. Previously, when a package like `lodash` was marked as external, subpath imports such as `lodash/merge` were still being bundled incorrectly. Now all subpaths are properly excluded.
+
+Fixes #10055

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -8,7 +8,13 @@ import * as path from 'node:path';
 import { rollup, type OutputChunk, type OutputAsset, type Plugin } from 'rollup';
 import { esbuild } from '../plugins/esbuild';
 import { aliasHono } from '../plugins/hono-alias';
-import { getCompiledDepCachePath, getPackageRootPath, rollupSafeName, slash } from '../utils';
+import {
+  getCompiledDepCachePath,
+  getPackageRootPath,
+  isDependencyPartOfPackage,
+  rollupSafeName,
+  slash,
+} from '../utils';
 import { type WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import type { DependencyMetadata } from '../types';
 import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS, DEPRECATED_EXTERNALS } from './constants';
@@ -17,6 +23,7 @@ import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
 import { readFile } from 'node:fs/promises';
 import { getPackageInfo } from 'local-pkg';
 import { ErrorCategory, ErrorDomain, MastraBaseError } from '@mastra/core/error';
+import { subpathExternalsResolver } from '../plugins/subpath-externals-resolver';
 
 type VirtualDependency = {
   name: string;
@@ -119,11 +126,13 @@ async function getInputPlugins(
     workspaceMap,
     bundlerOptions,
     rootDir,
+    externals,
   }: {
     transpilePackages: Set<string>;
     workspaceMap: Map<string, WorkspacePackageInfo>;
     bundlerOptions: { enableEsmShim: boolean; isDev: boolean };
     rootDir: string;
+    externals: string[];
   },
 ) {
   const transpilePackagesMap = new Map<string, string>();
@@ -147,6 +156,7 @@ async function getInputPlugins(
         {} as Record<string, string>,
       ),
     ),
+    subpathExternalsResolver(externals),
     transpilePackagesMap.size
       ? esbuild({
           format: 'esm',
@@ -277,6 +287,7 @@ async function buildExternalDependencies(
   if (virtualDependencies.size === 0) {
     return [] as unknown as [OutputChunk, ...(OutputAsset | OutputChunk)[]];
   }
+
   const bundler = await rollup({
     logLevel: process.env.MASTRA_BUNDLER_DEBUG === 'true' ? 'debug' : 'silent',
     input: Array.from(virtualDependencies.entries()).reduce(
@@ -293,6 +304,7 @@ async function buildExternalDependencies(
       workspaceMap,
       bundlerOptions,
       rootDir,
+      externals,
     }),
   });
 
@@ -347,6 +359,7 @@ async function buildExternalDependencies(
 
       return `${outputDirRelative}/[name].mjs`;
     },
+    assetFileNames: `${outputDirRelative}/[name][extname]`,
     hoistTransitiveImports: false,
   });
 
@@ -363,7 +376,7 @@ function findExternalImporter(module: OutputChunk, external: string, allOutputs:
   const capturedFiles = new Set();
 
   for (const id of module.imports) {
-    if (id === external) {
+    if (isDependencyPartOfPackage(id, external)) {
       return module;
     } else {
       if (id.endsWith('.mjs')) {

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -12,6 +12,7 @@ import { removeDeployer } from './plugins/remove-deployer';
 import { tsConfigPaths } from './plugins/tsconfig-paths';
 import { join } from 'node:path';
 import { slash } from './utils';
+import { subpathExternalsResolver } from './plugins/subpath-externals-resolver';
 
 export async function getInputOptions(
   entryFile: string,
@@ -43,18 +44,7 @@ export async function getInputOptions(
           browser: true,
         });
 
-  const externalsCopy = new Set<string>();
-  // make all nested imports external from the same package
-  for (const external of analyzedBundleInfo.externalDependencies) {
-    if (external.startsWith('@')) {
-      const [scope, name] = external.split('/', 3);
-      externalsCopy.add(`${scope}/${name}`);
-      externalsCopy.add(`${scope}/${name}/*`);
-    } else {
-      externalsCopy.add(external);
-      externalsCopy.add(`${external}/*`);
-    }
-  }
+  const externalsCopy = new Set<string>(analyzedBundleInfo.externalDependencies);
 
   const externals = Array.from(externalsCopy);
 
@@ -65,6 +55,7 @@ export async function getInputOptions(
     preserveSymlinks: true,
     external: externals,
     plugins: [
+      subpathExternalsResolver(externals),
       {
         name: 'alias-optimized-deps',
         resolveId(id: string) {

--- a/packages/deployer/src/build/plugins/subpath-externals-resolver.ts
+++ b/packages/deployer/src/build/plugins/subpath-externals-resolver.ts
@@ -1,0 +1,21 @@
+import type { Plugin } from 'rollup';
+import { isDependencyPartOfPackage } from '../utils';
+
+export function subpathExternalsResolver(externals: string[]): Plugin {
+  return {
+    name: 'subpath-externals-resolver',
+    resolveId(id) {
+      if (id.startsWith('.') || id.startsWith('/')) {
+        return null;
+      }
+
+      const isPartOfExternals = externals.some(external => isDependencyPartOfPackage(id, external));
+      if (isPartOfExternals) {
+        return {
+          id,
+          external: true,
+        };
+      }
+    },
+  } satisfies Plugin;
+}

--- a/packages/deployer/src/build/utils.ts
+++ b/packages/deployer/src/build/utils.ts
@@ -13,6 +13,14 @@ export function upsertMastraDir({ dir = process.cwd() }: { dir?: string }) {
   }
 }
 
+export function isDependencyPartOfPackage(dep: string, packageName: string) {
+  if (dep === packageName) {
+    return true;
+  }
+
+  return dep.startsWith(`${packageName}/`);
+}
+
 /**
  * Get the package name from a module ID
  */

--- a/packages/deployer/src/validator/custom-resolver.ts
+++ b/packages/deployer/src/validator/custom-resolver.ts
@@ -3,6 +3,7 @@ import type { ResolveHookContext } from 'node:module';
 import { builtinModules } from 'node:module';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { isDependencyPartOfPackage } from '../build/utils';
 
 const cache = new Map<string, Record<string, string>>();
 
@@ -52,12 +53,16 @@ async function getParentPath(specifier: string, url: string): Promise<string | n
   }
 
   const importers = cache.get(url);
-  if (!importers || !importers[specifier]) {
+  if (!importers) {
     return null;
   }
 
-  const specifierParent = importers[specifier];
+  const matchedPackage = Object.keys(importers).find(external => isDependencyPartOfPackage(specifier, external));
+  if (!matchedPackage) {
+    return null;
+  }
 
+  const specifierParent = importers[matchedPackage]!;
   return pathToFileURL(specifierParent).toString();
 }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fixed bundling to correctly exclude subpath imports of external packages. Previously, when a package like `lodash` was marked as external, subpath imports such as `lodash/merge` were still being bundled incorrectly. Now all subpaths are properly excluded.


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

Fixes #10055

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundling now correctly treats package subpath imports (e.g., lodash/merge) as external when a package is marked external, ensuring all subpaths are excluded from optimization and not bundled.
  * External dependency handling made more robust and deterministic, improving build correctness and output consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->