### PR TITLE
Fixed Braintrust span nesting so root spans correctly show as trace names

### DIFF
--- a/.changeset/fluffy-deer-tease.md
+++ b/.changeset/fluffy-deer-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': patch
+---
+
+Fixed Braintrust span nesting so root spans correctly show as the trace name.

--- a/observability/braintrust/src/braintrust-nesting.test.ts
+++ b/observability/braintrust/src/braintrust-nesting.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Integration tests using real Braintrust SDK to verify span nesting behavior.
+ *
+ * These tests verify that our BraintrustExporter correctly uses the SDK's
+ * startSpan() chain to establish proper parent-child relationships.
+ *
+ * Key behaviors tested:
+ * 1. Root spans get _rootSpanId = own _spanId (no parentSpanIds passed)
+ * 2. Child spans get correct _rootSpanId and _spanParents via startSpan() chain
+ * 3. External context spans properly nest under external parent
+ */
+
+import { SpanType, TracingEventType } from '@mastra/core/observability';
+import type { AnyExportedSpan } from '@mastra/core/observability';
+import { initLogger } from 'braintrust';
+import type { Logger, Span } from 'braintrust';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { BraintrustExporter } from './tracing';
+
+// Helper to access internal Braintrust span properties
+// These become root_span_id and span_parents in the Braintrust API
+function getSpanInternals(span: Span) {
+  return {
+    spanId: (span as any)._spanId as string,
+    rootSpanId: (span as any)._rootSpanId as string,
+    spanParents: (span as any)._spanParents as string[] | undefined,
+  };
+}
+
+// Helper to create mock Mastra spans for testing
+function createMastraSpan(options: {
+  id: string;
+  name: string;
+  type: SpanType;
+  isRoot: boolean;
+  parentSpanId?: string;
+  traceId?: string;
+  attributes?: Record<string, any>;
+}): AnyExportedSpan {
+  const traceId = options.traceId ?? (options.isRoot ? `${options.id}-trace` : 'shared-trace');
+  return {
+    id: options.id,
+    name: options.name,
+    type: options.type,
+    attributes: options.attributes ?? {},
+    metadata: {},
+    startTime: new Date(),
+    endTime: undefined,
+    traceId,
+    get isRootSpan() {
+      return options.isRoot;
+    },
+    parentSpanId: options.parentSpanId,
+    isEvent: false,
+  } as AnyExportedSpan;
+}
+
+// =============================================================================
+// Direct SDK Tests - Verify Braintrust SDK behavior
+// =============================================================================
+
+describe('Braintrust SDK - Direct startSpan() behavior', () => {
+  let logger: Logger<true>;
+
+  beforeAll(async () => {
+    logger = await initLogger({
+      projectName: 'test-sdk-direct',
+      apiKey: 'test-key',
+    });
+  });
+
+  it('logger.startSpan() without parentSpanIds auto-sets rootSpanId to itself', () => {
+    const rootSpan = logger.startSpan({ name: 'root', type: 'task' });
+    const root = getSpanInternals(rootSpan);
+
+    expect(root.rootSpanId).toBe(root.spanId);
+    expect(root.spanParents).toBeUndefined();
+
+    rootSpan.end();
+  });
+
+  it('parentSpan.startSpan() chain sets correct rootSpanId and spanParents', () => {
+    const rootSpan = logger.startSpan({ name: 'root', type: 'task' });
+    const childSpan = rootSpan.startSpan({ name: 'child', type: 'llm' });
+    const grandchildSpan = childSpan.startSpan({ name: 'grandchild', type: 'tool' });
+
+    const root = getSpanInternals(rootSpan);
+    const child = getSpanInternals(childSpan);
+    const grandchild = getSpanInternals(grandchildSpan);
+
+    // All share the same rootSpanId
+    expect(root.rootSpanId).toBe(root.spanId);
+    expect(child.rootSpanId).toBe(root.spanId);
+    expect(grandchild.rootSpanId).toBe(root.spanId);
+
+    // Each has correct immediate parent
+    expect(root.spanParents).toBeUndefined();
+    expect(child.spanParents).toEqual([root.spanId]);
+    expect(grandchild.spanParents).toEqual([child.spanId]);
+
+    grandchildSpan.end();
+    childSpan.end();
+    rootSpan.end();
+  });
+});
+
+// =============================================================================
+// Exporter Integration Tests - Non-External Case
+// =============================================================================
+
+describe('BraintrustExporter Integration - Non-External Case', () => {
+  let logger: Logger<true>;
+  let exporter: BraintrustExporter;
+
+  beforeAll(async () => {
+    logger = await initLogger({
+      projectName: 'test-exporter-integration',
+      apiKey: 'test-key',
+    });
+  });
+
+  beforeEach(() => {
+    exporter = new BraintrustExporter({
+      braintrustLogger: logger,
+    });
+  });
+
+  it('root span processed by exporter has correct rootSpanId = spanId', async () => {
+    const mastraRoot = createMastraSpan({
+      id: 'mastra-root-1',
+      name: 'agent-run',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+      attributes: { agentId: 'test-agent' },
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: mastraRoot,
+    });
+
+    // Get the Braintrust span from the exporter's internal state
+    const spanData = (exporter as any).traceMap.get(mastraRoot.traceId);
+    expect(spanData).toBeDefined();
+
+    const braintrustSpan = spanData.spans.get(mastraRoot.id);
+    expect(braintrustSpan).toBeDefined();
+
+    const internals = getSpanInternals(braintrustSpan);
+
+    // Root span should have rootSpanId = its own spanId
+    expect(internals.rootSpanId).toBe(internals.spanId);
+    expect(internals.spanParents).toBeUndefined();
+  });
+
+  it('child spans processed by exporter have correct parent chain', async () => {
+    // Create Mastra span hierarchy
+    const mastraRoot = createMastraSpan({
+      id: 'root-span',
+      name: 'agent-run',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+    });
+
+    const mastraLlm = createMastraSpan({
+      id: 'llm-span',
+      name: 'llm-call',
+      type: SpanType.MODEL_GENERATION,
+      isRoot: false,
+      parentSpanId: 'root-span',
+      traceId: mastraRoot.traceId,
+      attributes: { model: 'gpt-4' },
+    });
+
+    const mastraTool = createMastraSpan({
+      id: 'tool-span',
+      name: 'tool-call',
+      type: SpanType.TOOL_CALL,
+      isRoot: false,
+      parentSpanId: 'llm-span',
+      traceId: mastraRoot.traceId,
+      attributes: { toolId: 'calculator' },
+    });
+
+    // Process spans through exporter
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: mastraRoot,
+    });
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: mastraLlm,
+    });
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: mastraTool,
+    });
+
+    // Get Braintrust spans from exporter
+    const spanData = (exporter as any).traceMap.get(mastraRoot.traceId);
+    const rootBt = spanData.spans.get('root-span');
+    const llmBt = spanData.spans.get('llm-span');
+    const toolBt = spanData.spans.get('tool-span');
+
+    const root = getSpanInternals(rootBt);
+    const llm = getSpanInternals(llmBt);
+    const tool = getSpanInternals(toolBt);
+
+    // All should share the same rootSpanId (the root's spanId)
+    expect(root.rootSpanId).toBe(root.spanId);
+    expect(llm.rootSpanId).toBe(root.spanId);
+    expect(tool.rootSpanId).toBe(root.spanId);
+
+    // Each should have correct immediate parent
+    expect(root.spanParents).toBeUndefined();
+    expect(llm.spanParents).toEqual([root.spanId]);
+    expect(tool.spanParents).toEqual([llm.spanId]);
+  });
+
+  it('deeply nested spans (4 levels) have correct parent chain', async () => {
+    const traceId = 'deep-trace';
+
+    const spans = [
+      createMastraSpan({ id: 'l1', name: 'level1', type: SpanType.AGENT_RUN, isRoot: true, traceId }),
+      createMastraSpan({
+        id: 'l2',
+        name: 'level2',
+        type: SpanType.MODEL_GENERATION,
+        isRoot: false,
+        parentSpanId: 'l1',
+        traceId,
+      }),
+      createMastraSpan({
+        id: 'l3',
+        name: 'level3',
+        type: SpanType.TOOL_CALL,
+        isRoot: false,
+        parentSpanId: 'l2',
+        traceId,
+      }),
+      createMastraSpan({
+        id: 'l4',
+        name: 'level4',
+        type: SpanType.GENERIC,
+        isRoot: false,
+        parentSpanId: 'l3',
+        traceId,
+      }),
+    ];
+
+    for (const span of spans) {
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: span,
+      });
+    }
+
+    const spanData = (exporter as any).traceMap.get(traceId);
+    const l1 = getSpanInternals(spanData.spans.get('l1'));
+    const l2 = getSpanInternals(spanData.spans.get('l2'));
+    const l3 = getSpanInternals(spanData.spans.get('l3'));
+    const l4 = getSpanInternals(spanData.spans.get('l4'));
+
+    // All share rootSpanId
+    expect(l1.rootSpanId).toBe(l1.spanId);
+    expect(l2.rootSpanId).toBe(l1.spanId);
+    expect(l3.rootSpanId).toBe(l1.spanId);
+    expect(l4.rootSpanId).toBe(l1.spanId);
+
+    // Correct parent chain
+    expect(l1.spanParents).toBeUndefined();
+    expect(l2.spanParents).toEqual([l1.spanId]);
+    expect(l3.spanParents).toEqual([l2.spanId]);
+    expect(l4.spanParents).toEqual([l3.spanId]);
+  });
+});
+
+// =============================================================================
+// Exporter Integration Tests - External Case
+// =============================================================================
+
+describe('BraintrustExporter Integration - External Case', () => {
+  let logger: Logger<true>;
+
+  beforeAll(async () => {
+    logger = await initLogger({
+      projectName: 'test-external-integration',
+      apiKey: 'test-key',
+    });
+  });
+
+  it('spans attached to external span have external as true root', async () => {
+    // Simulate external span (from Eval or logger.traced())
+    const externalSpan = logger.startSpan({ name: 'external-eval', type: 'task' });
+    const externalInternals = getSpanInternals(externalSpan);
+
+    // Create exporter that will attach to the external span
+    // We need to mock currentSpan() to return our external span
+    // For this test, we'll use braintrustLogger with the external span directly
+    const exporter = new BraintrustExporter({
+      braintrustLogger: externalSpan as any, // Treat external span as the "logger"
+    });
+
+    // Create Mastra spans
+    const mastraRoot = createMastraSpan({
+      id: 'mastra-root',
+      name: 'mastra-agent',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+    });
+
+    const mastraChild = createMastraSpan({
+      id: 'mastra-child',
+      name: 'mastra-llm',
+      type: SpanType.MODEL_GENERATION,
+      isRoot: false,
+      parentSpanId: 'mastra-root',
+      traceId: mastraRoot.traceId,
+    });
+
+    // Process through exporter
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: mastraRoot,
+    });
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: mastraChild,
+    });
+
+    // Get Braintrust spans
+    const spanData = (exporter as any).traceMap.get(mastraRoot.traceId);
+    const rootBt = spanData.spans.get('mastra-root');
+    const childBt = spanData.spans.get('mastra-child');
+
+    const root = getSpanInternals(rootBt);
+    const child = getSpanInternals(childBt);
+
+    // Both should have external span as their root
+    expect(root.rootSpanId).toBe(externalInternals.spanId);
+    expect(child.rootSpanId).toBe(externalInternals.spanId);
+
+    // Mastra root's parent should be external span
+    expect(root.spanParents).toEqual([externalInternals.spanId]);
+    // Mastra child's parent should be mastra root
+    expect(child.spanParents).toEqual([root.spanId]);
+
+    // Cleanup
+    childBt.end();
+    rootBt.end();
+    externalSpan.end();
+  });
+});

