### PR TITLE
Allow custom pg client configuration

### DIFF
--- a/.changeset/pg-byoc-pool.md
+++ b/.changeset/pg-byoc-pool.md
@@ -1,0 +1,37 @@
+---
+"@mastra/pg": minor
+---
+
+Add BYOC (Bring Your Own Client) pool support for PostgresStore and PgVector
+
+**Features:**
+
+- PostgresStore now uses `pg.Pool` directly instead of `pg-promise`, enabling support for HTTP-based drivers like `@neondatabase/serverless`
+- Added `pool` parameter to both PostgresStore and PgVector for passing your own pg.Pool instance
+- Exposes `store.pool` and `pgVector.pool` for direct access to the underlying connection pool
+- Share a single pool between PgVector and PostgresStore for memory optimization in serverless environments
+- Supports Neon serverless driver, PlanetScale, and other pg-compatible HTTP drivers
+
+**Breaking Changes:**
+
+- Removed `client` parameter (pg-promise IDatabase) from PostgresStore - use `pool` instead
+- Removed `store.pgp` property - use `store.pool` for direct database access
+
+**Migration:**
+
+```typescript
+// Before (pg-promise client - no longer supported)
+const store = new PostgresStore({
+  client: pgPromiseDb,
+});
+
+// After (pg.Pool)
+import { Pool } from "pg";
+const pool = new Pool({ connectionString: "..." });
+const store = new PostgresStore({ pool });
+
+// Shared pool between vector and storage
+const vectorStore = new PgVector({ pool });
+const store = new PostgresStore({ pool });
+```
+

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
@@ -278,6 +278,52 @@ npx @mastra/codemod@beta v1/storage-postgres-schema-name .
 
 :::
 
+### PostgresStore BYOC: `client` to `pool`
+
+PostgresStore now uses `pg.Pool` directly instead of `pg-promise`. This enables support for HTTP-based drivers like `@neondatabase/serverless` for serverless environments.
+
+**Breaking changes:**
+- The `client` parameter (pg-promise `IDatabase`) has been removed - use `pool` instead
+- The `store.pgp` property has been removed - use `store.pool` for direct database access
+
+To migrate, replace pg-promise clients with pg pools:
+
+```diff
+- import pgPromise from 'pg-promise';
++ import { Pool } from 'pg';
+
+- const pgp = pgPromise();
+- const db = pgp('postgresql://user:pass@localhost:5432/db');
++ const pool = new Pool({
++   connectionString: 'postgresql://user:pass@localhost:5432/db',
++ });
+
+  const store = new PostgresStore({
+    id: 'my-store',
+-   client: db,
++   pool,
+  });
+
+  // Direct database access
+- store.pgp; // No longer available
++ store.pool; // Use pg.Pool directly
+```
+
+You can now share a pool between `PgVector` and `PostgresStore`:
+
+```typescript
+import { Pool } from 'pg';
+import { PgVector, PostgresStore } from '@mastra/pg';
+
+const pool = new Pool({ connectionString: '...' });
+
+const vectorStore = new PgVector({ id: 'vectors', pool });
+const store = new PostgresStore({ id: 'storage', pool });
+
+// When done, YOU close the pool
+await pool.end();
+```
+
 ### Score storage methods to `listScoresBy*` pattern
 
 Score storage APIs have been renamed to follow the `listScoresBy*` pattern. This change provides consistency with the broader API naming conventions.

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -42,6 +42,20 @@ const storage = new PostgresStore({
         "The name of the schema you want the storage to use. Will use the default schema if not provided.",
       isOptional: true,
     },
+    {
+      name: "pool",
+      type: "Pool",
+      description:
+        "Bring your own pg.Pool instance (e.g., from @neondatabase/serverless or pg). When provided, connection options are ignored.",
+      isOptional: true,
+    },
+    {
+      name: "client",
+      type: "IDatabase",
+      description:
+        "Bring your own pg-promise IDatabase instance. When provided, connection options are ignored.",
+      isOptional: true,
+    },
   ]}
 />
 
