### PR TITLE
Fix duplicate words and grammar errors

### DIFF
--- a/examples/travel-app/src/app/page.tsx
+++ b/examples/travel-app/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function Page() {
             1. Assemble Agent
           </h3>
           <p className="mb-2">
-            The agent is is defined with a name, a set of instructions, a model,
+            The agent is defined with a name, a set of instructions, a model,
             and a collection of enabled tools:
           </p>
           <CodeBlock

--- a/examples/travel-app/src/app/workflow/page.tsx
+++ b/examples/travel-app/src/app/workflow/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
 
         <h3 className="text-lg font-semibold mb-2">1. Assemble Agent</h3>
         <p className="mb-2">
-          The agent is is defined with a name, a set of instructions, and a
+          The agent is defined with a name, a set of instructions, and a
           model. This agent is not provided any tools and is just responsible
           for making calls to the LLM.
         </p>

--- a/packages/rag/src/document/prompts/prompt.ts
+++ b/packages/rag/src/document/prompts/prompt.ts
@@ -34,7 +34,7 @@ Provide keywords in the following comma-separated format: 'KEYWORDS: <keywords>'
 export const defaultQuestionExtractPrompt = new PromptTemplate({
   templateVars: ['numQuestions', 'context'],
   template: `(
-  "Given the contextual informations below, generate {numQuestions} questions this context can provides specific answers to which are unlikely to be found else where. Higher-level summaries of surrounding context may be provided as well. "
+  "Given the contextual information below, generate {numQuestions} questions this context can provide specific answers to which are unlikely to be found elsewhere. Higher-level summaries of surrounding context may be provided as well. "
   "Try using these summaries to generate better questions that this context can answer."
   "---------------------"
   "{context}"


### PR DESCRIPTION
 ## Description

  This PR corrects several duplicate words and grammar errors across the codebase. The changes are non-functional and
  purely textual to improve clarity and maintain a clean, professional codebase.

  ## Corrected errors

  - `examples/travel-app/src/app/page.tsx`: "is is" → "is"
  - `examples/travel-app/src/app/workflow/page.tsx`: "is is" → "is"
  - `packages/rag/src/document/prompts/prompt.ts`: "informations" → "information", "provides" → "provide","else where" → "elsewhere"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typographical and grammatical errors throughout example documentation and AI system prompts. Changes include fixing duplicate words, correcting verb conjugation, and improving word choice to enhance readability and ensure consistent, accurate phrasing in user-facing and system-generated content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->