### PR TITLE
Move useScorers to Trace page

### DIFF
--- a/.changeset/salty-items-doubt.md
+++ b/.changeset/salty-items-doubt.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Move useScorers down to trace page to trigger it once for all trace spans

--- a/packages/playground-ui/src/domains/observability/components/span-dialog.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-dialog.tsx
@@ -2,7 +2,7 @@ import { SideDialog, type KeyValueListItemData, TextAndIcon, getShortId } from '
 import { PanelTopIcon, ChevronsLeftRightEllipsisIcon, HashIcon, EyeIcon } from 'lucide-react';
 import { SpanRecord } from '@mastra/core/storage';
 
-import { ListScoresResponse } from '@mastra/client-js';
+import { ListScoresResponse, type GetScorerResponse } from '@mastra/client-js';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { SpanTabs } from './span-tabs';
 
@@ -21,6 +21,8 @@ type SpanDialogProps = {
   defaultActiveTab?: string;
   initialScoreId?: string;
   computeTraceLink: (traceId: string, spanId?: string) => string;
+  scorers?: Record<string, GetScorerResponse>;
+  isLoadingScorers?: boolean;
 };
 
 export function SpanDialog({
@@ -38,6 +40,8 @@ export function SpanDialog({
   defaultActiveTab = 'details',
   initialScoreId,
   computeTraceLink,
+  scorers,
+  isLoadingScorers,
 }: SpanDialogProps) {
   return (
     <SideDialog
@@ -83,6 +87,8 @@ export function SpanDialog({
           defaultActiveTab={defaultActiveTab}
           initialScoreId={initialScoreId}
           computeTraceLink={computeTraceLink}
+          scorers={scorers}
+          isLoadingScorers={isLoadingScorers}
         />
       </SideDialog.Content>
     </SideDialog>

--- a/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
@@ -1,4 +1,3 @@
-import { useScorers } from '@/domains/scores/hooks/use-scorers';
 import { Button } from '@/components/ui/elements/buttons';
 import { InfoIcon } from 'lucide-react';
 import { useTriggerScorer } from '@/domains/scores/hooks/use-trigger-scorer';

--- a/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
@@ -4,16 +4,25 @@ import { InfoIcon } from 'lucide-react';
 import { useTriggerScorer } from '@/domains/scores/hooks/use-trigger-scorer';
 import { Notification, SelectField, TextAndIcon } from '@/components/ui/elements';
 import { useEffect, useState } from 'react';
+import { type GetScorerResponse } from 'node_modules/@mastra/client-js/dist/types';
 
 export interface SpanScoringProps {
   traceId?: string;
   spanId?: string;
   entityType?: string;
   isTopLevelSpan?: boolean;
+  scorers?: Record<string, GetScorerResponse>;
+  isLoadingScorers?: boolean;
 }
 
-export const SpanScoring = ({ traceId, spanId, entityType, isTopLevelSpan }: SpanScoringProps) => {
-  const { data: scorers = {}, isLoading, error } = useScorers();
+export const SpanScoring = ({
+  traceId,
+  spanId,
+  entityType,
+  isTopLevelSpan,
+  scorers,
+  isLoadingScorers,
+}: SpanScoringProps) => {
   const [selectedScorer, setSelectedScorer] = useState<string | null>(null);
   const { mutate: triggerScorer, isPending, isSuccess } = useTriggerScorer();
   const [notificationIsVisible, setNotificationIsVisible] = useState(false);
@@ -24,7 +33,7 @@ export const SpanScoring = ({ traceId, spanId, entityType, isTopLevelSpan }: Spa
     }
   }, [isSuccess]);
 
-  let scorerList = Object.entries(scorers)
+  let scorerList = Object.entries(scorers || {})
     .map(([key, scorer]) => ({
       id: key,
       name: scorer.scorer.config.name,
@@ -39,7 +48,7 @@ export const SpanScoring = ({ traceId, spanId, entityType, isTopLevelSpan }: Spa
     scorerList = scorerList.filter(scorer => scorer.type !== 'agent');
   }
 
-  const isWaiting = isPending || isLoading;
+  const isWaiting = isPending || isLoadingScorers;
 
   const handleStartScoring = () => {
     if (selectedScorer) {
@@ -59,10 +68,10 @@ export const SpanScoring = ({ traceId, spanId, entityType, isTopLevelSpan }: Spa
 
   const selectedScorerDescription = scorerList.find(s => s.name === selectedScorer)?.description || '';
 
-  if (error) {
+  if (scorers === undefined && !isLoadingScorers) {
     return (
       <Notification isVisible={true} autoDismiss={false} type="error">
-        <InfoIcon /> {error?.message ? error.message : 'Failed to load scorers.'}
+        <InfoIcon /> Failed to load scorers.
       </Notification>
     );
   }

--- a/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
@@ -3,7 +3,7 @@ import { InfoIcon } from 'lucide-react';
 import { useTriggerScorer } from '@/domains/scores/hooks/use-trigger-scorer';
 import { Notification, SelectField, TextAndIcon } from '@/components/ui/elements';
 import { useEffect, useState } from 'react';
-import { type GetScorerResponse } from 'node_modules/@mastra/client-js/dist/types';
+import { type GetScorerResponse } from '@mastra/client-js';
 
 export interface SpanScoringProps {
   traceId?: string;

--- a/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
@@ -11,7 +11,7 @@ import {
 import { TraceSpanUsage } from './trace-span-usage';
 import { SpanDetails } from './span-details';
 import { CircleGaugeIcon } from 'lucide-react';
-import { ListScoresResponse } from '@mastra/client-js';
+import { ListScoresResponse, type GetScorerResponse } from '@mastra/client-js';
 import { SpanRecord } from '@mastra/core/storage';
 
 type SpanTabsProps = {
@@ -24,6 +24,8 @@ type SpanTabsProps = {
   defaultActiveTab?: string;
   initialScoreId?: string;
   computeTraceLink: (traceId: string, spanId?: string) => string;
+  scorers?: Record<string, GetScorerResponse>;
+  isLoadingScorers?: boolean;
 };
 
 export function SpanTabs({
@@ -36,6 +38,8 @@ export function SpanTabs({
   defaultActiveTab = 'details',
   initialScoreId,
   computeTraceLink,
+  scorers,
+  isLoadingScorers,
 }: SpanTabsProps) {
   const { Link } = useLinkComponent();
 
@@ -74,6 +78,8 @@ export function SpanTabs({
               isTopLevelSpan={span?.parentSpanId === null}
               spanId={span?.spanId}
               entityType={entityType}
+              scorers={scorers}
+              isLoadingScorers={isLoadingScorers}
             />
           </Section>
           <Section>

--- a/packages/playground-ui/src/domains/observability/components/trace-dialog.tsx
+++ b/packages/playground-ui/src/domains/observability/components/trace-dialog.tsx
@@ -23,6 +23,7 @@ import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores
 import { Button } from '@/components/ui/elements/buttons';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { SpanTabs } from './span-tabs';
+import { type GetScorerResponse } from '@mastra/client-js';
 
 type TraceDialogProps = {
   traceSpans?: SpanRecord[];
@@ -39,6 +40,8 @@ type TraceDialogProps = {
   initialSpanId?: string;
   initialSpanTab?: string;
   initialScoreId?: string;
+  scorers?: Record<string, GetScorerResponse>;
+  isLoadingScorers?: boolean;
 };
 
 export function TraceDialog({
@@ -54,6 +57,8 @@ export function TraceDialog({
   initialSpanId,
   initialSpanTab,
   initialScoreId,
+  scorers,
+  isLoadingScorers,
 }: TraceDialogProps) {
   const { Link, navigate } = useLinkComponent();
 
@@ -366,6 +371,8 @@ export function TraceDialog({
           defaultActiveTab={spanDialogDefaultTab}
           initialScoreId={initialScoreId}
           computeTraceLink={computeTraceLink}
+          scorers={scorers}
+          isLoadingScorers={isLoadingScorers}
         />
       )}
     </>

--- a/packages/playground/src/pages/observability/index.tsx
+++ b/packages/playground/src/pages/observability/index.tsx
@@ -19,6 +19,7 @@ import {
   getToPreviousEntryFn,
   useAgents,
   useWorkflows,
+  useScorers,
 } from '@mastra/playground-ui';
 import { useEffect, useState } from 'react';
 import { EyeIcon } from 'lucide-react';
@@ -41,6 +42,7 @@ export default function Observability() {
   const [dialogIsOpen, setDialogIsOpen] = useState<boolean>(false);
   const { data: agents = {}, isLoading: isLoadingAgents } = useAgents();
   const { data: workflows, isLoading: isLoadingWorkflows } = useWorkflows();
+  const { data: scorers = {}, isLoading: isLoadingScorers } = useScorers();
 
   const { data: Trace, isLoading: isLoadingTrace } = useTrace(selectedTraceId, { enabled: !!selectedTraceId });
 
@@ -225,6 +227,8 @@ export default function Observability() {
         onPrevious={toPreviousTrace}
         isLoadingSpans={isLoadingTrace}
         computeTraceLink={(traceId, spanId) => `/observability?traceId=${traceId}${spanId ? `&spanId=${spanId}` : ''}`}
+        scorers={scorers}
+        isLoadingScorers={isLoadingScorers}
       />
     </>
   );


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Move the useScore call to page instead of triggering it in modal nested component, the same scorers are used for all trace/spans so there is no need to call query separately for every span. 

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scorer information display to observability trace and span dialogs.
  * Improved handling of scorer data loading states in observability components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->