### PR TITLE
test(e2e): block npm fallback for @mastra/* packages in local registry

### DIFF
--- a/e2e-tests/_local-registry-setup/verdaccio.yaml
+++ b/e2e-tests/_local-registry-setup/verdaccio.yaml
@@ -8,6 +8,22 @@ uplinks:
     url: https://registry.npmjs.org/
 
 packages:
+  # Block npm fallback for @mastra/* packages - they MUST be published locally
+  # This ensures e2e tests fail fast if a package is missing from the publish list
+  '@mastra/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+    # No proxy - will 404 if not published locally
+
+  # Same for the unscoped 'mastra' package
+  'mastra':
+    access: $all
+    publish: $all
+    unpublish: $all
+    # No proxy - will 404 if not published locally
+
+  # All other packages can fall back to npm
   '**':
     access: $all
     publish: $all


### PR DESCRIPTION
## Summary

- Prevents e2e tests from silently falling back to npm when a `@mastra/*` package is missing from the local publish list
- Ensures tests fail fast with a clear 404 error instead of using stale published versions
- This caught a bug where `@mastra/deployer` wasn't being published to the local registry for e2e tests

## Test plan

- [ ] E2e tests should fail if a required `@mastra/*` package is not in the publish list
- [ ] E2e tests should still work when all required packages are published locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local package registry configuration to improve publishing controls and reliability for internal testing environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->