### PR TITLE
Add discord msg fetching to gh-debug-issue slash cmds

### DIFF
--- a/.claude/commands/gh-debug-issue.md
+++ b/.claude/commands/gh-debug-issue.md
@@ -4,6 +4,12 @@ Use the GH CLI to examine the GitHub issue for the current repository.
 
 RUN gh issue view $ISSUE --json title,body,comments,labels,assignees,milestone
 
+If the Github issue has a discord link in the first message, ie https://discord.com/channels/GUILD_ID/<THREAD_ID>, grab the THREAD_ID off the URL to apply to the next command.
+
+RUN curl -s -X GET -H "Authorization: Bot $MASTRA_DISCORD_BOT_TOKEN" "https://discord.com/api/v10/channels/<THREAD_ID>/messages?limit=100" > /tmp/discord_out.json && jq '[.[] | {timestamp, author: {username: .author.username, display_name: .author.global_name}, content, attachments: [.attachments[]? | {filename, url}], embeds: [.embeds[]? | {title, description, url}]}]' /tmp/discord_out.json ; rm -f /tmp/discord_out.json
+
+If discord returns a 401, ignore it, the user hasn't set up the token yet, continue on without the discord messages.
+
 Debugging Github issues has 3 stages. Each stage must be fully completed before moving on to the next.
 
 ## Stage 1 "Analyze"
@@ -17,7 +23,7 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE*SUMMARY*${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Create an ISSUE_SUMMARY${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.

--- a/.cursor/commands/gh-debug-issue.md
+++ b/.cursor/commands/gh-debug-issue.md
@@ -4,6 +4,12 @@ Use the GH CLI to examine the GitHub issue for the current repository.
 
 RUN gh issue view $ISSUE --json title,body,comments,labels,assignees,milestone
 
+If the Github issue has a discord link in the first message, ie https://discord.com/channels/GUILD_ID/<THREAD_ID>, grab the THREAD_ID off the URL to apply to the next command.
+
+RUN curl -s -X GET -H "Authorization: Bot $MASTRA_DISCORD_BOT_TOKEN" "https://discord.com/api/v10/channels/<THREAD_ID>/messages?limit=100" > /tmp/discord_out.json && jq '[.[] | {timestamp, author: {username: .author.username, display_name: .author.global_name}, content, attachments: [.attachments[]? | {filename, url}], embeds: [.embeds[]? | {title, description, url}]}]' /tmp/discord_out.json ; rm -f /tmp/discord_out.json
+
+If discord returns a 401, ignore it, the user hasn't set up the token yet, continue on without the discord messages.
+
 Debugging Github issues has 3 stages. Each stage must be fully completed before moving on to the next.
 
 ## Stage 1 "Analyze"
@@ -17,7 +23,7 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE*SUMMARY*${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Create an ISSUE_SUMMARY${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.

--- a/.github/prompts/gh-debug-issue.prompt.md
+++ b/.github/prompts/gh-debug-issue.prompt.md
@@ -9,6 +9,12 @@ Use the GH CLI to examine the GitHub issue for the current repository.
 
 RUN GH_PAGER=cat gh issue view ${input:issue} --json title,body,comments,labels,assignees,milestone
 
+If the Github issue has a discord link in the first message, ie https://discord.com/channels/GUILD_ID/<THREAD_ID>, grab the THREAD_ID off the URL to apply to the next command.
+
+RUN curl -s -X GET -H "Authorization: Bot $MASTRA_DISCORD_BOT_TOKEN" "https://discord.com/api/v10/channels/<THREAD_ID>/messages?limit=100" > /tmp/discord_out.json && jq '[.[] | {timestamp, author: {username: .author.username, display_name: .author.global_name}, content, attachments: [.attachments[]? | {filename, url}], embeds: [.embeds[]? | {title, description, url}]}]' /tmp/discord_out.json ; rm -f /tmp/discord_out.json
+
+If discord returns a 401, ignore it, the user hasn't set up the token yet, continue on without the discord messages.
+
 Debugging Github issues has 3 stages. Each stage must be fully completed before moving on to the next.
 
 ## Stage 1 "Analyze"
@@ -22,7 +28,7 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE*SUMMARY*${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Create an ISSUE_SUMMARY${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.


### PR DESCRIPTION
/gh-debug-issue slash commands now have an optional `MASTRA_DISCORD_BOT_TOKEN` that you can set to fetch additional information from the discord thread.

export the `MASTRA_DISCORD_BOT_TOKEN` value from your `.zshrc` for it to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Discord thread integration to the issue debugging workflow. When a Discord URL is present in an issue, the system will automatically fetch and include Discord thread messages in the debug output.

* **Improvements**
  * Enhanced error handling for missing Discord API configuration (continues gracefully if unavailable).
  * Updated debugging file naming convention for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->