### PR TITLE
Remove x-default alternate link from Head

### DIFF
--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -45,7 +45,6 @@ export default function Layout(props: Props): ReactNode {
       <Head>
         <link rel="canonical" href={canonicalUrl} />
         <link rel="alternate" hrefLang="en" href={canonicalUrl} />
-        <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
         <meta name="x-docs-origin" content="v1" />
       </Head>
 


### PR DESCRIPTION
I introduced this misuse, lets fix it by removing it.

See https://developers.google.com/search/docs/specialty/international/localized-versions#xdefault

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated language alternate link configuration in the documentation site, removing a default language alternate link while preserving canonical and English language links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->