### PR TITLE
fix auth when using studio by checking if accessing non protected paths

### DIFF
--- a/.changeset/eight-carrots-strive.md
+++ b/.changeset/eight-carrots-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix dev playground auth to allow non-protected paths to bypass authentication when `MASTRA_DEV=true`, while still requiring the `x-mastra-dev-playground` header for protected endpoints

--- a/packages/deployer/src/server/handlers/auth/helpers.ts
+++ b/packages/deployer/src/server/handlers/auth/helpers.ts
@@ -2,8 +2,12 @@ import type { MastraAuthConfig } from '@mastra/core/server';
 import type { HonoRequest } from 'hono';
 import { defaultAuthConfig } from './defaults';
 
-export const isDevPlaygroundRequest = (req: HonoRequest): boolean => {
-  return req.header('x-mastra-dev-playground') === 'true' && process.env.MASTRA_DEV === 'true';
+export const isDevPlaygroundRequest = (req: HonoRequest, authConfig: MastraAuthConfig): boolean => {
+  const protectedAccess = [...(defaultAuthConfig.protected || []), ...(authConfig.protected || [])];
+  return (
+    process.env.MASTRA_DEV === 'true' &&
+    (!isAnyMatch(req.path, req.method, protectedAccess) || req.header('x-mastra-dev-playground') === 'true')
+  );
 };
 
 export const isCustomRoutePublic = (

--- a/packages/deployer/src/server/handlers/auth/index.ts
+++ b/packages/deployer/src/server/handlers/auth/index.ts
@@ -13,7 +13,7 @@ export const authenticationMiddleware = async (c: ContextWithMastra, next: Next)
     return next();
   }
 
-  if (isDevPlaygroundRequest(c.req)) {
+  if (isDevPlaygroundRequest(c.req, authConfig)) {
     // Skip authentication for dev playground requests
     return next();
   }
@@ -78,7 +78,7 @@ export const authorizationMiddleware = async (c: ContextWithMastra, next: Next) 
   const path = c.req.path;
   const method = c.req.method;
 
-  if (isDevPlaygroundRequest(c.req)) {
+  if (isDevPlaygroundRequest(c.req, authConfig)) {
     // Skip authorization for dev playground requests
     return next();
   }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR fixes an issue where using auth and accessing studio would cause an authentication failure. This PR fixes that by checking whether MASTRA_DEV is true, and either accessing an unprotected path, or if the `x-mastra-dev-playground` header is set.
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development playground authentication behavior: when MASTRA_DEV is enabled, the authentication system now correctly distinguishes between protected and non-protected endpoints. Non-protected paths bypass authentication requirements, while protected endpoints continue to enforce authentication verification through the required header to ensure secure development-mode access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->