### PR TITLE
fix(processors): allow InputProcessors to access and modify system messages

### DIFF
--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -99,13 +99,15 @@ import type {
 } from "@mastra/core";
 
 export class CustomInputProcessor implements InputProcessor {
-  name = "custom-input";
+  id = "custom-input";
 
   async processInput({
     messages,
+    systemMessages,
     context,
   }: {
     messages: MastraMessageV2[];
+    systemMessages: CoreMessage[];
     context: RuntimeContext;
   }): Promise<MastraMessageV2[]> {
     // Transform messages before they reach the LLM
@@ -119,6 +121,43 @@ export class CustomInputProcessor implements InputProcessor {
   }
 }
 ```
+
+The `processInput` method receives:
+- `messages`: User and assistant messages (not system messages)
+- `systemMessages`: All system messages (agent instructions, memory context, user-provided system prompts)
+- `messageList`: The full MessageList instance for advanced use cases
+- `abort`: Function to stop processing and return early
+- `runtimeContext`: Execution metadata like `threadId` and `resourceId`
+
+### Modifying system messages
+
+To modify system messages (e.g., trim verbose prompts for smaller models), return an object with both `messages` and `systemMessages`:
+
+```typescript title="src/mastra/processors/system-trimmer.ts" showLineNumbers copy
+import type { InputProcessor, CoreMessage } from "@mastra/core";
+
+export class SystemTrimmer implements InputProcessor {
+  id = "system-trimmer";
+
+  async processInput({ messages, systemMessages }) {
+    // Trim system messages for smaller models
+    const trimmedSystemMessages = systemMessages.map((msg) => ({
+      ...msg,
+      content:
+        typeof msg.content === "string"
+          ? msg.content.substring(0, 500)
+          : msg.content,
+    }));
+
+    return { messages, systemMessages: trimmedSystemMessages };
+  }
+}
+```
+
+This is useful for:
+- Trimming verbose system prompts for models with smaller context windows
+- Filtering or modifying semantic recall content to prevent "prompt too long" errors
+- Dynamically adjusting system instructions based on the conversation
 
 ### Custom output processor
 
@@ -155,8 +194,6 @@ export class CustomOutputProcessor implements OutputProcessor {
   }
 }
 ```
-
-Both `processInput` and `processOutputResult` receive a `context` object containing execution metadata such as `threadId`, `resourceId`, and other runtime information.
 
 ## Built-in Utility Processors
 

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -94,7 +94,7 @@ Custom processors implement the `InputProcessor` or `OutputProcessor` interface:
 ```typescript title="src/mastra/processors/custom-input.ts" showLineNumbers copy
 import type {
   InputProcessor,
-  MastraMessageV2,
+  MastraDBMessage,
   RuntimeContext,
 } from "@mastra/core";
 
@@ -106,10 +106,10 @@ export class CustomInputProcessor implements InputProcessor {
     systemMessages,
     context,
   }: {
-    messages: MastraMessageV2[];
+    messages: MastraDBMessage[];
     systemMessages: CoreMessage[];
     context: RuntimeContext;
-  }): Promise<MastraMessageV2[]> {
+  }): Promise<MastraDBMessage[]> {
     // Transform messages before they reach the LLM
     return messages.map((msg) => ({
       ...msg,
@@ -130,8 +130,8 @@ The `processInput` method receives:
 - `runtimeContext`: Execution metadata like `threadId` and `resourceId`
 
 The method can return:
-- `MastraMessageV2[]` — Transformed messages array (backward compatible)
-- `{ messages: MastraMessageV2[]; systemMessages: CoreMessage[] }` — Both messages and modified system messages
+- `MastraDBMessage[]` — Transformed messages array (backward compatible)
+- `{ messages: MastraDBMessage[]; systemMessages: CoreMessage[] }` — Both messages and modified system messages
 
 The framework handles both return formats, so modifying system messages is optional and existing processors continue to work.
 
@@ -140,7 +140,7 @@ The framework handles both return formats, so modifying system messages is optio
 To modify system messages (e.g., trim verbose prompts for smaller models), return an object with both `messages` and `systemMessages`:
 
 ```typescript title="src/mastra/processors/system-trimmer.ts" showLineNumbers copy
-import type { InputProcessor, CoreMessage, MastraMessageV2 } from "@mastra/core";
+import type { InputProcessor, CoreMessage, MastraDBMessage } from "@mastra/core";
 
 export class SystemTrimmer implements InputProcessor {
   id = "system-trimmer";
@@ -148,7 +148,7 @@ export class SystemTrimmer implements InputProcessor {
   async processInput({
     messages,
     systemMessages,
-  }): Promise<{ messages: MastraMessageV2[]; systemMessages: CoreMessage[] }> {
+  }): Promise<{ messages: MastraDBMessage[]; systemMessages: CoreMessage[] }> {
     // Trim system messages for smaller models
     const trimmedSystemMessages = systemMessages.map((msg) => ({
       ...msg,
@@ -173,7 +173,7 @@ This is useful for:
 ```typescript title="src/mastra/processors/custom-output.ts" showLineNumbers copy
 import type {
   OutputProcessor,
-  MastraMessageV2,
+  MastraDBMessage,
   RuntimeContext,
 } from "@mastra/core";
 
@@ -184,9 +184,9 @@ export class CustomOutputProcessor implements OutputProcessor {
     messages,
     context,
   }: {
-    messages: MastraMessageV2[];
+    messages: MastraDBMessage[];
     context: RuntimeContext;
-  }): Promise<MastraMessageV2[]> {
+  }): Promise<MastraDBMessage[]> {
     // Transform messages after the LLM generates them
     return messages.filter((msg) => msg.role !== "system");
   }

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -129,17 +129,26 @@ The `processInput` method receives:
 - `abort`: Function to stop processing and return early
 - `runtimeContext`: Execution metadata like `threadId` and `resourceId`
 
+The method can return:
+- `MastraMessageV2[]` — Transformed messages array (backward compatible)
+- `{ messages: MastraMessageV2[]; systemMessages: CoreMessage[] }` — Both messages and modified system messages
+
+The framework handles both return formats, so modifying system messages is optional and existing processors continue to work.
+
 ### Modifying system messages
 
 To modify system messages (e.g., trim verbose prompts for smaller models), return an object with both `messages` and `systemMessages`:
 
 ```typescript title="src/mastra/processors/system-trimmer.ts" showLineNumbers copy
-import type { InputProcessor, CoreMessage } from "@mastra/core";
+import type { InputProcessor, CoreMessage, MastraMessageV2 } from "@mastra/core";
 
 export class SystemTrimmer implements InputProcessor {
   id = "system-trimmer";
 
-  async processInput({ messages, systemMessages }) {
+  async processInput({
+    messages,
+    systemMessages,
+  }): Promise<{ messages: MastraMessageV2[]; systemMessages: CoreMessage[] }> {
     // Trim system messages for smaller models
     const trimmedSystemMessages = systemMessages.map((msg) => ({
       ...msg,

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -87,18 +87,18 @@ This ordering ensures that if your output guardrail calls `abort()`, memory proc
 
 ## Creating custom processors
 
-Custom processors implement the `InputProcessor` or `OutputProcessor` interface:
+Custom processors implement the `Processor` interface:
 
 ### Custom input processor
 
 ```typescript title="src/mastra/processors/custom-input.ts" showLineNumbers copy
 import type {
-  InputProcessor,
+  Processor,
   MastraDBMessage,
   RuntimeContext,
 } from "@mastra/core";
 
-export class CustomInputProcessor implements InputProcessor {
+export class CustomInputProcessor implements Processor {
   id = "custom-input";
 
   async processInput({
@@ -140,9 +140,9 @@ The framework handles both return formats, so modifying system messages is optio
 To modify system messages (e.g., trim verbose prompts for smaller models), return an object with both `messages` and `systemMessages`:
 
 ```typescript title="src/mastra/processors/system-trimmer.ts" showLineNumbers copy
-import type { InputProcessor, CoreMessage, MastraDBMessage } from "@mastra/core";
+import type { Processor, CoreMessage, MastraDBMessage } from "@mastra/core";
 
-export class SystemTrimmer implements InputProcessor {
+export class SystemTrimmer implements Processor {
   id = "system-trimmer";
 
   async processInput({
@@ -172,13 +172,13 @@ This is useful for:
 
 ```typescript title="src/mastra/processors/custom-output.ts" showLineNumbers copy
 import type {
-  OutputProcessor,
+  Processor,
   MastraDBMessage,
   RuntimeContext,
 } from "@mastra/core";
 
-export class CustomOutputProcessor implements OutputProcessor {
-  name = "custom-output";
+export class CustomOutputProcessor implements Processor {
+  id = "custom-output";
 
   async processOutputResult({
     messages,

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
@@ -48,30 +48,6 @@ To migrate, update processor message type imports and usage.
   };
 ```
 
-### New `systemMessages` parameter in `processInput`
-
-Input processors now receive a `systemMessages` parameter containing all system messages (agent instructions, memory context, user-provided system prompts). This allows processors to read and modify system messages.
-
-To modify system messages, return an object with both `messages` and `systemMessages`:
-
-```typescript
-const processor: InputProcessor = {
-  id: 'system-trimmer',
-  processInput: async ({ messages, systemMessages }) => {
-    // Trim system messages for smaller models
-    const trimmed = systemMessages.map(msg => ({
-      ...msg,
-      content: typeof msg.content === 'string'
-        ? msg.content.substring(0, 500)
-        : msg.content,
-    }));
-    return { messages, systemMessages: trimmed };
-  },
-};
-```
-
-This is useful for trimming verbose system prompts, filtering semantic recall content, or dynamically adjusting instructions.
-
 ## Removed
 
 ### Deprecated input processor exports

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
@@ -48,6 +48,30 @@ To migrate, update processor message type imports and usage.
   };
 ```
 
+### New `systemMessages` parameter in `processInput`
+
+Input processors now receive a `systemMessages` parameter containing all system messages (agent instructions, memory context, user-provided system prompts). This allows processors to read and modify system messages.
+
+To modify system messages, return an object with both `messages` and `systemMessages`:
+
+```typescript
+const processor: InputProcessor = {
+  id: 'system-trimmer',
+  processInput: async ({ messages, systemMessages }) => {
+    // Trim system messages for smaller models
+    const trimmed = systemMessages.map(msg => ({
+      ...msg,
+      content: typeof msg.content === 'string'
+        ? msg.content.substring(0, 500)
+        : msg.content,
+    }));
+    return { messages, systemMessages: trimmed };
+  },
+};
+```
+
+This is useful for trimming verbose system prompts, filtering semantic recall content, or dynamically adjusting instructions.
+
 ## Removed
 
 ### Deprecated input processor exports

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -818,6 +818,34 @@ export class MessageList {
     return this.systemMessages;
   }
 
+  /**
+   * Get all system messages (both tagged and untagged)
+   * @returns Array of all system messages
+   */
+  public getAllSystemMessages(): CoreMessageV4[] {
+    return [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()];
+  }
+
+  /**
+   * Replace all system messages with new ones
+   * This clears both tagged and untagged system messages and replaces them with the provided array
+   * @param messages - Array of system messages to set
+   */
+  public replaceAllSystemMessages(messages: CoreMessageV4[]): this {
+    // Clear existing system messages
+    this.systemMessages = [];
+    this.taggedSystemMessages = {};
+
+    // Add all new messages as untagged (processors don't need to preserve tags)
+    for (const message of messages) {
+      if (message.role === 'system') {
+        this.systemMessages.push(message);
+      }
+    }
+
+    return this;
+  }
+
   public addSystem(
     messages:
       | CoreMessageV4

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -3806,4 +3806,99 @@ describe('MessageList', () => {
       );
     });
   });
+
+  describe('getAllSystemMessages', () => {
+    it('should return all untagged system messages when no tag is specified', () => {
+      const list = new MessageList();
+      list.addSystem('You are a helpful assistant.');
+      list.addSystem('Be concise.');
+
+      const systemMessages = list.getAllSystemMessages();
+
+      expect(systemMessages).toHaveLength(2);
+      expect(systemMessages[0].content).toBe('You are a helpful assistant.');
+      expect(systemMessages[1].content).toBe('Be concise.');
+    });
+
+    it('should return both tagged and untagged system messages', () => {
+      const list = new MessageList();
+      list.addSystem('You are a helpful assistant.'); // untagged
+      list.addSystem('Remember user preferences.', 'user-provided'); // tagged
+      list.addSystem('Relevant context from memory.', 'memory'); // tagged
+
+      const systemMessages = list.getAllSystemMessages();
+
+      expect(systemMessages).toHaveLength(3);
+      const contents = systemMessages.map(m => m.content);
+      expect(contents).toContain('You are a helpful assistant.');
+      expect(contents).toContain('Remember user preferences.');
+      expect(contents).toContain('Relevant context from memory.');
+    });
+
+    it('should return empty array when no system messages exist', () => {
+      const list = new MessageList();
+      list.add({ role: 'user', content: 'Hello' }, 'input');
+
+      const systemMessages = list.getAllSystemMessages();
+
+      expect(systemMessages).toHaveLength(0);
+    });
+  });
+
+  describe('replaceAllSystemMessages', () => {
+    it('should replace all system messages with new ones', () => {
+      const list = new MessageList();
+      list.addSystem('Original instruction 1');
+      list.addSystem('Original instruction 2', 'memory');
+
+      const newSystemMessages: AIV4Type.CoreSystemMessage[] = [
+        { role: 'system', content: 'New instruction 1' },
+        { role: 'system', content: 'New instruction 2' },
+      ];
+
+      list.replaceAllSystemMessages(newSystemMessages);
+
+      const systemMessages = list.getAllSystemMessages();
+      expect(systemMessages).toHaveLength(2);
+      expect(systemMessages[0].content).toBe('New instruction 1');
+      expect(systemMessages[1].content).toBe('New instruction 2');
+    });
+
+    it('should clear all existing system messages including tagged ones', () => {
+      const list = new MessageList();
+      list.addSystem('Instruction');
+      list.addSystem('Memory context', 'memory');
+      list.addSystem('User provided', 'user-provided');
+
+      list.replaceAllSystemMessages([]);
+
+      const systemMessages = list.getAllSystemMessages();
+      expect(systemMessages).toHaveLength(0);
+    });
+
+    it('should not affect non-system messages', () => {
+      const list = new MessageList();
+      list.addSystem('System instruction');
+      list.add({ role: 'user', content: 'Hello' }, 'input');
+      list.add({ role: 'assistant', content: 'Hi there!' }, 'response');
+
+      list.replaceAllSystemMessages([{ role: 'system', content: 'New instruction' }]);
+
+      const allMessages = list.get.all.db();
+      expect(allMessages).toHaveLength(2);
+      expect(allMessages[0].role).toBe('user');
+      expect(allMessages[1].role).toBe('assistant');
+
+      const systemMessages = list.getAllSystemMessages();
+      expect(systemMessages).toHaveLength(1);
+      expect(systemMessages[0].content).toBe('New instruction');
+    });
+
+    it('should return this for chaining', () => {
+      const list = new MessageList();
+      const result = list.replaceAllSystemMessages([{ role: 'system', content: 'Test' }]);
+
+      expect(result).toBe(list);
+    });
+  });
 });

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -1,7 +1,25 @@
+import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
+
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
 import type { TracingContext } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { ChunkType } from '../stream';
+
+/**
+ * Return type for processInput that includes modified system messages
+ */
+export interface ProcessInputResultWithSystemMessages {
+  messages: MastraDBMessage[];
+  systemMessages: CoreMessageV4[];
+}
+
+/**
+ * Possible return types from processInput
+ */
+export type ProcessInputResult =
+  | MessageList
+  | MastraDBMessage[]
+  | ProcessInputResultWithSystemMessages;
 
 export interface Processor<TId extends string = string> {
   readonly id: TId;
@@ -10,8 +28,9 @@ export interface Processor<TId extends string = string> {
   /**
    * Process input messages before they are sent to the LLM
    *
-   * @param args.messages - The current messages being processed
-   * @param args.messageList - Optional MessageList instance for managing message sources (used by memory processors)
+   * @param args.messages - The current messages being processed (user/assistant messages, not system)
+   * @param args.systemMessages - All system messages (agent instructions, user-provided, memory) for read/modify access
+   * @param args.messageList - MessageList instance for managing message sources (used by memory processors)
    * @param args.abort - Function to abort processing with an optional reason
    * @param args.tracingContext - Optional tracing context for observability
    * @param args.runtimeContext - Optional runtime context with execution metadata (used by memory processors)
@@ -19,14 +38,16 @@ export interface Processor<TId extends string = string> {
    * @returns Either:
    *  - MessageList: The same messageList instance passed in (indicates you've mutated it)
    *  - MastraDBMessage[]: Transformed messages array (for simple transformations)
+   *  - { messages, systemMessages }: Object with both messages and modified system messages
    */
   processInput?(args: {
     messages: MastraDBMessage[];
+    systemMessages: CoreMessageV4[];
     messageList: MessageList;
     abort: (reason?: string) => never;
     tracingContext?: TracingContext;
     runtimeContext?: RequestContext;
-  }): Promise<MessageList | MastraDBMessage[]> | MessageList | MastraDBMessage[];
+  }): Promise<ProcessInputResult> | ProcessInputResult;
 
   /**
    * Process output stream chunks with built-in state management

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -16,10 +16,7 @@ export interface ProcessInputResultWithSystemMessages {
 /**
  * Possible return types from processInput
  */
-export type ProcessInputResult =
-  | MessageList
-  | MastraDBMessage[]
-  | ProcessInputResultWithSystemMessages;
+export type ProcessInputResult = MessageList | MastraDBMessage[] | ProcessInputResultWithSystemMessages;
 
 export interface Processor<TId extends string = string> {
   readonly id: TId;

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -322,9 +322,12 @@ describe('ProcessorRunner', () => {
         expect(receivedSystemMessages).toHaveLength(3);
 
         // Verify system messages content
-        const systemTexts = receivedSystemMessages!.map((m: any) =>
-          typeof m.content === 'string' ? m.content : m.content,
-        );
+        const systemTexts = receivedSystemMessages!.map((m: any) => {
+          if (typeof m.content === 'string') return m.content;
+          // Handle structured content format with parts array
+          if (m.content?.parts?.[0]?.text) return m.content.parts[0].text;
+          return m.content;
+        });
         expect(systemTexts).toContain('You are a helpful assistant.');
         expect(systemTexts).toContain('Remember the user prefers formal language.');
         expect(systemTexts).toContain('Relevant context from previous conversations.');

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -347,8 +347,7 @@ describe('ProcessorRunner', () => {
               if (systemMessages) {
                 const modifiedSystemMessages = systemMessages.map((msg: any) => ({
                   ...msg,
-                  content:
-                    typeof msg.content === 'string' ? msg.content.substring(0, 20) + '...' : msg.content,
+                  content: typeof msg.content === 'string' ? msg.content.substring(0, 20) + '...' : msg.content,
                 }));
                 // Return modified system messages somehow (this is what the fix should enable)
                 return { messages, systemMessages: modifiedSystemMessages };

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -266,6 +266,167 @@ describe('ProcessorRunner', () => {
       expect((messages[1].content[0] as TextPart).text).toBe('from processor 1');
       expect((messages[2].content[0] as TextPart).text).toBe('from processor 3');
     });
+
+    /**
+     * Regression test for GitHub Issue #9969
+     * @see https://github.com/mastra-ai/mastra/issues/9969
+     *
+     * Users want to process system messages (including semantic recall, working memory,
+     * and user-provided system prompts) using InputProcessors. Currently, InputProcessors
+     * only receive user messages via the `messages` parameter.
+     *
+     * Use cases:
+     * - Manipulate system prompts for smaller models (trim markdown, reduce length)
+     * - Modify semantic recall to prevent context overflow ("prompt too long" errors)
+     */
+    describe('Issue #9969: System messages in InputProcessor', () => {
+      it('should provide systemMessages parameter to processInput for accessing system messages', async () => {
+        // Add system messages to the MessageList
+        messageList.addSystem('You are a helpful assistant.'); // untagged system message
+        messageList.addSystem('Remember the user prefers formal language.', 'user-provided'); // tagged system message
+        messageList.addSystem('Relevant context from previous conversations.', 'memory'); // memory tag (like semantic recall)
+
+        // Add a user message
+        messageList.add([createMessage('Hello, how are you?', 'user')], 'input');
+
+        let receivedMessages: any[] = [];
+        let receivedSystemMessages: any[] | undefined;
+
+        const inputProcessors: Processor[] = [
+          {
+            id: 'system-message-processor',
+            name: 'System Message Processor',
+            processInput: async ({ messages, systemMessages }) => {
+              receivedMessages = messages;
+              receivedSystemMessages = systemMessages;
+              return messages;
+            },
+          },
+        ];
+
+        runner = new ProcessorRunner({
+          inputProcessors,
+          outputProcessors: [],
+          logger: mockLogger,
+          agentName: 'test-agent',
+        });
+
+        await runner.runInputProcessors(messageList);
+
+        // The messages parameter should only contain user messages (current behavior)
+        expect(receivedMessages).toHaveLength(1);
+        expect(receivedMessages[0].role).toBe('user');
+
+        // NEW: systemMessages parameter should be provided and contain all system messages
+        expect(receivedSystemMessages).toBeDefined();
+        expect(receivedSystemMessages).toHaveLength(3);
+
+        // Verify system messages content
+        const systemTexts = receivedSystemMessages!.map((m: any) =>
+          typeof m.content === 'string' ? m.content : m.content,
+        );
+        expect(systemTexts).toContain('You are a helpful assistant.');
+        expect(systemTexts).toContain('Remember the user prefers formal language.');
+        expect(systemTexts).toContain('Relevant context from previous conversations.');
+      });
+
+      it('should allow InputProcessor to modify system messages via return value', async () => {
+        // Add system messages
+        messageList.addSystem('Original system prompt with verbose instructions.');
+        messageList.addSystem('Memory context that is too long and needs trimming.', 'memory');
+
+        // Add a user message
+        messageList.add([createMessage('Hello', 'user')], 'input');
+
+        const inputProcessors: Processor[] = [
+          {
+            id: 'system-trimmer',
+            name: 'System Trimmer',
+            processInput: async ({ messages, systemMessages }) => {
+              // Modify system messages - trim them for smaller models
+              if (systemMessages) {
+                const modifiedSystemMessages = systemMessages.map((msg: any) => ({
+                  ...msg,
+                  content:
+                    typeof msg.content === 'string' ? msg.content.substring(0, 20) + '...' : msg.content,
+                }));
+                // Return modified system messages somehow (this is what the fix should enable)
+                return { messages, systemMessages: modifiedSystemMessages };
+              }
+              return messages;
+            },
+          },
+        ];
+
+        runner = new ProcessorRunner({
+          inputProcessors,
+          outputProcessors: [],
+          logger: mockLogger,
+          agentName: 'test-agent',
+        });
+
+        const result = await runner.runInputProcessors(messageList);
+
+        // After processing, the system messages should be modified
+        const allMessages = await result.get.all.aiV5.prompt();
+        const systemMessages = allMessages.filter((m: any) => m.role === 'system');
+
+        // Verify system messages were trimmed
+        expect(systemMessages).toHaveLength(2);
+        systemMessages.forEach((msg: any) => {
+          const content = typeof msg.content === 'string' ? msg.content : msg.content[0]?.text;
+          expect(content.length).toBeLessThanOrEqual(24); // 20 chars + '...'
+        });
+      });
+
+      it('should continue to allow adding new system messages via return array (existing behavior)', async () => {
+        // This test verifies existing behavior that MUST NOT break
+        // Processors can currently add system messages by including them in the return array
+
+        messageList.add([createMessage('Hello', 'user')], 'input');
+
+        const inputProcessors: Processor[] = [
+          {
+            id: 'system-adder',
+            name: 'System Adder',
+            processInput: async ({ messages }) => {
+              // Add a new system message by including it in the return array
+              const newSystemMessage = {
+                id: `msg-${Math.random()}`,
+                role: 'system' as const,
+                content: {
+                  format: 2 as const,
+                  parts: [{ type: 'text' as const, text: 'New system instruction added by processor.' }],
+                },
+                createdAt: new Date(),
+                threadId: 'test-thread',
+              };
+              return [...messages, newSystemMessage];
+            },
+          },
+        ];
+
+        runner = new ProcessorRunner({
+          inputProcessors,
+          outputProcessors: [],
+          logger: mockLogger,
+          agentName: 'test-agent',
+        });
+
+        const result = await runner.runInputProcessors(messageList);
+
+        // Verify the system message was added
+        const allMessages = await result.get.all.aiV5.prompt();
+        const systemMessages = allMessages.filter((m: any) => m.role === 'system');
+
+        expect(systemMessages).toHaveLength(1);
+        const content =
+          typeof systemMessages[0].content === 'string'
+            ? systemMessages[0].content
+            : (systemMessages[0].content[0] as { text?: string })?.text;
+        expect(content).toBe('New system instruction added by processor.');
+      });
+    });
   });
 
   describe('Output Processors', () => {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -372,15 +372,19 @@ export class ProcessorRunner {
       // Start recording MessageList mutations for this processor
       messageList.startRecording();
 
+      // Get all system messages to pass to the processor
+      const currentSystemMessages = messageList.getAllSystemMessages();
+
       const result = await processMethod({
         messages: processableMessages,
+        systemMessages: currentSystemMessages,
         abort: ctx.abort,
         tracingContext: { currentSpan: processorSpan },
         messageList,
         runtimeContext,
       });
 
-      // Handle both MessageList and MastraDBMessage[] return types
+      // Handle MessageList, MastraDBMessage[], or { messages, systemMessages } return types
       let mutations: Array<{
         type: 'add' | 'addSystem' | 'removeByIds' | 'clear';
         source?: string;
@@ -407,6 +411,44 @@ export class ProcessorRunner {
           // Update processableMessages to reflect ALL current messages for next processor
           processableMessages = messageList.get.input.db();
         }
+      } else if (this.isProcessInputResultWithSystemMessages(result)) {
+        // Processor returned { messages, systemMessages } - handle both
+        mutations = messageList.stopRecording();
+
+        // Replace system messages with the modified ones
+        messageList.replaceAllSystemMessages(result.systemMessages);
+
+        // Handle regular messages
+        const regularMessages = result.messages;
+        if (regularMessages) {
+          const deletedIds = inputIds.filter(i => !regularMessages.some(m => m.id === i));
+          if (deletedIds.length) {
+            messageList.removeByIds(deletedIds);
+          }
+
+          // Separate any new system messages from other messages (backward compat)
+          const newSystemMessages = regularMessages.filter(m => m.role === 'system');
+          const nonSystemMessages = regularMessages.filter(m => m.role !== 'system');
+
+          // Add any new system messages from the messages array
+          for (const sysMsg of newSystemMessages) {
+            const systemText =
+              (sysMsg.content.content as string | undefined) ??
+              sysMsg.content.parts?.map(p => (p.type === 'text' ? p.text : '')).join('\n') ??
+              '';
+            messageList.addSystem(systemText);
+          }
+
+          // Add non-system messages normally
+          if (nonSystemMessages.length > 0) {
+            for (const message of nonSystemMessages) {
+              messageList.removeByIds([message.id]);
+              messageList.add(message, check.getSource(message) || 'input');
+            }
+          }
+        }
+
+        processableMessages = messageList.get.input.db();
       } else {
         // Processor returned an array - stop recording before clear/add (that's just internal plumbing)
         mutations = messageList.stopRecording();
@@ -451,5 +493,21 @@ export class ProcessorRunner {
     }
 
     return messageList;
+  }
+
+  /**
+   * Type guard to check if result is { messages, systemMessages }
+   */
+  private isProcessInputResultWithSystemMessages(
+    result: unknown,
+  ): result is { messages: MastraDBMessage[]; systemMessages: unknown[] } {
+    return (
+      result !== null &&
+      typeof result === 'object' &&
+      'messages' in result &&
+      'systemMessages' in result &&
+      Array.isArray((result as any).messages) &&
+      Array.isArray((result as any).systemMessages)
+    );
   }
 }


### PR DESCRIPTION
Fixes #9969

InputProcessors can now read and modify system messages (agent instructions, semantic recall, working memory, etc.)

**Before:** InputProcessors only received user messages via `messages` param, with no access to system messages.

**After:** InputProcessors receive a new `systemMessages` param and can return modified system messages:

```typescript
const processor: InputProcessor = {
  id: 'system-trimmer',
  processInput: async ({ messages, systemMessages }) => {
    // Trim system messages for smaller models
    const trimmed = systemMessages.map(msg => ({
      ...msg,
      content: msg.content.substring(0, 100) + '...',
    }));
    return { messages, systemMessages: trimmed };
  },
};
```

Backward compatible - existing processors work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processors can read and modify system messages alongside regular messages during processing.
  * Added ability to retrieve all system messages and to replace the complete set of system messages.
  * Message pipeline supports returning regular messages together with updated system messages for coordinated updates.

* **Tests**
  * Added regression tests verifying system-message handling and processor compatibility with the new combined return form.

* **Documentation**
  * Updated docs and examples to show systemMessages in processor input and combined output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->