### PR TITLE
feat(observability): Implement tags support in OtelExporter, OtelBrid…

### DIFF
--- a/.changeset/shiny-hornets-float.md
+++ b/.changeset/shiny-hornets-float.md
@@ -13,6 +13,11 @@ This change adds support for the `tracingOptions.tags` feature to the OpenTeleme
 - **OtelBridge**: Tags flow through the SpanConverter and are included in native OTEL spans as `mastra.tags`
 - **ArizeExporter**: Tags are mapped to the native OpenInference `tag.tags` semantic convention
 
+**Implementation Details:**
+- Tags are only included on root spans (by design)
+- Tags are stored as JSON-stringified arrays for maximum backend compatibility (many OTEL backends have limited native array support)
+- Empty or undefined tag arrays are not included in span attributes
+
 **Usage:**
 ```typescript
 const result = await agent.generate({

--- a/.changeset/shiny-hornets-float.md
+++ b/.changeset/shiny-hornets-float.md
@@ -1,0 +1,28 @@
+---
+'@mastra/otel-exporter': patch
+'@mastra/otel-bridge': patch
+'@mastra/arize': patch
+---
+
+feat(observability): Add tags support to OtelExporter, OtelBridge, and ArizeExporter
+
+This change adds support for the `tracingOptions.tags` feature to the OpenTelemetry-based exporters and bridge. Tags are now included as span attributes when present on root spans, following the same pattern as Braintrust and Langfuse exporters.
+
+**Changes:**
+- **OtelExporter**: Tags are now included as `mastra.tags` span attribute for root spans
+- **OtelBridge**: Tags flow through the SpanConverter and are included in native OTEL spans as `mastra.tags`
+- **ArizeExporter**: Tags are mapped to the native OpenInference `tag.tags` semantic convention
+
+**Usage:**
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2"],
+  },
+});
+```
+
+Fixes #10771
+
+

--- a/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
@@ -160,6 +160,25 @@ Both services must have:
 2. W3C Trace Context propagator enabled
 3. Mastra with OtelBridge configured
 
+## Using Tags
+
+Tags help you categorize and filter traces in your OTEL backend. Add tags when executing agents or workflows:
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+Tags are exported as a JSON string in the `mastra.tags` span attribute for broad backend compatibility. Common use cases include:
+
+- Environment labels: `"production"`, `"staging"`
+- Experiment tracking: `"experiment-v1"`, `"control-group"`
+- Priority levels: `"priority-high"`, `"batch-job"`
+
 ## Troubleshooting
 
 If traces aren't appearing or connecting as expected:

