### PR TITLE
deployer test fix

### DIFF
--- a/e2e-tests/deployers/setup.ts
+++ b/e2e-tests/deployers/setup.ts
@@ -30,6 +30,7 @@ export default async function setup(project: TestProject) {
     [
       '--filter="mastra^..."',
       '--filter="mastra"',
+      '--filter="@mastra/deployer"',
       '--filter="@mastra/deployer-cloudflare"',
       '--filter="@mastra/deployer-vercel"',
       '--filter="@mastra/deployer-netlify"',

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -102,7 +102,8 @@ async function captureDependenciesToOptimize(
   }
 
   for (const [dependency, bindings] of Object.entries(output.importedBindings)) {
-    if (isNodeBuiltin(dependency) || DEPS_TO_IGNORE.includes(dependency)) {
+    // Skip Node builtins, ignored deps, and subpath imports (virtual modules like #polyfills, #tools, etc.)
+    if (isNodeBuiltin(dependency) || DEPS_TO_IGNORE.includes(dependency) || dependency.startsWith('#')) {
       continue;
     }
 

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -106,7 +106,8 @@ export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }:
   return {
     name: PLUGIN_NAME,
     async resolveId(request, importer, options) {
-      if (!importer || request.startsWith('\0')) {
+      // Skip if no importer, request is virtual, or importer is virtual
+      if (!importer || request.startsWith('\0') || importer.startsWith('\0')) {
         return null;
       }
 


### PR DESCRIPTION
The tsConfigPaths plugin was entering an infinite loop when trying to resolve imports from virtual files. The findTsConfigForFile function walks up directories to find tsconfig.json, but virtual files (like \x00virtual:#entry) don't have valid filesystem paths. Calling path.dirname() on such paths produces . which never equals the filesystem root (/), causing the while (currentDir !== root) loop to run forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build module resolution by tightening virtual-module handling and ignoring virtual/subpath imports, reducing incorrect alias resolution.

* **Tests**
  * Expanded end-to-end test coverage to include the deployer package in deployment workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->