### PR TITLE
fix(deployer): Don't add ESM shim twice

### DIFF
--- a/.changeset/fair-needles-greet.md
+++ b/.changeset/fair-needles-greet.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed a bug where ESM shims were incorrectly injected even when the user had already declared `__filename` or `__dirname`

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -2,7 +2,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import virtual from '@rollup/plugin-virtual';
-import esmShim from '@rollup/plugin-esm-shim';
+import { esmShim } from '../plugins/esm-shim';
 import { basename } from 'node:path/posix';
 import * as path from 'node:path';
 import { rollup, type OutputChunk, type OutputAsset, type Plugin } from 'rollup';

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -2,7 +2,7 @@ import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import esmShim from '@rollup/plugin-esm-shim';
+import { esmShim } from './plugins/esm-shim';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { rollup, type InputOptions, type OutputOptions, type Plugin } from 'rollup';
 import { esbuild } from './plugins/esbuild';

--- a/packages/deployer/src/build/plugins/__fixtures__/esm-shim-no-declaration.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/esm-shim-no-declaration.js
@@ -1,0 +1,8 @@
+// Fixture: User uses __filename and __dirname without declaring them (needs shim)
+export function getDir() {
+  return __dirname;
+}
+
+export function getFile() {
+  return __filename;
+}

--- a/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-dirname.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-dirname.js
@@ -1,0 +1,9 @@
+// Fixture: User declares only __dirname (issue #10054 scenario 3)
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function getDir() {
+  return __dirname;
+}

--- a/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-filename.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-filename.js
@@ -1,0 +1,8 @@
+// Fixture: User declares only __filename (issue #10054 scenario 2)
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+export function getFile() {
+  return __filename;
+}

--- a/packages/deployer/src/build/plugins/__fixtures__/esm-shim-user-declared.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/esm-shim-user-declared.js
@@ -1,0 +1,14 @@
+// Fixture: User declares their own __filename and __dirname (like in issue #10054)
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export function getDir() {
+  return __dirname;
+}
+
+export function getFile() {
+  return __filename;
+}

--- a/packages/deployer/src/build/plugins/esm-shim.test.ts
+++ b/packages/deployer/src/build/plugins/esm-shim.test.ts
@@ -3,12 +3,12 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { rollup } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
-import esmShim from '@rollup/plugin-esm-shim';
+import { esmShim } from './esm-shim';
 
 describe('ESM Shim Plugin', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));
 
