### PR TITLE
fix: handle undefined values when spreading config in Mastra constructor

### DIFF
--- a/.changeset/fix-config-spread-undefined-access.md
+++ b/.changeset/fix-config-spread-undefined-access.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+---
+
+Fix error when spreading config objects in Mastra constructor
+
+Adds validation guards to handle undefined/null values that can occur when config objects are spread (`{ ...config }`). Previously, if getters or non-enumerable properties resulted in undefined values during spread, the constructor would throw cryptic errors when accessing `.id` or `.name` on undefined objects.
+

--- a/packages/core/src/mastra/config-spread.test.ts
+++ b/packages/core/src/mastra/config-spread.test.ts
@@ -1,0 +1,200 @@
+import { MockLanguageModelV1 } from '@internal/ai-sdk-v4';
+import { describe, expect, it } from 'vitest';
+import { Agent } from '../agent';
+import { MastraError } from '../error';
+import { Mastra, type Config } from './index';
+
+/**
+ * Tests for handling spread config objects in Mastra constructor.
+ *
+ * Issue: When config is spread ({ ...config }), some values might become
+ * undefined if the original object had getters or non-enumerable properties.
+ * The constructor should handle these cases gracefully.
+ */
+describe('Mastra Config Spread Handling', () => {
+  const createTestAgent = () =>
+    new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are a test agent',
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 10, completionTokens: 20 },
+          text: 'Test response',
+        }),
+      }),
+    });
+
+  it('should handle config with spread operator', () => {
+    const agent = createTestAgent();
+    const config = {
+      logger: false as const,
+      agents: {
+        testAgent: agent,
+      },
+    };
+
+    // Using spread operator should work
+    const mastra = new Mastra({ ...config });
+
+    expect(mastra.getAgent('testAgent')).toBe(agent);
+  });
+
+  it('should handle config with nested spread', () => {
+    const agent = createTestAgent();
+    const baseConfig = {
+      logger: false as const,
+    };
+
+    const agentsConfig = {
+      agents: {
+        testAgent: agent,
+      },
+    };
+
+    // Using nested spread should work
+    const mastra = new Mastra({
+      ...baseConfig,
+      ...agentsConfig,
+    });
+
+    expect(mastra.getAgent('testAgent')).toBe(agent);
+  });
+
+  it('should skip undefined agent values in config (handles spread edge cases)', () => {
+    // Simulate what might happen with spread when getters return undefined
+    const configWithUndefined = {
+      logger: false as const,
+      agents: {
+        validAgent: createTestAgent(),
+        undefinedAgent: undefined as unknown as Agent,
+      },
+    };
+
+    // Should not throw, should skip the undefined agent
+    const mastra = new Mastra(configWithUndefined);
+
+    // The valid agent should still be registered
+    expect(mastra.getAgent('validAgent')).toBeDefined();
+
+    // The undefined agent should not be registered
+    expect(() => mastra.getAgent('undefinedAgent' as any)).toThrow(MastraError);
+  });
+
+  it('should skip null values in config (handles spread edge cases)', () => {
+    const configWithNull = {
+      logger: false as const,
+      agents: {
+        validAgent: createTestAgent(),
+        nullAgent: null as unknown as Agent,
+      },
+    };
+
+    // Should not throw, should skip the null agent
+    const mastra = new Mastra(configWithNull);
+
+    // The valid agent should still be registered
+    expect(mastra.getAgent('validAgent')).toBeDefined();
+
+    // The null agent should not be registered
+    expect(() => mastra.getAgent('nullAgent' as any)).toThrow(MastraError);
+  });
+
+  it('should throw meaningful error when addAgent is called with undefined directly', () => {
+    const mastra = new Mastra({ logger: false });
+
+    expect(() => mastra.addAgent(undefined as any)).toThrow(MastraError);
+    expect(() => mastra.addAgent(undefined as any)).toThrow('Cannot add agent');
+    expect(() => mastra.addAgent(undefined as any)).toThrow('undefined');
+  });
+
+  it('should throw meaningful error when addAgent is called with null directly', () => {
+    const mastra = new Mastra({ logger: false });
+
+    expect(() => mastra.addAgent(null as any)).toThrow(MastraError);
+    expect(() => mastra.addAgent(null as any)).toThrow('Cannot add agent');
+    expect(() => mastra.addAgent(null as any)).toThrow('null');
+  });
+
+  it('should preserve server config when spreading', () => {
+    const config = {
+      logger: false as const,
+      server: {
+        port: 8080,
+        host: 'localhost',
+      },
+    };
+
+    // Server config should be preserved after spread
+    const mastra = new Mastra({ ...config });
+
+    // If getServer() is available, check it; otherwise just ensure no errors
+    expect(mastra).toBeDefined();
+  });
+
+  it('should handle config object created with Object.assign', () => {
+    const agent = createTestAgent();
+    const config = Object.assign(
+      {},
+      { logger: false as const },
+      {
+        agents: {
+          testAgent: agent,
+        },
+      },
+    );
+
+    const mastra = new Mastra(config);
+
+    expect(mastra.getAgent('testAgent')).toBe(agent);
+  });
+
+  it('should handle config with getter that returns proper values', () => {
+    const agent = createTestAgent();
+
+    // Create a config with a getter
+    const config = {
+      get logger() {
+        return false as const;
+      },
+      agents: {
+        testAgent: agent,
+      },
+    };
+
+    // When spread, getters are invoked and their values are copied
+    const mastra = new Mastra({ ...config });
+
+    expect(mastra.getAgent('testAgent')).toBe(agent);
+  });
+
+  it('should handle tools with undefined values in config', () => {
+    const mastra = new Mastra({
+      logger: false,
+      tools: {
+        validTool: undefined as any,
+      },
+    });
+
+    // Should not throw during construction
+    expect(mastra).toBeDefined();
+    // Tool should not be registered (getTool throws when not found)
+    expect(() => mastra.getTool('validTool' as any)).toThrow(MastraError);
+  });
+
+  it('should handle workflows with undefined values in config', () => {
+    const mastra = new Mastra({
+      logger: false,
+      workflows: {
+        validWorkflow: undefined as any,
+      },
+    });
+
+    // Should not throw during construction
+    expect(mastra).toBeDefined();
+    // Workflow should not be registered
+    expect(() => mastra.getWorkflow('validWorkflow' as any)).toThrow(MastraError);
+  });
+});

