### PR TITLE
fix: emit error chunk and call onError when agent workflow step fails

### DIFF
--- a/.changeset/rare-moles-sink.md
+++ b/.changeset/rare-moles-sink.md
@@ -2,6 +2,6 @@
 '@mastra/core': patch
 ---
 
-fix: emit error chunk and call onError when agent workflow step fails
+Emit error chunk and call onError when agent workflow step fails
 
 When a workflow step fails (e.g., tool not found), the error is now properly emitted as an error chunk to the stream and the onError callback is called. This fixes the issue where agent.generate() would throw "promise 'text' was not resolved or rejected" instead of the actual error message.

--- a/.changeset/rare-moles-sink.md
+++ b/.changeset/rare-moles-sink.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+fix: emit error chunk and call onError when agent workflow step fails
+
+When a workflow step fails (e.g., tool not found), the error is now properly emitted as an error chunk to the stream and the onError callback is called. This fixes the issue where agent.generate() would throw "promise 'text' was not resolved or rejected" instead of the actual error message.

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -4520,7 +4520,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
   });
 
   if (version === 'v2') {
-    describe('error handling consistency', () => {
+    describe.only('error handling consistency', () => {
       it('should preserve full APICallError in fullStream chunk, onError callback, and result.error', async () => {
         let onErrorCallbackError: any = null;
         let fullStreamError: any = null;
@@ -4732,6 +4732,151 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         expect(fullStreamError.requestId).toBe(testErrorRequestId);
         expect((resultError as any).statusCode).toBe(testErrorStatusCode);
         expect((resultError as any).requestId).toBe(testErrorRequestId);
+      });
+
+      // Helper to create a model that calls a non-existent tool
+      function createModelWithNonExistentToolCall() {
+        return new MockLanguageModelV2({
+          doGenerate: async () => ({
+            content: [
+              { type: 'tool-call', toolCallId: '123', toolName: 'nonExistentTool', input: '{"input": "test"}' },
+            ],
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            warnings: [],
+          }),
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolCallType: 'function',
+                toolName: 'nonExistentTool', // This tool doesn't exist in the agent's tools
+                input: '{"input": "test"}',
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+          }),
+        });
+      }
+
+      // Helper to create an agent with a tool that exists but the model will call a non-existent one
+      function createAgentWithMismatchedTool(model: MockLanguageModelV2) {
+        const existingTool = createTool({
+          id: 'existingTool',
+          description: 'A tool that exists',
+          inputSchema: z.object({ input: z.string() }),
+          execute: async () => ({ result: 'success' }),
+        });
+
+        return new Agent({
+          id: 'test-tool-not-found-error',
+          name: 'Test Tool Not Found Error',
+          model,
+          instructions: 'You are a helpful assistant.',
+          tools: { existingTool },
+        });
+      }
+
+      it('should throw correct error message in generate when workflow step fails (e.g. tool not found)', async () => {
+        const model = createModelWithNonExistentToolCall();
+        const agent = createAgentWithMismatchedTool(model);
+
+        let caughtError: Error | null = null;
+        try {
+          await agent.generate('Please use a tool');
+        } catch (err: any) {
+          caughtError = err;
+        }
+
+        expect(caughtError).toBeDefined();
+        expect(caughtError).toBeInstanceOf(Error);
+        // The error should contain the actual error message, not "promise 'text' was not resolved"
+        expect(caughtError!.message).toMatch(/Tool nonExistentTool not found/i);
+        expect(caughtError!.message).not.toMatch(/promise.*was not resolved/i);
+      });
+
+      it('should have correct error in output.error and fullStream error chunk when workflow step fails in stream', async () => {
+        const model = createModelWithNonExistentToolCall();
+        const agent = createAgentWithMismatchedTool(model);
+
+        const output = await agent.stream('Please use a tool');
+
+        let errorChunk: any;
+        for await (const chunk of output.fullStream) {
+          if (chunk.type === 'error') {
+            errorChunk = chunk;
+          }
+        }
+
+        // Verify error chunk has correct error
+        expect(errorChunk).toBeDefined();
+        expect(errorChunk.payload.error).toBeDefined();
+        expect(errorChunk.payload.error).toBeInstanceOf(Error);
+        expect((errorChunk.payload.error as Error).message).toMatch(/Tool nonExistentTool not found/i);
+        expect((errorChunk.payload.error as Error).message).not.toMatch(/promise.*was not resolved/i);
+
+        // Verify output.error has correct error
+        expect(output.error).toBeInstanceOf(Error);
+        expect((output.error as Error).message).toMatch(/Tool nonExistentTool not found/i);
+        expect((output.error as Error).message).not.toMatch(/promise.*was not resolved/i);
+
+        // Verify they are the same instance
+        expect(output.error).toBe(errorChunk.payload.error);
+      });
+
+      it('should call onError with correct error in generate when workflow step fails', async () => {
+        const model = createModelWithNonExistentToolCall();
+        const agent = createAgentWithMismatchedTool(model);
+
+        let onErrorCalled = false;
+        let onErrorArg: string | Error | null = null;
+
+        try {
+          await agent.generate('Please use a tool', {
+            onError: ({ error }) => {
+              onErrorCalled = true;
+              onErrorArg = error;
+            },
+          });
+        } catch {
+          // Expected to throw
+        }
+
+        expect(onErrorCalled).toBe(true);
+        expect(onErrorArg).toBeInstanceOf(Error);
+        expect((onErrorArg as unknown as Error).message).toMatch(/Tool nonExistentTool not found/i);
+        expect((onErrorArg as unknown as Error).message).not.toMatch(/promise.*was not resolved/i);
+      });
+
+      it('should call onError with correct error in stream when workflow step fails', async () => {
+        const model = createModelWithNonExistentToolCall();
+        const agent = createAgentWithMismatchedTool(model);
+
+        let onErrorCalled = false;
+        let onErrorArg: string | Error | null = null;
+
+        const output = await agent.stream('Please use a tool', {
+          onError: ({ error }) => {
+            onErrorCalled = true;
+            onErrorArg = error;
+          },
+        });
+
+        // Consume the stream to trigger the error
+        for await (const _ of output.fullStream) {
+          // Just consume
+        }
+
+        expect(onErrorCalled).toBe(true);
+        expect(onErrorArg).toBeInstanceOf(Error);
+        expect((onErrorArg as unknown as Error).message).toMatch(/Tool nonExistentTool not found/i);
+        expect((onErrorArg as unknown as Error).message).not.toMatch(/promise.*was not resolved/i);
       });
     });
 

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -4520,7 +4520,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
   });
 
   if (version === 'v2') {
-    describe.only('error handling consistency', () => {
+    describe('error handling consistency', () => {
       it('should preserve full APICallError in fullStream chunk, onError callback, and result.error', async () => {
         let onErrorCallbackError: any = null;
         let fullStreamError: any = null;

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -1,5 +1,6 @@
 import { ReadableStream, WritableStream } from 'node:stream/web';
 import type { ToolSet } from 'ai-v5';
+import { getErrorFromUnknown } from '../../error';
 import { RequestContext } from '../../request-context';
 import type { OutputSchema } from '../../stream/base/schema';
 import type { ChunkType } from '../../stream/types';
@@ -125,6 +126,36 @@ export function workflowLoopStream<
           });
 
       if (executionResult.status !== 'success') {
+        if (executionResult.status === 'failed') {
+          // Temporary fix for cleaning of workflow result error message.
+          // executionResult.error is typed as Error but is actually a string and has "Error: Error: " prepended to the message.
+          // TODO: This string handling can be removed when the workflow execution result error type is fixed (issue #9348) -- https://github.com/mastra-ai/mastra/issues/9348
+          let executionResultError: string | Error = executionResult.error;
+          if (typeof executionResult.error === 'string') {
+            const prependedErrorString = 'Error: ';
+            if ((executionResult.error as string).startsWith(`${prependedErrorString}${prependedErrorString}`)) {
+              executionResultError = (executionResult.error as string).substring(
+                `${prependedErrorString}${prependedErrorString}`.length,
+              );
+            } else if ((executionResult.error as string).startsWith(prependedErrorString)) {
+              executionResultError = (executionResult.error as string).substring(prependedErrorString.length);
+            }
+          }
+
+          const error = getErrorFromUnknown(executionResultError, {
+            fallbackMessage: 'Unknown error in agent workflow stream',
+          });
+
+          controller.enqueue({
+            type: 'error',
+            runId,
+            from: ChunkFrom.AGENT,
+            payload: { error },
+          });
+
+          await rest.options?.onError?.({ error });
+        }
+
         controller.close();
         return;
       }

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -153,7 +153,9 @@ export function workflowLoopStream<
             payload: { error },
           });
 
-          await rest.options?.onError?.({ error });
+          if (rest.options?.onError) {
+            await rest.options?.onError?.({ error });
+          }
         }
 
         controller.close();


### PR DESCRIPTION
## Summary

Fixes #10857 - `agent.generate()` with `structuredOutput.model` was throwing "promise 'text' was not resolved or rejected when stream finished" instead of the actual error message when a workflow step failed (e.g., tool not found).

**Root cause:** When a workflow step fails (like calling a non-existent tool), the error wasn't being emitted as an error chunk to the stream. This caused `MastraModelOutput`'s `flush()` method to reject delayed promises with a generic message instead of the actual error.

**Changes:**
- Emit error chunk in `workflowLoopStream` when workflow execution fails
- Call `onError` callback when workflow step errors occur
- Clean up double-prefixed "Error: Error: " messages from workflow execution results

## Test plan

- [x] Added test: `agent.generate` throws correct error message when workflow step fails
- [x] Added test: `agent.stream` has correct error in `output.error` and fullStream error chunk
- [x] Added test: `agent.generate` `onError` callback is called with correct error
- [x] Added test: `agent.stream` `onError` callback is called with correct error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emit an error chunk and invoke onError when a workflow step fails; normalize error messages in streaming so the original error is reported and preserved.

* **Tests**
  * Added tests for missing-tool failures, streaming error emission, and consistent error propagation across generate, stream, and callbacks.

* **Chores**
  * Added changelog entry for the patch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->