--- a/docs/src/content/en/docs/observability/tracing/exporters/arize.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/arize.mdx
@@ -203,6 +203,25 @@ Reserved fields such as `input`, `output`, `sessionId`, thread/user IDs, and Ope
 
 This exporter implements the [OpenInference Semantic Conventions](https://github.com/Arize-ai/openinference/tree/main/spec) for generative AI applications, providing standardized trace structure across different observability platforms.
 
+## Using Tags
+
+Tags help you categorize and filter traces in Phoenix and Arize AX. Add tags when executing agents or workflows:
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+Tags appear as the `tag.tags` attribute following OpenInference conventions and can be used to filter and search traces. Common use cases include:
+
+- Environment labels: `"production"`, `"staging"`
+- Experiment tracking: `"experiment-v1"`, `"control-group"`
+- Priority levels: `"priority-high"`, `"batch-job"`
+
 ## Related
 
 - [Tracing Overview](/docs/v1/observability/tracing/overview)

--- a/docs/src/content/en/docs/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/otel.mdx
@@ -266,6 +266,25 @@ Install the suggested package for your provider.
 3. **Authentication failures**: Verify API keys and headers are correct
 4. **No traces appearing**: Check that traces complete (root span must end)
 
+## Using Tags
+
+Tags help you categorize and filter traces in your observability platform. Add tags when executing agents or workflows:
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+Tags are exported as a JSON string in the `mastra.tags` span attribute for broad backend compatibility. Common use cases include:
+
+- Environment labels: `"production"`, `"staging"`
+- Experiment tracking: `"experiment-v1"`, `"control-group"`
+- Priority levels: `"priority-high"`, `"batch-job"`
+
 ## Related
 
 - [Tracing Overview](/docs/v1/observability/tracing/overview)

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -492,7 +492,12 @@ const result = await run.start({
 #### How Tags Work
 
 - **Root span only**: Tags are applied only to the root span of a trace (the agent run or workflow run span)
-- **Platform-specific**: Tags appear in Braintrust and Langfuse dashboards for filtering and searching
+- **Widely supported**: Tags are supported by most exporters for filtering and searching traces:
+  - **Braintrust** - Native `tags` field
+  - **Langfuse** - Native `tags` field on traces
+  - **ArizeExporter** - `tag.tags` OpenInference attribute
+  - **OtelExporter** - `mastra.tags` span attribute
+  - **OtelBridge** - `mastra.tags` span attribute
 - **Combinable with metadata**: You can use both `tags` and `metadata` in the same `tracingOptions`
 
 ```ts showLineNumbers copy

--- a/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
@@ -143,6 +143,33 @@ The OtelBridge requires an active OpenTelemetry SDK to function. The bridge read
 
 See the [OtelBridge Guide](/docs/v1/observability/tracing/bridges/otel#configuration) for complete setup instructions, including how to configure OTEL instrumentation and run your application.
 
+## Tags Support
+
+The OtelBridge supports trace tagging for categorization and filtering. Tags are only applied to root spans and are included as the `mastra.tags` attribute on native OTEL spans.
+
+### Usage
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+### How Tags Are Stored
+
+Tags are stored as a JSON-stringified array in the `mastra.tags` span attribute:
+
+```json
+{
+  "mastra.tags": "[\"production\",\"experiment-v2\",\"user-request\"]"
+}
+```
+
+This format ensures compatibility with all OTEL-compatible backends and collectors.
+
 ## Related
 
 - [OtelBridge Guide](/docs/v1/observability/tracing/bridges/otel) - Setup guide with examples

--- a/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
@@ -161,6 +161,31 @@ const exporter = new ArizeExporter({
 
 The ArizeExporter implements [OpenInference Semantic Conventions](https://github.com/Arize-ai/openinference/tree/main/spec) for generative AI applications, providing standardized trace structure across different observability platforms.
 
+## Tags Support
+
+The ArizeExporter supports trace tagging for categorization and filtering. Tags are only applied to root spans and are mapped to the native OpenInference `tag.tags` semantic convention.
+
+### Usage
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+### How Tags Are Stored
+
+Tags are stored using the OpenInference `tag.tags` attribute:
+
+```json
+{
+  "tag.tags": ["production", "experiment-v2", "user-request"]
+}
+```
+
 ## Related
 
 - [ArizeExporter Documentation](/docs/v1/observability/tracing/exporters/arize)

--- a/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
@@ -368,6 +368,35 @@ The exporter preserves span hierarchy from Mastra's Tracing:
 - Maintains correct nesting for agents, workflows, LLM calls, and tools
 - Exports complete traces with all relationships intact
 
+## Tags Support
+
+The OtelExporter supports trace tagging for categorization and filtering. Tags are only applied to root spans and are stored as the `mastra.tags` attribute.
+
+### Usage
+
+```typescript
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Hello" }],
+  tracingOptions: {
+    tags: ["production", "experiment-v2", "user-request"],
+  },
+});
+```
+
+### How Tags Are Stored
+
+Tags are stored as a JSON-stringified array in the `mastra.tags` span attribute for maximum backend compatibility:
+
+```json
+{
+  "mastra.tags": "[\"production\",\"experiment-v2\",\"user-request\"]"
+}
+```
+
+:::note
+While the OpenTelemetry specification supports native array attributes, many backends (Jaeger, Zipkin, Tempo) have limited array support. JSON strings ensure consistent behavior across all observability platforms.
+:::
+
 ## Related
 
 - [OtelExporter Guide](/docs/v1/observability/tracing/exporters/otel) - Setup guide with provider configurations

--- a/observability/arize/src/openInferenceOTLPExporter.ts
+++ b/observability/arize/src/openInferenceOTLPExporter.ts
@@ -92,7 +92,6 @@ export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
           processedAttributes[SemanticConventions.METADATA] = metadataPayload;
         }
         // Map mastra.tags to OpenInference native tag.tags convention (tags are only on root spans)
-        // Tags are passed as a native array of strings, not JSON-stringified
         if (attributes['mastra.tags']) {
           processedAttributes[SemanticConventions.TAG_TAGS] = attributes['mastra.tags'];
         }

--- a/observability/arize/src/openInferenceOTLPExporter.ts
+++ b/observability/arize/src/openInferenceOTLPExporter.ts
@@ -91,6 +91,11 @@ export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
         if (metadataPayload) {
           processedAttributes[SemanticConventions.METADATA] = metadataPayload;
         }
+        // Map mastra.tags to OpenInference native tag.tags convention (tags are only on root spans)
+        // Tags are passed as a native array of strings, not JSON-stringified
+        if (attributes['mastra.tags']) {
+          processedAttributes[SemanticConventions.TAG_TAGS] = attributes['mastra.tags'];
+        }
         mutableSpan.attributes = processedAttributes;
       }
 

--- a/observability/arize/src/tracing.test.ts
+++ b/observability/arize/src/tracing.test.ts
@@ -284,7 +284,6 @@ describe('ArizeExporter', () => {
     it('includes tags in the exported span attributes for root spans with tags', async () => {
       // This test verifies that tags are included in the exported data for Arize
       // using the native OpenInference tag.tags convention
-      // See GitHub issue #10771
       exporter = new ArizeExporter({
         endpoint: 'http://localhost:4318/v1/traces',
         projectName: 'test-project',

--- a/observability/otel-bridge/src/bridge.test.ts
+++ b/observability/otel-bridge/src/bridge.test.ts
@@ -159,7 +159,6 @@ describe('OtelBridge', () => {
     it('should include tags as mastra.tags attribute for root spans with tags', async () => {
       // This test verifies that tags are included in the OTEL span attributes
       // OtelBridge uses SpanConverter which should set mastra.tags on root spans
-      // See GitHub issue #10771
       const { SpanConverter } = await import('@mastra/otel-exporter');
       const converter = new SpanConverter();
 

--- a/observability/otel-bridge/src/bridge.test.ts
+++ b/observability/otel-bridge/src/bridge.test.ts
@@ -154,4 +154,79 @@ describe('OtelBridge', () => {
       bridge.shutdown();
     });
   });
+
+  describe('Tags Support', () => {
+    it('should include tags as mastra.tags attribute for root spans with tags', async () => {
+      // This test verifies that tags are included in the OTEL span attributes
+      // OtelBridge uses SpanConverter which should set mastra.tags on root spans
+      // See GitHub issue #10771
+      const { SpanConverter } = await import('@mastra/otel-exporter');
+      const converter = new SpanConverter();
+
+      const rootSpanWithTags = {
+        id: 'root-with-tags',
+        traceId: 'trace-with-tags',
+        type: SpanType.AGENT_RUN,
+        name: 'tagged-agent',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        attributes: { agentId: 'agent-123' },
+        tags: ['production', 'experiment-v2', 'user-request'],
+      } as any;
+
+      const readableSpan = converter.convertSpan(rootSpanWithTags);
+
+      // Tags should be present as mastra.tags attribute (JSON-stringified for backend compatibility)
+      expect(readableSpan.attributes['mastra.tags']).toBeDefined();
+      expect(readableSpan.attributes['mastra.tags']).toBe(
+        JSON.stringify(['production', 'experiment-v2', 'user-request']),
+      );
+    });
+
+    it('should not include mastra.tags attribute for child spans', async () => {
+      const { SpanConverter } = await import('@mastra/otel-exporter');
+      const converter = new SpanConverter();
+
+      const childSpanWithTags = {
+        id: 'child-with-tags',
+        traceId: 'trace-parent',
+        parentSpanId: 'root-span-id',
+        type: SpanType.TOOL_CALL,
+        name: 'child-tool',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        attributes: { toolId: 'calculator' },
+        tags: ['should-not-appear'],
+      } as any;
+
+      const readableSpan = converter.convertSpan(childSpanWithTags);
+
+      // Tags should NOT be present on child spans
+      expect(readableSpan.attributes['mastra.tags']).toBeUndefined();
+    });
+
+    it('should not include mastra.tags attribute when tags is empty or undefined', async () => {
+      const { SpanConverter } = await import('@mastra/otel-exporter');
+      const converter = new SpanConverter();
+
+      const rootSpanNoTags = {
+        id: 'root-no-tags',
+        traceId: 'trace-no-tags',
+        type: SpanType.AGENT_RUN,
+        name: 'agent-no-tags',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        attributes: { agentId: 'agent-123' },
+        tags: [],
+      } as any;
+
+      const readableSpan = converter.convertSpan(rootSpanNoTags);
+
+      // Tags should NOT be present when array is empty
+      expect(readableSpan.attributes['mastra.tags']).toBeUndefined();
+    });
+  });
 });

--- a/observability/otel-exporter/src/span-converter.ts
+++ b/observability/otel-exporter/src/span-converter.ts
@@ -148,6 +148,13 @@ export class SpanConverter {
       attributes['mastra.parent_span_id'] = Span.parentSpanId;
     }
 
+    // Add tags for root spans (only root spans can have tags)
+    // Tags are JSON-stringified for maximum backend compatibility
+    // While OTEL spec supports arrays, many backends (Jaeger, Zipkin, Tempo) don't fully support them
+    if (Span.isRootSpan && Span.tags?.length) {
+      attributes['mastra.tags'] = JSON.stringify(Span.tags);
+    }
+
     // Handle input/output based on span type
     // Always add input/output for Laminar compatibility
     if (Span.input !== undefined) {

--- a/observability/otel-exporter/src/tracing.test.ts
+++ b/observability/otel-exporter/src/tracing.test.ts
@@ -398,7 +398,6 @@ describe('OtelExporter', () => {
   describe('Tags Support', () => {
     it('should include tags as mastra.tags attribute for root spans with tags', async () => {
       // This test captures the expected behavior: tags should be included as span attributes
-      // See GitHub issue #10771
       const { SpanConverter } = await import('./span-converter');
       const converter = new SpanConverter();
 

--- a/observability/otel-exporter/src/tracing.test.ts
+++ b/observability/otel-exporter/src/tracing.test.ts
@@ -394,4 +394,124 @@ describe('OtelExporter', () => {
       expect(exporter).toBeDefined();
     });
   });
+
+  describe('Tags Support', () => {
+    it('should include tags as mastra.tags attribute for root spans with tags', async () => {
+      // This test captures the expected behavior: tags should be included as span attributes
+      // See GitHub issue #10771
+      const { SpanConverter } = await import('./span-converter');
+      const converter = new SpanConverter();
+
+      const rootSpanWithTags = {
+        id: 'root-with-tags',
+        traceId: 'trace-with-tags',
+        type: SpanType.AGENT_RUN,
+        name: 'tagged-agent',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        attributes: { agentId: 'agent-123' },
+        tags: ['production', 'experiment-v2', 'user-request'],
+      } as unknown as AnyExportedSpan;
+
+      const readableSpan = converter.convertSpan(rootSpanWithTags);
+
+      // Tags should be present as mastra.tags attribute (JSON-stringified for backend compatibility)
+      expect(readableSpan.attributes['mastra.tags']).toBeDefined();
+      expect(readableSpan.attributes['mastra.tags']).toBe(
+        JSON.stringify(['production', 'experiment-v2', 'user-request']),
+      );
+    });
+
+    it('should not include mastra.tags attribute when tags array is empty', async () => {
+      const { SpanConverter } = await import('./span-converter');
+      const converter = new SpanConverter();
+
+      const rootSpanEmptyTags = {
+        id: 'root-empty-tags',
+        traceId: 'trace-empty-tags',
+        type: SpanType.AGENT_RUN,
+        name: 'agent-no-tags',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        attributes: { agentId: 'agent-123' },
+        tags: [],
+      } as unknown as AnyExportedSpan;
+
+      const readableSpan = converter.convertSpan(rootSpanEmptyTags);
+
+      // Tags should NOT be present when array is empty
+      expect(readableSpan.attributes['mastra.tags']).toBeUndefined();
+    });
+
+    it('should not include mastra.tags attribute when tags is undefined', async () => {
+      const { SpanConverter } = await import('./span-converter');
+      const converter = new SpanConverter();
+
+      const rootSpanNoTags = {
+        id: 'root-no-tags',
+        traceId: 'trace-no-tags',
+        type: SpanType.AGENT_RUN,
+        name: 'agent-undefined-tags',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        attributes: { agentId: 'agent-123' },
+        // tags is undefined by default
+      } as unknown as AnyExportedSpan;
+
+      const readableSpan = converter.convertSpan(rootSpanNoTags);
+
+      // Tags should NOT be present when undefined
+      expect(readableSpan.attributes['mastra.tags']).toBeUndefined();
+    });
+
+    it('should not include mastra.tags attribute for child spans (tags only on root spans)', async () => {
+      const { SpanConverter } = await import('./span-converter');
+      const converter = new SpanConverter();
+
+      // Child spans should not have tags even if accidentally set
+      const childSpanWithTags = {
+        id: 'child-with-tags',
+        traceId: 'trace-parent',
+        parentSpanId: 'root-span-id',
+        type: SpanType.TOOL_CALL,
+        name: 'child-tool',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        attributes: { toolId: 'calculator' },
+        tags: ['should-not-appear'],
+      } as unknown as AnyExportedSpan;
+
+      const readableSpan = converter.convertSpan(childSpanWithTags);
+
+      // Tags should NOT be present on child spans
+      expect(readableSpan.attributes['mastra.tags']).toBeUndefined();
+    });
+
+    it('should include tags with workflow spans', async () => {
+      const { SpanConverter } = await import('./span-converter');
+      const converter = new SpanConverter();
+
+      const workflowSpanWithTags = {
+        id: 'workflow-with-tags',
+        traceId: 'trace-workflow',
+        type: SpanType.WORKFLOW_RUN,
+        name: 'data-processing-workflow',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        attributes: { workflowId: 'wf-123' },
+        tags: ['batch-processing', 'priority-high'],
+      } as unknown as AnyExportedSpan;
+
+      const readableSpan = converter.convertSpan(workflowSpanWithTags);
+
+      // Tags should be present as mastra.tags attribute (JSON-stringified for backend compatibility)
+      expect(readableSpan.attributes['mastra.tags']).toBeDefined();
+      expect(readableSpan.attributes['mastra.tags']).toBe(JSON.stringify(['batch-processing', 'priority-high']));
+    });
+  });
 });


### PR DESCRIPTION
## Description

…ge, and ArizeExporter

This update introduces support for `tracingOptions.tags` in the OpenTelemetry exporters and bridge, allowing tags to be included as span attributes for root spans. The implementation aligns with existing conventions used in Braintrust and Langfuse exporters.

**Key Changes:**
- **OtelExporter**: Adds `mastra.tags` attribute for root spans.
- **OtelBridge**: Ensures tags are passed through the SpanConverter to native OTEL spans.
- **ArizeExporter**: Maps tags to the OpenInference `tag.tags` convention.

**Testing**: Comprehensive tests added to verify tag inclusion for root spans and exclusion for child spans.



## Related Issue(s)

Fixes #10771.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * tracingOptions.tags now propagate to exporters/bridges; root spans include tags as span attributes for improved filtering and context. Tags omitted when empty/undefined.

* **Tests**
  * Added tests verifying tag propagation semantics (root-only, no leakage to child spans, omission when empty).

* **Documentation**
  * Added “Using Tags”/“Tags Support” guidance and examples across tracing and exporter docs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->