### PR TITLE
fix: replace or remove broken links to docs.mastra.ai

### DIFF
--- a/communications/releases/2025-02-09.md
+++ b/communications/releases/2025-02-09.md
@@ -496,8 +496,6 @@ Here's the changelog for the IBM Speech module covering February 2-9, 2025:
 
 Note: This period primarily focused on infrastructure and dependency management improvements. No significant feature additions or bug fixes were implemented during this timeframe.
 
-For detailed information about the IBM Speech integration, please visit our [documentation](https://docs.mastra.ai/speech/ibm).
-
 ## speech/murf
 
 Here's the changelog for Mastra AI's speech/murf module covering February 2-9, 2025:
@@ -550,7 +548,7 @@ February 2-9, 2025
 
 Note: This module has several version bumps related to dependency updates from the core package, but they don't directly affect the speech/openai functionality.
 
-For detailed technical documentation, visit our [OpenAI Speech Integration docs](https://docs.mastra.ai/speech/openai).
+For detailed technical documentation, visit our [OpenAI Speech Integration docs](https://mastra.ai/reference/voice/openai).
 
 ## speech/playai
 
@@ -622,7 +620,7 @@ Here's the changelog for Mastra AI's speechify module covering February 2-9, 202
 
 Note: Several minor version bumps and dependency updates were made to maintain compatibility with @mastra/core updates.
 
-For detailed API documentation, please visit our [Speechify Integration Guide](https://docs.mastra.ai/speech/speechify).
+For detailed API documentation, please visit our [Speechify Integration Guide](https://mastra.ai/reference/voice/speechify)).
 
 ## stores/pg
 

--- a/communications/releases/2025-02-09.md
+++ b/communications/releases/2025-02-09.md
@@ -620,7 +620,7 @@ Here's the changelog for Mastra AI's speechify module covering February 2-9, 202
 
 Note: Several minor version bumps and dependency updates were made to maintain compatibility with @mastra/core updates.
 
-For detailed API documentation, please visit our [Speechify Integration Guide](https://mastra.ai/reference/voice/speechify)).
+For detailed API documentation, please visit our [Speechify Integration Guide](https://mastra.ai/reference/voice/speechify).
 
 ## stores/pg
 

--- a/communications/releases/2025-03-19.md
+++ b/communications/releases/2025-03-19.md
@@ -643,7 +643,7 @@ Based on the git diff provided, here's the changelog for the Upstash module (v0.
 
 Note: This update primarily focused on integrating AgentNetwork capabilities and keeping dependencies in sync with the core package. Most changes were version bumps and dependency alignments rather than direct feature additions to the Upstash store module.
 
-For more information about using Upstash with Mastra AI, please refer to our [documentation](https://docs.mastra.ai/storage/upstash).
+For more information about using Upstash with Mastra AI, please refer to our [documentation](https://mastra.ai/reference/storage/upstash).
 
 ## stores/vectorize
 
@@ -658,5 +658,3 @@ Based on the git diff provided, here's the changelog for the Mastra AI Vectorize
 - Updated @mastra/core dependency to version 0.6.3
 
 Note: This release primarily focuses on integrating AgentNetwork capabilities and keeping dependencies in sync with the core package. Most changes appear to be version bumps and dependency alignments rather than major functional changes to the vectorize module itself.
-
-For more details about AgentNetwork functionality, please refer to our [documentation](https://docs.mastra.ai/agent-network).

--- a/examples/ai-sdk-v5/README.md
+++ b/examples/ai-sdk-v5/README.md
@@ -90,5 +90,5 @@ The agent will use its weather tool to fetch real-time data and provide detailed
 
 ## Learn More
 
-- [Mastra Documentation](https://docs.mastra.ai) - Learn about Mastra's features and capabilities
+- [Mastra Documentation](https://mastra.ai/docs) - Learn about Mastra's features and capabilities
 - [AI SDK Documentation](https://sdk.vercel.ai) - Explore AI SDK v5 features

--- a/templates/template-docs-chatbot/README.md
+++ b/templates/template-docs-chatbot/README.md
@@ -175,6 +175,6 @@ The Agent app should be deployed first, then the deployment URL should be added 
 
 ## Learn More
 
-- [Mastra Documentation](https://docs.mastra.ai)
-- [MCP Protocol](https://docs.mastra.ai/mcp)
+- [Mastra Documentation](https://mastra.ai/docs)
+- [MCP Protocol](https://mastra.ai/docs/mcp/overview)
 - [Turborepo Documentation](https://turborepo.com/docs)


### PR DESCRIPTION
## Description

These links are broken and need to be replaced. For some I could not find any replacement, so I removed them. If you know any replacement for these, I am super happy to add these!

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated external documentation links across release notes, examples, and templates for consistency (Mastra docs, OpenAI voice, Speechify, Upstash, MCP).
  * Removed outdated or redundant cross-references (e.g., IBM Speech entry, AgentNetwork reference) from release notes.
  * Standardized link formats and improved navigation in user-facing documentation content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->