### PR TITLE
fix(deployer): handle JSONC comments in tsconfig.json

### DIFF
--- a/.changeset/fix-tsconfig-jsonc-comments.md
+++ b/.changeset/fix-tsconfig-jsonc-comments.md
@@ -1,0 +1,8 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix tsconfig.json parsing when file contains JSONC comments
+
+The `hasPaths()` function now uses `strip-json-comments` to properly parse tsconfig.json files that contain comments. Previously, `JSON.parse()` would fail silently on JSONC comments, causing path aliases like `@src/*` to be incorrectly treated as npm scoped packages.
+

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -114,6 +114,7 @@
     "resolve.exports": "^2.0.3",
     "rollup": "~4.50.2",
     "rollup-plugin-esbuild": "^6.2.1",
+    "strip-json-comments": "^5.0.3",
     "tinyglobby": "^0.2.15",
     "typescript-paths": "^1.5.1"
   },

--- a/packages/deployer/src/build/plugins/__fixtures__/tsconfig-no-comments.json
+++ b/packages/deployer/src/build/plugins/__fixtures__/tsconfig-no-comments.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "paths": {
+      "@src/*": ["./src/*"],
+      "@specs/*": ["./specs/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/deployer/src/build/plugins/__fixtures__/tsconfig-no-paths.json
+++ b/packages/deployer/src/build/plugins/__fixtures__/tsconfig-no-paths.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022"
+  }
+}

--- a/packages/deployer/src/build/plugins/__fixtures__/tsconfig-with-comments.json
+++ b/packages/deployer/src/build/plugins/__fixtures__/tsconfig-with-comments.json
@@ -1,0 +1,15 @@
+{
+  // This is a comment
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    /* This is a block comment */
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "paths": {
+      "@src/*": ["./src/*"],
+      "@specs/*": ["./specs/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/deployer/src/build/plugins/tsconfig-paths.test.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { tsConfigPaths, hasPaths } from './tsconfig-paths';
+import { rollup } from 'rollup';
+
+describe('tsconfig-paths plugin', () => {
+  const _dirname = dirname(fileURLToPath(import.meta.url));
+  const fixturesDir = join(_dirname, '__fixtures__');
+
+  describe('hasPaths - JSONC parsing', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      // Create a temporary directory for test files
+      tempDir = fs.mkdtempSync(join(os.tmpdir(), 'mastra-test-'));
+    });
+
+    afterEach(() => {
+      // Clean up temp directory
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('should detect paths in tsconfig.json without comments', () => {
+      // Copy the no-comments fixture to temp dir
+      const tsConfigContent = fs.readFileSync(join(fixturesDir, 'tsconfig-no-comments.json'), 'utf-8');
+      const tsConfigPath = join(tempDir, 'tsconfig.json');
+      fs.writeFileSync(tsConfigPath, tsConfigContent);
+
+      // hasPaths should return true for a valid tsconfig with paths
+      expect(hasPaths(tsConfigPath)).toBe(true);
+    });
+
+    /**
+     * This test demonstrates the bug from issue #10942:
+     * When tsconfig.json contains JSONC comments, JSON.parse() fails silently
+     * and hasPaths() returns false even though paths are configured.
+     *
+     * @see https://github.com/mastra-ai/mastra/issues/10942
+     */
+    it('should detect paths in tsconfig.json WITH JSONC comments (issue #10942)', () => {
+      // Copy the with-comments fixture to temp dir
+      const tsConfigContent = fs.readFileSync(join(fixturesDir, 'tsconfig-with-comments.json'), 'utf-8');
+      const tsConfigPath = join(tempDir, 'tsconfig.json');
+      fs.writeFileSync(tsConfigPath, tsConfigContent);
+
+      // hasPaths should return true even with JSONC comments
+      // Currently this FAILS because JSON.parse can't handle JSONC comments
+      expect(hasPaths(tsConfigPath)).toBe(true);
+    });
+
+    it('should return false when tsconfig.json has no paths configured', () => {
+      // Copy the no-paths fixture to temp dir
+      const tsConfigContent = fs.readFileSync(join(fixturesDir, 'tsconfig-no-paths.json'), 'utf-8');
+      const tsConfigPath = join(tempDir, 'tsconfig.json');
+      fs.writeFileSync(tsConfigPath, tsConfigContent);
+
+      // hasPaths should return false when no paths are configured
+      expect(hasPaths(tsConfigPath)).toBe(false);
+    });
+
+    it('should return false for non-existent tsconfig.json', () => {
+      const tsConfigPath = join(tempDir, 'non-existent.json');
+      expect(hasPaths(tsConfigPath)).toBe(false);
+    });
+  });
+
+  describe('plugin integration', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(join(os.tmpdir(), 'mastra-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('should resolve path aliases when tsconfig has JSONC comments', async () => {
+      // Copy the with-comments fixture to temp dir
+      const tsConfigContent = fs.readFileSync(join(fixturesDir, 'tsconfig-with-comments.json'), 'utf-8');
+      const tsConfigPath = join(tempDir, 'tsconfig.json');
+      fs.writeFileSync(tsConfigPath, tsConfigContent);
+
+      // Create source files
+      const srcDir = join(tempDir, 'src');
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.writeFileSync(join(srcDir, 'utils.ts'), `export const hello = 'world';`);
+      fs.writeFileSync(join(srcDir, 'index.ts'), `import { hello } from '@src/utils';\nconsole.log(hello);`);
+
+      // Create the plugin with explicit tsconfig path
+      const plugin = tsConfigPaths({ tsConfigPath });
+
+      // Build using rollup to test plugin behavior
+      const bundle = await rollup({
+        logLevel: 'silent',
+        input: join(srcDir, 'index.ts'),
+        plugins: [
+          plugin,
+          {
+            name: 'mock-resolver',
+            resolveId(id) {
+              if (id.includes('/src/utils')) {
+                return { id: join(srcDir, 'utils.ts'), external: false };
+              }
+              return null;
+            },
+            load(id) {
+              if (id.endsWith('utils.ts')) {
+                return `export const hello = 'world';`;
+              }
+              if (id.endsWith('index.ts')) {
+                return `import { hello } from '@src/utils';\nconsole.log(hello);`;
+              }
+              return null;
+            },
+          },
+        ],
+      });
+
+      const result = await bundle.generate({ format: 'esm' });
+      expect(result.output[0].code).toContain('hello');
+    });
+  });
+});

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -2,12 +2,30 @@ import fs from 'node:fs';
 import path, { normalize } from 'node:path';
 import resolveFrom from 'resolve-from';
 import type { Plugin } from 'rollup';
+import stripJsonComments from 'strip-json-comments';
 import type { RegisterOptions } from 'typescript-paths';
 import { createHandler } from 'typescript-paths';
 
 const PLUGIN_NAME = 'tsconfig-paths';
 
 export type PluginOptions = Omit<RegisterOptions, 'loggerID'> & { localResolve?: boolean };
+
+/**
+ * Check if a tsconfig file has path mappings configured.
+ * Exported for testing purposes.
+ *
+ * @param tsConfigPath - Path to the tsconfig.json file
+ * @returns true if the tsconfig has paths configured, false otherwise
+ */
+export function hasPaths(tsConfigPath: string): boolean {
+  try {
+    const content = fs.readFileSync(tsConfigPath, 'utf8');
+    const config = JSON.parse(stripJsonComments(content));
+    return !!(config.compilerOptions?.paths && Object.keys(config.compilerOptions.paths).length > 0);
+  } catch {
+    return false;
+  }
+}
 
 export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }: PluginOptions = {}): Plugin {
   const handlerCache = new Map<string, ReturnType<typeof createHandler>>();
@@ -39,16 +57,6 @@ export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }:
     }
 
     return null;
