### PR TITLE
update 1.0 migration guide

### DIFF
--- a/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
@@ -1,15 +1,17 @@
 ---
-title: "Migration: Upgrade to Mastra v1 | Migration Guide"
-description: "Learn how to upgrade through breaking changes in pre-v1 versions of Mastra."
+title: "Migration: Upgrade to Latest 0.x | Migration Guide"
+description: "Learn how to upgrade through breaking changes in pre-v1 versions of Mastra to reach the latest 0.x release."
 ---
 
-# Upgrade to Mastra v1
+# Upgrade to Latest 0.x
 
+:::note Upgrading to Mastra 1.0-beta?
 
-:::warning
-If your goal is to upgrade to Mastra v1.0, you should first follow this guide to reach the latest 0.x version, then switch to the Beta documentation and follow the comprehensive [v1.0 migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to v1.0, including automated codemods to help with the migration.
+If your goal is to upgrade to Mastra 1.0-beta, you should first complete this guide to reach the latest 0.x version. Then, switch to the [Beta documentation](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview) and follow the comprehensive [1.0-beta migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to 1.0-beta, including automated codemods to help with the migration.
+
 :::
-In this guide you'll learn how to upgrade through breaking changes in pre-v1 versions of Mastra. It'll also help you upgrade to Mastra v1.
+
+This guide walks you through the breaking changes in pre-v1 versions of Mastra (0.x), helping you upgrade step-by-step to the latest 0.x release. You'll find detailed migration instructions for each version, including code examples and explanations of what changed and why.
 
 Use your package manager to update your project's versions. Be sure to update **all** Mastra packages at the same time.
 
@@ -103,3 +105,4 @@ No changes needed.
 
 - [VNext to Standard APIs](./vnext-to-standard-apis)
 - [AgentNetwork to .network()](./agentnetwork)
+

--- a/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
@@ -7,7 +7,7 @@ description: "Learn how to upgrade through breaking changes in pre-v1 versions o
 
 :::note Upgrading to Mastra 1.0-beta?
 
-If your goal is to upgrade to Mastra 1.0-beta, you should first complete this guide to reach the latest 0.x version. Then, switch to the [Beta documentation](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview) and follow the comprehensive [1.0-beta migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to 1.0-beta, including automated codemods to help with the migration.
+If your goal is to upgrade to Mastra 1.0-beta, you should first complete this guide to reach the latest 0.x version. Then, switch to the [Beta documentation](/guides/v1/migrations/upgrade-to-v1/overview) and follow the comprehensive [1.0-beta migration guide](/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to 1.0-beta, including automated codemods to help with the migration.
 
 :::
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
@@ -5,9 +5,9 @@ description: "Learn how to upgrade through breaking changes in pre-v1 versions o
 
 # Upgrade to Latest 0.x
 
-:::note Upgrading to Mastra 1.0-beta?
+:::note Upgrading to Mastra v1?
 
-If your goal is to upgrade to Mastra 1.0-beta, you should first complete this guide to reach the latest 0.x version. Then, switch to the [Beta documentation](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview) and follow the comprehensive [1.0-beta migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to 1.0-beta, including automated codemods to help with the migration.
+If your goal is to upgrade to Mastra v1, you should first complete this guide to reach the latest 0.x version. Then, switch to the [v1 documentation](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview) and follow the comprehensive [v1 migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to v1, including automated codemods to help with the migration.
 
 :::
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-latest-0x.mdx
@@ -7,7 +7,7 @@ description: "Learn how to upgrade through breaking changes in pre-v1 versions o
 
 :::note Upgrading to Mastra 1.0-beta?
 
-If your goal is to upgrade to Mastra 1.0-beta, you should first complete this guide to reach the latest 0.x version. Then, switch to the [Beta documentation](/guides/v1/migrations/upgrade-to-v1/overview) and follow the comprehensive [1.0-beta migration guide](/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to 1.0-beta, including automated codemods to help with the migration.
+If your goal is to upgrade to Mastra 1.0-beta, you should first complete this guide to reach the latest 0.x version. Then, switch to the [Beta documentation](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview) and follow the comprehensive [1.0-beta migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to 1.0-beta, including automated codemods to help with the migration.
 
 :::
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1.mdx
@@ -9,7 +9,7 @@ description: "Learn how to upgrade through breaking changes in pre-v1 versions o
 :::warning
 If your goal is to upgrade to Mastra v1.0, you should first follow this guide to reach the latest 0.x version, then switch to the Beta documentation and follow the comprehensive [v1.0 migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to v1.0, including automated codemods to help with the migration.
 :::
-This guide provides a comprehensive overview of breaking changes when upgrading from Mastra 0.x to v1.0. The migration is organized by package and feature area to help you systematically update your codebase.
+In this guide you'll learn how to upgrade through breaking changes in pre-v1 versions of Mastra. It'll also help you upgrade to Mastra v1.
 
 Use your package manager to update your project's versions. Be sure to update **all** Mastra packages at the same time.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1.mdx
@@ -5,7 +5,11 @@ description: "Learn how to upgrade through breaking changes in pre-v1 versions o
 
 # Upgrade to Mastra v1
 
-In this guide you'll learn how to upgrade through breaking changes in pre-v1 versions of Mastra. It'll also help you upgrade to Mastra v1.
+
+:::warning
+If your goal is to upgrade to Mastra v1.0, you should first follow this guide to reach the latest 0.x version, then switch to the Beta documentation and follow the comprehensive [v1.0 migration guide](https://mastra.ai/guides/v1/migrations/upgrade-to-v1/overview), which covers all breaking changes when upgrading from 0.x to v1.0, including automated codemods to help with the migration.
+:::
+This guide provides a comprehensive overview of breaking changes when upgrading from Mastra 0.x to v1.0. The migration is organized by package and feature area to help you systematically update your codebase.
 
 Use your package manager to update your project's versions. Be sure to update **all** Mastra packages at the same time.
 

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -64,8 +64,8 @@ const sidebars = {
       items: [
         {
           type: "doc",
-          id: "migrations/upgrade-to-v1",
-          label: "v1.0",
+          id: "migrations/upgrade-to-latest-0x",
+          label: "Upgrade to Latest 0.x",
         },
         {
           type: "doc",

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1561,6 +1561,11 @@
       "permanent": true
     },
     {
+      "source": "/:path(ja)?/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
+      "permanent": true
+    },
+    {
       "source": "/:path(ja)?/models/providers/iflowcn",
       "destination": "/:path/models/providers/",
       "permanent": true

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1427,12 +1427,12 @@
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/overview",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/agent",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
@@ -1497,67 +1497,67 @@
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/cli",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/client",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/evals",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/mastra",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/mcp",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/memory",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/processors",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/storage",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/tools",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/tracing",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/vectors",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/voice",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {
       "source": "/:path(ja)?/guides/migrations/upgrade-to-v1/workflows",
-      "destination": "/:path/guides/migrations/upgrade-to-v1",
+      "destination": "/:path/guides/migrations/upgrade-to-latest-0x",
       "permanent": true
     },
     {


### PR DESCRIPTION
In the 0.x (Stable) docs, I’ve renamed the “Upgrade to v1” guide to “Upgrade to Latest 0.x”.

I also added a callout at the top explaining that this guide is about getting onto the latest 0.x, which is a prerequisite before upgrading to 1.0

The old name (“Upgrade to v1”) was misleading and could make it seem like it was the actual 0.x → 1.0 migration guide, so this should make the path to 1.0 clearer.