### PR TITLE
feat(observability): add tags support for tracing to BrainTrust and Langfuse Observability Exporters

### DIFF
--- a/.changeset/long-feet-tell.md
+++ b/.changeset/long-feet-tell.md
@@ -1,0 +1,8 @@
+---
+'@mastra/braintrust': minor
+'@mastra/langfuse': minor
+'@mastra/observability': minor
+'@mastra/core': minor
+---
+
+Adds trace tagging support to the BrainTrust and Langfuse tracing exporters.

--- a/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
@@ -65,6 +65,25 @@ new BraintrustExporter({
 });
 ```
 
+## Using Tags
+
+Tags help you categorize and filter traces in the Braintrust dashboard. Add tags when executing agents or workflows:
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+Tags appear in Braintrust's trace view and can be used to filter and search traces. Common use cases include:
+
+- Environment labels: `"production"`, `"staging"`
+- Experiment tracking: `"experiment-v1"`, `"control-group"`
+- Priority levels: `"priority-high"`, `"batch-job"`
+
 ## Related
 
 - [Tracing Overview](/docs/v1/observability/tracing/overview)

--- a/docs/src/content/en/docs/observability/tracing/exporters/langfuse.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/langfuse.mdx
@@ -107,6 +107,26 @@ new LangfuseExporter({
 });
 ```
 
+## Using Tags
+
+Tags help you categorize and filter traces in the Langfuse dashboard. Add tags when executing agents or workflows:
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+Tags appear in Langfuse's trace view and can be used to filter and search traces. Common use cases include:
+
+- Environment labels: `"production"`, `"staging"`
+- Experiment tracking: `"experiment-v1"`, `"control-group"`
+- Priority levels: `"priority-high"`, `"batch-job"`
+- User segments: `"beta-user"`, `"enterprise"`
+
 ## Related
 
 - [Tracing Overview](/docs/v1/observability/tracing/overview)

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -464,6 +464,55 @@ requestContext.set("session", { data: { experimentId: "exp-999" } });
 3. **Child Span Extraction**: Child spans can also extract metadata if you pass `requestContext` when creating them
 4. **Metadata Precedence**: Explicit metadata passed to span options always takes precedence over extracted metadata
 
+### Adding Tags to Traces
+
+Tags are string labels that help you categorize and filter traces in observability platforms like Braintrust and Langfuse. Unlike metadata (which contains structured key-value data), tags are simple strings designed for quick filtering and organization.
+
+Use `tracingOptions.tags` to add tags when executing agents or workflows:
+
+```ts showLineNumbers copy
+// With agents
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+
+// With workflows
+const run = await mastra.getWorkflow("myWorkflow").createRun();
+const result = await run.start({
+  inputData: { data: "process this" },
+  tracingOptions: {
+    tags: ["batch-processing", "priority-high"],
+  },
+});
+```
+
+#### How Tags Work
+
+- **Root span only**: Tags are applied only to the root span of a trace (the agent run or workflow run span)
+- **Platform-specific**: Tags appear in Braintrust and Langfuse dashboards for filtering and searching
+- **Combinable with metadata**: You can use both `tags` and `metadata` in the same `tracingOptions`
+
+```ts showLineNumbers copy
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Analyze this" }],
+  tracingOptions: {
+    tags: ["production", "analytics"],
+    metadata: { userId: "user-123", experimentId: "exp-456" },
+  },
+});
+```
+
+#### Common Tag Patterns
+
+- **Environment**: `"production"`, `"staging"`, `"development"`
+- **Feature flags**: `"feature-x-enabled"`, `"beta-user"`
+- **Request types**: `"user-request"`, `"batch-job"`, `"scheduled-task"`
+- **Priority levels**: `"priority-high"`, `"priority-low"`
+- **Experiments**: `"experiment-v1"`, `"control-group"`, `"treatment-a"`
+
 #### Child Spans and Metadata Extraction
 
 When creating child spans within tools or workflow steps, you can pass the `requestContext` parameter to enable metadata extraction:

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -466,7 +466,7 @@ requestContext.set("session", { data: { experimentId: "exp-999" } });
 
 ### Adding Tags to Traces
 
