### PR TITLE
fix(memory): batch vector upserts to prevent connection pool exhaustion

### DIFF
--- a/.changeset/gentle-waves-swim.md
+++ b/.changeset/gentle-waves-swim.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fix connection pool exhaustion when saving many messages with semantic recall enabled. Instead of calling vector.upsert() for each message individually (which acquires a separate DB connection), all embeddings are now batched into a single upsert call.


### PR DESCRIPTION
When `saveMessages` is called with many messages and semantic recall is enabled, the code was calling `vector.upsert()` once per message inside a `Promise.all`. Each upsert acquires a DB connection from the pool, so with 15+ messages and a 2-second connection timeout, this would cause connection timeout errors.

Before (15 messages = 15 separate upsert calls):
```ts
await Promise.all(
  messages.map(async message => {
    // ...embed message
    await this.vector.upsert({ vectors: embeddings, ... });
  }),
);
```

After (all embeddings batched into 1 upsert call):
```ts
// First collect all embeddings (doesn't use pool)
const embeddingData = await Promise.all(messages.map(async m => embed(m)));

// Then single upsert with all vectors
await this.vector.upsert({
  vectors: allVectors,
  metadata: allMetadata,
});
```