### PR TITLE
fix(agent-builder/types): make targetPath optional in InstallInputSchema

### DIFF
--- a/.changeset/funky-signs-help.md
+++ b/.changeset/funky-signs-help.md
@@ -1,0 +1,5 @@
+---
+'@mastra/agent-builder': patch
+---
+
+Fix install step validation error by making targetPath optional in InstallInputSchema. This resolves the "expected string, received undefined" error when running the agent builder template workflow without explicitly providing a targetPath parameter.

--- a/packages/agent-builder/src/types.ts
+++ b/packages/agent-builder/src/types.ts
@@ -288,7 +288,7 @@ export const PackageMergeResultSchema = z.object({
 
 // Install schemas and types
 export const InstallInputSchema = z.object({
-  targetPath: z.string().describe('Path to the project to install packages in'),
+  targetPath: z.string().optional().describe('Path to the project to install packages in'),
 });
 
 export const InstallResultSchema = z.object({


### PR DESCRIPTION
## Description
Now that we validate workflow steps inputs by default, the agent builder was throwing the error below, even though a `targetPath` is not needed in this case:

> Error executing step workflow.agent-builder-template.step.install: Error: Step input validation failed: 
> - targetPath: Invalid input: expected string, received undefined
>     at validateStepInput 

This PR fixes install step validation error by making targetPath optional in InstallInputSchema. This resolves the "expected string, received undefined" error when running the agent builder template workflow without explicitly providing a targetPath parameter.

## Related Issue(s)

none yet :)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
