### PR TITLE
feat(processors): add providerOptions support to built-in processors

### DIFF
--- a/.changeset/fuzzy-onions-juggle.md
+++ b/.changeset/fuzzy-onions-juggle.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': patch
+---
+
+Built-in processors that use internal agents (PromptInjectionDetector, ModerationProcessor, PIIDetector, LanguageDetector, StructuredOutputProcessor) now accept `providerOptions` to control model behavior.
+
+This lets you pass provider-specific settings like `reasoningEffort` for OpenAI thinking models:
+
+```typescript
+const processor = new PromptInjectionDetector({
+  model: 'openai/o1-mini',
+  threshold: 0.7,
+  strategy: 'block',
+  providerOptions: {
+    openai: {
+      reasoningEffort: 'low',
+    },
+  },
+});
+```

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -253,6 +253,17 @@ const limitedResult = await agent.generate("Write a short poem about coding", {
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "providerOptions",
+              type: "ProviderOptions",
+              isOptional: true,
+              description:
+                "Provider-specific options passed to the internal structuring agent. Use this to control model behavior like reasoning effort for thinking models (e.g., `{ openai: { reasoningEffort: 'low' } }`).",
+            },
+          ],
+        },
       ],
     },
     {

--- a/docs/src/content/en/reference/processors/language-detector.mdx
+++ b/docs/src/content/en/reference/processors/language-detector.mdx
@@ -99,6 +99,13 @@ const processor = new LanguageDetector({
       isOptional: true,
       default: "'quality'",
     },
+    {
+      name: "providerOptions",
+      type: "ProviderOptions",
+      description: "Provider-specific options passed to the internal detection agent. Use this to control model behavior like reasoning effort for thinking models (e.g., `{ openai: { reasoningEffort: 'low' } }`)",
+      isOptional: true,
+      default: "undefined",
+    },
   ]}
 />
 

--- a/docs/src/content/en/reference/processors/moderation-processor.mdx
+++ b/docs/src/content/en/reference/processors/moderation-processor.mdx
@@ -85,6 +85,13 @@ const processor = new ModerationProcessor({
       isOptional: true,
       default: "0 (no context window)",
     },
+    {
+      name: "providerOptions",
+      type: "ProviderOptions",
+      description: "Provider-specific options passed to the internal moderation agent. Use this to control model behavior like reasoning effort for thinking models (e.g., `{ openai: { reasoningEffort: 'low' } }`)",
+      isOptional: true,
+      default: "undefined",
+    },
   ]}
 />
 

--- a/docs/src/content/en/reference/processors/pii-detector.mdx
+++ b/docs/src/content/en/reference/processors/pii-detector.mdx
@@ -92,6 +92,13 @@ const processor = new PIIDetector({
       isOptional: true,
       default: "true",
     },
+    {
+      name: "providerOptions",
+      type: "ProviderOptions",
+      description: "Provider-specific options passed to the internal detection agent. Use this to control model behavior like reasoning effort for thinking models (e.g., `{ openai: { reasoningEffort: 'low' } }`)",
+      isOptional: true,
+      default: "undefined",
+    },
   ]}
 />
 

--- a/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
+++ b/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
@@ -78,6 +78,13 @@ const processor = new PromptInjectionDetector({
       isOptional: true,
       default: "false",
     },
+    {
+      name: "providerOptions",
+      type: "ProviderOptions",
+      description: "Provider-specific options passed to the internal detection agent. Use this to control model behavior like reasoning effort for thinking models (e.g., `{ openai: { reasoningEffort: 'low' } }`)",
+      isOptional: true,
+      default: "undefined",
+    },
   ]}
 />
 

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -245,6 +245,17 @@ const aiSdkStream = await agent.stream("message for agent", {
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "providerOptions",
+              type: "ProviderOptions",
+              isOptional: true,
+              description:
+                "Provider-specific options passed to the internal structuring agent. Use this to control model behavior like reasoning effort for thinking models (e.g., `{ openai: { reasoningEffort: 'low' } }`).",
+            },
+          ],
+        },
       ],
     },
     {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -80,6 +80,19 @@ export type StructuredOutputOptions<OUTPUT extends OutputSchema = undefined> = {
    * Optional logger instance for structured logging
    */
   logger?: IMastraLogger;
+
+  /**
+   * Provider-specific options passed to the internal structuring agent.
+   * Use this to control model behavior like reasoning effort for thinking models.
+   *
+   * @example
+   * ```ts
+   * providerOptions: {
+   *   openai: { reasoningEffort: 'low' }
+   * }
+   * ```
+   */
+  providerOptions?: ProviderOptions;
 } & FallbackFields<OUTPUT>;
 
 export type SerializableStructuredOutputOptions<OUTPUT extends OutputSchema = undefined> = Omit<

--- a/packages/core/src/processors/processors/language-detector.ts
+++ b/packages/core/src/processors/processors/language-detector.ts
@@ -2,6 +2,7 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraDBMessage } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
+import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { TracingContext } from '../../observability';
 import type { Processor } from '../index';
