### PR TITLE
refactor(server): rename RuntimeContext to ServerContext, remove unused playground/isDev options

### DIFF
--- a/.changeset/hungry-stars-relate.md
+++ b/.changeset/hungry-stars-relate.md
@@ -1,0 +1,26 @@
+---
+'@mastra/express': patch
+'@mastra/hono': patch
+'@mastra/deployer': patch
+'@mastra/server': patch
+---
+
+### Breaking Changes
+
+- Renamed `RuntimeContext` type to `ServerContext` to avoid confusion with the user-facing `RequestContext` (previously called `RuntimeContext`)
+- Removed `playground` and `isDev` options from server adapter constructors - these only set context variables without any actual functionality
+
+### Changes
+
+**@mastra/server**
+- Renamed `RuntimeContext` type to `ServerContext` in route handler types
+- Renamed `createTestRuntimeContext` to `createTestServerContext` in test utilities
+- Renamed `isPlayground` parameter to `isStudio` in `formatAgent` function
+
+**@mastra/hono**
+- Removed `playground` and `isDev` from `HonoVariables` type
+- Removed setting of `playground` and `isDev` context variables in middleware
+
+**@mastra/express**
+- Removed `playground` and `isDev` from `Express.Locals` interface
+- Removed setting of `playground` and `isDev` in response locals

--- a/docs/src/content/en/reference/server/express-adapter.mdx
+++ b/docs/src/content/en/reference/server/express-adapter.mdx
@@ -149,20 +149,6 @@ app.listen(4111);
       description: "Task store for A2A (Agent-to-Agent) operations",
       isOptional: true,
     },
-    {
-      name: "playground",
-      type: "boolean",
-      description: "Can be read to set context values",
-      isOptional: true,
-      defaultValue: "false",
-    },
-    {
-      name: "isDev",
-      type: "boolean",
-      description: "Development mode flag",
-      isOptional: true,
-      defaultValue: "false",
-    },
   ]}
 />
 
@@ -230,8 +216,6 @@ Available properties on `res.locals`:
 | `abortSignal` | Request cancellation signal |
 | `tools` | Available tools |
 | `taskStore` | Task store for A2A operations |
-| `playground` | Whether playground is enabled |
-| `isDev` | Whether running in development mode |
 | `customRouteAuthConfig` | Per-route auth overrides |
 | `user` | Authenticated user (if auth configured) |
 

--- a/docs/src/content/en/reference/server/hono-adapter.mdx
+++ b/docs/src/content/en/reference/server/hono-adapter.mdx
@@ -139,20 +139,6 @@ export default app;
       description: "Task store for A2A (Agent-to-Agent) operations",
       isOptional: true,
     },
-    {
-      name: "playground",
-      type: "boolean",
-      description: "Can be read to set context values",
-      isOptional: true,
-      defaultValue: "false",
-    },
-    {
-      name: "isDev",
-      type: "boolean",
-      description: "Development mode flag",
-      isOptional: true,
-      defaultValue: "false",
-    },
   ]}
 />
 
@@ -210,8 +196,6 @@ Available context keys:
 | `abortSignal` | Request cancellation signal |
 | `tools` | Available tools |
 | `taskStore` | Task store for A2A operations |
-| `playground` | Whether playground is enabled |
-| `isDev` | Whether running in development mode |
 | `customRouteAuthConfig` | Per-route auth overrides |
 | `user` | Authenticated user (if auth configured) |
 

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -88,8 +88,6 @@ export async function createHonoServer(
     mastra,
     tools: options.tools,
     taskStore: a2aTaskStore,
-    playground: options.playground,
-    isDev: options.isDev,
     bodyLimitOptions,
     openapiPath: '/openapi.json',
     customRouteAuthConfig,

--- a/packages/server/src/server/handlers/agent-builder.test.ts
+++ b/packages/server/src/server/handlers/agent-builder.test.ts
@@ -25,7 +25,7 @@ import {
   OBSERVE_STREAM_VNEXT_AGENT_BUILDER_ACTION_ROUTE,
   RESUME_STREAM_AGENT_BUILDER_ACTION_ROUTE,
 } from './agent-builder';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 
 vi.mock('@mastra/agent-builder', () => ({
   agentBuilderWorkflows: {
@@ -149,7 +149,7 @@ describe('Agent Builder Handlers', () => {
   describe('LIST_AGENT_BUILDER_ACTIONS_ROUTE', () => {
     it('should get all agent builder actions successfully', async () => {
       const result = await LIST_AGENT_BUILDER_ACTIONS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
       });
 
       expect(result).toEqual({
@@ -172,7 +172,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: undefined as any,
         }),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -184,7 +184,7 @@ describe('Agent Builder Handlers', () => {
 
       await expect(
         GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'invalid-action',
         }),
       ).rejects.toThrow(
@@ -200,7 +200,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when action is not found', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'non-existent',
         }),
       ).rejects.toThrow(new HTTPException(404, { message: 'Workflow not found' }));
@@ -208,7 +208,7 @@ describe('Agent Builder Handlers', () => {
 
     it('should get action by ID successfully', async () => {
       const result = await GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
       });
 
@@ -234,7 +234,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         START_ASYNC_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           actionId: undefined,
         } as any),
@@ -244,7 +244,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when action is not found', async () => {
       await expect(
         START_ASYNC_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'non-existent',
           runId: 'test-run',
         } as any),
@@ -253,7 +253,7 @@ describe('Agent Builder Handlers', () => {
 
     it('should start action run successfully when runId is not passed', async () => {
       const result = await START_ASYNC_AGENT_BUILDER_ACTION_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         inputData: {},
       } as any);
@@ -277,7 +277,7 @@ describe('Agent Builder Handlers', () => {
 
     it('should start action run successfully when runId is passed', async () => {
       const result = await START_ASYNC_AGENT_BUILDER_ACTION_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         runId: 'test-run',
         inputData: {},
@@ -299,7 +299,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           actionId: undefined as any,
         }),
@@ -309,7 +309,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: undefined as any,
         }),
@@ -319,7 +319,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when action is not found', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'non-existent',
           runId: 'test-run',
         }),
@@ -334,7 +334,7 @@ describe('Agent Builder Handlers', () => {
       await run.start({ inputData: {} });
 
       const result = await GET_AGENT_BUILDER_ACTION_RUN_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         runId: 'test-run',
       });
@@ -355,7 +355,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_RUN_EXECUTION_RESULT_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           actionId: undefined as any,
         }),
@@ -365,7 +365,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_RUN_EXECUTION_RESULT_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: undefined as any,
         }),
@@ -379,7 +379,7 @@ describe('Agent Builder Handlers', () => {
       await run.start({ inputData: {} });
 
       const result = await GET_AGENT_BUILDER_ACTION_RUN_EXECUTION_RESULT_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         runId: 'test-run',
       });
@@ -416,7 +416,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         CREATE_AGENT_BUILDER_ACTION_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           actionId: undefined as any,
         }),
@@ -426,7 +426,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when action is not found', async () => {
       await expect(
         CREATE_AGENT_BUILDER_ACTION_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'non-existent',
           runId: 'test-run',
         }),
@@ -435,7 +435,7 @@ describe('Agent Builder Handlers', () => {
 
     it('should create action run successfully', async () => {
       const result = await CREATE_AGENT_BUILDER_ACTION_RUN_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         runId: 'test-run',
       });
@@ -462,7 +462,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         START_AGENT_BUILDER_ACTION_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           actionId: undefined,
         } as any),
@@ -472,7 +472,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         START_AGENT_BUILDER_ACTION_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: undefined,
         } as any),
@@ -487,7 +487,7 @@ describe('Agent Builder Handlers', () => {
       await run.start({ inputData: {} });
 
       const result = await START_AGENT_BUILDER_ACTION_RUN_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         runId: 'test-run',
         inputData: { test: 'data' },
@@ -509,7 +509,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         RESUME_ASYNC_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           step: 'test-step',
           resumeData: {},
@@ -521,7 +521,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         RESUME_ASYNC_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           step: 'test-step',
           resumeData: {},
@@ -533,7 +533,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on resume', async () => {
       await expect(
         RESUME_ASYNC_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: 'non-existent',
           step: 'test-step',
@@ -556,7 +556,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         RESUME_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           step: 'test-step',
           resumeData: {},
@@ -575,7 +575,7 @@ describe('Agent Builder Handlers', () => {
       });
 
       const result = await RESUME_AGENT_BUILDER_ACTION_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'workflow-builder',
         runId: 'test-run',
         step: 'test-step',
@@ -598,7 +598,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         LIST_AGENT_BUILDER_ACTION_RUNS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: undefined,
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -606,7 +606,7 @@ describe('Agent Builder Handlers', () => {
 
     it('should get action runs successfully (empty)', async () => {
       const result = await LIST_AGENT_BUILDER_ACTION_RUNS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         page: 0,
       });
@@ -632,7 +632,7 @@ describe('Agent Builder Handlers', () => {
       await run.start({ inputData: {} });
 
       const result = await LIST_AGENT_BUILDER_ACTION_RUNS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         actionId: 'merge-template',
         page: 0,
       });
@@ -653,7 +653,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on cancel', async () => {
       await expect(
         CANCEL_AGENT_BUILDER_ACTION_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: 'non-existent',
         }),
@@ -680,7 +680,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on stream', async () => {
       await expect(
         STREAM_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           inputData: {},
           runId: undefined,
@@ -708,7 +708,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on streamVNext', async () => {
       await expect(
         STREAM_VNEXT_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           inputData: {},
           runId: undefined,
@@ -736,7 +736,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on streamLegacy', async () => {
       await expect(
         STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           inputData: {},
           runId: undefined,
@@ -764,7 +764,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         OBSERVE_STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: undefined as any,
           runId: 'test-run',
         }),
@@ -774,7 +774,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         OBSERVE_STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: undefined as any,
         }),
@@ -784,7 +784,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on observeStreamLegacy', async () => {
       await expect(
         OBSERVE_STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: 'non-existent',
         }),
@@ -811,7 +811,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         OBSERVE_STREAM_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           actionId: undefined as any,
         }),
