### PR TITLE
fix -- preserve tool calls aisdk convert

### DIFF
--- a/packages/core/src/agent/message-list/utils/convert-messages.test.ts
+++ b/packages/core/src/agent/message-list/utils/convert-messages.test.ts
@@ -163,4 +163,283 @@ describe('convertMessages', () => {
       }).toThrow('Unsupported output format: INVALID');
     });
   });
+
+  /**
+   * Regression tests for GitHub Issue #10386
+   * https://github.com/mastra-ai/mastra/issues/10386
+   *
+   * Problem: When users pass messages in OpenAI format (with `tool_calls` array
+   * and `tool_call_id` properties), the convertMessages function drops the tool
+   * information entirely.
+   *
+   * Note: AIV5.Model conversion may produce more messages than the input
+   * because it splits tool calls and tool results into separate messages.
+   * The key assertion is that tool information is PRESERVED, not that
+   * message counts match exactly.
+   */
+  describe('OpenAI format tool messages (Issue #10386)', () => {
+    /**
+     * OpenAI format message types
+     * These match the format users would have stored in their existing databases
+     */
+    interface OpenAIAssistantMessage {
+      role: 'assistant';
+      content: string;
+      tool_calls?: {
+        id: string;
+        type: 'function';
+        function: {
+          name: string;
+          arguments: string;
+        };
+      }[];
+    }
+
+    interface OpenAIToolMessage {
+      role: 'tool';
+      content: string;
+      tool_call_id: string;
+    }
+
+    interface OpenAIUserMessage {
+      role: 'user';
+      content: string | { type: 'text'; text: string }[];
+    }
+
+    type OpenAIMessage = OpenAIAssistantMessage | OpenAIToolMessage | OpenAIUserMessage;
+
+    it('should preserve tool_calls from assistant messages', () => {
+      // This is the exact format from the issue reporter's example
+      const openAIMessages: OpenAIMessage[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Tell me about xyz' }],
+        },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_ZgjQ5HRiLUttzf4NFeTWYJd5',
+              type: 'function',
+              function: {
+                name: 'wikiSearchTool',
+                arguments: '{"query":"xyz"}',
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: JSON.stringify([{ content: 'No content was found' }]),
+          tool_call_id: 'call_ZgjQ5HRiLUttzf4NFeTWYJd5',
+        },
+      ];
+
+      const result = convertMessages(openAIMessages as any).to('AIV5.Model');
+
+      // Find the tool call with the expected toolName
+      let toolCallPart: AIV5.ToolCallPart | undefined;
+      for (const msg of result) {
+        if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+          for (const part of msg.content) {
+            if (part.type === 'tool-call' && part.toolName === 'wikiSearchTool') {
+              toolCallPart = part;
+            }
+          }
+        }
+      }
+
+      expect(toolCallPart).toBeDefined();
+      expect(toolCallPart?.toolCallId).toBe('call_ZgjQ5HRiLUttzf4NFeTWYJd5');
+      expect(toolCallPart?.input).toEqual({ query: 'xyz' });
+
+      // Find the tool result with the expected toolCallId
+      let toolResultPart: AIV5.ToolResultPart | undefined;
+      for (const msg of result) {
+        if (msg.role === 'tool' && Array.isArray(msg.content)) {
+          for (const part of msg.content) {
+            if (part.type === 'tool-result' && part.toolCallId === 'call_ZgjQ5HRiLUttzf4NFeTWYJd5') {
+              toolResultPart = part;
+            }
+          }
+        }
+      }
+
+      expect(toolResultPart).toBeDefined();
+    });
+
+    it('should handle multiple sequential tool calls in OpenAI format', () => {
+      const openAIMessages: OpenAIMessage[] = [
+        {
+          role: 'user',
+          content: 'Search for apples and oranges',
+        },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: {
+                name: 'search',
+                arguments: '{"query":"apples"}',
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: 'Results for apples',
+          tool_call_id: 'call_1',
+        },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_2',
+              type: 'function',
+              function: {
+                name: 'search',
+                arguments: '{"query":"oranges"}',
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: 'Results for oranges',
+          tool_call_id: 'call_2',
+        },
+        {
+          role: 'assistant',
+          content: 'Here is what I found about apples and oranges...',
+        },
+      ];
+
+      const result = convertMessages(openAIMessages as any).to('AIV5.Model');
+
+      // Find all tool calls in the result
+      const allToolCalls: AIV5.ToolCallPart[] = [];
+      for (const msg of result) {
+        if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+          for (const part of msg.content) {
+            if (part.type === 'tool-call') {
+              allToolCalls.push(part as AIV5.ToolCallPart);
+            }
+          }
+        }
+      }
+
+      // Should have both tool calls (may have duplicates from conversion)
+      expect(allToolCalls.length).toBeGreaterThanOrEqual(2);
+      expect(allToolCalls.some(tc => tc.toolCallId === 'call_1')).toBe(true);
+      expect(allToolCalls.some(tc => tc.toolCallId === 'call_2')).toBe(true);
+
+      // Find all tool results in the result
+      const allToolResults: AIV5.ToolResultPart[] = [];
+      for (const msg of result) {
+        if (msg.role === 'tool' && Array.isArray(msg.content)) {
+          for (const part of msg.content) {
+            if (part.type === 'tool-result') {
+              allToolResults.push(part as AIV5.ToolResultPart);
+            }
+          }
+        }
+      }
+
+      // Should have both tool results (may have duplicates from conversion)
+      expect(allToolResults.length).toBeGreaterThanOrEqual(2);
+      expect(allToolResults.some(tr => tr.toolCallId === 'call_1')).toBe(true);
+      expect(allToolResults.some(tr => tr.toolCallId === 'call_2')).toBe(true);
+
+      // Final assistant message should have text content
+      const textMessages = result.filter(
+        msg =>
+          msg.role === 'assistant' &&
+          Array.isArray(msg.content) &&
+          msg.content.some(part => part.type === 'text' && part.text.includes('apples and oranges')),
+      );
+      expect(textMessages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should roundtrip OpenAI format through Mastra.V2 storage', () => {
+      const openAIMessages: OpenAIMessage[] = [
+        {
+          role: 'user',
+          content: 'What is the weather?',
+        },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              type: 'function',
+              function: {
+                name: 'getWeather',
+                arguments: '{"location":"New York"}',
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: '{"temp": 72, "condition": "sunny"}',
+          tool_call_id: 'call_weather',
+        },
+      ];
+
+      // First convert to Mastra.V2 (database storage format)
+      const dbMessages = convertMessages(openAIMessages as any).to('Mastra.V2');
+
+      // Verify tool invocation is stored in DB format
+      expect(dbMessages.length).toBeGreaterThanOrEqual(2);
+
+      // Find the message with tool invocation
+      const dbMsgWithToolCall = dbMessages.find(
+        msg =>
+          msg.content.toolInvocations?.some(ti => ti.toolCallId === 'call_weather') ||
+          msg.content.parts?.some(p => p.type === 'tool-invocation' && p.toolInvocation?.toolCallId === 'call_weather'),
+      );
+      expect(dbMsgWithToolCall).toBeDefined();
+
+      // Then convert back to AIV5.Model (for sending to LLM)
+      const modelMessages = convertMessages(dbMessages).to('AIV5.Model');
+
+      // Find the tool call in model messages
+      let foundToolCall: AIV5.ToolCallPart | undefined;
+      for (const msg of modelMessages) {
+        if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+          const tc = msg.content.find(part => part.type === 'tool-call') as AIV5.ToolCallPart | undefined;
+          if (tc?.toolCallId === 'call_weather') {
+            foundToolCall = tc;
+            break;
+          }
+        }
+      }
+
+      expect(foundToolCall).toBeDefined();
+      expect(foundToolCall?.toolCallId).toBe('call_weather');
+      expect(foundToolCall?.toolName).toBe('getWeather');
+      expect(foundToolCall?.input).toEqual({ location: 'New York' });
+
+      // Find the tool result in model messages
+      let foundToolResult: AIV5.ToolResultPart | undefined;
+      for (const msg of modelMessages) {
+        if (msg.role === 'tool' && Array.isArray(msg.content)) {
+          const tr = msg.content.find(part => part.type === 'tool-result') as AIV5.ToolResultPart | undefined;
+          if (tr?.toolCallId === 'call_weather') {
+            foundToolResult = tr;
+            break;
+          }
+        }
+      }
+
+      expect(foundToolResult).toBeDefined();
+      expect(foundToolResult?.toolCallId).toBe('call_weather');
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR fixes an issue where messages in OpenAI's raw API format (with `tool_calls` array and `tool_call_id` properties) were having their tool information dropped during message conversion.

When users pass messages stored in OpenAI format to `convertMessages()`, the function was not recognizing the OpenAI-specific tool format and was treating these messages as regular content messages, causing tool calls and tool results to be lost.

**Changes:**
- Added type definitions for OpenAI format messages (`OpenAIToolCall`, `OpenAIAssistantMessageWithToolCalls`, `OpenAIToolResultMessage`)
- Added detection methods (`hasOpenAIToolCalls`, `hasOpenAIToolCallId`, `hasOpenAIToolFormat`) to identify OpenAI-formatted messages
- Added `openAIToolFormatToMastraDBMessage()` converter that properly transforms OpenAI format tool messages into Mastra's internal format with correct `tool-invocation` parts
- Updated `isAIV4CoreMessage` and `isAIV5CoreMessage` type guards to exclude OpenAI format messages to ensure proper routing
- Added comprehensive regression tests covering single tool calls, multiple sequential tool calls, and roundtrip through Mastra.V2 storage

## Related Issue(s)

#10386

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works