@@ -87,9 +101,126 @@ const store5 = new PostgresStore({
 });
 ```
 
-## Additional Notes
+## Bring Your Own Client (BYOC)
 
-### Schema Management
+PostgresStore supports bringing your own PostgreSQL pool or client. This is especially useful for:
+
+- **Serverless environments** where you need HTTP-based connections (Neon serverless, PlanetScale)
+- **Memory optimization** by sharing a single pool across vector and storage
+- **Custom drivers**
+
+### Using with Serverless
+
+The Neon serverless driver uses HTTP connections instead of TCP, making it ideal for serverless environments like Cloudflare Workers, Vercel Edge, etc.
+
+```ts
+import { Pool, neonConfig } from '@neondatabase/serverless';
+import { PostgresStore } from '@mastra/pg';
+
+// Create Neon pool - this uses HTTP connections, not TCP
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+// Use with PostgresStore - just pass the pool directly!
+const store = new PostgresStore({
+  id: 'neon-store',
+  pool,
+});
+
+await store.init();
+
+// When you're done, YOU are responsible for closing the pool
+await pool.end();
+```
+
+### Shared Pool
+
+```ts
+import { Pool } from 'pg';
+import { PgVector, PostgresStore } from '@mastra/pg';
+
+// Create a shared pool
+const pool = new Pool({
+  connectionString: 'postgresql://user:pass@localhost:5432/db',
+  max: 20,
+});
+
+// Use the same pool for both vector and storage operations
+const vectorStore = new PgVector({
+  id: 'my-vector-store',
+  pool,
+});
+
+const store = new PostgresStore({
+  id: 'my-store',
+  pool, // Same pool!
+});
+
+await store.init();
+
+// When you're done, YOU are responsible for closing the pool
+await pool.end();
+```
+
+### Using pg-promise directly
+
+If you're already using pg-promise in your application, you can pass its client directly:
+
+```ts
+import pgPromise from 'pg-promise';
+import { PostgresStore } from '@mastra/pg';
+
+const pgp = pgPromise();
+const db = pgp('postgresql://user:pass@localhost:5432/db');
+
+const store = new PostgresStore({
+  id: 'my-store',
+  client: db, // Pass pg-promise client directly
+});
+
+await store.init();
+```
+
+#### Important Notes for BYOC
+
+1. **Lifecycle Management**: When you provide your own pool or client, you are responsible for closing it. The stores will NOT close user-provided connections.
+
+2. **Schema Configuration**: You can still specify `schemaName` when using BYOC:
+
+   ```ts
+   const store = new PostgresStore({
+     id: 'my-store',
+     pool: myPool,
+     schemaName: 'custom_schema',
+   });
+   ```
+
+3. **Initialization**: `PostgresStore.init()` must still be called to set up tables, even when using BYOC.
+
+4. **Pool vs Client**:
+   - `pool`: Pass a `pg.Pool` or compatible pool (recommended for most cases)
+   - `client`: Pass a pg-promise `IDatabase` instance (for existing pg-promise users)
+
+## Direct Database and Pool Access
+
+`PostgresStore` exposes both the underlying database object and the pg-promise instance as public fields:
+
+```typescript
+store.db; // pg-promise database instance
+store.pgp; // pg-promise main instance
+```
+
+This enables direct queries and custom transaction management. When using these fields:
+
+- You are responsible for proper connection and transaction handling.
+- Closing the store (`store.close()`) will destroy the associated connection pool.
+- Direct access bypasses any additional logic or validation provided by PostgresStore methods.
+
+This approach is intended for advanced scenarios where low-level access is required.
+
+
+## Schema Management
 
 The storage implementation handles schema creation and updates automatically. It creates the following tables:
 
@@ -137,23 +268,6 @@ await storage.getThread({ threadId: "..." });
 :::warning
 If `init()` is not called, tables won't be created and storage operations will fail silently or throw errors.
 :::
-
-### Direct Database and Pool Access
-
-`PostgresStore` exposes both the underlying database object and the pg-promise instance as public fields:
-
-```typescript
-store.db; // pg-promise database instance
-store.pgp; // pg-promise main instance
-```
-
-This enables direct queries and custom transaction management. When using these fields:
-
-- You are responsible for proper connection and transaction handling.
-- Closing the store (`store.close()`) will destroy the associated connection pool.
-- Direct access bypasses any additional logic or validation provided by PostgresStore methods.
-
-This approach is intended for advanced scenarios where low-level access is required.
 
 ## Index Management
 

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -49,13 +49,6 @@ const storage = new PostgresStore({
         "Bring your own pg.Pool instance (e.g., from @neondatabase/serverless or pg). When provided, connection options are ignored.",
       isOptional: true,
     },
-    {
-      name: "client",
-      type: "IDatabase",
-      description:
-        "Bring your own pg-promise IDatabase instance. When provided, connection options are ignored.",
-      isOptional: true,
-    },
   ]}
 />
 
@@ -163,28 +156,9 @@ await store.init();
 await pool.end();
 ```
 
-### Using pg-promise directly
-
-If you're already using pg-promise in your application, you can pass its client directly:
-
-```ts
-import pgPromise from 'pg-promise';
-import { PostgresStore } from '@mastra/pg';
-
-const pgp = pgPromise();
-const db = pgp('postgresql://user:pass@localhost:5432/db');
-
-const store = new PostgresStore({
-  id: 'my-store',
-  client: db, // Pass pg-promise client directly
-});
-
-await store.init();
-```
-
 #### Important Notes for BYOC
 
-1. **Lifecycle Management**: When you provide your own pool or client, you are responsible for closing it. The stores will NOT close user-provided connections.
+1. **Lifecycle Management**: When you provide your own pool, you are responsible for closing it. The stores will NOT close user-provided connections.
 
 2. **Schema Configuration**: You can still specify `schemaName` when using BYOC:
 
@@ -198,23 +172,18 @@ await store.init();
 
 3. **Initialization**: `PostgresStore.init()` must still be called to set up tables, even when using BYOC.
 
-4. **Pool vs Client**:
-   - `pool`: Pass a `pg.Pool` or compatible pool (recommended for most cases)
-   - `client`: Pass a pg-promise `IDatabase` instance (for existing pg-promise users)
+## Direct Pool Access
 
-## Direct Database and Pool Access
-
-`PostgresStore` exposes both the underlying database object and the pg-promise instance as public fields:
+`PostgresStore` exposes the underlying PostgreSQL connection pool as a public field:
 
 ```typescript
-store.db; // pg-promise database instance
-store.pgp; // pg-promise main instance
+store.pool; // pg.Pool instance
 ```
 
-This enables direct queries and custom transaction management. When using these fields:
+This enables direct queries and custom transaction management. When using this field:
 
 - You are responsible for proper connection and transaction handling.
-- Closing the store (`store.close()`) will destroy the associated connection pool.
+- Closing the store (`store.close()`) will destroy the associated connection pool (unless you provided your own).
 - Direct access bypasses any additional logic or validation provided by PostgresStore methods.
 
 This approach is intended for advanced scenarios where low-level access is required.

