### PR TITLE
docs: add manual install guide back to menu

### DIFF
--- a/docs/.claude/settings.local.json
+++ b/docs/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mv:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/docs/.claude/settings.local.json
+++ b/docs/.claude/settings.local.json
@@ -1,8 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(mv:*)"
-    ],
+    "allow": ["Bash(mv:*)"],
     "deny": [],
     "ask": []
   }

--- a/docs/src/content/en/docs/getting-started/manual-install.mdx
+++ b/docs/src/content/en/docs/getting-started/manual-install.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Manual Install | Guides"
+title: "Manual Install | Getting Started"
 description: Set up a Mastra project manually without using the create mastra CLI.
 ---
 
@@ -11,7 +11,7 @@ import StepItem from "@site/src/components/StepItem";
 # Manual Install
 
 :::info
-Use this guide to manually build a standalone Mastra server step by step. In most cases, it's quicker to follow the [Standalone Server Quickstart](/guides/v1/getting-started/quickstart), which achieves the same result using the [`mastra create`](/reference/v1/cli/create-mastra) command. For existing projects, you can also use [`mastra init`](/reference/v1/cli/mastra#mastra-init).
+Use this guide to manually build a standalone Mastra server step by step. In most cases, it's quicker to follow a [getting-started guide](/docs/v1/getting-started/start), which achieves the same result using the [`mastra create`](/reference/v1/cli/create-mastra) command. For existing projects, you can also use [`mastra init`](/reference/v1/cli/mastra#mastra-init).
 :::
 
 If you prefer not to use our automatic CLI tool, you can set up your project yourself by following the guide below.

--- a/docs/src/content/en/docs/index.mdx
+++ b/docs/src/content/en/docs/index.mdx
@@ -51,7 +51,7 @@ Explore real-world examples in our [community showcase](/showcase).
 
 ## Get started
 
-Choose a [getting started guide](/docs/v1/getting-started/start) to get started, or see the [manual installation guide](/guides/v1/getting-started/manual-install) if you need more control over your setup.
+Choose a [getting started guide](/docs/v1/getting-started/start) to get started, or see the [manual installation guide](/docs/v1/getting-started/manual-install) if you need more control over your setup.
 
 If you're new to AI agents, check out our [templates](https://mastra.ai/templates), [course](https://mastra.ai/course), and [YouTube videos](https://youtube.com/@mastra-ai). You can also join our [Discord](https://discord.gg/BTYqqHKUrf) community to get help and share your projects.
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -41,6 +41,11 @@ const sidebars = {
           id: "getting-started/mcp-docs-server",
           label: "MCP Docs Server",
         },
+        {
+          type: "doc",
+          id: "getting-started/manual-install",
+          label: "Manual Install",
+        },
       ],
     },
     {

--- a/docs/src/content/en/guides/getting-started/quickstart.mdx
+++ b/docs/src/content/en/guides/getting-started/quickstart.mdx
@@ -13,7 +13,7 @@ import { VideoPlayer } from "@site/src/components/video-player";
 
 The `create mastra` CLI command is the quickest way to get started. It walks you through setup and creates example agents, workflows, and tools for you to run locally or adapt
 
-If you need more control over the setup, see the [manual installation guide](/guides/v1/getting-started/manual-install). You can also use [`mastra init`](/reference/v1/cli/mastra#mastra-init) for existing projects.
+If you need more control over the setup, see the [manual installation guide](/docs/v1/getting-started/manual-install). You can also use [`mastra init`](/reference/v1/cli/mastra#mastra-init) for existing projects.
 
 ## Before you begin
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -147,7 +147,12 @@
     },
     {
       "source": "/guides/v1/guide/manual-install",
-      "destination": "/guides/v1/getting-started/manual-install",
+      "destination": "/docs/v1/getting-started/manual-install",
+      "permanent": true
+    },
+    {
+      "source": "/guides/v1/getting-started/manual-install",
+      "destination": "/docs/v1/getting-started/manual-install",
       "permanent": true
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized getting-started guides within documentation structure.
  * Updated manual installation guide title, references and navigation links.
  * Added manual installation guide to Getting Started sidebar.
  * Implemented redirects for legacy guide URLs to new documentation paths.

* **Chores**
  * Added local documentation settings file for tooling configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->