### PR TITLE
feat: add stored agents support

### DIFF
--- a/.changeset/add-stored-agents-support.md
+++ b/.changeset/add-stored-agents-support.md
@@ -1,0 +1,45 @@
+---
+'@mastra/core': minor
+'@mastra/libsql': minor
+'@mastra/pg': minor
+'@mastra/server': minor
+---
+
+Add stored agents support
+
+Agents can now be stored in the database and loaded at runtime. This lets you persist agent configurations and dynamically create executable Agent instances from storage.
+
+```typescript
+import { Mastra } from '@mastra/core';
+import { LibSQLStore } from '@mastra/libsql';
+
+const mastra = new Mastra({
+  storage: new LibSQLStore({ url: ':memory:' }),
+  tools: { myTool },
+  scorers: { myScorer },
+});
+
+// Create agent in storage via API or directly
+await mastra.getStorage().createAgent({
+  agent: {
+    id: 'my-agent',
+    name: 'My Agent',
+    instructions: 'You are helpful',
+    model: { provider: 'openai', name: 'gpt-4' },
+    tools: { myTool: {} },
+    scorers: { myScorer: { sampling: { type: 'ratio', rate: 0.5 } } },
+  },
+});
+
+// Load and use the agent
+const agent = await mastra.getStoredAgentById('my-agent');
+const response = await agent.generate({ messages: 'Hello!' });
+
+// List all stored agents with pagination
+const { agents, total, hasMore } = await mastra.listStoredAgents({
+  page: 0,
+  perPage: 10,
+});
+```
+
+Also adds a memory registry to Mastra so stored agents can reference memory instances by key.

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -13,6 +13,7 @@ import {
   MCPTool,
   AgentBuilder,
   Observability,
+  StoredAgent,
 } from './resources';
 import type {
   ClientOptions,
@@ -44,6 +45,10 @@ import type {
   ListAgentsModelProvidersResponse,
   ListMemoryThreadsParams,
   ListMemoryThreadsResponse,
+  ListStoredAgentsParams,
+  ListStoredAgentsResponse,
+  CreateStoredAgentParams,
+  StoredAgentResponse,
 } from './types';
 import { base64RequestContext, parseClientRequestContext, requestContextQueryString } from './utils';
 
@@ -675,5 +680,57 @@ export class MastraClient extends BaseResource {
     targets: Array<{ traceId: string; spanId?: string }>;
   }): Promise<{ status: string; message: string }> {
     return this.observability.score(params);
+  }
+
+  // ============================================================================
+  // Stored Agents
+  // ============================================================================
+
+  /**
+   * Lists all stored agents with optional pagination
+   * @param params - Optional pagination and ordering parameters
+   * @returns Promise containing paginated list of stored agents
+   */
+  public listStoredAgents(params?: ListStoredAgentsParams): Promise<ListStoredAgentsResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (params?.page !== undefined) {
+      searchParams.set('page', String(params.page));
+    }
+    if (params?.perPage !== undefined) {
+      searchParams.set('perPage', String(params.perPage));
+    }
+    if (params?.orderBy) {
+      if (params.orderBy.field) {
+        searchParams.set('orderBy[field]', params.orderBy.field);
+      }
+      if (params.orderBy.direction) {
+        searchParams.set('orderBy[direction]', params.orderBy.direction);
+      }
+    }
+
+    const queryString = searchParams.toString();
+    return this.request(`/api/stored/agents${queryString ? `?${queryString}` : ''}`);
+  }
+
+  /**
+   * Creates a new stored agent
+   * @param params - Agent configuration including id, name, instructions, model, etc.
+   * @returns Promise containing the created stored agent
+   */
+  public createStoredAgent(params: CreateStoredAgentParams): Promise<StoredAgentResponse> {
+    return this.request('/api/stored/agents', {
+      method: 'POST',
+      body: params,
+    });
+  }
+
+  /**
+   * Gets a stored agent instance by ID for further operations (details, update, delete)
+   * @param storedAgentId - ID of the stored agent to retrieve
+   * @returns StoredAgent instance
+   */
+  public getStoredAgent(storedAgentId: string): StoredAgent {
+    return new StoredAgent(this.options, storedAgentId);
   }
 }

--- a/client-sdks/client-js/src/resources/index.ts
+++ b/client-sdks/client-js/src/resources/index.ts
@@ -8,3 +8,4 @@ export * from './a2a';
 export * from './mcp-tool';
 export * from './agent-builder';
 export * from './observability';
+export * from './stored-agent';