--- a/docs/src/content/en/reference/vectors/pg.mdx
+++ b/docs/src/content/en/reference/vectors/pg.mdx
@@ -79,6 +79,12 @@ It provides robust vector similarity search capabilities within your existing Po
       description: "Additional pg pool configuration options",
       isOptional: true,
     },
+    {
+      name: "pool",
+      type: "Pool",
+      description: "Bring your own PostgreSQL pool instance (e.g., from @neondatabase/serverless or pg). When provided, connection options are ignored.",
+      isOptional: true,
+    },
   ]}
 />
 
@@ -124,10 +130,99 @@ const vectorStore = new PgVector({
 });
 ```
 
+## Bring Your Own Client (BYOC)
+
+PgVector supports bringing your own PostgreSQL pool. This is especially useful for:
+
+- **Serverless environments** where you need HTTP-based connections (Neon serverless, PlanetScale)
+- **Memory optimization** by sharing a single pool across vector and storage
+- **Custom drivers**
+
+### Using with Serverless
+
+The Neon serverless driver uses HTTP connections instead of TCP, making it ideal for serverless environments like Cloudflare Workers, Vercel Edge, etc.
+
+```ts
+import { Pool, neonConfig } from '@neondatabase/serverless';
+import { PgVector } from '@mastra/pg';
+
+// Create Neon pool - this uses HTTP connections, not TCP
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+// Use with PgVector
+const vectorStore = new PgVector({
+  id: 'neon-vectors',
+  pool,
+});
+
+// When you're done, YOU are responsible for closing the pool
+await pool.end();
+```
+
+### Shared Pool
+
+```ts
+import { Pool } from 'pg';
+import { PgVector, PostgresStore } from '@mastra/pg';
+
+// Create a shared pool
+const pool = new Pool({
+  connectionString: 'postgresql://user:pass@localhost:5432/db',
+  max: 20,
+});
+
+// Use the same pool for both vector and storage operations
+const vectorStore = new PgVector({
+  id: 'my-vector-store',
+  pool,
+});
+
+const store = new PostgresStore({
+  id: 'my-store',
+  pool, // Same pool!
+});
+
+await store.init();
+
+// When you're done, YOU are responsible for closing the pool
+await pool.end();
+```
+
+#### Important Notes for BYOC
+
+1. **Lifecycle Management**: When you provide your own pool, you are responsible for closing it. The stores will NOT close user-provided connections.
+
+2. **Schema Configuration**: You can still specify `schemaName` when using BYOC:
+
+   ```ts
+   const vectorStore = new PgVector({
+     id: 'my-vectors',
+     pool: myPool,
+     schemaName: 'custom_schema',
+   });
+   ```
+
+## Direct Pool Access
+
+The `PgVector` class exposes its underlying PostgreSQL connection pool as a public field:
+
+```typescript
+pgVector.pool; // instance of pg.Pool
+```
+
+This enables advanced usage such as running direct SQL queries, managing transactions, or monitoring pool state. When using the pool directly:
+
+- You are responsible for releasing clients (`client.release()`) after use.
+- The pool remains accessible after calling `disconnect()`, but new queries will fail.
+- Direct access bypasses any validation or transaction logic provided by PgVector methods.
+
+This design supports advanced use cases but requires careful resource management by the user.
+
 ## Methods
 
 ### createIndex()
-
 <PropertiesTable
   content={[
     {
@@ -165,7 +260,6 @@ const vectorStore = new PgVector({
 />
 
 #### IndexConfig
-
 <PropertiesTable
   content={[
     {
@@ -624,22 +718,6 @@ The system automatically detects configuration changes and only rebuilds indexes
 - Adjust parameters like `lists` and `m` based on dataset size and query requirements.
 - **Monitor index performance** using `describeIndex()` to track usage
 - Rebuild indexes periodically to maintain efficiency, especially after significant data changes
-
-## Direct Pool Access
-
-The `PgVector` class exposes its underlying PostgreSQL connection pool as a public field:
-
-```typescript
-pgVector.pool; // instance of pg.Pool
-```
-
-This enables advanced usage such as running direct SQL queries, managing transactions, or monitoring pool state. When using the pool directly:
-
-- You are responsible for releasing clients (`client.release()`) after use.
-- The pool remains accessible after calling `disconnect()`, but new queries will fail.
-- Direct access bypasses any validation or transaction logic provided by PgVector methods.
-
-This design supports advanced use cases but requires careful resource management by the user.
 
 ## Related
 

--- a/stores/pg/README.md
+++ b/stores/pg/README.md
@@ -256,28 +256,9 @@ await store.init();
 await pool.end();
 ```
 
-#### Using pg-promise Client Directly
-
-If you're already using pg-promise in your application, you can pass its client directly:
-
-```typescript
-import pgPromise from 'pg-promise';
-import { PostgresStore } from '@mastra/pg';
-
-const pgp = pgPromise();
-const db = pgp('postgresql://user:pass@localhost:5432/db');
-
-const store = new PostgresStore({
-  id: 'my-store',
-  client: db, // Pass pg-promise client directly
-});
-
-await store.init();
-```
-
 #### Important Notes for BYOC
 
-1. **Lifecycle Management**: When you provide your own pool or client, you are responsible for closing it. The stores will NOT close user-provided connections.
+1. **Lifecycle Management**: When you provide your own pool, you are responsible for closing it. The stores will NOT close user-provided connections.
 
 2. **Schema Configuration**: You can still specify `schemaName` when using BYOC:
 
