### PR TITLE
feat(docs): bring back tags to the docs

### DIFF
--- a/docs/src/components/SidebarBadge.module.css
+++ b/docs/src/components/SidebarBadge.module.css
@@ -1,0 +1,46 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  height: 18px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  border-radius: 9px;
+  margin-left: 0.5rem;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+/* New badge - Green */
+.badge--new {
+  background-color: rgba(34, 197, 94, 0.1);
+  color: rgb(34, 197, 94);
+}
+
+[data-theme="dark"] .badge--new {
+  background-color: rgba(34, 197, 94, 0.2);
+  color: rgb(74, 222, 128);
+}
+
+/* Advanced badge - Blue */
+.badge--advanced {
+  background-color: rgba(59, 130, 246, 0.1);
+  color: rgb(59, 130, 246);
+}
+
+[data-theme="dark"] .badge--advanced {
+  background-color: rgba(59, 130, 246, 0.2);
+  color: rgb(96, 165, 250);
+}
+
+/* Experimental badge - Orange */
+.badge--experimental {
+  background-color: rgba(251, 146, 60, 0.1);
+  color: rgb(251, 146, 60);
+}
+
+[data-theme="dark"] .badge--experimental {
+  background-color: rgba(251, 146, 60, 0.2);
+  color: rgb(254, 215, 170);
+}

