### PR TITLE
fix(agent): pass toolCallId in context.agent for network tool execution

### DIFF
--- a/.changeset/fix-toolcallid-propagation.md
+++ b/.changeset/fix-toolcallid-propagation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix toolCallId propagation in agent network tool execution. The toolCallId property was undefined at runtime despite being required by TypeScript type definitions in AgentToolExecutionContext. Now properly passes the toolCallId through to the tool's context during network tool execution.

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -1,5 +1,5 @@
-import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai-v5/test';
 import { openai } from '@ai-sdk/openai-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai-v5/test';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { MastraError } from '../error';
@@ -763,7 +763,7 @@ describe('Agent - network - tool context validation', () => {
     });
 
     // Consume the stream to trigger tool execution through network
-    for await (const chunk of anStream) {
+    for await (const _chunk of anStream) {
       // Stream events are processed
     }
 

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -957,6 +957,7 @@ export async function createNetworkLoop({
           mastra: agent.getMastraInstance(),
           agent: {
             resourceId: initData.threadResourceId || networkName,
+            toolCallId,
             threadId: initData.threadId,
           },
           runId,


### PR DESCRIPTION
**Critical Issue**: When tools are executed through the agent network, the `context.agent.toolCallId` property is **undefined** despite being required by the TypeScript type definitions. This creates a type safety gap where the runtime behavior does not match the type contract.

### Type Definition vs Implementation Mismatch

The `AgentToolExecutionContext` type (from `packages/core/src/tools/types.ts`) defines toolCallId as a required string property:

```typescript
export interface AgentToolExecutionContext {
  toolCallId: string;        // ← Required, non-optional
  messages: any[];
  threadId?: string;
  resourceId?: string;
}
```

However, when tools execute through the network loop, `toolCallId` was never passed to the context, violating the type contract and leaving tools without access to a critical identifier.

### The Fix

This PR brings the runtime implementation into alignment with TypeScript type definitions by passing the `toolCallId` generated during network tool execution through to `context.agent`. Tools can now reliably access:
- `context.agent.toolCallId` - Unique identifier for this tool call
- `context.agent.threadId` - Memory thread identifier
- `context.agent.resourceId` - Memory resource identifier

All three properties now properly propagate through network execution, matching their type definitions.

## Related Issue(s)

Brings runtime implementation into alignment with type definitions for AgentToolExecutionContext

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation tests to confirm tools receive a complete agent context (including call identifiers) during network execution.

* **Improvements**
  * Tools now receive the call identifier (toolCallId) in their execution context for improved tracking and visibility at runtime.

* **Chores**
  * Recorded a patch changeset documenting the fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->