@@ -290,10 +271,6 @@ await store.init();
    ```
 
 3. **Initialization**: `PostgresStore.init()` must still be called to set up tables, even when using BYOC.
-
-4. **Pool vs Client for PostgresStore**:
-   - `pool`: Pass a `pg.Pool` or compatible pool (recommended for most cases)
-   - `client`: Pass a pg-promise `IDatabase` instance (for existing pg-promise users)
 
 ## Features
 

--- a/stores/pg/README.md
+++ b/stores/pg/README.md
@@ -192,7 +192,7 @@ Both `PgVector` and `PostgresStore` support bringing your own PostgreSQL client/
 - **Memory optimization** by sharing a single pool across vector and storage
 - **Custom drivers** like `@neondatabase/serverless` or `postgres-js`
 
-#### Using with Neon Serverless (Recommended for Serverless)
+#### Using with Serverless
 
 The Neon serverless driver uses HTTP connections instead of TCP, making it ideal for serverless environments like Cloudflare Workers, Vercel Edge, etc.
 
@@ -256,17 +256,7 @@ await store.init();
 await pool.end();
 ```
 
-#### Using with postgres-js
-
-```typescript
-import postgres from 'postgres';
-import { PostgresStore } from '@mastra/pg';
-
-// Note: postgres-js has a different API, so you may need an adapter
-// For direct pool support, use @neondatabase/serverless or pg
-```
-
-#### Advanced: Using pg-promise Client Directly
+#### Using pg-promise Client Directly
 
 If you're already using pg-promise in your application, you can pass its client directly:
 

--- a/stores/pg/src/index.ts
+++ b/stores/pg/src/index.ts
@@ -1,4 +1,11 @@
 export * from './vector';
 export * from './storage';
-export type { PostgresConfig, PostgresStoreConfig, PgVectorConfig } from './shared/config';
+export type {
+  PostgresConfig,
+  PostgresStoreConfig,
+  PostgresStoreClientConfig,
+  PgVectorConfig,
+  PgVectorPoolConfig,
+} from './shared/config';
+export { hasUserProvidedClient, hasUserProvidedPool } from './shared/config';
 export { PGVECTOR_PROMPT } from './vector/prompt';

--- a/stores/pg/src/index.ts
+++ b/stores/pg/src/index.ts
@@ -4,9 +4,8 @@ export type {
   PostgresConfig,
   PostgresStoreConfig,
   PostgresStorePoolConfig,
-  PostgresStoreClientConfig,
   PgVectorConfig,
   PgVectorPoolConfig,
 } from './shared/config';
-export { hasUserProvidedClient, hasUserProvidedStorePool, hasUserProvidedPool } from './shared/config';
+export { hasUserProvidedStorePool, hasUserProvidedPool } from './shared/config';
 export { PGVECTOR_PROMPT } from './vector/prompt';

--- a/stores/pg/src/index.ts
+++ b/stores/pg/src/index.ts
@@ -3,9 +3,10 @@ export * from './storage';
 export type {
   PostgresConfig,
   PostgresStoreConfig,
+  PostgresStorePoolConfig,
   PostgresStoreClientConfig,
   PgVectorConfig,
   PgVectorPoolConfig,
 } from './shared/config';
-export { hasUserProvidedClient, hasUserProvidedPool } from './shared/config';
+export { hasUserProvidedClient, hasUserProvidedStorePool, hasUserProvidedPool } from './shared/config';
 export { PGVECTOR_PROMPT } from './vector/prompt';

--- a/stores/pg/src/shared/config.ts
+++ b/stores/pg/src/shared/config.ts
@@ -1,6 +1,7 @@
 import type { ConnectionOptions } from 'node:tls';
 import type { ClientConfig } from 'pg';
 import type * as pg from 'pg';
+import type pgPromise from 'pg-promise';
 import type { ISSLConfig } from 'pg-promise/typescript/pg-subset';
 
 /**
@@ -31,14 +32,77 @@ export type PostgresConfig<SSLType = ISSLConfig | ConnectionOptions> = {
 
 /**
  * PostgreSQL configuration for PostgresStore (uses pg-promise with ISSLConfig)
+ * Users can provide their own pg-promise client via the `client` option.
  */
