### PR TITLE
fix(a2a): fix streaming and memory support for A2A protocol

### DIFF
--- a/.changeset/shiny-lions-fly.md
+++ b/.changeset/shiny-lions-fly.md
@@ -1,0 +1,13 @@
+---
+"@mastra/client-js": patch
+"@mastra/server": patch
+---
+
+fix(a2a): fix streaming and memory support for A2A protocol
+
+**Client (`@mastra/client-js`):**
+- Fixed `sendStreamingMessage` to properly return a streaming response instead of attempting to parse it as JSON
+
+**Server (`@mastra/server`):**
+- Fixed A2A message handler to pass `contextId` as `threadId` for memory persistence across conversations
+- Added support for user-provided `resourceId` via `params.metadata.resourceId` or `message.metadata.resourceId`, falling back to `agentId`

--- a/client-sdks/client-js/src/resources/a2a.test.ts
+++ b/client-sdks/client-js/src/resources/a2a.test.ts
@@ -2,7 +2,7 @@ import type { Server } from 'node:http';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import type { MessageSendParams } from '@mastra/core/a2a';
-import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import { A2A } from './a2a';
 
 describe('A2A', () => {

--- a/client-sdks/client-js/src/resources/a2a.test.ts
+++ b/client-sdks/client-js/src/resources/a2a.test.ts
@@ -1,0 +1,135 @@
+import type { Server } from 'node:http';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { MessageSendParams } from '@mastra/core/a2a';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { A2A } from './a2a';
+
+describe('A2A', () => {
+  let server: Server;
+  let serverUrl: string;
+
+  beforeEach(async () => {
+    server = createServer();
+
+    await new Promise<void>(resolve => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve();
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    serverUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close(err => (err ? reject(err) : resolve()));
+    });
+  });
+
+  describe('sendStreamingMessage', () => {
+    it('should return the raw response for streaming instead of parsing as JSON', async () => {
+      // Arrange: Set up server to return streaming response
+      const streamingData = [
+        JSON.stringify({ jsonrpc: '2.0', result: { state: 'working' } }),
+        JSON.stringify({ jsonrpc: '2.0', result: { state: 'completed', text: 'Hello!' } }),
+      ];
+
+      server.on('request', (req, res) => {
+        // Verify it's a POST to the A2A endpoint with message/stream method
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/a2a/test-agent');
+
+        res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+
+        // Send streaming chunks
+        for (const chunk of streamingData) {
+          res.write(chunk + '\x1E');
+        }
+        res.end();
+      });
+
+      const a2a = new A2A({ baseUrl: serverUrl }, 'test-agent');
+      const params: MessageSendParams = {
+        message: {
+          messageId: 'msg-1',
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'Hello' }],
+        },
+      };
+
+      // Act: Call sendStreamingMessage
+      const response = await a2a.sendStreamingMessage(params);
+
+      // Assert: Response should be a Response object (not parsed JSON)
+      // This verifies that stream: true is being passed to the request method
+      expect(response).toBeInstanceOf(Response);
+
+      // Read the body to verify we get the streaming data
+      const bodyText = await (response as unknown as Response).text();
+      expect(bodyText).toContain('working');
+      expect(bodyText).toContain('completed');
+    });
+
+    it('should not throw JSON parse error for streaming responses', async () => {
+      // Arrange: Set up server to return non-JSON streaming response
+      server.on('request', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+        res.write('data: {"state": "working"}\n\n');
+        res.write('data: {"state": "completed"}\n\n');
+        res.end();
+      });
+
+      const a2a = new A2A({ baseUrl: serverUrl }, 'test-agent');
+      const params: MessageSendParams = {
+        message: {
+          messageId: 'msg-1',
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'Hello' }],
+        },
+      };
+
+      // Act & Assert: Should NOT throw SyntaxError for JSON parsing
+      // Before the fix, this would throw: "SyntaxError: Unexpected non-whitespace character after JSON"
+      await expect(a2a.sendStreamingMessage(params)).resolves.toBeDefined();
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should parse JSON response for non-streaming requests', async () => {
+      // Arrange: Set up server to return JSON response
+      const mockResponse = {
+        jsonrpc: '2.0',
+        id: 'req-1',
+        result: {
+          id: 'task-1',
+          status: { state: 'completed', message: { text: 'Done!' } },
+        },
+      };
+
+      server.on('request', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(mockResponse));
+      });
+
+      const a2a = new A2A({ baseUrl: serverUrl }, 'test-agent');
+      const params: MessageSendParams = {
+        message: {
+          messageId: 'msg-1',
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'Hello' }],
+        },
+      };
+
+      // Act
+      const response = await a2a.sendMessage(params);
+
+      // Assert: Response should be parsed JSON
+      expect(response).toEqual(mockResponse);
+    });
+  });
+});

