### PR TITLE
feat: add query option to playground query client

### DIFF
--- a/.changeset/tame-bats-sniff.md
+++ b/.changeset/tame-bats-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Add the possibility to pass down options to the tanstack query client. Goal is to have cacheable request in cloud and it's not possible for now because of context resolution beeing different

--- a/packages/playground-ui/src/lib/tanstack-query.tsx
+++ b/packages/playground-ui/src/lib/tanstack-query.tsx
@@ -1,7 +1,12 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientConfig, QueryClientProvider } from '@tanstack/react-query';
 
-export const PlaygroundQueryClient = ({ children }: { children: React.ReactNode }) => {
-  const queryClient = new QueryClient();
+export interface PlaygroundQueryClientProps {
+  children: React.ReactNode;
+  options?: QueryClientConfig;
+}
+
+export const PlaygroundQueryClient = ({ children, options }: PlaygroundQueryClientProps) => {
+  const queryClient = new QueryClient(options);
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };


### PR DESCRIPTION
## Description

This pull request introduces a patch to `@mastra/playground-ui` that adds support for passing custom options to the Tanstack Query Client. This enhancement allows for cacheable requests in cloud environments by enabling more flexible context resolution.

**Tanstack Query Client configuration:**

* Updated the `PlaygroundQueryClient` component in `packages/playground-ui/src/lib/tanstack-query.tsx` to accept an optional `options` prop, which is forwarded to the `QueryClient` constructor. This enables users to customize query client behavior, such as caching strategies.

**Package update:**

* Documented the change in `.changeset/tame-bats-sniff.md`, noting that this patch allows passing options to the query client for better cacheability in cloud scenarios.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
