### PR TITLE
feat(config): enforce node: prefix for Node.js built-in imports

### DIFF
--- a/client-sdks/client-js/src/resources/agent-builder.test.ts
+++ b/client-sdks/client-js/src/resources/agent-builder.test.ts
@@ -1,6 +1,6 @@
-import type { Server, IncomingMessage } from 'http';
-import { createServer } from 'http';
-import type { AddressInfo } from 'net';
+import type { Server, IncomingMessage } from 'node:http';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { describe, it, beforeAll, beforeEach, afterAll, expect, vi, afterEach } from 'vitest';
 import type { ClientOptions } from '../types';
 import { AgentBuilder } from './agent-builder';

--- a/client-sdks/client-js/src/resources/base.test.ts
+++ b/client-sdks/client-js/src/resources/base.test.ts
@@ -1,6 +1,6 @@
-import type { Server } from 'http';
-import { createServer } from 'http';
-import type { AddressInfo } from 'net';
+import type { Server } from 'node:http';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import { BaseResource } from './base';
 

--- a/client-sdks/client-js/src/utils/process-mastra-stream.test.ts
+++ b/client-sdks/client-js/src/utils/process-mastra-stream.test.ts
@@ -1,4 +1,4 @@
-import { ReadableStream } from 'stream/web';
+import { ReadableStream } from 'node:stream/web';
 import type { ChunkType } from '@mastra/core/stream';
 import { ChunkFrom } from '@mastra/core/stream';
 import { describe, expect, it, vi, beforeEach } from 'vitest';

