### PR TITLE
fix(core): pass requestContext to sub-agent getModel in listAgentTools

### DIFF
--- a/.changeset/fix-sub-agent-request-context.md
+++ b/.changeset/fix-sub-agent-request-context.md
@@ -1,0 +1,9 @@
+---
+"@mastra/core": patch
+---
+
+Fix sub-agent requestContext propagation in listAgentTools
+
+Sub-agents with dynamic model configurations were broken because `requestContext` was not being passed to `getModel()` when creating agent tools. This caused sub-agents using function-based model configurations to receive an empty context instead of the parent's context.
+
+No code changes required for consumers - this fix restores expected behavior for dynamic model configurations in sub-agents.

--- a/packages/core/src/agent/__tests__/tool-handling.test.ts
+++ b/packages/core/src/agent/__tests__/tool-handling.test.ts
@@ -322,6 +322,46 @@ function toolhandlingTests(version: 'v1' | 'v2') {
   });
 
   describe('agents as tools', () => {
+    it('should pass requestContext to sub-agent getModel when determining model version', async () => {
+      let receivedRequestContext: RequestContext | undefined;
+
+      // Create a sub-agent with a function-based model that captures the requestContext
+      const subAgent = new Agent({
+        id: 'sub-agent',
+        name: 'sub-agent',
+        instructions: 'You are a sub-agent.',
+        model: ({ requestContext }) => {
+          receivedRequestContext = requestContext;
+          return dummyModel;
+        },
+      });
+
+      // Create an orchestrator agent with the sub-agent
+      const orchestratorAgent = new Agent({
+        id: 'orchestrator-agent',
+        name: 'orchestrator-agent',
+        instructions: 'You can delegate to sub-agents.',
+        model: openaiModel,
+        agents: {
+          subAgent,
+        },
+      });
+
+      // Create a requestContext with a specific value to track
+      const testRequestContext = new RequestContext();
+      testRequestContext.set('test-key', 'test-value');
+
+      // Call convertTools which internally calls listAgentTools -> agent.getModel()
+      await orchestratorAgent['convertTools']({
+        requestContext: testRequestContext,
+        methodType: 'generate',
+      });
+
+      // Verify that the sub-agent's model function received the correct requestContext
+      expect(receivedRequestContext).toBeDefined();
+      expect(receivedRequestContext?.get('test-key')).toBe('test-value');
+    });
+
     it('should expose sub-agents as tools when using generate/stream', async () => {
       // Create a research agent that will be used as a tool
       const researchAgent = new Agent({

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1685,7 +1685,7 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
           subAgentResourceId: z.string().describe('The resource ID of the agent').optional(),
         });
 
-        const modelVersion = (await agent.getModel()).specificationVersion;
+        const modelVersion = (await agent.getModel({ requestContext })).specificationVersion;
 
         const toolObj = createTool({
           id: `agent-${agentName}`,


### PR DESCRIPTION
**Critical bug fix:** Sub-agents with dynamic model configurations were completely broken because `requestContext` was not being propagated to their `getModel()` call. This is a 1-line fix with a test included.

When creating agent tools for sub-agents, the parent's requestContext was not being passed to getModel(), causing sub-agents with dynamic model configurations to receive an empty context instead of the parent's context.

## Description

In `listAgentTools`, when determining a sub-agent's model version, `agent.getModel()` was called without passing `requestContext`. This caused sub-agents with function-based model configurations (that depend on `requestContext` to select the appropriate model) to receive an empty `RequestContext()` instead of the parent's context.

The fix adds `{ requestContext }` to the `getModel()` call at `packages/core/src/agent/agent.ts:1689`.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed requestContext propagation in sub-agents with dynamic model configurations, ensuring context is properly passed through during agent tool operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->