### PR TITLE
fix: add time-to-first-token (TTFT) support for Langfuse integration

### DIFF
--- a/.changeset/add-langfuse-ttft-support.md
+++ b/.changeset/add-langfuse-ttft-support.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': patch
+'@mastra/observability': patch
+'@mastra/langfuse': patch
+---
+
+Add time-to-first-token (TTFT) support for Langfuse integration
+
+Adds `completionStartTime` to model generation spans, which Langfuse uses to calculate TTFT metrics. The timestamp is automatically captured when the first content chunk arrives during streaming.
+
+```typescript
+// completionStartTime is now automatically captured and sent to Langfuse
+// enabling TTFT metrics in your Langfuse dashboard
+const result = await agent.stream('Hello');
+```
+

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -445,6 +445,12 @@ export class LangfuseExporter extends BaseExporter {
         payload.modelParameters = modelAttr.parameters;
         attributesToOmit.push('parameters');
       }
+
+      // completionStartTime is used by Langfuse to calculate time-to-first-token (TTFT)
+      if (modelAttr.completionStartTime !== undefined) {
+        payload.completionStartTime = modelAttr.completionStartTime;
+        attributesToOmit.push('completionStartTime');
+      }
     }
 
     payload.metadata = {

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -120,6 +120,12 @@ export interface ModelGenerationAttributes extends AIBaseAttributes {
   streaming?: boolean;
   /** Reason the generation finished */
   finishReason?: string;
+  /**
+   * When the first token/chunk of the completion was received.
+   * Used to calculate time-to-first-token (TTFT) metrics.
+   * Only applicable for streaming responses.
+   */
+  completionStartTime?: Date;
 }
 
 /**


### PR DESCRIPTION
Fixes #9444

Previously, Langfuse showed 0 for the "time to first token" metric because we weren't setting `completionStartTime` on generation spans.

This adds `completionStartTime` to model generation spans. The timestamp is captured automatically when the first content chunk arrives during streaming (text, reasoning, tool-call, or object chunks).

```typescript
// Before: TTFT always showed 0 in Langfuse
// After: TTFT is calculated from completionStartTime - startTime
const result = await agent.stream('Hello');
```

Changes:
- Added `completionStartTime` field to `ModelGenerationAttributes`
- Updated Langfuse exporter to include `completionStartTime` as a top-level field
- Added first-chunk timestamp capture in `ModelSpanTracker`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added time-to-first-token (TTFT) support for Langfuse observability. Streaming model responses now automatically capture the timestamp when the first token arrives, enabling precise TTFT metrics within Langfuse for performance monitoring.

* **Tests**
  * Added comprehensive test coverage for TTFT functionality, validating automatic timestamp capture in streaming responses and proper behavior for non-streaming generation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->