### PR TITLE
qualify vector type to fix schema lookup

### DIFF
--- a/.changeset/fiery-pugs-appear.md
+++ b/.changeset/fiery-pugs-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+fix(pg): qualify vector type to fix schema lookup

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mastra/core/error', () => ({
+  ErrorCategory: { USER: 'USER', THIRD_PARTY: 'THIRD_PARTY' },
+  ErrorDomain: { MASTRA_VECTOR: 'MASTRA_VECTOR' },
+  MastraError: class MastraError extends Error {
+    constructor(
+      public metadata: any,
+      error?: Error,
+    ) {
+      super(error?.message ?? 'MastraError');
+    }
+  },
+}));
+
+vi.mock('@mastra/core/utils', () => ({
+  parseSqlIdentifier: (name: string) => name,
+}));
+
+vi.mock('@mastra/core/vector', () => ({
+  MastraVector: class MastraVector {
+    logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn(), trackException: vi.fn() };
+  },
+}));
+
+vi.mock('@mastra/core/vector/filter', () => ({
+  BaseFilterTranslator: class {
+    translate(filter: any) {
+      return filter;
+    }
+  },
+}));
+
+import type { PgVectorConfig } from '../shared/config';
+import { PgVector } from '.';
+
+type QueryCall = { text: string; values?: any[] };
+
+const queryHistory: QueryCall[] = [];
+
+const mockClient = {
+  query: vi.fn(),
+  release: vi.fn(),
+};
+
+vi.mock('pg', () => {
+  class MockPool {
+    public options: any;
+    public connect = vi.fn(async () => mockClient);
+    public end = vi.fn(async () => {});
+
+    constructor(options: any) {
+      this.options = options;
+    }
+  }
+
+  return { Pool: MockPool };
+});
+
+describe('PgVector schema-aware vector type handling', () => {
+  const config: PgVectorConfig & { id: string } = {
+    connectionString: 'postgresql://postgres:postgres@localhost:5432/mastra',
+    schemaName: 'custom_schema',
+    id: 'pg-vector-schema-test',
+  };
+
+  let vectorStore: PgVector;
+  let listIndexesSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    queryHistory.length = 0;
+    mockClient.query.mockImplementation(async (text: any, values?: any[]) => {
+      const sql = typeof text === 'string' ? text : text?.text || '';
+      queryHistory.push({ text: sql, values });
+
+      if (sql.includes('information_schema.schemata')) {
+        return { rows: [{ exists: true }] };
+      }
+
+      if (sql.includes('FROM pg_extension e')) {
+        return { rows: [{ schema_name: 'custom_schema' }] };
+      }
+
+      return { rows: [] };
+    });
+    mockClient.release.mockReset();
+
+    listIndexesSpy = vi.spyOn(PgVector.prototype, 'listIndexes').mockResolvedValue([]);
+
+    vectorStore = new PgVector(config);
+    await (vectorStore as any).cacheWarmupPromise;
+  });
+
+  afterEach(async () => {
+    await vectorStore.disconnect();
+    listIndexesSpy.mockRestore();
+    mockClient.query.mockReset();
+  });
+
+  it('prefixes vector type with schema when createIndex runs inside custom schema', async () => {
+    await vectorStore.createIndex({
+      indexName: 'nlQuery',
+      dimension: 1536,
+      buildIndex: false,
+    });
+
+    const createTableCall = queryHistory.find(call => call.text.includes('CREATE TABLE'));
+    expect(createTableCall?.text ?? '').toContain('embedding custom_schema.vector');
+  });
+});

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -196,11 +196,8 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       if (this.vectorExtensionSchema === 'pg_catalog') {
         return 'vector';
       }
-      // If it's in the current schema, return vector
-      if (this.vectorExtensionSchema === (this.schema || 'public')) {
-        return 'vector';
-      }
-      // Otherwise, qualify it with the schema where vector extension is installed
+      // Issue #10061: Always qualify with schema where vector extension is installed
+      // This ensures the type is found regardless of the session's search_path
       const validatedSchema = parseSqlIdentifier(this.vectorExtensionSchema, 'vector extension schema');
       return `${validatedSchema}.vector`;
     }


### PR DESCRIPTION
## Description

When using `PgVector` with a custom schema (e.g., `schemaName: 'postgres'`) where the vector extension is installed in the same schema, `createIndex()` would fail with `"type \"vector\" does not exist"`.

The root cause was in `getVectorTypeName()`: when `vectorExtensionSchema === schema`, it returned an unqualified `'vector'` type, assuming PostgreSQL's search_path would include that schema. However, custom schemas aren't in the default search_path (`"$user", public`), so the type wasn't found.

This PR removes the problematic optimization and always qualifies the vector type with its schema (e.g., `custom_schema.vector`), ensuring the type is found regardless of search_path configuration.

## Related Issue(s)

Fixes #10061

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vector type resolution to properly qualify schema locations, ensuring correct type handling in custom PostgreSQL schemas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->