### PR TITLE
feat: add custom fetch support to MastraClient

### DIFF
--- a/.changeset/add-custom-fetch-support.md
+++ b/.changeset/add-custom-fetch-support.md
@@ -4,3 +4,23 @@
 
 Add support for custom fetch function in MastraClient to enable environments like Tauri that require custom fetch implementations to avoid timeout errors.
 
+You can now pass a custom fetch function when creating a MastraClient:
+
+```typescript
+import { MastraClient } from '@mastra/client-js';
+
+// Before: Only global fetch was available
+const client = new MastraClient({
+  baseUrl: 'http://your-api-url',
+});
+
+// After: Custom fetch can be passed
+const client = new MastraClient({
+  baseUrl: 'http://your-api-url',
+  fetch: customFetch, // Your custom fetch implementation
+});
+```
+
+If no custom fetch is provided, it falls back to the global fetch function, maintaining backward compatibility.
+
+Fixes #10673

--- a/.changeset/add-custom-fetch-support.md
+++ b/.changeset/add-custom-fetch-support.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': minor
+---
+
+Add support for custom fetch function in MastraClient to enable environments like Tauri that require custom fetch implementations to avoid timeout errors.
+

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,0 +1,17 @@
+# PR
+
+The user will ask issue this command. You will need to do the following:
+
+1. Create a changeset in .changeset, ensuring the naming convention for the changeset file is inline with other changesets in the .changeset folder.
+
+- major changes are backward-incompatible
+- minor changes add new features while remaining backward-compatible
+- patch versions fix bugs with backward-compatible updates.
+
+2. Open a PR using the GitHub CLI
+
+Add a descriptive/concise title, use conventional commits in the title (eg "fix: title here")
+
+Add a concise, humble PR description without flowery or overly verbose language.
+Keep it casual/friendly but get to the point. Show simple code examples before/after for fixes, or just after examples for new features.
+Do not add lists or headings. Keep it simple and to the point

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,6 +1,6 @@
 # PR
 
-The user will ask issue this command. You will need to do the following:
+The user will issue this command. You will need to do the following:
 
 1. Create a changeset in .changeset, ensuring the naming convention for the changeset file is inline with other changesets in the .changeset folder.
 

--- a/client-sdks/client-js/src/client.test.ts
+++ b/client-sdks/client-js/src/client.test.ts
@@ -110,7 +110,7 @@ describe('MastraClient', () => {
     it('should use custom fetch function when provided', async () => {
       // Arrange: Create a custom fetch that tracks usage
       let customFetchCalled = false;
-      const customFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const customFetch = vi.fn(async (_url: string | URL | Request, _init?: RequestInit): Promise<Response> => {
         customFetchCalled = true;
         return {
           ok: true,

--- a/client-sdks/client-js/src/client.test.ts
+++ b/client-sdks/client-js/src/client.test.ts
@@ -106,6 +106,36 @@ describe('MastraClient', () => {
         }),
       );
     });
+
+    it('should use custom fetch function when provided', async () => {
+      // Arrange: Create a custom fetch that tracks usage
+      let customFetchCalled = false;
+      const customFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        customFetchCalled = true;
+        return {
+          ok: true,
+          headers: {
+            get: () => 'application/json',
+          },
+          json: async () => ({ customFetchUsed: true }),
+        } as Response;
+      });
+
+      const customClient = new MastraClient({
+        baseUrl: 'http://localhost:4111',
+        fetch: customFetch,
+      });
+
+      // Act: Make request
+      const result = await customClient.request('/test');
+
+      // Assert: Verify custom fetch was used instead of global fetch
+      expect(customFetchCalled).toBe(true);
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ customFetchUsed: true });
+      // Verify global fetch was NOT called
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('Integration Tests', () => {

--- a/client-sdks/client-js/src/resources/base.test.ts
+++ b/client-sdks/client-js/src/resources/base.test.ts
@@ -73,4 +73,51 @@ describe('BaseResource', () => {
       responseBody: 'Internal Server Error',
     });
   });
+
+  it('should use custom fetch function when provided', async () => {
+    // Arrange: Create a custom fetch that adds a custom header
+    const customFetch = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const response = await fetch(url, {
+        ...init,
+        headers: {
+          ...init?.headers,
+          'X-Custom-Fetch': 'true',
+        },
+      });
+      return response;
+    };
+
+    const customResource = new BaseResource({
+      baseUrl: serverUrl,
+      retries: 0,
+      fetch: customFetch,
+    });
+
+    // Set up server to respond successfully
+    server.on('request', (req, res) => {
+      const customHeader = req.headers['x-custom-fetch'];
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ customFetchUsed: customHeader === 'true' }));
+    });
+
+    // Act: Make request
+    const result = await customResource.request('/test');
+
+    // Assert: Verify custom fetch was used
+    expect(result).toEqual({ customFetchUsed: true });
+  });
+
+  it('should fall back to global fetch when custom fetch is not provided', async () => {
+    // Arrange: Set up server to respond successfully
+    server.on('request', (_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true }));
+    });
+
+    // Act: Make request without custom fetch
+    const result = await resource.request('/test');
+
+    // Assert: Verify request succeeded using global fetch
+    expect(result).toEqual({ success: true });
+  });
 });

--- a/client-sdks/client-js/src/resources/base.ts
+++ b/client-sdks/client-js/src/resources/base.ts
@@ -15,13 +15,22 @@ export class BaseResource {
    */
   public async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
     let lastError: Error | null = null;
-    const { baseUrl, retries = 3, backoffMs = 100, maxBackoffMs = 1000, headers = {}, credentials } = this.options;
+    const {
+      baseUrl,
+      retries = 3,
+      backoffMs = 100,
+      maxBackoffMs = 1000,
+      headers = {},
+      credentials,
+      fetch: customFetch,
+    } = this.options;
+    const fetchFn = customFetch || fetch;
 
     let delay = backoffMs;
 
     for (let attempt = 0; attempt <= retries; attempt++) {
       try {
-        const response = await fetch(`${baseUrl.replace(/\/$/, '')}${path}`, {
+        const response = await fetchFn(`${baseUrl.replace(/\/$/, '')}${path}`, {
           ...options,
           headers: {
             ...(options.body &&

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -54,6 +54,8 @@ export interface ClientOptions {
   abortSignal?: AbortSignal;
   /** Credentials mode for requests. See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials for more info. */
   credentials?: 'omit' | 'same-origin' | 'include';
+  /** Custom fetch function to use for HTTP requests. Useful for environments like Tauri that require custom fetch implementations. */
+  fetch?: typeof fetch;
 }
 
 export interface RequestOptions {


### PR DESCRIPTION
Adds support for passing a custom fetch function to MastraClient, similar to how ai-sdk handles it. This is useful for environments like Tauri that require custom fetch implementations to avoid timeout errors on macOS Safari webview.

You can now pass a custom fetch function when creating a MastraClient:

```typescript
const client = new MastraClient({
  baseUrl: 'http://your-api-url',
  fetch: customFetch, // Your custom fetch implementation
});
```

If no custom fetch is provided, it falls back to the global fetch function, maintaining backward compatibility.

Fixes #10673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MastraClient can be configured with a custom fetch implementation to support environments requiring alternate HTTP request handling.

* **Tests**
  * Added tests verifying custom fetch is used when provided and falling back to the default fetch when not.

* **Documentation**
  * Added a changeset documenting a minor package bump and a new PR workflow guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->