--- a/client-sdks/client-js/src/resources/a2a.ts
+++ b/client-sdks/client-js/src/resources/a2a.ts
@@ -59,6 +59,7 @@ export class A2A extends BaseResource {
         method: 'message/stream',
         params,
       },
+      stream: true,
     });
 
     return response;

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -279,6 +279,322 @@ describe('A2A Handler', () => {
       `);
     });
 
+    it('should pass contextId as threadId and agentId as resourceId to agent.generate for memory', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const contextId = 'test-context-id';
+      const userMessage = 'Hello, agent!';
+      const agentResponseText = 'Hello, user!';
+
+      const params: MessageSendParams = {
+        message: {
+          messageId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: userMessage }],
+          contextId, // Include contextId to test memory integration
+        },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue({ text: agentResponseText });
+
+      const requestContext = new RequestContext();
+      await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify that agent.generate was called with threadId and resourceId (defaults to agentId)
+      expect(mockAgent.generate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          threadId: contextId,
+          resourceId: agentId,
+        }),
+      );
+    });
+
+    it('should allow user to pass resourceId via params metadata', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const contextId = 'test-context-id';
+      const customResourceId = 'custom-user-resource';
+      const userMessage = 'Hello, agent!';
+      const agentResponseText = 'Hello, user!';
+
+      const params: MessageSendParams = {
+        message: {
+          messageId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: userMessage }],
+          contextId,
+        },
+        metadata: {
+          resourceId: customResourceId, // User-provided resourceId
+        },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue({ text: agentResponseText });
+
+      const requestContext = new RequestContext();
+      await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify that agent.generate was called with user-provided resourceId
+      expect(mockAgent.generate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          threadId: contextId,
+          resourceId: customResourceId,
+        }),
+      );
+    });
+
+    it('should allow user to pass resourceId via message metadata', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const contextId = 'test-context-id';
+      const customResourceId = 'custom-message-resource';
+      const userMessage = 'Hello, agent!';
+      const agentResponseText = 'Hello, user!';
+
+      const params: MessageSendParams = {
+        message: {
+          messageId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: userMessage }],
+          contextId,
+          metadata: {
+            resourceId: customResourceId, // User-provided resourceId in message
+          },
+        },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue({ text: agentResponseText });
+
+      const requestContext = new RequestContext();
+      await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify that agent.generate was called with user-provided resourceId from message
+      expect(mockAgent.generate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          threadId: contextId,
+          resourceId: customResourceId,
+        }),
+      );
+    });
+
+    it('should prefer params metadata resourceId over message metadata resourceId', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const contextId = 'test-context-id';
+      const paramsResourceId = 'params-resource';
+      const messageResourceId = 'message-resource';
+      const userMessage = 'Hello, agent!';
+      const agentResponseText = 'Hello, user!';
+
+      const params: MessageSendParams = {
+        message: {
+          messageId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: userMessage }],
+          contextId,
+          metadata: {
+            resourceId: messageResourceId,
+          },
+        },
+        metadata: {
+          resourceId: paramsResourceId, // Should take precedence
+        },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue({ text: agentResponseText });
+
+      const requestContext = new RequestContext();
+      await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify that params metadata resourceId takes precedence
+      expect(mockAgent.generate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          threadId: contextId,
+          resourceId: paramsResourceId,
+        }),
+      );
+    });
+
+    it('should allow user to pass custom resourceId via params metadata', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const contextId = 'test-context-id';
+      const customResourceId = 'custom-user-resource-id';
+      const userMessage = 'Hello, agent!';
+      const agentResponseText = 'Hello, user!';
+
+      const params: MessageSendParams = {
+        message: {
+          messageId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: userMessage }],
+          contextId,
+        },
+        metadata: {
+          resourceId: customResourceId, // User-provided resourceId
+        },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue({ text: agentResponseText });
+
+      const requestContext = new RequestContext();
+      await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify that agent.generate was called with the custom resourceId
+      expect(mockAgent.generate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          threadId: contextId,
+          resourceId: customResourceId,
+        }),
+      );
+    });
+
+    it('should allow user to pass custom resourceId via message metadata', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const contextId = 'test-context-id';
+      const customResourceId = 'message-level-resource-id';
+      const userMessage = 'Hello, agent!';
+      const agentResponseText = 'Hello, user!';
+
+      const params: MessageSendParams = {
+        message: {
+          messageId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: userMessage }],
+          contextId,
+          metadata: {
+            resourceId: customResourceId, // User-provided resourceId at message level
+          },
+        },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue({ text: agentResponseText });
+
+      const requestContext = new RequestContext();
+      await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify that agent.generate was called with the custom resourceId
+      expect(mockAgent.generate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          threadId: contextId,
+          resourceId: customResourceId,
+        }),
+      );
+    });
+
+    it('should not pass threadId/resourceId when contextId is not provided', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const userMessage = 'Hello, agent!';
+      const agentResponseText = 'Hello, user!';
+
+      const params: MessageSendParams = {
+        message: {
+          messageId,
+          kind: 'message',
+          role: 'user',
+          parts: [{ kind: 'text', text: userMessage }],
+          // No contextId
+        },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue({ text: agentResponseText });
+
+      const requestContext = new RequestContext();
+      await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify that agent.generate was NOT called with threadId/resourceId
+      expect(mockAgent.generate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.not.objectContaining({
+          threadId: expect.any(String),
+        }),
+      );
+    });
+
     it('should update an existing task and append new message/history', async () => {
       const requestId = 'test-request-id';
       const taskId = 'test-task-id';

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -155,9 +155,13 @@ export async function handleMessageSend({
   });
 
   try {
+    // Pass contextId as threadId for memory persistence across A2A conversations
+    // Allow user to pass resourceId via metadata, fall back to agentId
+    const resourceId = (metadata?.resourceId as string) ?? (message.metadata?.resourceId as string) ?? agentId;
     const { text } = await agent.generate([convertToCoreMessage(message)], {
       runId: taskId,
       requestContext,
+      ...(contextId ? { threadId: contextId, resourceId } : {}),
     });
 
     currentData = applyUpdateToTask(currentData, {


### PR DESCRIPTION
## Summary

Fixes #8411

This PR fixes two bugs with the A2A (Agent-to-Agent) implementation:

### Bug A: `sendStreamingMessage` Not Working
- **Problem**: The client's `sendStreamingMessage` method was not passing `stream: true` to the request method, causing the response to be parsed as JSON
- **Error**: `SyntaxError: Unexpected non-whitespace character after JSON`
- **Fix**: Added `stream: true` to the request options in `client-sdks/client-js/src/resources/a2a.ts`

### Bug B: Agent Memory Not Persisting Across A2A Messages  
- **Problem**: The `handleMessageSend` function extracted `contextId` from the A2A message but never passed it to `agent.generate()` as `threadId`
- **Fix**: Pass `contextId` as `threadId` to `agent.generate()` for memory correlation
- **Enhancement**: Allow users to provide custom `resourceId` via:
  - `params.metadata.resourceId` (highest priority)
  - `message.metadata.resourceId`
  - Falls back to `agentId` if neither is provided

### Tests Added
- **Client-side** (`client-sdks/client-js/src/resources/a2a.test.ts`):
  - Verify `sendStreamingMessage` returns raw Response instead of parsing JSON
  - Verify no JSON parse error occurs for streaming responses
  - Verify `sendMessage` still correctly parses JSON for non-streaming

- **Server-side** (`packages/server/src/server/handlers/a2a.test.ts`):
  - Verify `contextId` is passed as `threadId` to `agent.generate`
  - Verify `agentId` is used as default `resourceId`
  - Verify user can pass `resourceId` via `params.metadata`
  - Verify user can pass `resourceId` via `message.metadata`
  - Verify `params.metadata.resourceId` takes precedence over `message.metadata.resourceId`

### Usage Example

```typescript
// With user-provided resourceId
const params = {
  message: {
    messageId: 'msg-1',
    kind: 'message',
    role: 'user',
    parts: [{ kind: 'text', text: 'Hello' }],
    contextId: 'conversation-abc',  // Used as threadId for memory
  },
  metadata: {
    resourceId: 'user-123',  // Optional: custom resourceId for memory
  },
};
await a2a.sendMessage(params);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled streaming support for A2A interactions
  * Added memory persistence across A2A conversations with thread context
  * Enhanced resource scoping for agent calls via metadata parameters

* **Tests**
  * Added comprehensive test coverage for A2A streaming and non-streaming interactions
  * Added tests validating thread ID and resource ID propagation in agent calls

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->