### PR TITLE
feat(evals): add getReasoningFromRunOutput utility for reasoning models

### DIFF
--- a/.changeset/reasoning-text-scorer-utils.md
+++ b/.changeset/reasoning-text-scorer-utils.md
@@ -1,0 +1,6 @@
+---
+'@mastra/evals': minor
+---
+
+Add `getReasoningFromRunOutput` utility function for extracting reasoning text from scorer run outputs. This enables scorers to access chain-of-thought reasoning from models like deepseek-reasoner in preprocess functions.
+

--- a/docs/src/content/en/reference/evals/scorer-utils.mdx
+++ b/docs/src/content/en/reference/evals/scorer-utils.mdx
@@ -1,0 +1,362 @@
+---
+title: "Reference: Scorer Utils | Evals"
+description: Utility functions for extracting data from scorer run inputs and outputs, including text content, reasoning, system messages, and tool calls.
+---
+
+# Scorer Utils
+
+Mastra provides utility functions to help extract and process data from scorer run inputs and outputs. These utilities are particularly useful in the `preprocess` step of custom scorers.
+
+## Import
+
+```typescript
+import {
+  getAssistantMessageFromRunOutput,
+  getReasoningFromRunOutput,
+  getUserMessageFromRunInput,
+  getSystemMessagesFromRunInput,
+  getCombinedSystemPrompt,
+  extractToolCalls,
+  extractInputMessages,
+  extractAgentResponseMessages,
+} from "@mastra/evals/scorers/utils";
+```
+
+## Message Extraction
+
+### getAssistantMessageFromRunOutput
+
+Extracts the text content from the first assistant message in the run output.
+
+```typescript
+const scorer = createScorer({
+  id: "my-scorer",
+  description: "My scorer",
+  type: "agent",
+})
+  .preprocess(({ run }) => {
+    const response = getAssistantMessageFromRunOutput(run.output);
+    return { response };
+  })
+  .generateScore(({ results }) => {
+    return results.preprocessStepResult?.response ? 1 : 0;
+  });
+```
+
+<PropertiesTable
+  content={[
+    {
+      name: "output",
+      type: "ScorerRunOutputForAgent",
+      isOptional: true,
+      description: "The scorer run output (array of MastraDBMessage)",
+    },
+  ]}
+/>
+
+**Returns:** `string | undefined` - The assistant message text, or undefined if no assistant message is found.
+
+### getUserMessageFromRunInput
+
+Extracts the text content from the first user message in the run input.
+
+```typescript
+.preprocess(({ run }) => {
+  const userMessage = getUserMessageFromRunInput(run.input);
+  return { userMessage };
+})
+```
+
+<PropertiesTable
+  content={[
+    {
+      name: "input",
+      type: "ScorerRunInputForAgent",
+      isOptional: true,
+      description: "The scorer run input containing input messages",
+    },
+  ]}
+/>
+
+**Returns:** `string | undefined` - The user message text, or undefined if no user message is found.
+
+### extractInputMessages
+
+Extracts text content from all input messages as an array.
+
+```typescript
+.preprocess(({ run }) => {
+  const allUserMessages = extractInputMessages(run.input);
+  return { conversationHistory: allUserMessages.join("\n") };
+})
+```
+
+**Returns:** `string[]` - Array of text strings from each input message.
+
+### extractAgentResponseMessages
+
+Extracts text content from all assistant response messages as an array.
+
+```typescript
+.preprocess(({ run }) => {
+  const allResponses = extractAgentResponseMessages(run.output);
+  return { allResponses };
+})
+```
+
+**Returns:** `string[]` - Array of text strings from each assistant message.
+
+## Reasoning Extraction
+
+### getReasoningFromRunOutput
+
+Extracts reasoning text from the run output. This is particularly useful when evaluating responses from reasoning models like `deepseek-reasoner` that produce chain-of-thought reasoning.
+
+Reasoning can be stored in two places:
+1. `content.reasoning` - a string field on the message content
+2. `content.parts` - as parts with `type: 'reasoning'` containing `details`
+
+```typescript
+import { 
+  getReasoningFromRunOutput, 
+  getAssistantMessageFromRunOutput 
+} from "@mastra/evals/scorers/utils";
+
+const reasoningQualityScorer = createScorer({
+  id: "reasoning-quality",
+  name: "Reasoning Quality",
+  description: "Evaluates the quality of model reasoning",
+  type: "agent",
+})
+  .preprocess(({ run }) => {
+    const reasoning = getReasoningFromRunOutput(run.output);
+    const response = getAssistantMessageFromRunOutput(run.output);
+    return { reasoning, response };
+  })
+  .analyze(({ results }) => {
+    const { reasoning } = results.preprocessStepResult || {};
+    return {
+      hasReasoning: !!reasoning,
+      reasoningLength: reasoning?.length || 0,
+      hasStepByStep: reasoning?.includes("step") || false,
+    };
+  })
+  .generateScore(({ results }) => {
+    const { hasReasoning, reasoningLength } = results.analyzeStepResult || {};
+    if (!hasReasoning) return 0;
+    // Score based on reasoning length (normalized to 0-1)
+    return Math.min(reasoningLength / 500, 1);
+  })
+  .generateReason(({ results, score }) => {
+    const { hasReasoning, reasoningLength } = results.analyzeStepResult || {};
+    if (!hasReasoning) {
+      return "No reasoning was provided by the model.";
+    }
+    return `Model provided ${reasoningLength} characters of reasoning. Score: ${score}`;
+  });
+```
+
+<PropertiesTable
+  content={[
+    {
+      name: "output",
+      type: "ScorerRunOutputForAgent",
+      isOptional: true,
+      description: "The scorer run output (array of MastraDBMessage)",
+    },
+  ]}
+/>
+
+**Returns:** `string | undefined` - The reasoning text, or undefined if no reasoning is present.
+
+## System Message Extraction
+
+### getSystemMessagesFromRunInput
+
+Extracts all system messages from the run input, including both standard system messages and tagged system messages (specialized prompts like memory instructions).
+
+```typescript
+.preprocess(({ run }) => {
+  const systemMessages = getSystemMessagesFromRunInput(run.input);
+  return { 
+    systemPromptCount: systemMessages.length,
+    systemPrompts: systemMessages 
+  };
+})
+```
+
+**Returns:** `string[]` - Array of system message strings.
+
+### getCombinedSystemPrompt
+
+Combines all system messages into a single prompt string, joined with double newlines.
+
+```typescript
+.preprocess(({ run }) => {
+  const fullSystemPrompt = getCombinedSystemPrompt(run.input);
+  return { fullSystemPrompt };
+})
+```
+
+**Returns:** `string` - Combined system prompt string.
+
+## Tool Call Extraction
+
+### extractToolCalls
+
+Extracts information about all tool calls from the run output, including tool names, call IDs, and their positions in the message array.
+
+```typescript
+const toolUsageScorer = createScorer({
+  id: "tool-usage",
+  description: "Evaluates tool usage patterns",
+  type: "agent",
+})
+  .preprocess(({ run }) => {
+    const { tools, toolCallInfos } = extractToolCalls(run.output);
+    return {
+      toolsUsed: tools,
+      toolCount: tools.length,
+      toolDetails: toolCallInfos,
+    };
+  })
+  .generateScore(({ results }) => {
+    const { toolCount } = results.preprocessStepResult || {};
+    // Score based on appropriate tool usage
+    return toolCount > 0 ? 1 : 0;
+  });
+```
+
+**Returns:**
+
+```typescript
+{
+  tools: string[];           // Array of tool names
+  toolCallInfos: ToolCallInfo[];  // Detailed tool call information
+}
+```
+
+Where `ToolCallInfo` is:
+
+```typescript
+type ToolCallInfo = {
+  toolName: string;      // Name of the tool
+  toolCallId: string;    // Unique call identifier
+  messageIndex: number;  // Index in the output array
+  invocationIndex: number; // Index within message's tool invocations
+};
+```
+
+## Test Utilities
+
+These utilities help create test data for scorer development.
+
+### createTestMessage
+
+Creates a `MastraDBMessage` object for testing purposes.
+
+```typescript
+import { createTestMessage } from "@mastra/evals/scorers/utils";
+
+const userMessage = createTestMessage({
+  content: "What is the weather?",
+  role: "user",
+});
+
+const assistantMessage = createTestMessage({
+  content: "The weather is sunny.",
+  role: "assistant",
+  toolInvocations: [
+    {
+      toolCallId: "call-1",
+      toolName: "weatherTool",
+      args: { location: "London" },
+      result: { temp: 20 },
+      state: "result",
+    },
+  ],
+});
+```
+
+### createAgentTestRun
+
+Creates a complete test run object for testing scorers.
+
+```typescript
+import { createAgentTestRun, createTestMessage } from "@mastra/evals/scorers/utils";
+
+const testRun = createAgentTestRun({
+  inputMessages: [
+    createTestMessage({ content: "Hello", role: "user" }),
+  ],
+  output: [
+    createTestMessage({ content: "Hi there!", role: "assistant" }),
+  ],
+});
+
+// Run your scorer with the test data
+const result = await myScorer.run({
+  input: testRun.input,
+  output: testRun.output,
+});
+```
+
+## Complete Example
+
+Here's a complete example showing how to use multiple utilities together:
+
+```typescript
+import { createScorer } from "@mastra/core/evals";
+import {
+  getAssistantMessageFromRunOutput,
+  getReasoningFromRunOutput,
+  getUserMessageFromRunInput,
+  getCombinedSystemPrompt,
+  extractToolCalls,
+} from "@mastra/evals/scorers/utils";
+
+const comprehensiveScorer = createScorer({
+  id: "comprehensive-analysis",
+  name: "Comprehensive Analysis",
+  description: "Analyzes all aspects of an agent response",
+  type: "agent",
+})
+  .preprocess(({ run }) => {
+    // Extract all relevant data
+    const userMessage = getUserMessageFromRunInput(run.input);
+    const response = getAssistantMessageFromRunOutput(run.output);
+    const reasoning = getReasoningFromRunOutput(run.output);
+    const systemPrompt = getCombinedSystemPrompt(run.input);
+    const { tools, toolCallInfos } = extractToolCalls(run.output);
+
+    return {
+      userMessage,
+      response,
+      reasoning,
+      systemPrompt,
+      toolsUsed: tools,
+      toolCount: tools.length,
+    };
+  })
+  .generateScore(({ results }) => {
+    const { response, reasoning, toolCount } = results.preprocessStepResult || {};
+    
+    let score = 0;
+    if (response && response.length > 0) score += 0.4;
+    if (reasoning) score += 0.3;
+    if (toolCount > 0) score += 0.3;
+    
+    return score;
+  })
+  .generateReason(({ results, score }) => {
+    const { response, reasoning, toolCount } = results.preprocessStepResult || {};
+    
+    const parts = [];
+    if (response) parts.push("provided a response");
+    if (reasoning) parts.push("included reasoning");
+    if (toolCount > 0) parts.push(`used ${toolCount} tool(s)`);
+    
+    return `Score: ${score}. The agent ${parts.join(", ")}.`;
+  });
+```
+

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -585,6 +585,7 @@ const sidebars = {
       items: [
         { type: "doc", id: "evals/mastra-scorer", label: "MastraScorer" },
         { type: "doc", id: "evals/create-scorer", label: "createScorer" },
+        { type: "doc", id: "evals/scorer-utils", label: "Scorer Utils" },
         { type: "doc", id: "evals/run-evals", label: "runEvals" },
         { type: "doc", id: "evals/bias", label: "Bias" },
         { type: "doc", id: "evals/completeness", label: "Completeness" },

--- a/packages/evals/src/scorers/utils.test.ts
+++ b/packages/evals/src/scorers/utils.test.ts
@@ -1,0 +1,303 @@
+import type { MastraDBMessage } from '@mastra/core/agent';
+import { createScorer } from '@mastra/core/evals';
+import type { ScorerRunOutputForAgent, ScorerRunInputForAgent } from '@mastra/core/evals';
+import { describe, it, expect } from 'vitest';
+import {
+  getTextContentFromMastraDBMessage,
+  getAssistantMessageFromRunOutput,
+  getReasoningFromRunOutput,
+  createTestMessage,
+} from './utils';
+
+describe('Scorer Utils', () => {
+  describe('getTextContentFromMastraDBMessage', () => {
+    it('should extract text content from content.content string', () => {
+      const message = createTestMessage({
+        content: 'Hello world',
+        role: 'assistant',
+      });
+      const result = getTextContentFromMastraDBMessage(message);
+      expect(result).toBe('Hello world');
+    });
+
+    it('should extract text content from parts array', () => {
+      const message: MastraDBMessage = {
+        id: 'test-1',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Hello from parts' }],
+        },
+      };
+      const result = getTextContentFromMastraDBMessage(message);
+      expect(result).toBe('Hello from parts');
+    });
+  });
+
+  describe('getAssistantMessageFromRunOutput', () => {
+    it('should extract assistant text content from output', () => {
+      const output: ScorerRunOutputForAgent = [
+        createTestMessage({ content: 'User message', role: 'user' }),
+        createTestMessage({ content: 'Assistant response', role: 'assistant' }),
+      ];
+      const result = getAssistantMessageFromRunOutput(output);
+      expect(result).toBe('Assistant response');
+    });
+  });
+
+  /**
+   * When using a reasoning model, the reasoning text
+   * should be available in the scorer's preprocess function. Currently, there's
+   * no utility function to extract reasoning text from the run output.
+   */
+  describe('Reasoning text extraction', () => {
+    it('should extract reasoning from content.reasoning field', () => {
+      const messageWithReasoning: MastraDBMessage = {
+        id: 'test-reasoning-1',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'The answer is 42.' }],
+          content: 'The answer is 42.',
+          reasoning: 'Let me think about this step by step...', // reasoning string field
+        },
+      };
+
+      const output: ScorerRunOutputForAgent = [messageWithReasoning];
+
+      // Currently there's no function to get reasoning - this test documents the missing functionality
+      // We need a getReasoningFromRunOutput function similar to getAssistantMessageFromRunOutput
+      const reasoning = getReasoningFromRunOutput(output);
+
+      expect(reasoning).toBe('Let me think about this step by step...');
+    });
+
+    it('should extract reasoning from parts with type "reasoning"', () => {
+      // This is how reasoning is stored when using models like deepseek-reasoner
+      // The reasoning is in content.parts as { type: 'reasoning', details: [{ type: 'text', text: '...' }] }
+      const messageWithReasoningParts: MastraDBMessage = {
+        id: 'test-reasoning-2',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'reasoning',
+              reasoning: '', // This is often blank, the actual text is in details
+              details: [{ type: 'text', text: 'First, I need to consider the problem carefully...' }],
+            } as any,
+            { type: 'text', text: 'The final answer is 42.' },
+          ],
+          content: 'The final answer is 42.',
+        },
+      };
+
+      const output: ScorerRunOutputForAgent = [messageWithReasoningParts];
+
+      const reasoning = getReasoningFromRunOutput(output);
+
+      expect(reasoning).toBe('First, I need to consider the problem carefully...');
+    });
+
+    it('should return undefined when no reasoning is present', () => {
+      const messageWithoutReasoning: MastraDBMessage = {
+        id: 'test-no-reasoning',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Just a regular response.' }],
+          content: 'Just a regular response.',
+        },
+      };
+
+      const output: ScorerRunOutputForAgent = [messageWithoutReasoning];
+
+      const reasoning = getReasoningFromRunOutput(output);
+
+      expect(reasoning).toBeUndefined();
+    });
+
+    it('should handle multiple reasoning parts', () => {
+      const messageWithMultipleReasoningParts: MastraDBMessage = {
+        id: 'test-multi-reasoning',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'reasoning',
+              reasoning: '',
+              details: [{ type: 'text', text: 'Step 1: Analyze the question.' }],
+            } as any,
+            {
+              type: 'reasoning',
+              reasoning: '',
+              details: [{ type: 'text', text: 'Step 2: Consider the options.' }],
+            } as any,
+            { type: 'text', text: 'The answer is B.' },
+          ],
+          content: 'The answer is B.',
+        },
+      };
+
+      const output: ScorerRunOutputForAgent = [messageWithMultipleReasoningParts];
+
+      const reasoning = getReasoningFromRunOutput(output);
+
+      expect(reasoning).toContain('Step 1: Analyze the question.');
+      expect(reasoning).toContain('Step 2: Consider the options.');
+    });
+  });
+
+  /**
+   * Integration test: Proves reasoning text is available in scorer preprocess function
+   * This directly addresses GitHub Issue #9911
+   */
+  describe('Reasoning available in scorer preprocess - Issue #9911 Integration Test', () => {
+    it('should make reasoning text available in scorer preprocess function', async () => {
+      // Create a scorer that extracts reasoning in preprocess
+      const reasoningScorer = createScorer({
+        id: 'reasoning-test-scorer',
+        name: 'Reasoning Test Scorer',
+        description: 'Tests that reasoning text is available in preprocess',
+        type: 'agent',
+      })
+        .preprocess(({ run }) => {
+          // This is exactly what users want to do - access reasoning in preprocess
+          const reasoning = getReasoningFromRunOutput(run.output);
+          const response = getAssistantMessageFromRunOutput(run.output);
+          return { reasoning, response };
+        })
+        .generateScore(({ results }) => {
+          // Score based on whether reasoning was available
+          return results.preprocessStepResult?.reasoning ? 1 : 0;
+        });
+
+      // Simulate a run with reasoning model output (like deepseek-reasoner)
+      const inputMessages: ScorerRunInputForAgent['inputMessages'] = [
+        {
+          id: 'user-msg-1',
+          role: 'user',
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'What is the capital of France?' }],
+            content: 'What is the capital of France?',
+          },
+        },
+      ];
+
+      const outputWithReasoning: ScorerRunOutputForAgent = [
+        {
+          id: 'assistant-msg-1',
+          role: 'assistant',
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'reasoning',
+                reasoning: '',
+                details: [
+                  {
+                    type: 'text',
+                    text: 'The user is asking about geography. France is a country in Western Europe. Its capital city is Paris, which has been the capital since the 10th century.',
+                  },
+                ],
+              } as any,
+              { type: 'text', text: 'The capital of France is Paris.' },
+            ],
+            content: 'The capital of France is Paris.',
+          },
+        },
+      ];
+
+      // Run the scorer
+      const result = await reasoningScorer.run({
+        input: {
+          inputMessages,
+          rememberedMessages: [],
+          systemMessages: [],
+          taggedSystemMessages: {},
+        },
+        output: outputWithReasoning,
+      });
+
+      // Verify reasoning was extracted in preprocess
+      expect(result.preprocessStepResult).toBeDefined();
+      expect(result.preprocessStepResult?.reasoning).toBe(
+        'The user is asking about geography. France is a country in Western Europe. Its capital city is Paris, which has been the capital since the 10th century.',
+      );
+      expect(result.preprocessStepResult?.response).toBe('The capital of France is Paris.');
+
+      // Score should be 1 because reasoning was available
+      expect(result.score).toBe(1);
+    });
+
+    it('should handle run output without reasoning gracefully', async () => {
+      const reasoningScorer = createScorer({
+        id: 'reasoning-test-scorer-2',
+        name: 'Reasoning Test Scorer 2',
+        description: 'Tests handling of missing reasoning',
+        type: 'agent',
+      })
+        .preprocess(({ run }) => {
+          const reasoning = getReasoningFromRunOutput(run.output);
+          const response = getAssistantMessageFromRunOutput(run.output);
+          return { reasoning, response };
+        })
+        .generateScore(({ results }) => {
+          return results.preprocessStepResult?.reasoning ? 1 : 0;
+        });
+
+      const inputMessages: ScorerRunInputForAgent['inputMessages'] = [
+        {
+          id: 'user-msg-1',
+          role: 'user',
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'Hello' }],
+            content: 'Hello',
+          },
+        },
+      ];
+
+      // Output without reasoning (regular model)
+      const outputWithoutReasoning: ScorerRunOutputForAgent = [
+        {
+          id: 'assistant-msg-1',
+          role: 'assistant',
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'Hello! How can I help you today?' }],
+            content: 'Hello! How can I help you today?',
+          },
+        },
+      ];
+
+      const result = await reasoningScorer.run({
+        input: {
+          inputMessages,
+          rememberedMessages: [],
+          systemMessages: [],
+          taggedSystemMessages: {},
+        },
+        output: outputWithoutReasoning,
+      });
+
+      // Reasoning should be undefined
+      expect(result.preprocessStepResult?.reasoning).toBeUndefined();
+      expect(result.preprocessStepResult?.response).toBe('Hello! How can I help you today?');
+
+      // Score should be 0 because no reasoning was available
+      expect(result.score).toBe(0);
+    });
+  });
+});

