### PR TITLE
feat(telemetry): add safeStringify for robust serialization

### DIFF
--- a/.changeset/warm-dryers-switches.md
+++ b/.changeset/warm-dryers-switches.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Safe stringify objects in telemetry


### PR DESCRIPTION
## Summary
- Adds `safeStringify` function to handle edge cases that would cause `JSON.stringify` to throw
- Handles circular references (returns `[Circular]`)
- Handles functions (returns `[Function]`)
- Handles BigInt values (returns value with `n` suffix)
- Handles Error objects (returns `{ message, stack }`)

## Test plan
- [ ] Verify telemetry attributes are correctly set for objects with circular references
- [ ] Verify telemetry attributes are correctly set for objects containing functions
- [ ] Verify telemetry attributes are correctly set for objects containing BigInt values
- [ ] Verify telemetry attributes are correctly set for Error objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)