### PR TITLE
Backport 10730: fix(client-js): use schema-compat zodToJsonSchema for consistent Zod-to-JSON conversion

### DIFF
--- a/.changeset/every-ravens-tap.md
+++ b/.changeset/every-ravens-tap.md
@@ -1,0 +1,9 @@
+---
+'@mastra/client-js': patch
+---
+
+The client-js package had its own simpler zodToJsonSchema implementation that was missing critical features from schema-compat. This could cause issues when users pass Zod schemas with `z.record()` or `z.date()` through the MastraClient.
+
+Now the client uses the same implementation as the rest of the codebase, which includes the Zod v4 `z.record()` bug fix, date-time format conversion for `z.date()`, and proper handling of unrepresentable types.
+
+Also removes the now-unused `zod-to-json-schema` dependency from client-js.

--- a/client-sdks/client-js/package.json
+++ b/client-sdks/client-js/package.json
@@ -44,9 +44,9 @@
     "@ai-sdk/ui-utils": "^1.2.11",
     "@lukeed/uuid": "^2.0.1",
     "@mastra/core": "workspace:*",
+    "@mastra/schema-compat": "workspace:*",
     "json-schema": "^0.4.0",
-    "rxjs": "7.8.1",
-    "zod-to-json-schema": "^3.24.6"
+    "rxjs": "7.8.1"
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0"

--- a/client-sdks/client-js/src/utils/zod-to-json-schema.ts
+++ b/client-sdks/client-js/src/utils/zod-to-json-schema.ts
@@ -1,9 +1,11 @@
-import { z } from 'zod';
+import { zodToJsonSchema as schemaCompatZodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import type { ZodType } from 'zod';
-import originalZodToJsonSchema from 'zod-to-json-schema';
 
+/**
+ * Check if a value is a Zod schema type.
+ * This is a simple check that doesn't require any Node.js dependencies.
+ */
 function isZodType(value: unknown): value is ZodType {
-  // Check if it's a Zod schema by looking for common Zod properties and methods
   return (
     typeof value === 'object' &&
     value !== null &&
@@ -15,16 +17,20 @@ function isZodType(value: unknown): value is ZodType {
   );
 }
 
-export function zodToJsonSchema<T extends ZodType | any>(zodSchema: T) {
+/**
+ * Converts a Zod schema to JSON Schema, or passes through non-Zod values unchanged.
+ *
+ * Uses the schema-compat implementation which includes:
+ * - Zod v4 z.record() bug fix
+ * - Date to date-time format conversion
+ * - Handling of unrepresentable types
+ */
+export function zodToJsonSchema<T extends ZodType | any>(zodSchema: T): T {
   if (!isZodType(zodSchema)) {
     return zodSchema;
   }
 
-  if ('toJSONSchema' in z) {
-    const fn = 'toJSONSchema';
-    // @ts-expect-error Some nextjs compilation issue
-    return z[fn].call(z, zodSchema);
-  }
-
-  return originalZodToJsonSchema(zodSchema, { $refStrategy: 'relative' });
+  // Cast to T to maintain backwards compatibility with existing call sites
+  // that expect the same type back (even though it's actually JSONSchema7)
+  return schemaCompatZodToJsonSchema(zodSchema) as unknown as T;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,15 +267,15 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/schema-compat':
+        specifier: workspace:*
+        version: link:../../packages/schema-compat
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
       rxjs:
         specifier: 7.8.1
         version: 7.8.1
-      zod-to-json-schema:
-        specifier: ^3.24.6
-        version: 3.24.6(zod@3.25.76)
     devDependencies:
       '@babel/preset-env':
         specifier: ^7.28.3


### PR DESCRIPTION
Backport of #10730

The client-js package had its own simpler zodToJsonSchema implementation that was missing critical features from schema-compat:
- No z.record() bug fix for Zod v4
- No date-time format conversion for z.date()
- No unrepresentable: 'any' option for complex types

Now imports zodToJsonSchema from @mastra/schema-compat which includes all these fixes for consistent behavior across the codebase.

Adaptations for 0.x:
- Added explicit return type to maintain backwards compatibility
- Kept rxjs dependency (0.x-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
