### PR TITLE
fix: weird tools UI when no agents exist

### DIFF
--- a/.changeset/spotty-maps-know.md
+++ b/.changeset/spotty-maps-know.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix weird tool list UI when there are no agents

--- a/.changeset/spotty-maps-know.md
+++ b/.changeset/spotty-maps-know.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Fix weird tool list UI when there are no agents
+Fixed tool list empty state when there are no agents so the page renders correctly.

--- a/packages/playground/src/pages/tools/index.tsx
+++ b/packages/playground/src/pages/tools/index.tsx
@@ -19,7 +19,7 @@ export default function Tools() {
   const { data: agentsRecord = {}, isLoading: isLoadingAgents } = useAgents();
   const { data: tools = {}, isLoading: isLoadingTools } = useTools();
 
-  const isEmpty = !isLoadingTools && Object.keys(agentsRecord).length === 0;
+  const isEmpty = !isLoadingTools && Object.keys(tools).length === 0;
 
   return (
     <MainContentLayout>


### PR DESCRIPTION
## Description

This pull request addresses a UI issue in the tool list page by correctly determining when the list should be considered empty. The main change ensures that the empty state is based on the absence of tools, not agents, which fixes the display when there are no agents.

<img width="3840" height="2160" alt="CleanShot 2025-12-01 at 15 47 42@2x" src="https://github.com/user-attachments/assets/eb7768fd-8a2b-4c9f-8855-16b5f57cf2e3" />


UI bug fix:

* Updated the empty state logic in `packages/playground/src/pages/tools/index.tsx` to check for the absence of tools instead of agents, ensuring the tool list UI behaves correctly when there are no agents.
* Documented the patch fix in `.changeset/spotty-maps-know.md`.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/10690

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool list empty-state rendering so the page correctly shows the empty view when there are no tools, improving UI consistency.

* **Documentation**
  * Added a release metadata entry describing this patch and the empty-state fix for release notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->