### PR TITLE
fix(playground-ui): use useAssistantState instead of deprecated useMessagePart

### DIFF
--- a/.changeset/twenty-cities-cheat.md
+++ b/.changeset/twenty-cities-cheat.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': minor
+'@mastra/react': minor
+'mastra': minor
+---
+
+Fix "MessagePartRuntime is not available" error when chatting with agents in Studio playground by replacing deprecated `useMessagePart` hook with `useAssistantState`

--- a/packages/playground-ui/src/components/assistant-ui/messages/error-aware-text.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/messages/error-aware-text.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useMessagePart } from '@assistant-ui/react';
+import { useAssistantState } from '@assistant-ui/react';
 import { AlertCircle } from 'lucide-react';
 import { MarkdownText } from './markdown-text';
 import { MastraUIMessageMetadata } from '@mastra/react';
 import { Alert, AlertDescription, AlertTitle } from '@/ds/components/Alert';
 
 export const ErrorAwareText = () => {
-  const part = useMessagePart();
+  const part = useAssistantState(({ part }) => part);
 
   // Get text from the part - it's a TextPart so it has a text property
   const text = (part as any).text || '';


### PR DESCRIPTION
## Summary
- Fix "MessagePartRuntime is not available" error in Studio when chatting with agents
- Replace deprecated `useMessagePart` hook with `useAssistantState` API

## Problem
After upgrading `@assistant-ui/react` from `0.10.45` to `0.11.47` in #10884, the playground throws:
```
Uncaught Error: MessagePartRuntime is not available
```

The legacy `useMessagePart` hook internally uses `useMessagePartRuntime` which has context issues in v0.11.x.

## Solution
Switch to the newer `useAssistantState(({ part }) => part)` API which:
- Accesses state directly without the legacy runtime layer
- Is more stable and the recommended approach in v0.11+
- Is forward-compatible with v0.12

## Test plan
- [x] Build playground-ui package
- [ ] Run `mastra dev` in examples/agent and chat with weatherAgent in Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component implementation for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->