--- a/docs/src/components/SidebarBadge.tsx
+++ b/docs/src/components/SidebarBadge.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styles from './SidebarBadge.module.css';
+
+type BadgeType = 'new' | 'advanced' | 'experimental';
+
+interface SidebarBadgeProps {
+  type: BadgeType;
+}
+
+export function SidebarBadge({ type }: SidebarBadgeProps) {
+  const getLabel = (type: BadgeType) => {
+    switch (type) {
+      case 'new':
+        return 'NEW';
+      case 'advanced':
+        return 'ADVANCED';
+      case 'experimental':
+        return 'EXPERIMENTAL';
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <span className={`${styles.badge} ${styles[`badge--${type}`]}`}>
+      {getLabel(type)}
+    </span>
+  );
+}
+
+export default SidebarBadge;

--- a/docs/src/components/SidebarBadge.tsx
+++ b/docs/src/components/SidebarBadge.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import styles from './SidebarBadge.module.css';
+import React from "react";
+import styles from "./SidebarBadge.module.css";
 
-type BadgeType = 'new' | 'advanced' | 'experimental';
+type BadgeType = "new" | "advanced" | "experimental";
 
 interface SidebarBadgeProps {
   type: BadgeType;
@@ -10,14 +10,14 @@ interface SidebarBadgeProps {
 export function SidebarBadge({ type }: SidebarBadgeProps) {
   const getLabel = (type: BadgeType) => {
     switch (type) {
-      case 'new':
-        return 'NEW';
-      case 'advanced':
-        return 'ADVANCED';
-      case 'experimental':
-        return 'EXPERIMENTAL';
+      case "new":
+        return "NEW";
+      case "advanced":
+        return "ADVANCED";
+      case "experimental":
+        return "EXPERIMENTAL";
       default:
-        return '';
+        return "";
     }
   };
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -71,6 +71,9 @@ const sidebars = {
           type: "doc",
           id: "agents/networks",
           label: "Networks",
+          customProps: {
+            tags: ["advanced"]
+          }
         },
         {
           type: "doc",
@@ -143,6 +146,9 @@ const sidebars = {
           type: "doc",
           id: "streaming/overview",
           label: "Overview",
+          customProps: {
+            tags: ["new"]
+          }
         },
         {
           type: "doc",
@@ -568,6 +574,9 @@ const sidebars = {
           type: "doc",
           id: "voice/overview",
           label: "Overview",
+          customProps: {
+            tags: ["new"]
+          }
         },
         {
           type: "doc",

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -72,8 +72,8 @@ const sidebars = {
           id: "agents/networks",
           label: "Networks",
           customProps: {
-            tags: ["advanced"]
-          }
+            tags: ["advanced"],
+          },
         },
         {
           type: "doc",
@@ -147,8 +147,8 @@ const sidebars = {
           id: "streaming/overview",
           label: "Overview",
           customProps: {
-            tags: ["new"]
-          }
+            tags: ["new"],
+          },
         },
         {
           type: "doc",
@@ -575,8 +575,8 @@ const sidebars = {
           id: "voice/overview",
           label: "Overview",
           customProps: {
-            tags: ["new"]
-          }
+            tags: ["new"],
+          },
         },
         {
           type: "doc",

--- a/docs/src/theme/DocSidebarItem/Category/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Category/index.tsx
@@ -1,0 +1,312 @@
+import React, {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+} from "react";
+import clsx from "clsx";
+import {
+  ThemeClassNames,
+  useThemeConfig,
+  usePrevious,
+  Collapsible,
+  useCollapsible,
+} from "@docusaurus/theme-common";
+import { isSamePath } from "@docusaurus/theme-common/internal";
+import {
+  isActiveSidebarItem,
+  findFirstSidebarItemLink,
+  useDocSidebarItemsExpandedState,
+  useVisibleSidebarItems,
+} from "@docusaurus/plugin-content-docs/client";
+import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
+import useIsBrowser from "@docusaurus/useIsBrowser";
+import DocSidebarItems from "@theme/DocSidebarItems";
+import DocSidebarItemLink from "@theme/DocSidebarItem/Link";
+import type { Props } from "@theme/DocSidebarItem/Category";
+
+import type {
+  PropSidebarItemCategory,
+  PropSidebarItemLink,
+} from "@docusaurus/plugin-content-docs";
+import styles from "./styles.module.css";
+
+// If we navigate to a category and it becomes active, it should automatically
+// expand itself
+function useAutoExpandActiveCategory({
+  isActive,
+  collapsed,
+  updateCollapsed,
+  activePath,
+}: {
+  isActive: boolean;
+  collapsed: boolean;
+  updateCollapsed: (b: boolean) => void;
+  activePath: string;
+}) {
+  const wasActive = usePrevious(isActive);
+  const previousActivePath = usePrevious(activePath);
+  useEffect(() => {
+    const justBecameActive = isActive && !wasActive;
+    const stillActiveButPathChanged =
+      isActive && wasActive && activePath !== previousActivePath;
+    if ((justBecameActive || stillActiveButPathChanged) && collapsed) {
+      updateCollapsed(false);
+    }
+  }, [
+    isActive,
+    wasActive,
+    collapsed,
+    updateCollapsed,
+    activePath,
+    previousActivePath,
+  ]);
+}
+
+/**
+ * When a collapsible category has no link, we still link it to its first child
+ * during SSR as a temporary fallback. This allows to be able to navigate inside
+ * the category even when JS fails to load, is delayed or simply disabled
+ * React hydration becomes an optional progressive enhancement
+ * see https://github.com/facebookincubator/infima/issues/36#issuecomment-772543188
+ * see https://github.com/facebook/docusaurus/issues/3030
+ */
+function useCategoryHrefWithSSRFallback(
+  item: Props["item"],
+): string | undefined {
+  const isBrowser = useIsBrowser();
+  return useMemo(() => {
+    if (item.href && !item.linkUnlisted) {
+      return item.href;
+    }
+    // In these cases, it's not necessary to render a fallback
+    // We skip the "findFirstCategoryLink" computation
+    if (isBrowser || !item.collapsible) {
+      return undefined;
+    }
+    return findFirstSidebarItemLink(item);
+  }, [item, isBrowser]);
+}
+
+function CollapseButton({
+  collapsed,
+  categoryLabel,
+  onClick,
+}: {
+  collapsed: boolean;
+  categoryLabel: string;
+  onClick: ComponentProps<"button">["onClick"];
+}) {
+  return (
+    <button
+      aria-label={
+        collapsed
+          ? translate(
+              {
+                id: "theme.DocSidebarItem.expandCategoryAriaLabel",
+                message: "Expand sidebar category '{label}'",
+                description: "The ARIA label to expand the sidebar category",
+              },
+              { label: categoryLabel },
+            )
+          : translate(
+              {
+                id: "theme.DocSidebarItem.collapseCategoryAriaLabel",
+                message: "Collapse sidebar category '{label}'",
+                description: "The ARIA label to collapse the sidebar category",
+              },
+              { label: categoryLabel },
+            )
+      }
+      aria-expanded={!collapsed}
+      type="button"
+      className="clean-btn menu__caret"
+      onClick={onClick}
+    />
+  );
+}
+
+function CategoryLinkLabel({ label }: { label: string }) {
+  return (
+    <span title={label} className={styles.categoryLinkLabel}>
+      {label}
+    </span>
+  );
+}
+
+export default function DocSidebarItemCategory(props: Props): ReactNode {
+  const visibleChildren = useVisibleSidebarItems(
+    props.item.items,
+    props.activePath,
+  );
+  if (visibleChildren.length === 0) {
+    return <DocSidebarItemCategoryEmpty {...props} />;
+  } else {
+    return <DocSidebarItemCategoryCollapsible {...props} />;
+  }
+}
+
+function isCategoryWithHref(
+  category: PropSidebarItemCategory,
+): category is PropSidebarItemCategory & { href: string } {
+  return typeof category.href === "string";
+}
+
+// If a category doesn't have any visible children, we render it as a link
+function DocSidebarItemCategoryEmpty({ item, ...props }: Props): ReactNode {
+  // If the category has no link, we don't render anything
+  // It's not super useful to render a category you can't open nor click
+  if (!isCategoryWithHref(item)) {
+    return null;
+  }
+  // We remove props that don't make sense for a link and forward the rest
+  const {
+    type,
+    collapsed,
+    collapsible,
+    items,
+    linkUnlisted,
+    ...forwardableProps
+  } = item;
+  const linkItem: PropSidebarItemLink = {
+    type: "link",
+    ...forwardableProps,
+  };
+  return <DocSidebarItemLink item={linkItem} {...props} />;
+}
+
+function DocSidebarItemCategoryCollapsible({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}: Props): ReactNode {
+  const { items, label, collapsible, className, href } = item;
+  const {
+    docs: {
+      sidebar: { autoCollapseCategories },
+    },
+  } = useThemeConfig();
+  const hrefWithSSRFallback = useCategoryHrefWithSSRFallback(item);
+
+  const isActive = isActiveSidebarItem(item, activePath);
+  const isCurrentPage = isSamePath(href, activePath);
+
+  const { collapsed, setCollapsed } = useCollapsible({
+    // Active categories are always initialized as expanded. The default
+    // (`item.collapsed`) is only used for non-active categories.
+    initialState: () => {
+      if (!collapsible) {
+        return false;
+      }
+      return isActive ? false : item.collapsed;
+    },
+  });
+
+  const { expandedItem, setExpandedItem } = useDocSidebarItemsExpandedState();
+  // Use this instead of `setCollapsed`, because it is also reactive
+  const updateCollapsed = (toCollapsed: boolean = !collapsed) => {
+    setExpandedItem(toCollapsed ? null : index);
+    setCollapsed(toCollapsed);
+  };
+  useAutoExpandActiveCategory({
+    isActive,
+    collapsed,
+    updateCollapsed,
+    activePath,
+  });
+  useEffect(() => {
+    if (
+      collapsible &&
+      expandedItem != null &&
+      expandedItem !== index &&
+      autoCollapseCategories
+    ) {
+      setCollapsed(true);
+    }
+  }, [collapsible, expandedItem, index, setCollapsed, autoCollapseCategories]);
+
+  const handleItemClick: ComponentProps<"a">["onClick"] = (e) => {
+    onItemClick?.(item);
+    if (collapsible) {
+      if (href) {
+        // When already on the category's page, we collapse it
+        // We don't use "isActive" because it would collapse the
+        // category even when we browse a children element
+        // See https://github.com/facebook/docusaurus/issues/11213
+        if (isCurrentPage) {
+          e.preventDefault();
+          updateCollapsed();
+        } else {
+          // When navigating to a new category, we always expand
+          // see https://github.com/facebook/docusaurus/issues/10854#issuecomment-2609616182
+          updateCollapsed(false);
+        }
+      } else {
+        e.preventDefault();
+        updateCollapsed();
+      }
+    }
+  };
+
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemCategory,
+        ThemeClassNames.docs.docSidebarItemCategoryLevel(level),
+        "menu__list-item",
+        {
+          "menu__list-item--collapsed": collapsed,
+        },
+        className,
+      )}
+    >
+      <div
+        className={clsx("menu__list-item-collapsible", {
+          "menu__list-item-collapsible--active": isCurrentPage,
+        })}
+      >
+        <Link
+          className={clsx(styles.categoryLink, "menu__link", {
+            "menu__link--sublist": collapsible,
+            "menu__link--sublist-caret": !href && collapsible,
+            "menu__link--active": isActive,
+          })}
+          onClick={handleItemClick}
+          aria-current={isCurrentPage ? "page" : undefined}
+          role={collapsible && !href ? "button" : undefined}
+          aria-expanded={collapsible && !href ? !collapsed : undefined}
+          href={
+            collapsible ? (hrefWithSSRFallback ?? "#") : hrefWithSSRFallback
+          }
+          {...props}
+        >
+          <CategoryLinkLabel label={label} />
+        </Link>
+        {href && collapsible && (
+          <CollapseButton
+            collapsed={collapsed}
+            categoryLabel={label}
+            onClick={(e) => {
+              e.preventDefault();
+              updateCollapsed();
+            }}
+          />
+        )}
+      </div>
+
+      <Collapsible lazy as="ul" className="menu__list" collapsed={collapsed}>
+        <DocSidebarItems
+          items={items}
+          tabIndex={collapsed ? -1 : 0}
+          onItemClick={onItemClick}
+          activePath={activePath}
+          level={level + 1}
+        />
+      </Collapsible>
+    </li>
+  );
+}

--- a/docs/src/theme/DocSidebarItem/Category/styles.module.css
+++ b/docs/src/theme/DocSidebarItem/Category/styles.module.css
@@ -1,0 +1,19 @@
+.categoryLink {
+  overflow: hidden;
+}
+
+/*
+TODO merge this logic back in Infima?
+ */
+:global(.menu__link--sublist-caret)::after {
+  margin-left: var(--ifm-menu-link-padding-vertical);
+}
+
+.categoryLinkLabel {
+  flex: 1;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}

--- a/docs/src/theme/DocSidebarItem/Html/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Html/index.tsx
@@ -1,0 +1,27 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import type { Props } from "@theme/DocSidebarItem/Html";
+
+import styles from "./styles.module.css";
+
+export default function DocSidebarItemHtml({
+  item,
+  level,
+  index,
+}: Props): ReactNode {
+  const { value, defaultStyle, className } = item;
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemLink,
+        ThemeClassNames.docs.docSidebarItemLinkLevel(level),
+        defaultStyle && [styles.menuHtmlItem, "menu__list-item"],
+        className,
+      )}
+      key={index}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: value }}
+    />
+  );
+}

