### PR TITLE
feat(processors): add messageList to processOutputStream

### DIFF
--- a/.changeset/remembered-messages-output-processor.md
+++ b/.changeset/remembered-messages-output-processor.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": minor
+---
+
+Add `messageList` parameter to `processOutputStream` for accessing remembered messages during streaming
+

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -39,6 +39,7 @@ export interface Processor<TId extends string = string> {
    * @param args.abort - Function to abort processing with an optional reason
    * @param args.tracingContext - Optional tracing context for observability
    * @param args.runtimeContext - Optional runtime context with execution metadata
+   * @param args.messageList - Optional MessageList instance for accessing conversation history including remembered messages
    */
   processOutputStream?(args: {
     part: ChunkType;
@@ -47,6 +48,7 @@ export interface Processor<TId extends string = string> {
     abort: (reason?: string) => never;
     tracingContext?: TracingContext;
     runtimeContext?: RequestContext;
+    messageList?: MessageList;
   }): Promise<ChunkType | null | undefined>;
 
   /**

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -185,6 +185,8 @@ export class ProcessorRunner {
     part: ChunkType<OUTPUT>,
     processorStates: Map<string, ProcessorState<OUTPUT>>,
     tracingContext?: TracingContext,
+    runtimeContext?: RequestContext,
+    messageList?: MessageList,
   ): Promise<{
     part: ChunkType<OUTPUT> | null | undefined;
     blocked: boolean;
@@ -223,6 +225,8 @@ export class ProcessorRunner {
                 throw new TripWire(reason || `Stream part blocked by ${processor.id}`);
               },
               tracingContext: { currentSpan: state.span },
+              runtimeContext,
+              messageList,
             });
 
             if (state.span && !state.span.isEvent) {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -250,7 +250,13 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
                 part: processed,
                 blocked,
                 reason,
-              } = await processorRunner.processPart(chunk, processorStates, options.tracingContext);
+              } = await processorRunner.processPart(
+                chunk,
+                processorStates,
+                options.tracingContext,
+                options.requestContext,
+                self.messageList,
+              );
               if (blocked) {
                 // Emit a tripwire chunk so downstream knows about the abort
                 controller.enqueue({


### PR DESCRIPTION
Fixes #7933

Adds `messageList` parameter to `processOutputStream` so users can access remembered messages (conversation history) during streaming.

**Changes:**
- Add `messageList?: MessageList` to `processOutputStream` args
- Update `ProcessorRunner.processPart()` to pass messageList
- Update `MastraModelOutput` stream pipeline to pass messageList
- Add regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processors can access message history and runtime context during stream processing, enabling processors to inspect remembered messages and prior tool calls.

* **Tests**
  * Added regression tests verifying processors can read remembered messages during streaming and detect grounding from prior tool invocations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->