### PR TITLE
fix(core): handle unescaped newlines in JSON structured output

### DIFF
--- a/.changeset/fix-json-newlines.md
+++ b/.changeset/fix-json-newlines.md
@@ -1,0 +1,9 @@
+---
+"@mastra/core": patch
+---
+
+Fix JSON parsing errors when LLMs output unescaped newlines in structured output strings
+
+Some LLMs (particularly when not using native JSON mode) output actual newline characters inside JSON string values instead of properly escaped `\n` sequences. This breaks JSON parsing and causes structured output to fail.
+
+This change adds preprocessing to escape unescaped control characters (`\n`, `\r`, `\t`) within JSON string values before parsing, making structured output more robust across different LLM providers.

--- a/packages/core/src/stream/base/output-format-handlers.test.ts
+++ b/packages/core/src/stream/base/output-format-handlers.test.ts
@@ -7,7 +7,90 @@ import z3 from 'zod/v3';
 import z4 from 'zod/v4';
 import type { ChunkType } from '../types';
 import { ChunkFrom } from '../types';
-import { createObjectStreamTransformer } from './output-format-handlers';
+import { createObjectStreamTransformer, escapeUnescapedControlCharsInJsonStrings } from './output-format-handlers';
+
+describe('escapeUnescapedControlCharsInJsonStrings', () => {
+  it('should escape newlines inside JSON strings', () => {
+    const input = '{"message": "Hello\nWorld"}';
+    const expected = '{"message": "Hello\\nWorld"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should escape carriage returns inside JSON strings', () => {
+    const input = '{"message": "Hello\rWorld"}';
+    const expected = '{"message": "Hello\\rWorld"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should escape tabs inside JSON strings', () => {
+    const input = '{"message": "Hello\tWorld"}';
+    const expected = '{"message": "Hello\\tWorld"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should not escape newlines outside JSON strings', () => {
+    const input = '{\n  "message": "Hello"\n}';
+    const expected = '{\n  "message": "Hello"\n}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should preserve already-escaped sequences', () => {
+    const input = '{"message": "Hello\\nWorld"}';
+    const expected = '{"message": "Hello\\nWorld"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle escaped quotes inside strings', () => {
+    const input = '{"message": "He said \\"Hello\nWorld\\""}';
+    const expected = '{"message": "He said \\"Hello\\nWorld\\""}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle multiple strings with mixed newlines', () => {
+    const input = '{"a": "line1\nline2", "b": "line3\nline4"}';
+    const expected = '{"a": "line1\\nline2", "b": "line3\\nline4"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle complex nested JSON with newlines in strings', () => {
+    const input = `{"outer": {"inner": "value with
+newline"}, "array": ["item1
+continued", "item2"]}`;
+    const expected = '{"outer": {"inner": "value with\\nnewline"}, "array": ["item1\\ncontinued", "item2"]}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle empty strings', () => {
+    const input = '{"message": ""}';
+    const expected = '{"message": ""}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle string with only newline', () => {
+    const input = '{"message": "\n"}';
+    const expected = '{"message": "\\n"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle CRLF sequences', () => {
+    const input = '{"message": "Hello\r\nWorld"}';
+    const expected = '{"message": "Hello\\r\\nWorld"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle partial/incomplete JSON (streaming scenario)', () => {
+    // During streaming, we might have incomplete JSON
+    const input = '{"message": "Hello\nWor';
+    const expected = '{"message": "Hello\\nWor';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+
+  it('should handle backslash at end of string', () => {
+    const input = '{"path": "C:\\\\"}';
+    const expected = '{"path": "C:\\\\"}';
+    expect(escapeUnescapedControlCharsInJsonStrings(input)).toBe(expected);
+  });
+});
 
 describe('output-format-handlers', () => {
   describe('schema validation', () => {
@@ -767,6 +850,220 @@ describe('output-format-handlers', () => {
       const objectResultChunk = chunks.find(c => c?.type === 'object-result');
       expect(objectResultChunk).toBeDefined();
       expect(objectResultChunk?.object).toEqual({ title: 'Test', count: 5 });
+    });
+  });
+
+  describe('unescaped newlines in JSON strings', () => {
+    it('should handle LLM output with actual newlines in string values instead of \\n escape sequences', async () => {
+      // This test reproduces the issue where LLMs output actual newlines in JSON strings
+      // instead of properly escaped \n sequences, breaking JSON parsing
+      //
+      // User report: "Line breaks aren't being properly escaped: instead of getting \n
+      // in my strings, I'm getting actual newline characters that completely break
+      // the JSON object structure."
+      const schema = z.object({
+        fieldId: z.string(),
+        content: z.string(),
+        summary: z.string(),
+      });
+
+      const transformer = createObjectStreamTransformer({
+        structuredOutput: { schema },
+      });
+
+      // Simulates LLM outputting actual newlines instead of \n escape sequences
+      // This is invalid JSON but commonly produced by LLMs
+      const invalidJsonWithActualNewlines = `{"fieldId": "interview_notes", "content": "The candidate discussed:
+- Point 1
+- Point 2
+- Point 3", "summary": "Good candidate
+with strong skills"}`;
+
+      const streamParts: ChunkType<typeof schema>[] = [
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: invalidJsonWithActualNewlines },
+        },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1' },
+        },
+        {
+          type: 'finish',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            stepResult: { reason: 'stop' },
+            output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+            metadata: {},
+            messages: { all: [], user: [], nonUser: [] },
+          },
+        },
+      ];
+
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream(streamParts).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      // The system should handle this gracefully and parse the content
+      const objectResultChunk = chunks.find(c => c?.type === 'object-result');
+      expect(objectResultChunk).toBeDefined();
+      expect(objectResultChunk?.object).toEqual({
+        fieldId: 'interview_notes',
+        content: `The candidate discussed:
+- Point 1
+- Point 2
+- Point 3`,
+        summary: `Good candidate
+with strong skills`,
+      });
+
+      // Should NOT have an error chunk
+      const errorChunk = chunks.find(c => c?.type === 'error');
+      expect(errorChunk).toBeUndefined();
+    });
+
+    it('should handle streaming chunks with unescaped newlines spread across deltas', async () => {
+      // More realistic scenario: newlines appear across multiple streaming chunks
+      const schema = z.object({
+        notes: z.string(),
+        recommendation: z.string(),
+      });
+
+      const transformer = createObjectStreamTransformer({
+        structuredOutput: { schema },
+      });
+
+      const streamParts: ChunkType<typeof schema>[] = [
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: '{"notes": "First line' },
+        },
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          // Actual newline in the middle of a string value
+          payload: { id: 'text-1', text: '\nSecond line' },
+        },
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: '\nThird line", "recommendation": "Proceed' },
+        },
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: '\nwith interview"}' },
+        },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1' },
+        },
+        {
+          type: 'finish',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            stepResult: { reason: 'stop' },
+            output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+            metadata: {},
+            messages: { all: [], user: [], nonUser: [] },
+          },
+        },
+      ];
+
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream(streamParts).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      const objectResultChunk = chunks.find(c => c?.type === 'object-result');
+      expect(objectResultChunk).toBeDefined();
+      expect(objectResultChunk?.object).toEqual({
+        notes: 'First line\nSecond line\nThird line',
+        recommendation: 'Proceed\nwith interview',
+      });
+
+      const errorChunk = chunks.find(c => c?.type === 'error');
+      expect(errorChunk).toBeUndefined();
+    });
+
+    it('should handle interview transcript extraction with paragraph fields containing newlines', async () => {
+      // Reproduces the exact user scenario: interview transcription with paragraph fields
+      const noteFillerOutputSchema = z.object({
+        field_experience: z.string().describe('Previous work experience'),
+        field_skills: z.string().describe('Technical skills'),
+        field_motivation: z.string().describe('Motivation for the role'),
+      });
+
+      const transformer = createObjectStreamTransformer({
+        structuredOutput: { schema: noteFillerOutputSchema },
+      });
+
+      // This is what the LLM might output - actual newlines instead of \n
+      const llmOutput = `{"field_experience": "Worked at Company A for 3 years
+Key responsibilities:
+- Led team of 5 engineers
+- Delivered 3 major projects", "field_skills": "Languages:
+- Python
+- JavaScript
+- Go
+
+Frameworks:
+- React
+- Django", "field_motivation": "Looking for growth opportunities
+Want to work on challenging problems"}`;
+
+      const streamParts: ChunkType<typeof noteFillerOutputSchema>[] = [
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: llmOutput },
+        },
+        {
+          type: 'text-end',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1' },
+        },
+        {
+          type: 'finish',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            stepResult: { reason: 'stop' },
+            output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+            metadata: {},
+            messages: { all: [], user: [], nonUser: [] },
+          },
+        },
+      ];
+
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream(streamParts).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      const objectResultChunk = chunks.find(c => c?.type === 'object-result');
+      expect(objectResultChunk).toBeDefined();
+
+      // The content should be preserved with the newlines
+      expect(objectResultChunk?.object?.field_experience).toContain('Key responsibilities:');
+      expect(objectResultChunk?.object?.field_skills).toContain('Languages:');
+      expect(objectResultChunk?.object?.field_motivation).toContain('Looking for growth opportunities');
+
+      const errorChunk = chunks.find(c => c?.type === 'error');
+      expect(errorChunk).toBeUndefined();
     });
   });
 

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -13,6 +13,68 @@ import type { ChunkType } from '../types';
 import { getTransformedSchema } from './schema';
 import type { InferSchemaOutput, OutputSchema, PartialSchemaOutput, ZodLikePartialSchema } from './schema';
 