--- a/packages/core/src/mastra/config-spread.test.ts
+++ b/packages/core/src/mastra/config-spread.test.ts
@@ -2,7 +2,7 @@ import { MockLanguageModelV1 } from '@internal/ai-sdk-v4';
 import { describe, expect, it } from 'vitest';
 import { Agent } from '../agent';
 import { MastraError } from '../error';
-import { Mastra, type Config } from './index';
+import { Mastra } from './index';
 
 /**
  * Tests for handling spread config objects in Mastra constructor.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -29,6 +29,27 @@ import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-proc
 import { createOnScorerHook } from './hooks';
 
 /**
+ * Creates an error for when a null/undefined value is passed to an add* method.
+ * This commonly occurs when config is spread ({ ...config }) and the original
+ * object had getters or non-enumerable properties.
+ */
+function createUndefinedPrimitiveError(
+  type: 'agent' | 'tool' | 'processor' | 'vector' | 'scorer' | 'workflow' | 'mcp-server' | 'gateway',
+  value: null | undefined,
+  key?: string,
+): MastraError {
+  const typeLabel = type === 'mcp-server' ? 'MCP server' : type;
+  const errorId = `MASTRA_ADD_${type.toUpperCase().replace('-', '_')}_UNDEFINED` as Uppercase<string>;
+  return new MastraError({
+    id: errorId,
+    domain: ErrorDomain.MASTRA,
+    category: ErrorCategory.USER,
+    text: `Cannot add ${typeLabel}: ${typeLabel} is ${value === null ? 'null' : 'undefined'}. This may occur if config was spread ({ ...config }) and the original object had getters or non-enumerable properties.`,
+    details: { status: 400, ...(key && { key }) },
+  });
+}
+
+/**
  * Configuration interface for initializing a Mastra instance.
  *
  * The Config interface defines all the optional components that can be registered
@@ -459,58 +480,78 @@ export class Mastra<
 
     // Now add primitives - order matters for auto-registration
     // Tools and processors should be added before agents and MCP servers that might use them
+    // Note: We validate each entry to handle cases where config was spread ({ ...config })
+    // which can cause undefined values if the source object had getters or non-enumerable properties
     if (config?.tools) {
       Object.entries(config.tools).forEach(([key, tool]) => {
-        this.addTool(tool, key);
+        if (tool != null) {
+          this.addTool(tool, key);
+        }
       });
     }
 
     if (config?.processors) {
       Object.entries(config.processors).forEach(([key, processor]) => {
-        this.addProcessor(processor, key);
+        if (processor != null) {
+          this.addProcessor(processor, key);
+        }
       });
     }
 
     if (config?.vectors) {
       Object.entries(config.vectors).forEach(([key, vector]) => {
-        this.addVector(vector, key);
+        if (vector != null) {
+          this.addVector(vector, key);
+        }
       });
     }
 
     if (config?.scorers) {
       Object.entries(config.scorers).forEach(([key, scorer]) => {
-        this.addScorer(scorer, key);
+        if (scorer != null) {
+          this.addScorer(scorer, key);
+        }
       });
     }
 
     if (config?.workflows) {
       Object.entries(config.workflows).forEach(([key, workflow]) => {
-        this.addWorkflow(workflow, key);
+        if (workflow != null) {
+          this.addWorkflow(workflow, key);
+        }
       });
     }
 
     if (config?.gateways) {
       Object.entries(config.gateways).forEach(([key, gateway]) => {
-        this.addGateway(gateway, key);
+        if (gateway != null) {
+          this.addGateway(gateway, key);
+        }
       });
     }
 
     // Add MCP servers and agents last since they might reference other primitives
     if (config?.mcpServers) {
       Object.entries(config.mcpServers).forEach(([key, server]) => {
-        this.addMCPServer(server, key);
+        if (server != null) {
+          this.addMCPServer(server, key);
+        }
       });
     }
 
     if (config?.agents) {
       Object.entries(config.agents).forEach(([key, agent]) => {
-        this.addAgent(agent, key);
+        if (agent != null) {
+          this.addAgent(agent, key);
+        }
       });
     }
 
     if (config?.tts) {
       Object.entries(config.tts).forEach(([key, tts]) => {
-        (this.#tts as Record<string, MastraTTS>)[key] = tts;
+        if (tts != null) {
+          (this.#tts as Record<string, MastraTTS>)[key] = tts;
+        }
       });
     }
 
@@ -671,6 +712,9 @@ export class Mastra<
    * ```
    */
   public addAgent<A extends Agent<any>>(agent: A, key?: string): void {
+    if (!agent) {
+      throw createUndefinedPrimitiveError('agent', agent, key);
+    }
     const agentKey = key || agent.id;
     const agents = this.#agents as Record<string, Agent<any>>;
     if (agents[agentKey]) {
@@ -844,6 +888,9 @@ export class Mastra<
    * ```
    */
   public addVector<V extends MastraVector>(vector: V, key?: string): void {
+    if (!vector) {
+      throw createUndefinedPrimitiveError('vector', vector, key);
+    }
     const vectorKey = key || vector.id;
     const vectors = this.#vectors as Record<string, MastraVector>;
     if (vectors[vectorKey]) {
@@ -1132,6 +1179,9 @@ export class Mastra<
    * ```
    */
   public addScorer<S extends MastraScorer<any, any, any, any>>(scorer: S, key?: string): void {
+    if (!scorer) {
+      throw createUndefinedPrimitiveError('scorer', scorer, key);
+    }
     const scorerKey = key || scorer.id;
     const scorers = this.#scorers as Record<string, MastraScorer<any, any, any, any>>;
     if (scorers[scorerKey]) {
@@ -1372,6 +1422,9 @@ export class Mastra<
    * ```
    */
   public addTool<T extends ToolAction<any, any, any, any>>(tool: T, key?: string): void {
+    if (!tool) {
+      throw createUndefinedPrimitiveError('tool', tool, key);
+    }
     const toolKey = key || tool.id;
     const tools = this.#tools as Record<string, ToolAction<any, any, any, any>>;
     if (tools[toolKey]) {
@@ -1520,6 +1573,9 @@ export class Mastra<
    * ```
    */
   public addProcessor<P extends Processor>(processor: P, key?: string): void {
+    if (!processor) {
+      throw createUndefinedPrimitiveError('processor', processor, key);
+    }
     const processorKey = key || processor.id;
     const processors = this.#processors as Record<string, Processor>;
     if (processors[processorKey]) {
@@ -1587,6 +1643,9 @@ export class Mastra<
    * ```
    */
   public addWorkflow<W extends Workflow<any, any, any, any, any, any>>(workflow: W, key?: string): void {
+    if (!workflow) {
+      throw createUndefinedPrimitiveError('workflow', workflow, key);
+    }
     const workflowKey = key || workflow.id;
     const workflows = this.#workflows as Record<string, Workflow<any, any, any, any, any, any>>;
     if (workflows[workflowKey]) {
@@ -1940,6 +1999,9 @@ export class Mastra<
    * ```
    */
   public addMCPServer<M extends MCPServerBase>(server: M, key?: string): void {
+    if (!server) {
+      throw createUndefinedPrimitiveError('mcp-server', server, key);
+    }
     // If a key is provided, try to set it as the ID
     // The setId method will only update if the ID wasn't explicitly set by the user
     if (key) {
@@ -2284,6 +2346,9 @@ export class Mastra<
    * ```
    */
   public addGateway(gateway: MastraModelGateway, key?: string): void {
+    if (!gateway) {
+      throw createUndefinedPrimitiveError('gateway', gateway, key);
+    }
     const gatewayKey = key || gateway.getId();
     const gateways = this.#gateways as Record<string, MastraModelGateway>;
     if (gateways[gatewayKey]) {


### PR DESCRIPTION
When config is spread (`{ ...config }`), getters or non-enumerable properties can result in undefined values. Previously this would throw cryptic errors like "Cannot read property 'name' of undefined" when the constructor tried to access `.id` on these values.

Now the constructor skips undefined/null entries during iteration, and the `add*` methods throw helpful errors if called directly with undefined:

```typescript
// Before: cryptic error
new Mastra({ ...configWithGetters });
// TypeError: Cannot read property 'id' of undefined

// After: works, or throws helpful error
new Mastra({ ...configWithGetters });
// Skips undefined entries silently

mastra.addAgent(undefined);
// MastraError: Cannot add agent: agent is undefined. This may occur if config was spread...
```

Added tests to verify the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in Mastra constructor when configs contained undefined/null entries; constructor now skips invalid entries and surfaces clear errors when undefined/null items are registered.

* **Tests**
  * Added comprehensive tests covering spread-based config shapes and edge cases for agents, tools, workflows, and related registrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->