@@ -94,6 +95,19 @@ export interface LanguageDetectorOptions {
    * - 'balanced': Balance between speed and quality
    */
   translationQuality?: 'speed' | 'quality' | 'balanced';
+
+  /**
+   * Provider-specific options passed to the internal detection agent.
+   * Use this to control model behavior like reasoning effort for thinking models.
+   *
+   * @example
+   * ```ts
+   * providerOptions: {
+   *   openai: { reasoningEffort: 'low' }
+   * }
+   * ```
+   */
+  providerOptions?: ProviderOptions;
 }
 
 /**
@@ -115,6 +129,7 @@ export class LanguageDetector implements Processor<'language-detector'> {
   private minTextLength: number;
   private includeDetectionDetails: boolean;
   private translationQuality: 'speed' | 'quality' | 'balanced';
+  private providerOptions?: ProviderOptions;
 
   // Default target language
   private static readonly DEFAULT_TARGET_LANGUAGES = ['English', 'en'];
@@ -168,6 +183,7 @@ export class LanguageDetector implements Processor<'language-detector'> {
     this.minTextLength = options.minTextLength ?? 10;
     this.includeDetectionDetails = options.includeDetectionDetails ?? false;
     this.translationQuality = options.translationQuality || 'quality';
+    this.providerOptions = options.providerOptions;
 
     // Create internal detection and translation agent
     this.detectionAgent = new Agent({
@@ -277,12 +293,14 @@ export class LanguageDetector implements Processor<'language-detector'> {
           modelSettings: {
             temperature: 0,
           },
+          providerOptions: this.providerOptions,
           tracingContext,
         });
       } else {
         response = await this.detectionAgent.generateLegacy(prompt, {
           output: schema,
           temperature: 0,
+          providerOptions: this.providerOptions,
           tracingContext,
         });
       }

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -2,6 +2,7 @@ import z from 'zod';
 import { Agent } from '../../agent';
 import type { MastraDBMessage } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
+import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { TracingContext } from '../../observability';
 import type { ChunkType } from '../../stream';
@@ -83,6 +84,19 @@ export interface ModerationOptions {
      */
     jsonPromptInjection?: boolean;
   };
