### PR TITLE
fix(core): return processed text in result.text when using output processors

### DIFF
--- a/.changeset/nine-tables-smoke.md
+++ b/.changeset/nine-tables-smoke.md
@@ -1,0 +1,23 @@
+---
+'@mastra/core': patch
+---
+
+When using output processors with `agent.generate()`, `result.text` was returning the unprocessed LLM response instead of the processed text.
+
+**Before:**
+
+```ts
+const result = await agent.generate('hello');
+result.text; // "hello world" (unprocessed)
+result.response.messages[0].content[0].text; // "HELLO WORLD" (processed)
+```
+
+**After:**
+
+```ts
+const result = await agent.generate('hello');
+result.text; // "HELLO WORLD" (processed)
+result.object; // also now reflects processed values for structured output
+```
+
+The bug was caused by the `text` delayed promise being resolved twice - first correctly with the processed text, then overwritten with the unprocessed buffered text. Also moved `object` resolution to the finish step so structured output can also be processed.

--- a/packages/core/src/agent/agent-processor.test.ts
+++ b/packages/core/src/agent/agent-processor.test.ts
@@ -680,6 +680,84 @@ describe('Input and Output Processors', () => {
       expect((result.response.messages[0].content[0] as any).text).toBe('HELLO WORLD');
     });
 
+    it('should apply output processor modifications to result.text with structured output', async () => {
+      class JsonModifyingProcessor implements Processor {
+        readonly id = 'json-modifying-processor';
+        readonly name = 'JSON Modifying Processor';
+
+        async processOutputResult({ messages }) {
+          return messages.map(msg => ({
+            ...msg,
+            content: {
+              ...msg.content,
+              parts: msg.content.parts.map(part => {
+                if (part.type === 'text') {
+                  try {
+                    const data = JSON.parse(part.text);
+                    // Transform the name to uppercase
+                    const modified = { ...data, name: data.name.toUpperCase() };
+                    return { ...part, text: JSON.stringify(modified) };
+                  } catch {
+                    return part;
+                  }
+                }
+                return part;
+              }),
+            },
+          }));
+        }
+      }
+
+      const agent = new Agent({
+        id: 'structured-output-processor-test-agent',
+        name: 'Structured Output Processor Test Agent',
+        instructions: 'You are a helpful assistant.',
+        model: new MockLanguageModelV2({
+          doGenerate: async () => ({
+            content: [
+              {
+                type: 'text',
+                text: '{"name": "John", "age": 30}',
+              },
+            ],
+            finishReason: 'stop',
+            usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          }),
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: '{"name": "John", "age": 30}' },
+              { type: 'text-end', id: '1' },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+            ]),
+          }),
+        }),
+        outputProcessors: [new JsonModifyingProcessor()],
+      });
+
+      const result = await agent.generate('Get user info', {
+        structuredOutput: {
+          schema: z.object({
+            name: z.string(),
+            age: z.number(),
+          }),
+        },
+      });
+
+      // result.text should contain the PROCESSED JSON (name transformed to uppercase)
+      expect(result.text).toContain('JOHN');
+
+      // result.object should also contain the PROCESSED values
+      // (parsed from the processed text after output processors run)
+      expect(result.object).toBeDefined();
+      expect(result.object?.name).toBe('JOHN');
+      expect(result.object?.age).toBe(30);
+    });
+
     it('should process messages through multiple output processors in sequence', async () => {
       let finalProcessedText = '';
 


### PR DESCRIPTION
When using output processors with `agent.generate()`, `result.text` was returning the unprocessed LLM response instead of the processed text.

**Before:**
```ts
const result = await agent.generate('hello');
result.text // "hello world" (unprocessed)
result.response.messages[0].content[0].text // "HELLO WORLD" (processed)
```

**After:**
```ts
const result = await agent.generate('hello');
result.text // "HELLO WORLD" (processed)
result.object // also now reflects processed values for structured output
```

The bug was caused by the `text` delayed promise being resolved twice - first correctly with the processed text, then overwritten with the unprocessed buffered text. Also moved `object` resolution to the finish step so structured output can also be processed.

Fixes #9916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * result.text now reliably returns the final processed text and structured outputs reflect processor-modified values by deferring object resolution until processing completes.

* **Refactor**
  * Consolidated output validation into a single, consistent validation pathway for schema-backed outputs.

* **Tests**
  * Added tests verifying processor transformations for both plain text and structured (JSON-like) outputs.

* **Changelog**
  * Added a patch entry documenting the output processing fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->