### PR TITLE
feat(loggers): add redact option to PinoLogger for PII protection

### DIFF
--- a/.changeset/add-pino-logger-redact-option.md
+++ b/.changeset/add-pino-logger-redact-option.md
@@ -1,0 +1,23 @@
+---
+'@mastra/loggers': minor
+---
+
+Add redact option to PinoLogger for PII protection
+
+Exposes Pino's native `redact` option in `PinoLogger`, allowing sensitive data to be automatically redacted from logs.
+
+```typescript
+import { PinoLogger } from "@mastra/loggers";
+
+const logger = new PinoLogger({
+  name: "MyApp",
+  redact: {
+    paths: ["*.password", "*.token", "*.apiKey", "*.email"],
+    censor: "[REDACTED]",
+  },
+});
+
+logger.info("User login", { username: "john", password: "secret123" });
+// Output: { username: "john", password: "[REDACTED]", msg: "User login" }
+```
+

--- a/packages/loggers/src/pino.ts
+++ b/packages/loggers/src/pino.ts
@@ -13,6 +13,7 @@ export interface PinoLoggerOptions {
   transports?: TransportMap;
   overrideDefaultTransports?: boolean;
   formatters?: pino.LoggerOptions['formatters'];
+  redact?: pino.LoggerOptions['redact'];
 }
 
 interface PinoLoggerInternalOptions extends PinoLoggerOptions {
@@ -52,6 +53,7 @@ export class PinoLogger extends MastraLogger {
         name: options.name || 'app',
         level: options.level || LogLevel.INFO,
         formatters: options.formatters,
+        redact: options.redact,
       },
       options.overrideDefaultTransports
         ? options?.transports?.default


### PR DESCRIPTION
Closes #10869

Adds support for Pino's native `redact` option in `PinoLogger`, so you can automatically redact sensitive data from logs without manual sanitization.

```typescript
import { PinoLogger } from "@mastra/loggers";

const logger = new PinoLogger({
  name: "MyApp",
  redact: {
    paths: ["*.password", "*.token", "*.apiKey"],
    censor: "[REDACTED]",
  },
});

logger.info("User login", { username: "john", password: "secret123" });
// Output: { username: "john", password: "[REDACTED]", msg: "User login" }
```

Also works with simple path arrays and nested wildcards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added redact option to PinoLogger for automatically redacting sensitive fields from logs. Configure path patterns (e.g., "*.password", "*.token", "*.apiKey") and customize the redaction display value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->