--- a/client-sdks/client-js/src/utils/process-mastra-stream.ts
+++ b/client-sdks/client-js/src/utils/process-mastra-stream.ts
@@ -1,4 +1,4 @@
-import type { ReadableStream } from 'stream/web';
+import type { ReadableStream } from 'node:stream/web';
 import type { ChunkType, NetworkChunkType } from '@mastra/core/stream';
 
 async function sharedProcessMastraStream({

--- a/deployers/cloud/scripts/sync-versions.mjs
+++ b/deployers/cloud/scripts/sync-versions.mjs
@@ -1,5 +1,5 @@
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getPackages } from '@manypkg/get-packages';
 import { writeJson } from 'fs-extra/esm';
 

--- a/deployers/cloud/src/index.test.ts
+++ b/deployers/cloud/src/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { getAuthEntrypoint } from './utils/auth.js';

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -1,5 +1,5 @@
+import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { join, dirname } from 'path';
 import { Deployer } from '@mastra/deployer';
 import { readJSON } from 'fs-extra/esm';
 

--- a/deployers/cloud/src/integration.test.ts
+++ b/deployers/cloud/src/integration.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { ensureDir, writeFile, readFile } from 'fs-extra';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
@@ -50,7 +50,7 @@ describe('CloudDeployer Integration Tests', () => {
       await deployer.prepare(outputDir);
 
       // Verify output directories are created
-      const fs = await import('fs');
+      const fs = await import('node:fs');
       expect(fs.existsSync(join(outputDir, '.build'))).toBe(true);
       expect(fs.existsSync(join(outputDir, 'output'))).toBe(true);
     });

--- a/deployers/cloud/src/utils/constants.ts
+++ b/deployers/cloud/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 
 export const LOCAL = process.env.LOCAL === 'true';
 export const TEAM_ID: string = process.env.TEAM_ID ?? '';

--- a/deployers/cloud/src/utils/deps.test.ts
+++ b/deployers/cloud/src/utils/deps.test.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { MastraError } from '@mastra/core/error';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 

--- a/deployers/cloud/src/utils/deps.ts
+++ b/deployers/cloud/src/utils/deps.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import { join, resolve } from 'path';
+import * as fs from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import { MastraError } from '@mastra/core/error';
 import { runWithExeca } from './execa.js';

--- a/deployers/cloud/src/utils/execa.ts
+++ b/deployers/cloud/src/utils/execa.ts
@@ -1,4 +1,4 @@
-import { Transform } from 'stream';
+import { Transform } from 'node:stream';
 import { execa } from 'execa';
 import { PROJECT_ENV_VARS, PROJECT_ROOT } from './constants.js';
 import { logger } from './logger.js';
@@ -58,7 +58,7 @@ export function runWithChildProcess(cmd: string, args: string[]): { stdout?: str
   const pinoStream = createPinoStream();
 
   try {
-    const { stdout, stderr } = require('child_process').spawnSync(cmd, args, {
+    const { stdout, stderr } = require('node:child_process').spawnSync(cmd, args, {
       cwd: PROJECT_ROOT,
       encoding: 'utf8',
       shell: true,

--- a/deployers/cloud/src/utils/file.test.ts
+++ b/deployers/cloud/src/utils/file.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { MastraError } from '@mastra/core/error';
 import { FileService } from '@mastra/deployer';
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/deployers/cloud/src/utils/file.ts
+++ b/deployers/cloud/src/utils/file.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { MastraError } from '@mastra/core/error';
 import { FileService } from '@mastra/deployer';
 

--- a/deployers/cloud/src/utils/logger.ts
+++ b/deployers/cloud/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import type { TransformCallback } from 'stream';
+import type { TransformCallback } from 'node:stream';
 import type { BaseLogMessage, LogLevel } from '@mastra/core/logger';
 import { LoggerTransport } from '@mastra/core/logger';
 import { PinoLogger } from '@mastra/loggers';

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -1,5 +1,5 @@
-import { writeFile } from 'fs/promises';
-import { join } from 'path';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { Deployer } from '@mastra/deployer';
 import type { analyzeBundle } from '@mastra/deployer/analyze';
 import virtual from '@rollup/plugin-virtual';

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -1,5 +1,5 @@
-import { join } from 'path';
-import process from 'process';
+import { join } from 'node:path';
+import process from 'node:process';
 import { Deployer } from '@mastra/deployer';
 import { DepsService } from '@mastra/deployer/services';
 import { move, writeJson } from 'fs-extra/esm';

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -1,6 +1,6 @@
-import { writeFileSync } from 'fs';
-import { join } from 'path';
-import process from 'process';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
 import { Deployer } from '@mastra/deployer';
 import { move } from 'fs-extra/esm';
 import type { VcConfig, VcConfigOverrides, VercelDeployerOptions } from './types';

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -8,7 +8,7 @@
  * Hierarchy: MODEL_GENERATION -> MODEL_STEP -> MODEL_CHUNK
  */
 
-import { TransformStream } from 'stream/web';
+import { TransformStream } from 'node:stream/web';
 import { SpanType } from '@mastra/core/observability';
 import type {
   Span,

--- a/packages/_changeset-cli/src/config.ts
+++ b/packages/_changeset-cli/src/config.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const rootDir = path.resolve(__dirname, '../../../');

--- a/packages/_changeset-cli/src/git/backport.ts
+++ b/packages/_changeset-cli/src/git/backport.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import 'dotenv/config';
-import childProcess from 'child_process';
+import childProcess from 'node:child_process';
 import { Octokit } from '@octokit/rest';
 import { defineCommand, runMain } from 'citty';
 

--- a/packages/_changeset-cli/src/git/getChangedPackages.ts
+++ b/packages/_changeset-cli/src/git/getChangedPackages.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { getChangedPackagesSinceRef } from '@changesets/git';
 import { rootDir } from '../config.js';
 import { getPublicPackages } from '../pkg/getPublicPackages.js';

--- a/packages/_changeset-cli/src/pkg/getPackageJson.ts
+++ b/packages/_changeset-cli/src/pkg/getPackageJson.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { rootDir } from '../config.js';
 
 export interface PackageJson {

--- a/packages/_changeset-cli/src/pkg/updatePackageJson.ts
+++ b/packages/_changeset-cli/src/pkg/updatePackageJson.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { PackageJson } from './getPackageJson.js';
 
 export function updatePackageJson(packagePath: string, packageJson: PackageJson): void {

--- a/packages/_config/package.json
+++ b/packages/_config/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@vitest/eslint-plugin": "^1.3.20",
     "eslint-plugin-import-x": "^4.16.1",
+    "eslint-plugin-unicorn": "^59.0.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-testing-library": "^7.13.3",

--- a/packages/_config/src/eslint.js
+++ b/packages/_config/src/eslint.js
@@ -55,23 +55,6 @@ export const createConfig = async () =>
         'no-unexpected-multiline': ERROR,
         'no-warning-comments': [ERROR, { terms: ['FIXME'], location: 'anywhere' }],
         'import/no-duplicates': [ERROR, { 'prefer-inline': false }],
-        'no-restricted-imports': [
-          ERROR,
-          {
-            paths: [
-              {
-                name: 'lodash',
-                message: 'Use native JavaScript methods or lodash-es instead.',
-              },
-            ],
-            patterns: [
-              {
-                group: ['lodash/*'],
-                message: 'Use native JavaScript methods or lodash-es instead.',
-              },
-            ],
-          },
-        ],
         'unicorn/prefer-node-protocol': ERROR,
         'import/order': [
           ERROR,

--- a/packages/_config/src/eslint.js
+++ b/packages/_config/src/eslint.js
@@ -42,6 +42,7 @@ export const createConfig = async () =>
     {
       plugins: {
         import: (await import('eslint-plugin-import-x')).default,
+        unicorn: (await import('eslint-plugin-unicorn')).default,
       },
       languageOptions: {
         globals: {
@@ -54,6 +55,24 @@ export const createConfig = async () =>
         'no-unexpected-multiline': ERROR,
         'no-warning-comments': [ERROR, { terms: ['FIXME'], location: 'anywhere' }],
         'import/no-duplicates': [ERROR, { 'prefer-inline': false }],
+        'no-restricted-imports': [
+          ERROR,
+          {
+            paths: [
+              {
+                name: 'lodash',
+                message: 'Use native JavaScript methods or lodash-es instead.',
+              },
+            ],
+            patterns: [
+              {
+                group: ['lodash/*'],
+                message: 'Use native JavaScript methods or lodash-es instead.',
+              },
+            ],
+          },
+        ],
+        'unicorn/prefer-node-protocol': ERROR,
         'import/order': [
           ERROR,
           {

--- a/packages/agent-builder/src/defaults.ts
+++ b/packages/agent-builder/src/defaults.ts
@@ -1,6 +1,6 @@
-import { spawn as nodeSpawn } from 'child_process';
-import { readFile, writeFile, mkdir, stat, readdir } from 'fs/promises';
-import { join, dirname, relative, isAbsolute, resolve } from 'path';
+import { spawn as nodeSpawn } from 'node:child_process';
+import { readFile, writeFile, mkdir, stat, readdir } from 'node:fs/promises';
+import { join, dirname, relative, isAbsolute, resolve } from 'node:path';
 import { createTool } from '@mastra/core/tools';
 import ignore from 'ignore';
 import { z } from 'zod';

--- a/packages/agent-builder/src/processors/write-file.ts
+++ b/packages/agent-builder/src/processors/write-file.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs/promises';
+import { writeFile } from 'node:fs/promises';
 import type { CoreMessage } from '@mastra/core/llm';
 import { MemoryProcessor } from '@mastra/core/memory';
 

--- a/packages/agent-builder/src/utils.ts
+++ b/packages/agent-builder/src/utils.ts
@@ -1,10 +1,10 @@
-import { exec as execNodejs, execFile as execFileNodejs, spawn as nodeSpawn } from 'child_process';
-import type { SpawnOptions } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
-import { copyFile, readFile } from 'fs/promises';
-import { createRequire } from 'module';
-import { dirname, basename, extname, resolve, join } from 'path';
-import { promisify } from 'util';
+import { exec as execNodejs, execFile as execFileNodejs, spawn as nodeSpawn } from 'node:child_process';
+import type { SpawnOptions } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { copyFile, readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, basename, extname, resolve, join } from 'node:path';
+import { promisify } from 'node:util';
 import type { MastraLanguageModel } from '@mastra/core/agent';
 import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';

--- a/packages/agent-builder/src/workflows/template-builder/template-builder.ts
+++ b/packages/agent-builder/src/workflows/template-builder/template-builder.ts
@@ -1,7 +1,7 @@
-import { existsSync } from 'fs';
-import { mkdtemp, copyFile, readFile, mkdir, readdir, rm, writeFile } from 'fs/promises';
-import { tmpdir } from 'os';
-import { join, dirname, resolve, extname, basename } from 'path';
+import { existsSync } from 'node:fs';
+import { mkdtemp, copyFile, readFile, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve, extname, basename } from 'node:path';
 import { openai } from '@ai-sdk/openai';
 import { Agent, tryGenerateWithJsonFallback, tryStreamWithJsonFallback } from '@mastra/core/agent';
 import { createTool } from '@mastra/core/tools';

--- a/packages/agent-builder/src/workflows/workflow-builder/workflow-builder.ts
+++ b/packages/agent-builder/src/workflows/workflow-builder/workflow-builder.ts
@@ -1,6 +1,6 @@
-import { existsSync } from 'fs';
-import { readFile, readdir } from 'fs/promises';
-import { join } from 'path';
+import { existsSync } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import { createWorkflow, createStep } from '@mastra/core/workflows';
 import { stepCountIs } from 'ai';

--- a/packages/cli/src/analytics/index.ts
+++ b/packages/cli/src/analytics/index.ts
@@ -1,8 +1,8 @@
-import { randomUUID } from 'crypto';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
-import os from 'os';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { PostHog } from 'posthog-node';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -1,5 +1,5 @@
-import fsSync from 'fs';
-import fs from 'fs/promises';
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
 import * as p from '@clack/prompts';
 import color from 'picocolors';
 import pkgJson from '../../../package.json';

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -1,8 +1,8 @@
-import fsSync from 'fs';
-import fs from 'fs/promises';
 import child_process from 'node:child_process';
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import util from 'node:util';
-import path from 'path';
 import * as p from '@clack/prompts';
 import color from 'picocolors';
 

--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -1,4 +1,4 @@
-import type { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'node:child_process';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('execa', () => ({

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -1,6 +1,6 @@
-import type { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
 import process from 'node:process';
-import { join } from 'path';
 import devcert from '@expo/devcert';
 import { FileService } from '@mastra/deployer';
 import { getServerOptions } from '@mastra/deployer/build';

--- a/packages/cli/src/commands/init/mcp-docs-server-install.ts
+++ b/packages/cli/src/commands/init/mcp-docs-server-install.ts
@@ -1,6 +1,6 @@
-import { existsSync } from 'fs';
-import os from 'os';
-import path from 'path';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { ensureFile, readJSON, writeJSON } from 'fs-extra/esm';
 
 const createArgs = (versionTag?: string) => {

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -1,7 +1,7 @@
-import fs from 'fs/promises';
 import child_process from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import util from 'node:util';
-import path from 'path';
 import * as p from '@clack/prompts';
 import type { ModelRouterModelId } from '@mastra/core/llm/model';
 import fsExtra from 'fs-extra/esm';

--- a/packages/cli/src/commands/lint/index.ts
+++ b/packages/cli/src/commands/lint/index.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { getDeployer } from '@mastra/deployer';
 import { FileService } from '../../services/service.file.js';
 import { logger } from '../../utils/logger.js';

--- a/packages/cli/src/commands/lint/rules/nextConfigRule.ts
+++ b/packages/cli/src/commands/lint/rules/nextConfigRule.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { logger } from '../../../utils/logger.js';
 import type { LintContext, LintRule } from './types.js';
 

--- a/packages/cli/src/commands/lint/rules/tsConfigRule.ts
+++ b/packages/cli/src/commands/lint/rules/tsConfigRule.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import stripJsonComments from 'strip-json-comments';
 import { logger } from '../../../utils/logger.js';
 import type { LintContext, LintRule } from './types.js';

--- a/packages/cli/src/commands/scorers/file-utils.ts
+++ b/packages/cli/src/commands/scorers/file-utils.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import * as p from '@clack/prompts';
 
 const DEFAULT_SCORERS_DIR = 'src/mastra/scorers';

--- a/packages/cli/src/commands/start/start.ts
+++ b/packages/cli/src/commands/start/start.ts
@@ -1,6 +1,6 @@
-import { spawn } from 'child_process';
-import fs from 'fs';
-import { join } from 'path';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import { join } from 'node:path';
 import { config } from 'dotenv';
 import { logger } from '../../utils/logger';
 import { shouldSkipDotenvLoading } from '../utils';

--- a/packages/cli/src/services/service.deps.ts
+++ b/packages/cli/src/services/service.deps.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import fsPromises from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
 import { execa } from 'execa';
 import { getPackageManagerAddCommand } from '../utils/package-manager';
 import type { PackageManager } from '../utils/package-manager';

--- a/packages/cli/src/services/service.file.ts
+++ b/packages/cli/src/services/service.file.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import fsExtra from 'fs-extra/esm';
 

--- a/packages/cli/src/services/service.fileEnv.ts
+++ b/packages/cli/src/services/service.fileEnv.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 import { EnvService } from './service.env';
 

--- a/packages/cli/src/utils/clone-template.test.ts
+++ b/packages/cli/src/utils/clone-template.test.ts
@@ -156,7 +156,7 @@ describe('clone-template', () => {
         projectName: 'test-project',
       });
 
-      const fs = await import('fs/promises');
+      const fs = await import('node:fs/promises');
       const packageJsonContent = await fs.readFile('/test-project/package.json', 'utf-8');
       const packageJson = JSON.parse(packageJsonContent);
 
@@ -314,7 +314,7 @@ describe('clone-template', () => {
         llmProvider: 'anthropic',
       });
 
-      const fs = await import('fs/promises');
+      const fs = await import('node:fs/promises');
       const envContent = await fs.readFile('/test-project/.env', 'utf-8');
 
       expect(envContent).toContain('MODEL=anthropic/claude-sonnet-4-5');

--- a/packages/cli/src/utils/clone-template.ts
+++ b/packages/cli/src/utils/clone-template.ts
@@ -1,7 +1,7 @@
-import fs from 'fs/promises';
 import child_process from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import util from 'node:util';
-import path from 'path';
 import shellQuote from 'shell-quote';
 import yoctoSpinner from 'yocto-spinner';
 

--- a/packages/codemod/scripts/scaffold-codemod.ts
+++ b/packages/codemod/scripts/scaffold-codemod.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const codemodName = process.argv[2];
 const version = process.argv[3] ?? 'v1';

--- a/packages/codemod/src/lib/transform.ts
+++ b/packages/codemod/src/lib/transform.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
 import child_process from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import util from 'node:util';
-import path from 'path';
 import debug from 'debug';
 
 const exec = util.promisify(child_process.exec);

--- a/packages/codemod/src/test/test-utils.test.ts
+++ b/packages/codemod/src/test/test-utils.test.ts
@@ -1,8 +1,8 @@
 // Copied from https://github.com/vercel/ai/blob/main/packages/codemod/src/test/test-utils.test.ts
 // License: Apache-2.0
 
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as testUtils from './test-utils';
 

--- a/packages/codemod/src/test/test-utils.ts
+++ b/packages/codemod/src/test/test-utils.ts
@@ -2,8 +2,8 @@
 // Adjusted from https://github.com/vercel/ai/blob/main/packages/codemod/src/test/test-utils.ts
 // License: Apache-2.0
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { API, FileInfo } from 'jscodeshift';
 import jscodeshift from 'jscodeshift';
 import ts from 'typescript';

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -1,6 +1,6 @@
-import fs from 'fs/promises';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import type { ProviderConfig } from '../src/llm';
 import { EXCLUDED_PROVIDERS, PROVIDERS_WITH_INSTALLED_PACKAGES } from '../src/llm/model/gateways/constants';

--- a/packages/core/scripts/generate-provider-options-docs.ts
+++ b/packages/core/scripts/generate-provider-options-docs.ts
@@ -5,8 +5,8 @@
  * and generates markdown documentation for each provider's options.
  */
 
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Node, Project, TypeFormatFlags } from 'ts-morph';
 import type { Type } from 'ts-morph';
 

--- a/packages/core/scripts/generate-providers.ts
+++ b/packages/core/scripts/generate-providers.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { MastraModelGateway } from '../src/llm/model/gateways/index.js';
 import { ModelsDevGateway } from '../src/llm/model/gateways/models-dev.js';
 import { NetlifyGateway } from '../src/llm/model/gateways/netlify.js';

--- a/packages/core/src/agent/__tests__/stream-id.test.ts
+++ b/packages/core/src/agent/__tests__/stream-id.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { simulateReadableStream, MockLanguageModelV1 } from '@internal/ai-sdk-v4';
 import type { UIMessageChunk } from 'ai-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';

--- a/packages/core/src/agent/__tests__/stream.test.ts
+++ b/packages/core/src/agent/__tests__/stream.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { openai } from '@ai-sdk/openai';
 import { openai as openai_v5 } from '@ai-sdk/openai-v5';
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';

--- a/packages/core/src/agent/__tests__/voice.test.ts
+++ b/packages/core/src/agent/__tests__/voice.test.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 import { openai } from '@ai-sdk/openai-v5';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { CompositeVoice } from '../../voice/composite-voice';

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import type { WritableStream } from 'stream/web';
+import { randomUUID } from 'node:crypto';
+import type { WritableStream } from 'node:stream/web';
 import type { CoreMessage, UIMessage, Tool } from '@internal/ai-sdk-v4';
 import deepEqual from 'fast-deep-equal';
 import type { JSONSchema7 } from 'json-schema';

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import type { WritableStream } from 'stream/web';
+import { randomUUID } from 'node:crypto';
+import type { WritableStream } from 'node:stream/web';
 import type { TextPart, UIMessage, StreamObjectResult } from '@internal/ai-sdk-v4';
 import { OpenAIReasoningSchemaCompatLayer, OpenAISchemaCompatLayer } from '@mastra/schema-compat';
 import type { ModelInformation } from '@mastra/schema-compat';

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -1,4 +1,4 @@
-import type { WritableStream } from 'stream/web';
+import type { WritableStream } from 'node:stream/web';
 import type { ModelMessage, ToolChoice } from 'ai-v5';
 import type { MastraScorer, MastraScorers, ScoringSamplingConfig } from '../evals';
 import type { SystemMessage } from '../llm';

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { UIMessage, CoreMessage, Message } from '@internal/ai-sdk-v4';
 import { appendClientMessage, appendResponseMessages } from '@internal/ai-sdk-v4';
 import { describe, expect, it } from 'vitest';

--- a/packages/core/src/agent/trip-wire.ts
+++ b/packages/core/src/agent/trip-wire.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import { ReadableStream } from 'stream/web';
+import { randomUUID } from 'node:crypto';
+import { ReadableStream } from 'node:stream/web';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { TracingContext } from '../observability';
 import { ChunkFrom, MastraModelOutput } from '../stream';

--- a/packages/core/src/bundler/index.ts
+++ b/packages/core/src/bundler/index.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
 import { parse } from 'dotenv';
 
 import { MastraBase } from '../base';

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { Agent } from '../agent';
 import { tryGenerateWithJsonFallback } from '../agent/utils';

--- a/packages/core/src/events/event-emitter.ts
+++ b/packages/core/src/events/event-emitter.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 import { PubSub } from './pubsub';
 import type { Event } from './types';
 

--- a/packages/core/src/llm/model/aisdk/v5/model.ts
+++ b/packages/core/src/llm/model/aisdk/v5/model.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { LanguageModelV2, LanguageModelV2CallOptions } from '@ai-sdk/provider-v5';
 import type { MastraLanguageModelV2 } from '../../shared.types';
 

--- a/packages/core/src/llm/model/provider-registry.test.ts
+++ b/packages/core/src/llm/model/provider-registry.test.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import type { ProviderConfig } from './gateways/base.js';
 import { ModelsDevGateway } from './gateways/models-dev.js';

--- a/packages/core/src/llm/model/provider-registry.ts
+++ b/packages/core/src/llm/model/provider-registry.ts
@@ -3,10 +3,10 @@
  * Loads provider data from JSON file and exports typed interfaces
  */
 
-import fs from 'fs';
-import { createRequire } from 'module';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
 import type { ProviderConfig, MastraModelGateway } from './gateways/base.js';
 import staticRegistry from './provider-registry.json';
 import type { Provider, ModelForProvider, ModelRouterModelId, ProviderModels } from './provider-types.generated.js';

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -3,8 +3,8 @@
  * Used by both the CLI generation script and runtime refresh
  */
 
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import type { MastraModelGateway, ProviderConfig } from './gateways/base.js';
 
 /**

--- a/packages/core/src/logger/transport.ts
+++ b/packages/core/src/logger/transport.ts
@@ -1,4 +1,4 @@
-import { Transform } from 'stream';
+import { Transform } from 'node:stream';
 import type { LogLevel } from './constants';
 
 export interface BaseLogMessage {

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -1,4 +1,4 @@
-import { fail } from 'assert';
+import { fail } from 'node:assert';
 import {
   convertArrayToReadableStream,
   convertAsyncIterableToArray,

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -1,4 +1,4 @@
-import type { WritableStream } from 'stream/web';
+import type { WritableStream } from 'node:stream/web';
 import type { SharedV2ProviderOptions } from '@ai-sdk/provider-v5';
 import type { CallSettings, IdGenerator, StopCondition, ToolChoice, ToolSet, StepResult, ModelMessage } from 'ai-v5';
 import z from 'zod';

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1,4 +1,4 @@
-import type { ReadableStream } from 'stream/web';
+import type { ReadableStream } from 'node:stream/web';
 import { isAbortError } from '@ai-sdk/provider-utils-v5';
 import type { LanguageModelV2Usage } from '@ai-sdk/provider-v5';
 import type { ToolSet } from 'ai-v5';

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -1,4 +1,4 @@
-import type { WritableStream } from 'stream/web';
+import type { WritableStream } from 'node:stream/web';
 import type { StepResult, ToolSet } from 'ai-v5';
 import { InternalSpans } from '../../../observability';
 import type { OutputSchema } from '../../../stream/base/schema';

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -1,4 +1,4 @@
-import { ReadableStream, WritableStream } from 'stream/web';
+import { ReadableStream, WritableStream } from 'node:stream/web';
 import type { ToolSet } from 'ai-v5';
 import { RequestContext } from '../../request-context';
 import type { OutputSchema } from '../../stream/base/schema';

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import * as crypto from 'node:crypto';
 import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraDBMessage } from '../../agent/message-list';

--- a/packages/core/src/processors/processors/structured-output.test.ts
+++ b/packages/core/src/processors/processors/structured-output.test.ts
@@ -1,4 +1,4 @@
-import type { TransformStreamDefaultController } from 'stream/web';
+import type { TransformStreamDefaultController } from 'node:stream/web';
 import { openai } from '@ai-sdk/openai-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -1,4 +1,4 @@
-import type { TransformStreamDefaultController } from 'stream/web';
+import type { TransformStreamDefaultController } from 'node:stream/web';
 import { Agent } from '../../agent';
 import type { StructuredOutputOptions } from '../../agent/types';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';

--- a/packages/core/src/storage/bundle.test.ts
+++ b/packages/core/src/storage/bundle.test.ts
@@ -1,6 +1,6 @@
-import { spawn as spwn } from 'child_process';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { spawn as spwn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { RollupOutput } from 'rollup';
 import { rollup } from 'rollup';
 import { expect, beforeAll, it } from 'vitest';

--- a/packages/core/src/stream/MastraAgentNetworkStream.ts
+++ b/packages/core/src/stream/MastraAgentNetworkStream.ts
@@ -1,4 +1,4 @@
-import { ReadableStream } from 'stream/web';
+import { ReadableStream } from 'node:stream/web';
 import type { Run } from '../workflows';
 import type { ChunkType } from './types';
 

--- a/packages/core/src/stream/MastraWorkflowStream.ts
+++ b/packages/core/src/stream/MastraWorkflowStream.ts
@@ -1,4 +1,4 @@
-import { ReadableStream } from 'stream/web';
+import { ReadableStream } from 'node:stream/web';
 import type z from 'zod';
 import type { Run, Step, WorkflowRunStatus } from '../workflows';
 import type { ChunkType } from './types';

--- a/packages/core/src/stream/RunOutput.ts
+++ b/packages/core/src/stream/RunOutput.ts
@@ -1,6 +1,6 @@
-import EventEmitter from 'events';
-import { ReadableStream, WritableStream } from 'stream/web';
-import type { ReadableStreamGetReaderOptions, ReadableWritablePair, StreamPipeOptions } from 'stream/web';
+import EventEmitter from 'node:events';
+import { ReadableStream, WritableStream } from 'node:stream/web';
+import type { ReadableStreamGetReaderOptions, ReadableWritablePair, StreamPipeOptions } from 'node:stream/web';
 import type { LanguageModelUsage } from 'ai-v5';
 import type { WorkflowResult, WorkflowRunStatus } from '../workflows';
 import { DelayedPromise } from './aisdk/v5/compat';

--- a/packages/core/src/stream/aisdk/v5/output.ts
+++ b/packages/core/src/stream/aisdk/v5/output.ts
@@ -1,5 +1,5 @@
-import type { ReadableStream } from 'stream/web';
-import { TransformStream } from 'stream/web';
+import type { ReadableStream } from 'node:stream/web';
+import { TransformStream } from 'node:stream/web';
 import { getErrorMessage } from '@ai-sdk/provider-v5';
 import { createTextStreamResponse, createUIMessageStream, createUIMessageStreamResponse, generateId } from 'ai-v5';
 import type { ObjectStreamPart, TextStreamPart, ToolSet, UIMessage, UIMessageStreamOptions } from 'ai-v5';

--- a/packages/core/src/stream/base/base.ts
+++ b/packages/core/src/stream/base/base.ts
@@ -1,4 +1,4 @@
-import type { ReadableStream } from 'stream/web';
+import type { ReadableStream } from 'node:stream/web';
 import type { ConsumeStreamOptions } from '../aisdk/v5/compat';
 
 export interface MastraBaseStream<T> {

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -1,4 +1,4 @@
-import { TransformStream } from 'stream/web';
+import { TransformStream } from 'node:stream/web';
 import { asSchema, isDeepEqualData, jsonSchema, parsePartialJson } from 'ai-v5';
 import type { JSONSchema7, Schema } from 'ai-v5';
 import type z3 from 'zod/v3';

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events';
-import { ReadableStream, TransformStream } from 'stream/web';
+import { EventEmitter } from 'node:events';
+import { ReadableStream, TransformStream } from 'node:stream/web';
 import { TripWire } from '../../agent';
 import { MessageList } from '../../agent/message-list';
 import { MastraBase } from '../../base';

--- a/packages/core/src/tools/stream.ts
+++ b/packages/core/src/tools/stream.ts
@@ -1,4 +1,4 @@
-import { WritableStream } from 'stream/web';
+import { WritableStream } from 'node:stream/web';
 import type { DataChunkType } from '../stream/types';
 
 export class ToolStream<T> extends WritableStream<T> {

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -1,4 +1,4 @@
-import type { WritableStream } from 'stream/web';
+import type { WritableStream } from 'node:stream/web';
 import type {
   Tool,
   ToolV5,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'crypto';
-import type { WritableStream } from 'stream/web';
+import { createHash } from 'node:crypto';
+import type { WritableStream } from 'node:stream/web';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { z } from 'zod';

--- a/packages/core/src/voice/aisdk/__tests__/aisdk-voice.test.ts
+++ b/packages/core/src/voice/aisdk/__tests__/aisdk-voice.test.ts
@@ -1,6 +1,6 @@
-import { writeFileSync, mkdirSync } from 'fs';
-import path from 'path';
-import { PassThrough } from 'stream';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import { openai } from '@ai-sdk/openai-v5';
 import { describe, expect, it, beforeAll } from 'vitest';
 

--- a/packages/core/src/voice/aisdk/__tests__/composite-voice.test.ts
+++ b/packages/core/src/voice/aisdk/__tests__/composite-voice.test.ts
@@ -1,5 +1,5 @@
-import { writeFileSync, mkdirSync } from 'fs';
-import path from 'path';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
 import { openai } from '@ai-sdk/openai-v5';
 import { describe, expect, it, beforeAll } from 'vitest';
 

--- a/packages/core/src/voice/aisdk/speech.ts
+++ b/packages/core/src/voice/aisdk/speech.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 import { experimental_generateSpeech } from 'ai-v5';
 import type { SpeechModel } from 'ai-v5';
 import { MastraVoice } from '../voice';

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 import { createStep, createWorkflow } from './workflow';

--- a/packages/core/src/workflows/default.test.ts
+++ b/packages/core/src/workflows/default.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { RequestContext } from '../di';

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import type { WritableStream } from 'stream/web';
+import { randomUUID } from 'node:crypto';
+import type { WritableStream } from 'node:stream/web';
 import type { RequestContext } from '../di';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { IErrorDefinition } from '../error';

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { simulateReadableStream, MockLanguageModelV1 } from '@internal/ai-sdk-v4';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 import { MastraBase } from '../../base';
 import type { RequestContext } from '../../di';
 import { getErrorFromUnknown } from '../../error/utils.js';

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import EventEmitter from 'events';
+import { randomUUID } from 'node:crypto';
+import EventEmitter from 'node:events';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
 import { EventProcessor } from '../../../events/processor';
 import type { Event } from '../../../events/types';

--- a/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 import type { StepFlowEntry, StepResult } from '../..';
 import { RequestContext } from '../../../di';
 import type { PubSub } from '../../../events';

--- a/packages/core/src/workflows/evented/workflow-event-processor/parallel.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/parallel.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 import type { StepFlowEntry } from '../..';
 import { RequestContext } from '../../../di';
 import type { PubSub } from '../../../events';

--- a/packages/core/src/workflows/evented/workflow-event-processor/sleep.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/sleep.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 import type { StepFlowEntry, WorkflowRunState } from '../..';
 import { RequestContext } from '../../../di';
 import type { PubSub } from '../../../events';

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import z from 'zod';
 import type { Agent } from '../../agent';
 import { RequestContext } from '../../di';

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -1,4 +1,4 @@
-import type { WritableStream } from 'stream/web';
+import type { WritableStream } from 'node:stream/web';
 import { MastraBase } from '../base';
 import type { RequestContext } from '../di';
 import { RegisteredLogger } from '../logger';

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from 'crypto';
-import fs from 'fs';
-import path from 'path';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 import { simulateReadableStream, MockLanguageModelV1 } from '@internal/ai-sdk-v4';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1,6 +1,6 @@
-import EventEmitter from 'events';
 import { randomUUID } from 'node:crypto';
-import { WritableStream, ReadableStream, TransformStream } from 'stream/web';
+import EventEmitter from 'node:events';
+import { WritableStream, ReadableStream, TransformStream } from 'node:stream/web';
 import { z } from 'zod';
 import type { MastraPrimitives } from '../action';
 import { Agent } from '../agent';

--- a/packages/core/test-zod-compat.mjs
+++ b/packages/core/test-zod-compat.mjs
@@ -17,11 +17,11 @@
  * Runs in CI: As a separate step before unit tests
  */
 
-import { exec } from 'child_process';
-import { writeFile, unlink } from 'fs/promises';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { promisify } from 'util';
+import { exec } from 'node:child_process';
+import { writeFile, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/core/tools/commonjs-tsc-fixer.js
+++ b/packages/core/tools/commonjs-tsc-fixer.js
@@ -1,5 +1,5 @@
-import { readFile, writeFile, rm, mkdir } from 'fs/promises';
-import { dirname, join, relative } from 'path';
+import { readFile, writeFile, rm, mkdir } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
 import { globby } from 'globby';
 
 async function cleanupDtsFiles() {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,5 +1,5 @@
-import fs, { writeFileSync, readFileSync, readdirSync, copyFileSync } from 'fs';
-import path, { dirname, join, relative } from 'path';
+import fs, { writeFileSync, readFileSync, readdirSync, copyFileSync } from 'node:fs';
+import path, { dirname, join, relative } from 'node:path';
 
 import babel from '@babel/core';
 import { generateTypes } from '@internal/types-builder';

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -1,5 +1,5 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';

--- a/packages/create-mastra/src/utils.ts
+++ b/packages/create-mastra/src/utils.ts
@@ -1,5 +1,5 @@
-import path, { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
 import fsExtra from 'fs-extra';
 

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -1,7 +1,7 @@
 import { analyzeEntry } from './analyzeEntry';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFile } from 'fs-extra';
-import { join } from 'path';
+import { join } from 'node:path';
 import { noopLogger } from '@mastra/core/logger';
 import resolveFrom from 'resolve-from';
 import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';

--- a/packages/deployer/src/build/analyze/bundleExternals.test.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createVirtualDependencies, bundleExternals } from './bundleExternals';
 import type { DependencyMetadata } from '../types';
 import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { ensureDir, remove, pathExists, writeFile } from 'fs-extra';
 
 // Mock the utilities that bundleExternals depends on

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
@@ -1,4 +1,4 @@
-import { dirname, extname } from 'path';
+import { dirname, extname } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import resolveFrom from 'resolve-from';
 import type { Plugin } from 'rollup';

--- a/packages/deployer/src/build/plugins/pino.ts
+++ b/packages/deployer/src/build/plugins/pino.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import type { OutputChunk, Plugin } from 'rollup';
 
 export function pino() {

--- a/packages/deployer/src/build/utils.test.ts
+++ b/packages/deployer/src/build/utils.test.ts
@@ -1,4 +1,4 @@
-import { posix } from 'path';
+import { posix } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { getPackageName, getCompiledDepCachePath, slash, findNativePackageModule } from './utils';
 

--- a/packages/deployer/src/build/utils.ts
+++ b/packages/deployer/src/build/utils.ts
@@ -1,8 +1,8 @@
-import { execSync } from 'child_process';
-import { existsSync, mkdirSync } from 'fs';
-import { basename, join, relative } from 'path';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
 import { getPackageInfo } from 'local-pkg';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 
 export function upsertMastraDir({ dir = process.cwd() }: { dir?: string }) {
   const dirPath = join(dir, '.mastra');

--- a/packages/deployer/src/deploy/log.ts
+++ b/packages/deployer/src/deploy/log.ts
@@ -1,5 +1,5 @@
-import { spawn } from 'child_process';
-import { Transform } from 'stream';
+import { spawn } from 'node:child_process';
+import { Transform } from 'node:stream';
 import type { IMastraLogger } from '@mastra/core/logger';
 
 export const createPinoStream = (logger: IMastraLogger) => {

--- a/packages/deployer/src/server/handlers/a2a.ts
+++ b/packages/deployer/src/server/handlers/a2a.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { MessageSendParams, TaskQueryParams, TaskIdParams } from '@mastra/core/a2a';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -1,6 +1,6 @@
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
 import * as https from 'node:https';
-import { join } from 'path/posix';
+import { join } from 'node:path/posix';
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { swaggerUI } from '@hono/swagger-ui';

--- a/packages/deployer/src/server/openapi.script.js
+++ b/packages/deployer/src/server/openapi.script.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import fsPromises from 'fs/promises';
-import path, { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { MastraBase } from '@mastra/core/base';
 import { readJSON, writeJSON, ensureFile } from 'fs-extra/esm';
 import type { PackageJson } from 'type-fest';

--- a/packages/deployer/src/services/env.ts
+++ b/packages/deployer/src/services/env.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 export abstract class EnvService {
   abstract getEnvValue(key: string): Promise<string | null>;

--- a/packages/deployer/src/services/fs.ts
+++ b/packages/deployer/src/services/fs.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import fsExtra from 'fs-extra/esm';
 

--- a/packages/loggers/src/file/index.test.ts
+++ b/packages/loggers/src/file/index.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { LogLevel } from '@mastra/core/logger';
 import { describe, it, expect, beforeEach, vi, afterAll } from 'vitest';
 import { PinoLogger } from '../pino.js';

--- a/packages/loggers/src/file/index.ts
+++ b/packages/loggers/src/file/index.ts
@@ -1,5 +1,5 @@
-import type { WriteStream } from 'fs';
-import { createWriteStream, existsSync, readFileSync } from 'fs';
+import type { WriteStream } from 'node:fs';
+import { createWriteStream, existsSync, readFileSync } from 'node:fs';
 import { LoggerTransport } from '@mastra/core/logger';
 import type { BaseLogMessage, LogLevel } from '@mastra/core/logger';
 

--- a/packages/mcp-docs-server/src/logger.ts
+++ b/packages/mcp-docs-server/src/logger.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { MCPServer } from '@mastra/mcp';
 import type { LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
 

--- a/packages/mcp-docs-server/src/tools/__tests__/course.test.ts
+++ b/packages/mcp-docs-server/src/tools/__tests__/course.test.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, test, beforeAll, afterAll, afterEach } from 'vitest';
 import { callTool, mcp, server } from './test-setup';
 

--- a/packages/mcp-docs-server/src/tools/__tests__/test-setup.ts
+++ b/packages/mcp-docs-server/src/tools/__tests__/test-setup.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { serve } from '@hono/node-server';
 import { MCPClient } from '@mastra/mcp';
 import { Hono } from 'hono';

--- a/packages/mcp-docs-server/src/utils.ts
+++ b/packages/mcp-docs-server/src/utils.ts
@@ -1,6 +1,6 @@
-import fs from 'fs/promises';
-import path, { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs/promises';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import z from 'zod';
 
 const mdxFileCache = new Map<string, string[]>();

--- a/packages/mcp/src/__fixtures__/weather.ts
+++ b/packages/mcp/src/__fixtures__/weather.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage, ServerResponse } from 'http';
-import { createServer } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createServer } from 'node:http';
 import { createTool } from '@mastra/core/tools';
 import type { Prompt, PromptMessage, Resource, ResourceTemplate } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -1,5 +1,5 @@
-import { spawn } from 'child_process';
-import path from 'path';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import { RequestContext } from '@mastra/core/di';
 import type { ResourceTemplate } from '@modelcontextprotocol/sdk/types.js';

--- a/packages/mcp/src/server/server-logging.test.ts
+++ b/packages/mcp/src/server/server-logging.test.ts
@@ -1,5 +1,5 @@
-import { spawn } from 'child_process';
-import path from 'path';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import type { LogMessage } from '../client/client';
 import { MCPClient } from '../client/configuration';

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -1,5 +1,5 @@
 import http from 'node:http';
-import path from 'path';
+import path from 'node:path';
 import type { ServerType } from '@hono/node-server';
 import { serve } from '@hono/node-server';
 import { Agent } from '@mastra/core/agent';

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1025,7 +1025,7 @@ export class MCPServer extends MCPServerBase {
    *
    * @example
    * ```typescript
-   * import http from 'http';
+   * import http from 'node:http';
    *
    * const httpServer = http.createServer(async (req, res) => {
    *   await server.startSSE({
@@ -1185,8 +1185,8 @@ export class MCPServer extends MCPServerBase {
    *
    * @example
    * ```typescript
-   * import http from 'http';
-   * import { randomUUID } from 'crypto';
+   * import http from 'node:http';
+   * import { randomUUID } from 'node:crypto';
    *
    * const httpServer = http.createServer(async (req, res) => {
    *   await server.startHTTP({

--- a/packages/memory/integration-tests-v5/src/output-processor-memory.test.ts
+++ b/packages/memory/integration-tests-v5/src/output-processor-memory.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp } from 'fs/promises';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import type { Processor } from '@mastra/core/processors';
 import { LibSQLStore } from '@mastra/libsql';

--- a/packages/memory/integration-tests-v5/src/processors.test.ts
+++ b/packages/memory/integration-tests-v5/src/processors.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp } from 'fs/promises';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach } from 'node:test';
-import { tmpdir } from 'os';
-import { join } from 'path';
 import { openai } from '@ai-sdk/openai';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { Agent, MessageList } from '@mastra/core/agent';

--- a/packages/memory/integration-tests/src/reusable-tests.ts
+++ b/packages/memory/integration-tests/src/reusable-tests.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from 'crypto';
-import * as path from 'path';
-import { Worker } from 'worker_threads';
+import { randomUUID } from 'node:crypto';
+import * as path from 'node:path';
+import { Worker } from 'node:worker_threads';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import type { SharedMemoryConfig } from '@mastra/core/memory';

--- a/packages/memory/integration-tests/src/with-libsql-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-libsql-storage.test.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import fs from 'fs';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
 import { fastembed } from '@mastra/fastembed';
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';

--- a/packages/memory/integration-tests/src/with-pg-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-pg-storage.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { fastembed } from '@mastra/fastembed';
 import { Memory } from '@mastra/memory';
 import { PostgresStore, PgVector } from '@mastra/pg';

--- a/packages/memory/integration-tests/src/with-upstash-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-upstash-storage.test.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import fs from 'fs';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
 import { fastembed } from '@mastra/fastembed';
 import { LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';

--- a/packages/memory/integration-tests/src/worker/generic-memory-worker.ts
+++ b/packages/memory/integration-tests/src/worker/generic-memory-worker.ts
@@ -1,4 +1,4 @@
-import { parentPort, workerData } from 'worker_threads';
+import { parentPort, workerData } from 'node:worker_threads';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import type { SharedMemoryConfig } from '@mastra/core/memory';
 import type { LibSQLConfig, LibSQLVectorConfig } from '@mastra/libsql';

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -1,6 +1,6 @@
 import react from '@vitejs/plugin-react';
 import autoprefixer from 'autoprefixer';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import tailwindcss from 'tailwindcss';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import path from 'node:path';
 import { defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => {

--- a/packages/rag/src/document/schema/node.ts
+++ b/packages/rag/src/document/schema/node.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { NodeRelationship, ObjectType } from './types';
 import type { Metadata, RelatedNodeInfo, RelatedNodeType, BaseNodeParams, TextNodeParams } from './types';
 

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { MastraError } from '@mastra/core/error';
 import { HTTPException } from '../http-exception';
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1396,6 +1396,9 @@ importers:
       eslint-plugin-testing-library:
         specifier: ^7.13.3
         version: 7.13.3(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-unicorn:
+        specifier: ^59.0.1
+        version: 59.0.1(eslint@9.38.0(jiti@2.6.1))
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -7066,6 +7069,10 @@ packages:
     resolution: {integrity: sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.13.0':
+    resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/core@0.16.0':
     resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -7080,6 +7087,10 @@ packages:
 
   '@eslint/object-schema@2.1.7':
     resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.2.8':
+    resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/plugin-kit@0.4.0':
@@ -11408,6 +11419,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  builtin-modules@5.0.0:
+    resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
+    engines: {node: '>=18.20'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -11607,6 +11622,10 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+    engines: {node: '>=8'}
+
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
@@ -11621,6 +11640,10 @@ packages:
 
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
+  clean-regexp@1.0.0:
+    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
+    engines: {node: '>=4'}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -12395,6 +12418,12 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
+  eslint-plugin-unicorn@59.0.1:
+    resolution: {integrity: sha512-EtNXYuWPUmkgSU2E7Ttn57LbRREQesIP1BiLn7OZLKodopKfDXfBUkC/0j6mpw2JExwf43Uf3qLSvrSvppgy8Q==}
+    engines: {node: ^18.20.0 || ^20.10.0 || >=21.0.0}
+    peerDependencies:
+      eslint: '>=9.22.0'
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -12654,6 +12683,10 @@ packages:
   find-replace@3.0.0:
     resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
     engines: {node: '>=4.0.0'}
+
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
 
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -13267,6 +13300,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
 
@@ -13396,6 +13433,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-builtin-module@5.0.0:
+    resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
+    engines: {node: '>=18.20'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -13719,6 +13760,11 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsesc@3.0.2:
+    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -15645,6 +15691,10 @@ packages:
   regex@5.1.1:
     resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
 
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -15663,6 +15713,10 @@ packages:
 
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
+
+  regjsparser@0.12.0:
+    resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
+    hasBin: true
 
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
@@ -20105,6 +20159,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.16.0
 
+  '@eslint/core@0.13.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
   '@eslint/core@0.16.0':
     dependencies:
       '@types/json-schema': 7.0.15
@@ -20126,6 +20184,11 @@ snapshots:
   '@eslint/js@9.38.0': {}
 
   '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.2.8':
+    dependencies:
+      '@eslint/core': 0.13.0
+      levn: 0.4.1
 
   '@eslint/plugin-kit@0.4.0':
     dependencies:
@@ -25455,6 +25518,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  builtin-modules@5.0.0: {}
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -25645,6 +25710,8 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  ci-info@4.3.1: {}
+
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
@@ -25658,6 +25725,10 @@ snapshots:
   classcat@5.0.5: {}
 
   classnames@2.5.1: {}
+
+  clean-regexp@1.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   clean-stack@2.2.0:
     optional: true
@@ -25905,7 +25976,6 @@ snapshots:
   core-js-compat@3.46.0:
     dependencies:
       browserslist: 4.28.0
-    optional: true
 
   core-js@3.46.0: {}
 
@@ -26590,6 +26660,27 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-unicorn@59.0.1(eslint@9.38.0(jiti@2.6.1)):
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
+      '@eslint/plugin-kit': 0.2.8
+      ci-info: 4.3.1
+      clean-regexp: 1.0.0
+      core-js-compat: 3.46.0
+      eslint: 9.38.0(jiti@2.6.1)
+      esquery: 1.6.0
+      find-up-simple: 1.0.1
+      globals: 16.5.0
+      indent-string: 5.0.0
+      is-builtin-module: 5.0.0
+      jsesc: 3.1.0
+      pluralize: 8.0.0
+      regexp-tree: 0.1.27
+      regjsparser: 0.12.0
+      semver: 7.7.3
+      strip-indent: 4.1.1
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -27010,6 +27101,8 @@ snapshots:
   find-replace@3.0.0:
     dependencies:
       array-back: 3.1.0
+
+  find-up-simple@1.0.1: {}
 
   find-up@3.0.0:
     dependencies:
@@ -27722,6 +27815,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  indent-string@5.0.0: {}
+
   infer-owner@1.0.4:
     optional: true
 
@@ -27855,6 +27950,10 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-builtin-module@5.0.0:
+    dependencies:
+      builtin-modules: 5.0.0
 
   is-callable@1.2.7: {}
 
@@ -28162,6 +28261,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
 
@@ -30353,6 +30454,8 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  regexp-tree@0.1.27: {}
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -30382,6 +30485,10 @@ snapshots:
 
   regjsgen@0.8.0:
     optional: true
+
+  regjsparser@0.12.0:
+    dependencies:
+      jsesc: 3.0.2
 
   regjsparser@0.13.0:
     dependencies:

--- a/pubsub/google-cloud-pubsub/src/index.test.ts
+++ b/pubsub/google-cloud-pubsub/src/index.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import { RequestContext } from '@mastra/core/di';
 import { Mastra } from '@mastra/core/mastra';

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -1,4 +1,4 @@
-import type { Server } from 'http';
+import type { Server } from 'node:http';
 import type { AdapterTestContext, HttpRequest, HttpResponse } from '@internal/server-adapter-test-utils';
 import { createRouteAdapterTestSuite } from '@internal/server-adapter-test-utils';
 import { SERVER_ROUTES } from '@mastra/server/server-adapter';

--- a/stores/_test-utils/src/domains/memory/data.ts
+++ b/stores/_test-utils/src/domains/memory/data.ts
@@ -1,7 +1,7 @@
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import type { StorageResourceType } from '@mastra/core/storage';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 let role: 'assistant' | 'user' = 'assistant';
 export const getRole = () => {

--- a/stores/_test-utils/src/domains/memory/messages-update.ts
+++ b/stores/_test-utils/src/domains/memory/messages-update.ts
@@ -2,7 +2,7 @@ import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createSampleMessageV2, createSampleThread } from './data';
 import { MastraStorage } from '@mastra/core/storage';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 export function createMessagesUpdateTest({ storage }: { storage: MastraStorage }) {
   describe('updateMessages', () => {

--- a/stores/_test-utils/src/domains/memory/resources.ts
+++ b/stores/_test-utils/src/domains/memory/resources.ts
@@ -1,7 +1,7 @@
 import type { MastraStorage } from '@mastra/core/storage';
 import { describe, expect, it } from 'vitest';
 import { createSampleResource } from './data';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 export function createResourcesTest({ storage }: { storage: MastraStorage }) {
   describe('Resources', () => {

--- a/stores/_test-utils/src/domains/memory/threads.ts
+++ b/stores/_test-utils/src/domains/memory/threads.ts
@@ -2,7 +2,7 @@ import { TABLE_THREADS, type MastraStorage } from '@mastra/core/storage';
 import { createSampleMessageV1, createSampleMessageV2, createSampleThread, createSampleThreadWithParams } from './data';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 export function createThreadsTest({ storage }: { storage: MastraStorage }) {
   describe('Threads', () => {

--- a/stores/_test-utils/src/domains/observability/data.ts
+++ b/stores/_test-utils/src/domains/observability/data.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { SpanType } from '@mastra/core/observability';
 import type { SpanRecord } from '@mastra/core/storage';
 

--- a/stores/_test-utils/src/domains/scores/data.ts
+++ b/stores/_test-utils/src/domains/scores/data.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { ScoreRowData, ScoringEntityType, ScoringSource } from '@mastra/core/evals';
 
 export function createSampleScore({

--- a/stores/_test-utils/src/domains/scores/index.ts
+++ b/stores/_test-utils/src/domains/scores/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createSampleScore } from './data';
 import type { ScoreRowData } from '@mastra/core/evals';

--- a/stores/_test-utils/src/domains/workflows/data.ts
+++ b/stores/_test-utils/src/domains/workflows/data.ts
@@ -1,5 +1,5 @@
 import type { WorkflowRunState } from '@mastra/core/workflows';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { expect } from 'vitest';
 
 export const checkWorkflowSnapshot = (snapshot: WorkflowRunState | string, stepId: string, status: string) => {

--- a/stores/cloudflare-d1/src/storage/rest-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/rest-api.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import {
   createSampleMessageV1,
   createSampleMessageV2,

--- a/stores/cloudflare-d1/src/storage/test-utils.ts
+++ b/stores/cloudflare-d1/src/storage/test-utils.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 export const createSampleTrace = (name: string, scope?: string, attributes?: Record<string, string>) => ({
   id: `trace-${randomUUID()}`,

--- a/stores/cloudflare/src/storage/test-utils.ts
+++ b/stores/cloudflare/src/storage/test-utils.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 
 export const createSampleTrace = (name: string, scope?: string, attributes?: Record<string, string>) => ({

--- a/stores/couchbase/scripts/start-docker.js
+++ b/stores/couchbase/scripts/start-docker.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 try {
   execSync('docker compose -f "./docker-compose.yaml" ps --quiet');
   console.info('Container already running, bringing it down first...');

--- a/stores/couchbase/scripts/stop-docker.js
+++ b/stores/couchbase/scripts/stop-docker.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 try {
   execSync('docker compose -f "./docker-compose.yaml" down --volumes', { stdio: 'inherit' });
 } catch (error) {

--- a/stores/couchbase/src/vector/index.integration.test.ts
+++ b/stores/couchbase/src/vector/index.integration.test.ts
@@ -2,8 +2,8 @@
 // IMPORTANT: These tests require Docker Engine to be running.
 // The tests will automatically start and configure the required Couchbase container.
 
-import { execSync } from 'child_process';
-import { randomUUID } from 'crypto';
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import axios from 'axios';
 import type { Cluster, Bucket, Scope, Collection } from 'couchbase';
 import { connect, QueryScanConsistency } from 'couchbase';

--- a/stores/dynamodb/src/storage/index.test.ts
+++ b/stores/dynamodb/src/storage/index.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { spawn } from 'node:child_process';
 import {
   CreateTableCommand,
   DeleteTableCommand,

--- a/stores/pg/src/shared/config.ts
+++ b/stores/pg/src/shared/config.ts
@@ -1,4 +1,4 @@
-import type { ConnectionOptions } from 'tls';
+import type { ConnectionOptions } from 'node:tls';
 import type { ClientConfig } from 'pg';
 import type * as pg from 'pg';
 import type { ISSLConfig } from 'pg-promise/typescript/pg-subset';

--- a/stores/turbopuffer/vitest.config.ts
+++ b/stores/turbopuffer/vitest.config.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/stores/vectorize/src/vector/index.test.ts
+++ b/stores/vectorize/src/vector/index.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { QueryResult } from '@mastra/core/vector';
 import dotenv from 'dotenv';
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi, afterEach } from 'vitest';

--- a/voice/azure/src/index.test.ts
+++ b/voice/azure/src/index.test.ts
@@ -1,6 +1,6 @@
-import { createReadStream, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
-import { Readable } from 'stream';
+import { createReadStream, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import { describe, it, expect, beforeAll } from 'vitest';
 
 import { AzureVoice } from './index';

--- a/voice/azure/src/index.ts
+++ b/voice/azure/src/index.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { MastraVoice } from '@mastra/core/voice';
 import * as Azure from 'microsoft-cognitiveservices-speech-sdk';
 import { AZURE_VOICES } from './voices';

--- a/voice/cloudflare/src/index.test.ts
+++ b/voice/cloudflare/src/index.test.ts
@@ -1,5 +1,5 @@
-import { createReadStream } from 'fs';
-import path from 'path';
+import { createReadStream } from 'node:fs';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { CloudflareVoice } from './index';
 

--- a/voice/deepgram/src/index.test.ts
+++ b/voice/deepgram/src/index.test.ts
@@ -1,6 +1,6 @@
-import { writeFileSync, mkdirSync, createReadStream } from 'fs';
-import path from 'path';
-import { PassThrough } from 'stream';
+import { writeFileSync, mkdirSync, createReadStream } from 'node:fs';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import { describe, expect, it, beforeAll } from 'vitest';
 
 import { DeepgramVoice } from './index.js';

--- a/voice/deepgram/src/index.ts
+++ b/voice/deepgram/src/index.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 
 import { createClient } from '@deepgram/sdk';
 import { MastraVoice } from '@mastra/core/voice';

--- a/voice/elevenlabs/src/index.test.ts
+++ b/voice/elevenlabs/src/index.test.ts
@@ -1,5 +1,5 @@
-import { createWriteStream, writeFileSync, mkdirSync, createReadStream } from 'fs';
-import path from 'path';
+import { createWriteStream, writeFileSync, mkdirSync, createReadStream } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it, beforeAll } from 'vitest';
 
 import { ElevenLabsVoice } from './index.js';

--- a/voice/gladia/src/index.test.ts
+++ b/voice/gladia/src/index.test.ts
@@ -1,5 +1,5 @@
-import { createReadStream } from 'fs';
-import path from 'path';
+import { createReadStream } from 'node:fs';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { GladiaVoice } from './index';
 

--- a/voice/gladia/src/index.ts
+++ b/voice/gladia/src/index.ts
@@ -1,4 +1,4 @@
-import type { Readable } from 'stream';
+import type { Readable } from 'node:stream';
 import { MastraVoice } from '@mastra/core/voice';
 
 interface GladiaConfig {

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GeminiLiveVoice } from './index';
 

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { ToolsInput } from '@mastra/core/agent';
 import { MastraVoice } from '@mastra/core/voice';
 import type { VoiceEventType, VoiceConfig } from '@mastra/core/voice';

--- a/voice/google-gemini-live-api/src/managers/AudioStreamManager.ts
+++ b/voice/google-gemini-live-api/src/managers/AudioStreamManager.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 import type { AudioConfig } from '../types';
 
 /**

--- a/voice/google-gemini-live-api/src/managers/ConnectionManager.ts
+++ b/voice/google-gemini-live-api/src/managers/ConnectionManager.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { WebSocket } from 'ws';
 import { GeminiLiveErrorCode } from '../types';
 import { GeminiLiveError } from '../utils/errors';

--- a/voice/google-gemini-live-api/src/managers/EventManager.ts
+++ b/voice/google-gemini-live-api/src/managers/EventManager.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 // Make the event manager generic over an event map
 export type EventMap = Record<string, unknown>;
 

--- a/voice/google-gemini-live-api/src/managers/SessionManager.ts
+++ b/voice/google-gemini-live-api/src/managers/SessionManager.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 export interface SessionConfig {
   debug: boolean;

--- a/voice/google-gemini-live-api/src/tool-args-bug.test.ts
+++ b/voice/google-gemini-live-api/src/tool-args-bug.test.ts
@@ -10,7 +10,7 @@ import { GeminiLiveVoice } from './index';
 
 // Mock WebSocket
 vi.mock('ws', () => {
-  const EventEmitter = require('events');
+  const EventEmitter = require('node:events');
   class MockWebSocket extends EventEmitter {
     static CONNECTING = 0;
     static OPEN = 1;

--- a/voice/google/src/index.ts
+++ b/voice/google/src/index.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 
 import { SpeechClient } from '@google-cloud/speech';
 import type { google as SpeechTypes } from '@google-cloud/speech/build/protos/protos';

--- a/voice/murf/src/index.test.ts
+++ b/voice/murf/src/index.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync } from 'fs';
-import { writeFile, stat as fsStat } from 'fs/promises';
-import path, { join } from 'path';
-import { Readable } from 'stream';
+import { mkdirSync } from 'node:fs';
+import { writeFile, stat as fsStat } from 'node:fs/promises';
+import path, { join } from 'node:path';
+import { Readable } from 'node:stream';
 import { describe, expect, it, beforeAll } from 'vitest';
 
 import { MurfVoice } from './index';

--- a/voice/murf/src/index.ts
+++ b/voice/murf/src/index.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 
 import { MastraVoice } from '@mastra/core/voice';
 import ky from 'ky';

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events';
-import { PassThrough } from 'stream';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import type { ToolsInput } from '@mastra/core/agent';
 import type { RequestContext } from '@mastra/core/request-context';
 import { MastraVoice } from '@mastra/core/voice';

--- a/voice/openai-realtime-api/src/utils.ts
+++ b/voice/openai-realtime-api/src/utils.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import type { ToolsInput } from '@mastra/core/agent';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 

--- a/voice/openai/src/index.test.ts
+++ b/voice/openai/src/index.test.ts
@@ -1,6 +1,6 @@
-import { writeFileSync, mkdirSync, createReadStream } from 'fs';
-import path from 'path';
-import { PassThrough } from 'stream';
+import { writeFileSync, mkdirSync, createReadStream } from 'node:fs';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import { describe, expect, it, beforeAll } from 'vitest';
 
 import { OpenAIVoice } from './index.js';

--- a/voice/openai/src/index.ts
+++ b/voice/openai/src/index.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 
 import { MastraVoice } from '@mastra/core/voice';
 import OpenAI from 'openai';

--- a/voice/playai/src/index.test.ts
+++ b/voice/playai/src/index.test.ts
@@ -1,7 +1,7 @@
-import { createWriteStream, mkdirSync } from 'fs';
-import { writeFile } from 'fs/promises';
-import path from 'path';
-import { Readable } from 'stream';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { PlayAIVoice, PLAYAI_VOICES } from './index.js';

--- a/voice/playai/src/index.ts
+++ b/voice/playai/src/index.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 
 import { MastraVoice } from '@mastra/core/voice';
 

--- a/voice/sarvam/src/index.test.ts
+++ b/voice/sarvam/src/index.test.ts
@@ -1,7 +1,7 @@
-import { createWriteStream, createReadStream, mkdirSync } from 'fs';
-import { writeFile } from 'fs/promises';
-import path from 'path';
-import { Readable } from 'stream';
+import { createWriteStream, createReadStream, mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { SARVAM_VOICES } from './voices';
 import type { SarvamVoiceId } from './voices';

--- a/voice/sarvam/src/index.ts
+++ b/voice/sarvam/src/index.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 
 import { MastraVoice } from '@mastra/core/voice';
 import { SARVAM_VOICES } from './voices';

--- a/voice/speechify/src/index.test.ts
+++ b/voice/speechify/src/index.test.ts
@@ -1,6 +1,6 @@
-import { writeFileSync, mkdirSync } from 'fs';
-import path from 'path';
-import { Readable } from 'stream';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
 import { describe, expect, it, beforeAll } from 'vitest';
 
 import { SpeechifyVoice } from './index';

--- a/voice/speechify/src/index.ts
+++ b/voice/speechify/src/index.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 
 import { MastraVoice } from '@mastra/core/voice';
 import { Speechify } from '@speechify/api-sdk';

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { openai } from '@ai-sdk/openai';
 import { serve } from '@hono/node-server';
 import { realtimeMiddleware } from '@inngest/realtime/middleware';

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { ReadableStream, WritableStream } from 'node:stream/web';
 import { subscribe } from '@inngest/realtime';
 import type { Agent } from '@mastra/core/agent';


### PR DESCRIPTION
## Summary
- Add `unicorn/prefer-node-protocol` ESLint rule to enforce `node:` prefix on all Node.js built-in imports (e.g., `import fs from 'node:fs'` instead of `import fs from 'fs'`)
- Auto-fix applied across 197 files in the codebase

This improves code consistency and makes it explicit when importing Node.js built-ins vs npm packages.