### PR TITLE
`createStep` should not wrap inngest workflows into step

### DIFF
--- a/.changeset/nice-pants-play.md
+++ b/.changeset/nice-pants-play.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Using `createStep` with a nested Inngest workflow now returns the workflow itself, maintaining the correct `.invoke()` execution flow Inngest workflows need to operate.

--- a/.claude/commands/make-moves.md
+++ b/.claude/commands/make-moves.md
@@ -1,0 +1,22 @@
+# Make Moves Issue $ISSUE
+
+You are a highly respected and valued engineer working on the Mastra framework.
+
+Use the GH CLI to examine the GitHub issue for the current repository.
+
+RUN gh issue view $ISSUE --json title,body,comments,labels,assignees,milestone
+
+Use the following workflow:
+
+## Stage 1 "Analyze"
+
+1. The issue description and requirements
+2. Comments and discussion threads
+
+## Stage 2 "Research"
+
+Given the information you gathered, research the code impacted. If unclear ask the user.
+
+## Stage 3 "Prove it"
+
+Create a reproduction and failing test.

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -3090,6 +3090,128 @@ describe('MastraInngestWorkflow', () => {
 
       srv.close();
     });
+
+    it('should run foreach with nested workflow', async ctx => {
+      const inngest = new Inngest({
+        id: 'mastra',
+        baseUrl: `http://localhost:${(ctx as any).inngestPort}`,
+      });
+
+      const { createWorkflow, createStep } = init(inngest);
+
+      // Steps for the nested workflow (from issue #9965)
+      const cyclePhasesStep1 = createStep({
+        id: 'phase-1',
+        description: 'phase number 1',
+        inputSchema: z.object({
+          element: z.string(),
+        }),
+        outputSchema: z.object({
+          element: z.string(),
+        }),
+        execute: async ({ inputData }) => {
+          return { element: inputData.element };
+        },
+      });
+
+      const cyclePhasesStep2 = createStep({
+        id: 'phase-2',
+        description: 'phase number 2',
+        inputSchema: z.object({
+          element: z.string(),
+        }),
+        outputSchema: z.object({
+          element: z.string(),
+        }),
+        execute: async ({ inputData }) => {
+          return { element: inputData.element };
+        },
+      });
+
+      const cyclePhasesStep3 = createStep({
+        id: 'phase-3',
+        description: 'phase number 3',
+        inputSchema: z.object({
+          element: z.string(),
+        }),
+        outputSchema: z.object({
+          result: z.string(),
+        }),
+        execute: async ({ inputData }) => {
+          return { result: inputData.element };
+        },
+      });
+
+      // Create nested workflow with multiple steps
+      const dynamicWorkflowPhases = createWorkflow({
+        id: 'dynamicWorkflowPhases',
+        inputSchema: z.object({
+          element: z.string(),
+        }),
+        outputSchema: z.object({
+          result: z.string(),
+        }),
+      })
+        .then(cyclePhasesStep1)
+        .then(cyclePhasesStep2)
+        .then(cyclePhasesStep3)
+        .commit();
+
+      // Issue #9965: Wrap the nested workflow in createStep() - this causes the bug
+      // because createStep() strips the InngestWorkflow class identity
+      const dynamicWorkflowPhasesStep = createStep(dynamicWorkflowPhases);
+
+      // Create orchestrator workflow that uses foreach with the nested workflow
+      const dynamicWorkflowOrchestrator = createWorkflow({
+        id: 'dynamicWorkflowOrchestrator',
+        inputSchema: z.object({
+          elements: z.array(z.string()),
+        }),
+        outputSchema: z.array(z.object({ result: z.string() })),
+      })
+        .map(async ({ inputData }) => {
+          return inputData.elements.map(element => {
+            return { element: element };
+          });
+        })
+        .foreach(dynamicWorkflowPhasesStep)
+        .commit();
+
+      const mastra = new Mastra({
+        storage: new DefaultStorage({
+          id: 'test-storage',
+          url: ':memory:',
+        }),
+        workflows: {
+          'test-workflow': dynamicWorkflowOrchestrator,
+        },
+        server: {
+          apiRoutes: [
+            {
+              path: '/inngest/api',
+              method: 'ALL',
+              createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
+            },
+          ],
+        },
+      });
+
+      const app = await createHonoServer(mastra);
+
+      const srv = (globServer = serve({
+        fetch: app.fetch,
+        port: (ctx as any).handlerPort,
+      }));
+      await resetInngest();
+
+      const run = await dynamicWorkflowOrchestrator.createRun();
+      const result = await run.start({ inputData: { elements: ['a', 'b', 'c'] } });
+
+      expect(result.status).toBe('success');
+      expect(result.result).toEqual([{ result: 'a' }, { result: 'b' }, { result: 'c' }]);
+
+      srv.close();
+    });
   });
 
   describe('if-else branching', () => {

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -24,6 +24,10 @@ function isTool(params: any): params is Tool<any, any, any> {
   return params instanceof Tool;
 }
 
+function isInngestWorkflow(params: any): params is InngestWorkflow {
+  return params instanceof InngestWorkflow;
+}
+
 export function createStep<
   TStepId extends string,
   TState extends z.ZodObject<any>,
@@ -69,6 +73,20 @@ export function createStep<
     | ToolStep<TStepInput, TSuspendSchema, TResumeSchema, TStepOutput, any>,
   agentOptions?: AgentStepOptions,
 ): Step<TStepId, TState, TStepInput, TStepOutput, TResumeSchema, TSuspendSchema, InngestEngineType> {
+  // Issue #9965: Preserve InngestWorkflow identity when passed to createStep
+  // This ensures nested workflows in foreach are properly detected by isNestedWorkflowStep()
+  if (isInngestWorkflow(params)) {
+    return params as unknown as Step<
+      TStepId,
+      TState,
+      TStepInput,
+      TStepOutput,
+      TResumeSchema,
+      TSuspendSchema,
+      InngestEngineType
+    >;
+  }
+
   if (isAgent(params)) {
     return {
       id: params.name as TStepId,


### PR DESCRIPTION


## Description

`createStep` in inngest workflows should not wrap inngest workflows into step**

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/9965

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nested Inngest workflows now correctly preserve workflow identity and execution flow when used with createStep and foreach operations.

* **Tests**
  * Added comprehensive test coverage for nested workflows in foreach operations to ensure consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->