### PR TITLE
feat: add reserved keys in RequestContext for secure resourceId/threadId setting

### DIFF
--- a/.changeset/clever-keys-guard.md
+++ b/.changeset/clever-keys-guard.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': minor
+---
+
+Add reserved keys in RequestContext for secure resourceId/threadId setting from middleware
+
+This allows middleware to securely set `resourceId` and `threadId` via reserved keys in RequestContext (`MASTRA_RESOURCE_ID_KEY` and `MASTRA_THREAD_ID_KEY`), which take precedence over client-provided values for security.
+

--- a/packages/core/src/agent/__tests__/request-context-reserved-keys.test.ts
+++ b/packages/core/src/agent/__tests__/request-context-reserved-keys.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for RequestContext reserved keys feature
+ *
+ * This feature allows middleware to securely set resourceId and threadId
+ * via reserved keys in RequestContext, which take precedence over
+ * client-provided values for security.
+ *
+ * Reserved keys:
+ * - mastra__resourceId: Sets the resourceId for memory operations
+ * - mastra__threadId: Sets the threadId for memory operations
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/4296
+ */
+import { simulateReadableStream, MockLanguageModelV1 } from '@internal/ai-sdk-v4';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai-v5/test';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MockMemory } from '../../memory/mock';
+import { RequestContext, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../../request-context';
+import { Agent } from '../index';
+
+describe('RequestContext reserved keys for resourceId and threadId', () => {
+  describe('v2 - generate', () => {
+    let dummyModel: MockLanguageModelV2;
+
+    beforeEach(() => {
+      dummyModel = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          text: `Reserved keys test response`,
+          content: [{ type: 'text', text: 'Reserved keys test response' }],
+          warnings: [],
+        }),
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Reserved keys test response' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+          ]),
+        }),
+      });
+    });
+
+    it('should use mastra__resourceId and mastra__threadId from RequestContext', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      // Create a RequestContext with reserved keys set (simulating middleware setting these)
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'context-user-123');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'context-thread-456');
+
+      await agent.generate('hello', {
+        requestContext,
+        // Intentionally NOT passing resourceId/threadId in options
+        // The agent should use the values from RequestContext
+      });
+
+      // Verify the thread was created with the resourceId and threadId from RequestContext
+      const thread = await mockMemory.getThreadById({ threadId: 'context-thread-456' });
+      expect(thread).toBeDefined();
+      expect(thread?.id).toBe('context-thread-456');
+      expect(thread?.resourceId).toBe('context-user-123');
+    });
+
+    it('RequestContext reserved keys should take precedence over body values for security', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      // Create a RequestContext with reserved keys set (simulating auth middleware)
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'secure-user-from-middleware');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'secure-thread-from-middleware');
+
+      await agent.generate('hello', {
+        requestContext,
+        // An attacker might try to hijack another user's memory by passing different values
+        resourceId: 'attacker-trying-to-hijack',
+        threadId: 'attacker-thread',
+      });
+
+      // The middleware-set values should take precedence (for security)
+      // The attacker's values should NOT be used
+      const secureThread = await mockMemory.getThreadById({ threadId: 'secure-thread-from-middleware' });
+      expect(secureThread).toBeDefined();
+      expect(secureThread?.id).toBe('secure-thread-from-middleware');
+      expect(secureThread?.resourceId).toBe('secure-user-from-middleware');
+
+      // Verify the attacker's thread was NOT created
+      const attackerThread = await mockMemory.getThreadById({ threadId: 'attacker-thread' });
+      expect(attackerThread).toBeNull();
+    });
+
+    it('RequestContext reserved keys should take precedence over memory option values', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'middleware-resource');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'middleware-thread');
+
+      await agent.generate('hello', {
+        requestContext,
+        // Using the new memory option format - these should be overridden by RequestContext
+        memory: {
+          resource: 'body-resource-should-be-ignored',
+          thread: 'body-thread-should-be-ignored',
+        },
+      });
+
+      // The middleware values should win
+      const middlewareThread = await mockMemory.getThreadById({ threadId: 'middleware-thread' });
+      expect(middlewareThread).toBeDefined();
+      expect(middlewareThread?.id).toBe('middleware-thread');
+      expect(middlewareThread?.resourceId).toBe('middleware-resource');
+
+      // The body values should NOT be used
+      const bodyThread = await mockMemory.getThreadById({ threadId: 'body-thread-should-be-ignored' });
+      expect(bodyThread).toBeNull();
+    });
+  });
+
+  describe('v2 - stream', () => {
+    let dummyModel: MockLanguageModelV2;
+
+    beforeEach(() => {
+      dummyModel = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          text: `Reserved keys test response`,
+          content: [{ type: 'text', text: 'Reserved keys test response' }],
+          warnings: [],
+        }),
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Reserved keys test response' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+          ]),
+        }),
+      });
+    });
+
+    it('should use mastra__resourceId and mastra__threadId from RequestContext', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'stream-context-user');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'stream-context-thread');
+
+      const streamResult = await agent.stream('hello', {
+        requestContext,
+      });
+
+      await streamResult.consumeStream();
+
+      const thread = await mockMemory.getThreadById({ threadId: 'stream-context-thread' });
+      expect(thread).toBeDefined();
+      expect(thread?.id).toBe('stream-context-thread');
+      expect(thread?.resourceId).toBe('stream-context-user');
+    });
+
+    it('RequestContext reserved keys should take precedence over memory option values', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'middleware-resource');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'middleware-thread');
+
+      const streamResult = await agent.stream('hello', {
+        requestContext,
+        // Using the new memory option format - these should be overridden by RequestContext
+        memory: {
+          resource: 'body-resource-should-be-ignored',
+          thread: 'body-thread-should-be-ignored',
+        },
+      });
+
+      await streamResult.consumeStream();
+
+      // The middleware values should win
+      const middlewareThread = await mockMemory.getThreadById({ threadId: 'middleware-thread' });
+      expect(middlewareThread).toBeDefined();
+      expect(middlewareThread?.id).toBe('middleware-thread');
+      expect(middlewareThread?.resourceId).toBe('middleware-resource');
+
+      // The body values should NOT be used
+      const bodyThread = await mockMemory.getThreadById({ threadId: 'body-thread-should-be-ignored' });
+      expect(bodyThread).toBeNull();
+    });
+  });
+
+  describe('v1 - generateLegacy', () => {
+    let dummyModel: MockLanguageModelV1;
+
+    beforeEach(() => {
+      dummyModel = new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 10, completionTokens: 20 },
+          text: `Reserved keys test response`,
+        }),
+        doStream: async () => ({
+          stream: simulateReadableStream({
+            chunks: [{ type: 'text-delta', textDelta: 'Reserved keys test response' }],
+          }),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        }),
+      });
+    });
+
+    it('should use mastra__resourceId and mastra__threadId from RequestContext', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'legacy-context-user');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'legacy-context-thread');
+
+      await agent.generateLegacy('hello', {
+        requestContext,
+      });
+
+      const thread = await mockMemory.getThreadById({ threadId: 'legacy-context-thread' });
+      expect(thread).toBeDefined();
+      expect(thread?.id).toBe('legacy-context-thread');
+      expect(thread?.resourceId).toBe('legacy-context-user');
+    });
+
+    it('RequestContext reserved keys should take precedence over body values for security', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'secure-legacy-user');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'secure-legacy-thread');
+
+      await agent.generateLegacy('hello', {
+        requestContext,
+        resourceId: 'attacker-trying-to-hijack',
+        threadId: 'attacker-thread',
+      });
+
+      const secureThread = await mockMemory.getThreadById({ threadId: 'secure-legacy-thread' });
+      expect(secureThread).toBeDefined();
+      expect(secureThread?.id).toBe('secure-legacy-thread');
+      expect(secureThread?.resourceId).toBe('secure-legacy-user');
+
+      const attackerThread = await mockMemory.getThreadById({ threadId: 'attacker-thread' });
+      expect(attackerThread).toBeNull();
+    });
+  });
+
+  describe('v1 - streamLegacy', () => {
+    let dummyModel: MockLanguageModelV1;
+
+    beforeEach(() => {
+      dummyModel = new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 10, completionTokens: 20 },
+          text: `Reserved keys test response`,
+        }),
+        doStream: async () => ({
+          stream: simulateReadableStream({
+            chunks: [{ type: 'text-delta', textDelta: 'Reserved keys test response' }],
+          }),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        }),
+      });
+    });
+
+    it('should use mastra__resourceId and mastra__threadId from RequestContext', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'stream-legacy-user');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'stream-legacy-thread');
+
+      const streamResult = await agent.streamLegacy('hello', {
+        requestContext,
+      });
+
+      await streamResult.consumeStream();
+
+      const thread = await mockMemory.getThreadById({ threadId: 'stream-legacy-thread' });
+      expect(thread).toBeDefined();
+      expect(thread?.id).toBe('stream-legacy-thread');
+      expect(thread?.resourceId).toBe('stream-legacy-user');
+    });
+
+    it('RequestContext reserved keys should take precedence over body values for security', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'secure-stream-user');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'secure-stream-thread');
+
+      const streamResult = await agent.streamLegacy('hello', {
+        requestContext,
+        resourceId: 'attacker-stream-resource',
+        threadId: 'attacker-stream-thread',
+      });
+
+      await streamResult.consumeStream();
+
+      const secureThread = await mockMemory.getThreadById({ threadId: 'secure-stream-thread' });
+      expect(secureThread).toBeDefined();
+      expect(secureThread?.id).toBe('secure-stream-thread');
+      expect(secureThread?.resourceId).toBe('secure-stream-user');
+
+      const attackerThread = await mockMemory.getThreadById({ threadId: 'attacker-stream-thread' });
+      expect(attackerThread).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -24,7 +24,7 @@ import type { MemoryConfig, StorageThreadType } from '../memory/types';
 import type { Span, TracingContext, TracingOptions, TracingProperties } from '../observability';
 import { SpanType, getOrCreateSpan } from '../observability';
 import type { InputProcessor, OutputProcessor } from '../processors/index';