-Tags are string labels that help you categorize and filter traces in observability platforms like Braintrust and Langfuse. Unlike metadata (which contains structured key-value data), tags are simple strings designed for quick filtering and organization.
+Tags are string labels that help you categorize and filter traces. Unlike metadata (which contains structured key-value data), tags are simple strings designed for quick filtering and organization.
 
 Use `tracingOptions.tags` to add tags when executing agents or workflows:
 

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -587,6 +587,50 @@ const limitedResult = await agent.generate("Write a short poem about coding", {
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
   ]}

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -627,7 +627,7 @@ const limitedResult = await agent.generate("Write a short poem about coding", {
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -125,12 +125,6 @@ const limitedResult = await agent.generate("Write a short poem about coding", {
       ],
     },
     {
-      name: "tracingContext",
-      type: "TracingContext",
-      isOptional: true,
-      description: "Tracing context for span hierarchy and metadata.",
-    },
-    {
       name: "returnScorerData",
       type: "boolean",
       isOptional: true,

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -194,7 +194,7 @@ await agent.network(`
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -154,6 +154,50 @@ await agent.network(`
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
     {

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -90,6 +90,9 @@ interface Span<TType extends SpanType> {
   output?: any;
   errorInfo?: any;
 
+  /** Tags for categorizing traces (only present on root spans) */
+  tags?: string[];
+
   /** End the span */
   end(options?: EndSpanOptions<TType>): void;
 
@@ -549,6 +552,33 @@ Options passed when starting a new agent or workflow execution.
 interface TracingOptions {
   /** Metadata to add to the root trace span */
   metadata?: Record<string, any>;
+
+  /**
+   * Additional RequestContext keys to extract as metadata for this trace.
+   * These keys are added to the requestContextKeys config.
+   * Supports dot notation for nested values (e.g., 'user.id', 'session.data.experimentId').
+   */
+  requestContextKeys?: string[];
+
+  /**
+   * Trace ID to use for this execution (1-32 hexadecimal characters).
+   * If provided, this trace will be part of the specified trace rather than starting a new one.
+   */
+  traceId?: string;
+
+  /**
+   * Parent span ID to use for this execution (1-16 hexadecimal characters).
+   * If provided, the root span will be created as a child of this span.
+   */
+  parentSpanId?: string;
+
+  /**
+   * Tags to apply to this trace.
+   * Tags are string labels that can be used to categorize and filter traces
+   * in observability platforms like Braintrust and Langfuse.
+   * Note: Tags are only applied to the root span of a trace.
+   */
+  tags?: string[];
 }
 ```
 

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -575,7 +575,6 @@ interface TracingOptions {
   /**
    * Tags to apply to this trace.
    * Tags are string labels that can be used to categorize and filter traces
-   * in observability platforms like Braintrust and Langfuse.
    * Note: Tags are only applied to the root span of a trace.
    */
   tags?: string[];

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -635,7 +635,7 @@ const aiSdkStream = await agent.stream("message for agent", {
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -595,6 +595,50 @@ const aiSdkStream = await agent.stream("message for agent", {
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
   ]}

--- a/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
@@ -108,7 +108,7 @@ if (result!.status === "suspended") {
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
@@ -68,6 +68,50 @@ if (result!.status === "suspended") {
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
   ]}

--- a/docs/src/content/en/reference/streaming/workflows/stream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/stream.mdx
@@ -71,6 +71,50 @@ const stream = run.stream({
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
     {

--- a/docs/src/content/en/reference/streaming/workflows/stream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/stream.mdx
@@ -111,7 +111,7 @@ const stream = run.stream({
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/workflows/run-methods/restart.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/restart.mdx
@@ -66,6 +66,50 @@ const restartedResult = await run.restart();
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
   ]}

--- a/docs/src/content/en/reference/workflows/run-methods/restart.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/restart.mdx
@@ -106,7 +106,7 @@ const restartedResult = await run.restart();
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -127,7 +127,7 @@ if (result.status === "suspended") {
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -87,6 +87,50 @@ if (result.status === "suspended") {
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
     {

--- a/docs/src/content/en/reference/workflows/run-methods/start.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/start.mdx
@@ -118,7 +118,7 @@ const result = await run.start({
               type: "string[]",
               isOptional: true,
               description:
-                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+                "Tags to apply to this trace. String labels for categorizing and filtering traces.",
             },
           ],
         },

--- a/docs/src/content/en/reference/workflows/run-methods/start.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/start.mdx
@@ -78,6 +78,50 @@ const result = await run.start({
             },
           ],
         },
+        {
+          parameters: [
+            {
+              name: "requestContextKeys",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Additional RequestContext keys to extract as metadata for this trace. Supports dot notation for nested values (e.g., 'user.id').",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "traceId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Trace ID to use for this execution (1-32 hexadecimal characters). If provided, this trace will be part of the specified trace.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "parentSpanId",
+              type: "string",
+              isOptional: true,
+              description:
+                "Parent span ID to use for this execution (1-16 hexadecimal characters). If provided, the root span will be created as a child of this span.",
+            },
+          ],
+        },
+        {
+          parameters: [
+            {
+              name: "tags",
+              type: "string[]",
+              isOptional: true,
+              description:
+                "Tags to apply to this trace. String labels for categorizing and filtering traces in platforms like Braintrust and Langfuse.",
+            },
+          ],
+        },
       ],
     },
     {

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -843,8 +843,8 @@ describe('BraintrustExporter', () => {
         type: SpanType.AGENT_RUN,
         isRoot: true,
         attributes: { agentId: 'agent-123' },
+        tags: ['production', 'experiment-v2', 'user-request'],
       });
-      (rootSpanWithTags as any).tags = ['production', 'experiment-v2', 'user-request'];
 
       const event: TracingEvent = {
         type: TracingEventType.SPAN_STARTED,
@@ -869,8 +869,8 @@ describe('BraintrustExporter', () => {
         type: SpanType.AGENT_RUN,
         isRoot: true,
         attributes: { agentId: 'agent-123' },
+        tags: [],
       });
-      (rootSpanEmptyTags as any).tags = [];
 
       const event: TracingEvent = {
         type: TracingEventType.SPAN_STARTED,
@@ -919,8 +919,8 @@ describe('BraintrustExporter', () => {
         type: SpanType.WORKFLOW_RUN,
         isRoot: true,
         attributes: { workflowId: 'wf-123' },
+        tags: ['batch-processing', 'priority-high'],
       });
-      (workflowSpanWithTags as any).tags = ['batch-processing', 'priority-high'];
 
       const event: TracingEvent = {
         type: TracingEventType.SPAN_STARTED,
@@ -946,8 +946,8 @@ describe('BraintrustExporter', () => {
         type: SpanType.AGENT_RUN,
         isRoot: true,
         attributes: {},
+        tags: ['root-tag'],
       });
-      (rootSpan as any).tags = ['root-tag'];
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
@@ -958,18 +958,18 @@ describe('BraintrustExporter', () => {
       mockSpan.log.mockClear();
 
       // Create child span (should not have tags even if we set them)
+      // Child spans should not have tags set by the system
+      // but let's verify the exporter handles it correctly even if accidentally set
       const childSpan = createMockSpan({
         id: 'child-span-tags',
         name: 'child-tool',
         type: SpanType.TOOL_CALL,
         isRoot: false,
         attributes: { toolId: 'calculator' },
+        tags: ['should-not-appear'],
       });
       childSpan.traceId = rootSpan.traceId;
       childSpan.parentSpanId = 'root-span-tags';
-      // Child spans should not have tags set by the system
-      // but let's verify the exporter handles it correctly even if accidentally set
-      (childSpan as any).tags = ['should-not-appear'];
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
@@ -995,8 +995,8 @@ describe('BraintrustExporter', () => {
         type: SpanType.AGENT_RUN,
         isRoot: true,
         attributes: { agentId: 'agent-123' },
+        tags: ['lifecycle-tag'],
       });
-      (rootSpanWithTags as any).tags = ['lifecycle-tag'];
 
       // Start span - should include tags
       await exporter.exportTracingEvent({
@@ -1431,6 +1431,7 @@ function createMockSpan({
   input,
   output,
   errorInfo,
+  tags,
 }: {
   id: string;
   name: string;
@@ -1441,6 +1442,7 @@ function createMockSpan({
   input?: any;
   output?: any;
   errorInfo?: any;
+  tags?: string[];
 }): AnyExportedSpan {
   const mockSpan = {
     id,
@@ -1451,6 +1453,7 @@ function createMockSpan({
     input,
     output,
     errorInfo,
+    tags,
     startTime: new Date(),
     endTime: undefined,
     traceId: isRoot ? `${id}-trace` : 'parent-trace-id',

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -835,6 +835,214 @@ describe('BraintrustExporter', () => {
     });
   });
 
+  describe('Tags Support', () => {
+    it('should include tags in span.log() for root spans with tags', async () => {
+      const rootSpanWithTags = createMockSpan({
+        id: 'root-with-tags',
+        name: 'tagged-agent',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: { agentId: 'agent-123' },
+      });
+      (rootSpanWithTags as any).tags = ['production', 'experiment-v2', 'user-request'];
+
+      const event: TracingEvent = {
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpanWithTags,
+      };
+
+      await exporter.exportTracingEvent(event);
+
+      // Should log tags via span.log()
+      expect(mockSpan.log).toHaveBeenCalledWith({
+        metadata: {
+          'mastra-trace-id': rootSpanWithTags.traceId,
+        },
+        tags: ['production', 'experiment-v2', 'user-request'],
+      });
+    });
+
+    it('should not include tags in span.log() when tags array is empty', async () => {
+      const rootSpanEmptyTags = createMockSpan({
+        id: 'root-empty-tags',
+        name: 'agent-no-tags',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: { agentId: 'agent-123' },
+      });
+      (rootSpanEmptyTags as any).tags = [];
+
+      const event: TracingEvent = {
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpanEmptyTags,
+      };
+
+      await exporter.exportTracingEvent(event);
+
+      // Should log without tags property
+      expect(mockSpan.log).toHaveBeenCalledWith({
+        metadata: {
+          'mastra-trace-id': rootSpanEmptyTags.traceId,
+        },
+      });
+      // Verify tags is not in the call
+      const logCall = mockSpan.log.mock.calls[0][0];
+      expect(logCall.tags).toBeUndefined();
+    });
+
+    it('should not include tags in span.log() when tags is undefined', async () => {
+      const rootSpanNoTags = createMockSpan({
+        id: 'root-no-tags',
+        name: 'agent-undefined-tags',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: { agentId: 'agent-123' },
+      });
+      // tags is undefined by default
+
+      const event: TracingEvent = {
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpanNoTags,
+      };
+
+      await exporter.exportTracingEvent(event);
+
+      // Should log without tags property
+      const logCall = mockSpan.log.mock.calls[0][0];
+      expect(logCall.tags).toBeUndefined();
+    });
+
+    it('should include tags with workflow spans', async () => {
+      const workflowSpanWithTags = createMockSpan({
+        id: 'workflow-with-tags',
+        name: 'data-processing-workflow',
+        type: SpanType.WORKFLOW_RUN,
+        isRoot: true,
+        attributes: { workflowId: 'wf-123' },
+      });
+      (workflowSpanWithTags as any).tags = ['batch-processing', 'priority-high'];
+
+      const event: TracingEvent = {
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: workflowSpanWithTags,
+      };
+
+      await exporter.exportTracingEvent(event);
+
+      // Should log tags via span.log()
+      expect(mockSpan.log).toHaveBeenCalledWith({
+        metadata: {
+          'mastra-trace-id': workflowSpanWithTags.traceId,
+        },
+        tags: ['batch-processing', 'priority-high'],
+      });
+    });
+
+    it('should not include tags for child spans (only root spans get tags)', async () => {
+      // First create a root span with tags
+      const rootSpan = createMockSpan({
+        id: 'root-span-tags',
+        name: 'root-agent',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+      (rootSpan as any).tags = ['root-tag'];
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Clear mock to check child span log calls
+      mockSpan.log.mockClear();
+
+      // Create child span (should not have tags even if we set them)
+      const childSpan = createMockSpan({
+        id: 'child-span-tags',
+        name: 'child-tool',
+        type: SpanType.TOOL_CALL,
+        isRoot: false,
+        attributes: { toolId: 'calculator' },
+      });
+      childSpan.traceId = rootSpan.traceId;
+      childSpan.parentSpanId = 'root-span-tags';
+      // Child spans should not have tags set by the system
+      // but let's verify the exporter handles it correctly even if accidentally set
+      (childSpan as any).tags = ['should-not-appear'];
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: childSpan,
+      });
+
+      // Check that the log call for child span does not include tags
+      // Child spans log mastra-trace-id but NOT tags
+      expect(mockSpan.log).toHaveBeenCalledWith({
+        metadata: {
+          'mastra-trace-id': rootSpan.traceId,
+        },
+      });
+      // Verify tags is not in the child span log call
+      const logCall = mockSpan.log.mock.calls[0][0];
+      expect(logCall.tags).toBeUndefined();
+    });
+
+    it('should include tags only on initial log, not on updates or end', async () => {
+      const rootSpanWithTags = createMockSpan({
+        id: 'root-lifecycle-tags',
+        name: 'lifecycle-agent',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: { agentId: 'agent-123' },
+      });
+      (rootSpanWithTags as any).tags = ['lifecycle-tag'];
+
+      // Start span - should include tags
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpanWithTags,
+      });
+
+      // Verify initial log has tags
+      expect(mockSpan.log).toHaveBeenCalledWith({
+        metadata: {
+          'mastra-trace-id': rootSpanWithTags.traceId,
+        },
+        tags: ['lifecycle-tag'],
+      });
+
+      // Clear mock for update
+      mockSpan.log.mockClear();
+
+      // Update span
+      rootSpanWithTags.output = { result: 'updated' };
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_UPDATED,
+        exportedSpan: rootSpanWithTags,
+      });
+
+      // Update log should NOT include tags (tags are only sent once on start)
+      const updateLogCall = mockSpan.log.mock.calls[0][0];
+      expect(updateLogCall.tags).toBeUndefined();
+      expect(updateLogCall.output).toEqual({ result: 'updated' });
+
+      // Clear mock for end
+      mockSpan.log.mockClear();
+
+      // End span
+      rootSpanWithTags.endTime = new Date();
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: rootSpanWithTags,
+      });
+
+      // End log should NOT include tags
+      const endLogCall = mockSpan.log.mock.calls[0][0];
+      expect(endLogCall.tags).toBeUndefined();
+    });
+  });
+
   describe('Shutdown', () => {
     it('should end all spans and clear traceMap', async () => {
       // Create some spans

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -159,10 +159,12 @@ export class BraintrustExporter extends BaseExporter {
     });
 
     // Include the Mastra trace ID in the span metadata for correlation
+    // Also include tags if present (only for root spans)
     braintrustSpan.log({
       metadata: {
         [MASTRA_TRACE_ID_METADATA_KEY]: span.traceId,
       },
+      ...(span.isRootSpan && span.tags?.length ? { tags: span.tags } : {}),
     });
 
     spanData.spans.set(span.id, braintrustSpan);

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -336,6 +336,8 @@ export class LangfuseExporter extends BaseExporter {
     if (userId) payload.userId = userId;
     if (sessionId) payload.sessionId = sessionId;
     if (span.input) payload.input = span.input;
+    // Include tags if present (only for root spans, which is always the case here)
+    if (span.tags?.length) payload.tags = span.tags;
 
     payload.metadata = {
       spanType: span.type,

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -126,10 +126,14 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     // Extract metadata from RequestContext
     const enrichedMetadata = this.extractMetadataFromRequestContext(requestContext, metadata, traceState);
 
+    // Tags are only passed for root spans (no parent)
+    const tags = !options.parent ? tracingOptions?.tags : undefined;
+
     const span = this.createSpan<TType>({
       ...rest,
       metadata: enrichedMetadata,
       traceState,
+      tags,
     });
 
     if (span.isEvent) {

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -123,8 +123,12 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       traceState = this.computeTraceState(tracingOptions);
     }
 
+    // Merge tracingOptions.metadata with span metadata (tracingOptions.metadata takes precedence for root spans)
+    const tracingMetadata = !options.parent ? tracingOptions?.metadata : undefined;
+    const mergedMetadata = metadata || tracingMetadata ? { ...metadata, ...tracingMetadata } : undefined;
+
     // Extract metadata from RequestContext
-    const enrichedMetadata = this.extractMetadataFromRequestContext(requestContext, metadata, traceState);
+    const enrichedMetadata = this.extractMetadataFromRequestContext(requestContext, mergedMetadata, traceState);
 
     // Tags are only passed for root spans (no parent)
     const tags = !options.parent ? tracingOptions?.tags : undefined;

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -125,6 +125,7 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
   };
   public metadata?: Record<string, any>;
   public traceState?: TraceState;
+  public tags?: string[];
   /** Parent span ID (for root spans that are children of external spans) */
   protected parentSpanId?: string;
 
@@ -139,6 +140,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     this.isEvent = options.isEvent ?? false;
     this.isInternal = isSpanInternal(this.type, options.tracingPolicy?.internal);
     this.traceState = options.traceState;
+    // Tags are only set for root spans (spans without a parent)
+    this.tags = !options.parent && options.tags?.length ? options.tags : undefined;
 
     if (this.isEvent) {
       // Event spans don't have endTime or input.
@@ -232,6 +235,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
       isEvent: this.isEvent,
       isRootSpan: this.isRootSpan,
       parentSpanId: this.getParentSpanId(includeInternalSpans),
+      // Tags are only included for root spans
+      ...(this.isRootSpan && this.tags?.length ? { tags: this.tags } : {}),
     };
   }
 

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -124,8 +124,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     details?: Record<string, any>;
   };
   public metadata?: Record<string, any>;
-  public traceState?: TraceState;
   public tags?: string[];
+  public traceState?: TraceState;
   /** Parent span ID (for root spans that are children of external spans) */
   protected parentSpanId?: string;
 

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -337,6 +337,8 @@ interface BaseSpan<TType extends SpanType> {
   attributes?: SpanTypeMap[TType];
   /** User-defined metadata */
   metadata?: Record<string, any>;
+  /** Labels used to categorize and filter traces. Only valid on root spans. */
+  tags?: string[];
   /** Input passed at the start of the span */
   input?: any;
   /** Output generated at the end of the span */
@@ -365,11 +367,6 @@ export interface Span<TType extends SpanType> extends BaseSpan<TType> {
   observabilityInstance: ObservabilityInstance;
   /** Trace-level state shared across all spans in this trace */
   traceState?: TraceState;
-  /**
-   * Tags for this trace (only set on root spans).
-   * Tags are string labels used to categorize and filter traces.
-   */
-  tags?: string[];
 
   // Methods for span lifecycle
   /** End the span */
@@ -602,6 +599,8 @@ export interface CreateSpanOptions<TType extends SpanType> extends CreateBaseOpt
   input?: any;
   /** Output data (for event spans) */
   output?: any;
+  /** Labels used to categorize and filter traces. Only valid on root spans. */
+  tags?: string[];
   /** Parent span */
   parent?: AnySpan;
   /** Is an event span? */
@@ -618,11 +617,6 @@ export interface CreateSpanOptions<TType extends SpanType> extends CreateBaseOpt
   parentSpanId?: string;
   /** Trace-level state shared across all spans in this trace */
   traceState?: TraceState;
-  /**
-   * Tags for this trace (only used for root spans).
-   * Tags are string labels used to categorize and filter traces.
-   */
-  tags?: string[];
 }
 
 /**

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -785,7 +785,6 @@ export interface TracingOptions {
   /**
    * Tags to apply to this trace.
    * Tags are string labels that can be used to categorize and filter traces
-   * in observability platforms like Braintrust and Langfuse.
    * Note: Tags are only applied to the root span of a trace.
    */
   tags?: string[];

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -365,6 +365,11 @@ export interface Span<TType extends SpanType> extends BaseSpan<TType> {
   observabilityInstance: ObservabilityInstance;
   /** Trace-level state shared across all spans in this trace */
   traceState?: TraceState;
+  /**
+   * Tags for this trace (only set on root spans).
+   * Tags are string labels used to categorize and filter traces.
+   */
+  tags?: string[];
 
   // Methods for span lifecycle
   /** End the span */
@@ -497,6 +502,11 @@ export interface ExportedSpan<TType extends SpanType> extends BaseSpan<TType> {
   parentSpanId?: string;
   /** `TRUE` if the span is the root span of a trace */
   isRootSpan: boolean;
+  /**
+   * Tags for this trace (only present on root spans).
+   * Tags are string labels used to categorize and filter traces.
+   */
+  tags?: string[];
 }
 
 export interface IModelSpanTracker {
@@ -608,6 +618,11 @@ export interface CreateSpanOptions<TType extends SpanType> extends CreateBaseOpt
   parentSpanId?: string;
   /** Trace-level state shared across all spans in this trace */
   traceState?: TraceState;
+  /**
+   * Tags for this trace (only used for root spans).
+   * Tags are string labels used to categorize and filter traces.
+   */
+  tags?: string[];
 }
 
 /**
@@ -773,6 +788,13 @@ export interface TracingOptions {
    * If provided, the root span will be created as a child of this span.
    */
   parentSpanId?: string;
+  /**
+   * Tags to apply to this trace.
+   * Tags are string labels that can be used to categorize and filter traces
+   * in observability platforms like Braintrust and Langfuse.
+   * Note: Tags are only applied to the root span of a trace.
+   */
+  tags?: string[];
 }
 
 export interface SpanIds {


### PR DESCRIPTION
## Description

Adds tag support for filtering traces inside BrainTrust and Langfuse.

Example:
```
const result = await agent.generate({
  messages: [{ role: "user", content: "Hello" }],
  tracingOptions: {
    tags: ["production", "experiment-v2", "user-request"],
  },
});
```

Also
* Updates docs, including out-of-date TracingOptions for various methods.
* Adds tests

Does Not:
* Implement tag capture for Mastra Observability's Default & Cloud exporters
* Implement tag capture for other 3rd party Observability exporters, or OtelBridge

These will be implemented on future PRs.

## Related Issue(s)

For Braintrust, fixes: #9849
For Langfuse, implements part of the ask for: #10174

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trace tagging support to categorize and filter traces across BrainTrust and Langfuse exporters.
  * Extended tracing options with new fields: `requestContextKeys` for metadata extraction, `traceId` for trace association, `parentSpanId` for span relationships, and `tags` for trace labeling.

* **Documentation**
  * Added comprehensive guides for using tags with tracing exporters and updated API reference documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->