### PR TITLE
updated token usage tracking in observability

### DIFF
--- a/.changeset/slimy-parks-switch.md
+++ b/.changeset/slimy-parks-switch.md
@@ -1,0 +1,12 @@
+---
+'@mastra/otel-exporter': patch
+'@mastra/braintrust': patch
+'@mastra/langsmith': patch
+'@mastra/langfuse': patch
+'@mastra/posthog': patch
+'@mastra/observability': patch
+'@mastra/arize': patch
+'@mastra/core': patch
+---
+
+Fixed CachedToken tracking in all Observability Exporters. Also fixed TimeToFirstToken in Langfuse, Braintrust, PostHog exporters. Fixed trace formatting in Posthog Exporter.

--- a/observability/arize/src/openInferenceOTLPExporter.ts
+++ b/observability/arize/src/openInferenceOTLPExporter.ts
@@ -3,6 +3,14 @@ import type { Mutable } from '@arizeai/openinference-genai/types';
 import {
   INPUT_MIME_TYPE,
   INPUT_VALUE,
+  LLM_TOKEN_COUNT_COMPLETION,
+  LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO,
+  LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
+  LLM_TOKEN_COUNT_PROMPT,
+  LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO,
+  LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+  LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
+  LLM_TOKEN_COUNT_TOTAL,
   METADATA,
   OUTPUT_MIME_TYPE,
   OUTPUT_VALUE,
@@ -16,10 +24,76 @@ import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
   ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
 } from '@opentelemetry/semantic-conventions/incubating';
+
+// GenAI usage attribute keys (not all are in @opentelemetry/semantic-conventions yet)
+const GEN_AI_USAGE_REASONING_TOKENS = 'gen_ai.usage.reasoning_tokens';
+const GEN_AI_USAGE_CACHED_INPUT_TOKENS = 'gen_ai.usage.cached_input_tokens';
+const GEN_AI_USAGE_CACHE_WRITE_TOKENS = 'gen_ai.usage.cache_write_tokens';
+const GEN_AI_USAGE_AUDIO_INPUT_TOKENS = 'gen_ai.usage.audio_input_tokens';
+const GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS = 'gen_ai.usage.audio_output_tokens';
 
 const MASTRA_GENERAL_PREFIX = 'mastra.';
 const MASTRA_METADATA_PREFIX = 'mastra.metadata.';
