### PR TITLE
docs: remove confusing documentation example with default + custom configs (1.0)

### DIFF
--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -217,7 +217,6 @@ Use `configSelector` to choose the appropriate tracing configuration based on re
 ```ts title="src/mastra/index.ts" showLineNumbers copy
 export const mastra = new Mastra({
   observability: new Observability({
-    default: { enabled: true }, // Provides 'default' instance
     configs: {
       langfuse: {
         serviceName: "langfuse-service",
@@ -250,7 +249,7 @@ export const mastra = new Mastra({
         return "langfuse";
       }
 
-      return "default";
+      throw new Error('no config found')
     },
   }),
 });


### PR DESCRIPTION
According to the documentation:

> Having both the default config enabled and adding custom configs is an invalid configuration of Observability. Use either the default or custom config, but not both.

However, the earlier code example (which I edited) enabled the default config and added custom configs, which is invalid. I’ve removed the custom configs from that example.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated observability configuration handling to throw an error when no matching configuration is found, replacing previous fallback behavior.

* **Breaking Changes**
  * Removed default observability configuration entry. Users must now explicitly provide configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->