-export type PostgresStoreConfig = PostgresConfig<ISSLConfig>;
+export type PostgresStoreConfig = PostgresConfig<ISSLConfig> & {
+  /**
+   * Bring your own pg-promise client.
+   * When provided, the store will use this client instead of creating its own.
+   * The client will NOT be closed when the store is closed - you are responsible for managing its lifecycle.
+   */
+  client?: pgPromise.IDatabase<{}>;
+};
+
+/**
+ * Simplified config for BYOC with pg-promise client only (no connection details needed)
+ */
+export type PostgresStoreClientConfig = {
+  /** Unique identifier for this store instance */
+  id: string;
+  /** Custom PostgreSQL schema name (default: 'public') */
+  schemaName?: string;
+  /**
+   * Bring your own pg-promise client.
+   * When provided, the store will use this client instead of creating its own.
+   * The client will NOT be closed when the store is closed - you are responsible for managing its lifecycle.
+   */
+  client: pgPromise.IDatabase<{}>;
+};
 
 /**
  * PostgreSQL configuration for PgVector (uses pg with ConnectionOptions)
+ * Users can provide their own pg.Pool via the `pool` option.
  */
 export type PgVectorConfig = PostgresConfig<ConnectionOptions> & {
   pgPoolOptions?: Omit<pg.PoolConfig, 'connectionString'>;
+  /**
+   * Bring your own pg.Pool.
+   * When provided, the vector store will use this pool instead of creating its own.
+   * The pool will NOT be closed when disconnect() is called - you are responsible for managing its lifecycle.
+   */
+  pool?: pg.Pool;
+};
+
+/**
+ * Simplified config for BYOC with pg.Pool only (no connection details needed)
+ */
+export type PgVectorPoolConfig = {
+  /** Unique identifier for this vector store instance */
+  id: string;
+  /** Custom PostgreSQL schema name (default: 'public') */
+  schemaName?: string;
+  /**
+   * Bring your own pg.Pool.
+   * When provided, the vector store will use this pool instead of creating its own.
+   * The pool will NOT be closed when disconnect() is called - you are responsible for managing its lifecycle.
+   */
+  pool: pg.Pool;
+};
+
+/**
+ * Check if config has a user-provided pg-promise client
+ */
+export const hasUserProvidedClient = (
+  cfg: PostgresStoreConfig | PostgresStoreClientConfig,
+): cfg is PostgresStoreClientConfig => {
+  return 'client' in cfg && cfg.client !== undefined;
+};
+
+/**
+ * Check if config has a user-provided pg.Pool
+ */
+export const hasUserProvidedPool = (cfg: PgVectorConfig | PgVectorPoolConfig): cfg is PgVectorPoolConfig => {
+  return 'pool' in cfg && cfg.pool !== undefined;
 };
 
 export const isConnectionStringConfig = <SSLType>(
@@ -97,4 +161,38 @@ export const validateConfig = (name: string, config: PostgresConfig<ISSLConfig |
       `${name}: invalid config. Provide either {connectionString}, {host,port,database,user,password}, or a pg ClientConfig (e.g., Cloud SQL connector with \`stream\`).`,
     );
   }
+};
+
+/**
+ * Validate config for PgVector, including BYOC pool option
+ */
+export const validatePgVectorConfig = (config: PgVectorConfig | PgVectorPoolConfig) => {
+  if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
+    throw new Error(`PgVector: id must be provided and cannot be empty.`);
+  }
+
+  if (hasUserProvidedPool(config)) {
+    // User provided their own pool, no further validation needed
+    return;
+  }
+
+  // Validate as regular config
+  validateConfig('PgVector', config as PostgresConfig<ConnectionOptions>);
+};
+
+/**
+ * Validate config for PostgresStore, including BYOC client option
+ */
+export const validatePostgresStoreConfig = (config: PostgresStoreConfig | PostgresStoreClientConfig) => {
+  if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
+    throw new Error(`PostgresStore: id must be provided and cannot be empty.`);
+  }
+
+  if (hasUserProvidedClient(config)) {
+    // User provided their own client, no further validation needed
+    return;
+  }
+
+  // Validate as regular config
+  validateConfig('PostgresStore', config as PostgresConfig<ISSLConfig>);
 };

