### PR TITLE
fix(mcp): detect "Not connected" errors for auto-reconnection

### DIFF
--- a/.changeset/khaki-beers-invent.md
+++ b/.changeset/khaki-beers-invent.md
@@ -1,0 +1,7 @@
+---
+'@mastra/mcp': patch
+---
+
+Add "Not connected" error detection to MCP auto-reconnection
+
+Enhanced the MCPClient auto-reconnection feature to also detect and handle "Not connected" protocol errors. When the MCP SDK's transport layer throws this error (typically when the connection is in a disconnected state), the client will now automatically reconnect and retry the operation.

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -485,6 +485,7 @@ export class InternalMastraMCPClient extends MastraBase {
    * Common session-related errors include:
    * - "No valid session ID provided" (HTTP 400)
    * - "Server not initialized" (HTTP 400)
+   * - "Not connected" (protocol state error)
    * - Connection refused errors
    * 
    * @param error - The error to check
@@ -504,6 +505,7 @@ export class InternalMastraMCPClient extends MastraBase {
       errorMessage.includes('no valid session') ||
       errorMessage.includes('session') ||
       errorMessage.includes('server not initialized') ||
+      errorMessage.includes('not connected') ||
       errorMessage.includes('http 400') ||
       errorMessage.includes('http 401') ||
       errorMessage.includes('http 403') ||


### PR DESCRIPTION
## Description

Add "Not connected" to session error detection so the client automatically reconnects when the transport layer is disconnected.

## Related Issue(s)

slack

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved MCPClient auto-reconnection to detect and handle "Not connected" protocol errors, automatically triggering reconnection and retrying operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->