@@ -821,7 +821,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         OBSERVE_STREAM_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: undefined as any,
         }),
@@ -831,7 +831,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on observeStream', async () => {
       await expect(
         OBSERVE_STREAM_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: 'non-existent',
         }),
@@ -858,7 +858,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         OBSERVE_STREAM_VNEXT_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           actionId: undefined as any,
         }),
@@ -868,7 +868,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         OBSERVE_STREAM_VNEXT_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: undefined as any,
         }),
@@ -878,7 +878,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when action is not found', async () => {
       await expect(
         OBSERVE_STREAM_VNEXT_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'non-existent',
           runId: 'test-run',
         }),
@@ -888,7 +888,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on observeStreamVNext', async () => {
       await expect(
         OBSERVE_STREAM_VNEXT_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'merge-template',
           runId: 'non-existent',
         }),
@@ -915,7 +915,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when actionId is not provided', async () => {
       await expect(
         RESUME_STREAM_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           step: 'test-step',
           resumeData: {},
@@ -927,7 +927,7 @@ describe('Agent Builder Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         RESUME_STREAM_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'workflow-builder',
           step: 'test-step',
           resumeData: {},
@@ -939,7 +939,7 @@ describe('Agent Builder Handlers', () => {
     it('should handle workflow registry correctly on resumeStream', async () => {
       await expect(
         RESUME_STREAM_AGENT_BUILDER_ACTION_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: 'workflow-builder',
           runId: 'non-existent',
           step: 'test-step',
@@ -976,7 +976,7 @@ describe('Agent Builder Handlers', () => {
 
       await expect(
         GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: errorMastra }),
+          ...createTestServerContext({ mastra: errorMastra }),
           actionId: 'merge-template', // Use an action that exists in workflowMap
         }),
       ).rejects.toThrow('Workflow not found');
@@ -1000,7 +1000,7 @@ describe('Agent Builder Handlers', () => {
     it('should still register and cleanup workflows even when actionId is not provided', async () => {
       await expect(
         GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           actionId: undefined as any,
         }),
       ).rejects.toThrow();

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -20,7 +20,7 @@ import {
   STREAM_GENERATE_LEGACY_ROUTE,
   STREAM_GENERATE_ROUTE,
 } from './agents';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 class MockAgent extends Agent {
   constructor(config: AgentConfig) {
     super(config);
@@ -94,7 +94,7 @@ describe('Agent Handlers', () => {
   describe('listAgentsHandler', () => {
     it('should return serialized agents', async () => {
       const result = await LIST_AGENTS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         requestContext,
       });
 
@@ -175,7 +175,7 @@ describe('Agent Handlers', () => {
       });
 
       const result = await LIST_AGENTS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mastraWithCoreProcessors }),
+        ...createTestServerContext({ mastra: mastraWithCoreProcessors }),
         requestContext,
       });
 
@@ -241,7 +241,7 @@ describe('Agent Handlers', () => {
       });
 
       const result = await LIST_AGENTS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mastraWithSchemas }),
+        ...createTestServerContext({ mastra: mastraWithSchemas }),
         requestContext,
         partial: 'true',
       });
@@ -309,7 +309,7 @@ describe('Agent Handlers', () => {
       });
 
       const result = await LIST_AGENTS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mastraWithSchemas }),
+        ...createTestServerContext({ mastra: mastraWithSchemas }),
         requestContext,
         // No partial parameter provided
       });
@@ -363,7 +363,7 @@ describe('Agent Handlers', () => {
       mockAgent = makeMockAgent({ workflows: { hello: workflow } });
       mockMastra = makeMastraMock({ agents: { 'test-agent': mockAgent } });
       const result = await GET_AGENT_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-agent',
       });
 
@@ -402,7 +402,7 @@ describe('Agent Handlers', () => {
 
     it('should return serialized agent with model list', async () => {
       const result = await GET_AGENT_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-multi-model-agent',
         requestContext,
       });
@@ -433,7 +433,7 @@ describe('Agent Handlers', () => {
 
     it('should throw 404 when agent not found', async () => {
       await expect(
-        GET_AGENT_BY_ID_ROUTE.handler({ ...createTestRuntimeContext({ mastra: mockMastra }), agentId: 'non-existing' }),
+        GET_AGENT_BY_ID_ROUTE.handler({ ...createTestServerContext({ mastra: mockMastra }), agentId: 'non-existing' }),
       ).rejects.toThrow(
         new HTTPException(404, {
           message: 'Agent with id non-existing not found',
@@ -448,7 +448,7 @@ describe('Agent Handlers', () => {
       (mockAgent.generate as any).mockResolvedValue(mockResult);
 
       const result = await GENERATE_AGENT_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-agent',
         messages: ['test message'],
         resourceId: 'test-resource',
@@ -462,7 +462,7 @@ describe('Agent Handlers', () => {
     it('should throw 404 when agent not found', async () => {
       await expect(
         GENERATE_AGENT_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           agentId: 'non-existing',
           messages: ['test message'],
           resourceId: 'test-resource',
@@ -482,7 +482,7 @@ describe('Agent Handlers', () => {
       (mockAgent.stream as any).mockResolvedValue(mockStreamResult);
 
       const result = await STREAM_GENERATE_LEGACY_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-agent',
         messages: ['test message'],
         resourceId: 'test-resource',
@@ -496,7 +496,7 @@ describe('Agent Handlers', () => {
     it('should throw 404 when agent not found', async () => {
       await expect(
         STREAM_GENERATE_LEGACY_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           agentId: 'non-existing',
           messages: ['test message'],
           resourceId: 'test-resource',
@@ -517,7 +517,7 @@ describe('Agent Handlers', () => {
       };
       (mockAgent.stream as any).mockResolvedValue(mockStreamResult);
       const updateResult = await UPDATE_AGENT_MODEL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-agent',
         modelId: 'gpt-4o-mini',
         provider: 'openai',
@@ -531,7 +531,7 @@ describe('Agent Handlers', () => {
       //confirm that stream works fine after the model update
 
       const result = await STREAM_GENERATE_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-agent',
         messages: ['test message'],
         resourceId: 'test-resource',
@@ -556,7 +556,7 @@ describe('Agent Handlers', () => {
       const reversedModelListIds = modelListIds.reverse();
 
       await REORDER_AGENT_MODEL_LIST_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-multi-model-agent',
         reorderedModelIds: reversedModelListIds,
       });
@@ -576,7 +576,7 @@ describe('Agent Handlers', () => {
       expect(modelList?.length).toBe(3);
       const model1Id = modelList?.[1].id!;
       await UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-multi-model-agent',
         modelConfigId: model1Id,
         model: {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -319,12 +319,12 @@ async function formatAgent({
   mastra,
   agent,
   requestContext,
-  isPlayground,
+  isStudio,
 }: {
   mastra: Context['mastra'];
   agent: Agent;
   requestContext: RequestContext;
-  isPlayground: boolean;
+  isStudio: boolean;
 }): Promise<SerializedAgent> {
   const description = agent.getDescription();
   const tools = await agent.listTools({ requestContext });
@@ -369,7 +369,7 @@ async function formatAgent({
   }
 
   let proxyRequestContext = requestContext;
-  if (isPlayground) {
+  if (isStudio) {
     proxyRequestContext = new Proxy(requestContext, {
       get(target, prop) {
         if (prop === 'get') {
@@ -482,12 +482,12 @@ export const GET_AGENT_BY_ID_ROUTE = createRoute({
   handler: async ({ agentId, mastra, requestContext }) => {
     try {
       const agent = await getAgentFromSystem({ mastra, agentId });
-      const isPlayground = false; // TODO: Get from context if needed
+      const isStudio = false; // TODO: Get from context if needed
       const result = await formatAgent({
         mastra,
         agent,
         requestContext,
-        isPlayground,
+        isStudio,
       });
       return result;
     } catch (error) {

--- a/packages/server/src/server/handlers/logs.test.ts
+++ b/packages/server/src/server/handlers/logs.test.ts
@@ -5,7 +5,7 @@ import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
 import { LIST_LOGS_ROUTE, LIST_LOGS_BY_RUN_ID_ROUTE, LIST_LOG_TRANSPORTS_ROUTE } from './logs';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 
 type MockedLogger = {
   listLogsByRunId: Mock<IMastraLogger['listLogsByRunId']>;
@@ -59,7 +59,7 @@ describe('Logs Handlers', () => {
   describe('listLogsHandler', () => {
     it('should throw error when transportId is not provided', async () => {
       await expect(
-        LIST_LOGS_ROUTE.handler({ ...createTestRuntimeContext({ mastra }), page: 1, transportId: undefined as any }),
+        LIST_LOGS_ROUTE.handler({ ...createTestServerContext({ mastra }), page: 1, transportId: undefined as any }),
       ).rejects.toThrow(new HTTPException(400, { message: 'Argument "transportId" is required' }));
     });
 
@@ -68,7 +68,7 @@ describe('Logs Handlers', () => {
 
       mockLogger.listLogs.mockResolvedValue({ logs: mockLogs, total: 1, page: 1, perPage: 100, hasMore: false });
       const result = await LIST_LOGS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         page: 0,
         transportId: 'test-transport',
       });
@@ -82,7 +82,7 @@ describe('Logs Handlers', () => {
 
       mockLogger.listLogs.mockResolvedValue({ logs: mockLogs, total: 1, page: 1, perPage: 100, hasMore: false });
       const result = await LIST_LOGS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         transportId: 'test-transport',
         logLevel: LogLevel.INFO,
         page: 0,
@@ -99,7 +99,7 @@ describe('Logs Handlers', () => {
 
       mockLogger.listLogs.mockResolvedValue({ logs: mockLogs, total: 1, page: 1, perPage: 100, hasMore: false });
       const result = await LIST_LOGS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         transportId: 'test-transport',
         filters: ['timestamp:2024-01-01T10:30:00', 'url:https://example.com'],
         page: 0,
@@ -119,7 +119,7 @@ describe('Logs Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         LIST_LOGS_BY_RUN_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           runId: undefined as any,
           transportId: 'test-transport',
           page: 1,
@@ -130,7 +130,7 @@ describe('Logs Handlers', () => {
     it('should throw error when transportId is not provided', async () => {
       await expect(
         LIST_LOGS_BY_RUN_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           runId: 'test-run',
           page: 1,
           transportId: undefined as any,
@@ -149,7 +149,7 @@ describe('Logs Handlers', () => {
         hasMore: false,
       });
       const result = await LIST_LOGS_BY_RUN_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         runId: 'test-run',
         transportId: 'test-transport',
         page: 0,
@@ -170,7 +170,7 @@ describe('Logs Handlers', () => {
         ['file', {}],
       ]) as unknown as Record<string, unknown>;
 
-      const result = await LIST_LOG_TRANSPORTS_ROUTE.handler({ ...createTestRuntimeContext({ mastra }) });
+      const result = await LIST_LOG_TRANSPORTS_ROUTE.handler({ ...createTestServerContext({ mastra }) });
 
       expect(result).toEqual({
         transports: ['console', 'file'],
@@ -180,7 +180,7 @@ describe('Logs Handlers', () => {
     it('should handle empty transports', async () => {
       mockLogger.transports = new Map<string, unknown>() as unknown as Record<string, unknown>;
 
-      const result = await LIST_LOG_TRANSPORTS_ROUTE.handler({ ...createTestRuntimeContext({ mastra }) });
+      const result = await LIST_LOG_TRANSPORTS_ROUTE.handler({ ...createTestServerContext({ mastra }) });
 
       expect(result).toEqual({
         transports: [],

--- a/packages/server/src/server/handlers/mcp.test.ts
+++ b/packages/server/src/server/handlers/mcp.test.ts
@@ -9,7 +9,7 @@ import {
   GET_MCP_SERVER_TOOL_DETAIL_ROUTE,
   EXECUTE_MCP_SERVER_TOOL_ROUTE,
 } from './mcp';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 
 /**
  * MCP Registry Handler Tests
@@ -102,7 +102,7 @@ describe('MCP Registry Handlers', () => {
       } as unknown as Mastra;
 
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: emptyMastra }),
+        ...createTestServerContext({ mastra: emptyMastra }),
       });
 
       expect(result.servers).toEqual([]);
@@ -112,7 +112,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should return all servers when no pagination params provided', async () => {
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
       });
 
       expect(result.servers).toHaveLength(2);
@@ -124,7 +124,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should paginate servers when perPage is provided', async () => {
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         perPage: 1,
         page: 0,
       });
@@ -138,7 +138,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should paginate servers when legacy limit/offset is provided', async () => {
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         limit: 1,
         offset: 0,
       });
@@ -153,7 +153,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should calculate next URL correctly', async () => {
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         perPage: 1,
         page: 0,
       });
@@ -163,7 +163,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should return null for next when no more results', async () => {
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         perPage: 10,
         page: 0,
       });
@@ -173,7 +173,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should handle page correctly', async () => {
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         perPage: 1,
         page: 1,
       });
@@ -185,7 +185,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should convert legacy offset to page', async () => {
       const result = await LIST_MCP_SERVERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         limit: 1,
         offset: 1,
       });
@@ -200,7 +200,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         LIST_MCP_SERVERS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: invalidMastra }),
+          ...createTestServerContext({ mastra: invalidMastra }),
         }),
       ).rejects.toThrow(HTTPException);
     });
@@ -210,14 +210,14 @@ describe('MCP Registry Handlers', () => {
     it('should throw 404 when server not found', async () => {
       await expect(
         GET_MCP_SERVER_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           id: 'non-existent',
         }),
       ).rejects.toThrow(HTTPException);
 
       await expect(
         GET_MCP_SERVER_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           id: 'non-existent',
         }),
       ).rejects.toThrow(/not found/);
@@ -225,7 +225,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should return server details when found', async () => {
       const result = await GET_MCP_SERVER_DETAIL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         id: 'server1',
       });
 
@@ -235,7 +235,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should validate version parameter when provided', async () => {
       const result = await GET_MCP_SERVER_DETAIL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         id: 'server1',
         version: '1.0.0',
       });
@@ -246,7 +246,7 @@ describe('MCP Registry Handlers', () => {
     it('should throw 404 when version does not match', async () => {
       await expect(
         GET_MCP_SERVER_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           id: 'server1',
           version: '2.0.0',
         }),
@@ -254,7 +254,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         GET_MCP_SERVER_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           id: 'server1',
           version: '2.0.0',
         }),
@@ -266,7 +266,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         GET_MCP_SERVER_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: invalidMastra }),
+          ...createTestServerContext({ mastra: invalidMastra }),
           id: 'server1',
         }),
       ).rejects.toThrow(HTTPException);
@@ -277,14 +277,14 @@ describe('MCP Registry Handlers', () => {
     it('should throw 404 when server not found', async () => {
       await expect(
         LIST_MCP_SERVER_TOOLS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'non-existent',
         }),
       ).rejects.toThrow(HTTPException);
 
       await expect(
         LIST_MCP_SERVER_TOOLS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'non-existent',
         }),
       ).rejects.toThrow(/not found/);
@@ -292,7 +292,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should return tool list for server', async () => {
       const result = await LIST_MCP_SERVER_TOOLS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         serverId: 'server1',
       });
 
@@ -317,14 +317,14 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         LIST_MCP_SERVER_TOOLS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           serverId: 'server1',
         }),
       ).rejects.toThrow(HTTPException);
 
       await expect(
         LIST_MCP_SERVER_TOOLS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           serverId: 'server1',
         }),
       ).rejects.toThrow(/cannot list tools/);
@@ -335,7 +335,7 @@ describe('MCP Registry Handlers', () => {
     it('should throw 404 when server not found', async () => {
       await expect(
         GET_MCP_SERVER_TOOL_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'non-existent',
           toolId: 'tool1',
         }),
@@ -343,7 +343,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         GET_MCP_SERVER_TOOL_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'non-existent',
           toolId: 'tool1',
         }),
@@ -353,7 +353,7 @@ describe('MCP Registry Handlers', () => {
     it('should throw 404 when tool not found', async () => {
       await expect(
         GET_MCP_SERVER_TOOL_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'server1',
           toolId: 'non-existent',
         }),
@@ -361,7 +361,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         GET_MCP_SERVER_TOOL_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'server1',
           toolId: 'non-existent',
         }),
@@ -370,7 +370,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should return tool details when found', async () => {
       const result = await GET_MCP_SERVER_TOOL_DETAIL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         serverId: 'server1',
         toolId: 'tool1',
       });
@@ -395,7 +395,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         GET_MCP_SERVER_TOOL_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           serverId: 'server1',
           toolId: 'tool1',
         }),
@@ -403,7 +403,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         GET_MCP_SERVER_TOOL_DETAIL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           serverId: 'server1',
           toolId: 'tool1',
         }),
@@ -415,7 +415,7 @@ describe('MCP Registry Handlers', () => {
     it('should throw 404 when server not found', async () => {
       await expect(
         EXECUTE_MCP_SERVER_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'non-existent',
           toolId: 'tool1',
           data: {},
@@ -424,7 +424,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         EXECUTE_MCP_SERVER_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           serverId: 'non-existent',
           toolId: 'tool1',
           data: {},
@@ -436,7 +436,7 @@ describe('MCP Registry Handlers', () => {
       const testData = { input: 'test' };
 
       const result = await EXECUTE_MCP_SERVER_TOOL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         serverId: 'server1',
         toolId: 'tool1',
         data: testData,
@@ -450,7 +450,7 @@ describe('MCP Registry Handlers', () => {
 
     it('should execute tool without data', async () => {
       const result = await EXECUTE_MCP_SERVER_TOOL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         serverId: 'server1',
         toolId: 'tool1',
       });
@@ -471,7 +471,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         EXECUTE_MCP_SERVER_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           serverId: 'server1',
           toolId: 'tool1',
           data: {},
@@ -491,7 +491,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         EXECUTE_MCP_SERVER_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           serverId: 'server1',
           toolId: 'tool1',
           data: {},
@@ -500,7 +500,7 @@ describe('MCP Registry Handlers', () => {
 
       await expect(
         EXECUTE_MCP_SERVER_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           serverId: 'server1',
           toolId: 'tool1',
           data: {},

--- a/packages/server/src/server/handlers/mcp.ts
+++ b/packages/server/src/server/handlers/mcp.ts
@@ -13,7 +13,7 @@ import {
   mcpToolInfoSchema,
   executeToolResponseSchema,
 } from '../schemas/mcp';
-import type { RuntimeContext } from '../server-adapter';
+import type { ServerContext } from '../server-adapter';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
 // ============================================================================
@@ -35,7 +35,7 @@ export const LIST_MCP_SERVERS_ROUTE = createRoute({
     perPage,
     limit,
     offset,
-  }: RuntimeContext & { page?: number; perPage?: number; limit?: number; offset?: number }) => {
+  }: ServerContext & { page?: number; perPage?: number; limit?: number; offset?: number }) => {
     if (!mastra || typeof mastra.listMCPServers !== 'function') {
       throw new HTTPException(500, { message: 'Mastra instance or listMCPServers method not available' });
     }
@@ -106,7 +106,7 @@ export const GET_MCP_SERVER_DETAIL_ROUTE = createRoute({
   summary: 'Get MCP server details',
   description: 'Returns detailed information about a specific MCP server',
   tags: ['MCP'],
-  handler: async ({ mastra, id, version }: RuntimeContext & { id: string; version?: string }) => {
+  handler: async ({ mastra, id, version }: ServerContext & { id: string; version?: string }) => {
     if (!mastra || typeof mastra.getMCPServerById !== 'function') {
       throw new HTTPException(500, { message: 'Mastra instance or getMCPServerById method not available' });
     }
@@ -139,7 +139,7 @@ export const LIST_MCP_SERVER_TOOLS_ROUTE = createRoute({
   summary: 'List MCP server tools',
   description: 'Returns a list of tools available on the specified MCP server',
   tags: ['MCP'],
-  handler: async ({ mastra, serverId }: RuntimeContext & { serverId: string }) => {
+  handler: async ({ mastra, serverId }: ServerContext & { serverId: string }) => {
     if (!mastra || typeof mastra.getMCPServerById !== 'function') {
       throw new HTTPException(500, { message: 'Mastra instance or getMCPServerById method not available' });
     }
@@ -167,7 +167,7 @@ export const GET_MCP_SERVER_TOOL_DETAIL_ROUTE = createRoute({
   summary: 'Get MCP server tool details',
   description: 'Returns detailed information about a specific tool on the MCP server',
   tags: ['MCP'],
-  handler: async ({ mastra, serverId, toolId }: RuntimeContext & { serverId: string; toolId: string }) => {
+  handler: async ({ mastra, serverId, toolId }: ServerContext & { serverId: string; toolId: string }) => {
     if (!mastra || typeof mastra.getMCPServerById !== 'function') {
       throw new HTTPException(500, { message: 'Mastra instance or getMCPServerById method not available' });
     }
@@ -206,7 +206,7 @@ export const EXECUTE_MCP_SERVER_TOOL_ROUTE = createRoute({
     serverId,
     toolId,
     data,
-  }: RuntimeContext & { serverId: string; toolId: string; data?: unknown }) => {
+  }: ServerContext & { serverId: string; toolId: string; data?: unknown }) => {
     if (!mastra || typeof mastra.getMCPServerById !== 'function') {
       throw new HTTPException(500, { message: 'Mastra instance or getMCPServerById method not available' });
     }
@@ -257,7 +257,7 @@ export const MCP_HTTP_TRANSPORT_ROUTE = createRoute({
   summary: 'MCP HTTP Transport',
   description: 'Streamable HTTP transport endpoint for MCP protocol communication',
   tags: ['MCP'],
-  handler: async ({ mastra, serverId }: RuntimeContext & { serverId: string }): Promise<MCPHttpTransportResult> => {
+  handler: async ({ mastra, serverId }: ServerContext & { serverId: string }): Promise<MCPHttpTransportResult> => {
     if (!mastra || typeof mastra.getMCPServerById !== 'function') {
       throw new HTTPException(500, { message: 'Mastra instance or getMCPServerById method not available' });
     }
@@ -283,7 +283,7 @@ export const MCP_SSE_TRANSPORT_ROUTE = createRoute({
   summary: 'MCP SSE Transport',
   description: 'SSE transport endpoint for MCP protocol communication',
   tags: ['MCP'],
-  handler: async ({ mastra, serverId }: RuntimeContext & { serverId: string }): Promise<MCPSseTransportResult> => {
+  handler: async ({ mastra, serverId }: ServerContext & { serverId: string }): Promise<MCPSseTransportResult> => {
     if (!mastra || typeof mastra.getMCPServerById !== 'function') {
       throw new HTTPException(500, { message: 'Mastra instance or getMCPServerById method not available' });
     }

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -15,7 +15,7 @@ import {
   DELETE_MESSAGES_ROUTE,
   getTextContent,
 } from './memory';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 
 function createThread(overrides?: Partial<StorageThreadType>): StorageThreadType {
   const now = new Date();
@@ -55,7 +55,7 @@ describe('Memory Handlers', () => {
       });
 
       const result = await GET_MEMORY_STATUS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: undefined as any,
       });
       expect(result).toEqual({ result: false });
@@ -69,7 +69,7 @@ describe('Memory Handlers', () => {
       });
 
       const result = await GET_MEMORY_STATUS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: 'mockAgent',
       });
       expect(result).toEqual({ result: true });
@@ -85,7 +85,7 @@ describe('Memory Handlers', () => {
       });
 
       const result = await GET_MEMORY_STATUS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: 'test-agent',
       });
       expect(result).toEqual({ result: true });
@@ -97,7 +97,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         GET_MEMORY_STATUS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'non-existent',
         }),
       ).rejects.toThrow(HTTPException);
@@ -119,7 +119,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         LIST_THREADS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           resourceId: 'test-resource',
           agentId: 'test-agent',
           page: 0,
@@ -135,7 +135,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         LIST_THREADS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
           page: 0,
           perPage: 10,
@@ -155,7 +155,7 @@ describe('Memory Handlers', () => {
       const spy = vi.spyOn(mockMemory, 'listThreadsByResourceId');
 
       const result = await LIST_THREADS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         resourceId: 'test-resource',
         agentId: 'test-agent',
         page: 0,
@@ -188,7 +188,7 @@ describe('Memory Handlers', () => {
       const spy = vi.spyOn(mockMemory, 'listThreadsByResourceId');
 
       const result = await LIST_THREADS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         resourceId: 'test-resource',
         agentId: 'test-agent',
         page: 0,
@@ -219,7 +219,7 @@ describe('Memory Handlers', () => {
 
       // Test updatedAt DESC sorting
       const result = await LIST_THREADS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         resourceId: 'test-resource',
         agentId: 'test-agent',
         page: 0,
@@ -246,7 +246,7 @@ describe('Memory Handlers', () => {
       const spy = vi.spyOn(mockMemory, 'listThreadsByResourceId');
 
       const result = await LIST_THREADS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         resourceId: 'non-existent-resource',
         agentId: 'test-agent',
         page: 0,
@@ -267,7 +267,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         GET_THREAD_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           threadId: undefined as any,
           agentId: 'test-agent',
         }),
@@ -288,7 +288,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         GET_THREAD_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           threadId: 'test-thread',
           agentId: 'test-agent',
         }),
@@ -306,7 +306,7 @@ describe('Memory Handlers', () => {
 
       await expect(
         GET_THREAD_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           threadId: 'non-existent',
           agentId: 'test-agent',
         }),
@@ -327,7 +327,7 @@ describe('Memory Handlers', () => {
       const spy = vi.spyOn(mockMemory, 'getThreadById');
 
       const result = await GET_THREAD_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         threadId: 'test-thread',
         agentId: 'test-agent',
       });
@@ -351,7 +351,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         SAVE_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
           messages: [] as MastraDBMessage[],
         }),
@@ -367,7 +367,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         SAVE_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
           messages: undefined as unknown as MastraDBMessage[],
         }),
@@ -383,7 +383,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         SAVE_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
           messages: 'not-an-array' as unknown as MastraDBMessage[],
         }),
@@ -415,7 +415,7 @@ describe('Memory Handlers', () => {
       const spy = vi.spyOn(mockMemory, 'saveMessages');
 
       const result = await SAVE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: 'test-agent',
         messages: mockMessages,
       });
@@ -470,7 +470,7 @@ describe('Memory Handlers', () => {
 
       // Save both messages
       const saveResponse = await SAVE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: 'test-agent',
         messages: [v1Message, v2Message] as MastraDBMessage[],
       });
@@ -486,7 +486,7 @@ describe('Memory Handlers', () => {
 
       // Retrieve messages
       const getResponse = await LIST_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         threadId,
         resourceId,
         agentId: 'test-agent',
@@ -594,7 +594,7 @@ describe('Memory Handlers', () => {
 
       // Save mixed messages
       const saveResponse = await SAVE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: 'test-agent',
         messages: messages as MastraDBMessage[],
       });
@@ -627,7 +627,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         CREATE_THREAD_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: undefined as any,
           resourceId: 'test-resource',
         }),
@@ -643,7 +643,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         CREATE_THREAD_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
           resourceId: undefined as any,
         }),
@@ -660,7 +660,7 @@ describe('Memory Handlers', () => {
       const spy = vi.spyOn(mockMemory, 'createThread');
 
       const result = await CREATE_THREAD_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: 'test-agent',
         resourceId: 'test-resource',
         title: 'Test Thread',
@@ -686,7 +686,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         LIST_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           threadId: undefined as any,
           agentId: 'test-agent',
           page: 0,
@@ -708,7 +708,7 @@ describe('Memory Handlers', () => {
       });
       await expect(
         LIST_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           threadId: 'test-thread',
           agentId: 'testAgent',
           page: 0,
@@ -727,7 +727,7 @@ describe('Memory Handlers', () => {
       vi.spyOn(storage, 'getThreadById').mockResolvedValue(null);
       await expect(
         LIST_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           threadId: 'non-existent',
           agentId: 'test-agent',
           page: 0,
@@ -770,7 +770,7 @@ describe('Memory Handlers', () => {
       vi.spyOn(storage, 'listMessages').mockResolvedValue(mockResult);
 
       const result = await LIST_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         threadId: 'test-thread',
         resourceId: 'test-resource',
         agentId: 'test-agent',
@@ -842,7 +842,7 @@ describe('Memory Handlers', () => {
       vi.spyOn(mockMemory, 'recall');
 
       const result = await LIST_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         threadId,
         resourceId: 'test-resource',
         agentId: 'test-agent',
@@ -928,7 +928,7 @@ describe('Memory Handlers', () => {
       vi.spyOn(mockMemory, 'recall');
 
       const result = await LIST_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         threadId,
         resourceId: 'test-resource',
         agentId: 'test-agent',
@@ -986,7 +986,7 @@ describe('Memory Handlers', () => {
       vi.spyOn(mockMemory, 'recall');
 
       const result = await LIST_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         threadId,
         resourceId: 'test-resource',
         agentId: 'test-agent',
@@ -1069,7 +1069,7 @@ describe('Memory Handlers', () => {
       vi.spyOn(mockMemory, 'recall');
 
       const result = await LIST_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         threadId,
         resourceId: 'test-resource',
         agentId: 'test-agent',
@@ -1100,7 +1100,7 @@ describe('Memory Handlers', () => {
 
       await expect(
         DELETE_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           messageIds: undefined as any,
           agentId: 'test-agent',
         }),
@@ -1115,7 +1115,7 @@ describe('Memory Handlers', () => {
 
       await expect(
         DELETE_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           messageIds: ['test-message-id'],
           agentId: undefined as any,
         }),
@@ -1133,7 +1133,7 @@ describe('Memory Handlers', () => {
       mockMemory.deleteMessages = vi.fn().mockResolvedValue(undefined);
 
       const result = await DELETE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         messageIds: 'test-message-id',
         agentId: 'test-agent',
       });
@@ -1154,7 +1154,7 @@ describe('Memory Handlers', () => {
       mockMemory.deleteMessages = vi.fn().mockResolvedValue(undefined);
 
       const result = await DELETE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         messageIds: ['msg-1', 'msg-2', 'msg-3'],
         agentId: 'test-agent',
       });
@@ -1174,7 +1174,7 @@ describe('Memory Handlers', () => {
       mockMemory.deleteMessages = vi.fn().mockResolvedValue(undefined);
 
       const result = await DELETE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         messageIds: { id: 'test-message-id' },
         agentId: 'test-agent',
       });
@@ -1195,7 +1195,7 @@ describe('Memory Handlers', () => {
       mockMemory.deleteMessages = vi.fn().mockResolvedValue(undefined);
 
       const result = await DELETE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         messageIds: [{ id: 'msg-1' }, { id: 'msg-2' }],
         agentId: 'test-agent',
       });
@@ -1217,7 +1217,7 @@ describe('Memory Handlers', () => {
 
       await expect(
         DELETE_MESSAGES_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           messageIds: ['msg-1', 'msg-2'],
           agentId: 'test-agent',
         }),
@@ -1235,7 +1235,7 @@ describe('Memory Handlers', () => {
       mockMemory.deleteMessages = vi.fn().mockResolvedValue(undefined);
 
       await DELETE_MESSAGES_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         messageIds: ['msg-1', 'msg-2', 'msg-3'],
         agentId: 'test-agent',
       });

--- a/packages/server/src/server/handlers/observability.test.ts
+++ b/packages/server/src/server/handlers/observability.test.ts
@@ -11,7 +11,7 @@ import {
   listScoresBySpan,
   scoreTracesHandler,
 } from './observability';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 
 // Mock scoreTraces
 vi.mock('@mastra/core/evals/scoreTraces', () => ({
@@ -377,7 +377,7 @@ describe('Observability Handlers', () => {
         });
 
         const result = await GET_TRACES_PAGINATED_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           page: 1,
           perPage: 10,
           dateRange: dateRangeJson,

--- a/packages/server/src/server/handlers/scores.test.ts
+++ b/packages/server/src/server/handlers/scores.test.ts
@@ -14,7 +14,7 @@ import {
   LIST_SCORES_BY_ENTITY_ID_ROUTE,
   SAVE_SCORE_ROUTE,
 } from './scores';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 
 function createPagination(args: Partial<StoragePagination>): StoragePagination {
   return {
@@ -57,7 +57,7 @@ describe('Scores Handlers', () => {
   describe('listScorersHandler', () => {
     it('should return empty object', async () => {
       const result = await LIST_SCORERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         requestContext: new RequestContext(),
       });
       expect(result).toEqual({});
@@ -73,7 +73,7 @@ describe('Scores Handlers', () => {
       const pagination = createPagination({ page: 0, perPage: 10 });
 
       const result = await LIST_SCORES_BY_RUN_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         runId: mockScores?.[0]?.runId,
         page: pagination.page,
         perPage: pagination.perPage as number,
@@ -98,7 +98,7 @@ describe('Scores Handlers', () => {
       });
 
       const result = await LIST_SCORES_BY_RUN_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mastraWithoutStorage }),
+        ...createTestServerContext({ mastra: mastraWithoutStorage }),
         runId: 'test-run-1',
         page: pagination.page,
         perPage: pagination.perPage as number,
@@ -123,7 +123,7 @@ describe('Scores Handlers', () => {
 
       await expect(
         LIST_SCORES_BY_RUN_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           runId: 'test-run-1',
           page: pagination.page,
           perPage: pagination.perPage as number,
@@ -142,7 +142,7 @@ describe('Scores Handlers', () => {
 
       await expect(
         LIST_SCORES_BY_RUN_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           runId: 'test-run-1',
           page: pagination.page,
           perPage: pagination.perPage as number,
@@ -159,7 +159,7 @@ describe('Scores Handlers', () => {
       await mockStorage.saveScore(mockScores[0]);
 
       const result = await LIST_SCORES_BY_ENTITY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         entityId: 'test-agent',
         entityType: 'AGENT',
         page: pagination.page,
@@ -185,7 +185,7 @@ describe('Scores Handlers', () => {
       });
 
       const result = await LIST_SCORES_BY_ENTITY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mastraWithoutStorage }),
+        ...createTestServerContext({ mastra: mastraWithoutStorage }),
         entityId: 'test-agent',
         entityType: 'agent',
         page: pagination.page,
@@ -211,7 +211,7 @@ describe('Scores Handlers', () => {
 
       await expect(
         LIST_SCORES_BY_ENTITY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           entityId: 'test-agent',
           entityType: 'agent',
           page: pagination.page,
@@ -231,7 +231,7 @@ describe('Scores Handlers', () => {
 
       await expect(
         LIST_SCORES_BY_ENTITY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           entityId: 'test-agent',
           entityType: 'agent',
           page: pagination.page,
@@ -249,7 +249,7 @@ describe('Scores Handlers', () => {
       await mockStorage.saveScore(mockScores[0]);
 
       const result = await LIST_SCORES_BY_ENTITY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         entityId: 'test-workflow',
         entityType: 'WORKFLOW',
         page: pagination.page,
@@ -272,7 +272,7 @@ describe('Scores Handlers', () => {
       const savedScore = { score };
 
       const result = await SAVE_SCORE_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         score,
       });
 
@@ -289,7 +289,7 @@ describe('Scores Handlers', () => {
 
       await expect(
         SAVE_SCORE_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mastraWithoutStorage }),
+          ...createTestServerContext({ mastra: mastraWithoutStorage }),
           score,
         }),
       ).rejects.toThrow(HTTPException);
@@ -303,7 +303,7 @@ describe('Scores Handlers', () => {
 
       await expect(
         SAVE_SCORE_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           score,
         }),
       ).rejects.toThrow(HTTPException);
@@ -320,7 +320,7 @@ describe('Scores Handlers', () => {
 
       await expect(
         SAVE_SCORE_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           score,
         }),
       ).rejects.toThrow(HTTPException);
@@ -332,7 +332,7 @@ describe('Scores Handlers', () => {
       const savedScore = { score };
 
       const result = await SAVE_SCORE_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         score,
       });
 

--- a/packages/server/src/server/handlers/test-utils.ts
+++ b/packages/server/src/server/handlers/test-utils.ts
@@ -1,8 +1,8 @@
 import type { Mastra } from '@mastra/core';
 import { RequestContext } from '@mastra/core/request-context';
-import type { RuntimeContext } from '../server-adapter';
+import type { ServerContext } from '../server-adapter';
 
-export function createTestRuntimeContext({ mastra }: { mastra: Mastra }): RuntimeContext {
+export function createTestServerContext({ mastra }: { mastra: Mastra }): ServerContext {
   return {
     mastra,
     requestContext: new RequestContext(),

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -6,7 +6,7 @@ import type { ToolAction, VercelTool } from '@mastra/core/tools';
 import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 import {
   LIST_TOOLS_ROUTE,
   GET_TOOL_BY_ID_ROUTE,
@@ -41,13 +41,13 @@ describe('Tools Handlers', () => {
   describe('listToolsHandler', () => {
     it('should return empty object when no tools are provided', async () => {
       const mastra = new Mastra({ logger: false });
-      const result = await LIST_TOOLS_ROUTE.handler({ ...createTestRuntimeContext({ mastra }), tools: undefined });
+      const result = await LIST_TOOLS_ROUTE.handler({ ...createTestServerContext({ mastra }), tools: undefined });
       expect(result).toEqual({});
     });
 
     it('should return serialized tools when tools are provided', async () => {
       const mastra = new Mastra({ logger: false });
-      const result = await LIST_TOOLS_ROUTE.handler({ ...createTestRuntimeContext({ mastra }), tools: mockTools });
+      const result = await LIST_TOOLS_ROUTE.handler({ ...createTestServerContext({ mastra }), tools: mockTools });
       expect(result).toHaveProperty(mockTool.id);
       // expect(result).toHaveProperty(mockVercelTool.id);
       expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
@@ -60,7 +60,7 @@ describe('Tools Handlers', () => {
       const mastra = new Mastra({ logger: false });
       await expect(
         GET_TOOL_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           tools: mockTools,
           toolId: 'non-existent',
         }),
@@ -70,7 +70,7 @@ describe('Tools Handlers', () => {
     it('should return serialized tool when found', async () => {
       const mastra = new Mastra({ logger: false });
       const result = await GET_TOOL_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         tools: mockTools,
         toolId: mockTool.id,
       });
@@ -83,7 +83,7 @@ describe('Tools Handlers', () => {
     it('should throw error when toolId is not provided', async () => {
       await expect(
         EXECUTE_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: new Mastra({ logger: false }) }),
+          ...createTestServerContext({ mastra: new Mastra({ logger: false }) }),
           tools: mockTools,
           toolId: undefined as any,
           data: {},
@@ -94,7 +94,7 @@ describe('Tools Handlers', () => {
     it('should throw 404 when tool is not found', async () => {
       await expect(
         EXECUTE_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: new Mastra({ logger: false }) }),
+          ...createTestServerContext({ mastra: new Mastra({ logger: false }) }),
           tools: mockTools,
           toolId: 'non-existent',
           data: {},
@@ -108,7 +108,7 @@ describe('Tools Handlers', () => {
 
       await expect(
         EXECUTE_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: new Mastra() }),
+          ...createTestServerContext({ mastra: new Mastra() }),
           tools,
           toolId: nonExecutableTool.id,
           data: {},
@@ -119,7 +119,7 @@ describe('Tools Handlers', () => {
     it('should throw error when data is not provided', async () => {
       await expect(
         EXECUTE_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: new Mastra() }),
+          ...createTestServerContext({ mastra: new Mastra() }),
           tools: mockTools,
           toolId: mockTool.id,
           data: null as any,
@@ -134,7 +134,7 @@ describe('Tools Handlers', () => {
       const context = { test: 'data' };
 
       const result = await EXECUTE_TOOL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         tools: mockTools,
         toolId: mockTool.id,
         runId: 'test-run',
@@ -161,7 +161,7 @@ describe('Tools Handlers', () => {
       (mockVercelTool.execute as Mock<() => any>).mockResolvedValue(mockResult);
 
       const result = await EXECUTE_TOOL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         tools: mockTools,
         toolId: `tool`,
         data: { test: 'data' },
@@ -184,7 +184,7 @@ describe('Tools Handlers', () => {
     it('should throw 404 when agent is not found', async () => {
       await expect(
         EXECUTE_AGENT_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: new Mastra({ logger: false }) }),
+          ...createTestServerContext({ mastra: new Mastra({ logger: false }) }),
           agentId: 'non-existent',
           toolId: mockTool.id,
           data: {},
@@ -195,7 +195,7 @@ describe('Tools Handlers', () => {
     it('should throw 404 when tool is not found in agent', async () => {
       await expect(
         EXECUTE_AGENT_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({
+          ...createTestServerContext({
             mastra: new Mastra({
               logger: false,
               agents: { 'test-agent': mockAgent as any },
@@ -220,7 +220,7 @@ describe('Tools Handlers', () => {
 
       await expect(
         EXECUTE_AGENT_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({
+          ...createTestServerContext({
             mastra: new Mastra({
               logger: false,
               agents: { 'test-agent': agent as any },
@@ -247,7 +247,7 @@ describe('Tools Handlers', () => {
         test: 'data',
       };
       const result = await EXECUTE_AGENT_TOOL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-agent',
         toolId: mockTool.id,
         data: context,
@@ -274,7 +274,7 @@ describe('Tools Handlers', () => {
       });
 
       const result = await EXECUTE_AGENT_TOOL_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         agentId: 'test-agent',
         toolId: `tool`,
         data: {},
@@ -297,7 +297,7 @@ describe('Tools Handlers', () => {
     it('should throw 404 when agent is not found', async () => {
       await expect(
         GET_AGENT_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: new Mastra({ logger: false }) }),
+          ...createTestServerContext({ mastra: new Mastra({ logger: false }) }),
           agentId: 'non-existent',
           toolId: mockTool.id,
         }),
@@ -311,7 +311,7 @@ describe('Tools Handlers', () => {
     it('should throw 404 when tool is not found in agent', async () => {
       await expect(
         GET_AGENT_TOOL_ROUTE.handler({
-          ...createTestRuntimeContext({
+          ...createTestServerContext({
             mastra: new Mastra({
               logger: false,
               agents: { 'test-agent': mockAgent as any },
@@ -329,7 +329,7 @@ describe('Tools Handlers', () => {
 
     it('should return serialized tool when found', async () => {
       const result = await GET_AGENT_TOOL_ROUTE.handler({
-        ...createTestRuntimeContext({
+        ...createTestServerContext({
           mastra: new Mastra({
             logger: false,
             agents: { 'test-agent': mockAgent as any },

--- a/packages/server/src/server/handlers/voice.test.ts
+++ b/packages/server/src/server/handlers/voice.test.ts
@@ -3,7 +3,7 @@ import { Mastra } from '@mastra/core/mastra';
 import type { MastraVoice } from '@mastra/core/voice';
 import { CompositeVoice } from '@mastra/core/voice';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 import { GET_SPEAKERS_ROUTE, GENERATE_SPEECH_ROUTE, TRANSCRIBE_SPEECH_ROUTE } from './voice';
 
 vi.mock('@mastra/core/voice');
@@ -48,20 +48,20 @@ describe('Voice Handlers', () => {
   describe('getSpeakersHandler', () => {
     it('should throw error when agentId is not provided', async () => {
       await expect(
-        GET_SPEAKERS_ROUTE.handler({ ...createTestRuntimeContext({ mastra }), agentId: undefined as any }),
+        GET_SPEAKERS_ROUTE.handler({ ...createTestServerContext({ mastra }), agentId: undefined as any }),
       ).rejects.toThrow('Agent ID is required');
     });
 
     it('should throw error when agent is not found', async () => {
       await expect(
-        GET_SPEAKERS_ROUTE.handler({ ...createTestRuntimeContext({ mastra }), agentId: 'non-existent' as any }),
+        GET_SPEAKERS_ROUTE.handler({ ...createTestServerContext({ mastra }), agentId: 'non-existent' as any }),
       ).rejects.toThrow('Agent with id non-existent not found');
     });
 
     it('should return empty array when agent does not have voice capabilities', async () => {
       const agentWithoutVoice = createAgentWithVoice();
       const result = await GET_SPEAKERS_ROUTE.handler({
-        ...createTestRuntimeContext({
+        ...createTestServerContext({
           mastra: new Mastra({ logger: false, agents: { 'test-agent': agentWithoutVoice } }),
         }),
         agentId: 'test-agent',
@@ -78,7 +78,7 @@ describe('Voice Handlers', () => {
       } as any);
 
       const result = await GET_SPEAKERS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
+        ...createTestServerContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
         agentId: 'test-agent',
       });
 
@@ -90,7 +90,7 @@ describe('Voice Handlers', () => {
     it('should throw error when agentId is not provided', async () => {
       await expect(
         GENERATE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           text: 'test',
           speakerId: '1',
           agentId: undefined as any,
@@ -101,7 +101,7 @@ describe('Voice Handlers', () => {
     it('should throw error when text or speakerId is not provided', async () => {
       await expect(
         GENERATE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
           text: 'test',
         }),
@@ -111,7 +111,7 @@ describe('Voice Handlers', () => {
     it('should throw error when agent is not found', async () => {
       await expect(
         GENERATE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'non-existent',
           text: 'test',
           speakerId: '1',
@@ -124,7 +124,7 @@ describe('Voice Handlers', () => {
 
       await expect(
         GENERATE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({
+          ...createTestServerContext({
             mastra: new Mastra({ logger: false, agents: { 'test-agent': agentWithoutVoice } }),
           }),
           agentId: 'test-agent',
@@ -144,7 +144,7 @@ describe('Voice Handlers', () => {
 
       await expect(
         GENERATE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
+          ...createTestServerContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
           agentId: 'test-agent',
           text: 'test',
           speakerId: '1',
@@ -166,7 +166,7 @@ describe('Voice Handlers', () => {
       } as any);
 
       const audioStream = await GENERATE_SPEECH_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
+        ...createTestServerContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
         agentId: 'test-agent',
         text: 'test',
         speakerId: '1',
@@ -193,7 +193,7 @@ describe('Voice Handlers', () => {
       } as any);
 
       const audioStream = await GENERATE_SPEECH_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
+        ...createTestServerContext({ mastra: new Mastra({ logger: false, agents: { 'test-agent': agent } }) }),
         agentId: 'test-agent',
         text: 'test',
         speakerId: '1',
@@ -208,7 +208,7 @@ describe('Voice Handlers', () => {
     it('should throw error when agentId is not provided', async () => {
       await expect(
         TRANSCRIBE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: undefined as any,
           audioData: Buffer.from('test'),
         }),
@@ -218,7 +218,7 @@ describe('Voice Handlers', () => {
     it('should throw error when audioData is not provided', async () => {
       await expect(
         TRANSCRIBE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'test-agent',
           audioData: undefined as any,
         }),
@@ -228,7 +228,7 @@ describe('Voice Handlers', () => {
     it('should throw error when agent is not found', async () => {
       await expect(
         TRANSCRIBE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra }),
+          ...createTestServerContext({ mastra }),
           agentId: 'non-existent',
           audioData: Buffer.from('test'),
         }),
@@ -240,7 +240,7 @@ describe('Voice Handlers', () => {
 
       await expect(
         TRANSCRIBE_SPEECH_ROUTE.handler({
-          ...createTestRuntimeContext({
+          ...createTestServerContext({
             mastra: new Mastra({ logger: false, agents: { 'test-agent': agentWithoutVoice } }),
           }),
           agentId: 'test-agent',
@@ -258,7 +258,7 @@ describe('Voice Handlers', () => {
       } as any);
 
       const result = await TRANSCRIBE_SPEECH_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra }),
+        ...createTestServerContext({ mastra }),
         agentId: 'test-agent',
         audioData: Buffer.from('test'),
         options: { language: 'en' },

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -5,7 +5,7 @@ import type { Workflow } from '@mastra/core/workflows';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
 import { getWorkflowInfo } from '../utils';
-import { createTestRuntimeContext } from './test-utils';
+import { createTestServerContext } from './test-utils';
 import {
   LIST_WORKFLOWS_ROUTE,
   GET_WORKFLOW_BY_ID_ROUTE,
@@ -112,7 +112,7 @@ describe('vNext Workflow Handlers', () => {
 
   describe('LIST_WORKFLOWS_ROUTE', () => {
     it('should get all workflows successfully', async () => {
-      const result = await LIST_WORKFLOWS_ROUTE.handler({ ...createTestRuntimeContext({ mastra: mockMastra }) });
+      const result = await LIST_WORKFLOWS_ROUTE.handler({ ...createTestServerContext({ mastra: mockMastra }) });
       expect(result).toEqual({
         'test-workflow': serializeWorkflow(mockWorkflow),
         'reusable-workflow': serializeWorkflow(reusableWorkflow),
@@ -158,7 +158,7 @@ describe('vNext Workflow Handlers', () => {
       });
 
       const result = await LIST_WORKFLOWS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mastraWithSchemas }),
+        ...createTestServerContext({ mastra: mastraWithSchemas }),
         partial: 'true',
       });
 
@@ -211,7 +211,7 @@ describe('vNext Workflow Handlers', () => {
       });
 
       const result = await LIST_WORKFLOWS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mastraWithSchemas }),
+        ...createTestServerContext({ mastra: mastraWithSchemas }),
         // No partial parameter provided
       });
 
@@ -246,7 +246,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         GET_WORKFLOW_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: undefined as any,
         }),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -255,7 +255,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow is not found', async () => {
       await expect(
         GET_WORKFLOW_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'non-existent',
         }),
       ).rejects.toThrow(new HTTPException(404, { message: 'Workflow not found' }));
@@ -263,7 +263,7 @@ describe('vNext Workflow Handlers', () => {
 
     it('should get workflow by ID successfully', async () => {
       const result = await GET_WORKFLOW_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
       });
 
@@ -275,7 +275,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         START_ASYNC_WORKFLOW_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -284,7 +284,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow is not found', async () => {
       await expect(
         START_ASYNC_WORKFLOW_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'non-existent',
           runId: 'test-run',
         } as any),
@@ -293,7 +293,7 @@ describe('vNext Workflow Handlers', () => {
 
     it('should start workflow run successfully when runId is not passed', async () => {
       const result = await START_ASYNC_WORKFLOW_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
         inputData: {},
         tracingOptions,
@@ -304,7 +304,7 @@ describe('vNext Workflow Handlers', () => {
 
     it('should start workflow run successfully when runId is passed', async () => {
       const result = await START_ASYNC_WORKFLOW_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
         runId: 'test-run',
         inputData: {},
@@ -319,7 +319,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -328,7 +328,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Run ID is required' }));
@@ -337,7 +337,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow is not found', async () => {
       await expect(
         GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'non-existent',
           runId: 'test-run',
         }),
@@ -347,7 +347,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow run is not found', async () => {
       await expect(
         GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
           runId: 'non-existent',
         }),
@@ -362,7 +362,7 @@ describe('vNext Workflow Handlers', () => {
       await run.start({ inputData: {} });
 
       const result = await GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
         runId: 'test-run',
       });
@@ -375,7 +375,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         DELETE_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -384,7 +384,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         DELETE_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Run ID is required' }));
@@ -393,7 +393,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow is not found', async () => {
       await expect(
         DELETE_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'non-existent',
           runId: 'test-run',
         }),
@@ -408,7 +408,7 @@ describe('vNext Workflow Handlers', () => {
       await run.start({ inputData: {} });
 
       const result = await GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
         runId: 'test-run',
       });
@@ -416,7 +416,7 @@ describe('vNext Workflow Handlers', () => {
       expect(result).toBeDefined();
 
       const deleteResponse = await DELETE_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
         runId: 'test-run',
       });
@@ -425,7 +425,7 @@ describe('vNext Workflow Handlers', () => {
 
       await expect(
         GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
           runId: 'test-run',
         }),
@@ -437,7 +437,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         GET_WORKFLOW_RUN_EXECUTION_RESULT_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           workflowId: undefined as any,
         }),
@@ -447,7 +447,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         GET_WORKFLOW_RUN_EXECUTION_RESULT_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
           runId: undefined as any,
         }),
@@ -457,7 +457,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow is not found', async () => {
       await expect(
         GET_WORKFLOW_RUN_EXECUTION_RESULT_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'non-existent',
           runId: 'test-run',
         }),
@@ -467,7 +467,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow run is not found', async () => {
       await expect(
         GET_WORKFLOW_RUN_EXECUTION_RESULT_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
           runId: 'non-existent',
         }),
@@ -509,7 +509,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         CREATE_WORKFLOW_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -540,7 +540,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         START_WORKFLOW_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -549,7 +549,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         START_WORKFLOW_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'runId required to start run' }));
@@ -558,7 +558,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow run is not found', async () => {
       await expect(
         START_WORKFLOW_RUN_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
           runId: 'non-existent',
         } as any),
@@ -671,7 +671,7 @@ describe('vNext Workflow Handlers', () => {
       expect(runBeforeRestart?.resourceId).toBe(resourceId);
 
       const result = await RESUME_ASYNC_WORKFLOW_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: reusableWorkflow.name,
         runId: 'test-run-async-resume',
         step: 'test-step',
@@ -694,7 +694,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         RESUME_WORKFLOW_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           runId: 'test-run',
           step: 'test-step',
           resumeData: {},
@@ -705,7 +705,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when runId is not provided', async () => {
       await expect(
         RESUME_WORKFLOW_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
           step: 'test-step',
           resumeData: {},
@@ -716,7 +716,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflow run is not found', async () => {
       await expect(
         RESUME_WORKFLOW_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: 'test-workflow',
           runId: 'non-existent',
           step: 'test-step',
@@ -735,7 +735,7 @@ describe('vNext Workflow Handlers', () => {
       });
 
       const result = await RESUME_WORKFLOW_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: reusableWorkflow.name,
         runId: 'test-run',
         step: 'test-step',
@@ -768,7 +768,7 @@ describe('vNext Workflow Handlers', () => {
       });
 
       await RESUME_WORKFLOW_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: freshMastra }),
+        ...createTestServerContext({ mastra: freshMastra }),
         workflowId: 'reusable-workflow',
         runId: 'test-run-with-resource',
         step: 'test-step',
@@ -807,7 +807,7 @@ describe('vNext Workflow Handlers', () => {
       });
 
       const stream = await RESUME_STREAM_WORKFLOW_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: freshMastra }),
+        ...createTestServerContext({ mastra: freshMastra }),
         workflowId: 'reusable-workflow',
         runId: 'test-run-stream-resume',
         step: 'test-step',
@@ -829,7 +829,7 @@ describe('vNext Workflow Handlers', () => {
     it('should throw error when workflowId is not provided', async () => {
       await expect(
         LIST_WORKFLOW_RUNS_ROUTE.handler({
-          ...createTestRuntimeContext({ mastra: mockMastra }),
+          ...createTestServerContext({ mastra: mockMastra }),
           workflowId: undefined,
         } as any),
       ).rejects.toThrow(new HTTPException(400, { message: 'Workflow ID is required' }));
@@ -837,7 +837,7 @@ describe('vNext Workflow Handlers', () => {
 
     it('should get workflow runs successfully (empty)', async () => {
       const result = await LIST_WORKFLOW_RUNS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
       } as any);
 
@@ -853,7 +853,7 @@ describe('vNext Workflow Handlers', () => {
       });
       await run.start({ inputData: {} });
       const result = await LIST_WORKFLOW_RUNS_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: mockMastra }),
+        ...createTestServerContext({ mastra: mockMastra }),
         workflowId: 'test-workflow',
       } as any);
 
@@ -884,7 +884,7 @@ describe('vNext Workflow Handlers', () => {
       });
 
       const stream = await OBSERVE_STREAM_WORKFLOW_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: freshMastra }),
+        ...createTestServerContext({ mastra: freshMastra }),
         workflowId: 'test-workflow',
         runId: 'test-run-observe-resource',
       });
@@ -923,7 +923,7 @@ describe('vNext Workflow Handlers', () => {
       });
 
       const result = await CANCEL_WORKFLOW_RUN_ROUTE.handler({
-        ...createTestRuntimeContext({ mastra: freshMastra }),
+        ...createTestServerContext({ mastra: freshMastra }),
         workflowId: 'test-workflow',
         runId: 'test-run-cancel-resource',
       });

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -58,8 +58,6 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   protected prefix?: string;
   protected openapiPath?: string;
   protected taskStore?: InMemoryTaskStore;
-  protected playground?: boolean;
-  protected isDev?: boolean;
   protected customRouteAuthConfig?: Map<string, boolean>;
   protected streamOptions: StreamOptions;
 
@@ -71,8 +69,6 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     prefix = '',
     openapiPath = '',
     taskStore,
-    playground = false,
-    isDev = false,
     customRouteAuthConfig,
     streamOptions,
   }: {
@@ -83,8 +79,6 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     prefix?: string;
     openapiPath?: string;
     taskStore?: InMemoryTaskStore;
-    playground?: boolean;
-    isDev?: boolean;
     customRouteAuthConfig?: Map<string, boolean>;
     streamOptions?: StreamOptions;
   }) {
@@ -95,8 +89,6 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     this.prefix = prefix;
     this.openapiPath = openapiPath;
     this.taskStore = taskStore;
-    this.playground = playground;
-    this.isDev = isDev;
     this.customRouteAuthConfig = customRouteAuthConfig;
     this.streamOptions = { redact: true, ...streamOptions };
 

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -20,11 +20,11 @@ import { VECTORS_ROUTES } from './vectors';
 import { WORKFLOWS_ROUTES } from './workflows';
 
 /**
- * Runtime context fields that are available to route handlers.
+ * Server context fields that are available to route handlers.
  * These are injected by the server adapters (Express, Hono, etc.)
  * Fields other than `mastra` are optional to allow direct handler testing.
  */
-export type RuntimeContext = {
+export type ServerContext = {
   mastra: Mastra;
   requestContext: RequestContext;
   tools?: Record<string, Tool>;
@@ -59,7 +59,7 @@ export type ServerRouteHandler<
   TResponse = unknown,
   TResponseType extends ResponseType = 'json',
 > = (
-  params: TParams & RuntimeContext,
+  params: TParams & ServerContext,
 ) => Promise<
   TResponseType extends 'stream'
     ? MastraStreamReturn

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -41,8 +41,6 @@ export interface AdapterTestContext {
   tools?: Record<string, Tool>;
   taskStore?: InMemoryTaskStore;
   customRouteAuthConfig?: Map<string, boolean>;
-  playground?: boolean;
-  isDev?: boolean;
 }
 
 /**

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -28,8 +28,6 @@ describe('Express Server Adapter', () => {
         mastra: context.mastra,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
-        playground: context.playground,
-        isDev: context.isDev,
       });
 
       await adapter.init();

--- a/server-adapters/express/src/__tests__/mcp-routes.test.ts
+++ b/server-adapters/express/src/__tests__/mcp-routes.test.ts
@@ -24,8 +24,6 @@ describe('Express MCP Registry Routes Integration', () => {
         mastra: context.mastra,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
-        playground: context.playground,
-        isDev: context.isDev,
       });
 
       // Register context middleware

--- a/server-adapters/express/src/auth-middleware.ts
+++ b/server-adapters/express/src/auth-middleware.ts
@@ -133,8 +133,6 @@ export const authorizationMiddleware = async (req: Request, res: Response, next:
           if (key === 'tools') return res.locals.tools;
           if (key === 'taskStore') return res.locals.taskStore;
           if (key === 'customRouteAuthConfig') return res.locals.customRouteAuthConfig;
-          if (key === 'playground') return res.locals.playground;
-          if (key === 'isDev') return res.locals.isDev;
           return undefined;
         },
         req: req as any,

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -19,8 +19,6 @@ declare global {
       tools: Record<string, Tool>;
       taskStore: InMemoryTaskStore;
       customRouteAuthConfig?: Map<string, boolean>;
-      playground?: boolean;
-      isDev?: boolean;
     }
   }
 }
@@ -74,8 +72,6 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
       if (this.taskStore) {
         res.locals.taskStore = this.taskStore;
       }
-      res.locals.playground = this.playground === true;
-      res.locals.isDev = this.isDev === true;
       res.locals.customRouteAuthConfig = this.customRouteAuthConfig;
       const controller = new AbortController();
       // Use res.on('close') instead of req.on('close') because the request's 'close' event

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -25,8 +25,6 @@ describe('Hono Server Adapter', () => {
         tools: context.tools,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
-        playground: context.playground,
-        isDev: context.isDev,
       });
 
       await adapter.init();

--- a/server-adapters/hono/src/__tests__/mcp-routes.test.ts
+++ b/server-adapters/hono/src/__tests__/mcp-routes.test.ts
@@ -21,8 +21,6 @@ describe('Hono MCP Registry Routes Integration', () => {
         mastra: context.mastra,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
-        playground: context.playground,
-        isDev: context.isDev,
       });
 
       // Register context middleware

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -20,8 +20,6 @@ export type HonoVariables = {
   abortSignal: AbortSignal;
   taskStore: InMemoryTaskStore;
   customRouteAuthConfig?: Map<string, boolean>;
-  playground?: boolean;
-  isDev?: boolean;
 };
 
 export type HonoBindings = {};
@@ -101,8 +99,6 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       c.set('mastra', this.mastra);
       c.set('tools', this.tools || {});
       c.set('taskStore', this.taskStore);
-      c.set('playground', this.playground === true);
-      c.set('isDev', this.isDev === true);
       c.set('abortSignal', c.req.raw.signal);
       c.set('customRouteAuthConfig', this.customRouteAuthConfig);
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This PR cleans up the server adapter interfaces:

1. **Renamed `RuntimeContext` to `ServerContext`** - Avoids confusion with the user-facing `RequestContext` type (which was previously called `RuntimeContext`)

2. **Removed `playground` and `isDev` options** - These server adapter constructor options only set context variables but had no actual functionality. Removing them prevents user confusion (users expected `playground: true` to spin up the Studio UI)

3. **Renamed `isPlayground` to `isStudio`** - In the `formatAgent` function to align with "Studio" branding

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Renamed `RuntimeContext` to `ServerContext` across server adapters and route handlers
  * Removed `playground` and `isDev` configuration options from server adapter constructors
  * Renamed `isPlayground` parameter to `isStudio` in agent formatting functions
  * Updated test utility: `createTestRuntimeContext` → `createTestServerContext`

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->