### PR TITLE
fix: only show command shortcut after user agent has loaded

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1005,6 +1005,7 @@ ol {
     padding-inline: 0.38rem;
     padding-block: 0.2rem;
     display: flex;
+    font-size: 10px;
   }
 
   [data-theme="dark"] kbd {

--- a/docs/src/theme/Navbar/Search/index.tsx
+++ b/docs/src/theme/Navbar/Search/index.tsx
@@ -14,49 +14,28 @@ import { useChatbotSidebar } from "@site/src/theme/DocRoot/Layout/ChatbotSidebar
 
 const SHORTCUT_OS_KEY = "shortcut-os-preference";
 
-function getInitialIsMac(): boolean {
-  if (typeof window === "undefined") return false;
-
-  try {
-    const cached = localStorage.getItem(SHORTCUT_OS_KEY);
-    if (cached !== null) {
-      return cached === "mac";
-    }
-  } catch (error) {
-    console.error(
-      "Error reading shortcut preference from localStorage:",
-      error,
-    );
-  }
-
-  return false;
-}
-
 export function Shortcut({ shortcut }: { shortcut: string }) {
-  const [isMac, setIsMac] = useState(getInitialIsMac);
+  const [os, setOS] = useState<"mac" | "other" | null>(null);
 
   useEffect(() => {
-    const isMacOS = navigator.userAgent.includes("Mac");
-    setIsMac(isMacOS);
+    const userAgent = navigator.userAgent;
 
-    try {
-      localStorage.setItem(SHORTCUT_OS_KEY, isMacOS ? "mac" : "other");
-    } catch (error) {
-      console.error("Error saving shortcut preference to localStorage:", error);
+    if (userAgent.includes("Mac")) {
+      setOS("mac");
+    } else {
+      setOS("other");
     }
   }, []);
 
+  const shortCut = os === "mac" ? "⌘ K" : "CTRL K";
   return (
-    <kbd className="flex items-center py-2 gap-1 text-xs font-medium text-(--mastra-icons-3)">
-      {!isMac ? (
-        `CTRL ${shortcut}`
-      ) : (
-        <span className="inline-flex gap-1 items-center text-sm">
-          <span className="text-xs">⌘</span>
-          <span className="text-xs">{shortcut}</span>
-        </span>
-      )}
-    </kbd>
+    <>
+      {os ? (
+        <kbd className="flex items-center py-2 gap-1 text-xs font-medium text-(--mastra-icons-3)">
+          {shortCut}
+        </kbd>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
## Description

Fix: show command shortcut after user agent has loaded in the client.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased font size for ordered lists in documentation.

* **Search Updates**
  * Search keyboard shortcut now automatically detects your operating system and displays the correct command: ⌘ K for Mac users or CTRL K for Windows and Linux.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->