### PR TITLE
feat: use links instead of onchange

### DIFF
--- a/docs/src/components/version-control.tsx
+++ b/docs/src/components/version-control.tsx
@@ -25,6 +25,10 @@ const getVersionFromPath = (pathname: string): Version => {
 const getPathForVersion = (pathname: string, nextVersion: Version): string => {
   const pathChunks = pathname.split("/");
 
+  if (pathChunks.length < 3) {
+    return pathname;
+  }
+
   if (nextVersion === "beta") {
     if (pathChunks?.[2] !== "v1") {
       pathChunks.splice(2, 0, "v1");
@@ -94,7 +98,8 @@ export default function VersionControl({
         {versions.map((version) => {
           const isActive = version.value === currentVersion;
           const href =
-            versionPaths[version.value as Version] ?? window.location.pathname;
+            versionPaths[version.value as Version] ??
+            (typeof window !== "undefined" ? window.location.pathname : "");
           return (
             <DropdownMenuItem
               key={version.value}

--- a/docs/src/components/version-control.tsx
+++ b/docs/src/components/version-control.tsx
@@ -6,7 +6,8 @@ import {
   DropdownMenuTrigger,
 } from "@site/src/components/ui/dropdown";
 import { Check } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useLocation } from "@docusaurus/router";
 import { cn } from "../lib/utils";
 import { BetaIcon, StableIcon, TriggerIcon, VersionLabel } from "./icons/icon";
 
@@ -49,24 +50,10 @@ export default function VersionControl({
   className?: string;
   size?: "sm" | "default";
 }) {
-  const [currentVersion, setCurrentVersion] = useState<Version>("beta");
-  const [versionPaths, setVersionPaths] = useState<
-    Partial<Record<Version, string>>
-  >({});
+  const location = useLocation();
+  const pathname = location.pathname;
+  const currentVersion = getVersionFromPath(pathname);
   const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const currentPath = window.location.pathname;
-    const detectedVersion = getVersionFromPath(currentPath);
-
-    setCurrentVersion(detectedVersion);
-    setVersionPaths({
-      beta: getPathForVersion(currentPath, "beta"),
-      stable: getPathForVersion(currentPath, "stable"),
-    });
-  }, []);
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -97,9 +84,7 @@ export default function VersionControl({
       >
         {versions.map((version) => {
           const isActive = version.value === currentVersion;
-          const href =
-            versionPaths[version.value as Version] ??
-            (typeof window !== "undefined" ? window.location.pathname : "");
+          const href = getPathForVersion(pathname, version.value as Version);
           return (
             <DropdownMenuItem
               key={version.value}

--- a/docs/src/components/version-control.tsx
+++ b/docs/src/components/version-control.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuTrigger,
 } from "@site/src/components/ui/dropdown";
 import { Check } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "../lib/utils";
 import { BetaIcon, StableIcon, TriggerIcon, VersionLabel } from "./icons/icon";
 
@@ -15,6 +15,29 @@ const versions = [
   { value: "beta", label: "Beta" },
 ];
 
+type Version = "beta" | "stable";
+
+const getVersionFromPath = (pathname: string): Version => {
+  const pathChunks = pathname.split("/");
+  return pathChunks?.[2] === "v1" ? "beta" : "stable";
+};
+
+const getPathForVersion = (pathname: string, nextVersion: Version): string => {
+  const pathChunks = pathname.split("/");
+
+  if (nextVersion === "beta") {
+    if (pathChunks?.[2] !== "v1") {
+      pathChunks.splice(2, 0, "v1");
+    }
+  } else {
+    if (pathChunks?.[2] === "v1") {
+      pathChunks.splice(2, 1);
+    }
+  }
+
+  return pathChunks.join("/");
+};
+
 export default function VersionControl({
   className,
   size = "default",
@@ -22,36 +45,24 @@ export default function VersionControl({
   className?: string;
   size?: "sm" | "default";
 }) {
-  // Initialize to stable to match SSR output and prevent hydration mismatch
-  // Stable = 0.x (default /docs), Beta = v1 (/docs/v1)
-  const [currentVersion, setCurrentVersion] = useState<"beta" | "stable">(
-    "beta",
-  );
+  const [currentVersion, setCurrentVersion] = useState<Version>("beta");
+  const [versionPaths, setVersionPaths] = useState<
+    Partial<Record<Version, string>>
+  >({});
   const [open, setOpen] = useState(false);
 
-  const onChange = (nextVersion: string) => {
+  useEffect(() => {
     if (typeof window === "undefined") return;
 
     const currentPath = window.location.pathname;
-    let pathChunks = currentPath.split("/");
-    let newPath: string;
+    const detectedVersion = getVersionFromPath(currentPath);
 
-    if (nextVersion === "beta") {
-      if (pathChunks?.[2] !== "v1") {
-        pathChunks.splice(2, 0, "v1");
-        newPath = pathChunks.join("/");
-      }
-    } else {
-      if (pathChunks?.[2] === "v1") {
-        pathChunks.splice(2, 1);
-        newPath = pathChunks.join("/");
-      }
-    }
-
-    if (newPath) {
-      window.location.href = newPath;
-    }
-  };
+    setCurrentVersion(detectedVersion);
+    setVersionPaths({
+      beta: getPathForVersion(currentPath, "beta"),
+      stable: getPathForVersion(currentPath, "stable"),
+    });
+  }, []);
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -82,22 +93,29 @@ export default function VersionControl({
       >
         {versions.map((version) => {
           const isActive = version.value === currentVersion;
+          const href =
+            versionPaths[version.value as Version] ?? window.location.pathname;
           return (
             <DropdownMenuItem
               key={version.value}
-              onClick={() => onChange(version.value)}
+              asChild
               className={cn(
                 "flex items-center text-(--mastra-text-secondary) justify-between w-full",
                 isActive && " font-medium",
               )}
             >
-              <span className="inline-flex dark:text-white text-black items-center gap-2">
-                {version.value === "stable" ? <StableIcon /> : <BetaIcon />}
-                <span>{version.label}</span>
-              </span>
-              {isActive && (
-                <Check className="size-4 text-(--mastra-green-accent-2)" />
-              )}
+              <a
+                href={href}
+                className="flex w-full items-center justify-between"
+              >
+                <span className="inline-flex dark:text-white text-black items-center gap-2">
+                  {version.value === "stable" ? <StableIcon /> : <BetaIcon />}
+                  <span>{version.label}</span>
+                </span>
+                {isActive && (
+                  <Check className="size-4 text-(--mastra-green-accent-2)" />
+                )}
+              </a>
             </DropdownMenuItem>
           );
         })}

--- a/docs/src/components/version-control.tsx
+++ b/docs/src/components/version-control.tsx
@@ -111,7 +111,7 @@ export default function VersionControl({
             >
               <a
                 href={href}
-                className="flex w-full items-center justify-between"
+                className="flex w-full items-center no-underline! justify-between"
               >
                 <span className="inline-flex dark:text-white text-black items-center gap-2">
                   {version.value === "stable" ? <StableIcon /> : <BetaIcon />}


### PR DESCRIPTION
## Description

Replace `onChange` syntax with links instead.

## Related Issue(s)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Version selector now derives the active version from the URL for consistent default selection.
  * Navigation uses real links instead of click-only handlers, improving bookmarking, back/forward behavior and browser compatibility.
  * Version links are generated from the current path for reliable switching and link generation.
  * Active-state indicators and icons remain unchanged for a consistent UI experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->