### PR TITLE
docs: improve text around disabling old telemetry in 0.x

### DIFF
--- a/docs/src/content/en/docs/observability/otel-tracing.mdx
+++ b/docs/src/content/en/docs/observability/otel-tracing.mdx
@@ -1,9 +1,24 @@
 ---
-title: "OTEL Tracing | Observability"
+title: "OTEL Tracing (Deprecated) | Observability"
 description: "Set up OpenTelemetry tracing for Mastra applications"
 ---
 
-# OTEL Tracing
+# OTEL Tracing (Deprecated)
+
+:::warning[Deprecation Notice]
+The `telemetry` configuration for OTEL Tracing is deprecated and will be removed in a future release. For OpenTelemetry-compatible tracing, use [AI Tracing](/docs/observability/ai-tracing/overview) with the [OpenTelemetry exporter](/docs/observability/ai-tracing/exporters/otel) instead.
+
+**Important:** If you are not using this telemetry system, you must explicitly disable it to suppress deprecation warnings:
+
+```typescript
+export const mastra = new Mastra({
+  // ... other config
+  telemetry: {
+    enabled: false,
+  },
+});
+```
+:::
 
 Mastra supports the OpenTelemetry Protocol (OTLP) for tracing and monitoring your application. When telemetry is enabled, Mastra automatically traces all core primitives including agent operations, LLM interactions, tool executions, integration calls, workflow runs, and database operations. Your telemetry data can then be exported to any OTEL collector.
 

--- a/docs/src/content/en/docs/observability/overview.mdx
+++ b/docs/src/content/en/docs/observability/overview.mdx
@@ -25,7 +25,17 @@ Specialized tracing for AI operations that captures:
 - **Workflow steps**: Branching logic, parallel execution, and step outputs
 - **Automatic instrumentation**: Zero-configuration tracing with decorators
 
-### OTEL Tracing
+### OTEL Tracing (Deprecated)
+
+:::warning
+OTEL Tracing via the `telemetry` configuration is deprecated and will be removed in a future release. Use [AI Tracing](/docs/observability/ai-tracing/overview) with the [OpenTelemetry exporter](/docs/observability/ai-tracing/exporters/otel) instead for OTLP-compatible tracing.
+
+If you are not using the old `telemetry` system, you should explicitly disable it to suppress deprecation warnings:
+
+```typescript
+telemetry: { enabled: false }
+```
+:::
 
 Traditional distributed tracing with OpenTelemetry:
 
@@ -53,7 +63,7 @@ export const mastra = new Mastra({
     url: "file:./mastra.db", // Storage is required for tracing
   }),
   telemetry: {
-    enabled: true, // Enables OTEL Tracing
+    enabled: false, // Disable deprecated OTEL Tracing to suppress warnings
   },
 });
 ```


### PR DESCRIPTION
## Description

Users were receiving deprecation warnings even when not actively using the old telemetry system. This adds documentation explaining that users must explicitly set `telemetry: { enabled: false }` to suppress these warnings when using only the new observability system.

## Related Issue(s)

Fixes #10549

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