--- a/observability/braintrust/src/metrics.ts
+++ b/observability/braintrust/src/metrics.ts
@@ -53,7 +53,15 @@ export function normalizeUsageMetrics(modelAttr: ModelGenerationAttributes): Bra
 
   // Time to first token (TTFT) for streaming responses
   if (modelAttr.completionStartTime) {
-    metrics.time_to_first_token = modelAttr.completionStartTime.getTime();
+    // Handle both Date objects and already-converted timestamps (number/string)
+    const startTime = modelAttr.completionStartTime;
+    if (startTime instanceof Date) {
+      metrics.time_to_first_token = startTime.getTime();
+    } else if (typeof startTime === 'number') {
+      metrics.time_to_first_token = startTime;
+    } else if (typeof startTime === 'string') {
+      metrics.time_to_first_token = new Date(startTime).getTime();
+    }
   }
 
   return metrics;

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -137,10 +137,7 @@ describe('BraintrustExporter', () => {
         spanId: 'root-span-id',
         name: 'root-agent',
         type: 'task', // Default span type mapping for AGENT_RUN
-        parentSpanIds: {
-          spanId: rootSpan.traceId,
-          rootSpanId: rootSpan.traceId,
-        },
+        // No parentSpanIds for root spans!
         input: undefined,
         metadata: {
           spanType: 'agent_run',
@@ -189,13 +186,14 @@ describe('BraintrustExporter', () => {
       expect(mockInitLogger).not.toHaveBeenCalled();
 
       // Should create child span on parent span
+      // Child spans use rootSpanId pointing to the root span's ID
       expect(mockSpan.startSpan).toHaveBeenCalledWith({
         spanId: 'child-span-id',
         name: 'child-tool',
         type: 'tool', // TOOL_CALL maps to 'tool'
         parentSpanIds: {
           spanId: rootSpan.id,
-          rootSpanId: rootSpan.traceId,
+          rootSpanId: rootSpan.id,
         },
         input: undefined,
         metadata: {
@@ -414,10 +412,7 @@ describe('BraintrustExporter', () => {
         spanId: 'llm-span',
         name: 'gpt-4-call',
         type: 'llm',
-        parentSpanIds: {
-          spanId: llmSpan.traceId,
-          rootSpanId: llmSpan.traceId,
-        },
+        // No parentSpanIds for root spans!
         input: { messages: [{ role: 'user', content: 'Hello' }] },
         output: { content: 'Hi there!' },
         metrics: {
@@ -462,10 +457,7 @@ describe('BraintrustExporter', () => {
         spanId: 'minimal-llm',
         name: 'simple-llm',
         type: 'llm',
-        parentSpanIds: {
-          spanId: llmSpan.traceId,
-          rootSpanId: llmSpan.traceId,
-        },
+        // No parentSpanIds for root spans!
         metadata: {
           spanType: 'model_generation',
           model: 'gpt-3.5-turbo',
@@ -685,14 +677,12 @@ describe('BraintrustExporter', () => {
       });
 
       // Should create span with zero duration (matching start/end times)
+      // Root event spans should NOT have parentSpanIds
       expect(mockLogger.startSpan).toHaveBeenCalledWith({
         spanId: 'event-span',
         name: 'user-feedback',
         type: 'task',
-        parentSpanIds: {
-          spanId: eventSpan.traceId,
-          rootSpanId: eventSpan.traceId,
-        },
+        // No parentSpanIds for root spans!
         startTime: eventSpan.startTime.getTime() / 1000,
         output: { message: 'Great response!' },
         metadata: {
@@ -743,13 +733,14 @@ describe('BraintrustExporter', () => {
       });
 
       // Should create child span on parent
+      // Child spans use rootSpanId pointing to the actual root span's ID (not the trace ID)
       expect(mockSpan.startSpan).toHaveBeenCalledWith({
         spanId: 'child-event',
         name: 'tool-result',
         type: 'task',
         parentSpanIds: {
           spanId: rootSpan.id,
-          rootSpanId: rootSpan.traceId,
+          rootSpanId: rootSpan.id, // Points to root span's actual ID
         },
         startTime: childEventSpan.startTime.getTime() / 1000,
         output: { result: 42 },
@@ -1080,6 +1071,92 @@ describe('BraintrustExporter', () => {
     });
   });
 
+  describe('Root Span ID Tracking', () => {
+    it('should track rootSpanId in SpanData for proper parent-child relationships', async () => {
+      // Create root span
+      const rootSpan = createMockSpan({
+        id: 'root-span-id',
+        name: 'root-agent',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Verify SpanData has rootSpanId set to the root span's ID
+      const spanData = (exporter as any).traceMap.get(rootSpan.traceId);
+      expect(spanData).toBeDefined();
+      expect(spanData.rootSpanId).toBe('root-span-id');
+    });
+
+    it('should use rootSpanId for child span parentSpanIds', async () => {
+      // Create root span
+      const rootSpan = createMockSpan({
+        id: 'root-span-id',
+        name: 'root-agent',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      vi.clearAllMocks();
+
+      // Create child span
+      const childSpan = createMockSpan({
+        id: 'child-span-id',
+        name: 'child-tool',
+        type: SpanType.TOOL_CALL,
+        isRoot: false,
+        attributes: { toolId: 'calculator' },
+      });
+      childSpan.traceId = rootSpan.traceId;
+      childSpan.parentSpanId = 'root-span-id';
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: childSpan,
+      });
+
+      // Verify child span uses rootSpanId
+      expect(mockSpan.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpanIds: {
+            spanId: 'root-span-id',
+            rootSpanId: 'root-span-id',
+          },
+        }),
+      );
+    });
+
+    it('should NOT set parentSpanIds for root spans (makes Braintrust mark them is_root: true)', async () => {
+      const rootSpan = createMockSpan({
+        id: 'root-span-id',
+        name: 'root-agent',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Verify startSpan was called WITHOUT parentSpanIds
+      const startSpanCall = mockLogger.startSpan.mock.calls[0][0];
+      expect(startSpanCall.parentSpanIds).toBeUndefined();
+    });
+  });
+
   describe('Out-of-Order Events', () => {
     it('keeps trace until last child ends when root ends first', async () => {
       // Start root span
@@ -1244,10 +1321,7 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
       spanId: 'root-span-id',
       name: 'root-agent',
       type: 'task',
-      parentSpanIds: {
-        spanId: rootSpan.traceId,
-        rootSpanId: rootSpan.traceId,
-      },
+      // No parentSpanIds for root spans!
       metadata: {
         spanType: 'agent_run',
         agentId: 'test-agent',
@@ -1391,15 +1465,13 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
       },
     });
 
-    // Verify child span was created with proper parent relationship
+    // Verify child span was created WITHOUT parentSpanIds
+    // In external contexts, the startSpan() chain handles parent-child relationships
     expect(mockChildSpan.startSpan).toHaveBeenCalledWith({
       spanId: 'child-span-id',
       name: 'child-tool',
       type: 'tool',
-      parentSpanIds: {
-        spanId: parentSpan.id,
-        rootSpanId: parentSpan.traceId,
-      },
+      // No parentSpanIds in external context - startSpan() chain handles relationships
       metadata: {
         spanType: 'tool_call',
         toolId: 'calculator',
@@ -1417,6 +1489,154 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
     const spanData = (exporter as any).traceMap.get(parentSpan.traceId);
     expect(spanData).toBeDefined();
     expect(spanData.isExternal).toBe(true);
+  });
+
+  it('should properly nest multiple levels of spans in external context via startSpan() chain', async () => {
+    // This test verifies that in external contexts:
+    // 1. Each span's startSpan() is called on the correct parent (not always the external span)
+    // 2. No parentSpanIds is passed (startSpan() chain handles relationships)
+    // 3. The span hierarchy is: external -> agent -> llm -> tool
+
+    const { currentSpan: realCurrentSpan } = await import('braintrust');
+    const mockedCurrentSpan = vi.mocked(realCurrentSpan);
+
+    // Create mock spans for each level with tracking of which span called startSpan
+    const mockToolSpan = {
+      startSpan: vi.fn(),
+      log: vi.fn(),
+      end: vi.fn(),
+    };
+
+    const mockLlmSpan = {
+      startSpan: vi.fn().mockReturnValue(mockToolSpan),
+      log: vi.fn(),
+      end: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      startSpan: vi.fn().mockReturnValue(mockLlmSpan),
+      log: vi.fn(),
+      end: vi.fn(),
+    };
+
+    // External span (from Eval or logger.traced())
+    const mockExternalSpan = {
+      id: 'external-span-id',
+      startSpan: vi.fn().mockReturnValue(mockAgentSpan),
+      log: vi.fn(),
+      end: vi.fn(),
+    };
+
+    mockedCurrentSpan.mockReturnValue(mockExternalSpan as any);
+
+    const config: BraintrustExporterConfig = {
+      braintrustLogger: mockLogger as Logger<true>,
+    };
+    const exporter = new BraintrustExporter(config);
+
+    // Create Mastra span hierarchy: agent -> llm -> tool
+    const agentSpan = createMockSpan({
+      id: 'agent-span-id',
+      name: 'test-agent',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+      attributes: { agentId: 'test-agent' },
+    });
+
+    const llmSpan = createMockSpan({
+      id: 'llm-span-id',
+      name: 'gpt-4-call',
+      type: SpanType.MODEL_GENERATION,
+      isRoot: false,
+      attributes: { model: 'gpt-4' },
+    });
+    llmSpan.traceId = agentSpan.traceId;
+    llmSpan.parentSpanId = agentSpan.id;
+
+    const toolSpan = createMockSpan({
+      id: 'tool-span-id',
+      name: 'calculator',
+      type: SpanType.TOOL_CALL,
+      isRoot: false,
+      attributes: { toolId: 'calc' },
+    });
+    toolSpan.traceId = agentSpan.traceId;
+    toolSpan.parentSpanId = llmSpan.id;
+
+    // Export spans in order
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: agentSpan,
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: llmSpan,
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: toolSpan,
+    });
+
+    // Verify the startSpan() chain:
+    // 1. Agent span should be created on the EXTERNAL span
+    expect(mockExternalSpan.startSpan).toHaveBeenCalledTimes(1);
+    expect(mockExternalSpan.startSpan).toHaveBeenCalledWith({
+      spanId: 'agent-span-id',
+      name: 'test-agent',
+      type: 'task',
+      // No parentSpanIds in external context
+      metadata: {
+        spanType: 'agent_run',
+        agentId: 'test-agent',
+      },
+    });
+
+    // 2. LLM span should be created on the AGENT span (not external)
+    expect(mockAgentSpan.startSpan).toHaveBeenCalledTimes(1);
+    expect(mockAgentSpan.startSpan).toHaveBeenCalledWith({
+      spanId: 'llm-span-id',
+      name: 'gpt-4-call',
+      type: 'llm',
+      // No parentSpanIds in external context
+      metadata: {
+        spanType: 'model_generation',
+        model: 'gpt-4',
+      },
+    });
+
+    // 3. Tool span should be created on the LLM span (not agent, not external)
+    expect(mockLlmSpan.startSpan).toHaveBeenCalledTimes(1);
+    expect(mockLlmSpan.startSpan).toHaveBeenCalledWith({
+      spanId: 'tool-span-id',
+      name: 'calculator',
+      type: 'tool',
+      // No parentSpanIds in external context
+      metadata: {
+        spanType: 'tool_call',
+        toolId: 'calc',
+      },
+    });
+
+    // Verify trace is external
+    const spanData = (exporter as any).traceMap.get(agentSpan.traceId);
+    expect(spanData.isExternal).toBe(true);
+
+    // Verify spans are stored correctly in spanData.spans
+    // This proves getBraintrustParent() can find the right parent for each child
+    expect(spanData.spans.size).toBe(3);
+    expect(spanData.spans.get('agent-span-id')).toBe(mockAgentSpan);
+    expect(spanData.spans.get('llm-span-id')).toBe(mockLlmSpan);
+    expect(spanData.spans.get('tool-span-id')).toBe(mockToolSpan);
+
+    // The key proof of correct nesting:
+    // - mockAgentSpan was returned by mockExternalSpan.startSpan()
+    // - mockLlmSpan was returned by mockAgentSpan.startSpan()
+    // - mockToolSpan was returned by mockLlmSpan.startSpan()
+    // So when we verify mockAgentSpan.startSpan was called (not mockExternalSpan),
+    // it proves getBraintrustParent() returned mockAgentSpan (not external),
+    // which means it correctly looked up the agent span from spanData.spans
   });
 });
 


### PR DESCRIPTION
## Description

- Fix Braintrust span nesting so root spans correctly show is_root: true and appear as trace names
- Add rootSpanId tracking to properly establish parent-child relationships
- Fix completionStartTime.getTime is not a function error in metrics
- Add integration tests using real Braintrust SDK to verify nesting behavior

Root Cause: The exporter was incorrectly setting parentSpanIds on root spans, causing Braintrust to mark them with is_root: false. The rootSpanId was being set to the Mastra trace ID (which didn't exist as a Braintrust span), breaking the parent chain.

## Related Issue(s)

fixes #9820

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Braintrust span nesting so root spans correctly appear as trace names.
  * Improved parent-child span relationships and hierarchy within traces.
  * Enhanced timing metric handling to support multiple input types for more robust calculations.

* **Tests**
  * Added comprehensive test coverage for span nesting behavior and multi-level trace hierarchies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->