### PR TITLE
parallel state schema type error fix

### DIFF
--- a/.changeset/kind-zebras-rest.md
+++ b/.changeset/kind-zebras-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix type issue with workflow `.parallel()` when passing multiple steps, one or more of which has a `resumeSchema` provided.

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -747,11 +747,11 @@ export class Workflow<
         infer S extends z.ZodObject<any>,
         TPrevSchema,
         infer O,
-        infer R,
-        infer E,
+        any, // Don't infer TResumeSchema - causes issues with heterogeneous tuples
+        any, // Don't infer TSuspendSchema - causes issues with heterogeneous tuples
         TEngineType
       >
-        ? Step<string, SubsetOf<S, TState>, TPrevSchema, O, R, E, TEngineType>
+        ? Step<string, SubsetOf<S, TState>, TPrevSchema, O, any, any, TEngineType>
         : `Error: Expected Step with state schema that is a subset of workflow state`;
     },
   ) {


### PR DESCRIPTION


## Description

**Fix .parallel() type error when resumeSchema provided and passing multiple steps**

<img width="1556" height="2166" alt="image" src="https://github.com/user-attachments/assets/8dce73fa-8043-4669-ac49-371c5db2cbe2" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type checking issues in parallel workflow execution when multiple steps include resume schemas, preventing type inference errors during workflow configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->