-import { RequestContext } from '../request-context';
+import { RequestContext, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
 import type { ChunkType } from '../stream/types';
 import type { CoreTool } from '../tools/types';
 import type { DynamicArgument } from '../types';
@@ -685,8 +685,16 @@ export class AgentLegacyHandler {
       ...args
     } = options;
 
-    const threadFromArgs = resolveThreadIdFromArgs({ threadId: args.threadId, memory: args.memory });
-    const resourceId = (args.memory as any)?.resource || resourceIdFromArgs;
+    // Reserved keys from requestContext take precedence for security.
+    // This allows middleware to securely set resourceId/threadId based on authenticated user,
+    // preventing attackers from hijacking another user's memory by passing different values in the body.
+    const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+    const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+
+    const threadFromArgs = threadIdFromContext
+      ? { id: threadIdFromContext }
+      : resolveThreadIdFromArgs({ threadId: args.threadId, memory: args.memory });
+    const resourceId = resourceIdFromContext || (args.memory as any)?.resource || resourceIdFromArgs;
     const memoryConfig = (args.memory as any)?.options || memoryConfigFromArgs;
 
     if (resourceId && threadFromArgs && !this.capabilities.hasOwnMemory()) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -32,7 +32,7 @@ import type { TracingContext, TracingProperties } from '../observability';
 import { SpanType, getOrCreateSpan } from '../observability';
 import type { InputProcessor, OutputProcessor } from '../processors/index';
 import { ProcessorRunner } from '../processors/runner';
-import { RequestContext } from '../request-context';
+import { RequestContext, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
 import type { MastraModelOutput } from '../stream/base/output';
 import type { OutputSchema } from '../stream/base/schema';
 import type { ChunkType } from '../stream/types';
@@ -2404,12 +2404,21 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
     }
     const requestContext = options.requestContext || new RequestContext();
 
-    const threadFromArgs = resolveThreadIdFromArgs({
-      threadId: options.threadId || snapshotMemoryInfo?.threadId,
-      memory: options.memory,
-    });
+    // Reserved keys from requestContext take precedence for security.
+    // This allows middleware to securely set resourceId/threadId based on authenticated user,
+    // preventing attackers from hijacking another user's memory by passing different values in the body.
+    const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+    const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
 
-    const resourceId = options.memory?.resource || options.resourceId || snapshotMemoryInfo?.resourceId;
+    const threadFromArgs = threadIdFromContext
+      ? { id: threadIdFromContext }
+      : resolveThreadIdFromArgs({
+          threadId: options.threadId || snapshotMemoryInfo?.threadId,
+          memory: options.memory,
+        });
+
+    const resourceId =
+      resourceIdFromContext || options.memory?.resource || options.resourceId || snapshotMemoryInfo?.resourceId;
     const memoryConfig = options.memory?.options;
 
     if (resourceId && threadFromArgs && !this.hasOwnMemory()) {

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -1,1 +1,1 @@
-export { RequestContext } from '../request-context';
+export { RequestContext, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';

--- a/packages/core/src/request-context/index.ts
+++ b/packages/core/src/request-context/index.ts
@@ -2,6 +2,34 @@ type RecordToTuple<T> = {
   [K in keyof T]: [K, T[K]];
 }[keyof T][];
 
+/**
+ * Reserved key for setting resourceId from middleware.
+ * When set in RequestContext, this takes precedence over client-provided values
+ * for security (prevents attackers from hijacking another user's memory).
+ *
+ * @example
+ * ```typescript
+ * // In your auth middleware:
+ * const requestContext = c.get('requestContext');
+ * requestContext.set(MASTRA_RESOURCE_ID_KEY, authenticatedUser.id);
+ * ```
+ */
+export const MASTRA_RESOURCE_ID_KEY = 'mastra__resourceId';
+
+/**
+ * Reserved key for setting threadId from middleware.
+ * When set in RequestContext, this takes precedence over client-provided values
+ * for security (prevents attackers from hijacking another user's memory).
+ *
+ * @example
+ * ```typescript
+ * // In your auth middleware:
+ * const requestContext = c.get('requestContext');
+ * requestContext.set(MASTRA_THREAD_ID_KEY, threadId);
+ * ```
+ */
+export const MASTRA_THREAD_ID_KEY = 'mastra__threadId';
+
 export class RequestContext<Values extends Record<string, any> | unknown = unknown> {
   private registry = new Map<string, unknown>();
 


### PR DESCRIPTION
## Summary

This PR adds support for reserved keys in `RequestContext` that allow middleware to securely set `resourceId` and `threadId` for memory operations.

## Problem

When using Mastra server with authentication middleware, users want to set `resourceId` based on authenticated user data rather than trusting client-provided values. Currently, `resourceId` and `threadId` come from the request body, which could allow attackers to hijack another user's memory by sending a different resourceId.

## Solution

Introduce two reserved keys in `RequestContext`:
- `MASTRA_RESOURCE_ID_KEY` (`'mastra__resourceId'`)
- `MASTRA_THREAD_ID_KEY` (`'mastra__threadId'`)

When set by middleware, these values **take precedence** over any values passed in the request body, ensuring security.

## Usage Example

```typescript
import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '@mastra/core';

export const mastra = new Mastra({
  server: {
    middleware: [
      async (c, next) => {
        const user = await authenticateUser(c);
        const requestContext = c.get('requestContext');
        
        // Securely set resourceId/threadId from authenticated user
        requestContext.set(MASTRA_RESOURCE_ID_KEY, user.id);
        requestContext.set(MASTRA_THREAD_ID_KEY, user.preferredThread);
        
        await next();
      },
    ],
  },
});
```

## Changes

- `packages/core/src/request-context/index.ts`: Added `MASTRA_RESOURCE_ID_KEY` and `MASTRA_THREAD_ID_KEY` constants
- `packages/core/src/agent/agent.ts`: Modified `#execute` to check for reserved keys first
- `packages/core/src/agent/agent-legacy.ts`: Same changes for v1 API
- `packages/core/src/di/index.ts`: Export the reserved key constants
- Added comprehensive tests for both v1 and v2 APIs

## Tests

Added 9 tests covering:
- Using reserved keys from RequestContext
- Reserved keys taking precedence over body values (security)
- Reserved keys taking precedence over memory option values
- Both `generate` and `stream` methods
- Both v1 (legacy) and v2 APIs

Closes #4296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RequestContext supports reserved keys for thread and resource identity that take precedence over client-supplied values across standard and legacy execution paths to protect memory targeting.

* **Tests**
  * Comprehensive unit tests covering reserved-key precedence and propagation across generate/stream and legacy variants.

* **Documentation**
  * Added changelog entry describing the reserved-keys behavior and security precedence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->