+
+/**
+ * Converts GenAI usage metrics to OpenInference LLM token count attributes.
+ * Maps from OTEL GenAI semantic conventions to OpenInference semantic conventions.
+ *
+ * @param attributes - The span attributes containing GenAI usage metrics
+ * @returns OpenInference token count attributes
+ */
+function convertUsageMetricsToOpenInference(attributes: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
+
+  const inputTokens = attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS];
+  const outputTokens = attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS];
+
+  // Core token counts
+  if (inputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT] = inputTokens;
+  }
+  if (outputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_COMPLETION] = outputTokens;
+  }
+
+  // Total tokens (compute if we have both input and output)
+  if (inputTokens !== undefined && outputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_TOTAL] = inputTokens + outputTokens;
+  }
+
+  // Cache tokens (prompt details)
+  const cachedInputTokens = attributes[GEN_AI_USAGE_CACHED_INPUT_TOKENS];
+  if (cachedInputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = cachedInputTokens;
+  }
+
+  const cacheWriteTokens = attributes[GEN_AI_USAGE_CACHE_WRITE_TOKENS];
+  if (cacheWriteTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE] = cacheWriteTokens;
+  }
+
+  // Reasoning tokens (completion details)
+  const reasoningTokens = attributes[GEN_AI_USAGE_REASONING_TOKENS];
+  if (reasoningTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING] = reasoningTokens;
+  }
+
+  // Audio tokens
+  const audioInputTokens = attributes[GEN_AI_USAGE_AUDIO_INPUT_TOKENS];
+  if (audioInputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO] = audioInputTokens;
+  }
+
+  const audioOutputTokens = attributes[GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS];
+  if (audioOutputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO] = audioOutputTokens;
+  }
+
+  return result;
+}
 
 /**
  * Splits Mastra span attributes into two groups:
@@ -99,6 +173,10 @@ export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
           processedAttributes[OUTPUT_MIME_TYPE] = 'application/json';
           processedAttributes[OUTPUT_VALUE] = outputMessages;
         }
+
+        // Convert GenAI usage metrics to OpenInference token count attributes
+        const usageMetrics = convertUsageMetricsToOpenInference(attributes);
+        Object.assign(processedAttributes, usageMetrics);
 
         mutableSpan.attributes = { ...processedAttributes, ...mastraOther };
       }

--- a/observability/braintrust/src/metrics.test.ts
+++ b/observability/braintrust/src/metrics.test.ts
@@ -1,0 +1,36 @@
+import type { UsageStats } from '@mastra/core/observability';
+import { describe, it, expect } from 'vitest';
+import { formatUsageMetrics } from './metrics';
+
+describe('formatUsageMetrics', () => {
+  it('should extract basic tokens', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 50 };
+    const result = formatUsageMetrics(usage);
+    expect(result.prompt_tokens).toBe(100);
+    expect(result.completion_tokens).toBe(50);
+    expect(result.tokens).toBe(150);
+  });
+
+  it('should extract cacheRead from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.prompt_cached_tokens).toBe(800);
+  });
+
+  it('should extract cacheWrite from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.prompt_cache_creation_tokens).toBe(500);
+  });
+
+  it('should extract reasoning from outputDetails', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 500, outputDetails: { reasoning: 400 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.completion_reasoning_tokens).toBe(400);
+  });
+
+  it('should return empty metrics for undefined usage', () => {
+    const result = formatUsageMetrics(undefined);
+    expect(result).toEqual({});
+  });
+});

--- a/observability/braintrust/src/metrics.ts
+++ b/observability/braintrust/src/metrics.ts
@@ -1,16 +1,9 @@
-import type { ModelGenerationAttributes } from '@mastra/core/observability';
+import type { UsageStats } from '@mastra/core/observability';
+
 /**
  * BraintrustUsageMetrics
  *
  * Canonical metric keys expected by Braintrust for LLM usage accounting.
- * These map various provider/SDK-specific usage fields to a common schema.
- * - prompt_tokens: input-side tokens (aka inputTokens/promptTokens)
- * - completion_tokens: output-side tokens (aka outputTokens/completionTokens)
- * - tokens: total tokens (provided or derived)
- * - completion_reasoning_tokens: reasoning tokens, when available
- * - prompt_cached_tokens: tokens served from cache (provider-specific)
- * - prompt_cache_creation_tokens: tokens used to create cache (provider-specific)
- * - time_to_first_token: timestamp (ms since epoch) when first token arrived (streaming only)
  */
 export interface BraintrustUsageMetrics {
   prompt_tokens?: number;
@@ -19,49 +12,37 @@ export interface BraintrustUsageMetrics {
   completion_reasoning_tokens?: number;
   prompt_cached_tokens?: number;
   prompt_cache_creation_tokens?: number;
-  time_to_first_token?: number;
-  [key: string]: number | undefined;
 }
 
-export function normalizeUsageMetrics(modelAttr: ModelGenerationAttributes): BraintrustUsageMetrics {
+/**
+ * Formats UsageStats to Braintrust's expected metric format.
+ */
+export function formatUsageMetrics(usage?: UsageStats): BraintrustUsageMetrics {
   const metrics: BraintrustUsageMetrics = {};
 
-  if (modelAttr.usage?.inputTokens !== undefined) {
-    metrics.prompt_tokens = modelAttr.usage?.inputTokens;
-  } else if (modelAttr.usage?.promptTokens !== undefined) {
-    metrics.prompt_tokens = modelAttr.usage?.promptTokens;
+  if (usage?.inputTokens !== undefined) {
+    metrics.prompt_tokens = usage.inputTokens;
   }
 
-  if (modelAttr.usage?.outputTokens !== undefined) {
-    metrics.completion_tokens = modelAttr.usage?.outputTokens;
-  } else if (modelAttr.usage?.completionTokens !== undefined) {
-    metrics.completion_tokens = modelAttr.usage?.completionTokens;
+  if (usage?.outputTokens !== undefined) {
+    metrics.completion_tokens = usage.outputTokens;
   }
 
-  if (modelAttr.usage?.totalTokens !== undefined) {
-    metrics.tokens = modelAttr.usage?.totalTokens;
-  }
-  if (modelAttr.usage?.reasoningTokens !== undefined) {
-    metrics.completion_reasoning_tokens = modelAttr.usage?.reasoningTokens;
-  }
-  if (modelAttr.usage?.promptCacheHitTokens !== undefined) {
-    metrics.prompt_cached_tokens = modelAttr.usage?.promptCacheHitTokens;
-  }
-  if (modelAttr.usage?.promptCacheMissTokens !== undefined) {
-    metrics.prompt_cache_creation_tokens = modelAttr.usage?.promptCacheMissTokens;
+  // Compute total if we have both
+  if (metrics.prompt_tokens !== undefined && metrics.completion_tokens !== undefined) {
+    metrics.tokens = metrics.prompt_tokens + metrics.completion_tokens;
   }
 
-  // Time to first token (TTFT) for streaming responses
-  if (modelAttr.completionStartTime) {
-    // Handle both Date objects and already-converted timestamps (number/string)
-    const startTime = modelAttr.completionStartTime;
-    if (startTime instanceof Date) {
-      metrics.time_to_first_token = startTime.getTime();
-    } else if (typeof startTime === 'number') {
-      metrics.time_to_first_token = startTime;
-    } else if (typeof startTime === 'string') {
-      metrics.time_to_first_token = new Date(startTime).getTime();
-    }
+  if (usage?.outputDetails?.reasoning !== undefined) {
+    metrics.completion_reasoning_tokens = usage.outputDetails.reasoning;
+  }
+
+  if (usage?.inputDetails?.cacheRead !== undefined) {
+    metrics.prompt_cached_tokens = usage.inputDetails.cacheRead;
+  }
+
+  if (usage?.inputDetails?.cacheWrite !== undefined) {
+    metrics.prompt_cache_creation_tokens = usage.inputDetails.cacheWrite;
   }
 
   return metrics;

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -316,7 +316,7 @@ describe('BraintrustExporter', () => {
       );
     });
 
-    it('should map MODEL_CHUNK to "llm" type', async () => {
+    it('should map MODEL_CHUNK to "task" type', async () => {
       const chunkSpan = createMockSpan({
         id: 'chunk-span',
         name: 'llm-chunk',
@@ -332,7 +332,7 @@ describe('BraintrustExporter', () => {
 
       expect(mockLogger.startSpan).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'llm',
+          type: 'task',
         }),
       );
     });
@@ -478,9 +478,8 @@ describe('BraintrustExporter', () => {
           model: 'gpt-4',
           provider: 'openai',
           usage: {
-            promptTokens: 10,
-            completionTokens: 5,
-            totalTokens: 15,
+            inputTokens: 10,
+            outputTokens: 5,
           },
           parameters: {
             temperature: 0.7,
@@ -665,7 +664,7 @@ describe('BraintrustExporter', () => {
       // Update with usage info
       llmSpan.attributes = {
         ...llmSpan.attributes,
-        usage: { totalTokens: 150 },
+        usage: { inputTokens: 100, outputTokens: 50 },
       } as ModelGenerationAttributes;
       // Note: LLM output uses 'text' field, not 'content'
       llmSpan.output = { text: 'Updated response' };
@@ -678,7 +677,7 @@ describe('BraintrustExporter', () => {
       expect(mockSpan.log).toHaveBeenCalledWith({
         // Output is transformed: { text: '...' } -> { role: 'assistant', content: '...' } for Braintrust Thread view
         output: { role: 'assistant', content: 'Updated response' },
-        metrics: { tokens: 150 },
+        metrics: { prompt_tokens: 100, completion_tokens: 50, tokens: 150 },
         metadata: {
           spanType: 'model_generation',
           model: 'gpt-4',

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -13,7 +13,7 @@ import { BaseExporter } from '@mastra/observability';
 import type { BaseExporterConfig } from '@mastra/observability';
 import { initLogger, currentSpan } from 'braintrust';
 import type { Span, Logger } from 'braintrust';
-import { normalizeUsageMetrics } from './metrics';
+import { formatUsageMetrics } from './metrics';
 
 const MASTRA_TRACE_ID_METADATA_KEY = 'mastra-trace-id';
 
@@ -50,7 +50,6 @@ const DEFAULT_SPAN_TYPE = 'task';
 // Exceptions to the default mapping
 const SPAN_TYPE_EXCEPTIONS: Partial<Record<SpanType, string>> = {
   [SpanType.MODEL_GENERATION]: 'llm',
-  [SpanType.MODEL_CHUNK]: 'llm',
   [SpanType.TOOL_CALL]: 'tool',
   [SpanType.MCP_TOOL_CALL]: 'tool',
   [SpanType.WORKFLOW_CONDITIONAL_EVAL]: 'function',
@@ -426,7 +425,14 @@ export class BraintrustExporter extends BaseExporter {
       }
 
       // Usage/token info goes to metrics
-      payload.metrics = normalizeUsageMetrics(modelAttr);
+      payload.metrics = formatUsageMetrics(modelAttr.usage);
+
+      // Time to first token (TTFT) for streaming responses
+      // Braintrust expects TTFT in seconds (not milliseconds)
+      if (modelAttr.completionStartTime) {
+        payload.metrics.time_to_first_token =
+          (modelAttr.completionStartTime.getTime() - span.startTime.getTime()) / 1000;
+      }
 
       // Model parameters go to metadata
       if (modelAttr.parameters !== undefined) {
@@ -434,7 +440,7 @@ export class BraintrustExporter extends BaseExporter {
       }
 
       // Other LLM attributes go to metadata
-      const otherAttributes = omitKeys(attributes, ['model', 'usage', 'parameters']);
+      const otherAttributes = omitKeys(attributes, ['model', 'usage', 'parameters', 'completionStartTime']);
       payload.metadata = {
         ...payload.metadata,
         ...otherAttributes,

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -1367,143 +1367,141 @@ describe('LangfuseExporter', () => {
   });
 
   describe('Token Usage Normalization', () => {
-    describe('Token Usage Normalization', () => {
-      it('should handle token format with inputTokens/outputTokens', async () => {
-        const llmSpan = createMockSpan({
-          id: 'llm-v5-span',
-          name: 'llm-generation-v5',
-          type: SpanType.MODEL_GENERATION,
-          isRoot: true,
-          attributes: {
-            model: 'gpt-4o',
-            provider: 'openai',
-            usage: {
-              inputTokens: 120,
-              outputTokens: 60,
-            },
+    it('should handle token format with inputTokens/outputTokens', async () => {
+      const llmSpan = createMockSpan({
+        id: 'llm-v5-span',
+        name: 'llm-generation-v5',
+        type: SpanType.MODEL_GENERATION,
+        isRoot: true,
+        attributes: {
+          model: 'gpt-4o',
+          provider: 'openai',
+          usage: {
+            inputTokens: 120,
+            outputTokens: 60,
           },
-        });
-
-        await exporter.exportTracingEvent({
-          type: TracingEventType.SPAN_STARTED,
-          exportedSpan: llmSpan,
-        });
-
-        expect(mockTrace.generation).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: 'gpt-4o',
-            usageDetails: {
-              input: 120,
-              output: 60,
-              total: 180,
-            },
-          }),
-        );
+        },
       });
 
-      it('should handle reasoning tokens from outputDetails', async () => {
-        const llmSpan = createMockSpan({
-          id: 'llm-v5-reasoning-span',
-          name: 'llm-generation-reasoning',
-          type: SpanType.MODEL_GENERATION,
-          isRoot: true,
-          attributes: {
-            model: 'o1-preview',
-            provider: 'openai',
-            usage: {
-              inputTokens: 100,
-              outputTokens: 1050,
-              outputDetails: { reasoning: 1000 },
-            },
-          },
-        });
-
-        await exporter.exportTracingEvent({
-          type: TracingEventType.SPAN_STARTED,
-          exportedSpan: llmSpan,
-        });
-
-        expect(mockTrace.generation).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: 'o1-preview',
-            usageDetails: {
-              input: 100,
-              output: 1050,
-              reasoning: 1000,
-              total: 1150,
-            },
-          }),
-        );
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
       });
 
-      it('should handle cached input tokens from inputDetails', async () => {
-        const llmSpan = createMockSpan({
-          id: 'llm-v5-cached-span',
-          name: 'llm-generation-cached',
-          type: SpanType.MODEL_GENERATION,
-          isRoot: true,
-          attributes: {
-            model: 'claude-3-5-sonnet',
-            provider: 'anthropic',
-            usage: {
-              inputTokens: 150,
-              outputTokens: 75,
-              inputDetails: { cacheRead: 100 },
-            },
+      expect(mockTrace.generation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-4o',
+          usageDetails: {
+            input: 120,
+            output: 60,
+            total: 180,
           },
-        });
+        }),
+      );
+    });
 
-        await exporter.exportTracingEvent({
-          type: TracingEventType.SPAN_STARTED,
-          exportedSpan: llmSpan,
-        });
-
-        expect(mockTrace.generation).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: 'claude-3-5-sonnet',
-            usageDetails: {
-              input: 150,
-              output: 75,
-              cache_read_input_tokens: 100,
-              total: 225,
-            },
-          }),
-        );
+    it('should handle reasoning tokens from outputDetails', async () => {
+      const llmSpan = createMockSpan({
+        id: 'llm-v5-reasoning-span',
+        name: 'llm-generation-reasoning',
+        type: SpanType.MODEL_GENERATION,
+        isRoot: true,
+        attributes: {
+          model: 'o1-preview',
+          provider: 'openai',
+          usage: {
+            inputTokens: 100,
+            outputTokens: 1050,
+            outputDetails: { reasoning: 1000 },
+          },
+        },
       });
 
-      it('should calculate total tokens when not provided', async () => {
-        const llmSpan = createMockSpan({
-          id: 'llm-calculated-total',
-          name: 'llm-generation-calc',
-          type: SpanType.MODEL_GENERATION,
-          isRoot: true,
-          attributes: {
-            model: 'gpt-4',
-            provider: 'openai',
-            usage: {
-              inputTokens: 80,
-              outputTokens: 40,
-              // no totalTokens provided
-            },
-          },
-        });
-
-        await exporter.exportTracingEvent({
-          type: TracingEventType.SPAN_STARTED,
-          exportedSpan: llmSpan,
-        });
-
-        expect(mockTrace.generation).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: 'gpt-4',
-            usageDetails: {
-              input: 80,
-              output: 40,
-              total: 120, // calculated
-            },
-          }),
-        );
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
       });
+
+      expect(mockTrace.generation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'o1-preview',
+          usageDetails: {
+            input: 100,
+            output: 1050,
+            reasoning: 1000,
+            total: 1150,
+          },
+        }),
+      );
+    });
+
+    it('should handle cached input tokens from inputDetails', async () => {
+      const llmSpan = createMockSpan({
+        id: 'llm-v5-cached-span',
+        name: 'llm-generation-cached',
+        type: SpanType.MODEL_GENERATION,
+        isRoot: true,
+        attributes: {
+          model: 'claude-3-5-sonnet',
+          provider: 'anthropic',
+          usage: {
+            inputTokens: 150,
+            outputTokens: 75,
+            inputDetails: { cacheRead: 100 },
+          },
+        },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
+      });
+
+      expect(mockTrace.generation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-3-5-sonnet',
+          usageDetails: {
+            input: 150,
+            output: 75,
+            cache_read_input_tokens: 100,
+            total: 225,
+          },
+        }),
+      );
+    });
+
+    it('should calculate total tokens when not provided', async () => {
+      const llmSpan = createMockSpan({
+        id: 'llm-calculated-total',
+        name: 'llm-generation-calc',
+        type: SpanType.MODEL_GENERATION,
+        isRoot: true,
+        attributes: {
+          model: 'gpt-4',
+          provider: 'openai',
+          usage: {
+            inputTokens: 80,
+            outputTokens: 40,
+            // no totalTokens provided
+          },
+        },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
+      });
+
+      expect(mockTrace.generation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-4',
+          usageDetails: {
+            input: 80,
+            output: 40,
+            total: 120, // calculated
+          },
+        }),
+      );
     });
   });
 

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -426,9 +426,8 @@ describe('LangfuseExporter', () => {
           model: 'gpt-4',
           provider: 'openai',
           usage: {
-            promptTokens: 10,
-            completionTokens: 5,
-            totalTokens: 15,
+            inputTokens: 10,
+            outputTokens: 5,
           },
           parameters: {
             temperature: 0.7,
@@ -461,17 +460,17 @@ describe('LangfuseExporter', () => {
         },
         input: { messages: [{ role: 'user', content: 'Hello' }] },
         output: { content: 'Hi there!' },
-        usage: {
+        usageDetails: {
           input: 10,
           output: 5,
           total: 15,
         },
-        metadata: {
+        metadata: expect.objectContaining({
           provider: 'openai',
           resultType: 'response_generation',
           spanType: 'model_generation',
           streaming: false,
-        },
+        }),
       });
     });
 
@@ -663,7 +662,7 @@ describe('LangfuseExporter', () => {
       // Then update it
       llmSpan.attributes = {
         ...llmSpan.attributes,
-        usage: { totalTokens: 150 },
+        usage: { inputTokens: 100, outputTokens: 50 },
       } as ModelGenerationAttributes;
       llmSpan.output = { content: 'Updated response' };
 
@@ -678,7 +677,9 @@ describe('LangfuseExporter', () => {
         }),
         model: 'gpt-4',
         output: { content: 'Updated response' },
-        usage: {
+        usageDetails: {
+          input: 100,
+          output: 50,
           total: 150,
         },
       });
@@ -1365,43 +1366,9 @@ describe('LangfuseExporter', () => {
     });
   });
 
-  describe('AI SDK v4 and v5 Compatibility', () => {
+  describe('Token Usage Normalization', () => {
     describe('Token Usage Normalization', () => {
-      it('should handle AI SDK v4 token format (promptTokens/completionTokens)', async () => {
-        const llmSpan = createMockSpan({
-          id: 'llm-v4-span',
-          name: 'llm-generation-v4',
-          type: SpanType.MODEL_GENERATION,
-          isRoot: true,
-          attributes: {
-            model: 'gpt-4',
-            provider: 'openai',
-            usage: {
-              promptTokens: 100,
-              completionTokens: 50,
-              totalTokens: 150,
-            },
-          },
-        });
-
-        await exporter.exportTracingEvent({
-          type: TracingEventType.SPAN_STARTED,
-          exportedSpan: llmSpan,
-        });
-
-        expect(mockTrace.generation).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: 'gpt-4',
-            usage: {
-              input: 100,
-              output: 50,
-              total: 150,
-            },
-          }),
-        );
-      });
-
-      it('should handle AI SDK v5 token format (inputTokens/outputTokens)', async () => {
+      it('should handle token format with inputTokens/outputTokens', async () => {
         const llmSpan = createMockSpan({
           id: 'llm-v5-span',
           name: 'llm-generation-v5',
@@ -1413,7 +1380,6 @@ describe('LangfuseExporter', () => {
             usage: {
               inputTokens: 120,
               outputTokens: 60,
-              totalTokens: 180,
             },
           },
         });
@@ -1426,7 +1392,7 @@ describe('LangfuseExporter', () => {
         expect(mockTrace.generation).toHaveBeenCalledWith(
           expect.objectContaining({
             model: 'gpt-4o',
-            usage: {
+            usageDetails: {
               input: 120,
               output: 60,
               total: 180,
@@ -1435,7 +1401,7 @@ describe('LangfuseExporter', () => {
         );
       });
 
-      it('should handle AI SDK v5 reasoning tokens', async () => {
+      it('should handle reasoning tokens from outputDetails', async () => {
         const llmSpan = createMockSpan({
           id: 'llm-v5-reasoning-span',
           name: 'llm-generation-reasoning',
@@ -1446,9 +1412,8 @@ describe('LangfuseExporter', () => {
             provider: 'openai',
             usage: {
               inputTokens: 100,
-              outputTokens: 50,
-              reasoningTokens: 1000,
-              totalTokens: 1150,
+              outputTokens: 1050,
+              outputDetails: { reasoning: 1000 },
             },
           },
         });
@@ -1461,9 +1426,9 @@ describe('LangfuseExporter', () => {
         expect(mockTrace.generation).toHaveBeenCalledWith(
           expect.objectContaining({
             model: 'o1-preview',
-            usage: {
+            usageDetails: {
               input: 100,
-              output: 50,
+              output: 1050,
               reasoning: 1000,
               total: 1150,
             },
@@ -1471,7 +1436,7 @@ describe('LangfuseExporter', () => {
         );
       });
 
-      it('should handle AI SDK v5 cached input tokens', async () => {
+      it('should handle cached input tokens from inputDetails', async () => {
         const llmSpan = createMockSpan({
           id: 'llm-v5-cached-span',
           name: 'llm-generation-cached',
@@ -1483,8 +1448,7 @@ describe('LangfuseExporter', () => {
             usage: {
               inputTokens: 150,
               outputTokens: 75,
-              cachedInputTokens: 100,
-              totalTokens: 225,
+              inputDetails: { cacheRead: 100 },
             },
           },
         });
@@ -1497,49 +1461,11 @@ describe('LangfuseExporter', () => {
         expect(mockTrace.generation).toHaveBeenCalledWith(
           expect.objectContaining({
             model: 'claude-3-5-sonnet',
-            usage: {
+            usageDetails: {
               input: 150,
               output: 75,
-              cachedInput: 100,
+              cache_read_input_tokens: 100,
               total: 225,
-            },
-          }),
-        );
-      });
-
-      it('should handle legacy cache metrics (promptCacheHitTokens/promptCacheMissTokens)', async () => {
-        const llmSpan = createMockSpan({
-          id: 'llm-cache-legacy-span',
-          name: 'llm-generation-cache-legacy',
-          type: SpanType.MODEL_GENERATION,
-          isRoot: true,
-          attributes: {
-            model: 'gpt-4',
-            provider: 'openai',
-            usage: {
-              promptTokens: 200,
-              completionTokens: 100,
-              totalTokens: 300,
-              promptCacheHitTokens: 150,
-              promptCacheMissTokens: 50,
-            },
-          },
-        });
-
-        await exporter.exportTracingEvent({
-          type: TracingEventType.SPAN_STARTED,
-          exportedSpan: llmSpan,
-        });
-
-        expect(mockTrace.generation).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: 'gpt-4',
-            usage: {
-              input: 200,
-              output: 100,
-              total: 300,
-              promptCacheHit: 150,
-              promptCacheMiss: 50,
             },
           }),
         );
@@ -1570,47 +1496,10 @@ describe('LangfuseExporter', () => {
         expect(mockTrace.generation).toHaveBeenCalledWith(
           expect.objectContaining({
             model: 'gpt-4',
-            usage: {
+            usageDetails: {
               input: 80,
               output: 40,
               total: 120, // calculated
-            },
-          }),
-        );
-      });
-
-      it('should handle mixed v4/v5 format gracefully (prioritizing v5)', async () => {
-        const llmSpan = createMockSpan({
-          id: 'llm-mixed-span',
-          name: 'llm-generation-mixed',
-          type: SpanType.MODEL_GENERATION,
-          isRoot: true,
-          attributes: {
-            model: 'gpt-4',
-            provider: 'openai',
-            usage: {
-              // Both formats present - v5 should take precedence
-              inputTokens: 100,
-              promptTokens: 90,
-              outputTokens: 50,
-              completionTokens: 45,
-              totalTokens: 150,
-            },
-          },
-        });
-
-        await exporter.exportTracingEvent({
-          type: TracingEventType.SPAN_STARTED,
-          exportedSpan: llmSpan,
-        });
-
-        expect(mockTrace.generation).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: 'gpt-4',
-            usage: {
-              input: 100, // v5 value, not 90
-              output: 50, // v5 value, not 45
-              total: 150,
             },
           }),
         );

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -4,15 +4,9 @@
  * This exporter sends observability data to Langfuse.
  * Root spans start traces in Langfuse.
  * MODEL_GENERATION spans become Langfuse generations, all others become spans.
- *
- * Compatible with both AI SDK v4 and v5:
- * - Handles both legacy token usage format (promptTokens/completionTokens)
- *   and v5 format (inputTokens/outputTokens)
- * - Supports v5 reasoning tokens and cache-related metrics
- * - Adapts to v5 streaming protocol changes
  */
 
-import type { TracingEvent, AnyExportedSpan, ModelGenerationAttributes } from '@mastra/core/observability';
+import type { TracingEvent, AnyExportedSpan, ModelGenerationAttributes, UsageStats } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import { omitKeys } from '@mastra/core/utils';
 import { BaseExporter } from '@mastra/observability';
@@ -52,66 +46,54 @@ type TraceData = {
 type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient | LangfuseEventClient;
 
 /**
- * Normalized token usage format compatible with Langfuse.
- * This unified format supports both AI SDK v4 and v5 token structures.
- *
- * @example
- * ```typescript
- * // AI SDK v4 format normalizes to:
- * { input: 100, output: 50, total: 150 }
- *
- * // AI SDK v5 format normalizes to:
- * { input: 120, output: 60, total: 180, reasoning: 1000, cachedInput: 50 }
- * ```
+ * Token usage format compatible with Langfuse.
  */
-interface NormalizedUsage {
-  /**
-   * Input tokens sent to the model
-   * @source AI SDK v5: `inputTokens` | AI SDK v4: `promptTokens`
-   */
+export interface LangfuseUsageMetrics {
   input?: number;
-
-  /**
-   * Output tokens received from the model
-   * @source AI SDK v5: `outputTokens` | AI SDK v4: `completionTokens`
-   */
   output?: number;
-
-  /**
-   * Total tokens (input + output + reasoning if applicable)
-   * @source AI SDK v4 & v5: `totalTokens`
-   */
   total?: number;
-
-  /**
-   * Reasoning tokens used by reasoning models
-   * @source AI SDK v5: `reasoningTokens`
-   * @since AI SDK v5.0.0
-   * @example Models like o1-preview, o1-mini
-   */
   reasoning?: number;
+  cache_read_input_tokens?: number;
+  cache_write_input_tokens?: number;
+}
 
-  /**
-   * Cached input tokens (prompt cache hit)
-   * @source AI SDK v5: `cachedInputTokens`
-   * @since AI SDK v5.0.0
-   * @example Anthropic's prompt caching, OpenAI prompt caching
-   */
-  cachedInput?: number;
+/**
+ * Formats UsageStats to Langfuse's expected format.
+ */
+export function formatUsageMetrics(usage?: UsageStats): LangfuseUsageMetrics {
+  if (!usage) return {};
 
-  /**
-   * Prompt cache hit tokens (legacy format)
-   * @source AI SDK v4: `promptCacheHitTokens`
-   * @deprecated Prefer `cachedInput` from v5 format
-   */
-  promptCacheHit?: number;
+  const metrics: LangfuseUsageMetrics = {};
 
-  /**
-   * Prompt cache miss tokens (legacy format)
-   * @source AI SDK v4: `promptCacheMissTokens`
-   * @deprecated Prefer v5 format which uses `cachedInputTokens`
-   */
-  promptCacheMiss?: number;
+  if (usage.inputTokens !== undefined) {
+    metrics.input = usage.inputTokens;
+
+    if (usage.inputDetails?.cacheWrite !== undefined) {
+      metrics.cache_write_input_tokens = usage.inputDetails.cacheWrite;
+      metrics.input -= metrics.cache_write_input_tokens;
+    }
+  }
+
+  if (usage.inputDetails?.cacheRead !== undefined) {
+    metrics.cache_read_input_tokens = usage.inputDetails.cacheRead;
+  }
+
+  if (usage.outputTokens !== undefined) {
+    metrics.output = usage.outputTokens;
+  }
+
+  if (usage.outputDetails?.reasoning !== undefined) {
+    metrics.reasoning = usage.outputDetails.reasoning;
+  }
+
+  if (metrics.input && metrics.output) {
+    metrics.total = metrics.input + metrics.output;
+    if (metrics.cache_write_input_tokens) {
+      metrics.total += metrics.cache_write_input_tokens;
+    }
+  }
+
+  return metrics;
 }
 
 export class LangfuseExporter extends BaseExporter {
@@ -395,64 +377,6 @@ export class LangfuseExporter extends BaseExporter {
   }
 
   /**
-   * Normalize usage data to handle both AI SDK v4 and v5 formats.
-   *
-   * AI SDK v4 uses: promptTokens, completionTokens
-   * AI SDK v5 uses: inputTokens, outputTokens
-   *
-   * This function normalizes to a unified format that Langfuse can consume,
-   * prioritizing v5 format while maintaining backward compatibility.
-   *
-   * @param usage - Token usage data from AI SDK (v4 or v5 format)
-   * @returns Normalized usage object, or undefined if no usage data available
-   */
-  private normalizeUsage(usage: ModelGenerationAttributes['usage']): NormalizedUsage | undefined {
-    if (!usage) return undefined;
-
-    const normalized: NormalizedUsage = {};
-
-    // Handle input tokens (v5 'inputTokens' or v4 'promptTokens')
-    // Using ?? to prioritize v5 format while falling back to v4
-    const inputTokens = usage.inputTokens ?? usage.promptTokens;
-    if (inputTokens !== undefined) {
-      normalized.input = inputTokens;
-    }
-
-    // Handle output tokens (v5 'outputTokens' or v4 'completionTokens')
-    const outputTokens = usage.outputTokens ?? usage.completionTokens;
-    if (outputTokens !== undefined) {
-      normalized.output = outputTokens;
-    }
-
-    // Total tokens - calculate if not provided
-    if (usage.totalTokens !== undefined) {
-      normalized.total = usage.totalTokens;
-    } else if (normalized.input !== undefined && normalized.output !== undefined) {
-      normalized.total = normalized.input + normalized.output;
-    }
-
-    // AI SDK v5-specific: reasoning tokens
-    if (usage.reasoningTokens !== undefined) {
-      normalized.reasoning = usage.reasoningTokens;
-    }
-
-    // AI SDK v5-specific: cached tokens (cache hit)
-    if (usage.cachedInputTokens !== undefined) {
-      normalized.cachedInput = usage.cachedInputTokens;
-    }
-
-    // Legacy cache metrics (promptCacheHitTokens/promptCacheMissTokens)
-    if (usage.promptCacheHitTokens !== undefined) {
-      normalized.promptCacheHit = usage.promptCacheHitTokens;
-    }
-    if (usage.promptCacheMissTokens !== undefined) {
-      normalized.promptCacheMiss = usage.promptCacheMissTokens;
-    }
-
-    return Object.keys(normalized).length > 0 ? normalized : undefined;
-  }
-
-  /**
    * Look up the Langfuse prompt from the closest parent span that has one.
    * This enables prompt inheritance for MODEL_GENERATION spans when the prompt
    * is set on a parent span (e.g., AGENT_RUN) rather than directly on the generation.
@@ -516,12 +440,8 @@ export class LangfuseExporter extends BaseExporter {
       }
 
       if (modelAttr.usage !== undefined) {
-        // Normalize usage to handle both v4 and v5 formats
-        const normalizedUsage = this.normalizeUsage(modelAttr.usage);
-        if (normalizedUsage) {
-          payload.usage = normalizedUsage;
-        }
-        attributesToOmit.push('usage');
+        payload.usageDetails = formatUsageMetrics(modelAttr.usage);
+        attributesToOmit.push('usageDetails');
       }
 
       if (modelAttr.parameters !== undefined) {

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -441,7 +441,7 @@ export class LangfuseExporter extends BaseExporter {
 
       if (modelAttr.usage !== undefined) {
         payload.usageDetails = formatUsageMetrics(modelAttr.usage);
-        attributesToOmit.push('usageDetails');
+        attributesToOmit.push('usage');
       }
 
       if (modelAttr.parameters !== undefined) {

--- a/observability/langfuse/src/usage.test.ts
+++ b/observability/langfuse/src/usage.test.ts
@@ -1,0 +1,33 @@
+import type { UsageStats } from '@mastra/core/observability';
+import { describe, it, expect } from 'vitest';
+import { formatUsageMetrics } from './tracing';
+
+describe('formatUsageMetrics', () => {
+  it('should extract basic tokens', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 50 };
+    const result = formatUsageMetrics(usage);
+    expect(result?.input).toBe(100);
+    expect(result?.output).toBe(50);
+    expect(result?.total).toBe(150);
+  });
+
+  it('should extract cacheRead from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
+    const result = formatUsageMetrics(usage);
+    expect(result?.cache_read_input_tokens).toBe(800);
+  });
+
+  it('should extract cacheWrite from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
+    const result = formatUsageMetrics(usage);
+    expect(result?.cache_write_input_tokens).toBe(500);
+    // cacheWrite tokens are subtracted from input
+    expect(result?.input).toBe(500);
+  });
+
+  it('should extract reasoning from outputDetails', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 500, outputDetails: { reasoning: 400 } };
+    const result = formatUsageMetrics(usage);
+    expect(result?.reasoning).toBe(400);
+  });
+});

--- a/observability/langsmith/src/metrics.test.ts
+++ b/observability/langsmith/src/metrics.test.ts
@@ -1,0 +1,36 @@
+import type { UsageStats } from '@mastra/core/observability';
+import { describe, it, expect } from 'vitest';
+import { formatUsageMetrics } from './metrics';
+
+describe('formatUsageMetrics', () => {
+  it('should extract basic tokens', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 50 };
+    const result = formatUsageMetrics(usage);
+    expect(result.input_tokens).toBe(100);
+    expect(result.output_tokens).toBe(50);
+    expect(result.total_tokens).toBe(150);
+  });
+
+  it('should extract cacheRead from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.input_token_details?.cache_read).toBe(800);
+  });
+
+  it('should extract cacheWrite from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.input_token_details?.cache_write).toBe(500);
+  });
+
+  it('should extract reasoning from outputDetails', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 500, outputDetails: { reasoning: 400 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.output_token_details?.reasoning_tokens).toBe(400);
+  });
+
+  it('should return empty metrics for undefined usage', () => {
+    const result = formatUsageMetrics(undefined);
+    expect(result).toEqual({});
+  });
+});

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -583,7 +583,7 @@ const mockModelV2 = new MockLanguageModelV2({
           },
         ],
         finishReason: 'tool-calls' as const,
-        usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+        usage: { inputTokens: 15, outputTokens: 10 },
         warnings: [],
       };
     }
@@ -601,7 +601,7 @@ const mockModelV2 = new MockLanguageModelV2({
       return {
         content: [{ type: 'text', text: JSON.stringify(structuredData) }],
         finishReason: 'stop' as const,
-        usage: { inputTokens: 15, outputTokens: 25, totalTokens: 40 },
+        usage: { inputTokens: 15, outputTokens: 25 },
         warnings: [],
       };
     }
@@ -610,7 +610,7 @@ const mockModelV2 = new MockLanguageModelV2({
     return {
       content: [{ type: 'text', text: 'Mock V2 generate response' }],
       finishReason: 'stop' as const,
-      usage: { inputTokens: 15, outputTokens: 25, totalTokens: 40 },
+      usage: { inputTokens: 15, outputTokens: 25 },
       warnings: [],
     };
   },
@@ -643,7 +643,7 @@ const mockModelV2 = new MockLanguageModelV2({
             args: argsJson,
             input: argsJson,
           },
-          { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 } },
+          { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 15, outputTokens: 10 } },
         ]),
       };
     }
@@ -662,7 +662,7 @@ const mockModelV2 = new MockLanguageModelV2({
       return {
         stream: convertArrayToReadableStream([
           { type: 'text-delta', id: '1', delta: structuredOutput },
-          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 15, outputTokens: 25, totalTokens: 40 } },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 15, outputTokens: 25 } },
         ]),
       };
     }
@@ -673,7 +673,7 @@ const mockModelV2 = new MockLanguageModelV2({
         { type: 'text-delta', id: '1', delta: 'Mock ' },
         { type: 'text-delta', id: '2', delta: 'V2 stream ' },
         { type: 'text-delta', id: '3', delta: 'response' },
-        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 15, outputTokens: 25, totalTokens: 40 } },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 15, outputTokens: 25 } },
       ]),
     };
   },
@@ -1202,7 +1202,7 @@ describe('Tracing Integration Tests', () => {
             expect(agentRunSpan?.output.text).toBe(`Mock V2 ${name} response`);
             break;
         }
-        expect(llmGenerationSpan?.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+        expect(llmGenerationSpan?.attributes?.usage?.inputTokens).toBeGreaterThan(0);
 
         expect(llmGenerationSpan?.endTime).toBeDefined();
         expect(agentRunSpan?.endTime).toBeDefined();
@@ -1304,7 +1304,7 @@ describe('Tracing Integration Tests', () => {
             expect(agentRunSpan?.output.text).toBe(`Mock V2 ${name} response`);
             break;
         }
-        expect(llmGenerationSpan?.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+        expect(llmGenerationSpan?.attributes?.usage?.inputTokens).toBeGreaterThan(0);
 
         testExporter.finalExpectations();
       });
@@ -1382,7 +1382,7 @@ describe('Tracing Integration Tests', () => {
             expect(agentRunSpan?.output.text).toBe(`Mock V2 ${name} response`);
             break;
         }
-        expect(llmGenerationSpan?.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+        expect(llmGenerationSpan?.attributes?.usage?.inputTokens).toBeGreaterThan(0);
 
         expect(llmGenerationSpan?.endTime).toBeDefined();
         expect(agentRunSpan?.endTime).toBeDefined();
@@ -1489,8 +1489,8 @@ describe('Tracing Integration Tests', () => {
         expect(result.object).toHaveProperty('items');
         expect((result.object as any).items).toBe('test structured output');
 
-        expect(testAgentLlmSpan!.attributes?.usage?.totalTokens).toBeGreaterThan(1);
-        expect(processorAgentLlmSpan?.attributes?.usage?.totalTokens).toBeGreaterThan(1);
+        expect(testAgentLlmSpan!.attributes?.usage?.inputTokens).toBeGreaterThan(0);
+        expect(processorAgentLlmSpan?.attributes?.usage?.inputTokens).toBeGreaterThan(0);
 
         expect(testAgentLlmSpan!.endTime).toBeDefined();
         expect(testAgentSpan?.endTime).toBeDefined();
@@ -2000,7 +2000,7 @@ describe('Tracing Integration Tests', () => {
             type: 'finish',
             id: '1',
             finishReason: 'stop',
-            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            usage: { inputTokens: 10, outputTokens: 20 },
           },
         ]),
         rawCall: { rawPrompt: null, rawSettings: {} },

--- a/observability/mastra/src/span_processors/senstive-data-filter.test.ts
+++ b/observability/mastra/src/span_processors/senstive-data-filter.test.ts
@@ -79,7 +79,7 @@ describe('Tracing', () => {
         expect(attributes?.['sessionId']).toBe('session-789'); // sessionId should not be redacted
       });
 
-      it('should NOT redact fields like promptTokens and totalTokens', () => {
+      it('should NOT redact fields like inputTokens and outputTokens', () => {
         const processor = new SensitiveDataFilter();
 
         const mockSpan = {
@@ -91,11 +91,10 @@ describe('Tracing', () => {
           trace: { traceId: 'trace-123' } as any,
           attributes: {
             model: 'gpt-4',
-            promptTokens: 100, // Should NOT be redacted (normalizes to "prompttokens", not "token")
-            completionTokens: 50, // Should NOT be redacted (normalizes to "completiontokens")
-            totalTokens: 150, // Should NOT be redacted (normalizes to "totaltokens")
-            prompt_tokens: 100, // Should NOT be redacted (normalizes to "prompttokens")
-            total_tokens: 150, // Should NOT be redacted (normalizes to "totaltokens")
+            inputTokens: 100, // Should NOT be redacted (normalizes to "inputtokens", not "token")
+            outputTokens: 50, // Should NOT be redacted (normalizes to "outputtokens")
+            input_tokens: 100, // Should NOT be redacted (normalizes to "inputtokens")
+            output_tokens: 50, // Should NOT be redacted (normalizes to "outputtokens")
             token: 'auth-token-123', // Should be redacted (normalizes to "token")
             authToken: 'bearer-456', // Should NOT be redacted (normalizes to "authtoken", not "token")
             api_key: 'sk-123456', // Should be redacted (normalizes to "apikey")
@@ -118,11 +117,10 @@ describe('Tracing', () => {
         const attributes = filtered!.attributes;
 
         // Check that token-related metrics are NOT redacted
-        expect(attributes?.['promptTokens']).toBe(100);
-        expect(attributes?.['completionTokens']).toBe(50);
-        expect(attributes?.['totalTokens']).toBe(150);
-        expect(attributes?.['prompt_tokens']).toBe(100);
-        expect(attributes?.['total_tokens']).toBe(150);
+        expect(attributes?.['inputTokens']).toBe(100);
+        expect(attributes?.['outputTokens']).toBe(50);
+        expect(attributes?.['input_tokens']).toBe(100);
+        expect(attributes?.['output_tokens']).toBe(50);
 
         // Check that fields that don't exactly match after normalization are NOT redacted
         expect(attributes?.['authToken']).toBe('bearer-456');

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -3,7 +3,7 @@ import { SpanType, SamplingStrategyType, InternalSpans } from '@mastra/core/obse
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { DefaultObservabilityInstance } from '../instances';
-import { getExternalParentId } from './base';
+import { getExternalParentId, deepClean } from './base';
 
 // Simple test exporter for capturing events
 class TestExporter implements ObservabilityExporter {
@@ -451,6 +451,87 @@ describe('Span', () => {
       expect(getExternalParentId(options)).toBe(llmSpan.id);
 
       agentSpan.end();
+    });
+  });
+
+  describe('deepClean', () => {
+    it('should preserve Date objects as-is', () => {
+      const date = new Date('2024-01-15T12:30:00.000Z');
+      const nestedDate = new Date('2024-06-20T08:00:00.000Z');
+      const input = {
+        name: 'test',
+        createdAt: date,
+        nested: {
+          updatedAt: nestedDate,
+        },
+      };
+
+      const result = deepClean(input);
+
+      expect(result.name).toBe('test');
+      expect(result.createdAt).toBe(date);
+      expect(result.createdAt instanceof Date).toBe(true);
+      expect(result.nested.updatedAt).toBe(nestedDate);
+      expect(result.nested.updatedAt instanceof Date).toBe(true);
+    });
+
+    it('should handle Date objects in arrays', () => {
+      const date1 = new Date('2024-01-01T00:00:00.000Z');
+      const date2 = new Date('2024-12-31T23:59:59.000Z');
+      const input = {
+        dates: [date1, date2],
+      };
+
+      const result = deepClean(input);
+
+      expect(result.dates[0]).toBe(date1);
+      expect(result.dates[1]).toBe(date2);
+    });
+
+    it('should handle circular references', () => {
+      const obj: any = { name: 'test' };
+      obj.self = obj;
+
+      const result = deepClean(obj);
+
+      expect(result.name).toBe('test');
+      expect(result.self).toBe('[Circular]');
+    });
+
+    it('should strip specified keys', () => {
+      const input = {
+        name: 'test',
+        logger: { level: 'info' },
+        tracingContext: { traceId: '123' },
+        data: 'keep this',
+      };
+
+      const result = deepClean(input);
+
+      expect(result.name).toBe('test');
+      expect(result.data).toBe('keep this');
+      expect(result.logger).toBeUndefined();
+      expect(result.tracingContext).toBeUndefined();
+    });
+
+    it('should handle max depth', () => {
+      const deepObj: any = { level: 0 };
+      let current = deepObj;
+      for (let i = 1; i <= 15; i++) {
+        current.nested = { level: i };
+        current = current.nested;
+      }
+
+      const result = deepClean(deepObj, { maxDepth: 3 });
+
+      expect(result.level).toBe(0);
+      expect(result.nested.level).toBe(1);
+      expect(result.nested.nested.level).toBe(2);
+      // At depth 3, each property value is replaced with [MaxDepth]
+      expect(result.nested.nested.nested).toEqual({
+        level: '[MaxDepth]',
+        nested: '[MaxDepth]',
+      });
     });
   });
 });

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -324,6 +324,11 @@ export function deepClean(
 
   _seen.add(value);
 
+  // Handle Date objects - return as-is (they are JSON-serializable)
+  if (value instanceof Date) {
+    return value;
+  }
+
   if (Array.isArray(value)) {
     return value.map(item => deepClean(item, options, _seen, _depth + 1));
   }

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -1,0 +1,233 @@
+import type { LanguageModelUsage, ProviderMetadata } from '@mastra/core/stream';
+import { describe, it, expect } from 'vitest';
+import { extractUsageMetrics } from './usage';
+
+describe('extractUsageMetrics', () => {
+  describe('basic usage extraction', () => {
+    it('should return empty object when usage is undefined', () => {
+      const result = extractUsageMetrics(undefined);
+      expect(result).toEqual({});
+    });
+
+    it('should extract basic input and output tokens', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+      };
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(50);
+    });
+  });
+
+  describe('OpenAI / OpenRouter cache tokens', () => {
+    it('should extract cachedInputTokens from usage object', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cachedInputTokens: 800,
+      };
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputTokens).toBe(1000);
+      expect(result.outputTokens).toBe(200);
+      expect(result.inputDetails?.cacheRead).toBe(800);
+    });
+
+    it('should extract reasoningTokens from usage object (OpenAI o1 models)', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 500,
+        reasoningTokens: 400,
+      };
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.outputDetails?.reasoning).toBe(400);
+    });
+  });
+
+  describe('Anthropic cache tokens', () => {
+    it('should extract cache tokens from providerMetadata.anthropic', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100, // Base input tokens (does NOT include cache)
+        outputTokens: 50,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 800,
+          cacheCreationInputTokens: 200,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      // For Anthropic, total input = base + cacheRead + cacheCreation
+      expect(result.inputTokens).toBe(1100); // 100 + 800 + 200
+      expect(result.outputTokens).toBe(50);
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.inputDetails?.cacheRead).toBe(800);
+      expect(result.inputDetails?.cacheWrite).toBe(200);
+    });
+
+    it('should handle Anthropic with only cache read tokens', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 50,
+        outputTokens: 100,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 500,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(550); // 50 + 500
+      expect(result.inputDetails?.text).toBe(50);
+      expect(result.inputDetails?.cacheRead).toBe(500);
+      expect(result.inputDetails?.cacheWrite).toBeUndefined();
+    });
+
+    it('should handle Anthropic with only cache creation tokens', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheCreationInputTokens: 1000,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(1100); // 100 + 1000
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.inputDetails?.cacheWrite).toBe(1000);
+      expect(result.inputDetails?.cacheRead).toBeUndefined();
+    });
+  });
+
+  describe('Google/Gemini cache and thought tokens', () => {
+    it('should extract cache tokens from providerMetadata.google.usageMetadata', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 500,
+        outputTokens: 200,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        google: {
+          usageMetadata: {
+            cachedContentTokenCount: 300,
+          },
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(500);
+      expect(result.inputDetails?.cacheRead).toBe(300);
+    });
+
+    it('should extract thought tokens from providerMetadata.google.usageMetadata', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 500,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        google: {
+          usageMetadata: {
+            thoughtsTokenCount: 300,
+          },
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.outputDetails?.reasoning).toBe(300);
+    });
+
+    it('should extract both cache and thought tokens from Google', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 200,
+        outputTokens: 400,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        google: {
+          usageMetadata: {
+            cachedContentTokenCount: 150,
+            thoughtsTokenCount: 250,
+          },
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputDetails?.cacheRead).toBe(150);
+      expect(result.outputDetails?.reasoning).toBe(250);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle zero token counts', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 0,
+        outputTokens: 0,
+      };
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputTokens).toBe(0);
+      expect(result.outputTokens).toBe(0);
+    });
+
+    it('should not include inputDetails if empty', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+      };
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputDetails).toBeUndefined();
+      expect(result.outputDetails).toBeUndefined();
+    });
+
+    it('should handle empty providerMetadata', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+      };
+
+      const result = extractUsageMetrics(usage, {});
+
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(50);
+    });
+
+    it('should handle providerMetadata with empty anthropic object', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {},
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(100);
+      expect(result.inputDetails).toBeUndefined();
+    });
+  });
+});

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -1,0 +1,116 @@
+/**
+ * Usage extraction utilities for converting AI SDK usage to Mastra UsageStats
+ */
+
+import type { InputTokenDetails, OutputTokenDetails, UsageStats } from '@mastra/core/observability';
+import type { LanguageModelUsage, ProviderMetadata } from '@mastra/core/stream';
+
+/**
+ * Provider-specific metadata shapes for type-safe access.
+ * These match the actual shapes from AI SDK providers.
+ */
+interface AnthropicMetadata {
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
+}
+
+interface GoogleUsageMetadata {
+  cachedContentTokenCount?: number;
+  thoughtsTokenCount?: number;
+}
+
+interface GoogleMetadata {
+  usageMetadata?: GoogleUsageMetadata;
+}
+
+/**
+ * Extracts and normalizes token usage from AI SDK response, including
+ * provider-specific cache tokens from providerMetadata.
+ *
+ * Handles:
+ * - OpenAI: cachedInputTokens in usage object
+ * - Anthropic: cacheCreationInputTokens, cacheReadInputTokens in providerMetadata.anthropic
+ * - Google/Gemini: cachedContentTokenCount, thoughtsTokenCount in providerMetadata.google.usageMetadata
+ * - OpenRouter: Uses OpenAI-compatible structure (cache tokens in usage)
+ *
+ * @param usage - The LanguageModelV2Usage from AI SDK response
+ * @param providerMetadata - Optional provider-specific metadata
+ * @returns UsageStats with inputDetails and outputDetails
+ */
+export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata?: ProviderMetadata): UsageStats {
+  if (!usage) {
+    return {};
+  }
+
+  const inputDetails: InputTokenDetails = {};
+  const outputDetails: OutputTokenDetails = {};
+
+  let inputTokens = usage.inputTokens;
+  const outputTokens = usage.outputTokens;
+
+  // ===== OpenAI / OpenRouter =====
+  // cachedInputTokens is already in the usage object
+  // inputTokens INCLUDES cached tokens (no adjustment needed)
+  if (usage.cachedInputTokens) {
+    inputDetails.cacheRead = usage.cachedInputTokens;
+  }
+
+  // reasoningTokens from usage (OpenAI o1 models)
+  if (usage.reasoningTokens) {
+    outputDetails.reasoning = usage.reasoningTokens;
+  }
+
+  // ===== Anthropic =====
+  // Cache tokens are in providerMetadata.anthropic
+  // inputTokens does NOT include cache tokens - need to sum them
+  const anthropic = providerMetadata?.anthropic as AnthropicMetadata | undefined;
+
+  if (anthropic) {
+    if (anthropic.cacheReadInputTokens) {
+      inputDetails.cacheRead = anthropic.cacheReadInputTokens;
+    }
+    if (anthropic.cacheCreationInputTokens) {
+      inputDetails.cacheWrite = anthropic.cacheCreationInputTokens;
+    }
+
+    // For Anthropic, adjust inputTokens to include cache tokens
+    // Per Anthropic docs: "Total input tokens is the summation of input_tokens,
+    // cache_creation_input_tokens, and cache_read_input_tokens"
+    if (anthropic.cacheReadInputTokens || anthropic.cacheCreationInputTokens) {
+      inputDetails.text = usage.inputTokens;
+      inputTokens =
+        (usage.inputTokens ?? 0) + (anthropic.cacheReadInputTokens ?? 0) + (anthropic.cacheCreationInputTokens ?? 0);
+    }
+  }
+
+  // ===== Google/Gemini =====
+  // Cache tokens and thoughts are in providerMetadata.google.usageMetadata
+  // Available in @ai-sdk/google@1.2.23+
+  const google = providerMetadata?.google as GoogleMetadata | undefined;
+
+  if (google?.usageMetadata) {
+    if (google.usageMetadata.cachedContentTokenCount) {
+      inputDetails.cacheRead = google.usageMetadata.cachedContentTokenCount;
+    }
+    // Gemini "thoughts" are similar to reasoning tokens
+    if (google.usageMetadata.thoughtsTokenCount) {
+      outputDetails.reasoning = google.usageMetadata.thoughtsTokenCount;
+    }
+  }
+
+  // Build the final UsageStats object
+  const result: UsageStats = {
+    inputTokens,
+    outputTokens,
+  };
+
+  // Only include details if there's data
+  if (Object.keys(inputDetails).length > 0) {
+    result.inputDetails = inputDetails;
+  }
+  if (Object.keys(outputDetails).length > 0) {
+    result.outputDetails = outputDetails;
+  }
+
+  return result;
+}

--- a/observability/otel-exporter/src/gen-ai-semantics.test.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.test.ts
@@ -1,0 +1,92 @@
+import { SpanType } from '@mastra/core/observability';
+import type { AnyExportedSpan, ModelGenerationAttributes, UsageStats } from '@mastra/core/observability';
+import { describe, it, expect } from 'vitest';
+import { getAttributes, formatUsageMetrics } from './gen-ai-semantics';
+
+function createModelGenerationSpan(attributes: ModelGenerationAttributes): AnyExportedSpan {
+  return {
+    id: 'test-span-id',
+    traceId: 'test-trace-id',
+    name: 'test-generation',
+    type: SpanType.MODEL_GENERATION,
+    startTime: new Date(),
+    isRootSpan: false,
+    isEvent: false,
+    attributes,
+  } as AnyExportedSpan;
+}
+
+describe('getAttributes - token usage', () => {
+  it('should extract basic tokens', () => {
+    const span = createModelGenerationSpan({
+      model: 'gpt-4',
+      provider: 'openai',
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+    const attrs = getAttributes(span);
+    expect(attrs['gen_ai.usage.input_tokens']).toBe(100);
+    expect(attrs['gen_ai.usage.output_tokens']).toBe(50);
+  });
+
+  it('should extract cacheRead from inputDetails', () => {
+    const span = createModelGenerationSpan({
+      model: 'claude-3-opus',
+      provider: 'anthropic',
+      usage: { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } },
+    });
+    const attrs = getAttributes(span);
+    expect(attrs['gen_ai.usage.cached_input_tokens']).toBe(800);
+  });
+
+  it('should extract cacheWrite from inputDetails', () => {
+    const span = createModelGenerationSpan({
+      model: 'claude-3-opus',
+      provider: 'anthropic',
+      usage: { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } },
+    });
+    const attrs = getAttributes(span);
+    expect(attrs['gen_ai.usage.cache_write_tokens']).toBe(500);
+  });
+
+  it('should extract reasoning from outputDetails', () => {
+    const span = createModelGenerationSpan({
+      model: 'o1-preview',
+      provider: 'openai',
+      usage: { inputTokens: 100, outputTokens: 500, outputDetails: { reasoning: 400 } },
+    });
+    const attrs = getAttributes(span);
+    expect(attrs['gen_ai.usage.reasoning_tokens']).toBe(400);
+  });
+});
+
+describe('formatUsageMetrics', () => {
+  it('should extract basic tokens', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 50 };
+    const result = formatUsageMetrics(usage);
+    expect(result['gen_ai.usage.input_tokens']).toBe(100);
+    expect(result['gen_ai.usage.output_tokens']).toBe(50);
+  });
+
+  it('should extract cacheRead from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
+    const result = formatUsageMetrics(usage);
+    expect(result['gen_ai.usage.cached_input_tokens']).toBe(800);
+  });
+
+  it('should extract cacheWrite from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
+    const result = formatUsageMetrics(usage);
+    expect(result['gen_ai.usage.cache_write_tokens']).toBe(500);
+  });
+
+  it('should extract reasoning from outputDetails', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 500, outputDetails: { reasoning: 400 } };
+    const result = formatUsageMetrics(usage);
+    expect(result['gen_ai.usage.reasoning_tokens']).toBe(400);
+  });
+
+  it('should return empty metrics for undefined usage', () => {
+    const result = formatUsageMetrics(undefined);
+    expect(result).toEqual({});
+  });
+});

--- a/observability/otel-exporter/src/gen-ai-semantics.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.ts
@@ -16,6 +16,7 @@ import type {
   MCPToolCallAttributes,
   ModelGenerationAttributes,
   ToolCallAttributes,
+  UsageStats,
   WorkflowRunAttributes,
 } from '@mastra/core/observability';
 import type { Attributes } from '@opentelemetry/api';
@@ -50,6 +51,62 @@ import {
   ATTR_GEN_AI_TOOL_NAME,
 } from '@opentelemetry/semantic-conventions/incubating';
 import { convertMastraMessagesToGenAIMessages } from './gen-ai-messages';
+
+/**
+ * Token usage attributes following OTel GenAI semantic conventions.
+ * @see https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+ */
+export interface OtelUsageMetrics {
+  [ATTR_GEN_AI_USAGE_INPUT_TOKENS]?: number;
+  [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]?: number;
+  'gen_ai.usage.reasoning_tokens'?: number;
+  'gen_ai.usage.cached_input_tokens'?: number;
+  'gen_ai.usage.cache_write_tokens'?: number;
+  'gen_ai.usage.audio_input_tokens'?: number;
+  'gen_ai.usage.audio_output_tokens'?: number;
+}
+
+/**
+ * Formats UsageStats to OTel GenAI semantic convention attributes.
+ */
+export function formatUsageMetrics(usage?: UsageStats): OtelUsageMetrics {
+  if (!usage) return {};
+
+  const metrics: OtelUsageMetrics = {};
+
+  if (usage.inputTokens !== undefined) {
+    metrics[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = usage.inputTokens;
+  }
+
+  if (usage.outputTokens !== undefined) {
+    metrics[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = usage.outputTokens;
+  }
+
+  // Reasoning tokens from outputDetails
+  if (usage.outputDetails?.reasoning !== undefined) {
+    metrics['gen_ai.usage.reasoning_tokens'] = usage.outputDetails.reasoning;
+  }
+
+  // Cache read tokens from inputDetails
+  if (usage.inputDetails?.cacheRead !== undefined) {
+    metrics['gen_ai.usage.cached_input_tokens'] = usage.inputDetails.cacheRead;
+  }
+
+  // Cache write tokens from inputDetails
+  if (usage.inputDetails?.cacheWrite !== undefined) {
+    metrics['gen_ai.usage.cache_write_tokens'] = usage.inputDetails.cacheWrite;
+  }
+
+  // Audio tokens from inputDetails/outputDetails
+  if (usage.inputDetails?.audio !== undefined) {
+    metrics['gen_ai.usage.audio_input_tokens'] = usage.inputDetails.audio;
+  }
+  if (usage.outputDetails?.audio !== undefined) {
+    metrics['gen_ai.usage.audio_output_tokens'] = usage.outputDetails.audio;
+  }
+
+  return metrics;
+}
 
 /**
  * Get the operation name based on span type for gen_ai.operation.name
@@ -181,26 +238,8 @@ export function getAttributes(span: AnyExportedSpan): Attributes {
     if (modelAttrs.agentName) {
       attributes[ATTR_GEN_AI_AGENT_NAME] = modelAttrs.agentName;
     }
-
-    // Token usage - use OTEL standard naming
-    if (modelAttrs.usage) {
-      const inputTokens = modelAttrs.usage.inputTokens ?? modelAttrs.usage.promptTokens;
-      const outputTokens = modelAttrs.usage.outputTokens ?? modelAttrs.usage.completionTokens;
-
-      if (inputTokens !== undefined) {
-        attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = inputTokens;
-      }
-      if (outputTokens !== undefined) {
-        attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = outputTokens;
-      }
-      // Add other token metrics if present
-      if (modelAttrs.usage.reasoningTokens !== undefined) {
-        attributes['gen_ai.usage.reasoning_tokens'] = modelAttrs.usage.reasoningTokens;
-      }
-      if (modelAttrs.usage.cachedInputTokens !== undefined) {
-        attributes['gen_ai.usage.cached_input_tokens'] = modelAttrs.usage.cachedInputTokens;
-      }
-    }
+    // Token usage - use OTEL standard naming + OpenInference conventions
+    Object.assign(attributes, formatUsageMetrics(modelAttrs.usage));
 
     // Parameters using OTEL conventions
     if (modelAttrs.parameters) {

--- a/observability/otel-exporter/src/span-converter.test.ts
+++ b/observability/otel-exporter/src/span-converter.test.ts
@@ -234,7 +234,7 @@ describe('SpanConverter', () => {
   // TOKEN USAGE ATTRIBUTE MAPPING
   // =============================================================================
   describe('Token Usage Attribute Mapping', () => {
-    it('should map v5 token format correctly', async () => {
+    it('should map token format with inputDetails/outputDetails correctly', async () => {
       const span: ExportedSpan<SpanType.MODEL_GENERATION> = {
         id: 'span-1',
         traceId: 'trace-1',
@@ -249,9 +249,8 @@ describe('SpanConverter', () => {
           usage: {
             inputTokens: 100,
             outputTokens: 50,
-            totalTokens: 150,
-            reasoningTokens: 20,
-            cachedInputTokens: 30,
+            inputDetails: { cacheRead: 30 },
+            outputDetails: { reasoning: 20 },
           },
         } as ModelGenerationAttributes,
       };
@@ -267,35 +266,6 @@ describe('SpanConverter', () => {
       // Should NOT have old naming
       expect(attrs['llm.usage.prompt_tokens']).toBeUndefined();
       expect(attrs['gen_ai.usage.prompt_tokens']).toBeUndefined();
-    });
-
-    it('should map legacy token format correctly', async () => {
-      const span: ExportedSpan<SpanType.MODEL_GENERATION> = {
-        id: 'span-1',
-        traceId: 'trace-1',
-        name: 'llm-gen',
-        type: SpanType.MODEL_GENERATION,
-        startTime: new Date(),
-        endTime: new Date(),
-        isEvent: false,
-        isRootSpan: false,
-        attributes: {
-          model: 'gpt-3.5-turbo',
-          usage: {
-            promptTokens: 80,
-            completionTokens: 40,
-            totalTokens: 120,
-          },
-        } as ModelGenerationAttributes,
-      };
-
-      const result = await converter.convertSpan(span);
-      const attrs = result.attributes;
-
-      expect(attrs['gen_ai.usage.input_tokens']).toBe(80);
-      expect(attrs['gen_ai.usage.output_tokens']).toBe(40);
-      expect(attrs['gen_ai.usage.prompt_tokens']).toBeUndefined();
-      expect(attrs['gen_ai.usage.completion_tokens']).toBeUndefined();
     });
   });
 
@@ -381,7 +351,6 @@ describe('SpanConverter', () => {
           usage: {
             inputTokens: 100,
             outputTokens: 50,
-            totalTokens: 150,
           },
           parameters: {
             temperature: 0.7,

--- a/observability/otel-exporter/src/tracing.test.ts
+++ b/observability/otel-exporter/src/tracing.test.ts
@@ -281,9 +281,8 @@ describe('OtelExporter', () => {
         model: 'gpt-4',
         provider: 'openai',
         usage: {
-          promptTokens: 10,
-          completionTokens: 5,
-          totalTokens: 15,
+          inputTokens: 10,
+          outputTokens: 5,
         },
       } as unknown as AnyExportedSpan;
 

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -1,8 +1,43 @@
-import type { TracingEvent, AnyExportedSpan, ModelGenerationAttributes } from '@mastra/core/observability';
+import type { TracingEvent, AnyExportedSpan, ModelGenerationAttributes, UsageStats } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import type { BaseExporterConfig } from '@mastra/observability';
 import { BaseExporter } from '@mastra/observability';
 import { PostHog } from 'posthog-node';
+
+/**
+ * Token usage format compatible with PostHog.
+ * @see https://posthog.com/docs/llm-analytics/generations#event-properties
+ */
+export interface PostHogUsageMetrics {
+  $ai_input_tokens?: number;
+  $ai_output_tokens?: number;
+  $ai_cache_read_input_tokens?: number;
+  $ai_cache_creation_input_tokens?: number;
+}
+
+/**
+ * Formats UsageStats to PostHog's expected property format.
+ *
+ * @param usage - The UsageStats from span attributes
+ * @returns PostHog-formatted usage properties
+ */
+export function formatUsageMetrics(usage?: UsageStats): PostHogUsageMetrics {
+  if (!usage) return {};
+
+  const props: PostHogUsageMetrics = {};
+
+  if (usage.inputTokens !== undefined) props.$ai_input_tokens = usage.inputTokens;
+  if (usage.outputTokens !== undefined) props.$ai_output_tokens = usage.outputTokens;
+
+  // Cache read tokens from inputDetails
+  if (usage.inputDetails?.cacheRead !== undefined) props.$ai_cache_read_input_tokens = usage.inputDetails.cacheRead;
+
+  // Cache write tokens from inputDetails
+  if (usage.inputDetails?.cacheWrite !== undefined)
+    props.$ai_cache_creation_input_tokens = usage.inputDetails.cacheWrite;
+
+  return props;
+}
 
 interface PostHogMessage {
   role: 'user' | 'assistant' | 'system' | 'tool';
@@ -41,6 +76,7 @@ export interface PosthogExporterConfig extends BaseExporterConfig {
 type SpanCache = {
   startTime: Date;
   type: SpanType;
+  isRootSpan: boolean;
 };
 
 type TraceMetadata = {
@@ -74,12 +110,7 @@ export class PosthogExporter extends BaseExporter {
     this.logInitialization(config.serverless ?? false, clientConfig);
   }
 
-  private buildClientConfig(config: PosthogExporterConfig): {
-    host: string;
-    flushAt: number;
-    flushInterval: number;
-    privacyMode?: boolean;
-  } {
+  private buildClientConfig(config: PosthogExporterConfig) {
     const isServerless = config.serverless ?? false;
     const flushAt =
       config.flushAt ?? (isServerless ? PosthogExporter.SERVERLESS_FLUSH_AT : PosthogExporter.DEFAULT_FLUSH_AT);
@@ -107,15 +138,16 @@ export class PosthogExporter extends BaseExporter {
 
   private logInitialization(
     isServerless: boolean,
-    config: { host: string; flushAt: number; flushInterval: number },
+    config: { host: string; flushAt: number; flushInterval: number; privacyMode?: boolean },
   ): void {
     const message = isServerless ? 'PostHog exporter initialized in serverless mode' : 'PostHog exporter initialized';
-
-    this.logger.info(message, config);
+    this.logger.debug(message, config);
   }
 
   protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
-    if (!this.client) return;
+    if (!this.client) {
+      return;
+    }
 
     try {
       if (event.exportedSpan.isEvent) {
@@ -154,6 +186,7 @@ export class PosthogExporter extends BaseExporter {
     traceData.spans.set(span.id, {
       startTime: this.toDate(span.startTime),
       type: span.type,
+      isRootSpan: span.isRootSpan,
     });
 
     if (!traceData.distinctId) {
@@ -168,13 +201,11 @@ export class PosthogExporter extends BaseExporter {
     const traceData = this.traceMap.get(span.traceId);
 
     if (!traceData) {
-      this.logger.warn(`Trace data not found for ended span: ${span.id}`);
       return;
     }
 
     const cachedSpan = traceData.spans.get(span.id);
     if (!cachedSpan) {
-      this.logger.warn(`Span cache not found for ended span: ${span.id}`);
       return;
     }
 
@@ -182,21 +213,85 @@ export class PosthogExporter extends BaseExporter {
     const endTime = span.endTime ? this.toDate(span.endTime).getTime() : Date.now();
     const latency = (endTime - startTime) / 1000;
 
-    const eventName = this.mapToPostHogEvent(span.type);
     const distinctId = this.getDistinctId(span, traceData);
-    const properties = this.buildEventProperties(span, latency);
 
-    this.client.capture({
-      distinctId,
-      event: eventName,
-      properties,
-      timestamp: new Date(endTime),
-    });
+    // For root spans, only send $ai_trace (not $ai_span) to avoid duplicate entries
+    // For non-root spans, send $ai_span or $ai_generation as normal
+    if (span.isRootSpan) {
+      this.captureTraceEvent(span, distinctId, endTime);
+    } else {
+      const eventName = this.mapToPostHogEvent(span.type);
+
+      // Check if parent is the root span - if so, use traceId as parent_id
+      // since we don't create an $ai_span for root spans
+      const parentIsRootSpan = this.isParentRootSpan(span, traceData);
+      const properties = this.buildEventProperties(span, latency, parentIsRootSpan);
+
+      this.client.capture({
+        distinctId,
+        event: eventName,
+        properties,
+        timestamp: new Date(endTime),
+      });
+    }
 
     traceData.spans.delete(span.id);
     if (traceData.spans.size === 0) {
       this.traceMap.delete(span.traceId);
     }
+  }
+
+  /**
+   * Capture an explicit $ai_trace event for root spans.
+   * This gives us control over trace-level metadata like name and tags,
+   * rather than relying on PostHog's pseudo-trace auto-creation.
+   */
+  private captureTraceEvent(span: AnyExportedSpan, distinctId: string, endTime: number): void {
+    // Note: We don't set $ai_latency on $ai_trace events because PostHog
+    // aggregates latency from child events. Setting it here causes double-counting.
+    const traceProperties: Record<string, any> = {
+      $ai_trace_id: span.traceId,
+      $ai_span_name: span.name,
+      $ai_is_error: !!span.errorInfo,
+    };
+
+    if (span.metadata?.sessionId) {
+      traceProperties.$ai_session_id = span.metadata.sessionId;
+    }
+
+    if (span.input) {
+      traceProperties.$ai_input_state = span.input;
+    }
+
+    if (span.output) {
+      traceProperties.$ai_output_state = span.output;
+    }
+
+    if (span.errorInfo) {
+      traceProperties.$ai_error = {
+        message: span.errorInfo.message,
+        ...(span.errorInfo.id && { id: span.errorInfo.id }),
+        ...(span.errorInfo.category && { category: span.errorInfo.category }),
+      };
+    }
+
+    // Add tags as custom properties (PostHog doesn't have native tag support on traces)
+    if (span.tags?.length) {
+      for (const tag of span.tags) {
+        traceProperties[tag] = true;
+      }
+    }
+
+    // Add custom metadata (excluding userId and sessionId which are handled separately)
+    const { userId, sessionId, ...customMetadata } = span.metadata ?? {};
+    Object.assign(traceProperties, customMetadata);
+
+    this.client.capture({
+      distinctId,
+      event: '$ai_trace',
+      properties: traceProperties,
+      timestamp: new Date(endTime),
+    });
   }
 
   private async captureEventSpan(span: AnyExportedSpan): Promise<void> {
@@ -228,20 +323,10 @@ export class PosthogExporter extends BaseExporter {
   }
 
   private mapToPostHogEvent(spanType: SpanType): string {
-    switch (spanType) {
-      case SpanType.MODEL_GENERATION:
-      case SpanType.MODEL_STEP:
-        return '$ai_generation';
-      case SpanType.MODEL_CHUNK:
-      case SpanType.TOOL_CALL:
-      case SpanType.MCP_TOOL_CALL:
-      case SpanType.PROCESSOR_RUN:
-      case SpanType.AGENT_RUN:
-      case SpanType.WORKFLOW_RUN:
-      case SpanType.GENERIC:
-      default:
-        return '$ai_span';
+    if (spanType == SpanType.MODEL_GENERATION) {
+      return '$ai_generation';
     }
+    return '$ai_span';
   }
 
   private getDistinctId(span: AnyExportedSpan, traceData?: TraceMetadata): string {
@@ -260,7 +345,31 @@ export class PosthogExporter extends BaseExporter {
     return 'anonymous';
   }
 
-  private buildEventProperties(span: AnyExportedSpan, latency: number): Record<string, any> {
+  /**
+   * Check if the parent of this span is the root span.
+   * We need this because we don't create $ai_span for root spans,
+   * so children of root spans should use $ai_trace_id as their $ai_parent_id.
+   */
+  private isParentRootSpan(span: AnyExportedSpan, traceData: TraceMetadata): boolean {
+    if (!span.parentSpanId) {
+      return false;
+    }
+
+    // Look up the parent span in our cache to check if it's a root span
+    const parentCache = traceData.spans.get(span.parentSpanId);
+    if (parentCache) {
+      return parentCache.isRootSpan;
+    }
+
+    // Parent not found in cache - shouldn't happen normally, but default to false
+    return false;
+  }
+
+  private buildEventProperties(
+    span: AnyExportedSpan,
+    latency: number,
+    parentIsRootSpan: boolean = false,
+  ): Record<string, any> {
     const baseProperties: Record<string, any> = {
       $ai_trace_id: span.traceId,
       $ai_latency: latency,
@@ -268,7 +377,9 @@ export class PosthogExporter extends BaseExporter {
     };
 
     if (span.parentSpanId) {
-      baseProperties.$ai_parent_id = span.parentSpanId;
+      // If parent is the root span, use trace_id as parent_id since we don't
+      // create an $ai_span for root spans (only $ai_trace)
+      baseProperties.$ai_parent_id = parentIsRootSpan ? span.traceId : span.parentSpanId;
     }
 
     if (span.metadata?.sessionId) {
@@ -284,7 +395,7 @@ export class PosthogExporter extends BaseExporter {
       }
     }
 
-    if (span.type === SpanType.MODEL_GENERATION || span.type === SpanType.MODEL_STEP) {
+    if (span.type === SpanType.MODEL_GENERATION) {
       baseProperties.$ai_generation_id = span.id;
       return { ...baseProperties, ...this.buildGenerationProperties(span) };
     } else {
@@ -329,19 +440,8 @@ export class PosthogExporter extends BaseExporter {
     if (span.input) props.$ai_input = this.formatMessages(span.input, 'user');
     if (span.output) props.$ai_output_choices = this.formatMessages(span.output, 'assistant');
 
-    if (attrs.usage) {
-      const { usage } = attrs;
-      const inputTokens = usage.inputTokens ?? usage.promptTokens;
-      const outputTokens = usage.outputTokens ?? usage.completionTokens;
-      const totalTokens = usage.totalTokens;
-
-      if (inputTokens !== undefined) props.$ai_input_tokens = inputTokens;
-      if (outputTokens !== undefined) props.$ai_output_tokens = outputTokens;
-      if (totalTokens !== undefined) props.$ai_total_tokens = totalTokens;
-
-      if (usage.reasoningTokens !== undefined) props.reasoning_tokens = usage.reasoningTokens;
-      if (usage.cachedInputTokens !== undefined) props.cached_input_tokens = usage.cachedInputTokens;
-    }
+    // Extract usage properties using the shared utility
+    Object.assign(props, formatUsageMetrics(attrs.usage));
 
     if (attrs.parameters) {
       if (attrs.parameters.temperature !== undefined) props.$ai_temperature = attrs.parameters.temperature;

--- a/observability/posthog/src/usage.test.ts
+++ b/observability/posthog/src/usage.test.ts
@@ -1,0 +1,29 @@
+import type { UsageStats } from '@mastra/core/observability';
+import { describe, it, expect } from 'vitest';
+import { formatUsageMetrics } from './tracing';
+
+describe('formatUsageMetrics', () => {
+  it('should extract basic tokens', () => {
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 50 };
+    const result = formatUsageMetrics(usage);
+    expect(result.$ai_input_tokens).toBe(100);
+    expect(result.$ai_output_tokens).toBe(50);
+  });
+
+  it('should extract cacheRead from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.$ai_cache_read_input_tokens).toBe(800);
+  });
+
+  it('should extract cacheWrite from inputDetails', () => {
+    const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.$ai_cache_creation_input_tokens).toBe(500);
+  });
+
+  it('should return empty metrics for undefined usage', () => {
+    const result = formatUsageMetrics(undefined);
+    expect(result).toEqual({});
+  });
+});

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -283,6 +283,7 @@ export class MastraLLMVNext extends MastraBase {
           onFinish: async props => {
             // End the model generation span BEFORE calling the user's onFinish callback
             // This ensures the model span ends before the agent span
+            // Pass raw usage and providerMetadata - ModelSpanTracker will convert to UsageStats
             modelSpanTracker?.endGeneration({
               output: {
                 files: props?.files,
@@ -295,16 +296,11 @@ export class MastraLLMVNext extends MastraBase {
               },
               attributes: {
                 finishReason: props?.finishReason,
-                usage: {
-                  inputTokens: props?.totalUsage?.inputTokens,
-                  outputTokens: props?.totalUsage?.outputTokens,
-                  totalTokens: props?.totalUsage?.totalTokens,
-                  reasoningTokens: props?.totalUsage?.reasoningTokens,
-                  cachedInputTokens: props?.totalUsage?.cachedInputTokens,
-                },
                 responseId: props?.response.id,
                 responseModel: props?.response.modelId,
               },
+              usage: props?.totalUsage,
+              providerMetadata: props?.providerMetadata,
             });
 
             try {

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -26,6 +26,7 @@ import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { Mastra } from '../../mastra';
 import { SpanType } from '../../observability';
 import { executeWithContext, executeWithContextSync } from '../../observability/utils';
+import { convertV4Usage } from '../../stream/aisdk/v4/usage';
 import { delay, isZodType } from '../../utils';
 
 import type {
@@ -270,7 +271,7 @@ export class MastraLLMV1 extends MastraBase {
         },
         attributes: {
           finishReason: result.finishReason,
-          usage: result.usage,
+          usage: convertV4Usage(result.usage),
         },
       });
 
@@ -371,7 +372,7 @@ export class MastraLLMV1 extends MastraBase {
           },
           attributes: {
             finishReason: result.finishReason,
-            usage: result.usage,
+            usage: convertV4Usage(result.usage),
           },
         });
 
@@ -553,7 +554,7 @@ export class MastraLLMV1 extends MastraBase {
           },
           attributes: {
             finishReason: props?.finishReason,
-            usage: props?.usage,
+            usage: convertV4Usage(props?.usage),
           },
         });
 

--- a/packages/core/src/stream/aisdk/v4/usage.ts
+++ b/packages/core/src/stream/aisdk/v4/usage.ts
@@ -1,0 +1,28 @@
+import type { UsageStats } from '../../../observability/types/tracing';
+
+/**
+ * AI SDK v4 LanguageModelUsage type definition
+ * (matches the ai package's LanguageModelUsage)
+ */
+interface LanguageModelUsageV4 {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens?: number;
+}
+
+/**
+ * Converts AI SDK v4 LanguageModelUsage to our UsageStats format.
+ *
+ * @param usage - The LanguageModelUsage from AI SDK v4
+ * @returns Normalized UsageStats
+ */
+export function convertV4Usage(usage: LanguageModelUsageV4 | undefined): UsageStats {
+  if (!usage) {
+    return {};
+  }
+
+  return {
+    inputTokens: usage.promptTokens,
+    outputTokens: usage.completionTokens,
+  };
+}

--- a/packages/core/src/stream/index.ts
+++ b/packages/core/src/stream/index.ts
@@ -1,11 +1,13 @@
 export type {
   ChunkType,
   DataChunkType,
+  LanguageModelUsage,
   NetworkChunkType,
   ReadonlyJSONObject,
   AgentChunkType,
   StepFinishPayload,
   StepStartPayload,
+  ProviderMetadata,
 } from './types';
 export { ChunkFrom } from './types';
 export { MastraModelOutput } from './base/output';

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -1,11 +1,11 @@
 import type {
   LanguageModelV2FinishReason,
   LanguageModelV2Usage,
-  SharedV2ProviderMetadata,
   LanguageModelV2CallWarning,
   LanguageModelV2ResponseMetadata,
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider-v5';
+
 import type { FinishReason, LanguageModelRequestMetadata, LanguageModelV1LogProbs } from '@internal/ai-sdk-v4';
 import type { ModelMessage, StepResult, ToolSet, TypedToolCall, UIMessage } from 'ai-v5';
 import type { AIV5ResponseMessage } from '../agent/message-list';
@@ -26,6 +26,23 @@ export enum ChunkFrom {
   NETWORK = 'NETWORK',
 }
 
+/**
+A JSON value can be a string, number, boolean, object, array, or null.
+JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods.
+ */
+export type JSONValue = null | string | number | boolean | JSONObject | JSONArray;
+export type JSONObject = {
+  [key: string]: JSONValue;
+};
+export type JSONArray = JSONValue[];
+
+/**
+ * Additional provider-specific metadata.
+ * The outer record is keyed by the provider name, and the inner
+ * record is keyed by the provider-specific metadata key.
+ */
+export type ProviderMetadata = Record<string, Record<string, JSONValue>>;
+
 interface BaseChunkType {
   runId: string;
   from: ChunkFrom;
@@ -39,36 +56,36 @@ interface ResponseMetadataPayload {
 
 export interface TextStartPayload {
   id: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
 }
 
 export interface TextDeltaPayload {
   id: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   text: string;
 }
 
 interface TextEndPayload {
   id: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   [key: string]: unknown;
 }
 
 export interface ReasoningStartPayload {
   id: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   signature?: string;
 }
 
 export interface ReasoningDeltaPayload {
   id: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   text: string;
 }
 
 interface ReasoningEndPayload {
   id: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   signature?: string;
 }
 
@@ -79,19 +96,15 @@ export interface SourcePayload {
   mimeType?: string;
   filename?: string;
   url?: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
 }
 
 export interface FilePayload {
   data: string | Uint8Array;
   base64?: string;
   mimeType: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
 }
-
-type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
-type JSONObject = { [key: string]: JSONValue | undefined };
-type JSONArray = JSONValue[];
 
 export type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
@@ -129,7 +142,7 @@ export interface ToolCallPayload<TArgs = unknown, TOutput = unknown> {
     __mastraMetadata?: MastraMetadata;
   };
   providerExecuted?: boolean;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   output?: TOutput;
   dynamic?: boolean;
 }
@@ -140,7 +153,7 @@ export interface ToolResultPayload<TResult = unknown, TArgs = unknown> {
   result: TResult;
   isError?: boolean;
   providerExecuted?: boolean;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   args?: TArgs;
   dynamic?: boolean;
 }
@@ -152,20 +165,20 @@ interface ToolCallInputStreamingStartPayload {
   toolCallId: string;
   toolName: string;
   providerExecuted?: boolean;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   dynamic?: boolean;
 }
 
 interface ToolCallDeltaPayload {
   argsTextDelta: string;
   toolCallId: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   toolName?: string;
 }
 
 interface ToolCallInputStreamingEndPayload {
   toolCallId: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
 }
 
 interface FinishPayload {
@@ -179,7 +192,7 @@ interface FinishPayload {
     usage: LanguageModelV2Usage;
   };
   metadata: {
-    providerMetadata?: SharedV2ProviderMetadata;
+    providerMetadata?: ProviderMetadata;
     request?: LanguageModelRequestMetadata;
     [key: string]: unknown;
   };
@@ -216,7 +229,7 @@ export interface StepStartPayload {
 
 export interface StepFinishPayload<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchema = undefined> {
   id?: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   totalUsage?: LanguageModelV2Usage;
   response?: LanguageModelV2ResponseMetadata;
   messageId?: string;
@@ -235,7 +248,7 @@ export interface StepFinishPayload<Tools extends ToolSet = ToolSet, OUTPUT exten
   };
   metadata: {
     request?: LanguageModelRequestMetadata;
-    providerMetadata?: SharedV2ProviderMetadata;
+    providerMetadata?: ProviderMetadata;
     [key: string]: unknown;
   };
   messages?: {
@@ -248,7 +261,7 @@ export interface StepFinishPayload<Tools extends ToolSet = ToolSet, OUTPUT exten
 
 interface ToolErrorPayload {
   id?: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
   toolCallId: string;
   toolName: string;
   args?: Record<string, unknown>;
@@ -263,13 +276,13 @@ interface AbortPayload {
 interface ReasoningSignaturePayload {
   id: string;
   signature: string;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
 }
 
 interface RedactedReasoningPayload {
   id: string;
   data: unknown;
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerMetadata?: ProviderMetadata;
 }
 
 interface ToolOutputPayload<TOutput = unknown> {
@@ -717,5 +730,5 @@ export type LLMStepResult<OUTPUT extends OutputSchema = undefined> = {
     [key: string]: unknown;
   };
   reasoningText: string | undefined;
-  providerMetadata: SharedV2ProviderMetadata | undefined;
+  providerMetadata: ProviderMetadata | undefined;
 };


### PR DESCRIPTION
## Description

Fixes CachedToken tracking in all Observability Exporters. Also fixes time_to_first_token in Langfuse, Braintrust, PostHog exporters. Fixes trace formatting in PostHog Exporter.

## Related Issue(s)

Fixes: #10174, #9821, #9853

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized token usage reporting (input/output and detailed inputDetails/outputDetails) across exporters, including cache, reasoning, and audio breakdowns.
  * Time-to-first-token (streaming TTFT) events and root-span tag propagation added to several exporters.

* **Bug Fixes**
  * Fixed cached-token tracking, TTFT calculations, and trace formatting issues (including PostHog).

* **Chores**
  * Patch version bumps across observability packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->