### PR TITLE
fix(core): Agent network parts getLastMessage

### DIFF
--- a/.changeset/bold-rocks-post.md
+++ b/.changeset/bold-rocks-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a bug in agent networks where sometimes the task name was empty

--- a/packages/core/src/loop/network/index.test.ts
+++ b/packages/core/src/loop/network/index.test.ts
@@ -1,0 +1,79 @@
+import { it, describe, expect } from 'vitest';
+import type { MessageListInput } from '../../agent/message-list';
+import { getLastMessage } from './index';
+
+describe('getLastMessage', () => {
+  it('returns string directly', () => {
+    expect(getLastMessage('hello')).toBe('hello');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(getLastMessage('')).toBe('');
+    expect(getLastMessage([] as unknown as MessageListInput)).toBe('');
+  });
+
+  it('extracts from array of strings', () => {
+    expect(getLastMessage(['first', 'second', 'last'])).toBe('last');
+  });
+
+  it('extracts from message with string content', () => {
+    expect(getLastMessage([{ role: 'user', content: 'hello' }] as MessageListInput)).toBe('hello');
+  });
+
+  it('extracts from message with content array', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'first part' },
+          { type: 'text', text: 'last part' },
+        ],
+      },
+    ] as MessageListInput;
+    expect(getLastMessage(messages)).toBe('last part');
+  });
+
+  it('extracts from message with parts array', () => {
+    const messages = [
+      {
+        id: 'test-id',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Tell me about Spirited Away' }],
+      },
+    ] as MessageListInput;
+    expect(getLastMessage(messages)).toBe('Tell me about Spirited Away');
+  });
+
+  it('extracts last part from multiple parts', () => {
+    const messages = [
+      {
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'first' },
+          { type: 'text', text: 'second' },
+        ],
+      },
+    ] as MessageListInput;
+    expect(getLastMessage(messages)).toBe('second');
+  });
+
+  it('returns last message from multiple messages', () => {
+    const messages = [
+      { role: 'user', content: 'first message' },
+      { role: 'assistant', content: 'response' },
+      { role: 'user', content: 'last message' },
+    ] as MessageListInput;
+    expect(getLastMessage(messages)).toBe('last message');
+  });
+
+  it('handles single message object (not array)', () => {
+    expect(getLastMessage({ role: 'user', content: 'single' } as MessageListInput)).toBe('single');
+  });
+
+  it('returns empty string for non-text parts', () => {
+    const messages = [
+      { role: 'user', parts: [{ type: 'image', url: 'http://example.com' }] },
+    ] as unknown as MessageListInput;
+    expect(getLastMessage(messages)).toBe('');
+  });
+});

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -88,13 +88,22 @@ export function getLastMessage(messages: MessageListInput) {
     const lastMessage = Array.isArray(messages) ? messages[messages.length - 1] : messages;
     if (typeof lastMessage === 'string') {
       message = lastMessage;
-    } else if (lastMessage && `content` in lastMessage && lastMessage?.content) {
+    } else if (lastMessage && 'content' in lastMessage && lastMessage?.content) {
       const lastMessageContent = lastMessage.content;
       if (typeof lastMessageContent === 'string') {
         message = lastMessageContent;
       } else if (Array.isArray(lastMessageContent)) {
         const lastPart = lastMessageContent[lastMessageContent.length - 1];
         if (lastPart?.type === 'text') {
+          message = lastPart.text;
+        }
+      }
+    } else if (lastMessage && 'parts' in lastMessage && lastMessage?.parts) {
+      // Handle messages with 'parts' format (e.g. from MessageList)
+      const parts = lastMessage.parts;
+      if (Array.isArray(parts)) {
+        const lastPart = parts[parts.length - 1];
+        if (lastPart?.type === 'text' && lastPart?.text) {
           message = lastPart.text;
         }
       }


### PR DESCRIPTION
## Description

Adjust `getLastMessage()` to handle payloads where the messages are in the `parts` array.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug in agent networks where task name could be empty.

* **Tests**
  * Added comprehensive unit tests for message extraction functionality covering various input formats and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->