### PR TITLE
Hide time travel on map steps in Studio

### DIFF
--- a/.changeset/solid-books-try.md
+++ b/.changeset/solid-books-try.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Hide time travel on map steps in Studio

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -45,7 +45,7 @@ export const WorkflowStepActionBar = ({
   const dialogContentClass = 'bg-surface2 rounded-lg border-sm border-border1 max-w-4xl w-full px-0';
   const dialogTitleClass = 'border-b-sm border-border1 pb-4 px-6';
 
-  const showTimeTravel = !withoutTimeTravel && stepKey;
+  const showTimeTravel = !withoutTimeTravel && stepKey && !mapConfig;
 
   return (
     <>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

map step should not have the `time travel` button.

<img width="368" height="616" alt="Screenshot 2025-11-28 at 3 21 04 PM" src="https://github.com/user-attachments/assets/5a83da02-4dbf-424d-9f44-761e20cce134" />



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time travel is now hidden when working with map steps in the Studio workflow editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->