### PR TITLE
fix: install external peer deps for cloud deployer

### DIFF
--- a/.changeset/fix-cloud-install-peer-deps.md
+++ b/.changeset/fix-cloud-install-peer-deps.md
@@ -1,0 +1,8 @@
+---
+"@mastra/deployer-cloud": patch
+---
+
+Fix installing external peer deps for cloud deployer
+
+Adds `--force` and `--legacy-peer-deps=false` flags to npm install command to ensure peer dependencies for external packages are properly installed in the mastra output directory. The `--legacy-peer-deps=false` flag overrides package manager settings (like pnpm's default of `true`) to ensure consistent behavior.
+

--- a/deployers/cloud/src/utils/deps.ts
+++ b/deployers/cloud/src/utils/deps.ts
@@ -91,7 +91,9 @@ export async function installNodeVersion({ path }: { path: string }) {
 export async function installDeps({ path, pm }: { path: string; pm?: string }) {
   pm = pm ?? detectPm({ path });
   logger.info(`Installing dependencies with ${pm} in ${path}`);
-  const args = ['install'];
+  // --force is needed to install peer deps for external packages in the mastra output directory
+  // --legacy-peer-deps=false is needed to override other overrides by the repo package manager such as pnpm. Pnpm would set it to true
+  const args = ['install', '--legacy-peer-deps=false', '--force'];
   const { success, error } = await runWithExeca({ cmd: pm, args, cwd: path });
   if (!success) {
     throw new MastraError(


### PR DESCRIPTION
Adds `--force` and `--legacy-peer-deps=false` flags to the npm install command in the cloud deployer. The `--force` flag ensures peer dependencies for external packages are properly installed in the mastra output directory. The `--legacy-peer-deps=false` flag overrides package manager settings (like pnpm's default of `true`) to ensure consistent behavior across different package managers.

```typescript
// Before
const args = ['install'];

// After  
// --force is needed to install peer deps for external packages in the mastra output directory
// --legacy-peer-deps=false is needed to override other overrides by the repo package manager such as pnpm. Pnpm would set it to true
const args = ['install', '--legacy-peer-deps=false', '--force'];
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed peer dependency installation for the cloud deployer package. External dependencies now install correctly and consistently across all supported package managers, ensuring reliable deployment configurations and eliminating installation errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->