### PR TITLE
Fix workflow state merging for parallel execution

### DIFF
--- a/.changeset/parallel-state-merge.md
+++ b/.changeset/parallel-state-merge.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix workflow state not being properly merged from parallel branches and nested workflows (issue #10917).

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -415,7 +415,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * Apply mutable context changes back to the execution context.
    */
   applyMutableContext(executionContext: ExecutionContext, mutableContext: MutableContext): void {
-    executionContext.state = mutableContext.state;
+    Object.assign(executionContext.state, mutableContext.state);
     Object.assign(executionContext.suspendedPaths, mutableContext.suspendedPaths);
     Object.assign(executionContext.resumeLabels, mutableContext.resumeLabels);
   }


### PR DESCRIPTION
## Description

Fixes a bug where state updates from parallel branches (including nested workflows) were not being properly merged into a single shared state for subsequent steps. Previously, only the state from one parallel branch would be available to following steps, causing state loss.

This fix implements the `MutableContext` pattern to ensure that state changes from all parallel branches are merged using `Object.assign`, matching the semantics already used by `foreach` execution.
## Related Issue(s)

Fixes #10917

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow state merging across parallel branches and nested workflows to correctly preserve state data from all execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->