### PR TITLE
fix abort signal and add tests

### DIFF
--- a/.changeset/new-worms-do.md
+++ b/.changeset/new-worms-do.md
@@ -1,0 +1,7 @@
+---
+'@mastra/express': patch
+---
+
+Fix abort signal being prematurely aborted in Express adapter
+
+The abort signal was being triggered when the request body was parsed by `express.json()` middleware, causing `agent.generate()` to return empty responses with 0 tokens. Changed from `req.on('close')` to `res.on('close')` to properly detect client disconnection instead of body consumption.

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -383,4 +383,124 @@ describe('Express Server Adapter', () => {
       expect(textDelta.textDelta).toBe('Hello');
     });
   });
+
+  describe('Abort Signal', () => {
+    let context: AdapterTestContext;
+    let server: Server | null = null;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>(resolve => {
+          server!.close(() => resolve());
+        });
+        server = null;
+      }
+    });
+
+    it('should not have aborted signal when route handler executes', async () => {
+      const app = express();
+      app.use(express.json());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      // Track the abort signal state when the handler executes
+      let abortSignalAborted: boolean | undefined;
+
+      // Create a test route that checks the abort signal state
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/abort-signal',
+        responseType: 'json',
+        handler: async (params: any) => {
+          // Capture the abort signal state when handler runs
+          abortSignalAborted = params.abortSignal?.aborted;
+          return { signalAborted: abortSignalAborted };
+        },
+      };
+
+      app.use(adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      // Start server
+      server = await new Promise<Server>(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to get server address');
+      }
+      const port = address.port;
+
+      // Make a POST request with a JSON body (this triggers body parsing which can cause the issue)
+      const response = await fetch(`http://localhost:${port}/test/abort-signal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: 'data' }),
+      });
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+
+      // The abort signal should NOT be aborted during normal request handling
+      expect(result.signalAborted).toBe(false);
+      expect(abortSignalAborted).toBe(false);
+    });
+
+    it('should provide abort signal to route handlers', async () => {
+      const app = express();
+      app.use(express.json());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/abort-signal-exists',
+        responseType: 'json',
+        handler: async (params: any) => {
+          receivedAbortSignal = params.abortSignal;
+          return { hasSignal: !!params.abortSignal };
+        },
+      };
+
+      app.use(adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      server = await new Promise<Server>(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to get server address');
+      }
+      const port = address.port;
+
+      const response = await fetch(`http://localhost:${port}/test/abort-signal-exists`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+
+      // Route handler should receive an abort signal
+      expect(result.hasSignal).toBe(true);
+      expect(receivedAbortSignal).toBeDefined();
+      expect(receivedAbortSignal).toBeInstanceOf(AbortSignal);
+    });
+  });
 });

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -307,4 +307,95 @@ describe('Hono Server Adapter', () => {
       expect(textDelta.textDelta).toBe('Hello');
     });
   });
+
+  describe('Abort Signal', () => {
+    let context: AdapterTestContext;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    it('should not have aborted signal when route handler executes', async () => {
+      const app = new Hono();
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      // Track the abort signal state when the handler executes
+      let abortSignalAborted: boolean | undefined;
+
+      // Create a test route that checks the abort signal state
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/abort-signal',
+        responseType: 'json',
+        handler: async (params: any) => {
+          // Capture the abort signal state when handler runs
+          abortSignalAborted = params.abortSignal?.aborted;
+          return { signalAborted: abortSignalAborted };
+        },
+      };
+
+      app.use('*', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      // Make a POST request with a JSON body (this triggers body parsing which can cause the issue)
+      const response = await app.request(
+        new Request('http://localhost/test/abort-signal', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ test: 'data' }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+
+      // The abort signal should NOT be aborted during normal request handling
+      expect(result.signalAborted).toBe(false);
+      expect(abortSignalAborted).toBe(false);
+    });
+
+    it('should provide abort signal to route handlers', async () => {
+      const app = new Hono();
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/abort-signal-exists',
+        responseType: 'json',
+        handler: async (params: any) => {
+          receivedAbortSignal = params.abortSignal;
+          return { hasSignal: !!params.abortSignal };
+        },
+      };
+
+      app.use('*', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      const response = await app.request(
+        new Request('http://localhost/test/abort-signal-exists', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+
+      // Route handler should receive an abort signal
+      expect(result.hasSignal).toBe(true);
+      expect(receivedAbortSignal).toBeDefined();
+      expect(receivedAbortSignal).toBeInstanceOf(AbortSignal);
+    });
+  });
 });


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
The Express adapter was using `req.on('close')` to detect client disconnection and abort the signal. However, in Node.js, the `close` event on the request fires when the request body is fully consumed (e.g., after `express.json()` parses it), NOT when the client disconnects.

This caused the abort signal to be already aborted by the time the route handler ran, resulting in `agent.generate()` returning empty responses immediately.

Changed from `req.on('close')` to `res.on('close')` with a check for `res.writableFinished`. The response's `close` event only fires when the underlying connection is actually closed (client disconnect).
- Fixes the Express adapter returning empty responses (`text: ""`, `totalTokens: 0`) from agent endpoints
- Changes abort signal handling from `req.on('close')` to `res.on('close')`
- Adds abort signal tests for both Express and Hono adapters

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes #10882
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed abort signal handling in the Express adapter that was incorrectly triggering during request body parsing, causing agent.generate() to return empty responses with 0 tokens.
  * Enhanced client disconnection detection to work more reliably across different request scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->