### PR TITLE
backport/reasoning provider options duplication

### DIFF
--- a/.changeset/fix-reasoning-provider-options-duplication.md
+++ b/.changeset/fix-reasoning-provider-options-duplication.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+---
+
+Fix providerOptions loss and reasoning part duplication when convertToModelMessages splits messages at step-start markers. This ensures OpenAI GPT-5 reasoning itemId is preserved during recursive tool calls and prevents duplicate reasoning parts from appearing in multiple assistant messages.
+


### PR DESCRIPTION
## Problem

When `convertToModelMessages` splits assistant messages at `step-start` markers (added by `addStartStepPartsForAIV5`), two issues occurred:

1. **Lost `providerOptions`**: Reasoning parts lost their `providerOptions` (specifically `itemId`) because the index-based restoration logic failed when one UI message was split into multiple model messages. This broke OpenAI GPT-5 Responses API compatibility, which requires `itemId` on reasoning parts to link them to tool calls.

2. **Duplicate reasoning parts**: The same reasoning part appeared in multiple assistant messages after splitting, causing duplication in the final message list sent to the LLM.

## Solution

1. **Content-based `providerOptions` restoration**: Replaced index-based mapping with a pre-built `Map` that uses content-based keys (reasoning text or tool call ID) to efficiently restore `providerOptions` even after message splitting. This ensures O(1) lookups and works correctly when `convertToModelMessages` splits messages.

2. **Deep cloning to prevent circular references**: Use `JSON.parse(JSON.stringify())` to create deep copies of `providerMetadata` and `callProviderMetadata` before assigning to `providerOptions`, preventing `"[Circular]"` references in traces.

3. **Deduplication of reasoning parts**: Added logic to track reasoning parts by text and remove duplicates from later messages, ensuring each reasoning part appears only once in the final message list.

## Testing

- Added regression tests that verify:
  - `providerOptions` are preserved on all reasoning parts after message splitting
  - No reasoning parts are duplicated across multiple assistant messages
  - The fix works during recursive tool calls when messages are converted back to model format

All existing tests pass, and the new tests verify both the `providerOptions` preservation and deduplication.

## Related Issues

Fixes issues with OpenAI GPT-5 reasoning models (Responses API) that require `itemId` on reasoning parts. Related to GitHub issue #9005.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