--- a/stores/pg/src/shared/pg-pool-adapter.ts
+++ b/stores/pg/src/shared/pg-pool-adapter.ts
@@ -1,0 +1,180 @@
+/**
+ * PgPoolAdapter - Wraps a pg.Pool with a pg-promise-compatible interface
+ *
+ * This adapter enables BYOC (Bring Your Own Client) support for PostgresStore,
+ * allowing users to provide their own pg.Pool (including HTTP-based drivers like
+ * @neondatabase/serverless) while maintaining compatibility with the existing
+ * pg-promise-based query interface.
+ */
+import type { Pool, PoolClient, QueryResult } from 'pg';
+
+/**
+ * Interface matching the subset of pg-promise's IDatabase that we use
+ */
+export interface IPgPromiseCompatible {
+  none(query: string, values?: any[]): Promise<void>;
+  one<T = any>(query: string, values?: any[]): Promise<T>;
+  oneOrNone<T = any>(query: string, values?: any[]): Promise<T | null>;
+  any<T = any>(query: string, values?: any[]): Promise<T[]>;
+  many<T = any>(query: string, values?: any[]): Promise<T[]>;
+  manyOrNone<T = any>(query: string, values?: any[]): Promise<T[]>;
+  result(query: string, values?: any[]): Promise<QueryResult<any>>;
+  query<T = any>(query: string, values?: any[]): Promise<T[]>;
+  tx<T>(callback: (t: IPgPromiseCompatible) => Promise<T>): Promise<T>;
+  batch<T>(promises: Promise<T>[]): Promise<T[]>;
+}
+
+/**
+ * Transaction context for pg.Pool - wraps a PoolClient to provide
+ * the same interface as the main adapter
+ */
+class PgPoolTransactionContext implements IPgPromiseCompatible {
+  constructor(private client: PoolClient) {}
+
+  async none(query: string, values?: any[]): Promise<void> {
+    await this.client.query(query, values);
+  }
+
+  async one<T = any>(query: string, values?: any[]): Promise<T> {
+    const result = await this.client.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error('No data returned from query that expected exactly one row');
+    }
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned from query that expected exactly one row`);
+    }
+    return result.rows[0] as T;
+  }
+
+  async oneOrNone<T = any>(query: string, values?: any[]): Promise<T | null> {
+    const result = await this.client.query(query, values);
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned from query that expected at most one row`);
+    }
+    return (result.rows[0] as T) || null;
+  }
+
+  async any<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.client.query(query, values);
+    return result.rows as T[];
+  }
+
+  async many<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.client.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error('No data returned from query that expected at least one row');
+    }
+    return result.rows as T[];
+  }
+
+  async manyOrNone<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.client.query(query, values);
+    return result.rows as T[];
+  }
+
+  async result(query: string, values?: any[]): Promise<QueryResult<any>> {
+    return this.client.query(query, values);
+  }
+
+  async query<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.client.query(query, values);
+    return result.rows as T[];
+  }
+
+  async tx<T>(callback: (t: IPgPromiseCompatible) => Promise<T>): Promise<T> {
+    // Nested transactions - pg doesn't support true nested transactions,
+    // but we can use savepoints. For simplicity, we just run the callback
+    // on the same client (single transaction context).
+    return callback(this);
+  }
+
+  async batch<T>(promises: Promise<T>[]): Promise<T[]> {
+    return Promise.all(promises);
+  }
+}
+
+/**
+ * Adapter that wraps a pg.Pool with a pg-promise-compatible interface
+ *
+ * This allows PostgresStore to work with any pg.Pool-compatible driver,
+ * including HTTP-based drivers like @neondatabase/serverless.
+ */
+export class PgPoolAdapter implements IPgPromiseCompatible {
+  constructor(private pool: Pool) {}
+
+  async none(query: string, values?: any[]): Promise<void> {
+    await this.pool.query(query, values);
+  }
+
+  async one<T = any>(query: string, values?: any[]): Promise<T> {
+    const result = await this.pool.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error('No data returned from query that expected exactly one row');
+    }
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned from query that expected exactly one row`);
+    }
+    return result.rows[0] as T;
+  }
+
+  async oneOrNone<T = any>(query: string, values?: any[]): Promise<T | null> {
+    const result = await this.pool.query(query, values);
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned from query that expected at most one row`);
+    }
+    return (result.rows[0] as T) || null;
+  }
+
+  async any<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.pool.query(query, values);
+    return result.rows as T[];
+  }
+
+  async many<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.pool.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error('No data returned from query that expected at least one row');
+    }
+    return result.rows as T[];
+  }
+
+  async manyOrNone<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.pool.query(query, values);
+    return result.rows as T[];
+  }
+
+  async result(query: string, values?: any[]): Promise<QueryResult<any>> {
+    return this.pool.query(query, values);
+  }
+
+  async query<T = any>(query: string, values?: any[]): Promise<T[]> {
+    const result = await this.pool.query(query, values);
+    return result.rows as T[];
+  }
+
+  /**
+   * Execute a callback within a transaction
+   */
+  async tx<T>(callback: (t: IPgPromiseCompatible) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const txContext = new PgPoolTransactionContext(client);
+      const result = await callback(txContext);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Execute multiple promises in parallel (pg-promise compatibility)
+   */
+  async batch<T>(promises: Promise<T>[]): Promise<T[]> {
+    return Promise.all(promises);
+  }
+}

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -9,12 +9,12 @@ import type {
   PaginationInfo,
   UpdateSpanRecord,
 } from '@mastra/core/storage';
