### PR TITLE
fix: use tanstack query internal hashing for complex keys

### DIFF
--- a/.changeset/late-ads-try.md
+++ b/.changeset/late-ads-try.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Use the hash based stringification mechanism of tanstack query to ensure keys ordering (and to keep the caching key valid and consistent)

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent.ts
@@ -7,7 +7,7 @@ export const useAgent = (agentId?: string) => {
   const { requestContext } = usePlaygroundStore();
 
   return useQuery({
-    queryKey: ['agent', agentId, JSON.stringify(requestContext)],
+    queryKey: ['agent', agentId, requestContext],
     queryFn: () => (agentId ? client.getAgent(agentId).details(requestContext) : null),
     retry: false,
     enabled: Boolean(agentId),

--- a/packages/playground-ui/src/domains/agents/hooks/use-agents.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agents.ts
@@ -9,7 +9,7 @@ export const useAgents = () => {
   const { requestContext } = usePlaygroundStore();
 
   return useQuery({
-    queryKey: ['agents', JSON.stringify(requestContext)],
+    queryKey: ['agents', requestContext],
     queryFn: () => client.listAgents(requestContext),
   });
 };

--- a/packages/playground-ui/src/domains/workflows/hooks/use-workflows.ts
+++ b/packages/playground-ui/src/domains/workflows/hooks/use-workflows.ts
@@ -7,7 +7,7 @@ export const useWorkflows = () => {
   const { requestContext } = usePlaygroundStore();
 
   return useQuery({
-    queryKey: ['workflows', JSON.stringify(requestContext)],
+    queryKey: ['workflows', requestContext],
     queryFn: () => client.listWorkflows(requestContext),
   });
 };


### PR DESCRIPTION
## Description

Tanstack query has a deterministic and internal way to generate complex keys based on serializable objects/array. We should use it instead of JSON.stringify. It does not have an impact locally (requests are too fast) but it may cause cloud to not use the tanstack query cache

https://tanstack.com/query/v5/docs/framework/react/guides/query-keys#query-keys-are-hashed-deterministically

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query caching consistency for agents and workflows modules, ensuring reliable cache key ordering and memoization behavior for better application performance and reduced duplicate requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->