### PR TITLE
feat: format agent input/output for better Braintrust UI display

### DIFF
--- a/.changeset/format-braintrust-ui-input-output.md
+++ b/.changeset/format-braintrust-ui-input-output.md
@@ -1,0 +1,8 @@
+---
+'@mastra/braintrust': minor
+---
+
+Format agent input/output for better Braintrust UI display
+
+Formats agent run and workflow run spans to display human-readable text in Braintrust UI instead of raw JSON. Message arrays are converted to readable text format, and structured output objects extract the text field for cleaner display. LLM generation spans preserve raw data for debugging purposes.
+


### PR DESCRIPTION
Formats agent run and workflow run spans to display human-readable text in Braintrust UI instead of raw JSON.

Before:
- Input: `[{"role":"user","content":"What is the weather?"}]`
- Output: `{"text":"The weather is sunny.","object":null,"files":[]}`

After:
- Input: `What is the weather?`
- Output: `The weather is sunny.`

Message arrays are converted to readable text format, and structured output objects extract the text field for cleaner display. Multi-turn conversations are formatted with role prefixes. LLM generation spans preserve raw data for debugging purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced agent input/output formatting for Braintrust UI. Message arrays and structured outputs now display as readable text, improving visibility while preserving raw data for debugging and LLM generation spans.

* **Tests**
  * Added comprehensive test coverage for formatting behavior across multi-turn conversations, complex message structures, string inputs, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->