--- a/packages/evals/src/scorers/utils.ts
+++ b/packages/evals/src/scorers/utils.ts
@@ -4,8 +4,25 @@ import { RequestContext } from '@mastra/core/request-context';
 import type { ToolInvocation } from 'ai';
 
 /**
- * Extract text content from MastraDBMessage
- * Matches the logic used in MessageList.mastraDBMessageToAIV4UIMessage
+ * Extracts text content from a MastraDBMessage.
+ *
+ * This function matches the logic used in `MessageList.mastraDBMessageToAIV4UIMessage`.
+ * It first checks for a string `content.content` field, then falls back to extracting
+ * text from the `parts` array (returning only the last text part, like AI SDK does).
+ *
+ * @param message - The MastraDBMessage to extract text from
+ * @returns The extracted text content, or an empty string if no text is found
+ *
+ * @example
+ * ```ts
+ * const message: MastraDBMessage = {
+ *   id: 'msg-1',
+ *   role: 'assistant',
+ *   content: { format: 2, parts: [{ type: 'text', text: 'Hello!' }] },
+ *   createdAt: new Date(),
+ * };
+ * const text = getTextContentFromMastraDBMessage(message); // 'Hello!'
+ * ```
  */
 export function getTextContentFromMastraDBMessage(message: MastraDBMessage): string {
   if (typeof message.content.content === 'string' && message.content.content !== '') {
@@ -19,27 +36,85 @@ export function getTextContentFromMastraDBMessage(message: MastraDBMessage): str
   return '';
 }
 
+/**
+ * Rounds a number to two decimal places.
+ *
+ * Uses `Number.EPSILON` to handle floating-point precision issues.
+ *
+ * @param num - The number to round
+ * @returns The number rounded to two decimal places
+ *
+ * @example
+ * ```ts
+ * roundToTwoDecimals(0.1 + 0.2); // 0.3
+ * roundToTwoDecimals(1.005); // 1.01
+ * ```
+ */
 export const roundToTwoDecimals = (num: number) => {
   return Math.round((num + Number.EPSILON) * 100) / 100;
 };
 
+/**
+ * Determines if a value is closer to the first target than the second.
+ *
+ * @param value - The value to compare
+ * @param target1 - The first target value
+ * @param target2 - The second target value
+ * @returns `true` if `value` is closer to `target1` than `target2`
+ *
+ * @example
+ * ```ts
+ * isCloserTo(0.6, 1, 0); // true (0.6 is closer to 1)
+ * isCloserTo(0.3, 1, 0); // false (0.3 is closer to 0)
+ * ```
+ */
 export function isCloserTo(value: number, target1: number, target2: number): boolean {
   return Math.abs(value - target1) < Math.abs(value - target2);
 }
 
+/**
+ * Represents a test case for scorer evaluation.
+ */
 export type TestCase = {
+  /** The input text to evaluate */
   input: string;
+  /** The output text to evaluate */
   output: string;
+  /** The expected result of the evaluation */
   expectedResult: {
+    /** The expected score */
     score: number;
+    /** The optional expected reason */
     reason?: string;
   };
 };
 
+/**
+ * Represents a test case with additional context for scorer evaluation.
+ */
 export type TestCaseWithContext = TestCase & {
+  /** Additional context strings for the evaluation */
   context: string[];
 };
 
+/**
+ * Creates a scoring input object for testing purposes.
+ *
+ * @param input - The user input text
+ * @param output - The assistant output text
+ * @param additionalContext - Optional additional context data
+ * @param requestContext - Optional request context data
+ * @returns A ScoringInput object ready for use in scorer tests
+ *
+ * @example
+ * ```ts
+ * const run = createTestRun(
+ *   'What is 2+2?',
+ *   'The answer is 4.',
+ *   { topic: 'math' }
+ * );
+ * ```
+ */
 export const createTestRun = (
   input: string,
   output: string,
@@ -54,11 +129,46 @@ export const createTestRun = (
   };
 };
 
+/**
+ * Extracts the user message text from a scorer run input.
+ *
+ * Finds the first message with role 'user' and extracts its text content.
+ *
+ * @param input - The scorer run input containing input messages
+ * @returns The user message text, or `undefined` if no user message is found
+ *
+ * @example
+ * ```ts
+ * const scorer = createScorer({ ... })
+ *   .preprocess(({ run }) => {
+ *     const userText = getUserMessageFromRunInput(run.input);
+ *     return { userText };
+ *   });
+ * ```
+ */
 export const getUserMessageFromRunInput = (input?: ScorerRunInputForAgent): string | undefined => {
   const message = input?.inputMessages.find(({ role }) => role === 'user');
   return message ? getTextContentFromMastraDBMessage(message) : undefined;
 };
 
+/**
+ * Extracts all system messages from a scorer run input.
+ *
+ * Collects text from both standard system messages and tagged system messages
+ * (specialized system prompts like memory instructions).
+ *
+ * @param input - The scorer run input containing system messages
+ * @returns An array of system message strings
+ *
+ * @example
+ * ```ts
+ * const scorer = createScorer({ ... })
+ *   .preprocess(({ run }) => {
+ *     const systemMessages = getSystemMessagesFromRunInput(run.input);
+ *     return { systemPrompt: systemMessages.join('\n') };
+ *   });
+ * ```
+ */
 export const getSystemMessagesFromRunInput = (input?: ScorerRunInputForAgent): string[] => {
   const systemMessages: string[] = [];
 
@@ -97,16 +207,136 @@ export const getSystemMessagesFromRunInput = (input?: ScorerRunInputForAgent): s
   return systemMessages;
 };
 
+/**
+ * Combines all system messages into a single prompt string.
+ *
+ * Joins all system messages (standard and tagged) with double newlines.
+ *
+ * @param input - The scorer run input containing system messages
+ * @returns A combined system prompt string
+ *
+ * @example
+ * ```ts
+ * const scorer = createScorer({ ... })
+ *   .preprocess(({ run }) => {
+ *     const systemPrompt = getCombinedSystemPrompt(run.input);
+ *     return { systemPrompt };
+ *   });
+ * ```
+ */
 export const getCombinedSystemPrompt = (input?: ScorerRunInputForAgent): string => {
   const systemMessages = getSystemMessagesFromRunInput(input);
   return systemMessages.join('\n\n');
 };
 
+/**
+ * Extracts the assistant message text from a scorer run output.
+ *
+ * Finds the first message with role 'assistant' and extracts its text content.
+ *
+ * @param output - The scorer run output (array of MastraDBMessage)
+ * @returns The assistant message text, or `undefined` if no assistant message is found
+ *
+ * @example
+ * ```ts
+ * const scorer = createScorer({ ... })
+ *   .preprocess(({ run }) => {
+ *     const response = getAssistantMessageFromRunOutput(run.output);
+ *     return { response };
+ *   });
+ * ```
+ */
 export const getAssistantMessageFromRunOutput = (output?: ScorerRunOutputForAgent) => {
   const message = output?.find(({ role }) => role === 'assistant');
   return message ? getTextContentFromMastraDBMessage(message) : undefined;
 };
 
+/**
+ * Extracts reasoning text from a scorer run output.
+ *
+ * This function extracts reasoning content from assistant messages, which is
+ * produced by reasoning models like `deepseek-reasoner`. The reasoning can be
+ * stored in two places:
+ * 1. `content.reasoning` - a string field on the message content
+ * 2. `content.parts` - as parts with `type: 'reasoning'` containing `details`
+ *
+ * @param output - The scorer run output (array of MastraDBMessage)
+ * @returns The reasoning text, or `undefined` if no reasoning is present
+ *
+ * @example
+ * ```ts
+ * const reasoningScorer = createScorer({
+ *   id: 'reasoning-scorer',
+ *   name: 'Reasoning Quality',
+ *   description: 'Evaluates the quality of model reasoning',
+ *   type: 'agent',
+ * })
+ *   .preprocess(({ run }) => {
+ *     const reasoning = getReasoningFromRunOutput(run.output);
+ *     const response = getAssistantMessageFromRunOutput(run.output);
+ *     return { reasoning, response };
+ *   })
+ *   .generateScore(({ results }) => {
+ *     // Score based on reasoning quality
+ *     return results.preprocessStepResult?.reasoning ? 1 : 0;
+ *   });
+ * ```
+ */
+export const getReasoningFromRunOutput = (output?: ScorerRunOutputForAgent): string | undefined => {
+  if (!output) return undefined;
+
+  const message = output.find(({ role }) => role === 'assistant');
+  if (!message) return undefined;
+
+  // Check for reasoning in content.reasoning (string format)
+  if (message.content.reasoning) {
+    return message.content.reasoning;
+  }
+
+  // Check for reasoning in parts with type 'reasoning'
+  // Reasoning models store reasoning in parts as { type: 'reasoning', details: [{ type: 'text', text: '...' }] }
+  const reasoningParts = message.content.parts?.filter((p: any) => p.type === 'reasoning');
+  if (reasoningParts && reasoningParts.length > 0) {
+    const reasoningTexts = reasoningParts
+      .map((p: any) => {
+        // The reasoning text can be in p.reasoning or in p.details[].text
+        if (p.details && Array.isArray(p.details)) {
+          return p.details
+            .filter((d: any) => d.type === 'text')
+            .map((d: any) => d.text)
+            .join('');
+        }
+        return p.reasoning || '';
+      })
+      .filter(Boolean);
+
+    return reasoningTexts.length > 0 ? reasoningTexts.join('\n') : undefined;
+  }
+
+  return undefined;
+};
+
+/**
+ * Creates a tool invocation object for testing purposes.
+ *
+ * @param options - The tool invocation configuration
+ * @param options.toolCallId - Unique identifier for the tool call
+ * @param options.toolName - Name of the tool being called
+ * @param options.args - Arguments passed to the tool
+ * @param options.result - Result returned by the tool
+ * @param options.state - State of the invocation (default: 'result')
+ * @returns A tool invocation object
+ *
+ * @example
+ * ```ts
+ * const invocation = createToolInvocation({
+ *   toolCallId: 'call-123',
+ *   toolName: 'weatherTool',
+ *   args: { location: 'London' },
+ *   result: { temperature: 20, condition: 'sunny' },
+ * });
+ * ```
+ */
 export const createToolInvocation = ({
   toolCallId,
   toolName,
@@ -130,8 +360,37 @@ export const createToolInvocation = ({
 };
 
 /**
- * Helper function to create MastraDBMessage objects for tests
- * Supports optional tool invocations for testing tool call scenarios
+ * Creates a MastraDBMessage object for testing purposes.
+ *
+ * Supports optional tool invocations for testing tool call scenarios.
+ *
+ * @param options - The message configuration
+ * @param options.content - The text content of the message
+ * @param options.role - The role of the message sender ('user', 'assistant', or 'system')
+ * @param options.id - Optional message ID (default: 'test-message')
+ * @param options.toolInvocations - Optional array of tool invocations
+ * @returns A MastraDBMessage object
+ *
+ * @example
+ * ```ts
+ * const message = createTestMessage({
+ *   content: 'Hello, how can I help?',
+ *   role: 'assistant',
+ * });
+ *
+ * // With tool invocations
+ * const messageWithTools = createTestMessage({
+ *   content: 'Let me check the weather.',
+ *   role: 'assistant',
+ *   toolInvocations: [{
+ *     toolCallId: 'call-1',
+ *     toolName: 'weatherTool',
+ *     args: { location: 'Paris' },
+ *     result: { temp: 22 },
+ *     state: 'result',
+ *   }],
+ * });
+ * ```
  */
 export function createTestMessage({
   content,
@@ -171,6 +430,35 @@ export function createTestMessage({
   };
 }
 
+/**
+ * Creates a complete agent test run object for testing scorers.
+ *
+ * Provides a convenient way to construct the full run object that scorers receive,
+ * including input messages, output, system messages, and request context.
+ *
+ * @param options - The test run configuration
+ * @param options.inputMessages - Array of input messages (default: [])
+ * @param options.output - The output messages (required)
+ * @param options.rememberedMessages - Array of remembered messages from memory (default: [])
+ * @param options.systemMessages - Array of system messages (default: [])
+ * @param options.taggedSystemMessages - Tagged system messages map (default: {})
+ * @param options.requestContext - Request context (default: new RequestContext())
+ * @param options.runId - Unique run ID (default: random UUID)
+ * @returns A complete test run object
+ *
+ * @example
+ * ```ts
+ * const testRun = createAgentTestRun({
+ *   inputMessages: [createTestMessage({ content: 'Hello', role: 'user' })],
+ *   output: [createTestMessage({ content: 'Hi there!', role: 'assistant' })],
+ * });
+ *
+ * const result = await scorer.run({
+ *   input: testRun.input,
+ *   output: testRun.output,
+ * });
+ * ```
+ */
 export const createAgentTestRun = ({
   inputMessages = [],
   output,
@@ -206,13 +494,41 @@ export const createAgentTestRun = ({
   };
 };
 
+/**
+ * Information about a tool call extracted from scorer output.
+ */
 export type ToolCallInfo = {
+  /** Name of the tool that was called */
   toolName: string;
+  /** Unique identifier for the tool call */
   toolCallId: string;
+  /** Index of the message containing this tool call */
   messageIndex: number;
+  /** Index of the invocation within the message's tool invocations */
   invocationIndex: number;
 };
 
+/**
+ * Extracts all tool calls from a scorer run output.
+ *
+ * Iterates through all messages and their tool invocations to collect
+ * information about tools that were called (with state 'result' or 'call').
+ *
+ * @param output - The scorer run output (array of MastraDBMessage)
+ * @returns An object containing tool names and detailed tool call info
+ *
+ * @example
+ * ```ts
+ * const scorer = createScorer({ ... })
+ *   .preprocess(({ run }) => {
+ *     const { tools, toolCallInfos } = extractToolCalls(run.output);
+ *     return {
+ *       toolsUsed: tools,
+ *       toolCount: tools.length,
+ *     };
+ *   });
+ * ```
+ */
 export function extractToolCalls(output: ScorerRunOutputForAgent): { tools: string[]; toolCallInfos: ToolCallInfo[] } {
   const toolCalls: string[] = [];
   const toolCallInfos: ToolCallInfo[] = [];
@@ -239,10 +555,42 @@ export function extractToolCalls(output: ScorerRunOutputForAgent): { tools: stri
   return { tools: toolCalls, toolCallInfos };
 }
 
+/**
+ * Extracts text content from all input messages.
+ *
+ * @param runInput - The scorer run input
+ * @returns An array of text strings from each input message
+ *
+ * @example
+ * ```ts
+ * const scorer = createScorer({ ... })
+ *   .preprocess(({ run }) => {
+ *     const messages = extractInputMessages(run.input);
+ *     return { allUserMessages: messages.join('\n') };
+ *   });
+ * ```
+ */
 export const extractInputMessages = (runInput: ScorerRunInputForAgent | undefined): string[] => {
   return runInput?.inputMessages?.map(msg => getTextContentFromMastraDBMessage(msg)) || [];
 };
 
+/**
+ * Extracts text content from all assistant response messages.
+ *
+ * Filters for messages with role 'assistant' and extracts their text content.
+ *
+ * @param runOutput - The scorer run output (array of MastraDBMessage)
+ * @returns An array of text strings from each assistant message
+ *
+ * @example
+ * ```ts
+ * const scorer = createScorer({ ... })
+ *   .preprocess(({ run }) => {
+ *     const responses = extractAgentResponseMessages(run.output);
+ *     return { allResponses: responses.join('\n') };
+ *   });
+ * ```
+ */
 export const extractAgentResponseMessages = (runOutput: ScorerRunOutputForAgent): string[] => {
   return runOutput.filter(msg => msg.role === 'assistant').map(msg => getTextContentFromMastraDBMessage(msg));
 };


### PR DESCRIPTION
Adds a new `getReasoningFromRunOutput` utility function so scorers can access reasoning text from models like `deepseek-reasoner`.

Previously, reasoning text was available in the studio but undefined in scorer preprocess functions. Now you can do:

```typescript
import { getReasoningFromRunOutput, getAssistantMessageFromRunOutput } from '@mastra/evals/scorers/utils';

const scorer = createScorer({ id: 'my-scorer', type: 'agent', ... })
  .preprocess(({ run }) => {
    const reasoning = getReasoningFromRunOutput(run.output);
    const response = getAssistantMessageFromRunOutput(run.output);
    return { reasoning, response };
  })
  .generateScore(({ results }) => {
    return results.preprocessStepResult?.reasoning ? 1 : 0;
  });
```

Also added TSDoc to all scorer utils and a reference docs page.

Fixes #9911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utility functions to extract reasoning text, messages, and tool call information from scorer runs, enabling access to chain-of-thought reasoning from supported models.
  * Added test utilities for constructing scorer test data and validation scenarios.

* **Documentation**
  * Added comprehensive documentation for all available scorer utility functions with code examples and integration patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->