+/**
+ * Escapes unescaped newlines, carriage returns, and tabs within JSON string values.
+ *
+ * LLMs often output actual newline characters inside JSON strings instead of properly
+ * escaped \n sequences, which breaks JSON parsing. This function fixes that by:
+ * 1. Tracking whether we're inside a JSON string (after an unescaped quote)
+ * 2. Replacing literal newlines/tabs with their escape sequences only inside strings
+ * 3. Preserving already-escaped sequences like \\n
+ *
+ * @param text - Raw JSON text that may contain unescaped control characters in strings
+ * @returns JSON text with control characters properly escaped inside string values
+ */
+export function escapeUnescapedControlCharsInJsonStrings(text: string): string {
+  let result = '';
+  let inString = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const char = text[i];
+
+    // Check for escape sequences
+    if (char === '\\' && i + 1 < text.length) {
+      // This is an escape sequence - pass through both characters
+      result += char + text[i + 1];
+      i += 2;
+      continue;
+    }
+
+    // Track string boundaries (unescaped quotes)
+    if (char === '"') {
+      inString = !inString;
+      result += char;
+      i++;
+      continue;
+    }
+
+    // If inside a string, escape control characters
+    if (inString) {
+      if (char === '\n') {
+        result += '\\n';
+        i++;
+        continue;
+      }
+      if (char === '\r') {
+        result += '\\r';
+        i++;
+        continue;
+      }
+      if (char === '\t') {
+        result += '\\t';
+        i++;
+        continue;
+      }
+    }
+
+    result += char;
+    i++;
+  }
+
+  return result;
+}
+
 interface ProcessPartialChunkParams {
   /** Text accumulated from streaming so far */
   accumulatedText: string;
@@ -182,7 +244,8 @@ abstract class BaseFormatHandler<OUTPUT extends OutputSchema = undefined> {
   abstract validateAndTransformFinal(finalValue: string): Promise<ValidateAndTransformFinalResult<OUTPUT>>;
 
   /**
-   * Preprocesses accumulated text to handle LLMs that wrap JSON in code blocks.
+   * Preprocesses accumulated text to handle LLMs that wrap JSON in code blocks
+   * and fix common JSON formatting issues like unescaped newlines in strings.
    * Extracts content from the first complete valid ```json...``` code block or removes opening ```json prefix if no complete code block is found (streaming chunks).
    * @param accumulatedText - Raw accumulated text from streaming
    * @returns Processed text ready for JSON parsing
@@ -211,6 +274,10 @@ abstract class BaseFormatHandler<OUTPUT extends OutputSchema = undefined> {
         processedText = processedText.replace(/^```json\s*\n?/, '');
       }
     }
+
+    // LLMs often output actual newlines/tabs inside JSON strings instead of
+    // properly escaped \n sequences. Fix this before parsing.
+    processedText = escapeUnescapedControlCharsInJsonStrings(processedText);
 
     return processedText;
   }


### PR DESCRIPTION
## Summary

- Fix JSON parsing errors when LLMs output unescaped newlines in structured output strings

## Problem

Some LLMs (particularly when not using native JSON mode) output actual newline characters inside JSON string values instead of properly escaped `\n` sequences. This breaks JSON parsing and causes structured output to fail with errors like "invalid JSON".

Example of problematic LLM output:
```json
{"field": "line 1
line 2"}
```

Instead of valid JSON:
```json
{"field": "line 1\nline 2"}
```

## Solution

Add preprocessing in `BaseFormatHandler.preprocessText()` to escape unescaped control characters (`\n`, `\r`, `\t`) within JSON string values before parsing.

The fix:
- Tracks whether we're inside a JSON string (after an unescaped quote)
- Replaces literal control characters with their escape sequences only inside strings
- Preserves already-escaped sequences like `\\n`
- Is harmless when JSON is already valid

## Testing

- Added 13 unit tests for `escapeUnescapedControlCharsInJsonStrings()` helper
- Added 3 integration tests for streaming with malformed JSON input
- All 36 tests pass

## Notes

We were unable to fully reproduce the issue with current Mistral/OpenAI models, but the fix is defensive and the unit tests validate it works correctly when malformed JSON is encountered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON parsing errors when language models output unescaped newline characters and other control characters inside JSON string values, improving compatibility and robustness across different LLM providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->