### PR TITLE
docs(openai): add zero data retention guidance for OpenAI API usage

### DIFF
--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -355,66 +355,6 @@ const agent = new Agent({
 
 ${generateProviderOptionsSection(provider.id)}
 ${
-  provider.id === 'openai'
-    ? `
-## Zero Data Retention
-
-If your OpenAI organization has [zero data retention](https://platform.openai.com/docs/guides/your-data#zero-data-retention) enabled, you must explicitly set \`store: false\` in your provider options to prevent API errors.
-
-You can set this per request:
-
-\`\`\`typescript
-const agent = new Agent({
-  id: "zero-retention-agent",
-  name: "Zero Retention Agent",
-  instructions: "You are a helpful assistant",
-  model: "openai/gpt-4o"
-});
-
-// when using generate
-const response = await agent.generate("Hello!", {
-  providerOptions: {
-    openai: {
-      store: false  // Required for zero data retention orgs
-    }
-  }
-});
-
-// when using stream
-const stream = await agent.stream("Hello!", {
-  providerOptions: {
-    openai: {
-      store: false  // Required for zero data retention orgs
-    }
-  }
-});
-\`\`\`
-
-Or configure it globally for all requests from an agent using \`defaultOptions\`:
-
-\`\`\`typescript
-const agent = new Agent({
-  id: "zero-retention-agent",
-  name: "Zero Retention Agent",
-  instructions: "You are a helpful assistant",
-  model: "openai/gpt-4o",
-  defaultOptions: {
-    providerOptions: {
-      openai: {
-        store: false  // Applies to all generate/stream calls
-      }
-    }
-  }
-});
-
-// Now all calls will automatically include store: false
-const response = await agent.generate("Hello!");
-const stream = await agent.stream("Tell me a story");
-\`\`\`
-`
-    : ''
-}
-${
   provider.packageName && provider.packageName !== '@ai-sdk/openai-compatible'
     ? `
 ## Direct Provider Installation

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -355,6 +355,66 @@ const agent = new Agent({
 
 ${generateProviderOptionsSection(provider.id)}
 ${
+  provider.id === 'openai'
+    ? `
+## Zero Data Retention
+
+If your OpenAI organization has [zero data retention](https://platform.openai.com/docs/guides/your-data#zero-data-retention) enabled, you must explicitly set \`store: false\` in your provider options to prevent API errors.
+
+You can set this per request:
+
+\`\`\`typescript
+const agent = new Agent({
+  id: "zero-retention-agent",
+  name: "Zero Retention Agent",
+  instructions: "You are a helpful assistant",
+  model: "openai/gpt-4o"
+});
+
+// when using generate
+const response = await agent.generate("Hello!", {
+  providerOptions: {
+    openai: {
+      store: false  // Required for zero data retention orgs
+    }
+  }
+});
+
+// when using stream
+const stream = await agent.stream("Hello!", {
+  providerOptions: {
+    openai: {
+      store: false  // Required for zero data retention orgs
+    }
+  }
+});
+\`\`\`
+
+Or configure it globally for all requests from an agent using \`defaultOptions\`:
+
+\`\`\`typescript
+const agent = new Agent({
+  id: "zero-retention-agent",
+  name: "Zero Retention Agent",
+  instructions: "You are a helpful assistant",
+  model: "openai/gpt-4o",
+  defaultOptions: {
+    providerOptions: {
+      openai: {
+        store: false  // Applies to all generate/stream calls
+      }
+    }
+  }
+});
+
+// Now all calls will automatically include store: false
+const response = await agent.generate("Hello!");
+const stream = await agent.stream("Tell me a story");
+\`\`\`
+`
+    : ''
+}
+${
   provider.packageName && provider.packageName !== '@ai-sdk/openai-compatible'
     ? `
 ## Direct Provider Installation

--- a/packages/core/scripts/generate-provider-options-docs.ts
+++ b/packages/core/scripts/generate-provider-options-docs.ts
@@ -137,6 +137,16 @@ function generateProviderDocs(providerName: string, typeName: string, project: P
 }
 
 /**
+ * Custom descriptions for provider options that need additional context
+ */
+const CUSTOM_OPTION_DESCRIPTIONS: Record<string, Record<string, string>> = {
+  openai: {
+    store:
+      'Controls whether OpenAI stores your API requests for model training. Required to be "false" if your organization has zero data retention enabled. See: https://platform.openai.com/docs/guides/your-data#zero-data-retention',
+  },
+};
+
+/**
  * Generate provider options section for a specific provider (for use in provider docs)
  */
 export function generateProviderOptionsSection(providerId: string): string {
@@ -221,12 +231,23 @@ export function generateProviderOptionsSection(providerId: string): string {
   markdown += `### Available Options\n\n`;
 
   // Generate PropertiesTable component with JSON data
-  const tableData = properties.map(prop => ({
-    name: prop.name,
-    type: prop.type,
-    description: prop.description || '',
-    isOptional: prop.optional,
-  }));
+  const customDescriptions = CUSTOM_OPTION_DESCRIPTIONS[providerId] || {};
+  const tableData = properties.map(prop => {
+    let description = prop.description || '';
+    const customDesc = customDescriptions[prop.name];
+
+    // Combine existing description with custom description
+    if (customDesc) {
+      description = description ? `${description}\n\n${customDesc}` : customDesc;
+    }
+
+    return {
+      name: prop.name,
+      type: prop.type,
+      description,
+      isOptional: prop.optional,
+    };
+  });
 
   markdown += `<PropertiesTable\n`;
   markdown += `  content={${JSON.stringify(tableData, null, 4)}}\n`;


### PR DESCRIPTION
## Description

Introduced a new section in the OpenAI provider documentation detailing the requirement to set `store: false` for organizations with zero data retention enabled. Provided examples for both per-request and global configuration to ensure users can implement this setting correctly in their agents.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced provider option descriptions in generated documentation to include provider-specific notes and custom details, offering more comprehensive information for each option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->