### PR TITLE
feat(braintrust): add time_to_first_token metric support

### DIFF
--- a/.changeset/add-braintrust-ttft-support.md
+++ b/.changeset/add-braintrust-ttft-support.md
@@ -1,5 +1,6 @@
 ---
 '@mastra/braintrust': patch
+'@mastra/observability': patch
 ---
 
 Add time-to-first-token (TTFT) support for Braintrust integration

--- a/.changeset/add-braintrust-ttft-support.md
+++ b/.changeset/add-braintrust-ttft-support.md
@@ -1,0 +1,14 @@
+---
+'@mastra/braintrust': patch
+---
+
+Add time-to-first-token (TTFT) support for Braintrust integration
+
+Adds `time_to_first_token` metric to Braintrust spans, populated from the `completionStartTime` attribute captured when the first streaming chunk arrives.
+
+```typescript
+// time_to_first_token is now automatically sent to Braintrust
+// as part of span metrics during streaming
+const result = await agent.stream('Hello');
+```
+

--- a/observability/braintrust/src/metrics.ts
+++ b/observability/braintrust/src/metrics.ts
@@ -10,6 +10,7 @@ import type { ModelGenerationAttributes } from '@mastra/core/observability';
  * - completion_reasoning_tokens: reasoning tokens, when available
  * - prompt_cached_tokens: tokens served from cache (provider-specific)
  * - prompt_cache_creation_tokens: tokens used to create cache (provider-specific)
+ * - time_to_first_token: timestamp (ms since epoch) when first token arrived (streaming only)
  */
 export interface BraintrustUsageMetrics {
   prompt_tokens?: number;
@@ -18,6 +19,7 @@ export interface BraintrustUsageMetrics {
   completion_reasoning_tokens?: number;
   prompt_cached_tokens?: number;
   prompt_cache_creation_tokens?: number;
+  time_to_first_token?: number;
   [key: string]: number | undefined;
 }
 
@@ -47,6 +49,11 @@ export function normalizeUsageMetrics(modelAttr: ModelGenerationAttributes): Bra
   }
   if (modelAttr.usage?.promptCacheMissTokens !== undefined) {
     metrics.prompt_cache_creation_tokens = modelAttr.usage?.promptCacheMissTokens;
+  }
+
+  // Time to first token (TTFT) for streaming responses
+  if (modelAttr.completionStartTime) {
+    metrics.time_to_first_token = modelAttr.completionStartTime.getTime();
   }
 
   return metrics;


### PR DESCRIPTION
Adds `time_to_first_token` metric to Braintrust spans, using the `completionStartTime` attribute that gets captured when the first streaming chunk arrives.

```typescript
// Before: no TTFT metric sent to Braintrust

// After: time_to_first_token automatically included in metrics
const result = await agent.stream('Hello');
// metrics.time_to_first_token = completionStartTime.getTime()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time-to-first-token (TTFT) metric for Braintrust integration to measure latency to the first streaming token.
* **Bug Fixes / Reliability**
  * Ensures the TTFT is captured reliably on the very first streaming chunk and sent alongside other performance metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->