### PR TITLE
fix(core): normalize undefined/null input for tools with optional parameters

### DIFF
--- a/.changeset/fair-snakes-remain.md
+++ b/.changeset/fair-snakes-remain.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+When LLMs like Claude Sonnet 4.5 and Gemini 2.4 call tools with all-optional parameters, they send `args: undefined` instead of `args: {}`. This caused validation to fail with "root: Required".
+
+The fix normalizes `undefined`/`null` to `{}` for object schemas and `[]` for array schemas before validation.

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -566,6 +566,46 @@ describe('Tool Input Validation Integration Tests', () => {
       expect(result.error).toBe(true);
       expect(result.message).toContain('Tool input validation failed');
     });
+
+    it('should accept undefined input when schema is an array', async () => {
+      const tool = createTool({
+        id: 'array-schema',
+        description: 'Tool with array schema',
+        inputSchema: z.array(
+          z.object({
+            id: z.string().optional(),
+          }),
+        ),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // LLM might send undefined for an array schema too
+      const result = await tool.execute!(undefined as any);
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.receivedArgs).toEqual([]);
+    });
+
+    it('should accept null input when schema is an array', async () => {
+      const tool = createTool({
+        id: 'array-schema-null',
+        description: 'Tool with array schema',
+        inputSchema: z.array(z.string()),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // LLM might send null for an array schema
+      const result = await tool.execute!(null as any);
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.receivedArgs).toEqual([]);
+    });
   });
 
   describe('Edge cases', () => {

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -406,6 +406,168 @@ describe('Tool Input Validation Integration Tests', () => {
     });
   });
 
