### PR TITLE
Consolidated tool-output chunks from nested agents into single result span

### DIFF
--- a/.changeset/silent-cycles-join.md
+++ b/.changeset/silent-cycles-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Consolidated tool-output chunks from nested agents into single tool-result spans

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -1,0 +1,500 @@
+import { ReadableStream } from 'node:stream/web';
+import type { ObservabilityExporter, TracingEvent, ExportedSpan } from '@mastra/core/observability';
+import { SpanType, SamplingStrategyType, TracingEventType } from '@mastra/core/observability';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DefaultObservabilityInstance } from './instances';
+import { ModelSpanTracker } from './model-tracing';
+
+/**
+ * Simple test exporter for capturing events
+ */
+class TestExporter implements ObservabilityExporter {
+  name = 'test-exporter';
+  events: TracingEvent[] = [];
+
+  async exportTracingEvent(event: TracingEvent): Promise<void> {
+    this.events.push(event);
+  }
+
+  async shutdown(): Promise<void> {
+    this.events = [];
+  }
+
+  getSpansByName(name: string): ExportedSpan[] {
+    return this.events
+      .filter(e => e.type === TracingEventType.SPAN_ENDED && e.exportedSpan.name === name)
+      .map(e => e.exportedSpan);
+  }
+
+  getSpansByType(type: SpanType): ExportedSpan[] {
+    return this.events
+      .filter(e => e.type === TracingEventType.SPAN_ENDED && e.exportedSpan.type === type)
+      .map(e => e.exportedSpan);
+  }
+}
+
+/**
+ * Helper to create a readable stream from an array of chunks
+ */
+function createMockStream<T>(chunks: T[]): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index]!);
+        index++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+/**
+ * Helper to consume a stream and return all chunks
+ */
+async function consumeStream<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const chunks: T[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+}
+
+describe('ModelSpanTracker', () => {
+  let testExporter: TestExporter;
+  let tracing: DefaultObservabilityInstance;
+
+  beforeEach(() => {
+    testExporter = new TestExporter();
+    tracing = new DefaultObservabilityInstance({
+      serviceName: 'test-tracing',
+      name: 'test-instance',
+      sampling: { type: SamplingStrategyType.ALWAYS },
+      exporters: [testExporter],
+    });
+  });
+
+  describe('tool-output consolidation for sub-agent streaming', () => {
+    it('should consolidate multiple tool-output text-delta chunks into a single tool-result span', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      // Simulate streaming chunks from a sub-agent used as a tool
+      const toolCallId = 'call_test123';
+      const toolName = 'agent-subAgent';
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        // First tool-output with text-delta
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'Hello ' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        // More text-delta chunks
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'world' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: '!' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        // Finish chunk ends the tool output
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'finish', payload: {} },
+            toolCallId,
+            toolName,
+          },
+        },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+
+      modelSpan.end();
+
+      // Should have exactly one tool-result span (consolidated from multiple tool-output chunks)
+      const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
+      expect(toolResultSpans).toHaveLength(1);
+
+      // The span should have accumulated text
+      const span = toolResultSpans[0]!;
+      expect(span.output).toEqual({
+        toolCallId,
+        toolName,
+        text: 'Hello world!',
+      });
+    });
+
+    it('should consolidate reasoning-delta chunks from sub-agent', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const toolCallId = 'call_reasoning123';
+      const toolName = 'agent-reasoningAgent';
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'reasoning-delta', payload: { text: 'Let me think...' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'The answer is 42' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'finish', payload: {} },
+            toolCallId,
+            toolName,
+          },
+        },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+
+      modelSpan.end();
+
+      const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
+      expect(toolResultSpans).toHaveLength(1);
+
+      const span = toolResultSpans[0]!;
+      expect(span.output).toEqual({
+        toolCallId,
+        toolName,
+        text: 'The answer is 42',
+        reasoning: 'Let me think...',
+      });
+    });
+
+    it('should handle workflow-finish as end of tool output', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const toolCallId = 'call_workflow123';
+      const toolName = 'workflow-myWorkflow';
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'Workflow result' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        // Workflows emit workflow-finish instead of finish
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'workflow-finish', payload: { workflowStatus: 'success' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+
+      modelSpan.end();
+
+      const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
+      expect(toolResultSpans).toHaveLength(1);
+
+      const span = toolResultSpans[0]!;
+      expect(span.output).toEqual({
+        toolCallId,
+        toolName,
+        text: 'Workflow result',
+      });
+    });
+  });
+
+  describe('tool-result deduplication', () => {
+    it('should skip tool-result span when tool-output streaming already tracked the same toolCallId', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const toolCallId = 'call_dedupe123';
+      const toolName = 'agent-subAgent';
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        // Streaming tool-output chunks
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'Streamed content' } },
+            toolCallId,
+            toolName,
+          },
+        },
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'finish', payload: {} },
+            toolCallId,
+            toolName,
+          },
+        },
+        // After streaming ends, a tool-result chunk arrives (should be skipped)
+        {
+          type: 'tool-result',
+          payload: {
+            args: { prompt: 'test' },
+            toolCallId,
+            toolName,
+            result: { text: 'Streamed content' },
+          },
+        },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+
+      modelSpan.end();
+
+      // Should have only ONE tool-result span (from streaming), not two
+      const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
+      expect(toolResultSpans).toHaveLength(1);
+
+      // The span should have the streamed content, not the tool-result payload
+      const span = toolResultSpans[0]!;
+      expect(span.output).toEqual({
+        toolCallId,
+        toolName,
+        text: 'Streamed content',
+      });
+    });
+  });
+
+  describe('tool-result args removal', () => {
+    it('should remove args from tool-result output for non-streaming tools', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const toolCallId = 'call_regular123';
+      const toolName = 'regularTool';
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        // Non-streaming tool: just a tool-result chunk (no prior tool-output)
+        {
+          type: 'tool-result',
+          payload: {
+            args: { input: 'test input', option: true }, // args should be stripped
+            toolCallId,
+            toolName,
+            result: { output: 'tool result' },
+          },
+        },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+
+      modelSpan.end();
+
+      const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
+      expect(toolResultSpans).toHaveLength(1);
+
+      const span = toolResultSpans[0]!;
+      // args should not be in the output
+      expect(span.output).not.toHaveProperty('args');
+      // Other fields should be preserved
+      expect(span.output).toEqual({
+        toolCallId,
+        toolName,
+        result: { output: 'tool result' },
+      });
+    });
+  });
+
+  describe('multiple concurrent tool calls', () => {
+    it('should track multiple streaming tool calls independently', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      // Simulate interleaved streaming from two sub-agents
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        // First tool starts
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'Agent1: ' } },
+            toolCallId: 'call_agent1',
+            toolName: 'agent-first',
+          },
+        },
+        // Second tool starts
+        {
+          type: 'tool-output',
+          runId: 'run-2',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'Agent2: ' } },
+            toolCallId: 'call_agent2',
+            toolName: 'agent-second',
+          },
+        },
+        // Interleaved deltas
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'Hello' } },
+            toolCallId: 'call_agent1',
+            toolName: 'agent-first',
+          },
+        },
+        {
+          type: 'tool-output',
+          runId: 'run-2',
+          from: 'USER',
+          payload: {
+            output: { type: 'text-delta', payload: { text: 'World' } },
+            toolCallId: 'call_agent2',
+            toolName: 'agent-second',
+          },
+        },
+        // First tool finishes
+        {
+          type: 'tool-output',
+          runId: 'run-1',
+          from: 'USER',
+          payload: {
+            output: { type: 'finish', payload: {} },
+            toolCallId: 'call_agent1',
+            toolName: 'agent-first',
+          },
+        },
+        // Second tool finishes
+        {
+          type: 'tool-output',
+          runId: 'run-2',
+          from: 'USER',
+          payload: {
+            output: { type: 'finish', payload: {} },
+            toolCallId: 'call_agent2',
+            toolName: 'agent-second',
+          },
+        },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+
+      modelSpan.end();
+
+      const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
+      expect(toolResultSpans).toHaveLength(2);
+
+      // Find spans by toolCallId
+      const agent1Span = toolResultSpans.find(s => (s.output as any)?.toolCallId === 'call_agent1');
+      const agent2Span = toolResultSpans.find(s => (s.output as any)?.toolCallId === 'call_agent2');
+
+      expect(agent1Span).toBeDefined();
+      expect(agent1Span!.output).toEqual({
+        toolCallId: 'call_agent1',
+        toolName: 'agent-first',
+        text: 'Agent1: Hello',
+      });
+
+      expect(agent2Span).toBeDefined();
+      expect(agent2Span!.output).toEqual({
+        toolCallId: 'call_agent2',
+        toolName: 'agent-second',
+        text: 'Agent2: World',
+      });
+    });
+  });
+});

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -149,6 +149,10 @@ describe('ModelSpanTracker', () => {
       const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
       expect(toolResultSpans).toHaveLength(1);
 
+      // Should NOT have any individual tool-output spans (they should be consolidated)
+      const toolOutputSpans = testExporter.getSpansByName("chunk: 'tool-output'");
+      expect(toolOutputSpans).toHaveLength(0);
+
       // The span should have accumulated text
       const span = toolResultSpans[0]!;
       expect(span.output).toEqual({
@@ -477,6 +481,10 @@ describe('ModelSpanTracker', () => {
 
       const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
       expect(toolResultSpans).toHaveLength(2);
+
+      // Should NOT have any individual tool-output spans (6 chunks consolidated into 2 spans)
+      const toolOutputSpans = testExporter.getSpansByName("chunk: 'tool-output'");
+      expect(toolOutputSpans).toHaveLength(0);
 
       // Find spans by toolCallId
       const agent1Span = toolResultSpans.find(s => (s.output as any)?.toolCallId === 'call_agent1');

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -25,6 +25,18 @@ import type { OutputSchema, ChunkType, StepStartPayload, StepFinishPayload } fro
  * Should be instantiated once per MODEL_GENERATION span and shared across
  * all streaming steps (including after tool calls).
  */
+/**
+ * Tracks accumulated content for a single tool output stream
+ */
+interface ToolOutputAccumulator {
+  toolName: string;
+  toolCallId: string;
+  text: string;
+  reasoning: string;
+  span?: Span<SpanType.MODEL_CHUNK>;
+  sequenceNumber: number;
+}
+
 export class ModelSpanTracker {
   #modelSpan?: Span<SpanType.MODEL_GENERATION>;
   #currentStepSpan?: Span<SpanType.MODEL_STEP>;
@@ -34,6 +46,10 @@ export class ModelSpanTracker {
   #chunkSequence: number = 0;
   /** Tracks whether completionStartTime has been captured for this generation */
   #completionStartTimeCaptured: boolean = false;
+  /** Tracks tool output accumulators by toolCallId for consolidating sub-agent streams */
+  #toolOutputAccumulators: Map<string, ToolOutputAccumulator> = new Map();
+  /** Tracks toolCallIds that had streaming output (to skip redundant tool-result spans) */
+  #streamedToolCallIds: Set<string> = new Set();
 
   constructor(modelSpan?: Span<SpanType.MODEL_GENERATION>) {
     this.#modelSpan = modelSpan;
@@ -320,6 +336,118 @@ export class ModelSpanTracker {
   }
 
   /**
+   * Handle tool-output chunks from sub-agents.
+   * Consolidates streaming text/reasoning deltas into a single span per tool call.
+   */
+  #handleToolOutputChunk<OUTPUT extends OutputSchema>(chunk: ChunkType<OUTPUT>) {
+    if (chunk.type !== 'tool-output') return;
+
+    const payload = chunk.payload as {
+      output: any;
+      toolCallId: string;
+      toolName?: string;
+    };
+
+    const { output, toolCallId, toolName } = payload;
+
+    // Get or create accumulator for this tool call
+    let acc = this.#toolOutputAccumulators.get(toolCallId);
+    if (!acc) {
+      // Auto-create step if we see a chunk before step-start
+      if (!this.#currentStepSpan) {
+        this.#startStepSpan();
+      }
+
+      acc = {
+        toolName: toolName || 'unknown',
+        toolCallId,
+        text: '',
+        reasoning: '',
+        sequenceNumber: this.#chunkSequence++,
+        // Name the span 'tool-result' for consistency (tool-call → tool-result)
+        span: this.#currentStepSpan?.createChildSpan({
+          name: `chunk: 'tool-result'`,
+          type: SpanType.MODEL_CHUNK,
+          attributes: {
+            chunkType: 'tool-result',
+            sequenceNumber: this.#chunkSequence - 1,
+          },
+        }),
+      };
+      this.#toolOutputAccumulators.set(toolCallId, acc);
+    }
+
+    // Handle the inner chunk based on its type
+    if (output && typeof output === 'object' && 'type' in output) {
+      const innerType = output.type as string;
+
+      switch (innerType) {
+        case 'text-delta':
+          // Accumulate text content
+          if (output.payload?.text) {
+            acc.text += output.payload.text;
+          }
+          break;
+
+        case 'reasoning-delta':
+          // Accumulate reasoning content
+          if (output.payload?.text) {
+            acc.reasoning += output.payload.text;
+          }
+          break;
+
+        case 'finish':
+        case 'workflow-finish':
+          // End the span with accumulated content
+          this.#endToolOutputSpan(toolCallId);
+          break;
+
+        // Ignore start/end markers - we handle accumulation ourselves
+        case 'text-start':
+        case 'text-end':
+        case 'reasoning-start':
+        case 'reasoning-end':
+        case 'start':
+        case 'workflow-start':
+          break;
+
+        default:
+          // For other inner chunk types, we don't accumulate but we also don't
+          // create extra spans - they'll be included in the final output
+          break;
+      }
+    }
+  }
+
+  /**
+   * End a tool output span and clean up the accumulator
+   */
+  #endToolOutputSpan(toolCallId: string) {
+    const acc = this.#toolOutputAccumulators.get(toolCallId);
+    if (!acc) return;
+
+    // Build output with accumulated content
+    const output: Record<string, any> = {
+      toolCallId: acc.toolCallId,
+      toolName: acc.toolName,
+    };
+
+    if (acc.text) {
+      output.text = acc.text;
+    }
+    if (acc.reasoning) {
+      output.reasoning = acc.reasoning;
+    }
+
+    acc.span?.end({ output });
+    this.#toolOutputAccumulators.delete(toolCallId);
+
+    // Mark this toolCallId as having had streaming output
+    // so we can skip redundant tool-result spans
+    this.#streamedToolCallIds.add(toolCallId);
+  }
+
+  /**
    * Wraps a stream with model tracing transform to track MODEL_STEP and MODEL_CHUNK spans.
    *
    * This should be added to the stream pipeline to automatically
@@ -386,6 +514,28 @@ export class ModelSpanTracker {
             case 'finish':
               // don't output these chunks that don't have helpful output
               break;
+
+            case 'tool-output':
+              // Consolidate streaming tool outputs (e.g., from sub-agents) into single spans
+              this.#handleToolOutputChunk(chunk);
+              break;
+
+            case 'tool-result': {
+              const toolCallId = chunk.payload?.toolCallId;
+
+              // Skip tool-result if we already tracked streaming for this toolCallId
+              // (the tool-output span captures duration and content better)
+              if (toolCallId && this.#streamedToolCallIds.has(toolCallId)) {
+                this.#streamedToolCallIds.delete(toolCallId); // Clean up
+                break;
+              }
+
+              // For non-streaming tools, create the span but remove args from output
+              // (args are redundant - already on the TOOL_CALL span input)
+              const { args, ...cleanPayload } = chunk.payload || {};
+              this.#createEventSpan(chunk.type, cleanPayload);
+              break;
+            }
 
             // Default: auto-create event span for all other chunk types
             default: {


### PR DESCRIPTION
## Description

Summary

- Consolidate streaming tool-output chunks from nested agents into single tool-result spans
- Skip redundant tool-result spans when streaming already tracked the same toolCallId
- Remove args from tool-result output (redundant with TOOL_CALL span input)
- Add unit tests for ModelSpanTracker tool-output consolidation

Problem

When an agent is used as a tool within another agent (nested agents), the streaming text-delta chunks from the sub-agent were each being recorded as separate tool-output
 spans in the trace. This created excessive noise with dozens of individual spans for each word/token, plus duplicate spans (tool-output and tool-result for the same
tool call).

Solution

Added explicit handling for tool-output chunks in ModelSpanTracker:
- Track streaming tool outputs by toolCallId using a new accumulator map
- Accumulate text-delta and reasoning-delta content into single spans
- Name spans consistently as tool-result for the tool-call → tool-result pattern
- Skip creating redundant tool-result spans after streaming ends
- Strip args from non-streaming tool-result output

OLD Trace:

<img width="1189" height="833" alt="Screenshot 2025-12-03 at 6 01 50 PM" src="https://github.com/user-attachments/assets/a2a63600-ba61-41ab-a5a0-5d9d91c120fa" />

NEW Trace:
<img width="1100" height="582" alt="Screenshot 2025-12-03 at 5 33 58 PM" src="https://github.com/user-attachments/assets/6f2c54fa-ec9e-4831-b284-91e741933f36" />


## Related Issue(s)

Fixes: #10012
Partially fixes: #10773

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated streaming tool-output from nested agents into single consolidated tool-result spans, preserving accumulated text and reasoning and avoiding duplicate results.

* **Tests**
  * Added comprehensive unit tests for streaming workflows: concurrent tool calls, deduplication, end-of-output handling, and span aggregation validation.

* **Chores**
  * Added a patch changeset entry for the observability package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->