### PR TITLE
feat: add providerOptions support for tools

### DIFF
--- a/.changeset/swift-tools-provide.md
+++ b/.changeset/swift-tools-provide.md
@@ -1,0 +1,15 @@
+---
+"@mastra/core": patch
+---
+
+Add support for `providerOptions` when defining tools. This allows developers to specify provider-specific configurations (like Anthropic's `cacheControl`) per tool.
+
+```typescript
+createTool({
+  id: 'my-tool',
+  providerOptions: {
+    anthropic: { cacheControl: { type: 'ephemeral' } }
+  },
+  // ...
+})
+```

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -950,6 +950,143 @@ describe('Tool Input Validation', () => {
   });
 });
 
+describe('CoreToolBuilder providerOptions', () => {
+  it('should pass through providerOptions when building a tool', () => {
+    const toolWithProviderOptions = createTool({
+      id: 'cache-control-tool',
+      description: 'A tool with cache control',
+      inputSchema: z.object({ city: z.string() }),
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: 'ephemeral' },
+        },
+      },
+      execute: async ({ city }) => ({ result: city }),
+    });
+
+    const builder = new CoreToolBuilder({
+      originalTool: toolWithProviderOptions,
+      options: {
+        name: 'cache-control-tool',
+        logger: console as any,
+        description: 'A tool with cache control',
+        requestContext: new RequestContext(),
+        tracingContext: {},
+      },
+    });
+
+    const builtTool = builder.build();
+
+    expect(builtTool.providerOptions).toEqual({
+      anthropic: {
+        cacheControl: { type: 'ephemeral' },
+      },
+    });
+  });
+
+  it('should handle tools without providerOptions', () => {
+    const toolWithoutProviderOptions = createTool({
+      id: 'no-provider-options',
+      description: 'A tool without provider options',
+      inputSchema: z.object({ value: z.string() }),
+      execute: async ({ value }) => ({ result: value }),
+    });
+
+    const builder = new CoreToolBuilder({
+      originalTool: toolWithoutProviderOptions,
+      options: {
+        name: 'no-provider-options',
+        logger: console as any,
+        description: 'A tool without provider options',
+        requestContext: new RequestContext(),
+        tracingContext: {},
+      },
+    });
+
+    const builtTool = builder.build();
+
+    expect(builtTool.providerOptions).toBeUndefined();
+  });
+
+  it('should pass through multiple provider options', () => {
+    const toolWithMultipleProviders = createTool({
+      id: 'multi-provider-tool',
+      description: 'A tool with multiple provider options',
+      inputSchema: z.object({ query: z.string() }),
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: 'ephemeral' },
+        },
+        openai: {
+          customOption: 'value',
+        },
+        google: {
+          anotherOption: true,
+        },
+      },
+      execute: async ({ query }) => ({ result: query }),
+    });
+
+    const builder = new CoreToolBuilder({
+      originalTool: toolWithMultipleProviders,
+      options: {
+        name: 'multi-provider-tool',
+        logger: console as any,
+        description: 'A tool with multiple provider options',
+        requestContext: new RequestContext(),
+        tracingContext: {},
+      },
+    });
+
+    const builtTool = builder.build();
+
+    expect(builtTool.providerOptions).toEqual({
+      anthropic: {
+        cacheControl: { type: 'ephemeral' },
+      },
+      openai: {
+        customOption: 'value',
+      },
+      google: {
+        anotherOption: true,
+      },
+    });
+  });
+
+  it('should handle Vercel tools with providerOptions', () => {
+    // Simulate a Vercel tool that has providerOptions
+    const vercelToolWithProviderOptions = {
+      description: 'A Vercel tool with provider options',
+      parameters: z.object({ input: z.string() }),
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: 'ephemeral' },
+        },
+      },
+      execute: async (args: any) => ({ result: args.input }),
+    };
+
+    const builder = new CoreToolBuilder({
+      originalTool: vercelToolWithProviderOptions as any,
+      options: {
+        name: 'vercel-tool-with-options',
+        logger: console as any,
+        description: 'A Vercel tool with provider options',
+        requestContext: new RequestContext(),
+        tracingContext: {},
+      },
+    });
+
+    const builtTool = builder.build();
+
+    expect(builtTool.providerOptions).toEqual({
+      anthropic: {
+        cacheControl: { type: 'ephemeral' },
+      },
+    });
+  });
+});
+
 describe('CoreToolBuilder Output Schema', () => {
   it('should allow ZodTuple in outputSchema', () => {
     const mockModel = {

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -578,6 +578,7 @@ export class CoreToolBuilder extends MastraBase {
       id: 'id' in this.originalTool ? this.originalTool.id : undefined,
       parameters: processedSchema ?? z.object({}),
       outputSchema: processedOutputSchema,
+      providerOptions: 'providerOptions' in this.originalTool ? this.originalTool.providerOptions : undefined,
     } as unknown as CoreTool;
   }
 }

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -108,6 +108,20 @@ export class Tool<
   requireApproval?: boolean;
 
   /**
+   * Provider-specific options passed to the model when this tool is used.
+   * Keys are provider names (e.g., 'anthropic', 'openai'), values are provider-specific configs.
+   * @example
+   * ```typescript
+   * providerOptions: {
+   *   anthropic: {
+   *     cacheControl: { type: 'ephemeral' }
+   *   }
+   * }
+   * ```
+   */
+  providerOptions?: Record<string, Record<string, unknown>>;
+
+  /**
    * Creates a new Tool instance with input validation wrapper.
    *
    * @param opts - Tool configuration and execute function
@@ -130,6 +144,7 @@ export class Tool<
     this.resumeSchema = opts.resumeSchema;
     this.mastra = opts.mastra;
     this.requireApproval = opts.requireApproval || false;
+    this.providerOptions = opts.providerOptions;
 
     // Tools receive two parameters:
     // 1. input - The raw, validated input data

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -132,6 +132,10 @@ export type CoreTool = {
   outputSchema?: FlexibleSchema<any> | Schema;
   execute?: (params: any, options: MastraToolInvocationOptions) => Promise<any>;
   /**
+   * Provider-specific options passed to the model when this tool is used.
+   */
+  providerOptions?: Record<string, Record<string, unknown>>;
+  /**
    * Optional MCP-specific properties.
    * Only populated when the tool is being used in an MCP context.
    */
@@ -159,6 +163,10 @@ export type InternalCoreTool = {
   parameters: Schema;
   outputSchema?: Schema;
   execute?: (params: any, options: MastraToolInvocationOptions) => Promise<any>;
+  /**
+   * Provider-specific options passed to the model when this tool is used.
+   */
+  providerOptions?: Record<string, Record<string, unknown>>;
   /**
    * Optional MCP-specific properties.
    * Only populated when the tool is being used in an MCP context.
@@ -231,6 +239,19 @@ export interface ToolAction<
   ) => Promise<(TSchemaOut extends ZodLikeSchema ? InferZodLikeSchema<TSchemaOut> : any) | ValidationError>;
   mastra?: Mastra;
   requireApproval?: boolean;
+  /**
+   * Provider-specific options passed to the model when this tool is used.
+   * Keys are provider names (e.g., 'anthropic', 'openai'), values are provider-specific configs.
+   * @example
+   * ```typescript
+   * providerOptions: {
+   *   anthropic: {
+   *     cacheControl: { type: 'ephemeral' }
+   *   }
+   * }
+   * ```
+   */
+  providerOptions?: Record<string, Record<string, unknown>>;
   onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
   onInputDelta?: (
     options: {


### PR DESCRIPTION
## Summary

Adds support for `providerOptions` when defining tools, allowing developers to specify provider-specific configurations per tool.

## Example

```typescript
createTool({
  id: 'my-tool',
  description: 'A tool with cache control',
  inputSchema: z.object({ city: z.string() }),
  providerOptions: {
    anthropic: {
      cacheControl: { type: 'ephemeral' }
    }
  },
  execute: async ({ city }) => ({ result: city })
})
```

## Changes

- Added `providerOptions` field to `ToolAction` interface
- Added `providerOptions` field to `Tool` class
- Added `providerOptions` to `CoreTool` and `InternalCoreTool` types
- Pass `providerOptions` through `CoreToolBuilder.build()`
- Added unit tests for the new functionality

Closes #9068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for provider-specific configurations on tool definitions, enabling custom settings per provider (e.g., caching options).

* **Tests**
  * Expanded test coverage to verify proper handling and propagation of provider-specific configurations across various tool scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->