--- a/docs/src/theme/DocSidebarItem/Html/styles.module.css
+++ b/docs/src/theme/DocSidebarItem/Html/styles.module.css
@@ -1,0 +1,6 @@
+@media (min-width: 997px) {
+  .menuHtmlItem {
+    padding: var(--ifm-menu-link-padding-vertical)
+      var(--ifm-menu-link-padding-horizontal);
+  }
+}

--- a/docs/src/theme/DocSidebarItem/Link/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Link/index.tsx
@@ -1,0 +1,83 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import { isActiveSidebarItem } from "@docusaurus/plugin-content-docs/client";
+import Link from "@docusaurus/Link";
+import isInternalUrl from "@docusaurus/isInternalUrl";
+import IconExternalLink from "@theme/Icon/ExternalLink";
+import type { Props } from "@theme/DocSidebarItem/Link";
+import SidebarBadge from "@site/src/components/SidebarBadge";
+
+import styles from "./styles.module.css";
+
+function LinkLabel({ label, item }: { label: string; item: any }) {
+  // Get tags from customProps in sidebar config
+  const tags = item?.customProps?.tags;
+
+  // Determine which badge to show based on tags
+  const getBadgeType = () => {
+    if (!tags || tags.length === 0) return null;
+    if (tags.includes("new")) return "new";
+    if (tags.includes("experimental")) return "experimental";
+    if (tags.includes("advanced")) return "advanced";
+    return null;
+  };
+
+  const badgeType = getBadgeType();
+
+  return (
+    <>
+      <span title={label} className={styles.linkLabel}>
+        {label}
+      </span>
+      {badgeType && (
+        <SidebarBadge type={badgeType as "new" | "experimental" | "advanced"} />
+      )}
+    </>
+  );
+}
+
+export default function DocSidebarItemLink({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}: Props): ReactNode {
+  const { href, label, className, autoAddBaseUrl } = item;
+  const isActive = isActiveSidebarItem(item, activePath);
+  const isInternalLink = isInternalUrl(href);
+
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemLink,
+        ThemeClassNames.docs.docSidebarItemLinkLevel(level),
+        "menu__list-item",
+        className,
+      )}
+      key={label}
+    >
+      <Link
+        className={clsx(
+          "menu__link",
+          !isInternalLink && styles.menuExternalLink,
+          {
+            "menu__link--active": isActive,
+          },
+        )}
+        autoAddBaseUrl={autoAddBaseUrl}
+        aria-current={isActive ? "page" : undefined}
+        to={href}
+        {...(isInternalLink && {
+          onClick: onItemClick ? () => onItemClick(item) : undefined,
+        })}
+        {...props}
+      >
+        <LinkLabel label={label} item={item} />
+        {!isInternalLink && <IconExternalLink />}
+      </Link>
+    </li>
+  );
+}

