### PR TITLE
Remove x-default link from Head component (v0.x)

### DIFF
--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -48,7 +48,6 @@ export default function Layout(props: Props): ReactNode {
           hrefLang="ja"
           href={`${siteConfig.url}/ja${cleanPath}`}
         />
-        <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
       </Head>
 
       <SkipToContent />


### PR DESCRIPTION
I introduced this misuse, lets fix it by removing it.

See https://developers.google.com/search/docs/specialty/international/localized-versions#xdefault
