### PR TITLE
refactor(client-js): update SaveMessageToMemoryResponse type 

### DIFF
--- a/.changeset/four-zoos-shake.md
+++ b/.changeset/four-zoos-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fix `saveMessageToMemory` return type to match API response. The method now correctly returns `{ messages: MastraDBMessage[] }` instead of `MastraDBMessage[]` to align with the server endpoint response schema.

--- a/.changeset/four-zoos-shake.md
+++ b/.changeset/four-zoos-shake.md
@@ -2,4 +2,4 @@
 '@mastra/client-js': patch
 ---
 
-Fix `saveMessageToMemory` return type to match API response. The method now correctly returns `{ messages: MastraDBMessage[] }` instead of `MastraDBMessage[]` to align with the server endpoint response schema.
+Fix `saveMessageToMemory` return type to match API response. The method now correctly returns `{ messages: (MastraMessageV1 | MastraDBMessage)[] }` instead of `(MastraMessageV1 | MastraDBMessage)[]` to align with the server endpoint response schema.

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -255,7 +255,9 @@ export interface SaveNetworkMessageToMemoryParams {
   networkId: string;
 }
 
-export type SaveMessageToMemoryResponse = (MastraMessageV1 | MastraDBMessage)[];
+export type SaveMessageToMemoryResponse = {
+  messages: (MastraMessageV1 | MastraDBMessage)[];
+};
 
 export interface CreateMemoryThreadParams {
   title?: string;

--- a/client-sdks/client-js/src/v2-messages.test.ts
+++ b/client-sdks/client-js/src/v2-messages.test.ts
@@ -28,7 +28,7 @@ describe('V2 Message Format Support', () => {
 
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
-      json: async () => v1Messages,
+      json: async () => ({ messages: v1Messages }),
     });
 
     const result = await client.saveMessageToMemory({
@@ -36,7 +36,7 @@ describe('V2 Message Format Support', () => {
       messages: v1Messages,
     });
 
-    expect(result).toEqual(v1Messages);
+    expect(result).toEqual({ messages: v1Messages });
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/api/memory/save-messages'),
       expect.objectContaining({
@@ -64,7 +64,7 @@ describe('V2 Message Format Support', () => {
 
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
-      json: async () => v2Messages,
+      json: async () => ({ messages: v2Messages }),
     });
 
     const result = await client.saveMessageToMemory({
@@ -72,7 +72,7 @@ describe('V2 Message Format Support', () => {
       messages: v2Messages,
     });
 
-    expect(result).toEqual(v2Messages);
+    expect(result).toEqual({ messages: v2Messages });
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/api/memory/save-messages'),
       expect.objectContaining({
@@ -129,7 +129,7 @@ describe('V2 Message Format Support', () => {
 
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
-      json: async () => mixedMessages,
+      json: async () => ({ messages: mixedMessages }),
     });
 
     const result = await client.saveMessageToMemory({
@@ -137,7 +137,7 @@ describe('V2 Message Format Support', () => {
       messages: mixedMessages,
     });
 
-    expect(result).toEqual(mixedMessages);
+    expect(result).toEqual({ messages: mixedMessages });
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/api/memory/save-messages'),
       expect.objectContaining({
@@ -166,7 +166,7 @@ describe('V2 Message Format Support', () => {
 
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
-      json: async () => [v2MessageWithAttachments],
+      json: async () => ({ messages: [v2MessageWithAttachments] }),
     });
 
     const result = await client.saveMessageToMemory({
@@ -174,7 +174,7 @@ describe('V2 Message Format Support', () => {
       messages: [v2MessageWithAttachments],
     });
 
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual(v2MessageWithAttachments);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toEqual(v2MessageWithAttachments);
   });
 });

--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -101,8 +101,8 @@ export const mastraClient = new MastraClient({
     },
     {
       name: "saveMessageToMemory(params)",
-      type: "Promise<void>",
-      description: "Saves one or more messages to the memory system.",
+      type: "Promise<{ messages: (MastraMessageV1 | MastraDBMessage)[] }>",
+      description: "Saves one or more messages to the memory system. Returns the saved messages.",
     },
     {
       name: "getMemoryStatus()",

--- a/docs/src/content/en/reference/client-js/memory.mdx
+++ b/docs/src/content/en/reference/client-js/memory.mdx
@@ -76,7 +76,7 @@ await thread.delete();
 Save messages to memory:
 
 ```typescript
-const savedMessages = await mastraClient.saveMessageToMemory({
+const result = await mastraClient.saveMessageToMemory({
   messages: [
     {
       role: "user",
@@ -90,6 +90,9 @@ const savedMessages = await mastraClient.saveMessageToMemory({
   ],
   agentId: "agent-1",
 });
+
+// result.messages contains the saved messages
+console.log(result.messages);
 ```
 
 ### Retrieve Thread Messages


### PR DESCRIPTION
## Description

update SaveMessageToMemoryResponse type  and adjust related tests and documentation

- Changed SaveMessageToMemoryResponse type to return an object containing messages.
- Updated tests to reflect the new response structure.
- Modified documentation to clarify the return type of saveMessageToMemory method.

## Related Issue(s)

Slack issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `saveMessageToMemory` function response format has changed. It now returns an object with a `messages` property instead of a direct array.

* **Bug Fixes**
  * Aligned client response format with server endpoint schema.

* **Documentation**
  * Updated API reference and usage examples to reflect the new response structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->