### PR TITLE
fix(codemod): Add v1/workflow-stream-vnext

### DIFF
--- a/.changeset/eight-pillows-wink.md
+++ b/.changeset/eight-pillows-wink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/codemod': patch
+---
+
+Add `v1/workflow-stream-vnext` codemod. This codemod renames `streamVNext()`, `resumeStreamVNext()`, and `observeStreamVNext()` to their "non-VNext" counterparts.

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
@@ -177,8 +177,6 @@ To migrate, update any code that consumes branch outputs to handle optional valu
 
 If your code depends on non-optional types, add runtime checks or provide default values when accessing branch outputs.
 
-See [Run.resumeStream()](/reference/v1/streaming/workflows/resumeStream) for details.
-
 ## Removed
 
 ### `streamVNext`, `resumeStreamVNext`, and `observeStreamVNext` methods
@@ -188,6 +186,16 @@ The experimental `streamVNext()`, `resumeStreamVNext()`, and `observeStreamVNext
 To migrate, use the standard `stream()`, `resumeStream()`, and `observeStream()` methods. Update event type checks to use workflow-prefixed names and access stream properties directly.
 
 See [`Run.stream()`](/reference/v1/streaming/workflows/stream), [`Run.resumeStream()`](/reference/v1/streaming/workflows/resumeStream), and [`Run.observeStream()`](/reference/v1/streaming/workflows/observeStream) for details.
+
+:::tip[Codemod]
+
+You can use Mastra's codemod CLI to update your code automatically:
+
+```shell
+npx @mastra/codemod@beta v1/workflow-stream-vnext .
+```
+
+:::
 
 ### Legacy workflows export
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -70,6 +70,7 @@ npx @mastra/codemod@beta v1/mastra-core-imports .
 | `v1/workflow-create-run-async`       | Renames `workflow.createRunAsync()` → `workflow.createRun()`                                                       |
 | `v1/workflow-list-runs`              | Renames `workflow.getWorkflowRuns()` → `workflow.listWorkflowRuns()`                                               |
 | `v1/workflow-run-count`              | Renames `context.runCount` → `context.retryCount` in step execution functions                                      |
+| `v1/workflow-stream-vnext`           | Renames `streamVNext()`, `resumeStreamVNext()`, and `observeStreamVNext()`                                         |
 
 ## CLI Options
 

--- a/packages/codemod/src/codemods/v1/workflow-stream-vnext.ts
+++ b/packages/codemod/src/codemods/v1/workflow-stream-vnext.ts
@@ -1,0 +1,7 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // TODO
+});

--- a/packages/codemod/src/codemods/v1/workflow-stream-vnext.ts
+++ b/packages/codemod/src/codemods/v1/workflow-stream-vnext.ts
@@ -1,7 +1,46 @@
 import { createTransformer } from '../lib/create-transformer';
 
+/**
+ * Transforms workflow run VNext methods to their standard names:
+ * - run.streamVNext() → run.stream()
+ * - run.resumeStreamVNext() → run.resumeStream()
+ * - run.observeStreamVNext() → run.observeStream()
+ *
+ * These methods are called on the result of workflow.createRun().
+ */
 export default createTransformer((fileInfo, api, options, context) => {
   const { j, root } = context;
 
-  // TODO
+  // Map of old method names to new method names
+  const methodRenames: Record<string, string> = {
+    streamVNext: 'stream',
+    resumeStreamVNext: 'resumeStream',
+    observeStreamVNext: 'observeStream',
+  };
+
+  let count = 0;
+
+  // Find all call expressions and rename VNext methods
+  // These method names are unique enough to Mastra workflow runs
+  // that we can safely rename them globally
+  root.find(j.CallExpression).forEach(path => {
+    const { callee } = path.value;
+    if (callee.type !== 'MemberExpression') return;
+    if (callee.property.type !== 'Identifier') return;
+
+    const oldName = callee.property.name;
+    const newName = methodRenames[oldName];
+
+    if (newName) {
+      callee.property.name = newName;
+      count++;
+    }
+  });
+
+  if (count > 0) {
+    context.hasChanges = true;
+    context.messages.push(
+      `Renamed workflow run VNext methods: streamVNext/resumeStreamVNext/observeStreamVNext → stream/resumeStream/observeStream`,
+    );
+  }
 });

--- a/packages/codemod/src/lib/bundle.ts
+++ b/packages/codemod/src/lib/bundle.ts
@@ -26,6 +26,7 @@ export const BUNDLE = [
   'v1/workflow-create-run-async',
   'v1/workflow-run-count',
   'v1/workflow-list-runs',
+  'v1/workflow-stream-vnext',
   'v1/memory-query-to-recall',
   'v1/memory-vector-search-param',
   'v1/memory-message-v2-type',

--- a/packages/codemod/src/test/__fixtures__/workflow-stream-vnext.input.ts
+++ b/packages/codemod/src/test/__fixtures__/workflow-stream-vnext.input.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import { Workflow } from '@mastra/core/workflows';
+
+const workflow = new Workflow({
+  name: 'my-workflow',
+  // config
+});
+
+const run = await workflow.createRun();
+
+const stream = await run.streamVNext({
+  inputData: {
+    value: "initial data",
+  },
+});
+
+const newStream = await run.resumeStreamVNext();
+
+const observedStream = await run.observeStreamVNext();

--- a/packages/codemod/src/test/__fixtures__/workflow-stream-vnext.output.ts
+++ b/packages/codemod/src/test/__fixtures__/workflow-stream-vnext.output.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import { Workflow } from '@mastra/core/workflows';
+
+const workflow = new Workflow({
+  name: 'my-workflow',
+  // config
+});
+
+const run = await workflow.createRun();
+
+const stream = await run.stream({
+  inputData: {
+    value: "initial data",
+  },
+});
+
+const newStream = await run.resumeStream();
+
+const observedStream = await run.observeStream();

--- a/packages/codemod/src/test/workflow-stream-vnext.test.ts
+++ b/packages/codemod/src/test/workflow-stream-vnext.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v1/workflow-stream-vnext';
+import { testTransform } from './test-utils';
+
+describe('workflow-stream-vnext', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'workflow-stream-vnext');
+  });
+});


### PR DESCRIPTION
## Description

Add `v1/workflow-stream-vnext` codemod. This codemod renames `streamVNext()`, `resumeStreamVNext()`, and `observeStreamVNext()` to their "non-VNext" counterparts.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v1/workflow-stream-vnext codemod to automate renaming of workflow stream methods from VNext variants to standard equivalents.

* **Documentation**
  * Updated v1 migration guide with codemod installation and usage instructions for automated method renaming.

* **Tests**
  * Added test fixtures and test suite for the new codemod.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->