### PR TITLE
fix: highlight color in dark mode

### DIFF
--- a/docs/src/components/custom-search.tsx
+++ b/docs/src/components/custom-search.tsx
@@ -384,8 +384,8 @@ export const CustomSearch: FC<SearchProps> = ({
                         className={cn(
                           "flex flex-col gap-1 p-2 rounded-md cursor-pointer",
                           isSelected
-                            ? "dark:bg-surface-5 bg-(--mastra-surface-2)"
-                            : "bg-(--ifm-background-color) dark:bg-surface-4",
+                            ? "dark:bg-(--mastra-surface-5) bg-(--mastra-surface-2)"
+                            : "bg-(--ifm-background-color) dark:bg-transparent",
                         )}
                         onClick={() => handleSelect(subResult)}
                         onMouseEnter={() => setSelectedIndex(virtualItem.index)}
@@ -396,7 +396,7 @@ export const CustomSearch: FC<SearchProps> = ({
                         <div className="flex gap-2 items-center">
                           <IconComponent className="w-4 h-4 text-(--mastra-icons-3) shrink-0" />
                           <span
-                            className="text-sm font-medium truncate dark:text-white text-(--mastra-text-tertiary) [&_mark]:text-(--mastra-green-accent-3)! [&_mark]:bg-transparent"
+                            className="text-sm font-medium truncate dark:text-white text-(--mastra-text-tertiary) [&_mark]:text-(--mastra-green-accent-3)! dark:[&_mark]:text-(--mastra-green-accent-2)! [&_mark]:bg-transparent"
                             dangerouslySetInnerHTML={{
                               __html: subResult.title,
                             }}


### PR DESCRIPTION
## Description

Fix highlight color for search result item in dark mode.

## Related Issue(s)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced search results styling for improved dark mode experience
    * Selected search results now display with better contrast in dark mode
    * Unselected results use refined background styling in dark mode
    * Highlighted text within search results improved for better visibility in dark mode

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->