-  }
-
-  // Check if a tsconfig file has path mappings
-  function hasPaths(tsConfigPath: string): boolean {
-    try {
-      const config = JSON.parse(fs.readFileSync(tsConfigPath, 'utf8'));
-      return !!(config.compilerOptions?.paths && Object.keys(config.compilerOptions.paths).length > 0);
-    } catch {
-      return false;
-    }
   }
 
   // Get or create handler for a specific tsconfig file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1829,7 +1829,7 @@ importers:
         version: 2.0.1
       '@mastra/observability':
         specifier: '>=1.0.0-0 <2.0.0-0'
-        version: 1.0.0-beta.0(@mastra/core@1.0.0-beta.6)
+        version: 1.0.0-beta.0(@mastra/core@1.0.0-beta.7)
       '@mastra/schema-compat':
         specifier: workspace:*
         version: link:../schema-compat
@@ -2102,6 +2102,9 @@ importers:
       rollup-plugin-esbuild:
         specifier: ^6.2.1
         version: 6.2.1(esbuild@0.25.11)(rollup@4.50.2)
+      strip-json-comments:
+        specifier: ^5.0.3
+        version: 5.0.3
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -4696,7 +4699,7 @@ importers:
     dependencies:
       '@google/genai':
         specifier: latest
-        version: 1.30.0(@modelcontextprotocol/sdk@1.20.1)(bufferutil@4.0.9)
+        version: 1.31.0(@modelcontextprotocol/sdk@1.20.1)(bufferutil@4.0.9)
       google-auth-library:
         specifier: ^10.2.1
         version: 10.4.1
@@ -7812,8 +7815,8 @@ packages:
     resolution: {integrity: sha512-gAcNqVL6E6V+d7yZbv5pQAPh5ZTE66UB0n2AZB3QaVaQDo9H8yalja3u2v3NE4QTVt03DkpoIuyvzs4i3w/b7A==}
     engines: {node: '>=18'}
 
