### PR TITLE
add seperate handlers for all ai-sdk routes

### DIFF
--- a/.changeset/better-paths-dig.md
+++ b/.changeset/better-paths-dig.md
@@ -1,0 +1,32 @@
+---
+'@mastra/ai-sdk': minor
+---
+
+Add framework-agnostic stream handlers for use outside of Hono/Mastra server
+
+- `handleChatStream`: Standalone handler for streaming agent chat in AI SDK format
+- `handleWorkflowStream`: Standalone handler for streaming workflow execution in AI SDK format
+- `handleNetworkStream`: Standalone handler for streaming agent network execution in AI SDK format
+  These functions accept all arguments explicitly and return a `ReadableStream`, making them usable in any framework (Next.js App Router, Express, etc.) without depending on Hono context.
+
+Example usage:
+
+```typescript
+import { handleChatStream } from '@mastra/ai-sdk';
+import { createUIMessageStreamResponse } from 'ai';
+export async function POST(req: Request) {
+  const params = await req.json();
+  const stream = await handleChatStream({
+    mastra,
+    agentId: 'weatherAgent',
+    params,
+  });
+  return createUIMessageStreamResponse({ stream });
+}
+```
+
+New exports:
+
+- handleChatStream, ChatStreamHandlerParams, ChatStreamHandlerOptions
+- handleWorkflowStream, WorkflowStreamHandlerParams, WorkflowStreamHandlerOptions
+- handleNetworkStream, NetworkStreamHandlerParams, NetworkStreamHandlerOptions

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -14,7 +14,6 @@ export type ChatStreamHandlerParams<
 > = AgentExecutionOptions<OUTPUT, 'mastra'> & {
   messages: UI_MESSAGE[];
   resumeData?: Record<string, any>;
-  runId?: string;
 };
 
 export type ChatStreamHandlerOptions<UI_MESSAGE extends UIMessage, OUTPUT extends OutputSchema = undefined> = {

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -1,5 +1,5 @@
 import type { AgentExecutionOptions } from '@mastra/core/agent';
-import type { MessageInput } from '@mastra/core/agent/message-list';
+
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { registerApiRoute } from '@mastra/core/server';

--- a/client-sdks/ai-sdk/src/index.ts
+++ b/client-sdks/ai-sdk/src/index.ts
@@ -1,10 +1,10 @@
-export { chatRoute } from './chat-route';
-export type { chatRouteOptions } from './chat-route';
-export { workflowRoute } from './workflow-route';
-export type { WorkflowRouteOptions } from './workflow-route';
+export { chatRoute, handleChatStream } from './chat-route';
+export type { chatRouteOptions, ChatStreamHandlerParams, ChatStreamHandlerOptions } from './chat-route';
+export { workflowRoute, handleWorkflowStream } from './workflow-route';
+export type { WorkflowRouteOptions, WorkflowStreamHandlerParams, WorkflowStreamHandlerOptions } from './workflow-route';
 export type { WorkflowDataPart } from './transformers';
-export { networkRoute } from './network-route';
-export type { NetworkRouteOptions } from './network-route';
+export { networkRoute, handleNetworkStream } from './network-route';
+export type { NetworkRouteOptions, NetworkStreamHandlerParams, NetworkStreamHandlerOptions } from './network-route';
 export type { NetworkDataPart } from './transformers';
 export type { AgentDataPart } from './transformers';
 

--- a/client-sdks/ai-sdk/src/network-route.ts
+++ b/client-sdks/ai-sdk/src/network-route.ts
@@ -1,12 +1,72 @@
 import type { AgentExecutionOptions } from '@mastra/core/agent';
+import type { MessageListInput } from '@mastra/core/agent/message-list';
+import type { Mastra } from '@mastra/core/mastra';
 import { registerApiRoute } from '@mastra/core/server';
 import type { OutputSchema } from '@mastra/core/stream';
 import { createUIMessageStream, createUIMessageStreamResponse } from 'ai';
+import type { InferUIMessageChunk, UIMessage } from 'ai';
 import { toAISdkV5Stream } from './convert-streams';
 
+export type NetworkStreamHandlerParams<OUTPUT extends OutputSchema = undefined> = AgentExecutionOptions<
+  OUTPUT,
+  'mastra'
+> & {
+  messages: MessageListInput;
+};
+
+export type NetworkStreamHandlerOptions<OUTPUT extends OutputSchema = undefined> = {
+  mastra: Mastra;
+  agentId: string;
+  params: NetworkStreamHandlerParams<OUTPUT>;
+  defaultOptions?: AgentExecutionOptions<OUTPUT, 'mastra'>;
+};
+
+/**
+ * Framework-agnostic handler for streaming agent network execution in AI SDK format.
+ * Use this function directly when you need to handle network streaming outside of Hono/registerApiRoute.
+ *
+ * @example
+ * // Next.js App Router
+ * export async function POST(req: Request) {
+ *   const params = await req.json();
+ *   return handleNetworkStream({
+ *     mastra,
+ *     agentId: 'my-agent',
+ *     params,
+ *   });
+ * }
+ */
+export async function handleNetworkStream<UI_MESSAGE extends UIMessage, OUTPUT extends OutputSchema = undefined>({
+  mastra,
+  agentId,
+  params,
+  defaultOptions,
+}: NetworkStreamHandlerOptions<OUTPUT>): Promise<ReadableStream<InferUIMessageChunk<UI_MESSAGE>>> {
+  const { messages, ...rest } = params;
+
+  const agentObj = mastra.getAgentById(agentId);
+
+  if (!agentObj) {
+    throw new Error(`Agent ${agentId} not found`);
+  }
+
+  const result = await agentObj.network(messages, {
+    ...defaultOptions,
+    ...rest,
+  });
+
+  return createUIMessageStream<UI_MESSAGE>({
+    execute: async ({ writer }) => {
+      for await (const part of toAISdkV5Stream(result, { from: 'network' })) {
+        writer.write(part as InferUIMessageChunk<UI_MESSAGE>);
+      }
+    },
+  });
+}
+
 export type NetworkRouteOptions<OUTPUT extends OutputSchema = undefined> =
-  | { path: `${string}:agentId${string}`; agent?: never; defaultOptions?: AgentExecutionOptions<OUTPUT, 'aisdk'> }
-  | { path: string; agent: string; defaultOptions?: AgentExecutionOptions<OUTPUT, 'aisdk'> };
+  | { path: `${string}:agentId${string}`; agent?: never; defaultOptions?: AgentExecutionOptions<OUTPUT, 'mastra'> }
+  | { path: string; agent: string; defaultOptions?: AgentExecutionOptions<OUTPUT, 'mastra'> };
 
 export function networkRoute<OUTPUT extends OutputSchema = undefined>({
   path = '/network/:agentId',
@@ -69,7 +129,7 @@ export function networkRoute<OUTPUT extends OutputSchema = undefined>({
       },
     },
     handler: async c => {
-      const { messages, ...rest } = await c.req.json();
+      const params = (await c.req.json()) as NetworkStreamHandlerParams<OUTPUT>;
       const mastra = c.get('mastra');
 
       let agentToUse: string | undefined = agent;
@@ -90,23 +150,11 @@ export function networkRoute<OUTPUT extends OutputSchema = undefined>({
         throw new Error('Agent ID is required');
       }
 
-      const agentObj = mastra.getAgentById(agentToUse);
-
-      if (!agentObj) {
-        throw new Error(`Agent ${agentToUse} not found`);
-      }
-
-      const result = await agentObj.network(messages, {
-        ...defaultOptions,
-        ...rest,
-      });
-
-      const uiMessageStream = createUIMessageStream({
-        execute: async ({ writer }) => {
-          for await (const part of toAISdkV5Stream(result, { from: 'network' })) {
-            writer.write(part);
-          }
-        },
+      const uiMessageStream = await handleNetworkStream<UIMessage, OUTPUT>({
+        mastra,
+        agentId: agentToUse,
+        params,
+        defaultOptions,
       });
 
       return createUIMessageStreamResponse({ stream: uiMessageStream });

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -298,6 +298,7 @@ export async function POST(req: Request) {
 
   // Transform stream into AI SDK format and create UI messages stream
   const uiMessageStream = createUIMessageStream({
+    originalMessages: messages,
     execute: async ({ writer }) => {
       for await (const part of toAISdkStream(stream, { from: "agent" })!) {
         writer.write(part);
@@ -390,6 +391,7 @@ export async function POST(req: Request) {
   });
 
   const uiMessageStream = createUIMessageStream({
+    initialMessages: messages,
     execute: async ({ writer }) => {
       for await (const part of toAISdkStream(stream, {
         from: "agent",


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Add framework-agnostic stream handlers for use outside of Hono/Mastra server. It helps users in NextJS with proper deduplication logic

- `handleChatStream`: Standalone handler for streaming agent chat in AI SDK format
- `handleWorkflowStream`: Standalone handler for streaming workflow execution in AI SDK format
- `handleNetworkStream`: Standalone handler for streaming agent network execution in AI SDK format
  These functions accept all arguments explicitly and return a `ReadableStream`, making them usable in any framework (Next.js App Router, Express, etc.) without depending on Hono context.

Example usage:

```typescript
import { handleChatStream } from '@mastra/ai-sdk';
import { createUIMessageStreamResponse } from 'ai';
export async function POST(req: Request) {
  const params = await req.json();
  const stream = await handleChatStream({
    mastra,
    agentId: 'weatherAgent',
    params,
  });
  return createUIMessageStreamResponse({ stream });
}
```


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes https://github.com/mastra-ai/mastra/issues/9370

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framework-agnostic streaming handlers for chat, workflows, and network executions that return ReadableStreams for UI message streaming outside the Mastra server (e.g., Next.js, Express).
* **Documentation**
  * Added usage examples for the new handlers and guidance to include original/initial messages when creating UI message streams.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->