### PR TITLE
feat(mcp): add RequestOptions support for elicitation requests

### DIFF
--- a/.changeset/add-elicitation-request-options.md
+++ b/.changeset/add-elicitation-request-options.md
@@ -1,0 +1,28 @@
+---
+'@mastra/mcp': minor
+---
+
+Add support for RequestOptions in elicitation requests to allow custom timeouts and request cancellation.
+
+You can now pass RequestOptions when sending elicitation requests:
+
+```typescript
+// Within a tool's execute function
+const result = await options.mcp.elicitation.sendRequest(
+  {
+    message: 'Please provide your email',
+    requestedSchema: {
+      type: 'object',
+      properties: { email: { type: 'string' } },
+    },
+  },
+  { timeout: 120000 } // Custom 2-minute timeout
+);
+```
+
+The RequestOptions parameter supports:
+- `timeout`: Custom timeout in milliseconds (default: 60000ms)
+- `signal`: AbortSignal for request cancellation
+
+Fixes #10834
+

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -2356,6 +2356,127 @@ describe('MCPServer - Elicitation', () => {
     expect(client1Handler).toHaveBeenCalled();
     expect(client2Handler).not.toHaveBeenCalled();
   }, 10000);
+
+  it('should support custom timeout in elicitation request options', async () => {
+    let elicitationStartTime: number | undefined;
+    let elicitationEndTime: number | undefined;
+
+    // Create a tool that uses custom timeout for elicitation
+    const toolWithCustomTimeout: ToolsInput = {
+      customTimeoutTool: {
+        description: 'A tool that uses custom timeout for elicitation',
+        parameters: z.object({
+          message: z.string().describe('Message to show to user'),
+          customTimeout: z.number().optional().describe('Custom timeout in milliseconds'),
+        }),
+        execute: async (inputData, context) => {
+          try {
+            const elicitation = context?.mcp?.elicitation;
+            elicitationStartTime = Date.now();
+            const result = await elicitation.sendRequest(
+              {
+                message: inputData.message,
+                requestedSchema: {
+                  type: 'object',
+                  properties: {
+                    data: { type: 'string' },
+                  },
+                },
+              },
+              { timeout: inputData.customTimeout || 5000 },
+            );
+            elicitationEndTime = Date.now();
+            return result;
+          } catch (error) {
+            elicitationEndTime = Date.now();
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+        },
+      },
+    };
+
+    const customTimeoutPort = 9600 + Math.floor(Math.random() * 1000);
+    const customTimeoutServer = new MCPServer({
+      name: 'CustomTimeoutServer',
+      version: '1.0.0',
+      tools: toolWithCustomTimeout,
+    });
+
+    const customTimeoutHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+      const url = new URL(req.url || '', `http://localhost:${customTimeoutPort}`);
+      await customTimeoutServer.startHTTP({
+        url,
+        httpPath: '/http',
+        req,
+        res,
+      });
+    });
+
+    await new Promise<void>(resolve => customTimeoutHttpServer.listen(customTimeoutPort, () => resolve()));
+
+    try {
+      // Create a client that responds after a delay but within the custom timeout
+      const mockElicitationHandler = vi.fn(async () => {
+        // Simulate a slow response that takes 200ms
+        await new Promise(resolve => setTimeout(resolve, 200));
+        return {
+          action: 'accept' as const,
+          content: { data: 'response data' },
+        };
+      });
+
+      const customTimeoutClient = new InternalMastraMCPClient({
+        name: 'custom-timeout-client',
+        server: {
+          url: new URL(`http://localhost:${customTimeoutPort}/http`),
+        },
+      });
+      customTimeoutClient.elicitation.onRequest(mockElicitationHandler);
+      await customTimeoutClient.connect();
+
+      const tools = await customTimeoutClient.tools();
+      const tool = tools['customTimeoutTool'];
+      expect(tool).toBeDefined();
+
+      // Execute with a custom timeout of 5000ms (plenty of time for 200ms response)
+      const result = await tool.execute!({
+        message: 'Test with custom timeout',
+        customTimeout: 5000,
+      });
+
+      // Should succeed because the response (200ms) is well within the timeout (5000ms)
+      expect(mockElicitationHandler).toHaveBeenCalledTimes(1);
+      expect(result.isError).toBeFalsy();
+
+      // Verify the timing shows it completed successfully
+      expect(elicitationStartTime).toBeDefined();
+      expect(elicitationEndTime).toBeDefined();
+      const duration = elicitationEndTime! - elicitationStartTime!;
+      // Should take at least 200ms (the simulated delay)
+      expect(duration).toBeGreaterThanOrEqual(200);
+      // But should complete well before the timeout
+      expect(duration).toBeLessThan(5000);
+
+      await customTimeoutClient.disconnect();
+    } finally {
+      customTimeoutHttpServer.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        customTimeoutHttpServer.close(err => {
+          if (err) return reject(err);
+          resolve();
+        });
+      });
+      await customTimeoutServer.close();
+    }
+  }, 15000);
 });
 
 describe('MCPServer with Tool Output Schema', () => {

--- a/packages/mcp/src/server/types.ts
+++ b/packages/mcp/src/server/types.ts
@@ -1,4 +1,4 @@
-import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { RequestHandlerExtra, RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type {
   ElicitRequest,
   ElicitResult,
@@ -81,8 +81,14 @@ export type MCPServerPrompts = {
  * Actions for handling elicitation requests (interactive user input collection).
  */
 export type ElicitationActions = {
-  /** Function to send an elicitation request to the client */
-  sendRequest: (request: ElicitRequest['params']) => Promise<ElicitResult>;
+  /**
+   * Function to send an elicitation request to the client.
+   *
+   * @param request - The elicitation request parameters
+   * @param options - Optional request options (timeout, signal, etc.)
+   * @returns Promise resolving to the client's elicitation response
+   */
+  sendRequest: (request: ElicitRequest['params'], options?: RequestOptions) => Promise<ElicitResult>;
 };
 
 /**
@@ -95,5 +101,6 @@ export type MCPRequestHandlerExtra = RequestHandlerExtra<any, any>;
  *
  * - `Resource`: Represents a data resource exposed by the server
  * - `ResourceTemplate`: URI template for dynamic resource generation
+ * - `RequestOptions`: Options for MCP requests (timeout, signal, etc.)
  */
-export type { Resource, ResourceTemplate };
+export type { Resource, ResourceTemplate, RequestOptions };


### PR DESCRIPTION
Adds support for `RequestOptions` in elicitation requests, allowing custom timeouts and request cancellation. The default 60s timeout from the MCP SDK was previously hardcoded.

```typescript
// Now you can pass RequestOptions when sending elicitation requests
const result = await options.mcp.elicitation.sendRequest(
  {
    message: 'Please provide your email',
    requestedSchema: { type: 'object', properties: { email: { type: 'string' } } },
  },
  { timeout: 120000 } // Custom 2-minute timeout
);
```

Fixes #10834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Elicitation requests now support RequestOptions, enabling custom timeouts (milliseconds, default 60000) and cancellation signals via AbortSignal for enhanced control over request execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->