### PR TITLE
feat(client-js): add initialState support to workflow start methods

### DIFF
--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -122,6 +122,7 @@ export class Workflow extends BaseResource {
     runId: string;
     start: (params: {
       inputData: Record<string, any>;
+      initialState?: Record<string, any>;
       requestContext?: RequestContext | Record<string, any>;
       tracingOptions?: TracingOptions;
     }) => Promise<{ message: string }>;
@@ -133,10 +134,12 @@ export class Workflow extends BaseResource {
     }) => Promise<{ message: string }>;
     stream: (params: {
       inputData: Record<string, any>;
+      initialState?: Record<string, any>;
       requestContext?: RequestContext | Record<string, any>;
     }) => Promise<ReadableStream>;
     startAsync: (params: {
       inputData: Record<string, any>;
+      initialState?: Record<string, any>;
       requestContext?: RequestContext | Record<string, any>;
       tracingOptions?: TracingOptions;
     }) => Promise<WorkflowRunResult>;
@@ -171,30 +174,43 @@ export class Workflow extends BaseResource {
       runId,
       start: async (p: {
         inputData: Record<string, any>;
+        initialState?: Record<string, any>;
         requestContext?: RequestContext | Record<string, any>;
         tracingOptions?: TracingOptions;
       }) => {
         return this.start({
           runId,
           inputData: p.inputData,
+          initialState: p.initialState,
           requestContext: p.requestContext,
           tracingOptions: p.tracingOptions,
         });
       },
       startAsync: async (p: {
         inputData: Record<string, any>;
+        initialState?: Record<string, any>;
         requestContext?: RequestContext | Record<string, any>;
         tracingOptions?: TracingOptions;
       }) => {
         return this.startAsync({
           runId,
           inputData: p.inputData,
+          initialState: p.initialState,
           requestContext: p.requestContext,
           tracingOptions: p.tracingOptions,
         });
       },
-      stream: async (p: { inputData: Record<string, any>; requestContext?: RequestContext | Record<string, any> }) => {
-        return this.stream({ runId, inputData: p.inputData, requestContext: p.requestContext });
+      stream: async (p: {
+        inputData: Record<string, any>;
+        initialState?: Record<string, any>;
+        requestContext?: RequestContext | Record<string, any>;
+      }) => {
+        return this.stream({
+          runId,
+          inputData: p.inputData,
+          initialState: p.initialState,
+          requestContext: p.requestContext,
+        });
       },
       resume: async (p: {
         step?: string | string[];
@@ -241,19 +257,25 @@ export class Workflow extends BaseResource {
 
   /**
    * Starts a workflow run synchronously without waiting for the workflow to complete
-   * @param params - Object containing the runId, inputData and requestContext
+   * @param params - Object containing the runId, inputData, initialState and requestContext
    * @returns Promise containing success message
    */
   start(params: {
     runId: string;
     inputData: Record<string, any>;
+    initialState?: Record<string, any>;
     requestContext?: RequestContext | Record<string, any>;
     tracingOptions?: TracingOptions;
   }): Promise<{ message: string }> {
     const requestContext = parseClientRequestContext(params.requestContext);
     return this.request(`/api/workflows/${this.workflowId}/start?runId=${params.runId}`, {
       method: 'POST',
-      body: { inputData: params?.inputData, requestContext, tracingOptions: params.tracingOptions },
+      body: {
+        inputData: params?.inputData,
+        initialState: params?.initialState,
+        requestContext,
+        tracingOptions: params.tracingOptions,
+      },
     });
   }
 
@@ -289,12 +311,13 @@ export class Workflow extends BaseResource {
 
   /**
    * Starts a workflow run asynchronously and returns a promise that resolves when the workflow is complete
-   * @param params - Object containing the optional runId, inputData and requestContext
+   * @param params - Object containing the optional runId, inputData, initialState and requestContext
    * @returns Promise containing the workflow execution results
    */
   startAsync(params: {
     runId?: string;
     inputData: Record<string, any>;
+    initialState?: Record<string, any>;
     requestContext?: RequestContext | Record<string, any>;
     tracingOptions?: TracingOptions;
   }): Promise<WorkflowRunResult> {
@@ -308,18 +331,24 @@ export class Workflow extends BaseResource {
 
     return this.request(`/api/workflows/${this.workflowId}/start-async?${searchParams.toString()}`, {
       method: 'POST',
-      body: { inputData: params.inputData, requestContext, tracingOptions: params.tracingOptions },
+      body: {
+        inputData: params.inputData,
+        initialState: params.initialState,
+        requestContext,
+        tracingOptions: params.tracingOptions,
+      },
     });
   }
 
   /**
    * Starts a workflow run and returns a stream
-   * @param params - Object containing the optional runId, inputData and requestContext
+   * @param params - Object containing the optional runId, inputData, initialState and requestContext
    * @returns Promise containing the workflow execution results
    */
   async stream(params: {
     runId?: string;
     inputData: Record<string, any>;
+    initialState?: Record<string, any>;
     requestContext?: RequestContext | Record<string, any>;
     tracingOptions?: TracingOptions;
   }) {
@@ -334,7 +363,12 @@ export class Workflow extends BaseResource {
       `/api/workflows/${this.workflowId}/stream?${searchParams.toString()}`,
       {
         method: 'POST',
-        body: { inputData: params.inputData, requestContext, tracingOptions: params.tracingOptions },
+        body: {
+          inputData: params.inputData,
+          initialState: params.initialState,
+          requestContext,
+          tracingOptions: params.tracingOptions,
+        },
         stream: true,
       },
     );
@@ -447,12 +481,13 @@ export class Workflow extends BaseResource {
 
   /**
    * Starts a workflow run and returns a stream
-   * @param params - Object containing the optional runId, inputData and requestContext
+   * @param params - Object containing the optional runId, inputData, initialState and requestContext
    * @returns Promise containing the workflow execution results
    */
   async streamVNext(params: {
     runId?: string;
     inputData?: Record<string, any>;
+    initialState?: Record<string, any>;
     requestContext?: RequestContext;
     closeOnSuspend?: boolean;
     tracingOptions?: TracingOptions;
@@ -470,6 +505,7 @@ export class Workflow extends BaseResource {
         method: 'POST',
         body: {
           inputData: params.inputData,
+          initialState: params.initialState,
           requestContext,
           closeOnSuspend: params.closeOnSuspend,
           tracingOptions: params.tracingOptions,

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -17,7 +17,7 @@ const workflows = await mastraClient.listWorkflows();
 
 ## Working with a Specific Workflow
 
-Get an instance of a specific workflow as defined by the const name:
+Get an instance of a specific workflow by its ID:
 
 ```typescript title="src/mastra/workflows/test-workflow.ts"
 export const testWorkflow = createWorkflow({
@@ -26,12 +26,12 @@ export const testWorkflow = createWorkflow({
 ```
 
 ```typescript
-const workflow = mastraClient.getWorkflow("testWorkflow");
+const workflow = mastraClient.getWorkflow("city-workflow");
 ```
 
 ## Workflow Methods
 
-### Get Workflow Details
+### details()
 
 Retrieve detailed information about a workflow:
 
@@ -39,9 +39,20 @@ Retrieve detailed information about a workflow:
 const details = await workflow.details();
 ```
 
-### Start workflow run asynchronously
+### createRun()
 
-Start a workflow run with inputData and await full run results:
+Create a new workflow run instance:
+
+```typescript
+const run = await workflow.createRun();
+
+// Or with an existing runId
+const run = await workflow.createRun({ runId: "existing-run-id" });
+```
+
+### startAsync()
+
+Start a workflow run and await the full result:
 
 ```typescript
 const run = await workflow.createRun();
@@ -53,12 +64,47 @@ const result = await run.startAsync({
 });
 ```
 
-### Resume Workflow run asynchronously
+You can also pass `initialState` to set the starting values for the workflow's state:
 
-Resume a suspended workflow step and await full run result:
+```typescript
+const result = await run.startAsync({
+  inputData: {
+    city: "New York",
+  },
+  initialState: {
+    count: 0,
+    items: [],
+  },
+});
+```
+
+The `initialState` object should match the structure defined in the workflow's `stateSchema`. See [Workflow State](/docs/v1/workflows/workflow-state) for more details.
+
+### start()
+
+Start a workflow run without waiting for completion:
 
 ```typescript
 const run = await workflow.createRun();
+
+await run.start({
+  inputData: {
+    city: "New York",
+  },
+});
+
+// Poll for results later
+const result = await workflow.runExecutionResult(run.runId);
+```
+
+This is useful for long-running workflows where you want to start execution and check results later.
+
+### resumeAsync()
+
+Resume a suspended workflow step and await the full result:
+
+```typescript
+const run = await workflow.createRun({ runId: prevRunId });
 
 const result = await run.resumeAsync({
   step: "step-id",
@@ -66,82 +112,65 @@ const result = await run.resumeAsync({
 });
 ```
 
-### Resume Workflow
+### resume()
 
-Resume workflow run:
+Resume a suspended workflow step without waiting for completion:
 
 ```typescript
-try {
-  const workflow = mastraClient.getWorkflow("testWorkflow");
+const run = await workflow.createRun({ runId: prevRunId });
 
-  const run = await workflow.createRun({ runId: prevRunId });
-
-  run.resume({
-    step: "step-id",
-    resumeData: { key: "value" },
-  });
-} catch (e) {
-  console.error(e);
-}
+await run.resume({
+  step: "step-id",
+  resumeData: { key: "value" },
+});
 ```
 
-### Stream Workflow
+### stream()
 
 Stream workflow execution for real-time updates:
 
 ```typescript
-try {
-  const workflow = mastraClient.getWorkflow("testWorkflow");
+const run = await workflow.createRun();
 
-  const run = await workflow.createRun();
+const stream = await run.stream({
+  inputData: {
+    city: "New York",
+  },
+});
 
-  const stream = await run.stream({
-    inputData: {
-      city: "New York",
-    },
-  });
-
-  for await (const chunk of stream) {
-    console.log(JSON.stringify(chunk, null, 2));
-  }
-} catch (e) {
-  console.error("Workflow error:", e);
+for await (const chunk of stream) {
+  console.log(JSON.stringify(chunk, null, 2));
 }
 ```
 
-### Get Workflow Run result
+### runExecutionResult()
 
-Get the result of a workflow run:
+Get the execution result for a workflow run:
 
 ```typescript
-try {
-  const workflow = mastraClient.getWorkflow("testWorkflow");
-
-  const run = await workflow.createRun();
-
-  // start the workflow run
-  const startResult = await run.start({
-    inputData: {
-      city: "New York",
-    },
-  });
-
-  const result = await workflow.runExecutionResult(run.runId);
-
-  console.log(result);
-} catch (e) {
-  console.error(e);
-}
+const result = await workflow.runExecutionResult(runId);
 ```
 
-This is useful when dealing with long running workflows. You can use this to poll the result of the workflow run.
-
-### Workflow run result
+<h3>Run result format</h3>
 
 A workflow run result yields the following:
 
-| Field            | Type                                                                                                                                                                                                                                               | Description                                      |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `payload`        | `{currentStep?: {id: string, status: string, output?: Record<string, any>, payload?: Record<string, any>}, workflowState: {status: string, steps: Record<string, {status: string, output?: Record<string, any>, payload?: Record<string, any>}>}}` | The current step and workflow state of the run   |
-| `eventTimestamp` | `Date`                                                                                                                                                                                                                                             | The timestamp of the event                       |
-| `runId`          | `string`                                                                                                                                                                                                                                           | Unique identifier for this workflow run instance |
+<PropertiesTable
+  content={[
+    {
+      name: "runId",
+      type: "string",
+      description: "Unique identifier for this workflow run instance",
+    },
+    {
+      name: "eventTimestamp",
+      type: "Date",
+      description: "The timestamp of the event",
+    },
+    {
+      name: "payload",
+      type: "object",
+      description: "Contains currentStep (id, status, output, payload) and workflowState (status, steps record)",
+    },
+  ]}
+/>

--- a/packages/server/src/server/schemas/workflows.ts
+++ b/packages/server/src/server/schemas/workflows.ts
@@ -101,6 +101,7 @@ export const listWorkflowRunsQuerySchema = createOffsetPaginationSchema().extend
  */
 const workflowExecutionBodySchema = z.object({
   inputData: z.unknown().optional(),
+  initialState: z.unknown().optional(),
   requestContext: z.record(z.string(), z.unknown()).optional(),
   tracingOptions: tracingOptionsSchema.optional(),
 });


### PR DESCRIPTION
## Summary

Add `initialState` parameter to the client SDK workflow methods to allow users to set initial state when starting a workflow via the client SDK.

## Changes

### Server Schema (`packages/server/src/server/schemas/workflows.ts`)
- Added `initialState` to the `workflowExecutionBodySchema`

### Client SDK (`client-sdks/client-js/src/resources/workflow.ts`)
- Added `initialState` parameter to `start()` method
- Added `initialState` parameter to `startAsync()` method
- Added `initialState` parameter to `stream()` method
- Added `initialState` parameter to `streamVNext()` method
- Updated `createRun()` return type to include `initialState` in the `start`, `startAsync`, and `stream` methods

## Usage Example

```typescript
const client = new MastraClient({ baseUrl: 'http://localhost:3000' });
const workflow = client.getWorkflow('my-workflow');

// Using createRun
const run = await workflow.createRun();
await run.start({
  inputData: { name: 'John' },
  initialState: { count: 0, items: [] },
});

// Using startAsync directly
await workflow.startAsync({
  inputData: { name: 'John' },
  initialState: { count: 0, items: [] },
});

// Using stream
const stream = await workflow.stream({
  inputData: { name: 'John' },
  initialState: { count: 0, items: [] },
});
```

Fixes #9809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now accept an optional initialState when starting, starting asynchronously, or streaming — initial state is carried through execution and streaming requests.
  * New higher-level workflow APIs: createRun, start, startAsync, resume, resumeAsync, stream, details, and runExecutionResult for managing and observing runs.

* **Documentation**
  * Updated docs and examples showing new APIs, usage patterns, and guidance on supplying and validating initialState.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->