--- a/client-sdks/client-js/src/resources/stored-agent.test.ts
+++ b/client-sdks/client-js/src/resources/stored-agent.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, beforeEach, it, vi } from 'vitest';
+import { MastraClient } from '../client';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe('StoredAgent Resource', () => {
+  let client: MastraClient;
+  const clientOptions = {
+    baseUrl: 'http://localhost:4111',
+    headers: {
+      Authorization: 'Bearer test-key',
+      'x-mastra-client-type': 'js',
+    },
+  };
+
+  // Helper to mock successful API responses
+  const mockFetchResponse = (data: any) => {
+    const response = new Response(undefined, {
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+    });
+    response.json = () => Promise.resolve(data);
+    (global.fetch as any).mockResolvedValueOnce(response);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new MastraClient(clientOptions);
+  });
+
+  describe('listStoredAgents', () => {
+    it('should list stored agents', async () => {
+      const mockResponse = {
+        agents: [
+          {
+            id: 'agent-1',
+            name: 'Test Agent',
+            instructions: 'You are a helpful assistant',
+            model: { provider: 'openai', name: 'gpt-4' },
+            createdAt: '2024-01-01T00:00:00.000Z',
+            updatedAt: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+        total: 1,
+        page: 0,
+        perPage: 100,
+        hasMore: false,
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await client.listStoredAgents();
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents`,
+        expect.objectContaining({
+          headers: expect.objectContaining(clientOptions.headers),
+        }),
+      );
+    });
+
+    it('should list stored agents with pagination', async () => {
+      const mockResponse = {
+        agents: [],
+        total: 0,
+        page: 1,
+        perPage: 10,
+        hasMore: false,
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await client.listStoredAgents({ page: 1, perPage: 10 });
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents?page=1&perPage=10`,
+        expect.objectContaining({
+          headers: expect.objectContaining(clientOptions.headers),
+        }),
+      );
+    });
+
+    it('should list stored agents with orderBy', async () => {
+      const mockResponse = {
+        agents: [],
+        total: 0,
+        page: 0,
+        perPage: 100,
+        hasMore: false,
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await client.listStoredAgents({
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents?orderBy%5Bfield%5D=createdAt&orderBy%5Bdirection%5D=DESC`,
+        expect.objectContaining({
+          headers: expect.objectContaining(clientOptions.headers),
+        }),
+      );
+    });
+  });
+
+  describe('createStoredAgent', () => {
+    it('should create a stored agent', async () => {
+      const createParams = {
+        id: 'new-agent',
+        name: 'New Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+      };
+      const mockResponse = {
+        ...createParams,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await client.createStoredAgent(createParams);
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(createParams),
+          headers: expect.objectContaining({
+            'content-type': 'application/json',
+          }),
+        }),
+      );
+    });
+
+    it('should create a stored agent with all optional fields', async () => {
+      const createParams = {
+        id: 'full-agent',
+        name: 'Full Agent',
+        description: 'A fully configured agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+        tools: ['calculator', 'weather'],
+        workflows: ['workflow-1'],
+        agents: ['sub-agent-1'],
+        memory: 'my-memory',
+        scorers: {
+          'my-scorer': { sampling: { type: 'ratio' as const, rate: 0.5 } },
+        },
+        metadata: { version: '1.0' },
+      };
+      const mockResponse = {
+        ...createParams,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await client.createStoredAgent(createParams);
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getStoredAgent', () => {
+    const storedAgentId = 'test-stored-agent';
+    let storedAgent: ReturnType<typeof client.getStoredAgent>;
+
+    beforeEach(() => {
+      storedAgent = client.getStoredAgent(storedAgentId);
+    });
+
+    it('should get stored agent details', async () => {
+      const mockResponse = {
+        id: storedAgentId,
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await storedAgent.details();
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents/${storedAgentId}`,
+        expect.objectContaining({
+          headers: expect.objectContaining(clientOptions.headers),
+        }),
+      );
+    });
+
+    it('should update stored agent', async () => {
+      const updateParams = {
+        name: 'Updated Agent Name',
+        instructions: 'Updated instructions',
+      };
+      const mockResponse = {
+        id: storedAgentId,
+        ...updateParams,
+        model: { provider: 'openai', name: 'gpt-4' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await storedAgent.update(updateParams);
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents/${storedAgentId}`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify(updateParams),
+        }),
+      );
+    });
+
+    it('should delete stored agent', async () => {
+      const mockResponse = {
+        success: true,
+        message: `Agent ${storedAgentId} deleted successfully`,
+      };
+      mockFetchResponse(mockResponse);
+
+      const result = await storedAgent.delete();
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents/${storedAgentId}`,
+        expect.objectContaining({
+          method: 'DELETE',
+        }),
+      );
+    });
+
+    it('should handle special characters in storedAgentId', async () => {
+      const specialId = 'agent/with/slashes';
+      const encodedId = encodeURIComponent(specialId);
+      const specialStoredAgent = client.getStoredAgent(specialId);
+
+      const mockResponse = {
+        id: specialId,
+        name: 'Special Agent',
+        instructions: 'Test',
+        model: { provider: 'openai', name: 'gpt-4' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      mockFetchResponse(mockResponse);
+
+      await specialStoredAgent.details();
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/agents/${encodedId}`,
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/client-sdks/client-js/src/resources/stored-agent.ts
+++ b/client-sdks/client-js/src/resources/stored-agent.ts
@@ -1,0 +1,45 @@
+import type { ClientOptions, StoredAgentResponse, UpdateStoredAgentParams, DeleteStoredAgentResponse } from '../types';
+
+import { BaseResource } from './base';
+
+/**
+ * Resource for interacting with a specific stored agent
+ */
+export class StoredAgent extends BaseResource {
+  constructor(
+    options: ClientOptions,
+    private storedAgentId: string,
+  ) {
+    super(options);
+  }
+
+  /**
+   * Retrieves details about the stored agent
+   * @returns Promise containing stored agent details
+   */
+  details(): Promise<StoredAgentResponse> {
+    return this.request(`/api/stored/agents/${encodeURIComponent(this.storedAgentId)}`);
+  }
+
+  /**
+   * Updates the stored agent with the provided fields
+   * @param params - Fields to update
+   * @returns Promise containing the updated stored agent
+   */
+  update(params: UpdateStoredAgentParams): Promise<StoredAgentResponse> {
+    return this.request(`/api/stored/agents/${encodeURIComponent(this.storedAgentId)}`, {
+      method: 'PATCH',
+      body: params,
+    });
+  }
+
+  /**
+   * Deletes the stored agent
+   * @returns Promise containing deletion confirmation
+   */
+  delete(): Promise<DeleteStoredAgentResponse> {
+    return this.request(`/api/stored/agents/${encodeURIComponent(this.storedAgentId)}`, {
+      method: 'DELETE',
+    });
+  }
+}

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -550,6 +550,113 @@ export interface TimeTravelParams {
   tracingOptions?: TracingOptions;
 }
 
+// ============================================================================
+// Stored Agents Types
+// ============================================================================
+
+/**
+ * Scorer config for stored agents
+ */
+export interface StoredAgentScorerConfig {
+  sampling?: {
+    type: 'ratio' | 'count';
+    rate?: number;
+    count?: number;
+  };
+}
+
+/**
+ * Stored agent data returned from API
+ */
+export interface StoredAgentResponse {
+  id: string;
+  name: string;
+  description?: string;
+  instructions: string;
+  model: Record<string, unknown>;
+  tools?: string[];
+  defaultOptions?: Record<string, unknown>;
+  workflows?: string[];
+  agents?: string[];
+  inputProcessors?: Record<string, unknown>[];
+  outputProcessors?: Record<string, unknown>[];
+  memory?: string;
+  scorers?: Record<string, StoredAgentScorerConfig>;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Parameters for listing stored agents
+ */
+export interface ListStoredAgentsParams {
+  page?: number;
+  perPage?: number;
+  orderBy?: {
+    field?: 'createdAt' | 'updatedAt';
+    direction?: 'ASC' | 'DESC';
+  };
+}
+
+/**
+ * Response for listing stored agents
+ */
+export interface ListStoredAgentsResponse {
+  agents: StoredAgentResponse[];
+  total: number;
+  page: number;
+  perPage: number | false;
+  hasMore: boolean;
+}
+
+/**
+ * Parameters for creating a stored agent
+ */
+export interface CreateStoredAgentParams {
+  id: string;
+  name: string;
+  description?: string;
+  instructions: string;
+  model: Record<string, unknown>;
+  tools?: string[];
+  defaultOptions?: Record<string, unknown>;
+  workflows?: string[];
+  agents?: string[];
+  inputProcessors?: Record<string, unknown>[];
+  outputProcessors?: Record<string, unknown>[];
+  memory?: string;
+  scorers?: Record<string, StoredAgentScorerConfig>;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for updating a stored agent
+ */
+export interface UpdateStoredAgentParams {
+  name?: string;
+  description?: string;
+  instructions?: string;
+  model?: Record<string, unknown>;
+  tools?: string[];
+  defaultOptions?: Record<string, unknown>;
+  workflows?: string[];
+  agents?: string[];
+  inputProcessors?: Record<string, unknown>[];
+  outputProcessors?: Record<string, unknown>[];
+  memory?: string;
+  scorers?: Record<string, StoredAgentScorerConfig>;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Response for deleting a stored agent
+ */
+export interface DeleteStoredAgentResponse {
+  success: boolean;
+  message: string;
+}
+
 export interface ListAgentsModelProvidersResponse {
   providers: Provider[];
 }

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -15,19 +15,26 @@ Retrieve a list of all available agents:
 const agents = await mastraClient.listAgents();
 ```
 
-Returns a record of agent IDs to their serialized agent configurations. See the [Agent class reference](/reference/v1/agents/agent) for details on agent properties.
+Returns a record of agent IDs to their serialized agent configurations.
 
 ## Working with a Specific Agent
 
-Get an instance of a specific agent:
+Get an instance of a specific agent by its ID:
+
+```typescript title="src/mastra/agents/my-agent.ts"
+export const myAgent = new Agent({
+  id: "my-agent",
+  // ...
+});
+```
 
 ```typescript
-const agent = mastraClient.getAgent("agent-id");
+const agent = mastraClient.getAgent("my-agent");
 ```
 
 ## Agent Methods
 
-### Get Agent Details
+### details()
 
 Retrieve detailed information about an agent:
 
@@ -35,9 +42,7 @@ Retrieve detailed information about an agent:
 const details = await agent.details();
 ```
 
-Returns the serialized agent configuration. See the [Agent class reference](/reference/v1/agents/agent) for details on agent properties.
-
-### Generate Response
+### generate()
 
 Generate a response from the agent:
 
@@ -55,7 +60,16 @@ const response = await agent.generate({
 });
 ```
 
-### Stream Response
+You can also use the simplified string format:
+
+```typescript
+const response = await agent.generate("Hello, how are you?", {
+  threadId: "thread-1",
+  resourceId: "resource-1",
+});
+```
+
+### stream()
 
 Stream responses from the agent for real-time interactions:
 
@@ -75,8 +89,28 @@ response.processDataStream({
     console.log(chunk);
   },
 });
+```
 
-// You can also read from response body directly
+You can also use the simplified string format:
+
+```typescript
+const response = await agent.stream("Tell me a story", {
+  threadId: "thread-1",
+  clientTools: { colorChangeTool },
+});
+
+response.processDataStream({
+  onChunk: async (chunk) => {
+    if (chunk.type === "text-delta") {
+      console.log(chunk.payload.text);
+    }
+  },
+});
+```
+
+You can also read from response body directly:
+
+```typescript
 const reader = response.body.getReader();
 while (true) {
   const { done, value } = await reader.read();
@@ -85,11 +119,119 @@ while (true) {
 }
 ```
 
-### Client tools
+#### AI SDK compatible format
+
+To stream AI SDK-formatted parts on the client from an `agent.stream(...)` response, wrap `response.processDataStream` into a `ReadableStream<ChunkType>` and use `toAISdkStream`:
+
+```typescript title="client-ai-sdk-transform.ts" copy
+import { createUIMessageStream } from "ai";
+import { toAISdkStream } from "@mastra/ai-sdk";
+import type { ChunkType, MastraModelOutput } from "@mastra/core/stream";
+
+const response = await agent.stream({ messages: "Tell me a story" });
+
+const chunkStream: ReadableStream<ChunkType> = new ReadableStream<ChunkType>({
+  start(controller) {
+    response
+      .processDataStream({
+        onChunk: async (chunk) => controller.enqueue(chunk as ChunkType),
+      })
+      .finally(() => controller.close());
+  },
+});
+
+const uiMessageStream = createUIMessageStream({
+  execute: async ({ writer }) => {
+    for await (const part of toAISdkStream(
+      chunkStream as unknown as MastraModelOutput,
+      { from: "agent" },
+    )) {
+      writer.write(part);
+    }
+  },
+});
+
+for await (const part of uiMessageStream) {
+  console.log(part);
+}
+```
+
+### getTool()
+
+Retrieve information about a specific tool available to the agent:
+
+```typescript
+const tool = await agent.getTool("tool-id");
+```
+
+### executeTool()
+
+Execute a specific tool for the agent:
+
+```typescript
+const result = await agent.executeTool("tool-id", {
+  data: { input: "value" },
+});
+```
+
+### network()
+
+Stream responses from an agent network for multi-agent interactions:
+
+```typescript
+const response = await agent.network({
+  messages: [
+    {
+      role: "user",
+      content: "Research this topic and write a summary",
+    },
+  ],
+});
+
+response.processDataStream({
+  onChunk: async (chunk) => {
+    console.log(chunk);
+  },
+});
+```
+
+### approveToolCall()
+
+Approve a pending tool call that requires human confirmation:
+
+```typescript
+const response = await agent.approveToolCall({
+  runId: "run-123",
+  toolCallId: "tool-call-456",
+});
+
+response.processDataStream({
+  onChunk: async (chunk) => {
+    console.log(chunk);
+  },
+});
+```
+
+### declineToolCall()
+
+Decline a pending tool call that requires human confirmation:
+
+```typescript
+const response = await agent.declineToolCall({
+  runId: "run-123",
+  toolCallId: "tool-call-456",
+});
+
+response.processDataStream({
+  onChunk: async (chunk) => {
+    console.log(chunk);
+  },
+});
+```
+
+## Client Tools
 
 Client-side tools allow you to execute custom functions on the client side when the agent requests them.
-
-#### Basic Usage
 
 ```typescript
 import { createTool } from "@mastra/client-js";
@@ -132,90 +274,132 @@ response.processDataStream({
 });
 ```
 
-### Get Agent Tool
+## Stored Agents
 
-Retrieve information about a specific tool available to the agent:
+Stored agents are agent configurations stored in a database that can be created, updated, and deleted at runtime. They reference primitives (tools, workflows, other agents, memory, scorers) by key, which are resolved from the Mastra registry when the agent is instantiated.
+
+### listStoredAgents()
+
+Retrieve a paginated list of all stored agents:
 
 ```typescript
-const tool = await agent.getTool("tool-id");
+const result = await mastraClient.listStoredAgents();
+console.log(result.agents); // Array of stored agents
+console.log(result.total); // Total count
 ```
 
-### Get Agent Evaluations
-
-Get evaluation results for the agent:
+With pagination and ordering:
 
 ```typescript
-// Get CI evaluations
-const evals = await agent.evals();
-
-// Get live evaluations
-const liveEvals = await agent.liveEvals();
-```
-
-### Stream
-
-Stream responses using the enhanced API with improved method signatures. This method provides enhanced capabilities and format flexibility, with support for Mastra's native format.
-
-```typescript
-const response = await agent.stream("Tell me a story", {
-  threadId: "thread-1",
-  clientTools: { colorChangeTool },
-});
-
-// Process the stream
-response.processDataStream({
-  onChunk: async (chunk) => {
-    if (chunk.type === "text-delta") {
-      console.log(chunk.payload.text);
-    }
+const result = await mastraClient.listStoredAgents({
+  page: 0,
+  perPage: 20,
+  orderBy: {
+    field: "createdAt",
+    direction: "DESC",
   },
 });
 ```
 
-#### AI SDK compatible format
+### createStoredAgent()
 
-To stream AI SDK-formatted parts on the client from an `agent.stream(...)` response, wrap `response.processDataStream` into a `ReadableStream<ChunkType>` and use `toAISdkStream`:
-
-```typescript title="client-ai-sdk-transform.ts" copy
-import { createUIMessageStream } from "ai";
-import { toAISdkStream } from "@mastra/ai-sdk";
-import type { ChunkType, MastraModelOutput } from "@mastra/core/stream";
-
-const response = await agent.stream({ messages: "Tell me a story" });
-
-const chunkStream: ReadableStream<ChunkType> = new ReadableStream<ChunkType>({
-  start(controller) {
-    response
-      .processDataStream({
-        onChunk: async (chunk) => controller.enqueue(chunk as ChunkType),
-      })
-      .finally(() => controller.close());
-  },
-});
-
-const uiMessageStream = createUIMessageStream({
-  execute: async ({ writer }) => {
-    for await (const part of toAISdkStream(
-      chunkStream as unknown as MastraModelOutput,
-      { from: "agent" },
-    )) {
-      writer.write(part);
-    }
-  },
-});
-
-for await (const part of uiMessageStream) {
-  console.log(part);
-}
-```
-
-### Generate
-
-Generate a response using the enhanced API with improved method signatures and AI SDK v5 compatibility:
+Create a new stored agent:
 
 ```typescript
-const response = await agent.generate("Hello, how are you?", {
-  threadId: "thread-1",
-  resourceId: "resource-1",
+const agent = await mastraClient.createStoredAgent({
+  id: "my-agent",
+  name: "My Assistant",
+  instructions: "You are a helpful assistant.",
+  model: {
+    provider: "openai",
+    name: "gpt-4",
+  },
 });
+```
+
+With all options:
+
+```typescript
+const agent = await mastraClient.createStoredAgent({
+  id: "full-agent",
+  name: "Full Agent",
+  description: "A fully configured agent",
+  instructions: "You are a helpful assistant.",
+  model: {
+    provider: "openai",
+    name: "gpt-4",
+  },
+  tools: ["calculator", "weather"],
+  workflows: ["data-processing"],
+  agents: ["sub-agent-1"],
+  memory: "my-memory",
+  scorers: {
+    "quality-scorer": {
+      sampling: { type: "ratio", rate: 0.1 },
+    },
+  },
+  defaultOptions: {
+    maxSteps: 10,
+  },
+  metadata: {
+    version: "1.0",
+    team: "engineering",
+  },
+});
+```
+
+### getStoredAgent()
+
+Get an instance of a specific stored agent:
+
+```typescript
+const storedAgent = mastraClient.getStoredAgent("my-agent");
+```
+
+## Stored Agent Methods
+
+### details()
+
+Retrieve the stored agent configuration:
+
+```typescript
+const details = await storedAgent.details();
+console.log(details.name);
+console.log(details.instructions);
+console.log(details.model);
+```
+
+### update()
+
+Update specific fields of a stored agent. All fields are optional:
+
+```typescript
+const updated = await storedAgent.update({
+  name: "Updated Agent Name",
+  instructions: "New instructions for the agent.",
+});
+```
+
+```typescript
+// Update just the tools
+await storedAgent.update({
+  tools: ["new-tool-1", "new-tool-2"],
+});
+
+// Update metadata
+await storedAgent.update({
+  metadata: {
+    version: "2.0",
+    lastModifiedBy: "admin",
+  },
+});
+```
+
+### delete()
+
+Delete a stored agent:
+
+```typescript
+const result = await storedAgent.delete();
+console.log(result.success); // true
 ```

--- a/docs/src/content/en/reference/core/getMemory.mdx
+++ b/docs/src/content/en/reference/core/getMemory.mdx
@@ -1,0 +1,73 @@
+---
+title: "Reference: Mastra.getMemory() | Core"
+description: "Documentation for the `Mastra.getMemory()` method in Mastra, which retrieves a registered memory instance by its registry key."
+---
+
+# Mastra.getMemory()
+
+The `.getMemory()` method retrieves a memory instance from the Mastra registry by its key. Memory instances are registered in the Mastra constructor and can be referenced by stored agents.
+
+## Usage example
+
+```typescript copy
+const memory = mastra.getMemory("conversationMemory");
+
+// Use the memory instance
+const thread = await memory.createThread({
+  resourceId: "user-123",
+  title: "New Conversation",
+});
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "key",
+      type: "TMemoryKey extends keyof TMemory",
+      description:
+        "The registry key of the memory instance to retrieve. Must match a key used when registering memory in the Mastra constructor.",
+    },
+  ]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: "memory",
+      type: "TMemory[TMemoryKey]",
+      description:
+        "The memory instance with the specified key. Throws an error if the memory is not found.",
+    },
+  ]}
+/>
+
+## Example: Registering and Retrieving Memory
+
+```typescript copy
+import { Mastra } from "@mastra/core";
+import { Memory } from "@mastra/memory";
+import { LibSQLStore } from "@mastra/libsql";
+
+const conversationMemory = new Memory({
+  storage: new LibSQLStore({ url: ":memory:" }),
+});
+
+const mastra = new Mastra({
+  memory: {
+    conversationMemory,
+  },
+});
+
+// Later, retrieve the memory instance
+const memory = mastra.getMemory("conversationMemory");
+```
+
+## Related
+
+- [Mastra.listMemory()](/reference/core/listMemory)
+- [Memory overview](/docs/memory/overview)
+- [Agent Memory](/docs/agents/agent-memory)

--- a/docs/src/content/en/reference/core/getMemory.mdx
+++ b/docs/src/content/en/reference/core/getMemory.mdx
@@ -68,6 +68,6 @@ const memory = mastra.getMemory("conversationMemory");
 
 ## Related
 
-- [Mastra.listMemory()](/reference/core/listMemory)
-- [Memory overview](/docs/memory/overview)
-- [Agent Memory](/docs/agents/agent-memory)
+- [Mastra.listMemory()](/reference/v1/core/listMemory)
+- [Memory overview](/docs/v1/memory/overview)
+- [Agent Memory](/docs/v1/agents/agent-memory)

--- a/docs/src/content/en/reference/core/getStoredAgentById.mdx
+++ b/docs/src/content/en/reference/core/getStoredAgentById.mdx
@@ -1,0 +1,183 @@
+---
+title: "Reference: Mastra.getStoredAgentById() | Core"
+description: "Documentation for the `Mastra.getStoredAgentById()` method in Mastra, which retrieves an agent from storage and creates an executable Agent instance."
+---
+
+# Mastra.getStoredAgentById()
+
+The `.getStoredAgentById()` method retrieves an agent configuration from storage by its ID and creates an executable `Agent` instance. Stored agents allow you to persist agent configurations in a database and dynamically load them at runtime.
+
+## Usage example
+
+```typescript copy
+// Get an Agent instance from storage
+const agent = await mastra.getStoredAgentById("my-stored-agent");
+
+if (agent) {
+  const response = await agent.generate({ messages: "Hello!" });
+  console.log(response.text);
+}
+```
+
+```typescript copy
+// Get the raw storage data instead of an Agent instance
+const storedConfig = await mastra.getStoredAgentById("my-stored-agent", { raw: true });
+
+if (storedConfig) {
+  console.log(storedConfig.instructions);
+  console.log(storedConfig.createdAt);
+}
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description:
+        "The unique identifier of the stored agent to retrieve.",
+    },
+    {
+      name: "options",
+      type: "{ raw?: boolean }",
+      description:
+        "Optional configuration object.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+### Options
+
+<PropertiesTable
+  content={[
+    {
+      name: "raw",
+      type: "boolean",
+      description:
+        "When `true`, returns the raw `StorageAgentType` object from storage instead of creating an `Agent` instance. Useful for inspecting stored configuration or metadata.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+  ]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: "result",
+      type: "Agent | StorageAgentType | null",
+      description:
+        "Returns an `Agent` instance by default, or `StorageAgentType` when `raw: true`. Returns `null` if no agent with the given ID exists.",
+    },
+  ]}
+/>
+
+## Primitive Resolution
+
+When creating an `Agent` instance from stored configuration, the method resolves references to registered primitives:
+
+- **Tools**: Resolved from `tools` registered in Mastra config
+- **Workflows**: Resolved from `workflows` registered in Mastra config
+- **Sub-agents**: Resolved from `agents` registered in Mastra config
+- **Memory**: Resolved from `memory` registered in Mastra config
+- **Scorers**: Resolved from `scorers` registered in Mastra config, including sampling configuration
+
+If a referenced primitive is not found in the registry, a warning is logged but the agent is still created.
+
+## StorageAgentType
+
+When using `raw: true`, the returned object has the following structure:
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for the agent.",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Display name of the agent.",
+    },
+    {
+      name: "description",
+      type: "string",
+      description: "Optional description of the agent.",
+      isOptional: true,
+    },
+    {
+      name: "instructions",
+      type: "string",
+      description: "System instructions for the agent.",
+    },
+    {
+      name: "model",
+      type: "Record<string, unknown>",
+      description: "Model configuration with provider and name.",
+    },
+    {
+      name: "tools",
+      type: "Record<string, unknown>",
+      description: "Tool references to resolve from registry.",
+      isOptional: true,
+    },
+    {
+      name: "workflows",
+      type: "Record<string, unknown>",
+      description: "Workflow references to resolve from registry.",
+      isOptional: true,
+    },
+    {
+      name: "agents",
+      type: "Record<string, unknown>",
+      description: "Sub-agent references to resolve from registry.",
+      isOptional: true,
+    },
+    {
+      name: "memory",
+      type: "Record<string, unknown>",
+      description: "Memory reference to resolve from registry.",
+      isOptional: true,
+    },
+    {
+      name: "scorers",
+      type: "Record<string, unknown>",
+      description: "Scorer references with optional sampling config.",
+      isOptional: true,
+    },
+    {
+      name: "defaultOptions",
+      type: "Record<string, unknown>",
+      description: "Default options passed to agent execution.",
+      isOptional: true,
+    },
+    {
+      name: "metadata",
+      type: "Record<string, unknown>",
+      description: "Custom metadata stored with the agent.",
+      isOptional: true,
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp when the agent was created.",
+    },
+    {
+      name: "updatedAt",
+      type: "Date",
+      description: "Timestamp when the agent was last updated.",
+    },
+  ]}
+/>
+
+## Related
+
+- [Mastra.listStoredAgents()](/reference/core/listStoredAgents)
+- [Storage overview](/docs/server-db/storage)
+- [Agents overview](/docs/agents/overview)

--- a/docs/src/content/en/reference/core/getStoredAgentById.mdx
+++ b/docs/src/content/en/reference/core/getStoredAgentById.mdx
@@ -178,6 +178,6 @@ When using `raw: true`, the returned object has the following structure:
 
 ## Related
 
-- [Mastra.listStoredAgents()](/reference/core/listStoredAgents)
-- [Storage overview](/docs/server-db/storage)
-- [Agents overview](/docs/agents/overview)
+- [Mastra.listStoredAgents()](/reference/v1/core/listStoredAgents)
+- [Storage overview](/docs/v1/server-db/storage)
+- [Agents overview](/docs/v1/agents/overview)

--- a/docs/src/content/en/reference/core/listMemory.mdx
+++ b/docs/src/content/en/reference/core/listMemory.mdx
@@ -65,6 +65,6 @@ console.log(Object.keys(allMemory)); // ["conversationMemory", "analyticsMemory"
 
 ## Related
 
-- [Mastra.getMemory()](/reference/core/getMemory)
-- [Memory overview](/docs/memory/overview)
-- [Agent Memory](/docs/agents/agent-memory)
+- [Mastra.getMemory()](/reference/v1/core/getMemory)
+- [Memory overview](/docs/v1/memory/overview)
+- [Agent Memory](/docs/v1/agents/agent-memory)

--- a/docs/src/content/en/reference/core/listMemory.mdx
+++ b/docs/src/content/en/reference/core/listMemory.mdx
@@ -1,0 +1,70 @@
+---
+title: "Reference: Mastra.listMemory() | Core"
+description: "Documentation for the `Mastra.listMemory()` method in Mastra, which returns all registered memory instances."
+---
+
+# Mastra.listMemory()
+
+The `.listMemory()` method returns all memory instances registered with the Mastra instance.
+
+## Usage example
+
+```typescript copy
+const memoryInstances = mastra.listMemory();
+
+for (const [key, memory] of Object.entries(memoryInstances)) {
+  console.log(`Memory "${key}": ${memory.id}`);
+}
+```
+
+## Parameters
+
+This method takes no parameters.
+
+## Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: "memory",
+      type: "Record<string, MastraMemory>",
+      description:
+        "An object containing all registered memory instances, keyed by their registry keys.",
+    },
+  ]}
+/>
+
+## Example: Checking Registered Memory
+
+```typescript copy
+import { Mastra } from "@mastra/core";
+import { Memory } from "@mastra/memory";
+import { LibSQLStore } from "@mastra/libsql";
+
+const conversationMemory = new Memory({
+  id: "conversation-memory",
+  storage: new LibSQLStore({ url: ":memory:" }),
+});
+
+const analyticsMemory = new Memory({
+  id: "analytics-memory",
+  storage: new LibSQLStore({ url: ":memory:" }),
+});
+
+const mastra = new Mastra({
+  memory: {
+    conversationMemory,
+    analyticsMemory,
+  },
+});
+
+// List all registered memory instances
+const allMemory = mastra.listMemory();
+console.log(Object.keys(allMemory)); // ["conversationMemory", "analyticsMemory"]
+```
+
+## Related
+
+- [Mastra.getMemory()](/reference/core/getMemory)
+- [Memory overview](/docs/memory/overview)
+- [Agent Memory](/docs/agents/agent-memory)

--- a/docs/src/content/en/reference/core/listStoredAgents.mdx
+++ b/docs/src/content/en/reference/core/listStoredAgents.mdx
@@ -1,0 +1,151 @@
+---
+title: "Reference: Mastra.listStoredAgents() | Core"
+description: "Documentation for the `Mastra.listStoredAgents()` method in Mastra, which retrieves a paginated list of agents from storage."
+---
+
+# Mastra.listStoredAgents()
+
+The `.listStoredAgents()` method retrieves a paginated list of agent configurations from storage. By default, it returns executable `Agent` instances, but can also return raw storage data.
+
+## Usage example
+
+```typescript copy
+// Get Agent instances from storage
+const { agents, total, hasMore } = await mastra.listStoredAgents();
+
+for (const agent of agents) {
+  console.log(agent.id, agent.name);
+  // Each agent is ready to use
+  // const response = await agent.generate({ messages: "Hello!" });
+}
+```
+
+```typescript copy
+// Get paginated results with raw storage data
+const result = await mastra.listStoredAgents({
+  page: 0,
+  perPage: 10,
+  raw: true,
+});
+
+console.log(`Showing ${result.agents.length} of ${result.total} agents`);
+console.log(`Has more: ${result.hasMore}`);
+
+for (const config of result.agents) {
+  console.log(config.id, config.name, config.createdAt);
+}
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "args",
+      type: "object",
+      description:
+        "Optional configuration object for pagination and output format.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+### Args Options
+
+<PropertiesTable
+  content={[
+    {
+      name: "page",
+      type: "number",
+      description: "Zero-indexed page number for pagination.",
+      isOptional: true,
+      defaultValue: "0",
+    },
+    {
+      name: "perPage",
+      type: "number | false",
+      description:
+        "Number of items per page. Set to `false` to fetch all records without pagination.",
+      isOptional: true,
+      defaultValue: "100",
+    },
+    {
+      name: "raw",
+      type: "boolean",
+      description:
+        "When `true`, returns raw `StorageAgentType` objects instead of `Agent` instances.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+  ]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: "agents",
+      type: "Agent[] | StorageAgentType[]",
+      description:
+        "Array of `Agent` instances by default, or `StorageAgentType` objects when `raw: true`.",
+    },
+    {
+      name: "total",
+      type: "number",
+      description: "Total number of stored agents across all pages.",
+    },
+    {
+      name: "page",
+      type: "number",
+      description: "Current page number (zero-indexed).",
+    },
+    {
+      name: "perPage",
+      type: "number | false",
+      description: "Number of items per page, or `false` if fetching all.",
+    },
+    {
+      name: "hasMore",
+      type: "boolean",
+      description: "Whether there are more pages available.",
+    },
+  ]}
+/>
+
+## Primitive Resolution
+
+When creating `Agent` instances (default behavior), each stored agent's configuration is resolved against registered primitives:
+
+- **Tools**: Resolved from `tools` registered in Mastra config
+- **Workflows**: Resolved from `workflows` registered in Mastra config
+- **Sub-agents**: Resolved from `agents` registered in Mastra config
+- **Memory**: Resolved from `memory` registered in Mastra config
+- **Scorers**: Resolved from `scorers` registered in Mastra config
+
+If a referenced primitive is not found, a warning is logged but the agent is still created.
+
+## Example: Iterating Through All Stored Agents
+
+```typescript copy
+async function getAllStoredAgents(mastra: Mastra) {
+  const allAgents: Agent[] = [];
+  let page = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const result = await mastra.listStoredAgents({ page, perPage: 50 });
+    allAgents.push(...result.agents);
+    hasMore = result.hasMore;
+    page++;
+  }
+
+  return allAgents;
+}
+```
+
+## Related
+
+- [Mastra.getStoredAgentById()](/reference/core/getStoredAgentById)
+- [Storage overview](/docs/server-db/storage)
+- [Agents overview](/docs/agents/overview)

--- a/docs/src/content/en/reference/core/listStoredAgents.mdx
+++ b/docs/src/content/en/reference/core/listStoredAgents.mdx
@@ -146,6 +146,6 @@ async function getAllStoredAgents(mastra: Mastra) {
 
 ## Related
 
-- [Mastra.getStoredAgentById()](/reference/core/getStoredAgentById)
-- [Storage overview](/docs/server-db/storage)
-- [Agents overview](/docs/agents/overview)
+- [Mastra.getStoredAgentById()](/reference/v1/core/getStoredAgentById)
+- [Storage overview](/docs/v1/server-db/storage)
+- [Agents overview](/docs/v1/agents/overview)

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -148,5 +148,13 @@ export const mastra = new Mastra({
       isOptional: true,
       defaultValue: "{}",
     },
+    {
+      name: "memory",
+      type: "Record<string, MastraMemory>",
+      description:
+        "Memory instances to register. These can be referenced by stored agents and resolved at runtime. Structured as a key-value pair, with keys being the registry key and values being memory instances.",
+      isOptional: true,
+      defaultValue: "{}",
+    },
   ]}
 />

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -20,6 +20,16 @@ const sidebars = {
         { type: "doc", id: "core/getAgent", label: ".getAgent()" },
         { type: "doc", id: "core/listAgents", label: ".listAgents()" },
         { type: "doc", id: "core/getAgentById", label: ".getAgentById()" },
+        {
+          type: "doc",
+          id: "core/getStoredAgentById",
+          label: ".getStoredAgentById()",
+        },
+        {
+          type: "doc",
+          id: "core/listStoredAgents",
+          label: ".listStoredAgents()",
+        },
         { type: "doc", id: "core/getWorkflow", label: ".getWorkflow()" },
         { type: "doc", id: "core/listWorkflows", label: ".listWorkflows()" },
         { type: "doc", id: "core/setStorage", label: ".setStorage()" },
@@ -60,6 +70,8 @@ const sidebars = {
         },
         { type: "doc", id: "core/listGateways", label: ".listGateways()" },
         { type: "doc", id: "core/addGateway", label: ".addGateway()" },
+        { type: "doc", id: "core/getMemory", label: ".getMemory()" },
+        { type: "doc", id: "core/listMemory", label: ".listMemory()" },
         { type: "doc", id: "core/mastra-class", label: "Mastra Class" },
         {
           type: "doc",

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1001,7 +1001,7 @@ export class Mastra<
     const resolvedTools: Record<string, ToolAction<any, any, any, any, any, any>> = {};
     const registeredTools = this.#tools;
 
-    for (const [toolKey, toolConfig] of Object.entries(storedTools)) {
+    for (const [toolKey, _toolConfig] of Object.entries(storedTools)) {
       // Try to find the tool in registered tools
       if (registeredTools && registeredTools[toolKey]) {
         resolvedTools[toolKey] = registeredTools[toolKey];

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from 'node:crypto';
-import type { Agent } from '../agent';
+import { Agent } from '../agent';
 import type { BundlerConfig } from '../bundler/types';
 import { InMemoryServerCache } from '../cache';
 import type { MastraServerCache } from '../cache';
 import type { MastraDeployer } from '../deployer';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
-import type { MastraScorer } from '../evals';
+import type { MastraScorer, MastraScorers, ScoringSamplingConfig } from '../evals';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import type { PubSub } from '../events/pubsub';
 import type { Event } from '../events/types';
@@ -14,12 +14,13 @@ import type { MastraModelGateway } from '../llm/model/gateways';
 import { LogLevel, noopLogger, ConsoleLogger } from '../logger';
 import type { IMastraLogger } from '../logger';
 import type { MCPServerBase } from '../mcp';
+import type { MastraMemory } from '../memory';
 import type { ObservabilityEntrypoint } from '../observability';
 import { NoOpObservability } from '../observability';
 import type { Processor } from '../processors';
 import type { MastraServerBase } from '../server/base';
 import type { Middleware, ServerConfig } from '../server/types';
-import type { MastraStorage, WorkflowRuns } from '../storage';
+import type { MastraStorage, WorkflowRuns, StorageAgentType } from '../storage';
 import { augmentWithInit } from '../storage/storageWithInit';
 import type { ToolAction } from '../tools';
 import type { MastraTTS } from '../tts';
@@ -35,7 +36,7 @@ import { createOnScorerHook } from './hooks';
  * object had getters or non-enumerable properties.
  */
 function createUndefinedPrimitiveError(
-  type: 'agent' | 'tool' | 'processor' | 'vector' | 'scorer' | 'workflow' | 'mcp-server' | 'gateway',
+  type: 'agent' | 'tool' | 'processor' | 'vector' | 'scorer' | 'workflow' | 'mcp-server' | 'gateway' | 'memory',
   value: null | undefined,
   key?: string,
 ): MastraError {
@@ -97,6 +98,7 @@ export interface Config<
     ToolAction<any, any, any, any, any, any>
   >,
   TProcessors extends Record<string, Processor<any>> = Record<string, Processor<any>>,
+  TMemory extends Record<string, MastraMemory> = Record<string, MastraMemory>,
 > {
   /**
    * Agents are autonomous systems that can make decisions and take actions.
@@ -197,6 +199,12 @@ export interface Config<
   processors?: TProcessors;
 
   /**
+   * Memory instances that can be referenced by stored agents.
+   * Keys are used to look up memory instances when resolving stored agent configurations.
+   */
+  memory?: TMemory;
+
+  /**
    * Custom model router gateways for accessing LLM providers.
    * Gateways handle provider-specific authentication, URL construction, and model resolution.
    */
@@ -263,6 +271,7 @@ export class Mastra<
     ToolAction<any, any, any, any, any, any>
   >,
   TProcessors extends Record<string, Processor<any>> = Record<string, Processor<any>>,
+  TMemory extends Record<string, MastraMemory> = Record<string, MastraMemory>,
 > {
   #vectors?: TVectors;
   #agents: TAgents;
@@ -280,6 +289,7 @@ export class Mastra<
   #scorers?: TScorers;
   #tools?: TTools;
   #processors?: TProcessors;
+  #memory?: TMemory;
   #server?: ServerConfig;
   #serverAdapter?: MastraServerBase;
   #mcpServers?: TMCPServers;
@@ -392,7 +402,7 @@ export class Mastra<
    * ```
    */
   constructor(
-    config?: Config<TAgents, TWorkflows, TVectors, TTTS, TLogger, TMCPServers, TScorers, TTools, TProcessors>,
+    config?: Config<TAgents, TWorkflows, TVectors, TTTS, TLogger, TMCPServers, TScorers, TTools, TProcessors, TMemory>,
   ) {
     // This is only used internally for server handlers that require temporary persistence
     this.#serverCache = new InMemoryServerCache();
@@ -477,6 +487,7 @@ export class Mastra<
     this.#scorers = {} as TScorers;
     this.#tools = {} as TTools;
     this.#processors = {} as TProcessors;
+    this.#memory = {} as TMemory;
     this.#workflows = {} as TWorkflows;
     this.#gateways = {} as Record<string, MastraModelGateway>;
 
@@ -496,6 +507,14 @@ export class Mastra<
       Object.entries(config.processors).forEach(([key, processor]) => {
         if (processor != null) {
           this.addProcessor(processor, key);
+        }
+      });
+    }
+
+    if (config?.memory) {
+      Object.entries(config.memory).forEach(([key, memory]) => {
+        if (memory != null) {
+          this.addMemory(memory, key);
         }
       });
     }
@@ -690,6 +709,460 @@ export class Mastra<
    */
   public listAgents() {
     return this.#agents;
+  }
+
+  /**
+   * Retrieves a stored agent from the database by its unique identifier.
+   *
+   * By default, returns an executable Agent instance. Set `raw: true` to get
+   * the raw stored configuration data instead.
+   *
+   * @param id - The unique identifier of the stored agent
+   * @param options - Options for the query
+   * @param options.raw - If true, returns raw stored data instead of Agent instance
+   *
+   * @throws {MastraError} When storage is not configured or doesn't support agents
+   *
+   * @example
+   * ```typescript
+   * const mastra = new Mastra({
+   *   storage: new PostgresStore({ connectionString: process.env.DATABASE_URL })
+   * });
+   *
+   * // Get as executable Agent instance (default)
+   * const agent = await mastra.getStoredAgentById('my-agent-id');
+   * if (agent) {
+   *   const response = await agent.generate('Hello!');
+   *   console.log(response.text);
+   * }
+   *
+   * // Get raw stored configuration
+   * const rawConfig = await mastra.getStoredAgentById('my-agent-id', { raw: true });
+   * if (rawConfig) {
+   *   console.log(rawConfig.instructions);
+   * }
+   * ```
+   */
+  public async getStoredAgentById(id: string, options?: { raw?: false }): Promise<Agent | null>;
+  public async getStoredAgentById(id: string, options: { raw: true }): Promise<StorageAgentType | null>;
+  public async getStoredAgentById(id: string, options?: { raw?: boolean }): Promise<Agent | StorageAgentType | null> {
+    const storage = this.#storage;
+
+    if (!storage) {
+      const error = new MastraError({
+        id: 'MASTRA_GET_STORED_AGENT_STORAGE_NOT_CONFIGURED',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: 'Storage is not configured',
+        details: { status: 400 },
+      });
+      this.#logger?.trackException(error);
+      throw error;
+    }
+
+    if (!storage.supports.agents) {
+      const error = new MastraError({
+        id: 'MASTRA_GET_STORED_AGENT_NOT_SUPPORTED',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: 'Storage does not support agents',
+        details: { status: 400 },
+      });
+      this.#logger?.trackException(error);
+      throw error;
+    }
+
+    const storedAgent = await storage.getAgentById({ id });
+
+    if (!storedAgent) {
+      return null;
+    }
+
+    if (options?.raw) {
+      return storedAgent;
+    }
+
+    return this.#createAgentFromStoredConfig(storedAgent);
+  }
+
+  /**
+   * Lists all stored agents from the database with optional pagination.
+   *
+   * By default, returns executable Agent instances. Set `raw: true` to get
+   * the raw stored configuration data instead.
+   *
+   * @param args - Options for pagination and output format
+   * @param args.page - Zero-indexed page number (default: 0)
+   * @param args.perPage - Items per page, or false for all (default: 100)
+   * @param args.orderBy - Sort order configuration
+   * @param args.raw - If true, returns raw stored data instead of Agent instances
+   *
+   * @throws {MastraError} When storage is not configured or doesn't support agents
+   *
+   * @example
+   * ```typescript
+   * const mastra = new Mastra({
+   *   storage: new PostgresStore({ connectionString: process.env.DATABASE_URL })
+   * });
+   *
+   * // List as executable Agent instances (default)
+   * const result = await mastra.listStoredAgents();
+   * for (const agent of result.agents) {
+   *   const response = await agent.generate('Hello!');
+   * }
+   *
+   * // List raw stored configurations
+   * const rawResult = await mastra.listStoredAgents({ raw: true });
+   * for (const config of rawResult.agents) {
+   *   console.log(config.instructions, config.createdAt);
+   * }
+   *
+   * // With pagination
+   * const paginated = await mastra.listStoredAgents({
+   *   page: 0,
+   *   perPage: 10,
+   *   orderBy: { field: 'createdAt', direction: 'DESC' }
+   * });
+   * ```
+   */
+  public async listStoredAgents(args?: {
+    page?: number;
+    perPage?: number | false;
+    orderBy?: { field: 'createdAt' | 'updatedAt'; direction: 'ASC' | 'DESC' };
+    raw?: false;
+  }): Promise<{
+    agents: Agent[];
+    total: number;
+    page: number;
+    perPage: number | false;
+    hasMore: boolean;
+  }>;
+  public async listStoredAgents(args: {
+    page?: number;
+    perPage?: number | false;
+    orderBy?: { field: 'createdAt' | 'updatedAt'; direction: 'ASC' | 'DESC' };
+    raw: true;
+  }): Promise<{
+    agents: StorageAgentType[];
+    total: number;
+    page: number;
+    perPage: number | false;
+    hasMore: boolean;
+  }>;
+  public async listStoredAgents(args?: {
+    page?: number;
+    perPage?: number | false;
+    orderBy?: { field: 'createdAt' | 'updatedAt'; direction: 'ASC' | 'DESC' };
+    raw?: boolean;
+  }): Promise<{
+    agents: Agent[] | StorageAgentType[];
+    total: number;
+    page: number;
+    perPage: number | false;
+    hasMore: boolean;
+  }> {
+    const storage = this.#storage;
+
+    if (!storage) {
+      const error = new MastraError({
+        id: 'MASTRA_LIST_STORED_AGENTS_STORAGE_NOT_CONFIGURED',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: 'Storage is not configured',
+        details: { status: 400 },
+      });
+      this.#logger?.trackException(error);
+      throw error;
+    }
+
+    if (!storage.supports.agents) {
+      const error = new MastraError({
+        id: 'MASTRA_LIST_STORED_AGENTS_NOT_SUPPORTED',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: 'Storage does not support agents',
+        details: { status: 400 },
+      });
+      this.#logger?.trackException(error);
+      throw error;
+    }
+
+    const result = await storage.listAgents({
+      page: args?.page,
+      perPage: args?.perPage,
+      orderBy: args?.orderBy,
+    });
+
+    if (args?.raw) {
+      return result;
+    }
+
+    // Transform stored configs into Agent instances
+    const agents = result.agents.map(storedAgent => this.#createAgentFromStoredConfig(storedAgent));
+
+    return {
+      agents,
+      total: result.total,
+      page: result.page,
+      perPage: result.perPage,
+      hasMore: result.hasMore,
+    };
+  }
+
+  /**
+   * Creates an Agent instance from a stored agent configuration.
+   * @private
+   */
+  #createAgentFromStoredConfig(storedAgent: {
+    id: string;
+    name: string;
+    description?: string;
+    instructions: string;
+    model: Record<string, unknown>;
+    tools?: Record<string, unknown>;
+    defaultOptions?: Record<string, unknown>;
+    workflows?: Record<string, unknown>;
+    agents?: Record<string, unknown>;
+    memory?: Record<string, unknown>;
+    scorers?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+  }): Agent {
+    // Build model config from stored data
+    // The model field stores { provider, name, ...otherConfig }
+    const modelConfig = storedAgent.model as { provider?: string; name?: string; [key: string]: unknown };
+
+    // Build the model string in "provider/modelName" format
+    if (!modelConfig.provider || !modelConfig.name) {
+      throw new MastraError({
+        id: 'MASTRA_STORED_AGENT_INVALID_MODEL',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: `Stored agent "${storedAgent.id}" has invalid model configuration. Both provider and name are required.`,
+        details: { agentId: storedAgent.id, model: JSON.stringify(storedAgent.model) },
+      });
+    }
+
+    // Use model router format: "provider/modelName"
+    const model = `${modelConfig.provider}/${modelConfig.name}`;
+
+    // Resolve tools from the stored tool references
+    const tools = this.#resolveStoredTools(storedAgent.tools);
+
+    // Resolve workflows from the stored workflow references
+    const workflows = this.#resolveStoredWorkflows(storedAgent.workflows);
+
+    // Resolve sub-agents from the stored agent references
+    const agents = this.#resolveStoredAgents(storedAgent.agents);
+
+    // Resolve memory from the stored memory reference
+    const memory = this.#resolveStoredMemory(storedAgent.memory);
+
+    // Resolve scorers from the stored scorer references
+    const scorers = this.#resolveStoredScorers(storedAgent.scorers);
+
+    // Create the agent instance
+    const agent = new Agent({
+      id: storedAgent.id,
+      name: storedAgent.name,
+      description: storedAgent.description,
+      instructions: storedAgent.instructions,
+      model,
+      tools,
+      workflows,
+      agents,
+      memory,
+      scorers,
+      defaultOptions: storedAgent.defaultOptions,
+    });
+
+    // Register the agent with Mastra
+    agent.__setLogger(this.#logger);
+    agent.__registerMastra(this);
+    agent.__registerPrimitives({
+      logger: this.getLogger(),
+      storage: this.getStorage(),
+      agents: this.#agents as Record<string, Agent<any>>,
+      tts: this.#tts,
+      vectors: this.#vectors,
+    });
+
+    return agent;
+  }
+
+  /**
+   * Resolves tool references from stored configuration to actual tool instances.
+   * @private
+   */
+  #resolveStoredTools(storedTools?: Record<string, unknown>): Record<string, ToolAction<any, any, any, any, any, any>> {
+    if (!storedTools) {
+      return {};
+    }
+
+    const resolvedTools: Record<string, ToolAction<any, any, any, any, any, any>> = {};
+    const registeredTools = this.#tools;
+
+    for (const [toolKey, toolConfig] of Object.entries(storedTools)) {
+      // Try to find the tool in registered tools
+      if (registeredTools && registeredTools[toolKey]) {
+        resolvedTools[toolKey] = registeredTools[toolKey];
+      } else {
+        // Tool reference exists but tool is not registered - log warning
+        this.#logger?.warn(`Tool "${toolKey}" referenced in stored agent but not registered in Mastra`);
+      }
+    }
+
+    return resolvedTools;
+  }
+
+  /**
+   * Resolves workflow references from stored configuration to actual workflow instances.
+   * @private
+   */
+  #resolveStoredWorkflows(
+    storedWorkflows?: Record<string, unknown>,
+  ): Record<string, Workflow<any, any, any, any, any, any>> {
+    if (!storedWorkflows) {
+      return {};
+    }
+
+    const resolvedWorkflows: Record<string, Workflow<any, any, any, any, any, any>> = {};
+
+    for (const [workflowKey, workflowConfig] of Object.entries(storedWorkflows)) {
+      // Try to find the workflow in registered workflows
+      try {
+        const workflow = this.getWorkflow(workflowKey);
+        resolvedWorkflows[workflowKey] = workflow;
+      } catch {
+        // Try by ID if the config has an id field
+        const config = workflowConfig as { id?: string };
+        if (config.id) {
+          try {
+            const workflow = this.getWorkflowById(config.id);
+            resolvedWorkflows[workflowKey] = workflow;
+          } catch {
+            this.#logger?.warn(`Workflow "${workflowKey}" referenced in stored agent but not registered in Mastra`);
+          }
+        } else {
+          this.#logger?.warn(`Workflow "${workflowKey}" referenced in stored agent but not registered in Mastra`);
+        }
+      }
+    }
+
+    return resolvedWorkflows;
+  }
+
+  /**
+   * Resolves agent references from stored configuration to actual agent instances.
+   * @private
+   */
+  #resolveStoredAgents(storedAgents?: Record<string, unknown>): Record<string, Agent<any>> {
+    if (!storedAgents) {
+      return {};
+    }
+
+    const resolvedAgents: Record<string, Agent<any>> = {};
+
+    for (const [agentKey, agentConfig] of Object.entries(storedAgents)) {
+      // Try to find the agent in registered agents
+      try {
+        const agent = this.getAgent(agentKey as keyof TAgents);
+        resolvedAgents[agentKey] = agent;
+      } catch {
+        // Try by ID if the config has an id field
+        const config = agentConfig as { id?: string };
+        if (config.id) {
+          try {
+            const agent = this.getAgentById(config.id as TAgents[keyof TAgents]['id']);
+            resolvedAgents[agentKey] = agent;
+          } catch {
+            this.#logger?.warn(`Agent "${agentKey}" referenced in stored agent but not registered in Mastra`);
+          }
+        } else {
+          this.#logger?.warn(`Agent "${agentKey}" referenced in stored agent but not registered in Mastra`);
+        }
+      }
+    }
+
+    return resolvedAgents;
+  }
+
+  /**
+   * Resolves memory reference from stored configuration to actual memory instance.
+   * @private
+   */
+  #resolveStoredMemory(storedMemory?: Record<string, unknown>): MastraMemory | undefined {
+    if (!storedMemory) {
+      return undefined;
+    }
+
+    // The stored memory config should have an id or key reference
+    const memoryConfig = storedMemory as { id?: string; key?: string };
+
+    // Try by key first
+    if (memoryConfig.key) {
+      try {
+        return this.getMemory(memoryConfig.key as keyof TMemory);
+      } catch {
+        this.#logger?.warn(`Memory "${memoryConfig.key}" referenced in stored agent but not registered in Mastra`);
+      }
+    }
+
+    // Try by id
+    if (memoryConfig.id) {
+      try {
+        return this.getMemoryById(memoryConfig.id);
+      } catch {
+        this.#logger?.warn(
+          `Memory with id "${memoryConfig.id}" referenced in stored agent but not registered in Mastra`,
+        );
+      }
+    }
+
+    // If no key or id, log warning
+    this.#logger?.warn('Memory configuration in stored agent has no key or id to resolve');
+    return undefined;
+  }
+
+  /**
+   * Resolves scorer references from stored configuration to actual scorer instances.
+   * @private
+   */
+  #resolveStoredScorers(storedScorers?: Record<string, unknown>): MastraScorers | undefined {
+    if (!storedScorers) {
+      return undefined;
+    }
+
+    const resolvedScorers: MastraScorers = {};
+
+    for (const [scorerKey, scorerConfig] of Object.entries(storedScorers)) {
+      const config = scorerConfig as { id?: string; sampling?: ScoringSamplingConfig };
+
+      // Try to find the scorer in registered scorers
+      try {
+        const scorer = this.getScorer(scorerKey as keyof TScorers);
+        resolvedScorers[scorerKey] = {
+          scorer,
+          sampling: config.sampling,
+        };
+      } catch {
+        // Try by ID if the config has an id field
+        if (config.id) {
+          try {
+            const scorer = this.getScorerById(config.id);
+            resolvedScorers[scorerKey] = {
+              scorer,
+              sampling: config.sampling,
+            };
+          } catch {
+            this.#logger?.warn(`Scorer "${scorerKey}" referenced in stored agent but not registered in Mastra`);
+          }
+        } else {
+          this.#logger?.warn(`Scorer "${scorerKey}" referenced in stored agent but not registered in Mastra`);
+        }
+      }
+    }
+
+    return Object.keys(resolvedScorers).length > 0 ? resolvedScorers : undefined;
   }
 
   /**
@@ -1590,6 +2063,139 @@ export class Mastra<
     }
 
     processors[processorKey] = processor;
+  }
+
+  /**
+   * Retrieves a registered memory instance by its registration key.
+   *
+   * @throws {MastraError} When the memory instance with the specified key is not found
+   *
+   * @example
+   * ```typescript
+   * const mastra = new Mastra({
+   *   memory: {
+   *     chat: new Memory({ storage })
+   *   }
+   * });
+   *
+   * const chatMemory = mastra.getMemory('chat');
+   * ```
+   */
+  public getMemory<TMemoryName extends keyof TMemory>(name: TMemoryName): TMemory[TMemoryName] {
+    if (!this.#memory || !this.#memory[name]) {
+      const error = new MastraError({
+        id: 'MASTRA_GET_MEMORY_BY_KEY_NOT_FOUND',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: `Memory with key ${String(name)} not found`,
+        details: {
+          status: 404,
+          memoryKey: String(name),
+          memory: Object.keys(this.#memory ?? {}).join(', '),
+        },
+      });
+      this.#logger?.trackException(error);
+      throw error;
+    }
+    return this.#memory[name];
+  }
+
+  /**
+   * Retrieves a registered memory instance by its ID.
+   *
+   * Searches through all registered memory instances and returns the one whose ID matches.
+   *
+   * @throws {MastraError} When no memory instance with the specified ID is found
+   *
+   * @example
+   * ```typescript
+   * const mastra = new Mastra({
+   *   memory: {
+   *     chat: new Memory({ id: 'chat-memory', storage })
+   *   }
+   * });
+   *
+   * const memory = mastra.getMemoryById('chat-memory');
+   * ```
+   */
+  public getMemoryById(id: string): MastraMemory {
+    const allMemory = this.#memory;
+    if (allMemory) {
+      for (const [, memory] of Object.entries(allMemory)) {
+        if (memory.id === id) {
+          return memory;
+        }
+      }
+    }
+
+    const error = new MastraError({
+      id: 'MASTRA_GET_MEMORY_BY_ID_NOT_FOUND',
+      domain: ErrorDomain.MASTRA,
+      category: ErrorCategory.USER,
+      text: `Memory with id ${id} not found`,
+      details: {
+        status: 404,
+        memoryId: id,
+        availableIds: Object.values(allMemory ?? {})
+          .map(m => m.id)
+          .join(', '),
+      },
+    });
+    this.#logger?.trackException(error);
+    throw error;
+  }
+
+  /**
+   * Returns all registered memory instances as a record keyed by their names.
+   *
+   * @example
+   * ```typescript
+   * const mastra = new Mastra({
+   *   memory: {
+   *     chat: new Memory({ storage }),
+   *     longTerm: new Memory({ storage })
+   *   }
+   * });
+   *
+   * const allMemory = mastra.listMemory();
+   * console.log(Object.keys(allMemory)); // ['chat', 'longTerm']
+   * ```
+   */
+  public listMemory(): TMemory | undefined {
+    return this.#memory;
+  }
+
+  /**
+   * Adds a new memory instance to the Mastra instance.
+   *
+   * This method allows dynamic registration of memory instances after the Mastra instance
+   * has been created.
+   *
+   * @example
+   * ```typescript
+   * const mastra = new Mastra();
+   * const chatMemory = new Memory({
+   *   id: 'chat-memory',
+   *   storage: mastra.getStorage()
+   * });
+   * mastra.addMemory(chatMemory); // Uses memory.id as key
+   * // or
+   * mastra.addMemory(chatMemory, 'customKey'); // Uses custom key
+   * ```
+   */
+  public addMemory<M extends MastraMemory>(memory: M, key?: string): void {
+    if (!memory) {
+      throw createUndefinedPrimitiveError('memory', memory, key);
+    }
+    const memoryKey = key || memory.id;
+    const memoryRegistry = this.#memory as Record<string, MastraMemory>;
+    if (memoryRegistry[memoryKey]) {
+      const logger = this.getLogger();
+      logger.debug(`Memory with key ${memoryKey} already exists. Skipping addition.`);
+      return;
+    }
+
+    memoryRegistry[memoryKey] = memory;
   }
 
   /**

--- a/packages/core/src/mastra/stored-agents.test.ts
+++ b/packages/core/src/mastra/stored-agents.test.ts
@@ -1,0 +1,543 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from './index';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { createTool } from '../tools';
+import { createWorkflow, createStep } from '../workflows';
+import { createScorer } from '../evals';
+import { z } from 'zod';
+
+// Mock tool for testing
+const mockTool = createTool({
+  id: 'test-tool',
+  description: 'A test tool',
+  inputSchema: z.object({ input: z.string() }),
+  outputSchema: z.object({ output: z.string() }),
+  execute: async inputData => ({ output: `processed: ${inputData.input}` }),
+});
+
+// Sample stored agent data
+const sampleStoredAgent = {
+  id: 'stored-agent-1',
+  name: 'Test Stored Agent',
+  description: 'A test agent from storage',
+  instructions: 'You are a helpful test assistant',
+  model: { provider: 'openai', name: 'gpt-4' },
+  tools: { 'test-tool': { type: 'function' } },
+  defaultOptions: { maxSteps: 5 },
+  metadata: { version: '1.0' },
+};
+
+const sampleStoredAgent2 = {
+  id: 'stored-agent-2',
+  name: 'Second Stored Agent',
+  instructions: 'You are another test assistant',
+  model: { provider: 'anthropic', name: 'claude-3' },
+};
+
+describe('Mastra Stored Agents', () => {
+  describe('getStoredAgentById', () => {
+    it('should throw error when storage is not configured', async () => {
+      const mastra = new Mastra({});
+
+      await expect(mastra.getStoredAgentById('test-id')).rejects.toThrow('Storage is not configured');
+    });
+
+    it('should return null when agent is not found', async () => {
+      const storage = new InMemoryStore();
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.getStoredAgentById('non-existent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return an Agent instance by default', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+
+      const mastra = new Mastra({
+        storage,
+        tools: { 'test-tool': mockTool },
+      });
+
+      const result = await mastra.getStoredAgentById('stored-agent-1');
+
+      expect(result).toBeInstanceOf(Agent);
+      expect(result?.id).toBe('stored-agent-1');
+      expect(result?.name).toBe('Test Stored Agent');
+    });
+
+    it('should return raw StorageAgentType when raw option is true', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.getStoredAgentById('stored-agent-1', { raw: true });
+
+      expect(result).not.toBeInstanceOf(Agent);
+      expect(result?.id).toBe('stored-agent-1');
+      expect(result?.name).toBe('Test Stored Agent');
+      expect(result?.createdAt).toBeInstanceOf(Date);
+      expect(result?.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should resolve tools from registered tools', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+
+      const mastra = new Mastra({
+        storage,
+        tools: { 'test-tool': mockTool },
+      });
+
+      const agent = await mastra.getStoredAgentById('stored-agent-1');
+
+      expect(agent).toBeInstanceOf(Agent);
+      // The agent should have the tool resolved
+    });
+
+    it('should warn when referenced tool is not registered', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+
+      const warnSpy = vi.fn();
+      const mastra = new Mastra({
+        storage,
+        tools: {}, // No tools registered
+        logger: {
+          warn: warnSpy,
+          info: vi.fn(),
+          debug: vi.fn(),
+          error: vi.fn(),
+          child: vi.fn().mockReturnThis(),
+          trackException: vi.fn(),
+        } as any,
+      });
+
+      await mastra.getStoredAgentById('stored-agent-1');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Tool "test-tool" referenced in stored agent but not registered'),
+      );
+    });
+
+    it('should throw error when model config is invalid', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({
+        agent: {
+          id: 'invalid-model-agent',
+          name: 'Invalid Model Agent',
+          instructions: 'Test',
+          model: { invalid: 'config' }, // Missing provider and name
+        },
+      });
+
+      const mastra = new Mastra({ storage });
+
+      await expect(mastra.getStoredAgentById('invalid-model-agent')).rejects.toThrow('invalid model configuration');
+    });
+  });
+
+  describe('listStoredAgents', () => {
+    it('should throw error when storage is not configured', async () => {
+      const mastra = new Mastra({});
+
+      await expect(mastra.listStoredAgents()).rejects.toThrow('Storage is not configured');
+    });
+
+    it('should return empty list when no agents exist', async () => {
+      const storage = new InMemoryStore();
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.listStoredAgents();
+
+      expect(result.agents).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('should return Agent instances by default', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+      await storage.createAgent({ agent: sampleStoredAgent2 });
+
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.listStoredAgents();
+
+      expect(result.agents).toHaveLength(2);
+      expect(result.agents[0]).toBeInstanceOf(Agent);
+      expect(result.agents[1]).toBeInstanceOf(Agent);
+      expect(result.total).toBe(2);
+    });
+
+    it('should return raw StorageAgentType array when raw option is true', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+      await storage.createAgent({ agent: sampleStoredAgent2 });
+
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.listStoredAgents({ raw: true });
+
+      expect(result.agents).toHaveLength(2);
+      expect(result.agents[0]).not.toBeInstanceOf(Agent);
+      expect(result.agents[0].createdAt).toBeInstanceOf(Date);
+      expect(result.agents[1].createdAt).toBeInstanceOf(Date);
+    });
+
+    it('should return pagination info correctly', async () => {
+      const storage = new InMemoryStore();
+
+      // Create 25 agents
+      for (let i = 0; i < 25; i++) {
+        await storage.createAgent({
+          agent: {
+            ...sampleStoredAgent,
+            id: `agent-${i}`,
+            name: `Agent ${i}`,
+          },
+        });
+      }
+
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.listStoredAgents({ page: 0, perPage: 10 });
+
+      expect(result.agents).toHaveLength(10);
+      expect(result.total).toBe(25);
+      expect(result.page).toBe(0);
+      expect(result.perPage).toBe(10);
+      expect(result.hasMore).toBe(true);
+    });
+  });
+
+  describe('Agent instance creation from stored config', () => {
+    it('should create agent with correct model string format', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+
+      const mastra = new Mastra({ storage });
+
+      const agent = await mastra.getStoredAgentById('stored-agent-1');
+
+      expect(agent).toBeInstanceOf(Agent);
+      expect(agent?.id).toBe('stored-agent-1');
+    });
+
+    it('should resolve workflows from stored config', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({
+        agent: {
+          ...sampleStoredAgent,
+          id: 'agent-with-workflow',
+          workflows: { 'my-workflow': { id: 'my-workflow' } },
+        },
+      });
+
+      const warnSpy = vi.fn();
+      const mastra = new Mastra({
+        storage,
+        logger: {
+          warn: warnSpy,
+          info: vi.fn(),
+          debug: vi.fn(),
+          error: vi.fn(),
+          child: vi.fn().mockReturnThis(),
+          trackException: vi.fn(),
+        } as any,
+      });
+
+      await mastra.getStoredAgentById('agent-with-workflow');
+
+      // Should warn about unregistered workflow
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Workflow "my-workflow" referenced in stored agent but not registered'),
+      );
+    });
+
+    it('should resolve sub-agents from stored config', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({
+        agent: {
+          ...sampleStoredAgent,
+          id: 'agent-with-sub-agent',
+          agents: { 'sub-agent': { id: 'sub-agent' } },
+        },
+      });
+
+      const warnSpy = vi.fn();
+      const mastra = new Mastra({
+        storage,
+        logger: {
+          warn: warnSpy,
+          info: vi.fn(),
+          debug: vi.fn(),
+          error: vi.fn(),
+          child: vi.fn().mockReturnThis(),
+          trackException: vi.fn(),
+        } as any,
+      });
+
+      await mastra.getStoredAgentById('agent-with-sub-agent');
+
+      // Should warn about unregistered sub-agent
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Agent "sub-agent" referenced in stored agent but not registered'),
+      );
+    });
+
+    it('should pass defaultOptions to created agent', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+
+      const mastra = new Mastra({ storage });
+
+      const agent = await mastra.getStoredAgentById('stored-agent-1');
+
+      expect(agent).toBeInstanceOf(Agent);
+      // The agent should have defaultOptions set
+    });
+  });
+
+  describe('Type inference', () => {
+    it('should have correct return type for getStoredAgentById without raw option', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.getStoredAgentById('stored-agent-1');
+
+      // TypeScript should infer: Agent | null
+      if (result) {
+        // Should be able to call Agent methods
+        expect(typeof result.generate).toBe('function');
+      }
+    });
+
+    it('should have correct return type for getStoredAgentById with raw: true', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.getStoredAgentById('stored-agent-1', { raw: true });
+
+      // TypeScript should infer: StorageAgentType | null
+      if (result) {
+        // Should have StorageAgentType properties
+        expect(result.createdAt).toBeInstanceOf(Date);
+        expect(result.updatedAt).toBeInstanceOf(Date);
+      }
+    });
+
+    it('should have correct return type for listStoredAgents without raw option', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.listStoredAgents();
+
+      // TypeScript should infer: { agents: Agent[], ... }
+      for (const agent of result.agents) {
+        expect(typeof agent.generate).toBe('function');
+      }
+    });
+
+    it('should have correct return type for listStoredAgents with raw: true', async () => {
+      const storage = new InMemoryStore();
+      await storage.createAgent({ agent: sampleStoredAgent });
+      const mastra = new Mastra({ storage });
+
+      const result = await mastra.listStoredAgents({ raw: true });
+
+      // TypeScript should infer: { agents: StorageAgentType[], ... }
+      for (const agent of result.agents) {
+        expect(agent.createdAt).toBeInstanceOf(Date);
+        expect(agent.updatedAt).toBeInstanceOf(Date);
+      }
+    });
+  });
+
+  describe('Full primitive resolution', () => {
+    it('should resolve tools and workflows from stored config', async () => {
+      const storage = new InMemoryStore();
+
+      // Create registered primitives
+      const registeredTool = createTool({
+        id: 'registered-tool',
+        description: 'A registered tool',
+        inputSchema: z.object({ input: z.string() }),
+        outputSchema: z.object({ output: z.string() }),
+        execute: async inputData => ({ output: `processed: ${inputData.input}` }),
+      });
+
+      const registeredWorkflow = createWorkflow({
+        id: 'registered-workflow',
+        inputSchema: z.object({ value: z.number() }),
+        outputSchema: z.object({ result: z.number() }),
+      }).then(
+        createStep({
+          id: 'double',
+          inputSchema: z.object({ value: z.number() }),
+          outputSchema: z.object({ result: z.number() }),
+          execute: async ({ inputData }) => ({ result: inputData.value * 2 }),
+        }),
+      );
+      registeredWorkflow.commit();
+
+      const registeredSubAgent = new Agent({
+        id: 'registered-sub-agent',
+        name: 'Sub Agent',
+        instructions: 'You are a sub-agent',
+        model: 'openai/gpt-4',
+      });
+
+      // Create stored agent that references tools, workflows, and sub-agents
+      const fullStoredAgent = {
+        id: 'full-agent',
+        name: 'Full Test Agent',
+        description: 'An agent with primitives',
+        instructions: 'You are a comprehensive test assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+        tools: {
+          'registered-tool': { type: 'function' },
+        },
+        workflows: {
+          'registered-workflow': { id: 'registered-workflow' },
+        },
+        agents: {
+          'registered-sub-agent': { id: 'registered-sub-agent' },
+        },
+        defaultOptions: { maxSteps: 10 },
+        metadata: { version: '2.0', feature: 'full-test' },
+      };
+
+      await storage.createAgent({ agent: fullStoredAgent });
+
+      const mastra = new Mastra({
+        storage,
+        tools: { 'registered-tool': registeredTool },
+        workflows: { 'registered-workflow': registeredWorkflow },
+        agents: { 'registered-sub-agent': registeredSubAgent },
+      });
+
+      const agent = await mastra.getStoredAgentById('full-agent');
+
+      // Verify agent was created
+      expect(agent).toBeInstanceOf(Agent);
+      expect(agent?.id).toBe('full-agent');
+      expect(agent?.name).toBe('Full Test Agent');
+    });
+
+    it('should resolve scorers with sampling config from stored config', async () => {
+      const storage = new InMemoryStore();
+
+      const registeredScorer = createScorer({
+        id: 'registered-scorer',
+        description: 'A test scorer',
+      }).generateScore(() => 0.8);
+
+      // Create stored agent with scorer including sampling config
+      const storedAgentWithScorers = {
+        id: 'agent-with-scorers',
+        name: 'Agent With Scorers',
+        instructions: 'Test agent',
+        model: { provider: 'openai', name: 'gpt-4' },
+        scorers: {
+          'registered-scorer': {
+            sampling: { type: 'ratio', rate: 0.5 },
+          },
+        },
+      };
+
+      await storage.createAgent({ agent: storedAgentWithScorers });
+
+      const mastra = new Mastra({
+        storage,
+        scorers: { 'registered-scorer': registeredScorer },
+      });
+
+      const agent = await mastra.getStoredAgentById('agent-with-scorers');
+
+      expect(agent).toBeInstanceOf(Agent);
+      expect(agent?.id).toBe('agent-with-scorers');
+    });
+
+    it('should resolve scorers by id when key lookup fails', async () => {
+      const storage = new InMemoryStore();
+
+      const registeredScorer = createScorer({
+        id: 'scorer-by-id',
+        description: 'Scorer to find by ID',
+      }).generateScore(() => 0.5);
+
+      // Store agent with scorer reference by ID (not by registry key)
+      const storedAgent = {
+        id: 'agent-with-id-ref',
+        name: 'Agent With ID Reference',
+        instructions: 'Test agent',
+        model: { provider: 'openai', name: 'gpt-4' },
+        scorers: {
+          'different-key': {
+            id: 'scorer-by-id', // Reference by ID, not by registry key
+          },
+        },
+      };
+
+      await storage.createAgent({ agent: storedAgent });
+
+      const mastra = new Mastra({
+        storage,
+        scorers: { 'some-other-key': registeredScorer }, // Registered under different key
+      });
+
+      const agent = await mastra.getStoredAgentById('agent-with-id-ref');
+
+      expect(agent).toBeInstanceOf(Agent);
+    });
+
+    it('should handle missing primitives gracefully with warnings', async () => {
+      const storage = new InMemoryStore();
+
+      const storedAgent = {
+        id: 'agent-with-missing-refs',
+        name: 'Agent With Missing References',
+        instructions: 'Test agent',
+        model: { provider: 'openai', name: 'gpt-4' },
+        tools: { 'missing-tool': {} },
+        workflows: { 'missing-workflow': {} },
+        agents: { 'missing-agent': {} },
+        memory: { key: 'missing-memory' },
+        scorers: { 'missing-scorer': {} },
+      };
+
+      await storage.createAgent({ agent: storedAgent });
+
+      const warnSpy = vi.fn();
+      const mastra = new Mastra({
+        storage,
+        logger: {
+          warn: warnSpy,
+          info: vi.fn(),
+          debug: vi.fn(),
+          error: vi.fn(),
+          child: vi.fn().mockReturnThis(),
+          trackException: vi.fn(),
+        } as any,
+      });
+
+      const agent = await mastra.getStoredAgentById('agent-with-missing-refs');
+
+      expect(agent).toBeInstanceOf(Agent);
+
+      // Should have warnings for all missing primitives
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Tool "missing-tool"'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Workflow "missing-workflow"'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Agent "missing-agent"'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Memory "missing-memory"'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Scorer "missing-scorer"'));
+    });
+  });
+});

--- a/packages/core/src/mastra/stored-agents.test.ts
+++ b/packages/core/src/mastra/stored-agents.test.ts
@@ -23,7 +23,7 @@ const sampleStoredAgent = {
   description: 'A test agent from storage',
   instructions: 'You are a helpful test assistant',
   model: { provider: 'openai', name: 'gpt-4' },
-  tools: { 'test-tool': { type: 'function' } },
+  tools: ['test-tool'],
   defaultOptions: { maxSteps: 5 },
   metadata: { version: '1.0' },
 };
@@ -233,7 +233,7 @@ describe('Mastra Stored Agents', () => {
         agent: {
           ...sampleStoredAgent,
           id: 'agent-with-workflow',
-          workflows: { 'my-workflow': { id: 'my-workflow' } },
+          workflows: ['my-workflow'],
         },
       });
 
@@ -264,7 +264,7 @@ describe('Mastra Stored Agents', () => {
         agent: {
           ...sampleStoredAgent,
           id: 'agent-with-sub-agent',
-          agents: { 'sub-agent': { id: 'sub-agent' } },
+          agents: ['sub-agent'],
         },
       });
 
@@ -401,15 +401,9 @@ describe('Mastra Stored Agents', () => {
         description: 'An agent with primitives',
         instructions: 'You are a comprehensive test assistant',
         model: { provider: 'openai', name: 'gpt-4' },
-        tools: {
-          'registered-tool': { type: 'function' },
-        },
-        workflows: {
-          'registered-workflow': { id: 'registered-workflow' },
-        },
-        agents: {
-          'registered-sub-agent': { id: 'registered-sub-agent' },
-        },
+        tools: ['registered-tool'],
+        workflows: ['registered-workflow'],
+        agents: ['registered-sub-agent'],
         defaultOptions: { maxSteps: 10 },
         metadata: { version: '2.0', feature: 'full-test' },
       };
@@ -447,7 +441,7 @@ describe('Mastra Stored Agents', () => {
         model: { provider: 'openai', name: 'gpt-4' },
         scorers: {
           'registered-scorer': {
-            sampling: { type: 'ratio', rate: 0.5 },
+            sampling: { type: 'ratio' as const, rate: 0.5 },
           },
         },
       };
@@ -473,16 +467,14 @@ describe('Mastra Stored Agents', () => {
         description: 'Scorer to find by ID',
       }).generateScore(() => 0.5);
 
-      // Store agent with scorer reference by ID (not by registry key)
+      // Store agent with scorer reference by ID (the key is used to look up by key first, then by ID)
       const storedAgent = {
         id: 'agent-with-id-ref',
         name: 'Agent With ID Reference',
         instructions: 'Test agent',
         model: { provider: 'openai', name: 'gpt-4' },
         scorers: {
-          'different-key': {
-            id: 'scorer-by-id', // Reference by ID, not by registry key
-          },
+          'scorer-by-id': {}, // Use the scorer's ID as the key
         },
       };
 
@@ -506,10 +498,10 @@ describe('Mastra Stored Agents', () => {
         name: 'Agent With Missing References',
         instructions: 'Test agent',
         model: { provider: 'openai', name: 'gpt-4' },
-        tools: { 'missing-tool': {} },
-        workflows: { 'missing-workflow': {} },
-        agents: { 'missing-agent': {} },
-        memory: { key: 'missing-memory' },
+        tools: ['missing-tool'],
+        workflows: ['missing-workflow'],
+        agents: ['missing-agent'],
+        memory: 'missing-memory',
         scorers: { 'missing-scorer': {} },
       };
 

--- a/packages/core/src/mastra/stored-agents.test.ts
+++ b/packages/core/src/mastra/stored-agents.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Mastra } from './index';
+import { z } from 'zod';
 import { Agent } from '../agent';
+import { createScorer } from '../evals';
 import { InMemoryStore } from '../storage/mock';
 import { createTool } from '../tools';
 import { createWorkflow, createStep } from '../workflows';
-import { createScorer } from '../evals';
-import { z } from 'zod';
+import { Mastra } from './index';
 
 // Mock tool for testing
 const mockTool = createTool({

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -80,6 +80,12 @@ export const memoryDefaultOptions = {
  * - Handles memory processors to manipulate messages before they are sent to the LLM
  */
 export abstract class MastraMemory extends MastraBase {
+  /**
+   * Unique identifier for the memory instance.
+   * If not provided, defaults to a static name 'default-memory'.
+   */
+  readonly id: string;
+
   MAX_CONTEXT_TOKENS?: number;
 
   protected _storage?: MastraStorage;
@@ -88,8 +94,9 @@ export abstract class MastraMemory extends MastraBase {
   protected threadConfig: MemoryConfig = { ...memoryDefaultOptions };
   #mastra?: Mastra;
 
-  constructor(config: { name: string } & SharedMemoryConfig) {
+  constructor(config: { id?: string; name: string } & SharedMemoryConfig) {
     super({ component: 'MEMORY', name: config.name });
+    this.id = config.id ?? config.name ?? 'default-memory';
 
     if (config.options) this.threadConfig = this.getMergedThreadConfig(config.options);
 

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -15,9 +15,17 @@ import {
   TABLE_SCORERS,
   TABLE_SCHEMAS,
   TABLE_SPANS,
+  TABLE_AGENTS,
 } from './constants';
 import type { TABLE_NAMES } from './constants';
-import type { ScoresStorage, StoreOperations, WorkflowsStorage, MemoryStorage, ObservabilityStorage } from './domains';
+import type {
+  AgentsStorage,
+  ScoresStorage,
+  StoreOperations,
+  WorkflowsStorage,
+  MemoryStorage,
+  ObservabilityStorage,
+} from './domains';
 import type {
   PaginationInfo,
   StorageColumn,
@@ -38,6 +46,11 @@ import type {
   StorageListWorkflowRunsInput,
   StorageListThreadsByResourceIdInput,
   StorageListThreadsByResourceIdOutput,
+  StorageAgentType,
+  StorageCreateAgentInput,
+  StorageUpdateAgentInput,
+  StorageListAgentsInput,
+  StorageListAgentsOutput,
 } from './types';
 
 export type StorageDomains = {
@@ -46,6 +59,7 @@ export type StorageDomains = {
   scores: ScoresStorage;
   memory: MemoryStorage;
   observability?: ObservabilityStorage;
+  agents?: AgentsStorage;
 };
 
 export function ensureDate(date: Date | string | undefined): Date | undefined {
@@ -147,6 +161,7 @@ export abstract class MastraStorage extends MastraBase {
     observabilityInstance?: boolean;
     indexManagement?: boolean;
     listScoresBySpan?: boolean;
+    agents?: boolean;
   } {
     return {
       selectByIncludeResourceScope: false,
@@ -157,6 +172,7 @@ export abstract class MastraStorage extends MastraBase {
       observabilityInstance: false,
       indexManagement: false,
       listScoresBySpan: false,
+      agents: false,
     };
   }
 
@@ -388,6 +404,16 @@ export abstract class MastraStorage extends MastraBase {
         this.createTable({
           tableName: TABLE_SPANS,
           schema: TABLE_SCHEMAS[TABLE_SPANS],
+        }),
+      );
+    }
+
+    // Create agents table for storage adapters that support dynamic agent storage
+    if (this.supports.agents) {
+      tableCreationTasks.push(
+        this.createTable({
+          tableName: TABLE_AGENTS,
+          schema: TABLE_SCHEMAS[TABLE_AGENTS],
         }),
       );
     }
@@ -749,6 +775,102 @@ export abstract class MastraStorage extends MastraBase {
       domain: ErrorDomain.STORAGE,
       category: ErrorCategory.SYSTEM,
       text: `Index management is not supported by this storage adapter (${this.constructor.name})`,
+    });
+  }
+
+  /**
+   * AGENTS STORAGE
+   * These methods delegate to the agents store for agent CRUD operations.
+   * This enables dynamic creation of agents via Mastra Studio.
+   */
+
+  /**
+   * Retrieves an agent by its unique identifier.
+   * @param id - The unique identifier of the agent
+   * @returns The agent if found, null otherwise
+   * @throws {MastraError} if not supported by the storage adapter
+   */
+  async getAgentById({ id }: { id: string }): Promise<StorageAgentType | null> {
+    if (this.stores?.agents) {
+      return this.stores.agents.getAgentById({ id });
+    }
+    throw new MastraError({
+      id: 'MASTRA_STORAGE_GET_AGENT_BY_ID_NOT_SUPPORTED',
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.SYSTEM,
+      text: `Agent storage is not supported by this storage adapter (${this.constructor.name})`,
+    });
+  }
+
+  /**
+   * Creates a new agent in storage.
+   * @param agent - The agent data to create
+   * @returns The created agent with timestamps
+   * @throws {MastraError} if not supported by the storage adapter
+   */
+  async createAgent({ agent }: { agent: StorageCreateAgentInput }): Promise<StorageAgentType> {
+    if (this.stores?.agents) {
+      return this.stores.agents.createAgent({ agent });
+    }
+    throw new MastraError({
+      id: 'MASTRA_STORAGE_CREATE_AGENT_NOT_SUPPORTED',
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.SYSTEM,
+      text: `Agent storage is not supported by this storage adapter (${this.constructor.name})`,
+    });
+  }
+
+  /**
+   * Updates an existing agent in storage.
+   * @param id - The unique identifier of the agent to update
+   * @param updates - The fields to update
+   * @returns The updated agent
+   * @throws {MastraError} if not supported by the storage adapter
+   */
+  async updateAgent(args: StorageUpdateAgentInput): Promise<StorageAgentType> {
+    if (this.stores?.agents) {
+      return this.stores.agents.updateAgent(args);
+    }
+    throw new MastraError({
+      id: 'MASTRA_STORAGE_UPDATE_AGENT_NOT_SUPPORTED',
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.SYSTEM,
+      text: `Agent storage is not supported by this storage adapter (${this.constructor.name})`,
+    });
+  }
+
+  /**
+   * Deletes an agent from storage.
+   * @param id - The unique identifier of the agent to delete
+   * @throws {MastraError} if not supported by the storage adapter
+   */
+  async deleteAgent({ id }: { id: string }): Promise<void> {
+    if (this.stores?.agents) {
+      return this.stores.agents.deleteAgent({ id });
+    }
+    throw new MastraError({
+      id: 'MASTRA_STORAGE_DELETE_AGENT_NOT_SUPPORTED',
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.SYSTEM,
+      text: `Agent storage is not supported by this storage adapter (${this.constructor.name})`,
+    });
+  }
+
+  /**
+   * Lists all agents with optional pagination.
+   * @param args - Pagination and ordering options
+   * @returns Paginated list of agents
+   * @throws {MastraError} if not supported by the storage adapter
+   */
+  async listAgents(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput> {
+    if (this.stores?.agents) {
+      return this.stores.agents.listAgents(args);
+    }
+    throw new MastraError({
+      id: 'MASTRA_STORAGE_LIST_AGENTS_NOT_SUPPORTED',
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.SYSTEM,
+      text: `Agent storage is not supported by this storage adapter (${this.constructor.name})`,
     });
   }
 }

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -7,6 +7,7 @@ export const TABLE_TRACES = 'mastra_traces';
 export const TABLE_RESOURCES = 'mastra_resources';
 export const TABLE_SCORERS = 'mastra_scorers';
 export const TABLE_SPANS = 'mastra_ai_spans';
+export const TABLE_AGENTS = 'mastra_agents';
 
 export type TABLE_NAMES =
   | typeof TABLE_WORKFLOW_SNAPSHOT
@@ -15,7 +16,8 @@ export type TABLE_NAMES =
   | typeof TABLE_TRACES
   | typeof TABLE_RESOURCES
   | typeof TABLE_SCORERS
-  | typeof TABLE_SPANS;
+  | typeof TABLE_SPANS
+  | typeof TABLE_AGENTS;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
@@ -74,6 +76,25 @@ export const SPAN_SCHEMA: Record<string, StorageColumn> = {
   createdAt: { type: 'timestamp', nullable: false }, // The time the database record was created
   updatedAt: { type: 'timestamp', nullable: true }, // The time the database record was last updated
   isEvent: { type: 'boolean', nullable: false },
+};
+
+export const AGENTS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  instructions: { type: 'text', nullable: false }, // System instructions for the agent
+  model: { type: 'jsonb', nullable: false }, // Model configuration (provider, name, etc.)
+  tools: { type: 'jsonb', nullable: true }, // Serialized tool references/configurations
+  defaultOptions: { type: 'jsonb', nullable: true }, // Default options for generate/stream calls
+  workflows: { type: 'jsonb', nullable: true }, // Workflow references (IDs or configurations)
+  agents: { type: 'jsonb', nullable: true }, // Sub-agent references (IDs or configurations)
+  inputProcessors: { type: 'jsonb', nullable: true }, // Input processor configurations
+  outputProcessors: { type: 'jsonb', nullable: true }, // Output processor configurations
+  memory: { type: 'jsonb', nullable: true }, // Memory configuration
+  scorers: { type: 'jsonb', nullable: true }, // Scorer configurations
+  metadata: { type: 'jsonb', nullable: true }, // Additional metadata for the agent
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
 };
 
 export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> = {
@@ -137,4 +158,5 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     createdAt: { type: 'timestamp', nullable: false },
     updatedAt: { type: 'timestamp', nullable: false },
   },
+  [TABLE_AGENTS]: AGENTS_SCHEMA,
 };

--- a/packages/core/src/storage/domains/agents/base.ts
+++ b/packages/core/src/storage/domains/agents/base.ts
@@ -1,0 +1,79 @@
+import { MastraBase } from '../../../base';
+import type {
+  StorageAgentType,
+  StorageCreateAgentInput,
+  StorageUpdateAgentInput,
+  StorageListAgentsInput,
+  StorageListAgentsOutput,
+  StorageOrderBy,
+  ThreadOrderBy,
+  ThreadSortDirection,
+} from '../../types';
+
+export abstract class AgentsStorage extends MastraBase {
+  constructor() {
+    super({
+      component: 'STORAGE',
+      name: 'AGENTS',
+    });
+  }
+
+  /**
+   * Retrieves an agent by its unique identifier.
+   * @param id - The unique identifier of the agent
+   * @returns The agent if found, null otherwise
+   */
+  abstract getAgentById({ id }: { id: string }): Promise<StorageAgentType | null>;
+
+  /**
+   * Creates a new agent in storage.
+   * @param agent - The agent data to create
+   * @returns The created agent with timestamps
+   */
+  abstract createAgent({ agent }: { agent: StorageCreateAgentInput }): Promise<StorageAgentType>;
+
+  /**
+   * Updates an existing agent in storage.
+   * @param id - The unique identifier of the agent to update
+   * @param updates - The fields to update
+   * @returns The updated agent
+   */
+  abstract updateAgent({ id, ...updates }: StorageUpdateAgentInput): Promise<StorageAgentType>;
+
+  /**
+   * Deletes an agent from storage.
+   * @param id - The unique identifier of the agent to delete
+   */
+  abstract deleteAgent({ id }: { id: string }): Promise<void>;
+
+  /**
+   * Lists all agents with optional pagination.
+   * @param args - Pagination and ordering options
+   * @returns Paginated list of agents
+   */
+  abstract listAgents(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput>;
+
+  /**
+   * Parses orderBy input for consistent sorting behavior.
+   */
+  protected parseOrderBy(
+    orderBy?: StorageOrderBy,
+    defaultDirection: ThreadSortDirection = 'DESC',
+  ): { field: ThreadOrderBy; direction: ThreadSortDirection } {
+    return {
+      field: orderBy?.field && orderBy.field in AGENT_ORDER_BY_SET ? orderBy.field : 'createdAt',
+      direction:
+        orderBy?.direction && orderBy.direction in AGENT_SORT_DIRECTION_SET ? orderBy.direction : defaultDirection,
+    };
+  }
+}
+
+const AGENT_ORDER_BY_SET: Record<ThreadOrderBy, true> = {
+  createdAt: true,
+  updatedAt: true,
+};
+
+const AGENT_SORT_DIRECTION_SET: Record<ThreadSortDirection, true> = {
+  ASC: true,
+  DESC: true,
+};

--- a/packages/core/src/storage/domains/agents/index.ts
+++ b/packages/core/src/storage/domains/agents/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './inmemory';

--- a/packages/core/src/storage/domains/agents/inmemory.test.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import type { StorageCreateAgentInput } from '../../types';
-import { InMemoryAgentsStorage, type InMemoryAgents } from './inmemory';
+import { InMemoryAgentsStorage } from './inmemory';
+import type { InMemoryAgents } from './inmemory';
 
 describe('InMemoryAgentsStorage', () => {
   let storage: InMemoryAgentsStorage;

--- a/packages/core/src/storage/domains/agents/inmemory.test.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.test.ts
@@ -67,9 +67,8 @@ describe('InMemoryAgentsStorage', () => {
         description: 'A fully configured agent',
         instructions: 'You are a helpful assistant',
         model: { provider: 'openai', name: 'gpt-4' },
-        tools: { calculator: { type: 'function' } },
-        defaultGenerateOptions: { maxTokens: 1000 },
-        defaultStreamOptions: { temperature: 0.7 },
+        tools: ['calculator'],
+        defaultOptions: { maxTokens: 1000 },
         metadata: { category: 'test' },
       };
 

--- a/packages/core/src/storage/domains/agents/inmemory.test.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import type { StorageCreateAgentInput } from '../../types';
+import { InMemoryAgentsStorage, type InMemoryAgents } from './inmemory';
+
+describe('InMemoryAgentsStorage', () => {
+  let storage: InMemoryAgentsStorage;
+  let collection: InMemoryAgents;
+  let initialDate: Date;
+  let laterDate: Date;
+
+  beforeEach(() => {
+    // Set up two fixed dates for testing
+    initialDate = new Date('2024-01-01T00:00:00Z');
+    laterDate = new Date('2024-01-01T01:00:00Z');
+
+    // Use Vitest fake timers to control Date
+    vi.useFakeTimers();
+    vi.setSystemTime(initialDate);
+
+    // Initialize fresh collection and storage instance for each test
+    collection = new Map();
+    storage = new InMemoryAgentsStorage({ collection });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('createAgent', () => {
+    it('should create a new agent with timestamps', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+      };
+
+      const result = await storage.createAgent({ agent: agentInput });
+
+      expect(result).toEqual({
+        ...agentInput,
+        createdAt: initialDate,
+        updatedAt: initialDate,
+      });
+      expect(collection.has('agent-1')).toBe(true);
+    });
+
+    it('should throw error when creating agent with existing id', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+
+      await expect(storage.createAgent({ agent: agentInput })).rejects.toThrow('Agent with id agent-1 already exists');
+    });
+
+    it('should create agent with all optional fields', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-2',
+        name: 'Full Agent',
+        description: 'A fully configured agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+        tools: { calculator: { type: 'function' } },
+        defaultGenerateOptions: { maxTokens: 1000 },
+        defaultStreamOptions: { temperature: 0.7 },
+        metadata: { category: 'test' },
+      };
+
+      const result = await storage.createAgent({ agent: agentInput });
+
+      expect(result).toEqual({
+        ...agentInput,
+        createdAt: initialDate,
+        updatedAt: initialDate,
+      });
+    });
+  });
+
+  describe('getAgentById', () => {
+    it('should return null for non-existent agent', async () => {
+      const result = await storage.getAgentById({ id: 'non-existent' });
+      expect(result).toBeNull();
+    });
+
+    it('should return agent by id', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+        metadata: { key: 'value' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+      const result = await storage.getAgentById({ id: 'agent-1' });
+
+      expect(result).toEqual({
+        ...agentInput,
+        createdAt: initialDate,
+        updatedAt: initialDate,
+      });
+    });
+
+    it('should return a deep copy of agent data', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+        metadata: { key: 'value' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+      const result1 = await storage.getAgentById({ id: 'agent-1' });
+      const result2 = await storage.getAgentById({ id: 'agent-1' });
+
+      // Verify they are different object references
+      expect(result1).not.toBe(result2);
+      expect(result1?.model).not.toBe(result2?.model);
+      expect(result1?.metadata).not.toBe(result2?.metadata);
+    });
+  });
+
+  describe('updateAgent', () => {
+    it('should throw error when updating non-existent agent', async () => {
+      await expect(storage.updateAgent({ id: 'non-existent', name: 'Updated Name' })).rejects.toThrow(
+        'Agent with id non-existent not found',
+      );
+    });
+
+    it('should update agent name', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+
+      vi.setSystemTime(laterDate);
+
+      const result = await storage.updateAgent({ id: 'agent-1', name: 'Updated Agent' });
+
+      expect(result.name).toBe('Updated Agent');
+      expect(result.updatedAt).toEqual(laterDate);
+      expect(result.createdAt).toEqual(initialDate);
+    });
+
+    it('should update agent instructions', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+
+      vi.setSystemTime(laterDate);
+
+      const result = await storage.updateAgent({
+        id: 'agent-1',
+        instructions: 'You are an expert coder',
+      });
+
+      expect(result.instructions).toBe('You are an expert coder');
+      expect(result.updatedAt).toEqual(laterDate);
+    });
+
+    it('should merge metadata on update', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+        metadata: { key1: 'value1', key2: 'value2' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+
+      vi.setSystemTime(laterDate);
+
+      const result = await storage.updateAgent({
+        id: 'agent-1',
+        metadata: { key2: 'updated', key3: 'value3' },
+      });
+
+      expect(result.metadata).toEqual({
+        key1: 'value1',
+        key2: 'updated',
+        key3: 'value3',
+      });
+    });
+
+    it('should replace model on update', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+
+      const newModel = { provider: 'anthropic', name: 'claude-3' };
+      const result = await storage.updateAgent({ id: 'agent-1', model: newModel });
+
+      expect(result.model).toEqual(newModel);
+    });
+  });
+
+  describe('deleteAgent', () => {
+    it('should throw error when deleting non-existent agent', async () => {
+      await expect(storage.deleteAgent({ id: 'non-existent' })).rejects.toThrow('Agent with id non-existent not found');
+    });
+
+    it('should delete an existing agent', async () => {
+      const agentInput: StorageCreateAgentInput = {
+        id: 'agent-1',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: { provider: 'openai', name: 'gpt-4' },
+      };
+
+      await storage.createAgent({ agent: agentInput });
+      expect(collection.has('agent-1')).toBe(true);
+
+      await storage.deleteAgent({ id: 'agent-1' });
+      expect(collection.has('agent-1')).toBe(false);
+    });
+  });
+
+  describe('listAgents', () => {
+    const createMultipleAgents = async () => {
+      const agents: StorageCreateAgentInput[] = [
+        {
+          id: 'agent-1',
+          name: 'Agent One',
+          instructions: 'Instructions 1',
+          model: { provider: 'openai', name: 'gpt-4' },
+        },
+        {
+          id: 'agent-2',
+          name: 'Agent Two',
+          instructions: 'Instructions 2',
+          model: { provider: 'openai', name: 'gpt-4' },
+        },
+        {
+          id: 'agent-3',
+          name: 'Agent Three',
+          instructions: 'Instructions 3',
+          model: { provider: 'anthropic', name: 'claude-3' },
+        },
+      ];
+
+      // Create agents with different timestamps
+      for (let i = 0; i < agents.length; i++) {
+        vi.setSystemTime(new Date(initialDate.getTime() + i * 1000));
+        await storage.createAgent({ agent: agents[i]! });
+      }
+
+      return agents;
+    };
+
+    it('should return empty list when no agents exist', async () => {
+      const result = await storage.listAgents();
+
+      expect(result).toEqual({
+        agents: [],
+        total: 0,
+        page: 0,
+        perPage: 100,
+        hasMore: false,
+      });
+    });
+
+    it('should return all agents with default pagination', async () => {
+      await createMultipleAgents();
+
+      const result = await storage.listAgents();
+
+      expect(result.agents.length).toBe(3);
+      expect(result.total).toBe(3);
+      expect(result.page).toBe(0);
+      expect(result.perPage).toBe(100);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('should paginate results correctly', async () => {
+      await createMultipleAgents();
+
+      const page1 = await storage.listAgents({ page: 0, perPage: 2 });
+      expect(page1.agents.length).toBe(2);
+      expect(page1.hasMore).toBe(true);
+
+      const page2 = await storage.listAgents({ page: 1, perPage: 2 });
+      expect(page2.agents.length).toBe(1);
+      expect(page2.hasMore).toBe(false);
+    });
+
+    it('should return all agents when perPage is false', async () => {
+      await createMultipleAgents();
+
+      const result = await storage.listAgents({ perPage: false });
+
+      expect(result.agents.length).toBe(3);
+      expect(result.perPage).toBe(false);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('should sort agents by createdAt descending by default', async () => {
+      await createMultipleAgents();
+
+      const result = await storage.listAgents();
+
+      // Default sort is DESC, so newest first
+      expect(result.agents[0]?.id).toBe('agent-3');
+      expect(result.agents[2]?.id).toBe('agent-1');
+    });
+
+    it('should sort agents by createdAt ascending when specified', async () => {
+      await createMultipleAgents();
+
+      const result = await storage.listAgents({
+        orderBy: { field: 'createdAt', direction: 'ASC' },
+      });
+
+      // ASC sort, so oldest first
+      expect(result.agents[0]?.id).toBe('agent-1');
+      expect(result.agents[2]?.id).toBe('agent-3');
+    });
+
+    it('should throw error for negative page number', async () => {
+      await expect(storage.listAgents({ page: -1 })).rejects.toThrow('page must be >= 0');
+    });
+
+    it('should return cloned agent data', async () => {
+      await createMultipleAgents();
+
+      const result1 = await storage.listAgents();
+      const result2 = await storage.listAgents();
+
+      expect(result1.agents[0]).not.toBe(result2.agents[0]);
+      expect(result1.agents[0]?.model).not.toBe(result2.agents[0]?.model);
+    });
+  });
+});

--- a/packages/core/src/storage/domains/agents/inmemory.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.ts
@@ -28,7 +28,10 @@ export class InMemoryAgentsStorage extends AgentsStorage {
           ...agent,
           metadata: agent.metadata ? { ...agent.metadata } : agent.metadata,
           model: { ...agent.model },
-          tools: agent.tools ? { ...agent.tools } : agent.tools,
+          tools: agent.tools ? [...agent.tools] : agent.tools,
+          workflows: agent.workflows ? [...agent.workflows] : agent.workflows,
+          agents: agent.agents ? [...agent.agents] : agent.agents,
+          scorers: agent.scorers ? { ...agent.scorers } : agent.scorers,
         }
       : null;
   }
@@ -119,7 +122,10 @@ export class InMemoryAgentsStorage extends AgentsStorage {
       ...agent,
       metadata: agent.metadata ? { ...agent.metadata } : agent.metadata,
       model: { ...agent.model },
-      tools: agent.tools ? { ...agent.tools } : agent.tools,
+      tools: agent.tools ? [...agent.tools] : agent.tools,
+      workflows: agent.workflows ? [...agent.workflows] : agent.workflows,
+      agents: agent.agents ? [...agent.agents] : agent.agents,
+      scorers: agent.scorers ? { ...agent.scorers } : agent.scorers,
     }));
 
     const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);

--- a/packages/core/src/storage/domains/agents/inmemory.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.ts
@@ -1,0 +1,152 @@
+import { normalizePerPage, calculatePagination } from '../../base';
+import type {
+  StorageAgentType,
+  StorageCreateAgentInput,
+  StorageUpdateAgentInput,
+  StorageListAgentsInput,
+  StorageListAgentsOutput,
+  ThreadOrderBy,
+  ThreadSortDirection,
+} from '../../types';
+import { AgentsStorage } from './base';
+
+export type InMemoryAgents = Map<string, StorageAgentType>;
+
+export class InMemoryAgentsStorage extends AgentsStorage {
+  private collection: InMemoryAgents;
+
+  constructor({ collection }: { collection: InMemoryAgents }) {
+    super();
+    this.collection = collection;
+  }
+
+  async getAgentById({ id }: { id: string }): Promise<StorageAgentType | null> {
+    this.logger.debug(`InMemoryAgentsStorage: getAgentById called for ${id}`);
+    const agent = this.collection.get(id);
+    return agent
+      ? {
+          ...agent,
+          metadata: agent.metadata ? { ...agent.metadata } : agent.metadata,
+          model: { ...agent.model },
+          tools: agent.tools ? { ...agent.tools } : agent.tools,
+        }
+      : null;
+  }
+
+  async createAgent({ agent }: { agent: StorageCreateAgentInput }): Promise<StorageAgentType> {
+    this.logger.debug(`InMemoryAgentsStorage: createAgent called for ${agent.id}`);
+
+    if (this.collection.has(agent.id)) {
+      throw new Error(`Agent with id ${agent.id} already exists`);
+    }
+
+    const now = new Date();
+    const newAgent: StorageAgentType = {
+      ...agent,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.collection.set(agent.id, newAgent);
+    return { ...newAgent };
+  }
+
+  async updateAgent({ id, ...updates }: StorageUpdateAgentInput): Promise<StorageAgentType> {
+    this.logger.debug(`InMemoryAgentsStorage: updateAgent called for ${id}`);
+
+    const existingAgent = this.collection.get(id);
+    if (!existingAgent) {
+      throw new Error(`Agent with id ${id} not found`);
+    }
+
+    const updatedAgent: StorageAgentType = {
+      ...existingAgent,
+      ...(updates.name !== undefined && { name: updates.name }),
+      ...(updates.description !== undefined && { description: updates.description }),
+      ...(updates.instructions !== undefined && { instructions: updates.instructions }),
+      ...(updates.model !== undefined && { model: updates.model }),
+      ...(updates.tools !== undefined && { tools: updates.tools }),
+      ...(updates.defaultOptions !== undefined && {
+        defaultOptions: updates.defaultOptions,
+      }),
+      ...(updates.workflows !== undefined && { workflows: updates.workflows }),
+      ...(updates.agents !== undefined && { agents: updates.agents }),
+      ...(updates.inputProcessors !== undefined && { inputProcessors: updates.inputProcessors }),
+      ...(updates.outputProcessors !== undefined && { outputProcessors: updates.outputProcessors }),
+      ...(updates.memory !== undefined && { memory: updates.memory }),
+      ...(updates.scorers !== undefined && { scorers: updates.scorers }),
+      ...(updates.metadata !== undefined && {
+        metadata: { ...existingAgent.metadata, ...updates.metadata },
+      }),
+      updatedAt: new Date(),
+    };
+
+    this.collection.set(id, updatedAgent);
+    return { ...updatedAgent };
+  }
+
+  async deleteAgent({ id }: { id: string }): Promise<void> {
+    this.logger.debug(`InMemoryAgentsStorage: deleteAgent called for ${id}`);
+
+    if (!this.collection.has(id)) {
+      throw new Error(`Agent with id ${id} not found`);
+    }
+
+    this.collection.delete(id);
+  }
+
+  async listAgents(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput> {
+    const { page = 0, perPage: perPageInput, orderBy } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    this.logger.debug(`InMemoryAgentsStorage: listAgents called`);
+
+    // Normalize perPage for query (false → MAX_SAFE_INTEGER, 0 → 0, undefined → 100)
+    const perPage = normalizePerPage(perPageInput, 100);
+
+    if (page < 0) {
+      throw new Error('page must be >= 0');
+    }
+
+    // Prevent unreasonably large page values
+    const maxOffset = Number.MAX_SAFE_INTEGER / 2;
+    if (page * perPage > maxOffset) {
+      throw new Error('page value too large');
+    }
+
+    // Get all agents and sort them
+    const agents = Array.from(this.collection.values());
+    const sortedAgents = this.sortAgents(agents, field, direction);
+
+    // Clone agents to avoid mutation
+    const clonedAgents = sortedAgents.map(agent => ({
+      ...agent,
+      metadata: agent.metadata ? { ...agent.metadata } : agent.metadata,
+      model: { ...agent.model },
+      tools: agent.tools ? { ...agent.tools } : agent.tools,
+    }));
+
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    return {
+      agents: clonedAgents.slice(offset, offset + perPage),
+      total: clonedAgents.length,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + perPage < clonedAgents.length,
+    };
+  }
+
+  private sortAgents(
+    agents: StorageAgentType[],
+    field: ThreadOrderBy,
+    direction: ThreadSortDirection,
+  ): StorageAgentType[] {
+    return agents.sort((a, b) => {
+      const aValue = new Date(a[field]).getTime();
+      const bValue = new Date(b[field]).getTime();
+
+      return direction === 'ASC' ? aValue - bValue : bValue - aValue;
+    });
+  }
+}

--- a/packages/core/src/storage/domains/agents/inmemory.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.ts
@@ -87,11 +87,7 @@ export class InMemoryAgentsStorage extends AgentsStorage {
 
   async deleteAgent({ id }: { id: string }): Promise<void> {
     this.logger.debug(`InMemoryAgentsStorage: deleteAgent called for ${id}`);
-
-    if (!this.collection.has(id)) {
-      throw new Error(`Agent with id ${id} not found`);
-    }
-
+    // Idempotent delete - no-op if agent doesn't exist
     this.collection.delete(id);
   }
 

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -1,3 +1,4 @@
+export * from './agents';
 export * from './scores';
 export * from './observability';
 export * from './operations';

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -16,6 +16,7 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_resources: new Map(),
       mastra_scorers: new Map(),
       mastra_ai_spans: new Map(),
+      mastra_agents: new Map(),
     };
   }
 

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -5,6 +5,8 @@ import type { StepResult, WorkflowRunState } from '../workflows/types';
 import { MastraStorage } from './base';
 import type { StorageDomains } from './base';
 import type { TABLE_NAMES } from './constants';
+import { InMemoryAgentsStorage } from './domains/agents/inmemory';
+import type { InMemoryAgents } from './domains/agents/inmemory';
 import { InMemoryMemory } from './domains/memory/inmemory';
 import type { InMemoryThreads, InMemoryResources, InMemoryMessages } from './domains/memory/inmemory';
 import { ObservabilityInMemory } from './domains/observability/inmemory';
@@ -60,12 +62,18 @@ export class InMemoryStore extends MastraStorage {
       operations: operationsStorage,
     });
 
+    const agentsCollection: InMemoryAgents = new Map();
+    const agentsStorage = new InMemoryAgentsStorage({
+      collection: agentsCollection,
+    });
+
     this.stores = {
       operations: operationsStorage,
       workflows: workflowsStorage,
       scores: scoresStorage,
       memory: memoryStorage,
       observability: observabilityStorage,
+      agents: agentsStorage,
     };
   }
 
@@ -79,6 +87,7 @@ export class InMemoryStore extends MastraStorage {
       observabilityInstance: true,
       indexManagement: false,
       listScoresBySpan: true,
+      agents: true,
     };
   }
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -202,20 +202,48 @@ export interface TracesPaginatedArg {
 }
 
 // Agent Storage Types
+
+/**
+ * Scorer reference with optional sampling configuration
+ */
+export interface StorageScorerConfig {
+  /** Sampling configuration for this scorer */
+  sampling?: {
+    type: 'ratio' | 'count';
+    rate?: number;
+    count?: number;
+  };
+}
+
+/**
+ * Stored agent configuration type.
+ * Primitives (tools, workflows, agents, memory, scorers) are stored as references
+ * that get resolved from Mastra's registries at runtime.
+ */
 export interface StorageAgentType {
   id: string;
   name: string;
   description?: string;
   instructions: string;
+  /** Model configuration (provider, name, etc.) */
   model: Record<string, unknown>;
-  tools?: Record<string, unknown>;
+  /** Array of tool keys to resolve from Mastra's tool registry */
+  tools?: string[];
+  /** Default options for generate/stream calls */
   defaultOptions?: Record<string, unknown>;
-  workflows?: Record<string, unknown>;
-  agents?: Record<string, unknown>;
+  /** Array of workflow keys to resolve from Mastra's workflow registry */
+  workflows?: string[];
+  /** Array of agent keys to resolve from Mastra's agent registry */
+  agents?: string[];
+  /** Input processor configurations */
   inputProcessors?: Record<string, unknown>[];
+  /** Output processor configurations */
   outputProcessors?: Record<string, unknown>[];
-  memory?: Record<string, unknown>;
-  scorers?: Record<string, unknown>;
+  /** Memory key to resolve from Mastra's memory registry */
+  memory?: string;
+  /** Scorer keys with optional sampling config, to resolve from Mastra's scorer registry */
+  scorers?: Record<string, StorageScorerConfig>;
+  /** Additional metadata for the agent */
   metadata?: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
@@ -229,14 +257,19 @@ export type StorageUpdateAgentInput = {
   description?: string;
   instructions?: string;
   model?: Record<string, unknown>;
-  tools?: Record<string, unknown>;
+  /** Array of tool keys to resolve from Mastra's tool registry */
+  tools?: string[];
   defaultOptions?: Record<string, unknown>;
-  workflows?: Record<string, unknown>;
-  agents?: Record<string, unknown>;
+  /** Array of workflow keys to resolve from Mastra's workflow registry */
+  workflows?: string[];
+  /** Array of agent keys to resolve from Mastra's agent registry */
+  agents?: string[];
   inputProcessors?: Record<string, unknown>[];
   outputProcessors?: Record<string, unknown>[];
-  memory?: Record<string, unknown>;
-  scorers?: Record<string, unknown>;
+  /** Memory key to resolve from Mastra's memory registry */
+  memory?: string;
+  /** Scorer keys with optional sampling config */
+  scorers?: Record<string, StorageScorerConfig>;
   metadata?: Record<string, unknown>;
 };
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -201,6 +201,63 @@ export interface TracesPaginatedArg {
   pagination?: PaginationArgs;
 }
 
+// Agent Storage Types
+export interface StorageAgentType {
+  id: string;
+  name: string;
+  description?: string;
+  instructions: string;
+  model: Record<string, unknown>;
+  tools?: Record<string, unknown>;
+  defaultOptions?: Record<string, unknown>;
+  workflows?: Record<string, unknown>;
+  agents?: Record<string, unknown>;
+  inputProcessors?: Record<string, unknown>[];
+  outputProcessors?: Record<string, unknown>[];
+  memory?: Record<string, unknown>;
+  scorers?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type StorageCreateAgentInput = Omit<StorageAgentType, 'createdAt' | 'updatedAt'>;
+
+export type StorageUpdateAgentInput = {
+  id: string;
+  name?: string;
+  description?: string;
+  instructions?: string;
+  model?: Record<string, unknown>;
+  tools?: Record<string, unknown>;
+  defaultOptions?: Record<string, unknown>;
+  workflows?: Record<string, unknown>;
+  agents?: Record<string, unknown>;
+  inputProcessors?: Record<string, unknown>[];
+  outputProcessors?: Record<string, unknown>[];
+  memory?: Record<string, unknown>;
+  scorers?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+};
+
+export type StorageListAgentsInput = {
+  /**
+   * Number of items per page, or `false` to fetch all records without pagination limit.
+   * Defaults to 100 if not specified.
+   */
+  perPage?: number | false;
+  /**
+   * Zero-indexed page number for pagination.
+   * Defaults to 0 if not specified.
+   */
+  page?: number;
+  orderBy?: StorageOrderBy;
+};
+
+export type StorageListAgentsOutput = PaginationInfo & {
+  agents: StorageAgentType[];
+};
+
 // Basic Index Management Types
 export interface CreateIndexOptions {
   name: string;

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -1,0 +1,231 @@
+import { HTTPException } from '../http-exception';
+import {
+  storedAgentIdPathParams,
+  listStoredAgentsQuerySchema,
+  createStoredAgentBodySchema,
+  updateStoredAgentBodySchema,
+  listStoredAgentsResponseSchema,
+  getStoredAgentResponseSchema,
+  createStoredAgentResponseSchema,
+  updateStoredAgentResponseSchema,
+  deleteStoredAgentResponseSchema,
+} from '../schemas/stored-agents';
+import { createRoute } from '../server-adapter/routes/route-builder';
+
+import { handleError } from './error';
+
+// ============================================================================
+// Route Definitions
+// ============================================================================
+
+/**
+ * GET /api/stored/agents - List all stored agents
+ */
+export const LIST_STORED_AGENTS_ROUTE = createRoute({
+  method: 'GET',
+  path: '/api/stored/agents',
+  responseType: 'json',
+  queryParamSchema: listStoredAgentsQuerySchema,
+  responseSchema: listStoredAgentsResponseSchema,
+  summary: 'List stored agents',
+  description: 'Returns a paginated list of all agents stored in the database',
+  tags: ['Stored Agents'],
+  handler: async ({ mastra, page, perPage, orderBy }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(400, { message: 'Storage is not configured' });
+      }
+
+      if (!storage.supports.agents) {
+        throw new HTTPException(400, { message: 'Storage does not support agents' });
+      }
+
+      const result = await storage.listAgents({
+        page,
+        perPage,
+        orderBy,
+      });
+
+      return result;
+    } catch (error) {
+      return handleError(error, 'Error listing stored agents');
+    }
+  },
+});
+
+/**
+ * GET /api/stored/agents/:storedAgentId - Get a stored agent by ID
+ */
+export const GET_STORED_AGENT_ROUTE = createRoute({
+  method: 'GET',
+  path: '/api/stored/agents/:storedAgentId',
+  responseType: 'json',
+  pathParamSchema: storedAgentIdPathParams,
+  responseSchema: getStoredAgentResponseSchema,
+  summary: 'Get stored agent by ID',
+  description: 'Returns a specific agent from storage by its unique identifier',
+  tags: ['Stored Agents'],
+  handler: async ({ mastra, storedAgentId }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(400, { message: 'Storage is not configured' });
+      }
+
+      if (!storage.supports.agents) {
+        throw new HTTPException(400, { message: 'Storage does not support agents' });
+      }
+
+      const agent = await storage.getAgentById({ id: storedAgentId });
+
+      if (!agent) {
+        throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });
+      }
+
+      return agent;
+    } catch (error) {
+      return handleError(error, 'Error getting stored agent');
+    }
+  },
+});
+
+/**
+ * POST /api/stored/agents - Create a new stored agent
+ */
+export const CREATE_STORED_AGENT_ROUTE = createRoute({
+  method: 'POST',
+  path: '/api/stored/agents',
+  responseType: 'json',
+  bodySchema: createStoredAgentBodySchema,
+  responseSchema: createStoredAgentResponseSchema,
+  summary: 'Create stored agent',
+  description: 'Creates a new agent in storage with the provided configuration',
+  tags: ['Stored Agents'],
+  handler: async ({ mastra, ...agentData }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(400, { message: 'Storage is not configured' });
+      }
+
+      if (!storage.supports.agents) {
+        throw new HTTPException(400, { message: 'Storage does not support agents' });
+      }
+
+      // Check if agent with this ID already exists
+      const existing = await storage.getAgentById({ id: agentData.id });
+      if (existing) {
+        throw new HTTPException(409, { message: `Agent with id ${agentData.id} already exists` });
+      }
+
+      const agent = await storage.createAgent({
+        agent: {
+          id: agentData.id,
+          name: agentData.name,
+          description: agentData.description,
+          instructions: agentData.instructions,
+          model: agentData.model,
+          tools: agentData.tools,
+          defaultOptions: agentData.defaultOptions,
+          workflows: agentData.workflows,
+          agents: agentData.agents,
+          inputProcessors: agentData.inputProcessors,
+          outputProcessors: agentData.outputProcessors,
+          memory: agentData.memory,
+          scorers: agentData.scorers,
+          metadata: agentData.metadata,
+        },
+      });
+
+      return agent;
+    } catch (error) {
+      return handleError(error, 'Error creating stored agent');
+    }
+  },
+});
+
+/**
+ * PATCH /api/stored/agents/:storedAgentId - Update a stored agent
+ */
+export const UPDATE_STORED_AGENT_ROUTE = createRoute({
+  method: 'PATCH',
+  path: '/api/stored/agents/:storedAgentId',
+  responseType: 'json',
+  pathParamSchema: storedAgentIdPathParams,
+  bodySchema: updateStoredAgentBodySchema,
+  responseSchema: updateStoredAgentResponseSchema,
+  summary: 'Update stored agent',
+  description: 'Updates an existing agent in storage with the provided fields',
+  tags: ['Stored Agents'],
+  handler: async ({ mastra, storedAgentId, ...updates }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(400, { message: 'Storage is not configured' });
+      }
+
+      if (!storage.supports.agents) {
+        throw new HTTPException(400, { message: 'Storage does not support agents' });
+      }
+
+      // Check if agent exists
+      const existing = await storage.getAgentById({ id: storedAgentId });
+      if (!existing) {
+        throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });
+      }
+
+      const agent = await storage.updateAgent({
+        id: storedAgentId,
+        ...updates,
+      });
+
+      return agent;
+    } catch (error) {
+      return handleError(error, 'Error updating stored agent');
+    }
+  },
+});
+
+/**
+ * DELETE /api/stored/agents/:storedAgentId - Delete a stored agent
+ */
+export const DELETE_STORED_AGENT_ROUTE = createRoute({
+  method: 'DELETE',
+  path: '/api/stored/agents/:storedAgentId',
+  responseType: 'json',
+  pathParamSchema: storedAgentIdPathParams,
+  responseSchema: deleteStoredAgentResponseSchema,
+  summary: 'Delete stored agent',
+  description: 'Deletes an agent from storage by its unique identifier',
+  tags: ['Stored Agents'],
+  handler: async ({ mastra, storedAgentId }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(400, { message: 'Storage is not configured' });
+      }
+
+      if (!storage.supports.agents) {
+        throw new HTTPException(400, { message: 'Storage does not support agents' });
+      }
+
+      // Check if agent exists
+      const existing = await storage.getAgentById({ id: storedAgentId });
+      if (!existing) {
+        throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });
+      }
+
+      await storage.deleteAgent({ id: storedAgentId });
+
+      return { success: true, message: `Agent ${storedAgentId} deleted successfully` };
+    } catch (error) {
+      return handleError(error, 'Error deleting stored agent');
+    }
+  },
+});

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -104,7 +104,23 @@ export const CREATE_STORED_AGENT_ROUTE = createRoute({
   summary: 'Create stored agent',
   description: 'Creates a new agent in storage with the provided configuration',
   tags: ['Stored Agents'],
-  handler: async ({ mastra, ...agentData }) => {
+  handler: async ({
+    mastra,
+    id,
+    name,
+    description,
+    instructions,
+    model,
+    tools,
+    defaultOptions,
+    workflows,
+    agents,
+    inputProcessors,
+    outputProcessors,
+    memory,
+    scorers,
+    metadata,
+  }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -117,27 +133,30 @@ export const CREATE_STORED_AGENT_ROUTE = createRoute({
       }
 
       // Check if agent with this ID already exists
-      const existing = await storage.getAgentById({ id: agentData.id });
+      const existing = await storage.getAgentById({ id });
       if (existing) {
-        throw new HTTPException(409, { message: `Agent with id ${agentData.id} already exists` });
+        throw new HTTPException(409, { message: `Agent with id ${id} already exists` });
       }
+
+      // Only include tools if it's actually an array from the body (not {} from adapter)
+      const toolsFromBody = Array.isArray(tools) ? tools : undefined;
 
       const agent = await storage.createAgent({
         agent: {
-          id: agentData.id,
-          name: agentData.name,
-          description: agentData.description,
-          instructions: agentData.instructions,
-          model: agentData.model,
-          tools: agentData.tools,
-          defaultOptions: agentData.defaultOptions,
-          workflows: agentData.workflows,
-          agents: agentData.agents,
-          inputProcessors: agentData.inputProcessors,
-          outputProcessors: agentData.outputProcessors,
-          memory: agentData.memory,
-          scorers: agentData.scorers,
-          metadata: agentData.metadata,
+          id,
+          name,
+          description,
+          instructions,
+          model,
+          tools: toolsFromBody,
+          defaultOptions,
+          workflows,
+          agents,
+          inputProcessors,
+          outputProcessors,
+          memory,
+          scorers,
+          metadata,
         },
       });
 
@@ -161,7 +180,23 @@ export const UPDATE_STORED_AGENT_ROUTE = createRoute({
   summary: 'Update stored agent',
   description: 'Updates an existing agent in storage with the provided fields',
   tags: ['Stored Agents'],
-  handler: async ({ mastra, storedAgentId, ...updates }) => {
+  handler: async ({
+    mastra,
+    storedAgentId,
+    name,
+    description,
+    instructions,
+    model,
+    tools,
+    defaultOptions,
+    workflows,
+    agents,
+    inputProcessors,
+    outputProcessors,
+    memory,
+    scorers,
+    metadata,
+  }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -179,9 +214,24 @@ export const UPDATE_STORED_AGENT_ROUTE = createRoute({
         throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });
       }
 
+      // Only include tools if it's actually an array from the body (not {} from adapter)
+      const toolsFromBody = Array.isArray(tools) ? tools : undefined;
+
       const agent = await storage.updateAgent({
         id: storedAgentId,
-        ...updates,
+        name,
+        description,
+        instructions,
+        model,
+        tools: toolsFromBody,
+        defaultOptions,
+        workflows,
+        agents,
+        inputProcessors,
+        outputProcessors,
+        memory,
+        scorers,
+        metadata,
       });
 
       return agent;

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -1,0 +1,110 @@
+import z from 'zod';
+import { paginationInfoSchema, createPagePaginationSchema } from './common';
+
+// ============================================================================
+// Path Parameter Schemas
+// ============================================================================
+
+/**
+ * Path parameter for stored agent ID
+ */
+export const storedAgentIdPathParams = z.object({
+  storedAgentId: z.string().describe('Unique identifier for the stored agent'),
+});
+
+// ============================================================================
+// Query Parameter Schemas
+// ============================================================================
+
+/**
+ * Storage order by configuration
+ */
+const storageOrderBySchema = z.object({
+  field: z.enum(['createdAt', 'updatedAt']).optional(),
+  direction: z.enum(['ASC', 'DESC']).optional(),
+});
+
+/**
+ * GET /api/storage/agents - List stored agents
+ */
+export const listStoredAgentsQuerySchema = createPagePaginationSchema(100).extend({
+  orderBy: storageOrderBySchema.optional(),
+});
+
+// ============================================================================
+// Body Parameter Schemas
+// ============================================================================
+
+/**
+ * Base stored agent schema (shared fields)
+ */
+const storedAgentBaseSchema = z.object({
+  name: z.string().describe('Name of the agent'),
+  description: z.string().optional().describe('Description of the agent'),
+  instructions: z.string().describe('System instructions for the agent'),
+  model: z.record(z.string(), z.unknown()).describe('Model configuration (provider, name, etc.)'),
+  tools: z.record(z.string(), z.unknown()).optional().describe('Serialized tool references/configurations'),
+  defaultOptions: z.record(z.string(), z.unknown()).optional().describe('Default options for generate/stream calls'),
+  workflows: z.record(z.string(), z.unknown()).optional().describe('Workflow references (IDs or configurations)'),
+  agents: z.record(z.string(), z.unknown()).optional().describe('Sub-agent references (IDs or configurations)'),
+  inputProcessors: z.array(z.record(z.string(), z.unknown())).optional().describe('Input processor configurations'),
+  outputProcessors: z.array(z.record(z.string(), z.unknown())).optional().describe('Output processor configurations'),
+  memory: z.record(z.string(), z.unknown()).optional().describe('Memory configuration'),
+  scorers: z.record(z.string(), z.unknown()).optional().describe('Scorer configurations'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Additional metadata for the agent'),
+});
+
+/**
+ * POST /api/storage/agents - Create stored agent body
+ */
+export const createStoredAgentBodySchema = storedAgentBaseSchema.extend({
+  id: z.string().describe('Unique identifier for the agent'),
+});
+
+/**
+ * PATCH /api/storage/agents/:storedAgentId - Update stored agent body
+ */
+export const updateStoredAgentBodySchema = storedAgentBaseSchema.partial();
+
+// ============================================================================
+// Response Schemas
+// ============================================================================
+
+/**
+ * Stored agent object schema (full response)
+ */
+export const storedAgentSchema = storedAgentBaseSchema.extend({
+  id: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+/**
+ * Response for GET /api/storage/agents
+ */
+export const listStoredAgentsResponseSchema = paginationInfoSchema.extend({
+  agents: z.array(storedAgentSchema),
+});
+
+/**
+ * Response for GET /api/storage/agents/:storedAgentId
+ */
+export const getStoredAgentResponseSchema = storedAgentSchema;
+
+/**
+ * Response for POST /api/storage/agents
+ */
+export const createStoredAgentResponseSchema = storedAgentSchema;
+
+/**
+ * Response for PATCH /api/storage/agents/:storedAgentId
+ */
+export const updateStoredAgentResponseSchema = storedAgentSchema;
+
+/**
+ * Response for DELETE /api/storage/agents/:storedAgentId
+ */
+export const deleteStoredAgentResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -36,6 +36,19 @@ export const listStoredAgentsQuerySchema = createPagePaginationSchema(100).exten
 // ============================================================================
 
 /**
+ * Scorer config schema with optional sampling
+ */
+const scorerConfigSchema = z.object({
+  sampling: z
+    .object({
+      type: z.enum(['ratio', 'count']),
+      rate: z.number().optional(),
+      count: z.number().optional(),
+    })
+    .optional(),
+});
+
+/**
  * Base stored agent schema (shared fields)
  */
 const storedAgentBaseSchema = z.object({
@@ -43,14 +56,14 @@ const storedAgentBaseSchema = z.object({
   description: z.string().optional().describe('Description of the agent'),
   instructions: z.string().describe('System instructions for the agent'),
   model: z.record(z.string(), z.unknown()).describe('Model configuration (provider, name, etc.)'),
-  tools: z.record(z.string(), z.unknown()).optional().describe('Serialized tool references/configurations'),
+  tools: z.array(z.string()).optional().describe('Array of tool keys to resolve from Mastra registry'),
   defaultOptions: z.record(z.string(), z.unknown()).optional().describe('Default options for generate/stream calls'),
-  workflows: z.record(z.string(), z.unknown()).optional().describe('Workflow references (IDs or configurations)'),
-  agents: z.record(z.string(), z.unknown()).optional().describe('Sub-agent references (IDs or configurations)'),
+  workflows: z.array(z.string()).optional().describe('Array of workflow keys to resolve from Mastra registry'),
+  agents: z.array(z.string()).optional().describe('Array of agent keys to resolve from Mastra registry'),
   inputProcessors: z.array(z.record(z.string(), z.unknown())).optional().describe('Input processor configurations'),
   outputProcessors: z.array(z.record(z.string(), z.unknown())).optional().describe('Output processor configurations'),
-  memory: z.record(z.string(), z.unknown()).optional().describe('Memory configuration'),
-  scorers: z.record(z.string(), z.unknown()).optional().describe('Scorer configurations'),
+  memory: z.string().optional().describe('Memory key to resolve from Mastra registry'),
+  scorers: z.record(z.string(), scorerConfigSchema).optional().describe('Scorer keys with optional sampling config'),
   metadata: z.record(z.string(), z.unknown()).optional().describe('Additional metadata for the agent'),
 });
 

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -13,6 +13,7 @@ import { MCP_ROUTES } from './mcp';
 import { MEMORY_ROUTES } from './memory';
 import { OBSERVABILITY_ROUTES } from './observability';
 import { SCORES_ROUTES } from './scorers';
+import { STORED_AGENTS_ROUTES } from './stored-agents';
 import type { MastraStreamReturn } from './stream-types';
 import { TOOLS_ROUTES } from './tools';
 import { VECTORS_ROUTES } from './vectors';
@@ -97,6 +98,7 @@ export const SERVER_ROUTES: ServerRoute<any, any, any>[] = [
   ...AGENT_BUILDER_ROUTES,
   ...LEGACY_ROUTES,
   ...MCP_ROUTES,
+  ...STORED_AGENTS_ROUTES,
 ];
 
 // Export route builder and OpenAPI utilities

--- a/packages/server/src/server/server-adapter/routes/stored-agents.ts
+++ b/packages/server/src/server/server-adapter/routes/stored-agents.ts
@@ -1,0 +1,24 @@
+import {
+  LIST_STORED_AGENTS_ROUTE,
+  GET_STORED_AGENT_ROUTE,
+  CREATE_STORED_AGENT_ROUTE,
+  UPDATE_STORED_AGENT_ROUTE,
+  DELETE_STORED_AGENT_ROUTE,
+} from '../../handlers/stored-agents';
+import type { ServerRoute } from '.';
+
+/**
+ * Routes for stored agents CRUD operations.
+ * These routes provide API access to agent configurations stored in the database,
+ * enabling dynamic creation and management of agents via Mastra Studio.
+ */
+export const STORED_AGENTS_ROUTES: ServerRoute<any, any, any>[] = [
+  // ============================================================================
+  // Stored Agents CRUD Routes
+  // ============================================================================
+  LIST_STORED_AGENTS_ROUTE,
+  GET_STORED_AGENT_ROUTE,
+  CREATE_STORED_AGENT_ROUTE,
+  UPDATE_STORED_AGENT_ROUTE,
+  DELETE_STORED_AGENT_ROUTE,
+];

--- a/server-adapters/_test-utils/src/route-test-utils.ts
+++ b/server-adapters/_test-utils/src/route-test-utils.ts
@@ -158,6 +158,7 @@ export function getDefaultValidPathParams(route: ServerRoute): Record<string, an
   if (route.path.includes(':entityType')) params.entityType = 'AGENT';
   if (route.path.includes(':entityId')) params.entityId = 'test-agent';
   if (route.path.includes(':actionId')) params.actionId = 'merge-template';
+  if (route.path.includes(':storedAgentId')) params.storedAgentId = 'test-stored-agent';
 
   // MCP route params - need to get actual server ID from test context
   if (route.path.includes(':id') && route.path.includes('/mcp/v0/servers/')) params.id = 'test-server-1';

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -422,6 +422,19 @@ export async function createDefaultTestContext(): Promise<AdapterTestContext> {
       error: null,
       isEvent: false,
     });
+
+    // Add test stored agent for stored agents routes
+    if (storage.supports.agents) {
+      await storage.createAgent({
+        agent: {
+          id: 'test-stored-agent',
+          name: 'Test Stored Agent',
+          description: 'A test stored agent for integration tests',
+          instructions: 'Test instructions for stored agent',
+          model: { provider: 'openai', name: 'gpt-4o' },
+        },
+      });
+    }
   }
 
   return {

--- a/stores/_test-utils/src/domains/agents/data.ts
+++ b/stores/_test-utils/src/domains/agents/data.ts
@@ -55,35 +55,18 @@ export const createFullSampleAgent = ({
     temperature: 0.7,
     maxTokens: 2000,
   },
-  tools: {
-    calculator: {
-      type: 'function',
-      description: 'Performs calculations',
-    },
-    webSearch: {
-      type: 'function',
-      description: 'Searches the web',
-    },
-  },
+  tools: ['calculator', 'webSearch'],
   defaultOptions: {
     maxSteps: 5,
     temperature: 0.5,
   },
-  workflows: {
-    orderProcessing: { id: 'order-workflow' },
-    customerSupport: { id: 'support-workflow' },
-  },
-  agents: {
-    subAgent: { id: 'helper-agent' },
-  },
+  workflows: ['order-workflow', 'support-workflow'],
+  agents: ['helper-agent'],
   inputProcessors: [{ type: 'sanitize', config: { stripHtml: true } }],
   outputProcessors: [{ type: 'format', config: { style: 'markdown' } }],
-  memory: {
-    type: 'thread',
-    maxMessages: 100,
-  },
+  memory: 'thread-memory',
   scorers: {
-    relevance: { threshold: 0.8 },
+    relevance: { sampling: { type: 'ratio', rate: 0.8 } },
   },
   metadata: {
     category: 'test',

--- a/stores/_test-utils/src/domains/agents/data.ts
+++ b/stores/_test-utils/src/domains/agents/data.ts
@@ -1,0 +1,115 @@
+import type { StorageCreateAgentInput } from '@mastra/core/storage';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Creates a sample agent input for testing storage operations.
+ * @param overrides - Optional fields to override the default values
+ */
+export const createSampleAgent = ({
+  id = `agent-${randomUUID()}`,
+  name = 'Test Agent',
+  description,
+  instructions = 'You are a helpful assistant',
+  model = { provider: 'openai', name: 'gpt-4' },
+  tools,
+  defaultOptions,
+  workflows,
+  agents,
+  inputProcessors,
+  outputProcessors,
+  memory,
+  scorers,
+  metadata,
+}: Partial<StorageCreateAgentInput> = {}): StorageCreateAgentInput => ({
+  id,
+  name,
+  ...(description && { description }),
+  instructions,
+  model,
+  ...(tools && { tools }),
+  ...(defaultOptions && { defaultOptions }),
+  ...(workflows && { workflows }),
+  ...(agents && { agents }),
+  ...(inputProcessors && { inputProcessors }),
+  ...(outputProcessors && { outputProcessors }),
+  ...(memory && { memory }),
+  ...(scorers && { scorers }),
+  ...(metadata && { metadata }),
+});
+
+/**
+ * Creates a sample agent with all fields populated for comprehensive testing.
+ */
+export const createFullSampleAgent = ({
+  id = `agent-${randomUUID()}`,
+}: {
+  id?: string;
+} = {}): StorageCreateAgentInput => ({
+  id,
+  name: 'Full Test Agent',
+  description: 'A fully configured test agent with all fields',
+  instructions: 'You are a comprehensive test assistant with multiple capabilities',
+  model: {
+    provider: 'openai',
+    name: 'gpt-4',
+    temperature: 0.7,
+    maxTokens: 2000,
+  },
+  tools: {
+    calculator: {
+      type: 'function',
+      description: 'Performs calculations',
+    },
+    webSearch: {
+      type: 'function',
+      description: 'Searches the web',
+    },
+  },
+  defaultOptions: {
+    maxSteps: 5,
+    temperature: 0.5,
+  },
+  workflows: {
+    orderProcessing: { id: 'order-workflow' },
+    customerSupport: { id: 'support-workflow' },
+  },
+  agents: {
+    subAgent: { id: 'helper-agent' },
+  },
+  inputProcessors: [{ type: 'sanitize', config: { stripHtml: true } }],
+  outputProcessors: [{ type: 'format', config: { style: 'markdown' } }],
+  memory: {
+    type: 'thread',
+    maxMessages: 100,
+  },
+  scorers: {
+    relevance: { threshold: 0.8 },
+  },
+  metadata: {
+    category: 'test',
+    version: '1.0.0',
+    tags: ['testing', 'sample'],
+    createdBy: 'test-suite',
+  },
+});
+
+/**
+ * Creates multiple sample agents for pagination and list testing.
+ * @param count - Number of agents to create
+ */
+export const createSampleAgents = (count: number): StorageCreateAgentInput[] => {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `agent-${randomUUID()}`,
+    name: `Test Agent ${i + 1}`,
+    description: `Description for agent ${i + 1}`,
+    instructions: `Instructions for agent ${i + 1}`,
+    model: {
+      provider: i % 2 === 0 ? 'openai' : 'anthropic',
+      name: i % 2 === 0 ? 'gpt-4' : 'claude-3',
+    },
+    metadata: {
+      index: i + 1,
+      createdOrder: i,
+    },
+  }));
+};

--- a/stores/_test-utils/src/domains/agents/index.ts
+++ b/stores/_test-utils/src/domains/agents/index.ts
@@ -213,6 +213,22 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
         const afterDelete = await storage.getAgentById({ id: agent.id });
         expect(afterDelete).toBeNull();
       });
+
+      it('should be idempotent when deleting non-existent agent', async () => {
+        // Deleting a non-existent agent should not throw - it's a no-op
+        await expect(storage.deleteAgent({ id: 'non-existent-agent-id' })).resolves.toBeUndefined();
+      });
+
+      it('should be idempotent when deleting same agent twice', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        // First delete
+        await storage.deleteAgent({ id: agent.id });
+
+        // Second delete should not throw
+        await expect(storage.deleteAgent({ id: agent.id })).resolves.toBeUndefined();
+      });
     });
 
     describe('listAgents', () => {

--- a/stores/_test-utils/src/domains/agents/index.ts
+++ b/stores/_test-utils/src/domains/agents/index.ts
@@ -1,0 +1,433 @@
+import { TABLE_AGENTS, type MastraStorage } from '@mastra/core/storage';
+import { createSampleAgent, createFullSampleAgent, createSampleAgents } from './data';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+export function createAgentsTests({ storage }: { storage: MastraStorage }) {
+  // Skip tests if storage doesn't support agents
+  const describeAgents = storage.supports.agents ? describe : describe.skip;
+
+  describeAgents('Agents Storage', () => {
+    beforeAll(async () => {
+      const start = Date.now();
+      console.log('Clearing agents table before tests');
+      await storage.clearTable({ tableName: TABLE_AGENTS });
+      const end = Date.now();
+      console.log(`Agents table cleared in ${end - start}ms`);
+    });
+
+    describe('createAgent', () => {
+      it('should create and retrieve an agent', async () => {
+        const agent = createSampleAgent();
+
+        const savedAgent = await storage.createAgent({ agent });
+
+        expect(savedAgent.id).toBe(agent.id);
+        expect(savedAgent.name).toBe(agent.name);
+        expect(savedAgent.instructions).toBe(agent.instructions);
+        expect(savedAgent.model).toEqual(agent.model);
+        expect(savedAgent.createdAt).toBeInstanceOf(Date);
+        expect(savedAgent.updatedAt).toBeInstanceOf(Date);
+
+        // Retrieve and verify
+        const retrievedAgent = await storage.getAgentById({ id: agent.id });
+        expect(retrievedAgent).toBeDefined();
+        expect(retrievedAgent?.name).toBe(agent.name);
+      });
+
+      it('should create agent with all optional fields', async () => {
+        const agent = createFullSampleAgent();
+
+        const savedAgent = await storage.createAgent({ agent });
+
+        expect(savedAgent.id).toBe(agent.id);
+        expect(savedAgent.name).toBe(agent.name);
+        expect(savedAgent.description).toBe(agent.description);
+        expect(savedAgent.instructions).toBe(agent.instructions);
+        expect(savedAgent.model).toEqual(agent.model);
+        expect(savedAgent.tools).toEqual(agent.tools);
+        expect(savedAgent.defaultOptions).toEqual(agent.defaultOptions);
+        expect(savedAgent.workflows).toEqual(agent.workflows);
+        expect(savedAgent.agents).toEqual(agent.agents);
+        expect(savedAgent.inputProcessors).toEqual(agent.inputProcessors);
+        expect(savedAgent.outputProcessors).toEqual(agent.outputProcessors);
+        expect(savedAgent.memory).toEqual(agent.memory);
+        expect(savedAgent.scorers).toEqual(agent.scorers);
+        expect(savedAgent.metadata).toEqual(agent.metadata);
+      });
+
+      it('should handle agents with minimal required fields', async () => {
+        const minimalAgent = {
+          id: `agent-minimal-${randomUUID()}`,
+          name: 'Minimal Agent',
+          instructions: 'Minimal instructions',
+          model: { provider: 'openai' },
+        };
+
+        const savedAgent = await storage.createAgent({ agent: minimalAgent });
+
+        expect(savedAgent.id).toBe(minimalAgent.id);
+        expect(savedAgent.name).toBe(minimalAgent.name);
+        expect(savedAgent.description).toBeUndefined();
+        expect(savedAgent.tools).toBeUndefined();
+      });
+    });
+
+    describe('getAgentById', () => {
+      it('should return null for non-existent agent', async () => {
+        const result = await storage.getAgentById({ id: 'non-existent-agent' });
+        expect(result).toBeNull();
+      });
+
+      it('should retrieve an existing agent by ID', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        const retrievedAgent = await storage.getAgentById({ id: agent.id });
+
+        expect(retrievedAgent).toBeDefined();
+        expect(retrievedAgent?.id).toBe(agent.id);
+        expect(retrievedAgent?.name).toBe(agent.name);
+        expect(retrievedAgent?.instructions).toBe(agent.instructions);
+      });
+    });
+
+    describe('updateAgent', () => {
+      it('should update agent name', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        const updatedAgent = await storage.updateAgent({
+          id: agent.id,
+          name: 'Updated Agent Name',
+        });
+
+        expect(updatedAgent.name).toBe('Updated Agent Name');
+        expect(updatedAgent.instructions).toBe(agent.instructions); // Unchanged
+
+        // Verify persistence
+        const retrievedAgent = await storage.getAgentById({ id: agent.id });
+        expect(retrievedAgent?.name).toBe('Updated Agent Name');
+      });
+
+      it('should update agent instructions', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        const newInstructions = 'You are an updated expert assistant';
+        const updatedAgent = await storage.updateAgent({
+          id: agent.id,
+          instructions: newInstructions,
+        });
+
+        expect(updatedAgent.instructions).toBe(newInstructions);
+      });
+
+      it('should update agent model', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        const newModel = { provider: 'anthropic', name: 'claude-3-opus' };
+        const updatedAgent = await storage.updateAgent({
+          id: agent.id,
+          model: newModel,
+        });
+
+        expect(updatedAgent.model).toEqual(newModel);
+      });
+
+      it('should merge metadata on update', async () => {
+        const agent = createSampleAgent({
+          metadata: { key1: 'value1', key2: 'value2' },
+        });
+        await storage.createAgent({ agent });
+
+        const updatedAgent = await storage.updateAgent({
+          id: agent.id,
+          metadata: { key2: 'updated', key3: 'value3' },
+        });
+
+        expect(updatedAgent.metadata).toEqual({
+          key1: 'value1',
+          key2: 'updated',
+          key3: 'value3',
+        });
+      });
+
+      it('should update multiple fields at once', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        const updatedAgent = await storage.updateAgent({
+          id: agent.id,
+          name: 'Completely Updated Agent',
+          description: 'New description',
+          instructions: 'New instructions',
+          model: { provider: 'google', name: 'gemini-pro' },
+        });
+
+        expect(updatedAgent.name).toBe('Completely Updated Agent');
+        expect(updatedAgent.description).toBe('New description');
+        expect(updatedAgent.instructions).toBe('New instructions');
+        expect(updatedAgent.model).toEqual({ provider: 'google', name: 'gemini-pro' });
+      });
+
+      it('should update updatedAt timestamp', async () => {
+        const agent = createSampleAgent();
+        const createdAgent = await storage.createAgent({ agent });
+        const originalUpdatedAt = createdAgent.updatedAt;
+
+        // Wait a small amount to ensure different timestamp
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const updatedAgent = await storage.updateAgent({
+          id: agent.id,
+          name: 'Updated Name',
+        });
+
+        const updatedAtTime =
+          updatedAgent.updatedAt instanceof Date
+            ? updatedAgent.updatedAt.getTime()
+            : new Date(updatedAgent.updatedAt).getTime();
+
+        const originalTime =
+          originalUpdatedAt instanceof Date ? originalUpdatedAt.getTime() : new Date(originalUpdatedAt).getTime();
+
+        expect(updatedAtTime).toBeGreaterThan(originalTime);
+      });
+    });
+
+    describe('deleteAgent', () => {
+      it('should delete an existing agent', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        // Verify it exists
+        const beforeDelete = await storage.getAgentById({ id: agent.id });
+        expect(beforeDelete).toBeDefined();
+
+        // Delete
+        await storage.deleteAgent({ id: agent.id });
+
+        // Verify it's gone
+        const afterDelete = await storage.getAgentById({ id: agent.id });
+        expect(afterDelete).toBeNull();
+      });
+    });
+
+    describe('listAgents', () => {
+      beforeEach(async () => {
+        await storage.clearTable({ tableName: TABLE_AGENTS });
+      });
+
+      it('should return empty list when no agents exist', async () => {
+        const result = await storage.listAgents();
+
+        expect(result.agents).toHaveLength(0);
+        expect(result.total).toBe(0);
+        expect(result.hasMore).toBe(false);
+      });
+
+      it('should list all agents with default pagination', async () => {
+        const agents = createSampleAgents(5);
+        for (const agent of agents) {
+          await storage.createAgent({ agent });
+        }
+
+        const result = await storage.listAgents();
+
+        expect(result.agents.length).toBe(5);
+        expect(result.total).toBe(5);
+        expect(result.hasMore).toBe(false);
+      });
+
+      it('should paginate results correctly', async () => {
+        const agents = createSampleAgents(15);
+        for (const agent of agents) {
+          await storage.createAgent({ agent });
+        }
+
+        const page1 = await storage.listAgents({ page: 0, perPage: 5 });
+        expect(page1.agents.length).toBe(5);
+        expect(page1.total).toBe(15);
+        expect(page1.page).toBe(0);
+        expect(page1.perPage).toBe(5);
+        expect(page1.hasMore).toBe(true);
+
+        const page2 = await storage.listAgents({ page: 1, perPage: 5 });
+        expect(page2.agents.length).toBe(5);
+        expect(page2.page).toBe(1);
+        expect(page2.hasMore).toBe(true);
+
+        const page3 = await storage.listAgents({ page: 2, perPage: 5 });
+        expect(page3.agents.length).toBe(5);
+        expect(page3.hasMore).toBe(false);
+      });
+
+      it('should return all agents when perPage is false', async () => {
+        const agents = createSampleAgents(10);
+        for (const agent of agents) {
+          await storage.createAgent({ agent });
+        }
+
+        const result = await storage.listAgents({ perPage: false });
+
+        expect(result.agents.length).toBe(10);
+        expect(result.perPage).toBe(false);
+        expect(result.hasMore).toBe(false);
+      });
+
+      it('should sort agents by createdAt DESC by default', async () => {
+        // Create agents with small delays to ensure different timestamps
+        const agent1 = createSampleAgent({ name: 'First Agent' });
+        await storage.createAgent({ agent: agent1 });
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const agent2 = createSampleAgent({ name: 'Second Agent' });
+        await storage.createAgent({ agent: agent2 });
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const agent3 = createSampleAgent({ name: 'Third Agent' });
+        await storage.createAgent({ agent: agent3 });
+
+        const result = await storage.listAgents();
+
+        // Default sort is DESC, so newest first
+        expect(result.agents[0]?.name).toBe('Third Agent');
+        expect(result.agents[2]?.name).toBe('First Agent');
+      });
+
+      it('should sort agents by createdAt ASC when specified', async () => {
+        // Create agents with small delays
+        const agent1 = createSampleAgent({ name: 'First Agent' });
+        await storage.createAgent({ agent: agent1 });
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const agent2 = createSampleAgent({ name: 'Second Agent' });
+        await storage.createAgent({ agent: agent2 });
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const agent3 = createSampleAgent({ name: 'Third Agent' });
+        await storage.createAgent({ agent: agent3 });
+
+        const result = await storage.listAgents({
+          orderBy: { field: 'createdAt', direction: 'ASC' },
+        });
+
+        // ASC sort, so oldest first
+        expect(result.agents[0]?.name).toBe('First Agent');
+        expect(result.agents[2]?.name).toBe('Third Agent');
+      });
+    });
+
+    describe('Edge Cases and Error Handling', () => {
+      it('should handle large model configurations', async () => {
+        const agent = createSampleAgent({
+          model: {
+            provider: 'openai',
+            name: 'gpt-4',
+            temperature: 0.7,
+            maxTokens: 4000,
+            topP: 0.9,
+            frequencyPenalty: 0.5,
+            presencePenalty: 0.5,
+            customConfig: {
+              nested: {
+                deeply: {
+                  value: 'test',
+                },
+              },
+            },
+          },
+        });
+
+        const savedAgent = await storage.createAgent({ agent });
+        const retrievedAgent = await storage.getAgentById({ id: agent.id });
+
+        expect(retrievedAgent?.model).toEqual(agent.model);
+      });
+
+      it('should handle special characters in instructions', async () => {
+        const specialInstructions = `You are a helpful assistant.
+        Handle these characters: 'quotes' and "double quotes" and emoji 🎉
+        Also: <html> tags & ampersands
+        And unicode: こんにちは`;
+
+        const agent = createSampleAgent({
+          instructions: specialInstructions,
+        });
+
+        await storage.createAgent({ agent });
+        const retrievedAgent = await storage.getAgentById({ id: agent.id });
+
+        expect(retrievedAgent?.instructions).toBe(specialInstructions);
+      });
+
+      it('should handle large metadata objects', async () => {
+        const largeMetadata = {
+          tags: Array.from({ length: 50 }, (_, i) => `tag-${i}`),
+          config: {
+            nested: {
+              array: Array.from({ length: 20 }, (_, i) => ({ index: i, data: 'test'.repeat(10) })),
+            },
+          },
+        };
+
+        const agent = createSampleAgent({
+          metadata: largeMetadata,
+        });
+
+        await storage.createAgent({ agent });
+        const retrievedAgent = await storage.getAgentById({ id: agent.id });
+
+        expect(retrievedAgent?.metadata).toEqual(largeMetadata);
+      });
+
+      it('should handle concurrent agent updates', async () => {
+        const agent = createSampleAgent();
+        await storage.createAgent({ agent });
+
+        // Perform multiple updates concurrently
+        const updates = Array.from({ length: 5 }, (_, i) =>
+          storage.updateAgent({
+            id: agent.id,
+            name: `Update ${i}`,
+            metadata: { update: i },
+          }),
+        );
+
+        await expect(Promise.all(updates)).resolves.toBeDefined();
+
+        // Verify final state exists
+        const finalAgent = await storage.getAgentById({ id: agent.id });
+        expect(finalAgent).toBeDefined();
+      });
+
+      it('should handle tools configuration', async () => {
+        const tools = {
+          calculator: {
+            type: 'function',
+            description: 'Performs mathematical calculations',
+            parameters: {
+              type: 'object',
+              properties: {
+                expression: { type: 'string' },
+              },
+            },
+          },
+          webSearch: {
+            type: 'function',
+            description: 'Searches the web',
+          },
+        };
+
+        const agent = createSampleAgent({ tools });
+
+        await storage.createAgent({ agent });
+        const retrievedAgent = await storage.getAgentById({ id: agent.id });
+
+        expect(retrievedAgent?.tools).toEqual(tools);
+      });
+    });
+  });
+}

--- a/stores/_test-utils/src/domains/agents/index.ts
+++ b/stores/_test-utils/src/domains/agents/index.ts
@@ -420,22 +420,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
       });
 
       it('should handle tools configuration', async () => {
-        const tools = {
-          calculator: {
-            type: 'function',
-            description: 'Performs mathematical calculations',
-            parameters: {
-              type: 'object',
-              properties: {
-                expression: { type: 'string' },
-              },
-            },
-          },
-          webSearch: {
-            type: 'function',
-            description: 'Searches the web',
-          },
-        };
+        const tools = ['calculator', 'webSearch', 'codeInterpreter'];
 
         const agent = createSampleAgent({ tools });
 

--- a/stores/_test-utils/src/domains/agents/index.ts
+++ b/stores/_test-utils/src/domains/agents/index.ts
@@ -341,7 +341,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
           },
         });
 
-        const savedAgent = await storage.createAgent({ agent });
+        await storage.createAgent({ agent });
         const retrievedAgent = await storage.getAgentById({ id: agent.id });
 
         expect(retrievedAgent?.model).toEqual(agent.model);

--- a/stores/_test-utils/src/factory.ts
+++ b/stores/_test-utils/src/factory.ts
@@ -8,16 +8,19 @@ import {
   TABLE_SCORERS,
   TABLE_TRACES,
   TABLE_SPANS,
+  TABLE_AGENTS,
 } from '@mastra/core/storage';
 import { createScoresTest } from './domains/scores';
 import { createMemoryTest } from './domains/memory';
 import { createWorkflowsTests } from './domains/workflows';
 import { createOperationsTests } from './domains/operations';
 import { createObservabilityTests } from './domains/observability';
+import { createAgentsTests } from './domains/agents';
 export * from './domains/memory/data';
 export * from './domains/workflows/data';
 export * from './domains/scores/data';
 export * from './domains/observability/data';
+export * from './domains/agents/data';
 
 export function createTestSuite(storage: MastraStorage) {
   describe(storage.constructor.name, () => {
@@ -39,6 +42,7 @@ export function createTestSuite(storage: MastraStorage) {
         storage.clearTable({ tableName: TABLE_SCORERS }),
         storage.clearTable({ tableName: TABLE_TRACES }),
         storage.supports.observabilityInstance && storage.clearTable({ tableName: TABLE_SPANS }),
+        storage.supports.agents && storage.clearTable({ tableName: TABLE_AGENTS }),
       ]);
     });
 
@@ -53,5 +57,8 @@ export function createTestSuite(storage: MastraStorage) {
     if (storage.supports.observabilityInstance) {
       createObservabilityTests({ storage });
     }
+
+    // Agents tests are conditionally run based on storage.supports.agents inside the test suite
+    createAgentsTests({ storage });
   });
 }

--- a/stores/clickhouse/src/storage/domains/utils.ts
+++ b/stores/clickhouse/src/storage/domains/utils.ts
@@ -19,6 +19,7 @@ export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_RESOURCES]: `ReplacingMergeTree()`,
   // TODO: verify this is the correct engine for Spans when implementing clickhouse storage
   [TABLE_SPANS]: `ReplacingMergeTree()`,
+  mastra_agents: `ReplacingMergeTree()`,
 };
 
 export const COLUMN_TYPES: Record<StorageColumn['type'], string> = {

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -11,7 +11,9 @@ import type {
   StorageResourceType,
   TABLE_SCORERS,
   TABLE_SPANS,
+  TABLE_AGENTS,
   SpanRecord,
+  StorageAgentType,
 } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 
@@ -105,6 +107,7 @@ export type RecordTypes = {
   [TABLE_TRACES]: any;
   [TABLE_RESOURCES]: StorageResourceType;
   [TABLE_SPANS]: SpanRecord;
+  [TABLE_AGENTS]: StorageAgentType;
 };
 
 export type ListOptions = {

--- a/stores/dynamodb/src/storage/domains/operations/index.ts
+++ b/stores/dynamodb/src/storage/domains/operations/index.ts
@@ -50,6 +50,7 @@ export class StoreOperationsDynamoDB extends StoreOperations {
       [TABLE_TRACES]: 'trace',
       [TABLE_RESOURCES]: 'resource',
       [TABLE_SPANS]: 'ai_span',
+      mastra_agents: 'agent',
     };
     return mapping[tableName] || null;
   }

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -1,0 +1,336 @@
+import type { Client, InValue } from '@libsql/client';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  AgentsStorage,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_AGENTS,
+} from '@mastra/core/storage';
+import type {
+  StorageAgentType,
+  StorageCreateAgentInput,
+  StorageUpdateAgentInput,
+  StorageListAgentsInput,
+  StorageListAgentsOutput,
+} from '@mastra/core/storage';
+import type { StoreOperationsLibSQL } from '../operations';
+
+export class AgentsLibSQL extends AgentsStorage {
+  private client: Client;
+
+  constructor({ client, operations: _ }: { client: Client; operations: StoreOperationsLibSQL }) {
+    super();
+    this.client = client;
+  }
+
+  private parseJson(value: any): any {
+    if (!value) return undefined;
+    return typeof value === 'string' ? JSON.parse(value) : value;
+  }
+
+  private parseRow(row: any): StorageAgentType {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      description: row.description as string | undefined,
+      instructions: row.instructions as string,
+      model: typeof row.model === 'string' ? JSON.parse(row.model) : row.model,
+      tools: this.parseJson(row.tools),
+      defaultOptions: this.parseJson(row.defaultOptions),
+      workflows: this.parseJson(row.workflows),
+      agents: this.parseJson(row.agents),
+      inputProcessors: this.parseJson(row.inputProcessors),
+      outputProcessors: this.parseJson(row.outputProcessors),
+      memory: this.parseJson(row.memory),
+      scorers: this.parseJson(row.scorers),
+      metadata: this.parseJson(row.metadata),
+      createdAt: new Date(row.createdAt as string),
+      updatedAt: new Date(row.updatedAt as string),
+    };
+  }
+
+  async getAgentById({ id }: { id: string }): Promise<StorageAgentType | null> {
+    try {
+      const result = await this.client.execute({
+        sql: `SELECT * FROM "${TABLE_AGENTS}" WHERE id = ?`,
+        args: [id],
+      });
+
+      if (!result.rows || result.rows.length === 0) {
+        return null;
+      }
+
+      return this.parseRow(result.rows[0]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_AGENT_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async createAgent({ agent }: { agent: StorageCreateAgentInput }): Promise<StorageAgentType> {
+    try {
+      const now = new Date();
+      const nowIso = now.toISOString();
+
+      await this.client.execute({
+        sql: `INSERT INTO "${TABLE_AGENTS}" (id, name, description, instructions, model, tools, "defaultOptions", workflows, agents, "inputProcessors", "outputProcessors", memory, scorers, metadata, "createdAt", "updatedAt")
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: [
+          agent.id,
+          agent.name,
+          agent.description ?? null,
+          agent.instructions,
+          JSON.stringify(agent.model),
+          agent.tools ? JSON.stringify(agent.tools) : null,
+          agent.defaultOptions ? JSON.stringify(agent.defaultOptions) : null,
+          agent.workflows ? JSON.stringify(agent.workflows) : null,
+          agent.agents ? JSON.stringify(agent.agents) : null,
+          agent.inputProcessors ? JSON.stringify(agent.inputProcessors) : null,
+          agent.outputProcessors ? JSON.stringify(agent.outputProcessors) : null,
+          agent.memory ? JSON.stringify(agent.memory) : null,
+          agent.scorers ? JSON.stringify(agent.scorers) : null,
+          agent.metadata ? JSON.stringify(agent.metadata) : null,
+          nowIso,
+          nowIso,
+        ],
+      });
+
+      return {
+        ...agent,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'CREATE_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: agent.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateAgent({ id, ...updates }: StorageUpdateAgentInput): Promise<StorageAgentType> {
+    try {
+      // First, get the existing agent
+      const existingAgent = await this.getAgentById({ id });
+      if (!existingAgent) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'UPDATE_AGENT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Agent ${id} not found`,
+          details: { agentId: id },
+        });
+      }
+
+      const setClauses: string[] = [];
+      const args: InValue[] = [];
+
+      if (updates.name !== undefined) {
+        setClauses.push('name = ?');
+        args.push(updates.name);
+      }
+
+      if (updates.description !== undefined) {
+        setClauses.push('description = ?');
+        args.push(updates.description);
+      }
+
+      if (updates.instructions !== undefined) {
+        setClauses.push('instructions = ?');
+        args.push(updates.instructions);
+      }
+
+      if (updates.model !== undefined) {
+        setClauses.push('model = ?');
+        args.push(JSON.stringify(updates.model));
+      }
+
+      if (updates.tools !== undefined) {
+        setClauses.push('tools = ?');
+        args.push(JSON.stringify(updates.tools));
+      }
+
+      if (updates.defaultOptions !== undefined) {
+        setClauses.push('"defaultOptions" = ?');
+        args.push(JSON.stringify(updates.defaultOptions));
+      }
+
+      if (updates.workflows !== undefined) {
+        setClauses.push('workflows = ?');
+        args.push(JSON.stringify(updates.workflows));
+      }
+
+      if (updates.agents !== undefined) {
+        setClauses.push('agents = ?');
+        args.push(JSON.stringify(updates.agents));
+      }
+
+      if (updates.inputProcessors !== undefined) {
+        setClauses.push('"inputProcessors" = ?');
+        args.push(JSON.stringify(updates.inputProcessors));
+      }
+
+      if (updates.outputProcessors !== undefined) {
+        setClauses.push('"outputProcessors" = ?');
+        args.push(JSON.stringify(updates.outputProcessors));
+      }
+
+      if (updates.memory !== undefined) {
+        setClauses.push('memory = ?');
+        args.push(JSON.stringify(updates.memory));
+      }
+
+      if (updates.scorers !== undefined) {
+        setClauses.push('scorers = ?');
+        args.push(JSON.stringify(updates.scorers));
+      }
+
+      if (updates.metadata !== undefined) {
+        // Merge metadata
+        const mergedMetadata = { ...existingAgent.metadata, ...updates.metadata };
+        setClauses.push('metadata = ?');
+        args.push(JSON.stringify(mergedMetadata));
+      }
+
+      // Always update the updatedAt timestamp
+      const now = new Date();
+      setClauses.push('"updatedAt" = ?');
+      args.push(now.toISOString());
+
+      // Add the ID for the WHERE clause
+      args.push(id);
+
+      if (setClauses.length > 1) {
+        // More than just updatedAt
+        await this.client.execute({
+          sql: `UPDATE "${TABLE_AGENTS}" SET ${setClauses.join(', ')} WHERE id = ?`,
+          args,
+        });
+      }
+
+      // Return the updated agent
+      const updatedAgent = await this.getAgentById({ id });
+      if (!updatedAgent) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'UPDATE_AGENT', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Agent ${id} not found after update`,
+          details: { agentId: id },
+        });
+      }
+
+      return updatedAgent;
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'UPDATE_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteAgent({ id }: { id: string }): Promise<void> {
+    try {
+      await this.client.execute({
+        sql: `DELETE FROM "${TABLE_AGENTS}" WHERE id = ?`,
+        args: [id],
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'DELETE_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listAgents(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput> {
+    const { page = 0, perPage: perPageInput, orderBy } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_AGENTS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      // Get total count
+      const countResult = await this.client.execute({
+        sql: `SELECT COUNT(*) as count FROM "${TABLE_AGENTS}"`,
+        args: [],
+      });
+      const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+      if (total === 0) {
+        return {
+          agents: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      // Get paginated results
+      const limitValue = perPageInput === false ? total : perPage;
+      const dataResult = await this.client.execute({
+        sql: `SELECT * FROM "${TABLE_AGENTS}" ORDER BY "${field}" ${direction} LIMIT ? OFFSET ?`,
+        args: [limitValue, offset],
+      });
+
+      const agents = (dataResult.rows || []).map(row => this.parseRow(row));
+
+      return {
+        agents,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_AGENTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -20,6 +20,7 @@ import type {
 } from '@mastra/core/storage';
 
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { AgentsLibSQL } from './domains/agents';
 import { MemoryLibSQL } from './domains/memory';
 import { ObservabilityLibSQL } from './domains/observability';
 import { StoreOperationsLibSQL } from './domains/operations';
@@ -125,6 +126,7 @@ export class LibSQLStore extends MastraStorage {
     const workflows = new WorkflowsLibSQL({ client: this.client, operations });
     const memory = new MemoryLibSQL({ client: this.client, operations });
     const observability = new ObservabilityLibSQL({ operations });
+    const agents = new AgentsLibSQL({ client: this.client, operations });
 
     this.stores = {
       operations,
@@ -132,6 +134,7 @@ export class LibSQLStore extends MastraStorage {
       workflows,
       memory,
       observability,
+      agents,
     };
   }
 
@@ -144,6 +147,7 @@ export class LibSQLStore extends MastraStorage {
       deleteMessages: true,
       observabilityInstance: true,
       listScoresBySpan: true,
+      agents: true,
     };
   }
 

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -1,0 +1,343 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  AgentsStorage,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_AGENTS,
+} from '@mastra/core/storage';
+import type {
+  StorageAgentType,
+  StorageCreateAgentInput,
+  StorageUpdateAgentInput,
+  StorageListAgentsInput,
+  StorageListAgentsOutput,
+} from '@mastra/core/storage';
+import type { IDatabase } from 'pg-promise';
+import { getTableName, getSchemaName } from '../utils';
+
+export class AgentsPG extends AgentsStorage {
+  private client: IDatabase<{}>;
+  private schema: string;
+
+  constructor({ client, schema }: { client: IDatabase<{}>; schema: string }) {
+    super();
+    this.client = client;
+    this.schema = schema;
+  }
+
+  private parseJson(value: any): any {
+    if (!value) return undefined;
+    return typeof value === 'string' ? JSON.parse(value) : value;
+  }
+
+  private parseRow(row: any): StorageAgentType {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      description: row.description as string | undefined,
+      instructions: row.instructions as string,
+      model: typeof row.model === 'string' ? JSON.parse(row.model) : row.model,
+      tools: this.parseJson(row.tools),
+      defaultOptions: this.parseJson(row.defaultOptions),
+      workflows: this.parseJson(row.workflows),
+      agents: this.parseJson(row.agents),
+      inputProcessors: this.parseJson(row.inputProcessors),
+      outputProcessors: this.parseJson(row.outputProcessors),
+      memory: this.parseJson(row.memory),
+      scorers: this.parseJson(row.scorers),
+      metadata: this.parseJson(row.metadata),
+      createdAt: row.createdAtZ || row.createdAt,
+      updatedAt: row.updatedAtZ || row.updatedAt,
+    };
+  }
+
+  async getAgentById({ id }: { id: string }): Promise<StorageAgentType | null> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENTS, schemaName: getSchemaName(this.schema) });
+
+      const result = await this.client.oneOrNone(`SELECT * FROM ${tableName} WHERE id = $1`, [id]);
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_AGENT_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async createAgent({ agent }: { agent: StorageCreateAgentInput }): Promise<StorageAgentType> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENTS, schemaName: getSchemaName(this.schema) });
+      const now = new Date();
+      const nowIso = now.toISOString();
+
+      await this.client.none(
+        `INSERT INTO ${tableName} (
+          id, name, description, instructions, model, tools, 
+          "defaultOptions", workflows, agents, "inputProcessors", "outputProcessors", memory, scorers, metadata, 
+          "createdAt", "createdAtZ", "updatedAt", "updatedAtZ"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
+        [
+          agent.id,
+          agent.name,
+          agent.description ?? null,
+          agent.instructions,
+          JSON.stringify(agent.model),
+          agent.tools ? JSON.stringify(agent.tools) : null,
+          agent.defaultOptions ? JSON.stringify(agent.defaultOptions) : null,
+          agent.workflows ? JSON.stringify(agent.workflows) : null,
+          agent.agents ? JSON.stringify(agent.agents) : null,
+          agent.inputProcessors ? JSON.stringify(agent.inputProcessors) : null,
+          agent.outputProcessors ? JSON.stringify(agent.outputProcessors) : null,
+          agent.memory ? JSON.stringify(agent.memory) : null,
+          agent.scorers ? JSON.stringify(agent.scorers) : null,
+          agent.metadata ? JSON.stringify(agent.metadata) : null,
+          nowIso,
+          nowIso,
+          nowIso,
+          nowIso,
+        ],
+      );
+
+      return {
+        ...agent,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'CREATE_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: agent.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateAgent({ id, ...updates }: StorageUpdateAgentInput): Promise<StorageAgentType> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENTS, schemaName: getSchemaName(this.schema) });
+
+      // First, get the existing agent
+      const existingAgent = await this.getAgentById({ id });
+      if (!existingAgent) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_AGENT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Agent ${id} not found`,
+          details: { agentId: id },
+        });
+      }
+
+      const setClauses: string[] = [];
+      const values: any[] = [];
+      let paramIndex = 1;
+
+      if (updates.name !== undefined) {
+        setClauses.push(`name = $${paramIndex++}`);
+        values.push(updates.name);
+      }
+
+      if (updates.description !== undefined) {
+        setClauses.push(`description = $${paramIndex++}`);
+        values.push(updates.description);
+      }
+
+      if (updates.instructions !== undefined) {
+        setClauses.push(`instructions = $${paramIndex++}`);
+        values.push(updates.instructions);
+      }
+
+      if (updates.model !== undefined) {
+        setClauses.push(`model = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.model));
+      }
+
+      if (updates.tools !== undefined) {
+        setClauses.push(`tools = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.tools));
+      }
+
+      if (updates.defaultOptions !== undefined) {
+        setClauses.push(`"defaultOptions" = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.defaultOptions));
+      }
+
+      if (updates.workflows !== undefined) {
+        setClauses.push(`workflows = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.workflows));
+      }
+
+      if (updates.agents !== undefined) {
+        setClauses.push(`agents = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.agents));
+      }
+
+      if (updates.inputProcessors !== undefined) {
+        setClauses.push(`"inputProcessors" = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.inputProcessors));
+      }
+
+      if (updates.outputProcessors !== undefined) {
+        setClauses.push(`"outputProcessors" = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.outputProcessors));
+      }
+
+      if (updates.memory !== undefined) {
+        setClauses.push(`memory = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.memory));
+      }
+
+      if (updates.scorers !== undefined) {
+        setClauses.push(`scorers = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.scorers));
+      }
+
+      if (updates.metadata !== undefined) {
+        // Merge metadata
+        const mergedMetadata = { ...existingAgent.metadata, ...updates.metadata };
+        setClauses.push(`metadata = $${paramIndex++}`);
+        values.push(JSON.stringify(mergedMetadata));
+      }
+
+      // Always update the updatedAt timestamp
+      const now = new Date().toISOString();
+      setClauses.push(`"updatedAt" = $${paramIndex++}`);
+      values.push(now);
+      setClauses.push(`"updatedAtZ" = $${paramIndex++}`);
+      values.push(now);
+
+      // Add the ID for the WHERE clause
+      values.push(id);
+
+      if (setClauses.length > 2) {
+        // More than just updatedAt and updatedAtZ
+        await this.client.none(`UPDATE ${tableName} SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`, values);
+      }
+
+      // Return the updated agent
+      const updatedAgent = await this.getAgentById({ id });
+      if (!updatedAgent) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_AGENT', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Agent ${id} not found after update`,
+          details: { agentId: id },
+        });
+      }
+
+      return updatedAgent;
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'UPDATE_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteAgent({ id }: { id: string }): Promise<void> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENTS, schemaName: getSchemaName(this.schema) });
+
+      await this.client.none(`DELETE FROM ${tableName} WHERE id = $1`, [id]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'DELETE_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listAgents(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput> {
+    const { page = 0, perPage: perPageInput, orderBy } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_AGENTS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENTS, schemaName: getSchemaName(this.schema) });
+
+      // Get total count
+      const countResult = await this.client.one(`SELECT COUNT(*) as count FROM ${tableName}`);
+      const total = parseInt(countResult.count, 10);
+
+      if (total === 0) {
+        return {
+          agents: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      // Get paginated results
+      const limitValue = perPageInput === false ? total : perPage;
+      const dataResult = await this.client.manyOrNone(
+        `SELECT * FROM ${tableName} ORDER BY "${field}" ${direction} LIMIT $1 OFFSET $2`,
+        [limitValue, offset],
+      );
+
+      const agents = (dataResult || []).map(row => this.parseRow(row));
+
+      return {
+        agents,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_AGENTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -26,9 +26,31 @@ export class AgentsPG extends AgentsStorage {
     this.schema = schema;
   }
 
-  private parseJson(value: any): any {
+  private parseJson(value: any, fieldName?: string): any {
     if (!value) return undefined;
-    return typeof value === 'string' ? JSON.parse(value) : value;
+    if (typeof value !== 'string') return value;
+
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      const details: Record<string, string> = {
+        value: value.length > 100 ? value.substring(0, 100) + '...' : value,
+      };
+      if (fieldName) {
+        details.field = fieldName;
+      }
+
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'PARSE_JSON', 'INVALID_JSON'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Failed to parse JSON${fieldName ? ` for field "${fieldName}"` : ''}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          details,
+        },
+        error,
+      );
+    }
   }
 
   private parseRow(row: any): StorageAgentType {
@@ -37,16 +59,16 @@ export class AgentsPG extends AgentsStorage {
       name: row.name as string,
       description: row.description as string | undefined,
       instructions: row.instructions as string,
-      model: typeof row.model === 'string' ? JSON.parse(row.model) : row.model,
-      tools: this.parseJson(row.tools),
-      defaultOptions: this.parseJson(row.defaultOptions),
-      workflows: this.parseJson(row.workflows),
-      agents: this.parseJson(row.agents),
-      inputProcessors: this.parseJson(row.inputProcessors),
-      outputProcessors: this.parseJson(row.outputProcessors),
-      memory: this.parseJson(row.memory),
-      scorers: this.parseJson(row.scorers),
-      metadata: this.parseJson(row.metadata),
+      model: this.parseJson(row.model, 'model'),
+      tools: this.parseJson(row.tools, 'tools'),
+      defaultOptions: this.parseJson(row.defaultOptions, 'defaultOptions'),
+      workflows: this.parseJson(row.workflows, 'workflows'),
+      agents: this.parseJson(row.agents, 'agents'),
+      inputProcessors: this.parseJson(row.inputProcessors, 'inputProcessors'),
+      outputProcessors: this.parseJson(row.outputProcessors, 'outputProcessors'),
+      memory: this.parseJson(row.memory, 'memory'),
+      scorers: this.parseJson(row.scorers, 'scorers'),
+      metadata: this.parseJson(row.metadata, 'metadata'),
       createdAt: row.createdAtZ || row.createdAt,
       updatedAt: row.updatedAtZ || row.updatedAt,
     };

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -21,6 +21,7 @@ import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import pgPromise from 'pg-promise';
 import { validateConfig, isCloudSqlConfig, isConnectionStringConfig, isHostConfig } from '../shared/config';
 import type { PostgresStoreConfig } from '../shared/config';
+import { AgentsPG } from './domains/agents';
 import { MemoryPG } from './domains/memory';
 import { ObservabilityPG } from './domains/observability';
 import { StoreOperationsPG } from './domains/operations';
@@ -94,6 +95,7 @@ export class PostgresStore extends MastraStorage {
       const workflows = new WorkflowsPG({ client: this.#db, operations, schema: this.schema });
       const memory = new MemoryPG({ client: this.#db, schema: this.schema, operations });
       const observability = new ObservabilityPG({ client: this.#db, operations, schema: this.schema });
+      const agents = new AgentsPG({ client: this.#db, schema: this.schema });
 
       this.stores = {
         operations,
@@ -101,6 +103,7 @@ export class PostgresStore extends MastraStorage {
         workflows,
         memory,
         observability,
+        agents,
       };
     } catch (e) {
       throw new MastraError(
@@ -164,6 +167,7 @@ export class PostgresStore extends MastraStorage {
       observabilityInstance: true,
       indexManagement: true,
       listScoresBySpan: true,
+      agents: true,
     };
   }
 


### PR DESCRIPTION
Adds the ability to store agent configurations in the database and load them at runtime as executable Agent instances.

```typescript
const mastra = new Mastra({
  storage: new LibSQLStore({ url: ':memory:' }),
  tools: { myTool },
  scorers: { myScorer },
});

// Store an agent config
await mastra.getStorage().createAgent({
  agent: {
    id: 'my-agent',
    name: 'My Agent',
    instructions: 'You are helpful',
    model: { provider: 'openai', name: 'gpt-4' },
    tools: { myTool: {} },
    scorers: { myScorer: { sampling: { type: 'ratio', rate: 0.5 } } },
  },
});

// Load and use it
const agent = await mastra.getStoredAgentById('my-agent');
const response = await agent.generate({ messages: 'Hello!' });

// List with pagination
const { agents, total } = await mastra.listStoredAgents({ page: 0, perPage: 10 });
```

When loading stored agents, primitives (tools, workflows, agents, memory, scorers) are resolved from the Mastra registry. Also adds a memory registry to Mastra so stored agents can reference memory instances.

Implemented for LibSQL, PostgreSQL, and InMemory stores. Added server API routes at `/api/stored/agents`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted agent management: create, read, update, delete, and paginated listing of stored agents
  * Memory registry: register named memory instances for agents to reference at runtime
  * Client SDK: JS client methods to list, create, and manage stored agents
  * Server: REST endpoints for stored-agent CRUD and listing

* **Documentation**
  * New reference pages and examples for stored agents and memory APIs; sidebar updated

* **Tests**
  * Extensive tests covering stored-agent flows, storage backends, pagination, resolution, and warnings/errors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->