-import type { IDatabase } from 'pg-promise';
+import type { IPgPromiseCompatible } from '../../../shared/pg-pool-adapter';
 import type { StoreOperationsPG } from '../operations';
 import { buildDateRangeFilter, prepareWhereClause, transformFromSqlRow, getTableName, getSchemaName } from '../utils';
 
 export class ObservabilityPG extends ObservabilityStorage {
-  public client: IDatabase<{}>;
+  public client: IPgPromiseCompatible;
   private operations: StoreOperationsPG;
   private schema?: string;
 
@@ -23,7 +23,7 @@ export class ObservabilityPG extends ObservabilityStorage {
     operations,
     schema,
   }: {
-    client: IDatabase<{}>;
+    client: IPgPromiseCompatible;
     operations: StoreOperationsPG;
     schema?: string;
   }) {

--- a/stores/pg/src/storage/domains/operations/index.ts
+++ b/stores/pg/src/storage/domains/operations/index.ts
@@ -17,19 +17,19 @@ import type {
   StorageIndexStats,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
-import type { IDatabase } from 'pg-promise';
+import type { IPgPromiseCompatible } from '../../../shared/pg-pool-adapter';
 import { getSchemaName, getTableName } from '../utils';
 
 // Re-export the types for convenience
 export type { CreateIndexOptions, IndexInfo, StorageIndexStats };
 
 export class StoreOperationsPG extends StoreOperations {
-  public client: IDatabase<{}>;
+  public client: IPgPromiseCompatible;
   public schemaName?: string;
   private setupSchemaPromise: Promise<void> | null = null;
   private schemaSetupComplete: boolean | undefined = undefined;
 
-  constructor({ client, schemaName }: { client: IDatabase<{}>; schemaName?: string }) {
+  constructor({ client, schemaName }: { client: IPgPromiseCompatible; schemaName?: string }) {
     super();
     this.client = client;
     this.schemaName = schemaName;

--- a/stores/pg/src/storage/domains/scores/index.ts
+++ b/stores/pg/src/storage/domains/scores/index.ts
@@ -9,7 +9,7 @@ import {
   TABLE_SCORERS,
   transformScoreRow as coreTransformScoreRow,
 } from '@mastra/core/storage';
-import type { IDatabase } from 'pg-promise';
+import type { IPgPromiseCompatible } from '../../../shared/pg-pool-adapter';
 import type { StoreOperationsPG } from '../operations';
 import { getTableName } from '../utils';
 
@@ -27,7 +27,7 @@ function transformScoreRow(row: Record<string, any>): ScoreRowData {
 }
 
 export class ScoresPG extends ScoresStorage {
-  public client: IDatabase<{}>;
+  public client: IPgPromiseCompatible;
   private operations: StoreOperationsPG;
   private schema?: string;
 
@@ -36,7 +36,7 @@ export class ScoresPG extends ScoresStorage {
     operations,
     schema,
   }: {
-    client: IDatabase<{}>;
+    client: IPgPromiseCompatible;
     operations: StoreOperationsPG;
     schema?: string;
   }) {

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -2,7 +2,7 @@ import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { normalizePerPage, TABLE_WORKFLOW_SNAPSHOT, WorkflowsStorage } from '@mastra/core/storage';
 import type { StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
-import type { IDatabase } from 'pg-promise';
+import type { IPgPromiseCompatible } from '../../../shared/pg-pool-adapter';
 import type { StoreOperationsPG } from '../operations';
 import { getTableName } from '../utils';
 
@@ -27,7 +27,7 @@ function parseWorkflowRun(row: Record<string, any>): WorkflowRun {
 }
 
 export class WorkflowsPG extends WorkflowsStorage {
-  public client: IDatabase<{}>;
+  public client: IPgPromiseCompatible;
   private operations: StoreOperationsPG;
   private schema: string;
 
@@ -36,7 +36,7 @@ export class WorkflowsPG extends WorkflowsStorage {
     operations,
     schema,
   }: {
-    client: IDatabase<{}>;
+    client: IPgPromiseCompatible;
     operations: StoreOperationsPG;
     schema: string;
   }) {

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -1,7 +1,6 @@
 import { createTestSuite } from '@internal/storage-test-utils';
 import { Pool } from 'pg';
-import pgPromise from 'pg-promise';
-import { afterAll, beforeAll, describe, vi } from 'vitest';
+import { afterAll, describe, vi } from 'vitest';
 import { pgTests, TEST_CONFIG, connectionString } from './test-utils';
 import { PostgresStore } from '.';
 
@@ -15,45 +14,17 @@ createTestSuite(new PostgresStore({ ...TEST_CONFIG, schemaName: 'my_schema' }));
 
 // Test with BYOC pool
 describe('PostgresStore with BYOC pool', () => {
-  let pool: Pool;
-  let store: PostgresStore;
-
-  beforeAll(() => {
-    pool = new Pool({ connectionString });
-    store = new PostgresStore({
-      id: 'byoc-pool-test',
-      pool,
-      schemaName: 'byoc_pool_schema',
-    });
+  // Initialize at describe block level so it's available when createTestSuite runs
+  const pool = new Pool({ connectionString, allowExitOnIdle: true });
+  const store = new PostgresStore({
+    id: 'byoc-pool-test',
+    pool,
+    schemaName: 'byoc_pool_schema',
   });
 
   afterAll(async () => {
     await store.close();
     await pool.end();
-  });
-
-  createTestSuite(store);
-});
-
-// Test with BYOC pg-promise client
-describe('PostgresStore with BYOC pg-promise client', () => {
-  let pgp: pgPromise.IMain;
-  let client: pgPromise.IDatabase<{}>;
-  let store: PostgresStore;
-
-  beforeAll(() => {
-    pgp = pgPromise();
-    client = pgp(connectionString);
-    store = new PostgresStore({
-      id: 'byoc-client-test',
-      client,
-      schemaName: 'byoc_client_schema',
-    });
-  });
-
-  afterAll(async () => {
-    await store.close();
-    pgp.end();
   });
 
   createTestSuite(store);

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -1,11 +1,62 @@
 import { createTestSuite } from '@internal/storage-test-utils';
-import { vi } from 'vitest';
-import { pgTests, TEST_CONFIG } from './test-utils';
+import { Pool } from 'pg';
+import pgPromise from 'pg-promise';
+import { afterAll, beforeAll, describe, vi } from 'vitest';
+import { pgTests, TEST_CONFIG, connectionString } from './test-utils';
 import { PostgresStore } from '.';
 
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 
+// Test with standard config
 createTestSuite(new PostgresStore(TEST_CONFIG));
+
+// Test with custom schema
 createTestSuite(new PostgresStore({ ...TEST_CONFIG, schemaName: 'my_schema' }));
+
+// Test with BYOC pool
+describe('PostgresStore with BYOC pool', () => {
+  let pool: Pool;
+  let store: PostgresStore;
+
+  beforeAll(() => {
+    pool = new Pool({ connectionString });
+    store = new PostgresStore({
+      id: 'byoc-pool-test',
+      pool,
+      schemaName: 'byoc_pool_schema',
+    });
+  });
+
+  afterAll(async () => {
+    await store.close();
+    await pool.end();
+  });
+
+  createTestSuite(store);
+});
+
+// Test with BYOC pg-promise client
+describe('PostgresStore with BYOC pg-promise client', () => {
+  let pgp: pgPromise.IMain;
+  let client: pgPromise.IDatabase<{}>;
+  let store: PostgresStore;
+
+  beforeAll(() => {
+    pgp = pgPromise();
+    client = pgp(connectionString);
+    store = new PostgresStore({
+      id: 'byoc-client-test',
+      client,
+      schemaName: 'byoc_client_schema',
+    });
+  });
+
+  afterAll(async () => {
+    await store.close();
+    pgp.end();
+  });
+
+  createTestSuite(store);
+});
 
 pgTests();

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -95,8 +95,8 @@ export class PostgresStore extends MastraStorage {
           poolConfig = {
             connectionString: this.#config.connectionString,
             ssl: this.#config.ssl,
-            // High defaults to match pg-promise behavior
-            max: this.#config.max ?? 20,
+            // Default pool size of 10 (balanced for most use cases)
+            max: this.#config.max ?? 10,
             idleTimeoutMillis: this.#config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
             allowExitOnIdle: true,
@@ -109,8 +109,8 @@ export class PostgresStore extends MastraStorage {
             user: this.#config.user,
             password: this.#config.password,
             ssl: this.#config.ssl,
-            // High defaults to match pg-promise behavior
-            max: this.#config.max ?? 20,
+            // Default pool size of 10 (balanced for most use cases)
+            max: this.#config.max ?? 10,
             idleTimeoutMillis: this.#config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
             allowExitOnIdle: true,

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -3688,6 +3688,10 @@ describe('PgVector Metadata Filtering', () => {
   const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
   const metadataVectorDB = new PgVector({ connectionString, id: 'pg-metadata-test' });
 
+  afterAll(async () => {
+    await metadataVectorDB.disconnect();
+  });
+
   createVectorTestSuite({
     vector: metadataVectorDB,
     createIndex: async (indexName: string) => {
@@ -3713,6 +3717,7 @@ describe('PgVector with BYOC pool', () => {
     connectionString,
     max: 5,
     idleTimeoutMillis: 10000,
+    allowExitOnIdle: true,
   });
 
   // Create PgVector with BYOC pool at describe block level

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -3706,23 +3706,20 @@ describe('PgVector Metadata Filtering', () => {
 // BYOC Pool tests - verify that user-provided pools work correctly
 describe('PgVector with BYOC pool', () => {
   const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
-  let sharedPool: pg.Pool;
-  let byocVectorDB: PgVector;
 
-  beforeAll(() => {
-    // Create a shared pool that we'll provide to PgVector
-    sharedPool = new pg.Pool({
-      connectionString,
-      max: 5,
-      idleTimeoutMillis: 10000,
-    });
+  // Create a shared pool that we'll provide to PgVector
+  // Initialized at describe block level so it's available when createVectorTestSuite runs
+  const sharedPool = new pg.Pool({
+    connectionString,
+    max: 5,
+    idleTimeoutMillis: 10000,
+  });
 
-    // Create PgVector with BYOC pool
-    byocVectorDB = new PgVector({
-      id: 'pg-byoc-pool-test',
-      pool: sharedPool,
-      schemaName: 'byoc_vector_schema',
-    });
+  // Create PgVector with BYOC pool at describe block level
+  const byocVectorDB = new PgVector({
+    id: 'pg-byoc-pool-test',
+    pool: sharedPool,
+    schemaName: 'byoc_vector_schema',
   });
 
   afterAll(async () => {

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -98,7 +98,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
           poolConfig = {
             connectionString: config.connectionString,
             ssl: config.ssl,
-            max: config.max ?? 20,
+            max: config.max ?? 10,
             idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
             allowExitOnIdle: true,
@@ -107,7 +107,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         } else if (isCloudSqlConfig(config)) {
           poolConfig = {
             ...config,
-            max: config.max ?? 20,
+            max: config.max ?? 10,
             idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
             allowExitOnIdle: true,
@@ -121,7 +121,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             user: config.user,
             password: config.password,
             ssl: config.ssl,
-            max: config.max ?? 20,
+            max: config.max ?? 10,
             idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
             allowExitOnIdle: true,

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -101,6 +101,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             max: config.max ?? 20,
             idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
+            allowExitOnIdle: true,
             ...config.pgPoolOptions,
           };
         } else if (isCloudSqlConfig(config)) {
@@ -109,6 +110,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             max: config.max ?? 20,
             idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
+            allowExitOnIdle: true,
             ...config.pgPoolOptions,
           } as pg.PoolConfig;
         } else if (isHostConfig(config)) {
@@ -122,6 +124,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             max: config.max ?? 20,
             idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
             connectionTimeoutMillis: 2000,
+            allowExitOnIdle: true,
             ...config.pgPoolOptions,
           };
         } else {


### PR DESCRIPTION
## Description

This PR implements "Bring Your Own Client" (BYOC) functionality for `PgVector` and `PostgresStore`. Users can now provide their own `pg.Pool` (for both stores) or `pg-promise.IDatabase` instance (for `PostgresStore`).

This change is crucial for:
*   **Serverless compatibility:** Enables the use of lightweight, HTTP-based drivers like `@neondatabase/serverless` to prevent memory issues and TCP connection limitations in serverless environments.
*   **Memory optimization:** Allows sharing a single `pg.Pool` between vector and storage instances, reducing resource consumption.
*   **Flexibility:** Integrates seamlessly with existing connection management strategies.

When a client or pool is provided, the user is responsible for its lifecycle management.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

---
<a href="https://cursor.com/background-agent?bcId=bc-7c11654f-9cd3-4d67-a08b-ffdf5554edd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c11654f-9cd3-4d67-a08b-ffdf5554edd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bring Your Own Client (BYOC) support, allowing you to supply your own PostgreSQL pool to PostgresStore and PgVector.
  * Enabled pool sharing between PostgresStore and PgVector components.
  * Added support for serverless PostgreSQL environments (e.g., Neon).
  * Introduced pool property for direct pool access and lifecycle management.

* **Documentation**
  * Expanded documentation with BYOC usage patterns, serverless configuration examples, and shared pool usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->