-  '@google/genai@1.30.0':
-    resolution: {integrity: sha512-3MRcgczBFbUat1wIlZoLJ0vCCfXgm7Qxjh59cZi2X08RgWLtm9hKOspzp7TOg1TV2e26/MLxR2GR5yD5GmBV2w==}
+  '@google/genai@1.31.0':
+    resolution: {integrity: sha512-rK0RKXxNkbK35eDl+G651SxtxwHNEOogjyeZJUJe+Ed4yxu3xy5ufCiU0+QLT7xo4M9Spey8OAYfD8LPRlYBKw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.20.1
@@ -8634,8 +8637,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@mastra/core@1.0.0-beta.6':
-    resolution: {integrity: sha512-xkjFPrSo0JHmn3df+EcBEi9VzlmAm6cUzC8saj4cTS/JUXexxJEMk1pMmZdGC/Rxx2W/bF30YTJO9KFu2So77g==}
+  '@mastra/core@1.0.0-beta.7':
+    resolution: {integrity: sha512-+vBtN5TrwefVSaHAz5/xk6NgxPOZsYs9LgrIPYpyJJHWzr4hVshMaHAfA2dEw5BLbpik/uDd+HpxoZPdG38m2Q==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       '@mastra/observability': '>=1.0.0-0 <2.0.0-0'
@@ -22100,7 +22103,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google/genai@1.30.0(@modelcontextprotocol/sdk@1.20.1)(bufferutil@4.0.9)':
+  '@google/genai@1.31.0(@modelcontextprotocol/sdk@1.20.1)(bufferutil@4.0.9)':
     dependencies:
       google-auth-library: 10.4.1
       ws: 8.18.3(bufferutil@4.0.9)
@@ -22926,7 +22929,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mastra/core@1.0.0-beta.6(@mastra/observability@1.0.0-beta.0)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod@3.25.76))(@types/json-schema@7.0.15)(ai@5.0.106(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)':
+  '@mastra/core@1.0.0-beta.7(@mastra/observability@1.0.0-beta.0)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod@3.25.76))(@types/json-schema@7.0.15)(ai@5.0.106(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ai-sdk/azure': 2.0.74(zod@3.25.76)
@@ -22952,7 +22955,7 @@ snapshots:
       xxhash-wasm: 1.1.0
       zod: 3.25.76
     optionalDependencies:
-      '@mastra/observability': 1.0.0-beta.0(@mastra/core@1.0.0-beta.6)
+      '@mastra/observability': 1.0.0-beta.0(@mastra/core@1.0.0-beta.7)
     transitivePeerDependencies:
       - '@hono/standard-validator'
       - '@standard-community/standard-json'
@@ -22962,9 +22965,9 @@ snapshots:
       - openapi-types
       - supports-color
 
-  '@mastra/observability@1.0.0-beta.0(@mastra/core@1.0.0-beta.6)':
+  '@mastra/observability@1.0.0-beta.0(@mastra/core@1.0.0-beta.7)':
     dependencies:
-      '@mastra/core': 1.0.0-beta.6(@mastra/observability@1.0.0-beta.0)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod@3.25.76))(@types/json-schema@7.0.15)(ai@5.0.106(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)
+      '@mastra/core': 1.0.0-beta.7(@mastra/observability@1.0.0-beta.0)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod@3.25.76))(@types/json-schema@7.0.15)(ai@5.0.106(zod@3.25.76))(openapi-types@12.1.3)(zod@3.25.76)
       zod: 3.25.76
 
   '@mastra/schema-compat@1.0.0-beta.2(zod@3.25.76)':
@@ -27020,6 +27023,15 @@ snapshots:
     optionalDependencies:
       msw: 2.11.6(@types/node@22.13.17)(typescript@5.9.3)
       vite: 7.2.6(@types/node@22.13.17)(jiti@1.21.7)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.12
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.6(@types/node@22.13.17)(typescript@5.9.3)
+      vite: 7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -35159,7 +35171,7 @@ snapshots:
   vitest@4.0.12(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@22.13.17)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.2)(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.12
-      '@vitest/mocker': 4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.12(msw@2.11.6(@types/node@22.13.17)(typescript@5.9.3))(vite@7.2.6(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.12
       '@vitest/runner': 4.0.12
       '@vitest/snapshot': 4.0.12


### PR DESCRIPTION
The `hasPaths()` function was using `JSON.parse()` to read tsconfig.json, which fails on JSONC comments. This caused path aliases like `@src/*` to not be resolved, leading to them being treated as npm scoped packages.

Before (broken):
```js
const config = JSON.parse(fs.readFileSync(tsConfigPath, 'utf8'));
// throws on comments, catch returns false
```

After (fixed):
```js
const content = fs.readFileSync(tsConfigPath, 'utf8');
const config = JSON.parse(stripJsonComments(content));
// now works with JSONC comments
```

Fixes #10942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of TypeScript configuration files containing comments, ensuring path aliases (e.g., `@src/*`) are correctly recognized instead of being misclassified as npm scopes.

* **Tests**
  * Added comprehensive test coverage for configuration file parsing and plugin integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->