### PR TITLE
(fix) Add missing  workflowRoute  data chunks

### DIFF
--- a/.changeset/rare-jars-behave.md
+++ b/.changeset/rare-jars-behave.md
@@ -1,0 +1,9 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed tool-call-suspended chunks being dropped in workflow-step-output when using AI SDK. Previously, when an agent inside a workflow step called a tool that got suspended, the tool-call-suspended chunk was not received on the frontend even though tool-input-available chunks were correctly received.
+
+The issue occurred because tool-call-suspended was not included in the isMastraTextStreamChunk list, causing it to be filtered out in transformWorkflow. Now tool-call-suspended, tool-call-approval, object, and tripwire chunks are properly included in the text stream chunk list and will be transformed and passed through correctly.
+
+Fixes #10978

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -360,6 +360,110 @@ describe('WorkflowStreamToAISDKTransformer', () => {
       expect(toolOutputAvailableChunk.output).toEqual({ results: ['result 1', 'result 2'] });
     });
 
+    it('should transform tool-call-suspended chunks from workflow-step-output', async () => {
+      const mockStream = new ReadableStream<ChunkType>({
+        async start(controller) {
+          // Workflow starts
+          controller.enqueue({
+            type: 'workflow-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              workflowId: 'test-workflow',
+            },
+          });
+
+          // Step starts
+          controller.enqueue({
+            id: 'agent-step',
+            type: 'workflow-step-start',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'agent-step',
+              stepCallId: 'call-1',
+              status: 'running',
+            },
+          });
+
+          // Tool call suspended chunk (Mastra chunk format)
+          controller.enqueue({
+            type: 'workflow-step-output',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              output: {
+                type: 'tool-call-suspended',
+                from: ChunkFrom.AGENT,
+                runId: 'agent-run-id',
+                payload: {
+                  toolCallId: 'tool-call-1',
+                  toolName: 'suspendable-tool',
+                  suspendPayload: {
+                    reason: 'Waiting for user approval',
+                    data: { value: 42 },
+                  },
+                },
+              },
+            },
+          });
+
+          // Step result
+          controller.enqueue({
+            type: 'workflow-step-result',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              id: 'agent-step',
+              stepCallId: 'call-1',
+              status: 'success',
+              output: {},
+            },
+          });
+
+          // Workflow finish
+          controller.enqueue({
+            type: 'workflow-finish',
+            runId: 'test-run-id',
+            from: ChunkFrom.WORKFLOW,
+            payload: {
+              metadata: {},
+              workflowStatus: 'success',
+              output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const transformedStream = mockStream.pipeThrough(
+        WorkflowStreamToAISDKTransformer({ includeTextStreamParts: true }),
+      );
+
+      const chunks: any[] = [];
+      for await (const chunk of transformedStream) {
+        chunks.push(chunk);
+      }
+
+      // Find the tool-call-suspended chunk (converted to data-tool-call-suspended)
+      const toolCallSuspendedChunk = chunks.find(chunk => chunk.type === 'data-tool-call-suspended');
+
+      // Verify tool-call-suspended is transformed and passed through
+      expect(toolCallSuspendedChunk).toBeDefined();
+      expect(toolCallSuspendedChunk.type).toBe('data-tool-call-suspended');
+      expect(toolCallSuspendedChunk.id).toBe('tool-call-1');
+      expect(toolCallSuspendedChunk.data).toEqual({
+        runId: 'agent-run-id',
+        toolCallId: 'tool-call-1',
+        toolName: 'suspendable-tool',
+        suspendPayload: {
+          reason: 'Waiting for user approval',
+          data: { value: 42 },
+        },
+      });
+    });
+
     it('should not include text stream chunks when includeTextStreamParts is false', async () => {
       const mockStream = new ReadableStream<ChunkType>({
         async start(controller) {

--- a/client-sdks/ai-sdk/src/utils.ts
+++ b/client-sdks/ai-sdk/src/utils.ts
@@ -21,6 +21,8 @@ export const isMastraTextStreamChunk = (chunk: any): chunk is ChunkType<OutputSc
       'source',
       'tool-input-start',
       'tool-input-delta',
+      'tool-call-approval',
+      'tool-call-suspended',
       'tool-call',
       'tool-result',
       'tool-error',
@@ -31,6 +33,8 @@ export const isMastraTextStreamChunk = (chunk: any): chunk is ChunkType<OutputSc
       'finish',
       'abort',
       'tool-input-end',
+      'object',
+      'tripwire',
       'raw',
     ].includes(chunk.type)
   );


### PR DESCRIPTION
- **(fix) Add missing workflowRoute data chunks**
- **changeset**

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)
Fixes #10978
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where tool-call-suspended chunks were being dropped during workflow transformations, ensuring they are now properly included in the text stream when a tool is suspended inside a workflow step.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->