### PR TITLE
Seo: fix empty links in v0 docs

### DIFF
--- a/docs/src/theme/MDXComponents/Heading.tsx
+++ b/docs/src/theme/MDXComponents/Heading.tsx
@@ -1,7 +1,42 @@
-import React, { type ReactNode } from "react";
-import Heading from "@theme/Heading";
-import type { Props } from "@theme/MDXComponents/Heading";
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useAnchorTargetClassName} from '@docusaurus/theme-common';
+import Link from '@docusaurus/Link';
+import useBrokenLinks from '@docusaurus/useBrokenLinks';
 
-export default function MDXHeading(props: Props): ReactNode {
-  return <Heading {...props} />;
+export default function Heading({as: As, id, ...props}) {
+  const brokenLinks = useBrokenLinks();
+  const anchorTargetClassName = useAnchorTargetClassName(id);
+  // H1 headings do not need an id because they don't appear in the TOC.
+  if (As === 'h1' || !id) {
+    return <As {...props} id={undefined} />;
+  }
+  brokenLinks.collectAnchor(id);
+  const anchorTitle = translate(
+    {
+      id: 'theme.common.headingLinkTitle',
+      message: 'Direct link to {heading}',
+      description: 'Title for link to heading',
+    },
+    {
+      heading: typeof props.children === 'string' ? props.children : id,
+    },
+  );
+  return (
+    <As
+      {...props}
+      className={clsx('anchor', anchorTargetClassName, props.className)}
+      id={id}>
+      {props.children}
+      <Link
+        className="hash-link"
+        to={`#${id}`}
+        aria-label={anchorTitle}
+        title={anchorTitle}
+        translate="no">
+        <span className="sr-only">{anchorTitle}</span>
+      </Link>
+    </As>
+  );
 }

--- a/docs/src/theme/MDXComponents/Heading.tsx
+++ b/docs/src/theme/MDXComponents/Heading.tsx
@@ -1,40 +1,42 @@
-import React from 'react';
-import clsx from 'clsx';
-import {translate} from '@docusaurus/Translate';
-import {useAnchorTargetClassName} from '@docusaurus/theme-common';
-import Link from '@docusaurus/Link';
-import useBrokenLinks from '@docusaurus/useBrokenLinks';
+import React from "react";
+import clsx from "clsx";
+import { translate } from "@docusaurus/Translate";
+import { useAnchorTargetClassName } from "@docusaurus/theme-common";
+import Link from "@docusaurus/Link";
+import useBrokenLinks from "@docusaurus/useBrokenLinks";
 
-export default function Heading({as: As, id, ...props}) {
+export default function Heading({ as: As, id, ...props }) {
   const brokenLinks = useBrokenLinks();
   const anchorTargetClassName = useAnchorTargetClassName(id);
   // H1 headings do not need an id because they don't appear in the TOC.
-  if (As === 'h1' || !id) {
+  if (As === "h1" || !id) {
     return <As {...props} id={undefined} />;
   }
   brokenLinks.collectAnchor(id);
   const anchorTitle = translate(
     {
-      id: 'theme.common.headingLinkTitle',
-      message: 'Direct link to {heading}',
-      description: 'Title for link to heading',
+      id: "theme.common.headingLinkTitle",
+      message: "Direct link to {heading}",
+      description: "Title for link to heading",
     },
     {
-      heading: typeof props.children === 'string' ? props.children : id,
+      heading: typeof props.children === "string" ? props.children : id,
     },
   );
   return (
     <As
       {...props}
-      className={clsx('anchor', anchorTargetClassName, props.className)}
-      id={id}>
+      className={clsx("anchor", anchorTargetClassName, props.className)}
+      id={id}
+    >
       {props.children}
       <Link
         className="hash-link"
         to={`#${id}`}
         aria-label={anchorTitle}
         title={anchorTitle}
-        translate="no">
+        translate="no"
+      >
         <span className="sr-only">{anchorTitle}</span>
       </Link>
     </As>


### PR DESCRIPTION
We have 8,423 links with no anchor text, most of them are from here. Lets fix it, so we can see the actual empty links.


It basically copies the original theme heading and replaces the anchor links empty space with screan-reader only text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct anchor links to documentation headings, enabling users to copy shareable heading references.

* **Accessibility**
  * Improved screen reader support with translated anchor titles and enhanced aria-labels for better heading navigation across languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->