-  it('should NOT inject shims when user already declares __filename and __dirname (issue #10054)', async () => {
+  it('should NOT inject shims when user already declares __filename and __dirname', async () => {
     const file = join(_dirname, './__fixtures__/esm-shim-user-declared.js');
 
     const bundle = await rollup({
@@ -97,5 +97,93 @@ describe('ESM Shim Plugin', () => {
 
     // The code SHOULD contain the shim since user didn't declare their own
     expect(code).toContain('// -- Shims --');
+  });
+
+  it('should NOT inject shims when user declares only __filename', async () => {
+    const file = join(_dirname, './__fixtures__/esm-shim-only-filename.js');
+
+    const bundle = await rollup({
+      logLevel: 'silent',
+      input: file,
+      cache: false,
+      treeshake: 'smallest',
+      plugins: [
+        {
+          name: 'externalize-all',
+          resolveId(id) {
+            return {
+              id,
+              external: id !== file,
+            };
+          },
+        },
+        esbuild({
+          target: 'esnext',
+          platform: 'node',
+          minify: false,
+        }),
+        esmShim(),
+      ],
+    });
+
+    const result = await bundle.generate({
+      format: 'esm',
+    });
+
+    const code = result?.output[0].code;
+
+    // Count occurrences of __filename declarations
+    const filenameDeclarations = (code.match(/const __filename\s*=/g) || []).length;
+
+    // There should be exactly ONE declaration (the user's own)
+    // If the shim is incorrectly injected, there will be TWO declarations
+    expect(filenameDeclarations).toBe(1);
+
+    // The code should NOT contain the shim comment
+    expect(code).not.toContain('// -- Shims --');
+  });
+
+  it('should NOT inject shims when user declares only __dirname', async () => {
+    const file = join(_dirname, './__fixtures__/esm-shim-only-dirname.js');
+
+    const bundle = await rollup({
+      logLevel: 'silent',
+      input: file,
+      cache: false,
+      treeshake: 'smallest',
+      plugins: [
+        {
+          name: 'externalize-all',
+          resolveId(id) {
+            return {
+              id,
+              external: id !== file,
+            };
+          },
+        },
+        esbuild({
+          target: 'esnext',
+          platform: 'node',
+          minify: false,
+        }),
+        esmShim(),
+      ],
+    });
+
+    const result = await bundle.generate({
+      format: 'esm',
+    });
+
+    const code = result?.output[0].code;
+
+    // Count occurrences of __dirname declarations
+    const dirnameDeclarations = (code.match(/const __dirname\s*=/g) || []).length;
+
+    // There should be exactly ONE declaration (the user's own)
+    // If the shim is incorrectly injected, there will be TWO declarations
+    expect(dirnameDeclarations).toBe(1);
+
+    // The code should NOT contain the shim comment
+    expect(code).not.toContain('// -- Shims --');
   });
 });

--- a/packages/deployer/src/build/plugins/esm-shim.test.ts
+++ b/packages/deployer/src/build/plugins/esm-shim.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { rollup } from 'rollup';
+import esbuild from 'rollup-plugin-esbuild';
+import esmShim from '@rollup/plugin-esm-shim';
+
+describe('ESM Shim Plugin', () => {
+  const _dirname = dirname(fileURLToPath(import.meta.url));
+
+  it('should NOT inject shims when user already declares __filename and __dirname (issue #10054)', async () => {
+    const file = join(_dirname, './__fixtures__/esm-shim-user-declared.js');
+
+    const bundle = await rollup({
+      logLevel: 'silent',
+      input: file,
+      cache: false,
+      treeshake: 'smallest',
+      plugins: [
+        {
+          name: 'externalize-all',
+          resolveId(id) {
+            return {
+              id,
+              external: id !== file,
+            };
+          },
+        },
+        esbuild({
+          target: 'esnext',
+          platform: 'node',
+          minify: false,
+        }),
+        esmShim(),
+      ],
+    });
+
+    const result = await bundle.generate({
+      format: 'esm',
+    });
+
+    const code = result?.output[0].code;
+
+    // Count occurrences of __filename declarations
+    const filenameDeclarations = (code.match(/const __filename\s*=/g) || []).length;
+    const dirnameDeclarations = (code.match(/const __dirname\s*=/g) || []).length;
+
+    // There should be exactly ONE declaration of each (the user's own)
+    // If the shim is incorrectly injected, there will be TWO declarations
+    expect(filenameDeclarations).toBe(1);
+    expect(dirnameDeclarations).toBe(1);
+
+    // The code should NOT contain the shim comment since user declared their own
+    expect(code).not.toContain('// -- Shims --');
+  });
+
+  it('should inject shims when user uses __filename/__dirname without declaring them', async () => {
+    const file = join(_dirname, './__fixtures__/esm-shim-no-declaration.js');
+
+    const bundle = await rollup({
+      logLevel: 'silent',
+      input: file,
+      cache: false,
+      treeshake: 'smallest',
+      plugins: [
+        {
+          name: 'externalize-all',
+          resolveId(id) {
+            return {
+              id,
+              external: id !== file,
+            };
+          },
+        },
+        esbuild({
+          target: 'esnext',
+          platform: 'node',
+          minify: false,
+        }),
+        esmShim(),
+      ],
+    });
+
+    const result = await bundle.generate({
+      format: 'esm',
+    });
+
+    const code = result?.output[0].code;
+
+    // Count occurrences of __filename declarations
+    const filenameDeclarations = (code.match(/const __filename\s*=/g) || []).length;
+    const dirnameDeclarations = (code.match(/const __dirname\s*=/g) || []).length;
+
+    // There should be exactly ONE declaration of each (from the shim)
+    expect(filenameDeclarations).toBe(1);
+    expect(dirnameDeclarations).toBe(1);
+
+    // The code SHOULD contain the shim since user didn't declare their own
+    expect(code).toContain('// -- Shims --');
+  });
+});

--- a/packages/deployer/src/build/plugins/esm-shim.test.ts
+++ b/packages/deployer/src/build/plugins/esm-shim.test.ts
@@ -5,39 +5,39 @@ import { rollup } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 import { esmShim } from './esm-shim';
 
+async function buildWithEsmShim(fixturePath: string) {
+  const bundle = await rollup({
+    logLevel: 'silent',
+    input: fixturePath,
+    cache: false,
+    treeshake: 'smallest',
+    plugins: [
+      {
+        name: 'externalize-all',
+        resolveId(id) {
+          return {
+            id,
+            external: id !== fixturePath,
+          };
+        },
+      },
+      esbuild({
+        target: 'esnext',
+        platform: 'node',
+        minify: false,
+      }),
+      esmShim(),
+    ],
+  });
+
+  return bundle.generate({ format: 'esm' });
+}
+
 describe('ESM Shim Plugin', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));
 
   it('should NOT inject shims when user already declares __filename and __dirname', async () => {
-    const file = join(_dirname, './__fixtures__/esm-shim-user-declared.js');
-
-    const bundle = await rollup({
-      logLevel: 'silent',
-      input: file,
-      cache: false,
-      treeshake: 'smallest',
-      plugins: [
-        {
-          name: 'externalize-all',
-          resolveId(id) {
-            return {
-              id,
-              external: id !== file,
-            };
-          },
-        },
-        esbuild({
-          target: 'esnext',
-          platform: 'node',
-          minify: false,
-        }),
-        esmShim(),
-      ],
-    });
-
-    const result = await bundle.generate({
-      format: 'esm',
-    });
+    const result = await buildWithEsmShim(join(_dirname, './__fixtures__/esm-shim-user-declared.js'));
 
     const code = result?.output[0].code;
 
@@ -55,35 +55,7 @@ describe('ESM Shim Plugin', () => {
   });
 
   it('should inject shims when user uses __filename/__dirname without declaring them', async () => {
-    const file = join(_dirname, './__fixtures__/esm-shim-no-declaration.js');
-
-    const bundle = await rollup({
-      logLevel: 'silent',
-      input: file,
-      cache: false,
-      treeshake: 'smallest',
-      plugins: [
-        {
-          name: 'externalize-all',
-          resolveId(id) {
-            return {
-              id,
-              external: id !== file,
-            };
-          },
-        },
-        esbuild({
-          target: 'esnext',
-          platform: 'node',
-          minify: false,
-        }),
-        esmShim(),
-      ],
-    });
-
-    const result = await bundle.generate({
-      format: 'esm',
-    });
+    const result = await buildWithEsmShim(join(_dirname, './__fixtures__/esm-shim-no-declaration.js'));
 
     const code = result?.output[0].code;
 
@@ -100,35 +72,7 @@ describe('ESM Shim Plugin', () => {
   });
 
   it('should NOT inject shims when user declares only __filename', async () => {
-    const file = join(_dirname, './__fixtures__/esm-shim-only-filename.js');
-
-    const bundle = await rollup({
-      logLevel: 'silent',
-      input: file,
-      cache: false,
-      treeshake: 'smallest',
-      plugins: [
-        {
-          name: 'externalize-all',
-          resolveId(id) {
-            return {
-              id,
-              external: id !== file,
-            };
-          },
-        },
-        esbuild({
-          target: 'esnext',
-          platform: 'node',
-          minify: false,
-        }),
-        esmShim(),
-      ],
-    });
-
-    const result = await bundle.generate({
-      format: 'esm',
-    });
+    const result = await buildWithEsmShim(join(_dirname, './__fixtures__/esm-shim-only-filename.js'));
 
     const code = result?.output[0].code;
 
@@ -139,40 +83,17 @@ describe('ESM Shim Plugin', () => {
     // If the shim is incorrectly injected, there will be TWO declarations
     expect(filenameDeclarations).toBe(1);
 
+    // Since the shim is skipped when __filename is declared,
+    // __dirname should also NOT be injected (should be 0 if not used in fixture)
+    const dirnameDeclarations = (code.match(/const __dirname\s*=/g) || []).length;
+    expect(dirnameDeclarations).toBe(0);
+
     // The code should NOT contain the shim comment
     expect(code).not.toContain('// -- Shims --');
   });
 
   it('should NOT inject shims when user declares only __dirname', async () => {
-    const file = join(_dirname, './__fixtures__/esm-shim-only-dirname.js');
-
-    const bundle = await rollup({
-      logLevel: 'silent',
-      input: file,
-      cache: false,
-      treeshake: 'smallest',
-      plugins: [
-        {
-          name: 'externalize-all',
-          resolveId(id) {
-            return {
-              id,
-              external: id !== file,
-            };
-          },
-        },
-        esbuild({
-          target: 'esnext',
-          platform: 'node',
-          minify: false,
-        }),
-        esmShim(),
-      ],
-    });
-
-    const result = await bundle.generate({
-      format: 'esm',
-    });
+    const result = await buildWithEsmShim(join(_dirname, './__fixtures__/esm-shim-only-dirname.js'));
 
     const code = result?.output[0].code;
 
@@ -182,6 +103,11 @@ describe('ESM Shim Plugin', () => {
     // There should be exactly ONE declaration (the user's own)
     // If the shim is incorrectly injected, there will be TWO declarations
     expect(dirnameDeclarations).toBe(1);
+
+    // Since the shim is skipped when __dirname is declared,
+    // __filename should also NOT be injected (should be 0 if not used in fixture)
+    const filenameDeclarations = (code.match(/const __filename\s*=/g) || []).length;
+    expect(filenameDeclarations).toBe(0);
 
     // The code should NOT contain the shim comment
     expect(code).not.toContain('// -- Shims --');

--- a/packages/deployer/src/build/plugins/esm-shim.ts
+++ b/packages/deployer/src/build/plugins/esm-shim.ts
@@ -1,0 +1,48 @@
+import originalEsmShim from '@rollup/plugin-esm-shim';
+import type { Plugin } from 'rollup';
+
+// Regex to detect DECLARATIONS of __filename, __dirname
+// Using non-capturing group (?:) for slightly better performance
+const FilenameDeclarationRegex = /(?:const|let|var)\s+__filename/;
+const DirnameDeclarationRegex = /(?:const|let|var)\s+__dirname/;
+
+/**
+ * Custom ESM shim plugin wrapper that respects user-declared __filename/__dirname variables.
+ *
+ * The original @rollup/plugin-esm-shim would inject shims even when users had already declared
+ * their own __filename/__dirname, causing "Identifier '__filename' has already been declared" errors.
+ *
+ * This wrapper checks if the user has already declared these variables and skips the shim injection
+ * if so. If either variable is declared, we skip the shim entirely since the original plugin injects
+ * both together and we assume users who declare one will also handle the other if needed.
+ */
+export function esmShim(): Plugin {
+  const original = originalEsmShim();
+
+  return {
+    name: 'esm-shim',
+    renderChunk(code, chunk, opts, meta) {
+      // Fast path: use includes() first to avoid regex if identifiers aren't present
+      const hasFilename = code.includes('__filename');
+      const hasDirname = code.includes('__dirname');
+
+      // If user declared either __filename or __dirname, skip shim injection entirely
+      // since the original plugin injects both together
+      const userDeclaredFilename = hasFilename && FilenameDeclarationRegex.test(code);
+      const userDeclaredDirname = hasDirname && DirnameDeclarationRegex.test(code);
+
+      if (userDeclaredFilename || userDeclaredDirname) {
+        return null;
+      }
+
+      // Otherwise, delegate to the original plugin
+      if (typeof original.renderChunk === 'function') {
+        return original.renderChunk.call(this, code, chunk, opts, meta);
+      }
+
+      return null;
+    },
+  };
+}
+
+export default esmShim;


### PR DESCRIPTION
## Description

When users declare their own `__filename` or `__dirname` variables using the standard ESM pattern, Mastra's bundler would inject duplicate declarations causing `SyntaxError: Identifier '__filename' has already been declared`.

```ts
// User's code
const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);
```

The `@rollup/plugin-esm-shim` plugin detects **usage** of these variables and injects shims, but doesn't check if the user has already **declared** them. It only checks if the code contains its own shim (https://github.com/rollup/plugins/blob/master/packages/esm-shim/src/constants.ts)

Created a wrapper plugin that checks for user declarations before delegating to the original plugin. If the user has declared either `__filename` or `__dirname`, shim injection is skipped entirely.

## Related Issue(s)

Fixes #10054

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ESM shims for __filename and __dirname are no longer injected when those variables are already declared by user code.

* **Tests**
  * Added test coverage verifying shim injection behavior across scenarios (both, one, or no declarations).

* **Chores**
  * Prepared a patch changeset for the release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->