--- a/docs/src/theme/DocSidebarItem/Link/styles.module.css
+++ b/docs/src/theme/DocSidebarItem/Link/styles.module.css
@@ -1,0 +1,11 @@
+.menuExternalLink {
+  align-items: center;
+}
+
+.linkLabel {
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}

--- a/docs/src/theme/DocSidebarItem/index.tsx
+++ b/docs/src/theme/DocSidebarItem/index.tsx
@@ -1,0 +1,17 @@
+import React, { type ReactNode } from "react";
+import DocSidebarItemCategory from "@theme/DocSidebarItem/Category";
+import DocSidebarItemLink from "@theme/DocSidebarItem/Link";
+import DocSidebarItemHtml from "@theme/DocSidebarItem/Html";
+import type { Props } from "@theme/DocSidebarItem";
+
+export default function DocSidebarItem({ item, ...props }: Props): ReactNode {
+  switch (item.type) {
+    case "category":
+      return <DocSidebarItemCategory item={item} {...props} />;
+    case "html":
+      return <DocSidebarItemHtml item={item} {...props} />;
+    case "link":
+    default:
+      return <DocSidebarItemLink item={item} {...props} />;
+  }
+}


### PR DESCRIPTION
## Description

Tags implementation in docs. Tags are added to the `sidebar` config by passing in `customProps`

```tsx
customProps: {
    tags: ["advanced"]
 }
```

<img width="542" height="330" alt="CleanShot 2025-12-01 at 11 12 49@2x" src="https://github.com/user-attachments/assets/e2cbb1cb-8206-49bb-81be-27fff4ca8005" />

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds visible badge indicators ("New", "Advanced", "Experimental") to sidebar links.
  * Enhances sidebar items: collapsible categories with auto-expand behavior, improved link rendering (external link treatment) and HTML sidebar item support.
* **Documentation**
  * Tagged select docs to enable badge display and improve sidebar organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->