+
+  /**
+   * Provider-specific options passed to the internal moderation agent.
+   * Use this to control model behavior like reasoning effort for thinking models.
+   *
+   * @example
+   * ```ts
+   * providerOptions: {
+   *   openai: { reasoningEffort: 'low' }
+   * }
+   * ```
+   */
+  providerOptions?: ProviderOptions;
 }
 
 /**
@@ -103,6 +117,7 @@ export class ModerationProcessor implements Processor<'moderation'> {
   private includeScores: boolean;
   private chunkWindow: number;
   private structuredOutputOptions?: ModerationOptions['structuredOutputOptions'];
+  private providerOptions?: ProviderOptions;
 
   // Default OpenAI moderation categories
   private static readonly DEFAULT_CATEGORIES = [
@@ -126,6 +141,7 @@ export class ModerationProcessor implements Processor<'moderation'> {
     this.includeScores = options.includeScores ?? false;
     this.chunkWindow = options.chunkWindow ?? 0;
     this.structuredOutputOptions = options.structuredOutputOptions;
+    this.providerOptions = options.providerOptions;
 
     // Create internal moderation agent
     this.moderationAgent = new Agent({
@@ -272,12 +288,14 @@ export class ModerationProcessor implements Processor<'moderation'> {
           modelSettings: {
             temperature: 0,
           },
+          providerOptions: this.providerOptions,
           tracingContext,
         });
       } else {
         response = await this.moderationAgent.generateLegacy(prompt, {
           output: schema,
           temperature: 0,
+          providerOptions: this.providerOptions,
           tracingContext,
         });
       }

--- a/packages/core/src/processors/processors/prompt-injection-detector.test.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.test.ts
@@ -1,5 +1,4 @@
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4';
-import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { MastraDBMessage } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';

--- a/packages/core/src/processors/processors/prompt-injection-detector.test.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.test.ts
@@ -680,9 +680,6 @@ describe('PromptInjectionDetector', () => {
       });
 
       // Create detector with providerOptions
-      // This test should FAIL initially because:
-      // 1. PromptInjectionOptions doesn't include providerOptions in its type definition
-      // 2. Even if we add it, the processor doesn't pass it to agent.generate()
       const detector = new PromptInjectionDetector({
         model: mockModel,
         providerOptions: {
@@ -690,7 +687,7 @@ describe('PromptInjectionDetector', () => {
             reasoningEffort: 'low',
           },
         },
-      } as any); // Using 'as any' to bypass type check for now - the type should be fixed
+      });
 
       const mockAbort = vi.fn();
       const messages = [createTestMessage('Test message', 'user')];
@@ -698,11 +695,10 @@ describe('PromptInjectionDetector', () => {
       await detector.processInput({ messages, abort: mockAbort as any });
 
       // Verify providerOptions were passed to the internal agent's generate call
-      // The mock model should have captured the doGenerate call with providerOptions
       expect(mockModel.doGenerateCalls).toHaveLength(1);
       const generateCall = mockModel.doGenerateCalls[0];
 
-      // This assertion should FAIL because the processor doesn't pass providerOptions
+      // Verify providerOptions are passed through
       expect(generateCall.providerOptions).toEqual({
         openai: {
           reasoningEffort: 'low',

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -2,6 +2,7 @@ import type { TransformStreamDefaultController } from 'node:stream/web';
 import { Agent } from '../../agent';
 import type { StructuredOutputOptions } from '../../agent/types';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
+import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { TracingContext } from '../../observability';
 import { ChunkFrom } from '../../stream';
 import type { ChunkType, OutputSchema } from '../../stream';
@@ -35,6 +36,7 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
   private fallbackValue?: InferSchemaOutput<OUTPUT>;
   private isStructuringAgentStreamStarted = false;
   private jsonPromptInjection?: boolean;
+  private providerOptions?: ProviderOptions;
 
   constructor(options: StructuredOutputOptions<OUTPUT>) {
     if (!options.schema) {
@@ -58,6 +60,7 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
     this.errorStrategy = options.errorStrategy ?? 'strict';
     this.fallbackValue = options.fallbackValue;
     this.jsonPromptInjection = options.jsonPromptInjection;
+    this.providerOptions = options.providerOptions;
     // Create internal structuring agent
     this.structuringAgent = new Agent({
       id: 'structured-output-structurer',
@@ -111,6 +114,7 @@ export class StructuredOutputProcessor<OUTPUT extends OutputSchema> implements P
           schema: this.schema as OUTPUT extends OutputSchema ? OUTPUT : never,
           jsonPromptInjection: this.jsonPromptInjection,
         },
+        providerOptions: this.providerOptions,
         tracingContext,
       });
 


### PR DESCRIPTION
Closes #8112

Built-in processors that use internal agents (PromptInjectionDetector, ModerationProcessor, PIIDetector, LanguageDetector, StructuredOutputProcessor) now accept `providerOptions` to control model behavior.

This lets you pass provider-specific settings like `reasoningEffort` for OpenAI thinking models:

```typescript
const processor = new PromptInjectionDetector({
  model: 'openai/o1-mini',
  threshold: 0.7,
  strategy: 'block',
  providerOptions: {
    openai: {
      reasoningEffort: 'low',
    },
  },
});
```

Also adds `providerOptions` to `structuredOutput` options in `agent.generate()` and `agent.stream()` for consistency.