### PR TITLE
fix: hide copy button with metadata

### DIFF
--- a/docs/src/content/en/guides/index.mdx
+++ b/docs/src/content/en/guides/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Overview"
 description: "Guides on building with Mastra"
+showCopyButton: false
 ---
 
 import { CardGrid, CardGridItem } from "@site/src/components/CardGrid";

--- a/docs/src/content/en/reference/index.mdx
+++ b/docs/src/content/en/reference/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Reference: Overview"
 description: "Reference documentation on Mastra's APIs and tools"
+showCopyButton: false
 ---
 
 import { ReferenceCards } from "@site/src/components/ReferenceCards";

--- a/docs/src/theme/MDXComponents/index.tsx
+++ b/docs/src/theme/MDXComponents/index.tsx
@@ -1,26 +1,27 @@
-import React, { type ComponentProps } from "react";
 import Head from "@docusaurus/Head";
-import MDXCode from "@theme/MDXComponents/Code";
+import Admonition from "@theme/Admonition";
 import MDXA from "@theme/MDXComponents/A";
-import MDXPre from "@theme/MDXComponents/Pre";
+import MDXCode from "@theme/MDXComponents/Code";
 import MDXDetails from "@theme/MDXComponents/Details";
 import MDXHeading from "@theme/MDXComponents/Heading";
-import MDXUl from "@theme/MDXComponents/Ul";
-import MDXLi from "@theme/MDXComponents/Li";
 import MDXImg from "@theme/MDXComponents/Img";
-import Admonition from "@theme/Admonition";
+import MDXLi from "@theme/MDXComponents/Li";
+import MDXPre from "@theme/MDXComponents/Pre";
+import MDXUl from "@theme/MDXComponents/Ul";
 import Mermaid from "@theme/Mermaid";
+import { type ComponentProps } from "react";
 
-import type { MDXComponentsObject } from "@theme/MDXComponents";
-import { CopyPageButton } from "@site/src/components/copy-page-button";
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { useDoc } from "@docusaurus/plugin-content-docs/lib/client/doc.js";
+import { CardGrid, CardGridItem } from "@site/src/components/CardGrid";
+import { CopyPageButton } from "@site/src/components/copy-page-button";
 import GithubLink from "@site/src/components/GithubLink";
 import NetlifyLogo from "@site/src/components/NetlifyLogo";
 import OperatorsTable from "@site/src/components/OperatorsTable";
-import ProviderModelsTable from "@site/src/components/ProviderModelsTable";
 import PropertiesTable from "@site/src/components/PropertiesTable";
-import { CardGrid, CardGridItem } from "@site/src/components/CardGrid";
+import ProviderModelsTable from "@site/src/components/ProviderModelsTable";
 import YouTube from "@site/src/components/YouTube-player";
+import type { MDXComponentsObject } from "@theme/MDXComponents";
 
 const MDXComponents: MDXComponentsObject = {
   Head,
@@ -32,18 +33,24 @@ const MDXComponents: MDXComponentsObject = {
   ul: MDXUl,
   li: MDXLi,
   img: MDXImg,
-  h1: (props: ComponentProps<"h1">) => (
-    <div className="flex justify-between items-start">
-      <MDXHeading as="h1" {...props} />
-      <BrowserOnly fallback={<div />}>
-        {() => (
-          <div className="relative hidden @[600px]:block">
-            <CopyPageButton />
-          </div>
-        )}
-      </BrowserOnly>
-    </div>
-  ),
+  h1: (props: ComponentProps<"h1">) => {
+    const { frontMatter } = useDoc();
+    const showCopyButton = (frontMatter as any)?.showCopyButton !== false;
+    return (
+      <div className="flex justify-between items-start">
+        <MDXHeading as="h1" {...props} />
+        {showCopyButton ? (
+          <BrowserOnly fallback={<div />}>
+            {() => (
+              <div className="relative hidden @[600px]:block">
+                <CopyPageButton />
+              </div>
+            )}
+          </BrowserOnly>
+        ) : null}
+      </div>
+    );
+  },
   h2: (props: ComponentProps<"h2">) => <MDXHeading as="h2" {...props} />,
   h3: (props: ComponentProps<"h3">) => <MDXHeading as="h3" {...props} />,
   h4: (props: ComponentProps<"h4">) => <MDXHeading as="h4" {...props} />,


### PR DESCRIPTION
## Description

This PR adds the ability to hide the copy button for select pages. Example:

```
---
title: "Overview"
description: "Guides on building with Mastra"
showCopyButton: false
---
```

<img width="1418" height="1016" alt="CleanShot 2025-11-28 at 17 57 32@2x" src="https://github.com/user-attachments/assets/114bdb1d-9a4d-41b9-951a-5dcfaf616c0b" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Improved documentation component rendering systems to support conditional display of code block features and interactive elements, enabling customization on a per-page basis.

**Style**
- Copy buttons on code blocks in the guides and reference documentation sections have been disabled to create a cleaner user interface and improve overall documentation presentation aesthetics and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->