### PR TITLE
feat: add native Perplexity provider support

### DIFF
--- a/.changeset/fresh-sloths-reply.md
+++ b/.changeset/fresh-sloths-reply.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+feat: add native Perplexity provider support

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -230,6 +230,7 @@
     "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.27",
     "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.69",
     "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.33",
+    "@ai-sdk/perplexity-v5": "npm:@ai-sdk/perplexity@2.0.5",
     "@babel/core": "^7.28.5",
     "@internal/ai-sdk-v4": "workspace:*",
     "@internal/external-types": "workspace:*",

--- a/packages/core/src/llm/model/gateways/constants.ts
+++ b/packages/core/src/llm/model/gateways/constants.ts
@@ -7,6 +7,7 @@ export const PROVIDERS_WITH_INSTALLED_PACKAGES = [
   'openai',
   'openrouter',
   'xai',
+  'perplexity', // added
 ];
 
 // anything here doesn't show up in model router. for now that's just copilot which requires a special oauth flow

--- a/packages/core/src/llm/model/gateways/constants.ts
+++ b/packages/core/src/llm/model/gateways/constants.ts
@@ -6,8 +6,8 @@ export const PROVIDERS_WITH_INSTALLED_PACKAGES = [
   'mistral',
   'openai',
   'openrouter',
-  'xai',
   'perplexity',
+  'xai',
 ];
 
 // anything here doesn't show up in model router. for now that's just copilot which requires a special oauth flow

--- a/packages/core/src/llm/model/gateways/constants.ts
+++ b/packages/core/src/llm/model/gateways/constants.ts
@@ -7,7 +7,7 @@ export const PROVIDERS_WITH_INSTALLED_PACKAGES = [
   'openai',
   'openrouter',
   'xai',
-  'perplexity', // added
+  'perplexity',
 ];
 
 // anything here doesn't show up in model router. for now that's just copilot which requires a special oauth flow

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -4,6 +4,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google-v5';
 import { createMistral } from '@ai-sdk/mistral-v5';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
 import { createOpenAI } from '@ai-sdk/openai-v5';
+import { createPerplexity } from '@ai-sdk/perplexity-v5';
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { createXai } from '@ai-sdk/xai-v5';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider-v5';
@@ -47,9 +48,6 @@ const OPENAI_COMPATIBLE_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
   },
   deepinfra: {
     url: 'https://api.deepinfra.com/v1/openai',
-  },
-  perplexity: {
-    url: 'https://api.perplexity.ai',
   },
   vercel: {
     url: 'https://ai-gateway.vercel.sh/v1',
@@ -209,6 +207,8 @@ export class ModelsDevGateway extends MastraModelGateway {
         return createDeepSeek({
           apiKey,
         })(modelId);
+      case 'perplexity':
+        return createPerplexity({ apiKey })(modelId);
       default:
         if (!baseURL) throw new Error(`No API URL found for ${providerId}/${modelId}`);
         return createOpenAICompatible({ name: providerId, apiKey, baseURL, supportsStructuredOutputs: true }).chatModel(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1894,6 +1894,9 @@ importers:
       '@ai-sdk/openai-v5':
         specifier: npm:@ai-sdk/openai@2.0.69
         version: '@ai-sdk/openai@2.0.69(zod@3.25.76)'
+      '@ai-sdk/perplexity-v5':
+        specifier: npm:@ai-sdk/perplexity@2.0.5
+        version: '@ai-sdk/perplexity@2.0.5(zod@3.25.76)'
       '@ai-sdk/xai-v5':
         specifier: npm:@ai-sdk/xai@2.0.33
         version: '@ai-sdk/xai@2.0.33(zod@3.25.76)'
@@ -5236,6 +5239,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/perplexity@2.0.5':
+    resolution: {integrity: sha512-2CXyEXH/hIM/xwVuU+a9SelPEYzVDAB3BUfk0uaM6Qx1x4l6QghCJ+wqfb7UXP7Yjv+EbszN7p3OcVVoBOyhEw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/provider-utils@2.1.10':
     resolution: {integrity: sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==}
     engines: {node: '>=18'}
@@ -5283,6 +5292,12 @@ packages:
 
   '@ai-sdk/provider-utils@3.0.3':
     resolution: {integrity: sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.5':
+    resolution: {integrity: sha512-HliwB/yzufw3iwczbFVE2Fiwf1XqROB/I6ng8EKUsPM5+2wnIa8f4VbljZcDx+grhFrPV+PnRZH7zBqi8WZM7Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -18973,6 +18988,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.17(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/perplexity@2.0.5(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@2.1.10(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.0.9
@@ -19052,6 +19073,14 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
+
+  '@ai-sdk/provider-utils@3.0.5(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.0(zod@3.25.76)
 
   '@ai-sdk/provider@1.0.9':
     dependencies:
@@ -27058,6 +27087,15 @@ snapshots:
     optionalDependencies:
       msw: 2.11.6(@types/node@22.13.17)(typescript@5.9.3)
       vite: 7.1.11(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.12
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.6(@types/node@22.13.17)(typescript@5.9.3)
+      vite: 7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -35178,7 +35216,7 @@ snapshots:
   vitest@4.0.12(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@22.13.17)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.2)(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.12
-      '@vitest/mocker': 4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.12
       '@vitest/runner': 4.0.12
       '@vitest/snapshot': 4.0.12


### PR DESCRIPTION
Fixes #10861

Adds full native support for Perplexity models by routing them through
the @ai-sdk/perplexity provider instead of the OpenAI-compatible fallback.

## Why this change?

The OpenAI-compatible fallback breaks Perplexity citations. Perplexity models
emit special `source` chunks during streaming that contain citation URLs, but
when routed through `createOpenAICompatible`, these chunks are lost and
`response.sources` remains empty.

This directly addresses [issue #10861](https://github.com/mastra-ai/mastra/issues/10861) where users cannot access sources/citations from the Perplexity provider.

## How this fixes it

This patch updates the model routing logic to use the native `@ai-sdk/perplexity`
provider, which properly handles Perplexity's citation format and streaming
behavior.

## Changes

- [x] Use @ai-sdk/perplexity instead of OpenAI-compat
- [x] Add perplexity to installed providers list
- [x] Remove manual override forcing OpenAI-compatible routing
- [x] Add resolveLanguageModel switch case
- [x] Add @ai-sdk/perplexity-v5 package to devDependencies

## Outcome

Perplexity models now correctly emit citation `source` chunks and
populate `response.sources`, enabling fully functional retrieval-style
Mastra agents.

This aligns Mastra with upstream AI SDK provider support patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native support for Perplexity v5 as a selectable LLM provider, enabling direct use of Perplexity models.

* **Chores**
  * Added the Perplexity SDK dependency and updated package metadata to enable the new provider.

* **Documentation / Releases**
  * Added a changeset and release notes entry announcing native Perplexity provider support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->