### PR TITLE
Validate `setState` data against step `stateSchema`

### DIFF
--- a/.changeset/ready-carrots-exist.md
+++ b/.changeset/ready-carrots-exist.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Validate `setState` data against step `stateSchema`

--- a/.changeset/ready-carrots-exist.md
+++ b/.changeset/ready-carrots-exist.md
@@ -2,4 +2,8 @@
 '@mastra/core': patch
 ---
 
-Validate `setState` data against step `stateSchema`
+`setState` is now async
+
+- `setState` must now be awaited: `await setState({ key: value })`
+- State updates are merged automatically—no need to spread the previous state
+- State data is validated against the step's `stateSchema` when `validateInputs` is enabled (default: `true`)

--- a/docs/src/content/en/docs/workflows/workflow-state.mdx
+++ b/docs/src/content/en/docs/workflows/workflow-state.mdx
@@ -28,7 +28,7 @@ const step1 = createStep({
     console.log(state.sharedCounter);
 
     // Update state for subsequent steps
-    setState({ ...state, sharedCounter: state.sharedCounter + 1 });
+    await setState({ sharedCounter: state.sharedCounter + 1 });
 
     // Return output that flows to next step's inputData
     return { step1Output: "processed" };
@@ -50,8 +50,7 @@ const step1 = createStep({
     const { message } = inputData;
     const { processedItems } = state;
 
-    setState({
-      ...state,
+    await setState({
       processedItems: [...processedItems, "item-1", "item-2"],
     });
 
@@ -124,7 +123,7 @@ const step1 = createStep({
   execute: async ({ state, setState, suspend, resumeData }) => {
     if (!resumeData) {
       // First run: update state and suspend
-      setState({ ...state, count: state.count + 1, items: [...state.items, "item-1"] });
+      await setState({ count: state.count + 1, items: [...state.items, "item-1"] });
       await suspend({});
       return {};
     }
@@ -166,7 +165,7 @@ const parentStep = createStep({
   stateSchema: z.object({ sharedValue: z.string() }),
   execute: async ({ state, setState }) => {
     // Modify state before nested workflow runs
-    setState({ ...state, sharedValue: "modified-by-parent" });
+    await setState({ sharedValue: "modified-by-parent" });
     return {};
   },
 });

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
@@ -212,9 +212,9 @@ npx @mastra/codemod@beta v1/workflow-stream-vnext .
 
 :::
 
-### `suspend` and `setState` are not available in step conditon functions parameters
+### `suspend` and `setState` are not available in step condition functions parameters
 
-The `suspend` and `setState` functions are not available in step conditon functions parameters.
+The `suspend` and `setState` functions are not available in step condition functions parameters.
 
 To migrate, use the `suspend` function in the step execute function instead.
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
@@ -212,6 +212,22 @@ npx @mastra/codemod@beta v1/workflow-stream-vnext .
 
 :::
 
+### `suspend` and `setState` are not available in step conditon functions parameters
+
+The `suspend` and `setState` functions are not available in step conditon functions parameters.
+
+To migrate, use the `suspend` function in the step execute function instead.
+
+```diff
+.dowhile(step, async ({ suspend, state, setState }) => {
+- setState({...state, updatedState: "updated state"})
+- await suspend({ reason: "Suspension reason" });
++ // Use the suspend/setState in the step execute function instead
+});
+```
+
+This is the same for `dountil` and `branch` condition functions parameters.
+
 ### Legacy workflows export
 
 The `./workflows/legacy` export path has been removed from `@mastra/core`. Legacy workflows are no longer supported.

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
@@ -177,6 +177,21 @@ To migrate, update any code that consumes branch outputs to handle optional valu
 
 If your code depends on non-optional types, add runtime checks or provide default values when accessing branch outputs.
 
+### `setState` is now async and the data passed is validated
+
+The `setState` function is now async. The data passed is now validated against the `stateSchema` defined in the step.
+The state data validation also uses the `validateInputs` flag to determine whether to validate the state data or not.
+Also, when calling `setState`, you can now pass only the state data being updated, instead of adding the previous state spread (`...state`).
+
+To migrate, update the `setState` function to be async.
+
+```diff
+- setState({ ...state, sharedCounter: state.sharedCounter + 1 });
++ await setState({ sharedCounter: state.sharedCounter + 1 });
++ // await setState({ ...state, sharedCounter: state.sharedCounter + 1 }); 
++ // this also works, as the previous state spread remains supported
+```
+
 ## Removed
 
 ### `streamVNext`, `resumeStreamVNext`, and `observeStreamVNext` methods

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -25,7 +25,7 @@ import type { ExecuteSleepParams, ExecuteSleepUntilParams } from './handlers/sle
 import { executeSleep as executeSleepHandler, executeSleepUntil as executeSleepUntilHandler } from './handlers/sleep';
 import type { ExecuteStepParams } from './handlers/step';
 import { executeStep as executeStepHandler } from './handlers/step';
-import type { ConditionFunction, ExecuteFunctionParams, Step } from './step';
+import type { ConditionFunction, ConditionFunctionParams, Step } from './step';
 import type {
   DefaultEngineType,
   Emitter,
@@ -176,7 +176,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
   async evaluateCondition(
     conditionFn: ConditionFunction<any, any, any, any, DefaultEngineType>,
     index: number,
-    context: ExecuteFunctionParams<any, any, any, any, DefaultEngineType>,
+    context: ConditionFunctionParams<any, any, any, any, DefaultEngineType>,
     operationId: string,
   ): Promise<number | null> {
     return this.wrapDurableOperation(operationId, async () => {

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -415,7 +415,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * Apply mutable context changes back to the execution context.
    */
   applyMutableContext(executionContext: ExecutionContext, mutableContext: MutableContext): void {
-    executionContext.state = mutableContext.state;
+    Object.assign(executionContext.state, mutableContext.state);
     Object.assign(executionContext.suspendedPaths, mutableContext.suspendedPaths);
     Object.assign(executionContext.resumeLabels, mutableContext.resumeLabels);
   }

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -96,7 +96,7 @@ export class StepExecutor extends MastraBase {
             requestContext,
             inputData,
             state: params.state,
-            setState: (state: any) => {
+            setState: async (state: any) => {
               // TODO
               params.state = state;
             },
@@ -109,6 +109,7 @@ export class StepExecutor extends MastraBase {
               const { suspendData, validationError } = await validateStepSuspendData({
                 suspendData: suspendPayload,
                 step,
+                validateInputs: params.validateInputs ?? true,
               });
               if (validationError) {
                 throw validationError;
@@ -275,16 +276,10 @@ export class StepExecutor extends MastraBase {
           requestContext,
           inputData,
           state,
-          setState: (_state: any) => {
-            // TODO
-          },
           retryCount,
           resumeData: resumeData,
           getInitData: () => stepResults?.input as any,
           getStepResult: getStepResult.bind(this, stepResults),
-          suspend: async (_suspendPayload: any): Promise<any> => {
-            throw new Error('Not implemented');
-          },
           bail: (_result: any) => {
             throw new Error('Not implemented');
           },
@@ -345,7 +340,7 @@ export class StepExecutor extends MastraBase {
             inputData: params.input,
             // TODO: implement state
             state: {},
-            setState: (_state: any) => {
+            setState: async (_state: any) => {
               // TODO
             },
             retryCount,
@@ -418,7 +413,7 @@ export class StepExecutor extends MastraBase {
             inputData: params.input,
             // TODO: implement state
             state: {},
-            setState: (_state: any) => {
+            setState: async (_state: any) => {
               // TODO
             },
             retryCount,

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -288,15 +288,12 @@ export async function executeConditional(
             requestContext,
             inputData: prevOutput,
             state: executionContext.state,
-            setState: async (_state: any) => {},
             retryCount: -1,
             tracingContext: {
               currentSpan: evalSpan,
             },
             getInitData: () => stepResults?.input as any,
             getStepResult: getStepResult.bind(null, stepResults),
-            // TODO: this function shouldn't have suspend probably?
-            suspend: async (_suspendPayload: any): Promise<any> => {},
             bail: () => {},
             abort: () => {
               abortController?.abort();
@@ -604,7 +601,6 @@ export async function executeLoop(
           requestContext,
           inputData: result.output,
           state: executionContext.state,
-          setState: async (_state: any) => {},
           retryCount: -1,
           tracingContext: {
             currentSpan: evalSpan,
@@ -612,7 +608,6 @@ export async function executeLoop(
           iterationCount: iteration + 1,
           getInitData: () => stepResults?.input as any,
           getStepResult: getStepResult.bind(null, stepResults),
-          suspend: async (_suspendPayload: any): Promise<any> => {},
           bail: () => {},
           abort: () => {
             abortController?.abort();

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -288,9 +288,7 @@ export async function executeConditional(
             requestContext,
             inputData: prevOutput,
             state: executionContext.state,
-            setState: (state: any) => {
-              executionContext.state = state;
-            },
+            setState: async (_state: any) => {},
             retryCount: -1,
             tracingContext: {
               currentSpan: evalSpan,
@@ -606,9 +604,7 @@ export async function executeLoop(
           requestContext,
           inputData: result.output,
           state: executionContext.state,
-          setState: (state: any) => {
-            executionContext.state = state;
-          },
+          setState: async (_state: any) => {},
           retryCount: -1,
           tracingContext: {
             currentSpan: evalSpan,

--- a/packages/core/src/workflows/handlers/sleep.ts
+++ b/packages/core/src/workflows/handlers/sleep.ts
@@ -82,7 +82,7 @@ export async function executeSleep(engine: DefaultExecutionEngine, params: Execu
         requestContext,
         inputData: prevOutput,
         state: executionContext.state,
-        setState: (state: any) => {
+        setState: async (state: any) => {
           executionContext.state = state;
         },
         retryCount: -1,
@@ -198,7 +198,7 @@ export async function executeSleepUntil(
         requestContext,
         inputData: prevOutput,
         state: executionContext.state,
-        setState: (state: any) => {
+        setState: async (state: any) => {
           executionContext.state = state;
         },
         retryCount: -1,

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -28,6 +28,7 @@ import {
   runCountDeprecationMessage,
   validateStepResumeData,
   validateStepSuspendData,
+  validateStepStateData,
 } from '../utils';
 
 export interface ExecuteStepParams {
@@ -255,9 +256,17 @@ export async function executeStep(
         requestContext,
         inputData,
         state: executionContext.state,
-        setState: (state: any) => {
-          executionContext.state = state;
-          contextMutations.stateUpdate = state;
+        setState: async (state: any) => {
+          const { stateData, validationError: stateValidationError } = await validateStepStateData({
+            stateData: state,
+            step,
+            validateInputs: engine.options?.validateInputs ?? true,
+          });
+          if (stateValidationError) {
+            throw stateValidationError;
+          }
+          // executionContext.state = stateData;
+          contextMutations.stateUpdate = stateData;
         },
         retryCount,
         resumeData: resumeDataToUse,
@@ -269,6 +278,7 @@ export async function executeStep(
           const { suspendData, validationError: suspendValidationError } = await validateStepSuspendData({
             suspendData: suspendPayload,
             step,
+            validateInputs: engine.options?.validateInputs ?? true,
           });
           if (suspendValidationError) {
             throw suspendValidationError;
@@ -366,9 +376,9 @@ export async function executeStep(
     // For Inngest: on replay, the wrapped function didn't re-execute, so we restore from the memoized result
     Object.assign(executionContext.suspendedPaths, durableResult.contextMutations.suspendedPaths);
     Object.assign(executionContext.resumeLabels, durableResult.contextMutations.resumeLabels);
-    if (durableResult.contextMutations.stateUpdate !== null) {
-      executionContext.state = durableResult.contextMutations.stateUpdate;
-    }
+    // if (durableResult.contextMutations.stateUpdate !== null) {
+    //   executionContext.state = durableResult.contextMutations.stateUpdate;
+    // }
     // Restore requestContext from memoized result (only for engines that need it)
     if (engine.requiresDurableContextSerialization() && durableResult.contextMutations.requestContextUpdate) {
       requestContext.clear();
@@ -434,7 +444,12 @@ export async function executeStep(
   return {
     result: stepResult,
     stepResults: { [step.id]: stepResult },
-    mutableContext: engine.buildMutableContext(executionContext),
+    mutableContext: engine.buildMutableContext({
+      ...executionContext,
+      state: stepRetryResult.ok
+        ? (stepRetryResult.result.contextMutations.stateUpdate ?? executionContext.state)
+        : executionContext.state,
+    }),
     requestContext: engine.serializeRequestContext(requestContext),
   };
 }

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -376,9 +376,7 @@ export async function executeStep(
     // For Inngest: on replay, the wrapped function didn't re-execute, so we restore from the memoized result
     Object.assign(executionContext.suspendedPaths, durableResult.contextMutations.suspendedPaths);
     Object.assign(executionContext.resumeLabels, durableResult.contextMutations.resumeLabels);
-    // if (durableResult.contextMutations.stateUpdate !== null) {
-    //   executionContext.state = durableResult.contextMutations.stateUpdate;
-    // }
+
     // Restore requestContext from memoized result (only for engines that need it)
     if (engine.requiresDurableContextSerialization() && durableResult.contextMutations.requestContextUpdate) {
       requestContext.clear();

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -21,7 +21,7 @@ export type ExecuteFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSch
   requestContext: RequestContext;
   inputData: TStepInput;
   state: TState;
-  setState(state: TState): void;
+  setState(state: TState): Promise<void>;
   resumeData?: TResumeSchema;
   suspendData?: TSuspendSchema;
   retryCount: number;

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -50,16 +50,21 @@ export type ExecuteFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSch
   validateSchemas?: boolean;
 };
 
+export type ConditionFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType> = Omit<
+  ExecuteFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType>,
+  'setState' | 'suspend'
+>;
+
 export type ExecuteFunction<TState, TStepInput, TStepOutput, TResumeSchema, TSuspendSchema, EngineType> = (
   params: ExecuteFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType>,
 ) => Promise<TStepOutput>;
 
 export type ConditionFunction<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType> = (
-  params: ExecuteFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType>,
+  params: ConditionFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType>,
 ) => Promise<boolean>;
 
 export type LoopConditionFunction<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType> = (
-  params: ExecuteFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType> & {
+  params: ConditionFunctionParams<TState, TStepInput, TResumeSchema, TSuspendSchema, EngineType> & {
     iterationCount: number;
   },
 ) => Promise<boolean>;

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -4120,7 +4120,7 @@ describe('Workflow', () => {
         outputSchema: shareSchema,
         stateSchema: shareSchema,
       })
-        .parallel([step1, setSteps])
+        .parallel([step1, workflow2])
         .then(step2)
         .commit();
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1137,7 +1137,7 @@ export class Workflow<
     inputData: z.infer<TInput>;
     resumeData?: any;
     state: z.infer<TState>;
-    setState: (state: z.infer<TState>) => void;
+    setState: (state: z.infer<TState>) => Promise<void>;
     getStepResult<T extends Step<any, any, any, any, any, any, TEngineType>>(
       stepId: T,
     ): T['outputSchema'] extends undefined ? unknown : z.infer<NonNullable<T['outputSchema']>>;
@@ -1258,7 +1258,7 @@ export class Workflow<
     });
 
     if (res.state) {
-      setState(res.state);
+      await setState(res.state);
     }
 
     if (suspendedSteps?.length) {

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -475,7 +475,7 @@ describe('MastraInngestWorkflow', () => {
         id: 'step1',
         execute: async ({ state, setState }) => {
           calls++;
-          setState({ ...state, value: state.value + '!!!' });
+          await setState({ ...state, value: state.value + '!!!' });
           return {};
         },
         inputSchema: z.object({}),
@@ -4154,7 +4154,7 @@ describe('MastraInngestWorkflow', () => {
       const improveResponseAction = vi
         .fn()
         .mockImplementationOnce(async ({ suspend, state, setState }) => {
-          setState({ ...state, value: 'test state' });
+          await setState({ ...state, value: 'test state' });
           await suspend();
           return undefined;
         })


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Validate `setState` data against step `stateSchema`
This fixes the parallel states step issue

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#10917 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * setState is now asynchronous and validates state updates against a step's stateSchema when validation is enabled.

* **Improvements**
  * Condition function parameters simplified (no setState/suspend inside condition callbacks).
  * State updates may be provided as partials without spreading the full state.
  * Suspend payloads now undergo validation when enabled.

* **Documentation**
  * Migration guide and workflow docs updated with async setState patterns and examples.

* **Tests**
  * Tests updated to await setState and cover parallel/state-propagation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->