### PR TITLE
docs/add-cloudflare-env

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -125,6 +125,8 @@ Create a `.env` file in the root directory with the following content:
 OPENAI_API_KEY=
 COHERE_API_KEY=
 PINECONE_API_KEY=
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_API_TOKEN=
 DB_URL=postgresql://postgres:postgres@localhost:5432/mastra
 ```
 


### PR DESCRIPTION
New contributors may run `pnpm test:combined-stores` and face failures or confusion because Cloudflare creds are needed for `stores/vectorize/index.test.ts`, but this wasn't documented.

This PR adds:
- `CLOUDFLARE_ACCOUNT_ID`
- `CLOUDFLARE_API_TOKEN`

to avoid onboarding friction and make test setup clearer for new contributors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded development setup guidance with additional environment variable configuration examples required for complete platform integration setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->