### PR TITLE
feature(LangfuseExporter): Reuse traces with shared traceId

### DIFF
--- a/.changeset/pretty-beds-draw.md
+++ b/.changeset/pretty-beds-draw.md
@@ -1,0 +1,7 @@
+---
+'@mastra/langfuse': patch
+---
+
+Fix Langfuse exporter to reuse existing traces when multiple root spans share the same traceId. This resolves an issue where multiple agent.stream() calls with client-side tools would create separate traces in Langfuse instead of grouping them under a single trace. The exporter now checks if a trace already exists before creating a new one, allowing proper trace consolidation for conversations with multiple agent interactions.
+
+Fixes #8830

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -269,6 +269,23 @@ export class LangfuseExporter extends BaseExporter {
   }
 
   private initTrace(span: AnyExportedSpan): void {
+    // Check if trace already exists in our local traceMap
+    // This allows multiple root spans (e.g., from multiple agent.stream calls)
+    // to be grouped under the same Langfuse trace
+    if (this.traceMap.has(span.traceId)) {
+      this.logger.debug('Langfuse exporter: Reusing existing trace from local map', {
+        traceId: span.traceId,
+        spanId: span.id,
+        spanName: span.name,
+      });
+      return; // Reuse existing trace
+    }
+
+    // Note: If the traceId already exists in Langfuse (e.g., from a previous server instance
+    // or session), the Langfuse SDK handles this gracefully. Calling client.trace() with
+    // an existing ID is idempotent - it will update/continue the existing trace rather than
+    // failing or creating a duplicate. This is by design for distributed tracing scenarios.
+    // See: https://langfuse.com/docs/tracing-features/trace-ids
     const trace = this.client.trace(this.buildTracePayload(span));
     this.traceMap.set(span.traceId, {
       trace,


### PR DESCRIPTION
## Description

- Enhanced initTrace method to check for existing traces in the local traceMap, allowing for efficient trace grouping.
- Added tests to ensure proper reuse of existing traces when multiple root spans share the same traceId.
## Related Issue(s)

fixes https://github.com/mastra-ai/mastra/issues/7175

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reuse existing remote traces when multiple root spans share the same trace ID, preventing duplicate traces and improving recovery after server restarts.

* **Tests**
  * Added tests covering trace reuse, idempotent trace updates, and parent–child span association scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->