### PR TITLE
feat(rag): add maxSize support for HTML chunking strategies

### DIFF
--- a/.changeset/add-html-chunking-maxsize-support.md
+++ b/.changeset/add-html-chunking-maxsize-support.md
@@ -1,0 +1,38 @@
+---
+'@mastra/rag': patch
+---
+
+Add maxSize support for HTML chunking strategies
+
+Added support for the `maxSize` option in HTML chunking strategies (`headers` and `sections`), allowing users to control the maximum chunk size when chunking HTML documents. Previously, HTML chunks could be excessively large when sections contained substantial content.
+
+**Changes:**
+- Added `maxSize` support to `headers` strategy - applies `RecursiveCharacterTransformer` after header-based splitting
+- Added `maxSize` support to `sections` strategy - applies `RecursiveCharacterTransformer` after section-based splitting  
+- Fixed `splitHtmlByHeaders` content extraction bug - changed from broken `nextElementSibling` to working `parentNode.childNodes` approach
+- Added comprehensive test coverage including integration test with real arXiv paper
+
+**Usage:**
+```typescript
+import { MDocument } from '@mastra/rag';
+
+const doc = MDocument.fromHTML(htmlContent);
+
+const chunks = await doc.chunk({
+  strategy: 'html',
+  headers: [
+    ['h1', 'Header 1'],
+    ['h2', 'Header 2'],
+    ['h3', 'Header 3'],
+  ],
+  maxSize: 512,  // Control chunk size
+  overlap: 50,   // Optional overlap for context
+});
+```
+
+**Results from real arXiv paper test:**
+- Without maxSize: 22 chunks, max 45,531 chars (too big!)
+- With maxSize=512: 499 chunks, max 512 chars (properly sized)
+
+Fixes #7942
+

--- a/packages/rag/src/document/document.ts
+++ b/packages/rag/src/document/document.ts
@@ -207,7 +207,20 @@ export class MDocument {
     if (options?.headers?.length) {
       const rt = new HTMLHeaderTransformer(options as HTMLChunkOptions & { headers: [string, string][] });
 
-      const textSplit = rt.transformDocuments(this.chunks);
+      let textSplit = rt.transformDocuments(this.chunks);
+
+      // Apply size-based splitting if maxSize is specified
+      if (options?.maxSize) {
+        const textSplitter = new RecursiveCharacterTransformer({
+          maxSize: options.maxSize,
+          overlap: options.overlap,
+          keepSeparator: options.keepSeparator,
+          addStartIndex: options.addStartIndex,
+          stripWhitespace: options.stripWhitespace,
+        });
+        textSplit = textSplitter.splitDocuments(textSplit);
+      }
+
       this.chunks = textSplit;
       return;
     }
@@ -215,7 +228,20 @@ export class MDocument {
     if (options?.sections?.length) {
       const rt = new HTMLSectionTransformer(options as HTMLChunkOptions & { sections: [string, string][] });
 
-      const textSplit = rt.transformDocuments(this.chunks);
+      let textSplit = rt.transformDocuments(this.chunks);
+
+      // Apply size-based splitting if maxSize is specified
+      if (options?.maxSize) {
+        const textSplitter = new RecursiveCharacterTransformer({
+          maxSize: options.maxSize,
+          overlap: options.overlap,
+          keepSeparator: options.keepSeparator,
+          addStartIndex: options.addStartIndex,
+          stripWhitespace: options.stripWhitespace,
+        });
+        textSplit = textSplitter.splitDocuments(textSplit);
+      }
+
       this.chunks = textSplit;
       return;
     }


### PR DESCRIPTION
## Summary

Fixes #7942 - HTML chunks were too big when using HTML chunking strategies.

## Changes

### 1. Fixed `splitHtmlByHeaders` content extraction (`html.ts`)
- Changed from broken `nextElementSibling` to working `parentNode.childNodes` approach
- Added `getTextContent` helper method for proper text extraction
- Now correctly extracts content between header elements

### 2. Added `maxSize` support to both HTML strategies (`document.ts`)
- `headers` strategy: Apply RecursiveCharacterTransformer when maxSize specified
- `sections` strategy: Apply RecursiveCharacterTransformer when maxSize specified
- Both strategies now properly respect maxSize, overlap, and other BaseChunkOptions

### 3. Comprehensive tests
- Basic maxSize test for headers strategy
- Basic maxSize test for sections strategy  
- Backward compatibility test (no maxSize = no splitting)
- arXiv-style paper structure test with multiple header levels
- Integration test with real arXiv paper (skipped in CI)

## Example usage

```typescript
const doc = MDocument.fromHTML(paperText);
await doc.chunk({
  strategy: 'html',
  headers: [['h1', 'Header 1'], ['h2', 'Header 2']],
  maxSize: 512,  // NEW: Control chunk size
  overlap: 50,
});
```

## Results from real arXiv paper test

| Metric | Without maxSize | With maxSize=512 |
|--------|-----------------|------------------|
| Chunks | 22 | 499 |
| Max size | 45,531 chars | 512 chars |

## Test Results

All 230 tests pass (integration test skipped in CI).