### PR TITLE
feat(storage): add disableInit option to all storage adapters

### DIFF
--- a/.changeset/storage-disable-init-option.md
+++ b/.changeset/storage-disable-init-option.md
@@ -1,0 +1,36 @@
+---
+'@mastra/core': minor
+'@mastra/pg': minor
+'@mastra/libsql': minor
+'@mastra/upstash': minor
+'@mastra/mssql': minor
+'@mastra/mongodb': minor
+'@mastra/dynamodb': minor
+'@mastra/convex': minor
+'@mastra/cloudflare': minor
+'@mastra/cloudflare-d1': minor
+'@mastra/clickhouse': minor
+'@mastra/lance': minor
+---
+
+Add `disableInit` option to all storage adapters
+
+Adds a new `disableInit` config option to all storage providers that allows users to disable automatic table creation/migrations at runtime. This is useful for CI/CD pipelines where you want to run migrations during deployment with elevated credentials, then run the application with `disableInit: true` so it doesn't attempt schema changes at runtime.
+
+```typescript
+// CI/CD script - run migrations
+const storage = new PostgresStore({ 
+  connectionString: DATABASE_URL,
+  id: 'pg-storage',
+});
+await storage.init();
+
+// Runtime - skip auto-init
+const storage = new PostgresStore({ 
+  connectionString: DATABASE_URL,
+  id: 'pg-storage',
+  disableInit: true,
+});
+```
+
+

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -105,7 +105,28 @@ export abstract class MastraStorage extends MastraBase {
   id: string;
   stores?: StorageDomains;
 
-  constructor({ id, name }: { id: string; name: string }) {
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new PostgresStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new PostgresStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit: boolean = false;
+
+  constructor({ id, name, disableInit }: { id: string; name: string; disableInit?: boolean }) {
     if (!id || typeof id !== 'string' || id.trim() === '') {
       throw new Error(`${name}: id must be provided and cannot be empty.`);
     }
@@ -114,6 +135,7 @@ export abstract class MastraStorage extends MastraBase {
       name,
     });
     this.id = id;
+    this.disableInit = disableInit ?? false;
   }
 
   public get supports(): {

--- a/packages/core/src/storage/storageWithInit.test.ts
+++ b/packages/core/src/storage/storageWithInit.test.ts
@@ -1,27 +1,73 @@
-import { it, expect, vi } from 'vitest';
+import { it, expect, vi, describe } from 'vitest';
 import type { MastraStorage } from './base';
 import { augmentWithInit } from './storageWithInit';
 
-it('should augment the storage with init', async () => {
-  const mockStorage = {
-    init: vi.fn().mockResolvedValue(true),
-    listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
-  } as unknown as MastraStorage;
+describe('augmentWithInit', () => {
+  it('should augment the storage with init', async () => {
+    const mockStorage = {
+      init: vi.fn().mockResolvedValue(true),
+      listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+      disableInit: false,
+    } as unknown as MastraStorage;
 
-  const augmentedStorage = augmentWithInit(mockStorage);
-  await augmentedStorage.listMessages({ threadId: '1' });
+    const augmentedStorage = augmentWithInit(mockStorage);
+    await augmentedStorage.listMessages({ threadId: '1' });
 
-  expect(mockStorage.init).toHaveBeenCalled();
-});
+    expect(mockStorage.init).toHaveBeenCalled();
+  });
 
-it("shouln't double augment the storage", async () => {
-  const mockStorage = {
-    init: vi.fn().mockResolvedValue(true),
-    listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
-  } as unknown as MastraStorage;
+  it("shouln't double augment the storage", async () => {
+    const mockStorage = {
+      init: vi.fn().mockResolvedValue(true),
+      listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+      disableInit: false,
+    } as unknown as MastraStorage;
 
-  const augmentedStorage = augmentWithInit(mockStorage);
-  const extraAugmentedStorage = augmentWithInit(augmentedStorage);
+    const augmentedStorage = augmentWithInit(mockStorage);
+    const extraAugmentedStorage = augmentWithInit(augmentedStorage);
 
-  expect(extraAugmentedStorage).toBe(augmentedStorage);
+    expect(extraAugmentedStorage).toBe(augmentedStorage);
+  });
+
+  it('should NOT call init when disableInit is true', async () => {
+    const mockStorage = {
+      init: vi.fn().mockResolvedValue(true),
+      listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+      disableInit: true,
+    } as unknown as MastraStorage;
+
+    const augmentedStorage = augmentWithInit(mockStorage);
+    await augmentedStorage.listMessages({ threadId: '1' });
+
+    expect(mockStorage.init).not.toHaveBeenCalled();
+    expect(mockStorage.listMessages).toHaveBeenCalled();
+  });
+
+  it('should still allow explicit init() call when disableInit is true', async () => {
+    const mockStorage = {
+      init: vi.fn().mockResolvedValue(true),
+      listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+      disableInit: true,
+    } as unknown as MastraStorage;
+
+    const augmentedStorage = augmentWithInit(mockStorage);
+
+    // Explicit init should work even when disableInit is true
+    await augmentedStorage.init();
+
+    expect(mockStorage.init).toHaveBeenCalled();
+  });
+
+  it('should default disableInit to false when not specified', async () => {
+    const mockStorage = {
+      init: vi.fn().mockResolvedValue(true),
+      listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+      disableInit: false,
+    } as unknown as MastraStorage;
+
+    const augmentedStorage = augmentWithInit(mockStorage);
+    await augmentedStorage.listMessages({ threadId: '1' });
+
+    expect(mockStorage.init).toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/storage/storageWithInit.ts
+++ b/packages/core/src/storage/storageWithInit.ts
@@ -6,6 +6,11 @@ export function augmentWithInit(storage: MastraStorage): MastraStorage {
   let hasInitialized: null | Promise<void> = null;
 
   const ensureInit = async () => {
+    // Skip auto-initialization if disableInit is true
+    if (storage.disableInit) {
+      return;
+    }
+
     if (!hasInitialized) {
       hasInitialized = storage.init();
     }

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -53,6 +53,26 @@ export type ClickhouseConfig = {
       }>;
     };
   };
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new ClickhouseStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new ClickhouseStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
 };
 
 export class ClickhouseStore extends MastraStorage {
@@ -62,7 +82,7 @@ export class ClickhouseStore extends MastraStorage {
   stores: StorageDomains;
 
   constructor(config: ClickhouseConfig) {
-    super({ id: config.id, name: 'ClickhouseStore' });
+    super({ id: config.id, name: 'ClickhouseStore', disableInit: config.disableInit });
 
     this.db = createClient({
       url: config.url,

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -76,7 +76,7 @@ export class CloudflareStore extends MastraStorage {
   }
 
   constructor(config: CloudflareStoreConfig) {
-    super({ id: config.id, name: 'Cloudflare' });
+    super({ id: config.id, name: 'Cloudflare', disableInit: config.disableInit });
 
     try {
       if (isWorkersConfig(config)) {

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -16,11 +16,37 @@ import type {
 import type { WorkflowRunState } from '@mastra/core/workflows';
 
 /**
- * Configuration for Cloudflare KV using REST API
+ * Base configuration options shared across Cloudflare configurations
  */
-export interface CloudflareRestConfig {
+export interface CloudflareBaseConfig {
   /** Storage instance ID */
   id: string;
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new CloudflareStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new CloudflareStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
+}
+
+/**
+ * Configuration for Cloudflare KV using REST API
+ */
+export interface CloudflareRestConfig extends CloudflareBaseConfig {
   /** Cloudflare account ID */
   accountId: string;
   /** Cloudflare API token with KV access */
@@ -36,9 +62,7 @@ export interface CloudflareRestConfig {
 /**
  * Configuration for Cloudflare KV using Workers Binding API
  */
-export interface CloudflareWorkersConfig {
-  /** Storage instance ID */
-  id: string;
+export interface CloudflareWorkersConfig extends CloudflareBaseConfig {
   /** KV namespace bindings from Workers environment */
   bindings: {
     [key in TABLE_NAMES]: KVNamespace;

--- a/stores/convex/src/storage/index.ts
+++ b/stores/convex/src/storage/index.ts
@@ -27,6 +27,26 @@ import { StoreOperationsConvex } from './operations';
 export type ConvexStoreConfig = ConvexAdminClientConfig & {
   id: string;
   name?: string;
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new ConvexStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new ConvexStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
 };
 
 export class ConvexStore extends MastraStorage {
@@ -36,7 +56,7 @@ export class ConvexStore extends MastraStorage {
   private readonly scores: ScoresConvex;
 
   constructor(config: ConvexStoreConfig) {
-    super({ id: config.id, name: config.name ?? 'ConvexStore' });
+    super({ id: config.id, name: config.name ?? 'ConvexStore', disableInit: config.disableInit });
 
     const client = new ConvexAdminClient(config);
     this.operations = new StoreOperationsConvex(client);

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -34,6 +34,26 @@ export interface DynamoDBStoreConfig {
     accessKeyId: string;
     secretAccessKey: string;
   };
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new DynamoDBStore({ name: 'my-store', config: { ...config, disableInit: false } });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new DynamoDBStore({ name: 'my-store', config: { ...config, disableInit: true } });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
 }
 
 // Define a type for our service that allows string indexing
@@ -49,7 +69,7 @@ export class DynamoDBStore extends MastraStorage {
   stores: StorageDomains;
 
   constructor({ name, config }: { name: string; config: DynamoDBStoreConfig }) {
-    super({ id: config.id, name });
+    super({ id: config.id, name, disableInit: config.disableInit });
 
     // Validate required config
     try {

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -21,6 +21,29 @@ import { StoreOperationsLance } from './domains/operations';
 import { StoreScoresLance } from './domains/scores';
 import { StoreWorkflowsLance } from './domains/workflows';
 
+export interface LanceStorageOptions {
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = await LanceStorage.create('id', 'name', '/path/to/db', undefined, { disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = await LanceStorage.create('id', 'name', '/path/to/db', undefined, { disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
+}
+
 export class LanceStorage extends MastraStorage {
   stores: StorageDomains;
   private lanceClient!: Connection;
@@ -29,7 +52,8 @@ export class LanceStorage extends MastraStorage {
    * @param id The unique identifier for this storage instance
    * @param name The name for this storage instance
    * @param uri The URI to connect to LanceDB
-   * @param options connection options
+   * @param connectionOptions connection options for LanceDB
+   * @param storageOptions storage options including disableInit
    *
    * Usage:
    *
@@ -47,16 +71,22 @@ export class LanceStorage extends MastraStorage {
    * ```ts
    * const store = await LanceStorage.create('my-storage-id', 'MyStorage', 's3://bucket/db', { storageOptions: { timeout: '60s' } });
    * ```
+   *
+   * Disable auto-init for runtime (after CI/CD has run migrations)
+   * ```ts
+   * const store = await LanceStorage.create('my-storage-id', 'MyStorage', '/path/to/db', undefined, { disableInit: true });
+   * ```
    */
   public static async create(
     id: string,
     name: string,
     uri: string,
-    options?: ConnectionOptions,
+    connectionOptions?: ConnectionOptions,
+    storageOptions?: LanceStorageOptions,
   ): Promise<LanceStorage> {
-    const instance = new LanceStorage(id, name);
+    const instance = new LanceStorage(id, name, storageOptions?.disableInit);
     try {
-      instance.lanceClient = await connect(uri, options);
+      instance.lanceClient = await connect(uri, connectionOptions);
       const operations = new StoreOperationsLance({ client: instance.lanceClient });
       instance.stores = {
         operations: new StoreOperationsLance({ client: instance.lanceClient }),
@@ -72,7 +102,7 @@ export class LanceStorage extends MastraStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           text: `Failed to connect to LanceDB: ${e.message || e}`,
-          details: { uri, optionsProvided: !!options },
+          details: { uri, optionsProvided: !!connectionOptions },
         },
         e,
       );
@@ -83,8 +113,8 @@ export class LanceStorage extends MastraStorage {
    * @internal
    * Private constructor to enforce using the create factory method
    */
-  private constructor(id: string, name: string) {
-    super({ id, name });
+  private constructor(id: string, name: string, disableInit?: boolean) {
+    super({ id, name, disableInit });
     const operations = new StoreOperationsLance({ client: this.lanceClient });
 
     this.stores = {

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -26,29 +26,52 @@ import { StoreOperationsLibSQL } from './domains/operations';
 import { ScoresLibSQL } from './domains/scores';
 import { WorkflowsLibSQL } from './domains/workflows';
 
+/**
+ * Base configuration options shared across LibSQL configurations
+ */
+export type LibSQLBaseConfig = {
+  id: string;
+  /**
+   * Maximum number of retries for write operations if an SQLITE_BUSY error occurs.
+   * @default 5
+   */
+  maxRetries?: number;
+  /**
+   * Initial backoff time in milliseconds for retrying write operations on SQLITE_BUSY.
+   * The backoff time will double with each retry (exponential backoff).
+   * @default 100
+   */
+  initialBackoffMs?: number;
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new LibSQLStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new LibSQLStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
+};
+
 export type LibSQLConfig =
-  | {
-      id: string;
+  | (LibSQLBaseConfig & {
       url: string;
       authToken?: string;
-      /**
-       * Maximum number of retries for write operations if an SQLITE_BUSY error occurs.
-       * @default 5
-       */
-      maxRetries?: number;
-      /**
-       * Initial backoff time in milliseconds for retrying write operations on SQLITE_BUSY.
-       * The backoff time will double with each retry (exponential backoff).
-       * @default 100
-       */
-      initialBackoffMs?: number;
-    }
-  | {
-      id: string;
+    })
+  | (LibSQLBaseConfig & {
       client: Client;
-      maxRetries?: number;
-      initialBackoffMs?: number;
-    };
+    });
 
 export class LibSQLStore extends MastraStorage {
   private client: Client;
@@ -61,7 +84,7 @@ export class LibSQLStore extends MastraStorage {
     if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
       throw new Error('LibSQLStore: id must be provided and cannot be empty.');
     }
-    super({ id: config.id, name: `LibSQLStore` });
+    super({ id: config.id, name: `LibSQLStore`, disableInit: config.disableInit });
 
     this.maxRetries = config.maxRetries ?? 5;
     this.initialBackoffMs = config.initialBackoffMs ?? 100;

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -89,7 +89,7 @@ export class MongoDBStore extends MastraStorage {
   }
 
   constructor(config: MongoDBConfig) {
-    super({ id: config.id, name: 'MongoDBStore' });
+    super({ id: config.id, name: 'MongoDBStore', disableInit: config.disableInit });
 
     this.stores = {} as StorageDomains;
 

--- a/stores/mongodb/src/storage/types.ts
+++ b/stores/mongodb/src/storage/types.ts
@@ -1,15 +1,40 @@
 import type { MongoClientOptions } from 'mongodb';
 import type { ConnectorHandler } from './connectors/base';
 
+/**
+ * Base configuration options shared across MongoDB configurations
+ */
+export type MongoDBBaseConfig = {
+  id: string;
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new MongoDBStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new MongoDBStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
+};
+
 export type MongoDBConfig =
   | DatabaseConfig
-  | {
-      id: string;
+  | (MongoDBBaseConfig & {
       connectorHandler: ConnectorHandler;
-    };
+    });
 
-export type DatabaseConfig = {
-  id: string;
+export type DatabaseConfig = MongoDBBaseConfig & {
   url: string;
   dbName: string;
   options?: MongoClientOptions;

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -34,6 +34,26 @@ import { WorkflowsMSSQL } from './domains/workflows';
 export type MSSQLConfigType = {
   id: string;
   schemaName?: string;
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new MSSQLStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new MSSQLStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
 } & (
   | {
       server: string;
@@ -60,7 +80,7 @@ export class MSSQLStore extends MastraStorage {
     if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
       throw new Error('MSSQLStore: id must be provided and cannot be empty.');
     }
-    super({ id: config.id, name: 'MSSQLStore' });
+    super({ id: config.id, name: 'MSSQLStore', disableInit: config.disableInit });
     try {
       if ('connectionString' in config) {
         if (

--- a/stores/pg/src/shared/config.ts
+++ b/stores/pg/src/shared/config.ts
@@ -12,6 +12,26 @@ export type PostgresConfig<SSLType = ISSLConfig | ConnectionOptions> = {
   schemaName?: string;
   max?: number;
   idleTimeoutMillis?: number;
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new PostgresStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new PostgresStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
 } & (
   | {
       host: string;

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -42,7 +42,7 @@ export class PostgresStore extends MastraStorage {
     // Validation: connectionString or host/database/user/password must not be empty
     try {
       validateConfig('PostgresStore', config);
-      super({ id: config.id, name: 'PostgresStore' });
+      super({ id: config.id, name: 'PostgresStore', disableInit: config.disableInit });
       this.schema = config.schemaName || 'public';
       if (isConnectionStringConfig(config)) {
         this.#config = {

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -25,6 +25,26 @@ export interface UpstashConfig {
   id: string;
   url: string;
   token: string;
+  /**
+   * When true, automatic initialization (table creation/migrations) is disabled.
+   * This is useful for CI/CD pipelines where you want to:
+   * 1. Run migrations explicitly during deployment (not at runtime)
+   * 2. Use different credentials for schema changes vs runtime operations
+   *
+   * When disableInit is true:
+   * - The storage will not automatically create/alter tables on first use
+   * - You must call `storage.init()` explicitly in your CI/CD scripts
+   *
+   * @example
+   * // In CI/CD script:
+   * const storage = new UpstashStore({ ...config, disableInit: false });
+   * await storage.init(); // Explicitly run migrations
+   *
+   * // In runtime application:
+   * const storage = new UpstashStore({ ...config, disableInit: true });
+   * // No auto-init, tables must already exist
+   */
+  disableInit?: boolean;
 }
 
 export class UpstashStore extends MastraStorage {
@@ -32,7 +52,7 @@ export class UpstashStore extends MastraStorage {
   stores: StorageDomains;
 
   constructor(config: UpstashConfig) {
-    super({ id: config.id, name: 'Upstash' });
+    super({ id: config.id, name: 'Upstash', disableInit: config.disableInit });
     this.redis = new Redis({
       url: config.url,
       token: config.token,


### PR DESCRIPTION
Fixes #7468

Adds a `disableInit` config option to all storage providers. This lets you skip automatic table creation/migrations at runtime - useful for CI/CD pipelines where you want to run migrations during deployment with elevated credentials, then run with `disableInit: true` at runtime.

```typescript
// CI/CD - run migrations with deploy credentials
const storage = new PostgresStore({ 
  connectionString: DATABASE_URL,
  id: 'pg-storage',
});
await storage.init();

// Runtime - skip auto-init, tables already exist
const storage = new PostgresStore({ 
  connectionString: DATABASE_URL,
  id: 'pg-storage',
  disableInit: true,
});
```

Added to all 11 storage adapters: PostgresStore, LibSQLStore, UpstashStore, MSSQLStore, MongoDBStore, DynamoDBStore, ConvexStore, CloudflareStore, D1Store, ClickhouseStore, and LanceStorage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `disableInit` configuration option across all storage adapters to prevent automatic table creation and migrations during application startup. When enabled, allows separate migration execution in CI/CD environments with elevated credentials, while runtime instances skip automatic schema initialization. Applies to ClickHouse, Cloudflare D1/KV, Convex, DynamoDB, Lance, LibSQL, MongoDB, MSSQL, PostgreSQL, and Upstash.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->