### PR TITLE
feat(langsmith): add projectName config option

### DIFF
--- a/.changeset/swift-lemons-glow.md
+++ b/.changeset/swift-lemons-glow.md
@@ -1,0 +1,15 @@
+---
+'@mastra/langsmith': minor
+---
+
+Add projectName config option for LangSmith exporter
+
+You can now specify which LangSmith project to send traces to via the `projectName` config option. This overrides the `LANGCHAIN_PROJECT` environment variable.
+
+```typescript
+new LangSmithExporter({
+  apiKey: process.env.LANGSMITH_API_KEY,
+  projectName: 'my-custom-project',
+})
+```
+

--- a/docs/src/content/en/docs/observability/tracing/exporters/langsmith.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/langsmith.mdx
@@ -23,6 +23,7 @@ npm install @mastra/langsmith@beta
 
 ```bash title=".env"
 LANGSMITH_API_KEY=ls-xxxxxxxxxxxx
+LANGCHAIN_PROJECT=my-project  # Optional: default project for traces
 LANGSMITH_BASE_URL=https://api.smith.langchain.com  # Optional for self-hosted
 ```
 
@@ -60,6 +61,7 @@ new LangSmithExporter({
 
   // Optional settings
   apiUrl: process.env.LANGSMITH_BASE_URL, // Default: https://api.smith.langchain.com
+  projectName: "my-project", // Project to send traces to (overrides LANGCHAIN_PROJECT env var)
   callerOptions: {
     // HTTP client options
     timeout: 30000, // Request timeout in ms
@@ -72,6 +74,16 @@ new LangSmithExporter({
   hideOutputs: false, // Hide output data in UI
 });
 ```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LANGSMITH_API_KEY` | Your LangSmith API key (required) |
+| `LANGCHAIN_PROJECT` | Default project name for traces (optional, defaults to "default") |
+| `LANGSMITH_BASE_URL` | API URL for self-hosted instances (optional) |
+
+The `projectName` config option takes precedence over the `LANGCHAIN_PROJECT` environment variable, allowing you to programmatically route traces to different projects.
 
 ## Related
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/langsmith.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/langsmith.mdx
@@ -20,6 +20,7 @@ new LangSmithExporter(config: LangSmithExporterConfig)
 ```typescript
 interface LangSmithExporterConfig extends ClientConfig, BaseExporterConfig {
   client?: Client;
+  projectName?: string;
 }
 ```
 
@@ -32,7 +33,13 @@ Extends both `ClientConfig` (from LangSmith SDK) and `BaseExporterConfig`:
     {
       name: "apiKey",
       type: "string",
-      description: "LangSmith API key",
+      description: "LangSmith API key. Defaults to LANGSMITH_API_KEY env var.",
+      required: false,
+    },
+    {
+      name: "projectName",
+      type: "string",
+      description: "The LangSmith project to send traces to. Overrides LANGCHAIN_PROJECT env var. Defaults to 'default'.",
       required: false,
     },
     {
@@ -99,10 +106,19 @@ import { LangSmithExporter } from "@mastra/langsmith";
 
 const exporter = new LangSmithExporter({
   apiKey: process.env.LANGSMITH_API_KEY,
+  projectName: "my-project", // Optional: specify which project to send traces to
   apiUrl: "https://api.smith.langchain.com",
   logLevel: "info",
 });
 ```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LANGSMITH_API_KEY` | Your LangSmith API key |
+| `LANGCHAIN_PROJECT` | Default project name for traces (used if `projectName` not specified) |
+| `LANGSMITH_BASE_URL` | API URL for self-hosted instances |
 
 ## Span Type Mapping
 

--- a/observability/langsmith/README.md
+++ b/observability/langsmith/README.md
@@ -25,6 +25,7 @@ const mastra = new Mastra({
         exporters: [
           new LangSmithExporter({
             apiKey: process.env.LANGSMITH_API_KEY, // Defaults to process.env.LANGSMITH_API_KEY
+            projectName: 'my-custom-project', // Optional: specify which LangSmith project to send traces to
           }),
         ],
       },
@@ -32,6 +33,15 @@ const mastra = new Mastra({
   },
 });
 ```
+
+### Configuration Options
+
+| Option        | Type     | Description                                                                                |
+| ------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `apiKey`      | `string` | LangSmith API key. Defaults to `process.env.LANGSMITH_API_KEY`                             |
+| `projectName` | `string` | The name of the LangSmith project to send traces to. Overrides `LANGCHAIN_PROJECT` env var |
+| `apiUrl`      | `string` | Custom LangSmith API URL (for self-hosted instances)                                       |
+| `client`      | `Client` | Custom LangSmith client instance                                                           |
 
 ## Features
 

--- a/observability/langsmith/src/tracing.test.ts
+++ b/observability/langsmith/src/tracing.test.ts
@@ -83,6 +83,34 @@ describe('LangSmithExporter', () => {
       expect(exporter.name).toBe('langsmith');
     });
 
+    it('should pass projectName to RunTree when configured', async () => {
+      // Create exporter with custom projectName
+      const exporterWithProject = new LangSmithExporter({
+        apiKey: 'test-api-key',
+        projectName: 'my-custom-project',
+      });
+
+      const rootSpan = createMockSpan({
+        id: 'test-span',
+        name: 'test',
+        type: SpanType.GENERIC,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporterWithProject.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Should pass project_name to the RunTree constructor
+      expect(MockRunTreeClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project_name: 'my-custom-project',
+        }),
+      );
+    });
+
     it('should disable exporter when apiKey is missing', async () => {
       const invalidConfig = {
         // Missing apiKey

--- a/observability/langsmith/src/tracing.ts
+++ b/observability/langsmith/src/tracing.ts
@@ -19,6 +19,12 @@ import { normalizeUsageMetrics } from './metrics';
 export interface LangSmithExporterConfig extends ClientConfig, BaseExporterConfig {
   /** LangSmith client instance */
   client?: Client;
+  /**
+   * The name of the LangSmith project to send traces to.
+   * Overrides the LANGCHAIN_PROJECT environment variable.
+   * If neither is set, traces are sent to the "default" project.
+   */
+  projectName?: string;
 }
 
 type SpanData = {
@@ -284,6 +290,11 @@ export class LangSmithExporter extends BaseExporter {
         ...span.metadata,
       },
     };
+
+    // Add project name if configured
+    if (this.config.projectName) {
+      payload.project_name = this.config.projectName;
+    }
 
     // Core span data
     if (span.input !== undefined) {


### PR DESCRIPTION
Closes #10748

Adds support for specifying which LangSmith project to send traces to via the `projectName` config option. This overrides the `LANGCHAIN_PROJECT` environment variable if both are set.

```typescript
new LangSmithExporter({
  apiKey: process.env.LANGSMITH_API_KEY,
  projectName: 'my-custom-project',
})
```

This is useful for multi-tenant apps or when you want to programmatically route traces to different projects without changing env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `projectName` configuration to LangSmith exporter, enabling programmatic routing of traces to specific LangSmith projects and overriding the `LANGCHAIN_PROJECT` environment variable when both are provided.

* **Documentation**
  * Enhanced documentation with configuration examples, dedicated Environment Variables section, and clarification on precedence between `projectName` and environment variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->