+  describe('All-optional parameters', () => {
+    it('should accept undefined input when all parameters are optional', async () => {
+      const tool = createTool({
+        id: 'all-optional-tool',
+        description: 'Tool with all optional parameters',
+        inputSchema: z.object({
+          startTime: z.string().optional(),
+          endTime: z.string().optional(),
+          limit: z.number().optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // Simulate LLM sending undefined (as Claude Sonnet 4.5, Gemini 2.4 do)
+      const result = await tool.execute!(undefined);
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.receivedArgs).toEqual({});
+    });
+
+    it('should accept null input when all parameters are optional', async () => {
+      const tool = createTool({
+        id: 'all-optional-null',
+        description: 'Tool with all optional parameters',
+        inputSchema: z.object({
+          filter: z.string().optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // Some LLMs might send null instead of undefined
+      const result = await tool.execute!(null as any);
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.receivedArgs).toEqual({});
+    });
+
+    it('should accept empty object input when all parameters are optional', async () => {
+      const tool = createTool({
+        id: 'all-optional-empty',
+        description: 'Tool with all optional parameters',
+        inputSchema: z.object({
+          startTime: z.string().optional(),
+          endTime: z.string().optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // Empty object should work (this already works, but good to verify)
+      const result = await tool.execute!({});
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.receivedArgs).toEqual({});
+    });
+
+    it('should still validate when partial args are provided with all-optional schema', async () => {
+      const tool = createTool({
+        id: 'partial-optional',
+        description: 'Tool with all optional parameters',
+        inputSchema: z.object({
+          startTime: z.string().optional(),
+          limit: z.number().optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // Providing some args should still work
+      const result = await tool.execute!({ limit: 10 });
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.receivedArgs).toEqual({ limit: 10 });
+    });
+
+    it('should still reject invalid types even with undefined-to-empty normalization', async () => {
+      const tool = createTool({
+        id: 'optional-type-check',
+        description: 'Tool with all optional parameters',
+        inputSchema: z.object({
+          limit: z.number().optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // Invalid type should still fail
+      const result = await tool.execute!({ limit: 'not-a-number' } as any);
+
+      expect(result.error).toBe(true);
+      expect(result.message).toContain('Tool input validation failed');
+    });
+
+    it('should reject array input when object schema is expected', async () => {
+      const tool = createTool({
+        id: 'object-not-array',
+        description: 'Tool expecting object, not array',
+        inputSchema: z.object({
+          items: z.array(z.string()).optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // Array should NOT be normalized to {} - it should fail validation
+      const result = await tool.execute!(['item1', 'item2'] as any);
+
+      expect(result.error).toBe(true);
+      expect(result.message).toContain('Tool input validation failed');
+    });
+
+    it('should reject string input when object schema is expected', async () => {
+      const tool = createTool({
+        id: 'object-not-string',
+        description: 'Tool expecting object, not string',
+        inputSchema: z.object({
+          name: z.string().optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // String should NOT be normalized to {} - it should fail validation
+      const result = await tool.execute!('some string' as any);
+
+      expect(result.error).toBe(true);
+      expect(result.message).toContain('Tool input validation failed');
+    });
+
+    it('should reject number input when object schema is expected', async () => {
+      const tool = createTool({
+        id: 'object-not-number',
+        description: 'Tool expecting object, not number',
+        inputSchema: z.object({
+          count: z.number().optional(),
+        }),
+        execute: async inputData => {
+          return { success: true, receivedArgs: inputData };
+        },
+      });
+
+      // Number should NOT be normalized to {} - it should fail validation
+      const result = await tool.execute!(42 as any);
+
+      expect(result.error).toBe(true);
+      expect(result.message).toContain('Tool input validation failed');
+    });
+  });
+
   describe('Edge cases', () => {
     it('should handle tools without input schema', async () => {
       const tool = createTool({
@@ -416,7 +578,7 @@ describe('Tool Input Validation Integration Tests', () => {
         },
       });
 
-      const result = await tool.execute({ anything: 'goes' } as any);
+      const result = await tool.execute!({ anything: 'goes' } as any);
 
       expect(result.error).toBeUndefined();
       expect(result.received).toEqual({ anything: 'goes' });

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import { z } from 'zod';
 import type { ZodLikeSchema } from '../types/zod-compat';
 
 export interface ValidationError<T = any> {
@@ -65,6 +65,34 @@ export function validateToolSuspendData<T = any>(
 }
 
 /**
+ * Normalizes undefined/null input to an appropriate default value based on schema type.
+ * This handles LLMs (Claude Sonnet 4.5, Gemini 2.4, etc.) that send undefined/null
+ * instead of {} or [] when all parameters are optional.
+ *
+ * @param schema The Zod schema to check
+ * @param input The input to normalize
+ * @returns The normalized input (original value, {}, or [])
+ */
+function normalizeNullishInput(schema: ZodLikeSchema, input: unknown): unknown {
+  if (input !== undefined && input !== null) {
+    return input;
+  }
+
+  // Check if schema is an array type
+  if (schema instanceof z.ZodArray) {
+    return [];
+  }
+
+  // Check if schema is an object type
+  if (schema instanceof z.ZodObject) {
+    return {};
+  }
+
+  // For other schema types, return the original input and let Zod validate
+  return input;
+}
+
+/**
  * Validates raw input data against a Zod schema.
  *
  * @param schema The Zod schema to validate against
@@ -82,8 +110,12 @@ export function validateToolInput<T = any>(
     return { data: input };
   }
 
-  // Validate the input directly - no unwrapping needed in v1.0
-  const validation = schema.safeParse(input);
+  // Normalize undefined/null input to appropriate default for the schema type
+  // This handles LLMs that send undefined instead of {} or [] for optional parameters
+  const normalizedInput = normalizeNullishInput(schema, input);
+
+  // Validate the normalized input
+  const validation = schema.safeParse(normalizedInput);
 
   if (validation.success) {
     return { data: validation.data };


### PR DESCRIPTION
When LLMs like Claude Sonnet 4.5 and Gemini 2.4 call tools with all-optional parameters, they send `args: undefined` instead of `args: {}`. This caused validation to fail with "root: Required".

Before:
```typescript
const tool = createTool({
  id: 'fetch_data',
  inputSchema: z.object({
    limit: z.number().optional(),
  }),
  execute: async (args) => ({ args }),
});

await tool.execute(undefined);
// ❌ Error: "Tool validation failed... root: Required"
```

After:
```typescript
await tool.execute(undefined);
// ✅ { args: {} }
```

The fix normalizes `undefined`/`null` to `{}` for object schemas and `[]` for array schemas before validation.

Fixes #10031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed validation failures when tools with all-optional parameters are invoked without arguments or with null/undefined values. Previously, these calls would fail with validation errors. The system now properly normalizes missing or null parameters before validation, ensuring successful tool execution while maintaining strict validation for genuinely invalid inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->