### PR TITLE
feat(workflows): add suspendData parameter to workflow steps

### DIFF
--- a/.changeset/fancy-parrots-tickle.md
+++ b/.changeset/fancy-parrots-tickle.md
@@ -1,0 +1,29 @@
+---
+'@mastra/core': minor
+---
+
+feat(workflows): add suspendData parameter to step execute function
+
+Adds a new `suspendData` parameter to workflow step execute functions that provides access to the data originally passed to `suspend()` when the step was suspended. This enables steps to access context about why they were suspended when they are later resumed.
+
+**New Features:**
+- `suspendData` parameter automatically populated in step execute function when resuming
+- Type-safe access to suspend data matching the step's `suspendSchema`
+- Backward compatible - existing workflows continue to work unchanged
+
+**Example:**
+```typescript
+const step = createStep({
+  suspendSchema: z.object({ reason: z.string() }),
+  resumeSchema: z.object({ approved: z.boolean() }),
+  execute: async ({ suspend, suspendData, resumeData }) => {
+    if (!resumeData?.approved) {
+      return await suspend({ reason: "Approval required" });
+    }
+    
+    // Access original suspend data when resuming
+    console.log(`Resuming after: ${suspendData?.reason}`);
+    return { result: "Approved" };
+  }
+});
+```

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -93,6 +93,50 @@ midnight.setUTCHours(24, 0, 0, 0);
 setTimeout(handleResume, midnight.getTime() - Date.now());
 ```
 
+## Accessing suspend data with `suspendData`
+When a step is suspended, you may want to access the data that was provided to `suspend()` when the step is later resumed. Use the `suspendData` parameter in your step's execute function to access this data.
+
+```typescript {22-25,29-30} title="src/mastra/workflows/user-approval.ts" showLineNumbers copy
+const approvalStep = createStep({
+  id: "user-approval",
+  inputSchema: z.object({
+    requestId: z.string()
+  }),
+  resumeSchema: z.object({
+    approved: z.boolean()
+  }),
+  suspendSchema: z.object({
+    reason: z.string(),
+    requestDetails: z.string()
+  }),
+  outputSchema: z.object({
+    result: z.string()
+  }),
+  execute: async ({ inputData, resumeData, suspend, suspendData }) => {
+    const { requestId } = inputData;
+    const { approved } = resumeData ?? {};
+    
+    // On first execution, suspend with context
+    if (!approved) {
+      return await suspend({
+        reason: "User approval required",
+        requestDetails: `Request ${requestId} pending review`
+      });
+    }
+    
+    // On resume, access the original suspend data
+    const suspendReason = suspendData?.reason || "Unknown";
+    const details = suspendData?.requestDetails || "No details";
+    
+    return {
+      result: `${details} - ${suspendReason} - Decision: ${approved ? 'Approved' : 'Rejected'}`
+    };
+  }
+});
+```
+
+The `suspendData` parameter is automatically populated when a step is resumed and contains the exact data that was passed to the `suspend()` function during the original suspension. This allows you to maintain context about why the workflow was suspended and use that information during the resume process.
+
 ## Identifying suspended executions
 
 When a workflow is suspended, it restarts from the step where it paused. You can check the workflow's `status` to confirm it's suspended, and use `suspended` to identify the paused step or [nested workflow](/docs/v1/workflows/overview#workflows-as-steps).

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -104,6 +104,12 @@ const step1 = createStep({
         "The resume data matching the resumeSchema, when resuming the step from a suspended state. Only exists if the step is being resumed.",
     },
     {
+      name: "suspendData",
+      type: "z.infer<TSuspendSchema>",
+      description:
+        "The suspend data that was originally passed to suspend() when the step was suspended. Only exists if the step is being resumed and was previously suspended with data.",
+    },
+    {
       name: "mastra",
       type: "Mastra",
       description: "Access to Mastra services (agents, tools, etc.)",

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -76,7 +76,7 @@ export class StepExecutor extends MastraBase {
     let suspendDataToUse =
       params.stepResults[step.id]?.status === 'suspended' ? params.stepResults[step.id]?.suspendPayload : undefined;
 
-    // Filter out internal workflow metadata (similar to line 70 for resumePayload)
+    // Filter out internal workflow metadata before exposing to step code
     if (suspendDataToUse && '__workflow_meta' in suspendDataToUse) {
       const { __workflow_meta, ...userSuspendData } = suspendDataToUse;
       suspendDataToUse = userSuspendData;

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -109,6 +109,16 @@ export async function executeStep(
     resumeDataToUse = resume?.resumePayload;
   }
 
+  // Extract suspend data if this step was previously suspended
+  let suspendDataToUse =
+    stepResults[step.id]?.status === 'suspended' ? stepResults[step.id]?.suspendPayload : undefined;
+
+  // Filter out internal workflow metadata before exposing to step code
+  if (suspendDataToUse && '__workflow_meta' in suspendDataToUse) {
+    const { __workflow_meta, ...userSuspendData } = suspendDataToUse;
+    suspendDataToUse = userSuspendData;
+  }
+
   const startTime = resumeDataToUse ? undefined : Date.now();
   const resumeTime = resumeDataToUse ? Date.now() : undefined;
 
@@ -251,6 +261,7 @@ export async function executeStep(
         },
         retryCount,
         resumeData: resumeDataToUse,
+        suspendData: suspendDataToUse,
         tracingContext: { currentSpan: stepSpan },
         getInitData: () => stepResults?.input as any,
         getStepResult: getStepResult.bind(null, stepResults),

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -24,6 +24,7 @@ export type ExecuteFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSch
   state: TState;
   setState(state: TState): void;
   resumeData?: TResumeSchema;
+  suspendData?: TSuspendSchema;
   retryCount: number;
   tracingContext: TracingContext;
   getInitData<T extends z.ZodType<any>>(): z.infer<T>;

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -17038,4 +17038,132 @@ describe('Workflow', () => {
       expect(typedStep).toBeDefined();
     });
   });
+
+  describe('Suspend Data Access', () => {
+    it('should provide access to suspendData in workflow step on resume', async () => {
+      const mastra = new Mastra({
+        logger: false,
+        storage: testStorage,
+      });
+
+      const suspendDataAccess = createStep({
+        id: 'suspend-data-access-test',
+        inputSchema: z.object({
+          value: z.string(),
+        }),
+        resumeSchema: z.object({
+          confirm: z.boolean(),
+        }),
+        suspendSchema: z.object({
+          reason: z.string(),
+          originalValue: z.string(),
+        }),
+        outputSchema: z.object({
+          result: z.string(),
+          wasResumed: z.boolean(),
+          suspendReason: z.string().optional(),
+        }),
+        execute: async ({ inputData, resumeData, suspend, suspendData }) => {
+          const { value } = inputData;
+          const { confirm } = resumeData ?? {};
+
+          // On first execution, suspend with context
+          if (!confirm) {
+            return await suspend({
+              reason: 'User confirmation required',
+              originalValue: value,
+            });
+          }
+
+          // On resume, we can now access the suspend data!
+          const suspendReason = suspendData?.reason || 'Unknown';
+          const originalValue = suspendData?.originalValue || 'Unknown';
+
+          return {
+            result: `Processed ${originalValue} after ${suspendReason}`,
+            wasResumed: true,
+            suspendReason,
+          };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'suspend-data-test-workflow',
+        mastra,
+        inputSchema: z.object({
+          value: z.string(),
+        }),
+        outputSchema: z.object({
+          result: z.string(),
+          wasResumed: z.boolean(),
+          suspendReason: z.string().optional(),
+        }),
+      });
+
+      workflow.then(suspendDataAccess).commit();
+
+      const run = await workflow.createRun();
+
+      // Start the workflow - should suspend
+      const initialResult = await run.start({
+        inputData: { value: 'test-value' },
+      });
+
+      expect(initialResult.status).toBe('suspended');
+
+      // Resume the workflow with confirmation
+      const resumedResult = await run.resume({
+        step: suspendDataAccess,
+        resumeData: { confirm: true },
+      });
+
+      expect(resumedResult.status).toBe('success');
+      expect(resumedResult.result.suspendReason).toBe('User confirmation required');
+      expect(resumedResult.result.result).toBe('Processed test-value after User confirmation required');
+    });
+
+    it('should handle missing suspendData gracefully', async () => {
+      const mastra = new Mastra({
+        logger: false,
+        storage: testStorage,
+      });
+
+      const stepWithoutSuspend = createStep({
+        id: 'no-suspend-step',
+        inputSchema: z.object({
+          value: z.string(),
+        }),
+        outputSchema: z.object({
+          result: z.string(),
+        }),
+        execute: async ({ inputData, suspendData }) => {
+          // Should handle missing suspendData gracefully
+          const message = suspendData ? 'Had suspend data' : 'No suspend data';
+          return { result: `${inputData.value}: ${message}` };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'no-suspend-workflow',
+        mastra,
+        inputSchema: z.object({
+          value: z.string(),
+        }),
+        outputSchema: z.object({
+          result: z.string(),
+        }),
+      });
+
+      workflow.then(stepWithoutSuspend).commit();
+
+      const run = await workflow.createRun();
+
+      const result = await run.start({
+        inputData: { value: 'test' },
+      });
+
+      expect(result.status).toBe('success');
+      expect(result.result.result).toBe('test: No suspend data');
+    });
+  });
 });


### PR DESCRIPTION
## Description

Allow steps to access the original data passed to suspend() when resumed. The suspendData parameter is automatically populated during step resumption and contains the exact data from the initial suspension, enabling workflows to maintain context about why they were suspended.

Implementation:
- Extract suspendData from step results when status is 'suspended'
- Filter out internal __workflow_meta before exposing to user code
- Add suspendData to ExecuteFunctionParams type
- Update both evented and standard step executors

Includes documentation with usage examples and tests verifying correct access to suspend data and graceful handling when not present.

## Related Issue(s)

fix https://github.com/mastra-ai/mastra/issues/8039

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Steps now receive suspendData when a suspended step is resumed, letting workflows access the original suspend payload and preserve context across suspend/resume.

* **Documentation**
  * Added guidance and a TypeScript example showing how to store context when suspending and consume suspendData on resume.

* **Tests**
  * Added tests verifying suspendData propagation on resume and graceful handling when suspendData is absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->