### PR TITLE
fix(workflows): change WorkflowState and WorkflowRunState error type

### DIFF
--- a/.changeset/four-bugs-take.md
+++ b/.changeset/four-bugs-take.md
@@ -1,0 +1,24 @@
+---
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/dynamodb': patch
+'@mastra/inngest': patch
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/core': patch
+'@mastra/convex': patch
+'@mastra/libsql': patch
+'@mastra/lance': patch
+'@mastra/mssql': patch
+'@mastra/pg': patch
+---
+
+fix(workflows): preserve error details when thrown from workflow steps
+
+- Changed `WorkflowState.error` and `WorkflowRunState.error` types from `string | Error` to `SerializedError`
+- Updated `formatResultError` in execution engines to serialize errors immediately via `.toJSON()`
+- Errors are now consistently serialized at workflow level for storage compatibility
+- Step-level errors remain as `Error` instances; only workflow-level `result.error` is serialized
+- Custom error properties (statusCode, responseHeaders, cause chain, etc.) are preserved through serialization
+- Updated all storage implementations to use `SerializedError` type for workflow errors

--- a/.changeset/four-bugs-take.md
+++ b/.changeset/four-bugs-take.md
@@ -21,4 +21,4 @@ fix(workflows): preserve error details when thrown from workflow steps
 - Errors are now consistently serialized at workflow level for storage compatibility
 - Step-level errors remain as `Error` instances; only workflow-level `result.error` is serialized
 - Custom error properties (statusCode, responseHeaders, cause chain, etc.) are preserved through serialization
-- Updated all storage implementations to use `SerializedError` type for workflow errors
+- Added `UpdateWorkflowStateOptions` type to consolidate workflow state update parameters across all storage implementations

--- a/.changeset/neat-baboons-throw.md
+++ b/.changeset/neat-baboons-throw.md
@@ -1,0 +1,17 @@
+---
+'@mastra/client-js': patch
+---
+
+Deserialize workflow errors on the client side
+
+When workflows fail, the server sends `SerializedError` (plain JSON object) over HTTP. This change deserializes those errors back to proper `Error` instances on the client, enabling:
+- `instanceof Error` checks
+- Access to `error.message`, `error.name`, `error.stack`
+- Preservation of custom error properties (e.g., `statusCode`, `responseHeaders`)
+- Proper cause chain reconstruction
+
+Affected methods:
+- `startAsync()`
+- `resumeAsync()`
+- `restartAsync()`
+- `timeTravelAsync()`

--- a/client-sdks/client-js/src/resources/workflow.test.ts
+++ b/client-sdks/client-js/src/resources/workflow.test.ts
@@ -142,6 +142,184 @@ describe('Workflow (fetch-mocked)', () => {
 // Mock fetch globally for client tests
 global.fetch = vi.fn();
 
+describe('Workflow error deserialization', () => {
+  let fetchMock: any;
+  let wf: Workflow;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+
+    const options: ClientOptions = { baseUrl: 'http://localhost', retries: 0 } as any;
+    wf = new Workflow(options, 'wf-1');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createJsonResponse = (data: any) => ({ ok: true, json: async () => data });
+
+  it('deserializes failed workflow error in startAsync', async () => {
+    const serializedError = {
+      name: 'StepError',
+      message: 'Step failed with validation error',
+      stack: 'Error: Step failed...\n    at ...',
+      statusCode: 400,
+      cause: {
+        name: 'ValidationError',
+        message: 'Invalid input',
+      },
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/start-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.startAsync({ inputData: {} })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Step failed with validation error');
+    expect(result.error?.name).toBe('StepError');
+    expect(result.error.statusCode).toBe(400);
+    expect(result.error?.cause).toBeDefined();
+    expect(result.error?.cause?.message).toBe('Invalid input');
+  });
+
+  it('deserializes failed workflow error in resumeAsync', async () => {
+    const serializedError = {
+      name: 'ResumeError',
+      message: 'Resume step failed',
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/resume-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.resumeAsync({ runId: 'r-123', step: 's1' })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Resume step failed');
+    expect(result.error?.name).toBe('ResumeError');
+  });
+
+  it('deserializes failed workflow error in restartAsync', async () => {
+    const serializedError = {
+      name: 'RestartError',
+      message: 'Restart failed',
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/restart-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.restartAsync({ runId: 'r-123' })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Restart failed');
+  });
+
+  it('deserializes failed workflow error in timeTravelAsync', async () => {
+    const serializedError = {
+      name: 'TimeTravelError',
+      message: 'Time travel failed',
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/time-travel-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.timeTravelAsync({ runId: 'r-123', step: 's1' })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Time travel failed');
+  });
+
+  it('passes through successful workflow result unchanged', async () => {
+    const successResult = {
+      status: 'success',
+      result: { data: 'test-output' },
+      steps: {},
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/start-async')) {
+        return Promise.resolve(createJsonResponse(successResult));
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.startAsync({ inputData: {} })) as any;
+
+    expect(result.status).toBe('success');
+    expect(result.result).toEqual({ data: 'test-output' });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('passes through suspended workflow result unchanged', async () => {
+    const suspendedResult = {
+      status: 'suspended',
+      steps: {
+        step1: { status: 'suspended', suspendPayload: { waitingFor: 'approval' } },
+      },
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/start-async')) {
+        return Promise.resolve(createJsonResponse(suspendedResult));
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.startAsync({ inputData: {} })) as any;
+
+    expect(result.status).toBe('suspended');
+    expect(result.error).toBeUndefined();
+  });
+});
+
 describe('Workflow Client Methods', () => {
   let client: MastraClient;
   const clientOptions = {

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -1,3 +1,4 @@
+import { getErrorFromUnknown } from '@mastra/core/error';
 import type { TracingOptions } from '@mastra/core/observability';
 import type { RequestContext } from '@mastra/core/request-context';
 import type {
@@ -14,6 +15,20 @@ import type {
 
 import { parseClientRequestContext, base64RequestContext, requestContextQueryString } from '../utils';
 import { BaseResource } from './base';
+
+/**
+ * Deserializes the error property in a workflow result back to an Error instance.
+ * Server sends SerializedError (plain object), client converts to Error for instanceof checks.
+ */
+function deserializeWorkflowError<T extends WorkflowRunResult>(result: T): T {
+  if (result.status === 'failed' && result.error) {
+    result.error = getErrorFromUnknown(result.error, {
+      fallbackMessage: 'Unknown workflow error',
+      supportSerialization: false,
+    });
+  }
+  return result;
+}
 
 const RECORD_SEPARATOR = '\x1E';
 
@@ -347,7 +362,7 @@ export class Workflow extends BaseResource {
 
     const requestContext = parseClientRequestContext(params.requestContext);
 
-    return this.request(`/api/workflows/${this.workflowId}/start-async?${searchParams.toString()}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/start-async?${searchParams.toString()}`, {
       method: 'POST',
       body: {
         inputData: params.inputData,
@@ -355,7 +370,7 @@ export class Workflow extends BaseResource {
         requestContext,
         tracingOptions: params.tracingOptions,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**
@@ -652,7 +667,7 @@ export class Workflow extends BaseResource {
     tracingOptions?: TracingOptions;
   }): Promise<WorkflowRunResult> {
     const requestContext = parseClientRequestContext(params.requestContext);
-    return this.request(`/api/workflows/${this.workflowId}/resume-async?runId=${params.runId}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/resume-async?runId=${params.runId}`, {
       method: 'POST',
       body: {
         step: params.step,
@@ -660,7 +675,7 @@ export class Workflow extends BaseResource {
         requestContext,
         tracingOptions: params.tracingOptions,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**
@@ -792,13 +807,13 @@ export class Workflow extends BaseResource {
     tracingOptions?: TracingOptions;
   }): Promise<WorkflowRunResult> {
     const requestContext = parseClientRequestContext(params.requestContext);
-    return this.request(`/api/workflows/${this.workflowId}/restart-async?runId=${params.runId}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/restart-async?runId=${params.runId}`, {
       method: 'POST',
       body: {
         requestContext,
         tracingOptions: params.tracingOptions,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**
@@ -852,13 +867,13 @@ export class Workflow extends BaseResource {
     ...params
   }: TimeTravelParams): Promise<WorkflowRunResult> {
     const requestContext = parseClientRequestContext(paramsRequestContext);
-    return this.request(`/api/workflows/${this.workflowId}/time-travel-async?runId=${runId}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/time-travel-async?runId=${runId}`, {
       method: 'POST',
       body: {
         ...params,
         requestContext,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -1,6 +1,6 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '../agent';
 import { MastraBase } from '../base';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '../error';
+import { ErrorCategory, ErrorDomain, MastraError } from '../error';
 import type { ScoreRowData, ScoringSource, ValidatedSaveScorePayload } from '../evals';
 import type { StorageThreadType } from '../memory/types';
 import type { TracingStorageStrategy } from '../observability';
@@ -51,6 +51,7 @@ import type {
   StorageUpdateAgentInput,
   StorageListAgentsInput,
   StorageListAgentsOutput,
+  UpdateWorkflowStateOptions,
 } from './types';
 
 export type StorageDomains = {
@@ -487,13 +488,7 @@ export abstract class MastraStorage extends MastraBase {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined>;
 
   async loadWorkflowSnapshot({

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -1,6 +1,6 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '../agent';
 import { MastraBase } from '../base';
-import { ErrorCategory, ErrorDomain, MastraError } from '../error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '../error';
 import type { ScoreRowData, ScoringSource, ValidatedSaveScorePayload } from '../evals';
 import type { StorageThreadType } from '../memory/types';
 import type { TracingStorageStrategy } from '../observability';
@@ -490,7 +490,7 @@ export abstract class MastraStorage extends MastraBase {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/packages/core/src/storage/domains/workflows/base.ts
+++ b/packages/core/src/storage/domains/workflows/base.ts
@@ -1,7 +1,6 @@
 import { MastraBase } from '../../../base';
-import type { SerializedError } from '../../../error';
 import type { StepResult, WorkflowRunState } from '../../../workflows';
-import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '../../types';
+import type { UpdateWorkflowStateOptions, WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '../../types';
 
 export abstract class WorkflowsStorage extends MastraBase {
   constructor() {
@@ -32,13 +31,7 @@ export abstract class WorkflowsStorage extends MastraBase {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined>;
 
   abstract persistWorkflowSnapshot(_: {

--- a/packages/core/src/storage/domains/workflows/base.ts
+++ b/packages/core/src/storage/domains/workflows/base.ts
@@ -1,4 +1,5 @@
 import { MastraBase } from '../../../base';
+import type { SerializedError } from '../../../error';
 import type { StepResult, WorkflowRunState } from '../../../workflows';
 import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '../../types';
 
@@ -34,7 +35,7 @@ export abstract class WorkflowsStorage extends MastraBase {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -1,8 +1,13 @@
-import type { SerializedError } from '../../../error';
 import type { StepResult, WorkflowRunState } from '../../../workflows';
 import { normalizePerPage } from '../../base';
 import { TABLE_WORKFLOW_SNAPSHOT } from '../../constants';
-import type { StorageWorkflowRun, WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '../../types';
+import type {
+  StorageWorkflowRun,
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
+} from '../../types';
 import type { StoreOperations } from '../operations';
 import { WorkflowsStorage } from './base';
 
@@ -84,13 +89,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     const run = this.collection.get(`${workflowName}-${runId}`);
 

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -1,3 +1,4 @@
+import type { SerializedError } from '../../../error';
 import type { StepResult, WorkflowRunState } from '../../../workflows';
 import { normalizePerPage } from '../../base';
 import { TABLE_WORKFLOW_SNAPSHOT } from '../../constants';
@@ -86,7 +87,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from '../agent';
+import type { SerializedError } from '../error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '../evals/types';
 import type { StorageThreadType } from '../memory/types';
 import type { StepResult, WorkflowRunState } from '../workflows/types';
@@ -175,7 +176,7 @@ export class InMemoryStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -1,5 +1,4 @@
 import type { MastraDBMessage } from '../agent';
-import type { SerializedError } from '../error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '../evals/types';
 import type { StorageThreadType } from '../memory/types';
 import type { StepResult, WorkflowRunState } from '../workflows/types';
@@ -25,6 +24,7 @@ import type {
   StorageColumn,
   StoragePagination,
   StorageResourceType,
+  UpdateWorkflowStateOptions,
   WorkflowRun,
 } from './types';
 
@@ -173,13 +173,7 @@ export class InMemoryStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,6 +1,7 @@
+import type { SerializedError } from '../error';
 import type { MastraDBMessage, StorageThreadType } from '../memory/types';
 import type { SpanType } from '../observability';
-import type { WorkflowRunState, WorkflowRunStatus } from '../workflows';
+import type { StepResult, WorkflowRunState, WorkflowRunStatus } from '../workflows';
 
 export type StoragePagination = {
   page: number;
@@ -320,4 +321,14 @@ export interface StorageIndexStats extends IndexInfo {
   tuples_fetched: number; // Number of tuples fetched
   last_used?: Date; // Last time index was used
   method?: string; // Index method (btree, hash, etc)
+}
+
+// Workflow Storage Types
+
+export interface UpdateWorkflowStateOptions {
+  status: WorkflowRunStatus;
+  result?: StepResult<any, any, any, any>;
+  error?: SerializedError;
+  suspendedPaths?: Record<string, number[]>;
+  waitingPaths?: Record<string, number[]>;
 }

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -1,5 +1,5 @@
 import type { RequestContext } from '../di';
-import { MastraError, ErrorDomain, ErrorCategory } from '../error';
+import { MastraError, ErrorDomain, ErrorCategory, type SerializedError } from '../error';
 import { getErrorFromUnknown } from '../error/utils.js';
 import type { Span, SpanType, TracingContext } from '../observability';
 import type { ExecutionGraph } from './execution-engine';
@@ -304,14 +304,14 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * Format an error for the workflow result.
    * Override to customize error formatting (e.g., include stack traces).
    */
-  protected formatResultError(error: Error | unknown, lastOutput: StepResult<any, any, any, any>): Error {
+  protected formatResultError(error: Error | unknown, lastOutput: StepResult<any, any, any, any>): SerializedError {
     const outputError = (lastOutput as StepFailure<any, any, any, any>)?.error;
     const errorSource = error || outputError;
     const errorInstance = getErrorFromUnknown(errorSource, {
       serializeStack: false,
       fallbackMessage: 'Unknown workflow error',
     });
-    return errorInstance;
+    return errorInstance.toJSON();
   }
 
   protected async fmtReturnValue<TOutput>(
@@ -325,7 +325,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       steps: Record<string, StepResult<any, any, any, any>>;
       input: StepResult<any, any, any, any> | undefined;
       result?: any;
-      error?: Error;
+      error?: SerializedError;
       suspended?: string[][];
     } = {
       status: lastOutput.status,

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -1,5 +1,6 @@
 import type { RequestContext } from '../di';
-import { MastraError, ErrorDomain, ErrorCategory, type SerializedError } from '../error';
+import { MastraError, ErrorDomain, ErrorCategory } from '../error';
+import type { SerializedError } from '../error';
 import { getErrorFromUnknown } from '../error/utils.js';
 import type { Span, SpanType, TracingContext } from '../observability';
 import type { ExecutionGraph } from './execution-engine';

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import EventEmitter from 'node:events';
-import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
+import { ErrorCategory, ErrorDomain, MastraError, getErrorFromUnknown } from '../../../error';
 import { EventProcessor } from '../../../events/processor';
 import type { Event } from '../../../events/types';
 import type { Mastra } from '../../../mastra';
@@ -79,7 +79,7 @@ export class WorkflowEventProcessor extends EventProcessor {
         executionPath: [],
         resumeSteps,
         stepResults,
-        prevResult: { status: 'failed', error: e.stack ?? e.message },
+        prevResult: { status: 'failed', error: getErrorFromUnknown(e).toJSON() },
         requestContext,
         resumeData,
         activeSteps: {},

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -1,4 +1,5 @@
 import type { RequestContext } from '../../di';
+import type { SerializedError } from '../../error';
 import type { TracingContext } from '../../observability';
 import type { DefaultExecutionEngine } from '../default';
 import type {
@@ -22,7 +23,7 @@ export interface PersistStepUpdateParams {
   executionContext: ExecutionContext;
   workflowStatus: 'success' | 'failed' | 'suspended' | 'running' | 'waiting';
   result?: Record<string, any>;
-  error?: Error;
+  error?: SerializedError;
   requestContext: RequestContext;
 }
 

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -250,7 +250,7 @@ export interface WorkflowState {
       output?: Record<string, any>;
       payload?: Record<string, any>;
       resumePayload?: Record<string, any>;
-      error?: string | Error;
+      error?: SerializedError;
       startedAt: number;
       endedAt: number;
       suspendedAt?: number;
@@ -259,7 +259,7 @@ export interface WorkflowState {
   >;
   result?: Record<string, any>;
   payload?: Record<string, any>;
-  error?: string | Error;
+  error?: SerializedError;
 }
 
 export interface WorkflowRunState {
@@ -267,7 +267,7 @@ export interface WorkflowRunState {
   runId: string;
   status: WorkflowRunStatus;
   result?: Record<string, any>;
-  error?: string | Error;
+  error?: SerializedError;
   requestContext?: Record<string, any>;
   value: Record<string, string>;
   context: { input?: Record<string, any> } & Record<string, SerializedStepResult<any, any, any, any>>;

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -6384,25 +6384,26 @@ describe('Workflow', () => {
       expect(result.status).toBe('failed');
 
       if (result.status === 'failed') {
-        // result.error should be an Error instance (not a string)
-        expect(result.error).toBeInstanceOf(Error);
+        // result.error should be a SerializedError (plain object, not Error instance)
+        // This is intentional - errors are serialized for storage compatibility
+        expect(result.error).toBeDefined();
+        expect(result.error).not.toBeInstanceOf(Error);
 
-        // The exact same error instance should be preserved
-        expect(result.error).toBe(customError);
-
-        // Custom properties should be preserved on the error
+        // Custom properties should be preserved on the serialized error
+        expect((result.error as any).message).toBe('API rate limit exceeded');
+        expect((result.error as any).name).toBe('Error');
         expect((result.error as any).statusCode).toBe(429);
         expect((result.error as any).responseHeaders).toEqual({ 'retry-after': '60' });
         expect((result.error as any).isRetryable).toBe(true);
       }
 
-      // Also check step-level error
+      // Also check step-level error (step errors remain as Error instances)
       const step1Result = result.steps?.step1;
       expect(step1Result).toBeDefined();
       expect(step1Result?.status).toBe('failed');
 
       if (step1Result?.status === 'failed') {
-        // Step error should also be the exact same error instance
+        // Step error is still the original Error instance
         expect(step1Result.error).toBeInstanceOf(Error);
         expect(step1Result.error).toBe(customError);
         expect((step1Result.error as any).statusCode).toBe(429);

--- a/stores/clickhouse/src/storage/domains/workflows/index.ts
+++ b/stores/clickhouse/src/storage/domains/workflows/index.ts
@@ -1,5 +1,5 @@
 import type { ClickHouseClient } from '@clickhouse/client';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   normalizePerPage,
@@ -53,7 +53,7 @@ export class WorkflowsStorageClickhouse extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/clickhouse/src/storage/domains/workflows/index.ts
+++ b/stores/clickhouse/src/storage/domains/workflows/index.ts
@@ -1,12 +1,17 @@
 import type { ClickHouseClient } from '@clickhouse/client';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   normalizePerPage,
   TABLE_WORKFLOW_SNAPSHOT,
   WorkflowsStorage,
 } from '@mastra/core/storage';
-import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
+import type {
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import type { StoreOperationsClickhouse } from '../operations';
 import { TABLE_ENGINES } from '../utils';
@@ -50,13 +55,7 @@ export class WorkflowsStorageClickhouse extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new MastraError({

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -1,7 +1,7 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
+import { MastraError, ErrorDomain, ErrorCategory, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -233,7 +233,7 @@ export class ClickhouseStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -1,7 +1,7 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { MastraError, ErrorDomain, ErrorCategory, type SerializedError } from '@mastra/core/error';
+import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -16,6 +16,7 @@ import type {
   StorageDomains,
   StorageResourceType,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import { MemoryStorageClickhouse } from './domains/memory';
@@ -230,13 +231,7 @@ export class ClickhouseStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/cloudflare-d1/src/storage/domains/workflows/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/workflows/index.ts
@@ -1,5 +1,10 @@
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
-import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import type {
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import { createStorageErrorId, ensureDate, TABLE_WORKFLOW_SNAPSHOT, WorkflowsStorage } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import { createSqlBuilder } from '../../sql-builder';
@@ -40,13 +45,7 @@ export class WorkflowsStorageD1 extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new Error('Method not implemented.');

--- a/stores/cloudflare-d1/src/storage/domains/workflows/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
 import { createStorageErrorId, ensureDate, TABLE_WORKFLOW_SNAPSHOT, WorkflowsStorage } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
@@ -43,7 +43,7 @@ export class WorkflowsStorageD1 extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -1,6 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
+import { MastraError, ErrorDomain, ErrorCategory, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType, MastraDBMessage } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -291,7 +291,7 @@ export class D1Store extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -1,6 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { MastraError, ErrorDomain, ErrorCategory, type SerializedError } from '@mastra/core/error';
+import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType, MastraDBMessage } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -14,6 +14,7 @@ import type {
   WorkflowRuns,
   StorageDomains,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import Cloudflare from 'cloudflare';
@@ -288,13 +289,7 @@ export class D1Store extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/cloudflare/src/storage/domains/workflows/index.ts
+++ b/stores/cloudflare/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   TABLE_WORKFLOW_SNAPSHOT,
@@ -6,7 +6,12 @@ import {
   WorkflowsStorage,
   normalizePerPage,
 } from '@mastra/core/storage';
-import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
+import type {
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import type { StoreOperationsCloudflare } from '../operations';
 
@@ -50,13 +55,7 @@ export class WorkflowsStorageCloudflare extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new Error('Method not implemented.');

--- a/stores/cloudflare/src/storage/domains/workflows/index.ts
+++ b/stores/cloudflare/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   TABLE_WORKFLOW_SNAPSHOT,
@@ -53,7 +53,7 @@ export class WorkflowsStorageCloudflare extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -1,6 +1,6 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType, MastraDBMessage } from '@mastra/core/memory';
 import {
@@ -21,6 +21,7 @@ import type {
   StorageDomains,
   StorageResourceType,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import Cloudflare from 'cloudflare';
@@ -223,13 +224,7 @@ export class CloudflareStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -1,6 +1,6 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType, MastraDBMessage } from '@mastra/core/memory';
 import {
@@ -226,7 +226,7 @@ export class CloudflareStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/convex/src/storage/domains/workflows.ts
+++ b/stores/convex/src/storage/domains/workflows.ts
@@ -1,6 +1,11 @@
-import type { SerializedError } from '@mastra/core/error';
 import { TABLE_WORKFLOW_SNAPSHOT, normalizePerPage, WorkflowsStorage } from '@mastra/core/storage';
-import type { StorageListWorkflowRunsInput, StorageWorkflowRun, WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
+import type {
+  StorageListWorkflowRunsInput,
+  StorageWorkflowRun,
+  WorkflowRun,
+  WorkflowRuns,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState, WorkflowRunStatus } from '@mastra/core/workflows';
 
 import type { StoreOperationsConvex } from '../operations';
@@ -54,19 +59,13 @@ export class WorkflowsConvex extends WorkflowsStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: WorkflowRunStatus;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     const run = await this.getRun(workflowName, runId);
     if (!run) return undefined;
 
     const snapshot = this.ensureSnapshot(run);
-    const updated: WorkflowRunState = { ...snapshot, ...opts };
+    const updated = { ...snapshot, ...opts };
 
     await this.persistWorkflowSnapshot({
       workflowName,

--- a/stores/convex/src/storage/domains/workflows.ts
+++ b/stores/convex/src/storage/domains/workflows.ts
@@ -6,7 +6,7 @@ import type {
   WorkflowRuns,
   UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
-import type { StepResult, WorkflowRunState, WorkflowRunStatus } from '@mastra/core/workflows';
+import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 
 import type { StoreOperationsConvex } from '../operations';
 

--- a/stores/convex/src/storage/domains/workflows.ts
+++ b/stores/convex/src/storage/domains/workflows.ts
@@ -1,3 +1,4 @@
+import type { SerializedError } from '@mastra/core/error';
 import { TABLE_WORKFLOW_SNAPSHOT, normalizePerPage, WorkflowsStorage } from '@mastra/core/storage';
 import type { StorageListWorkflowRunsInput, StorageWorkflowRun, WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState, WorkflowRunStatus } from '@mastra/core/workflows';
@@ -56,7 +57,7 @@ export class WorkflowsConvex extends WorkflowsStorage {
     opts: {
       status: WorkflowRunStatus;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/convex/src/storage/index.ts
+++ b/stores/convex/src/storage/index.ts
@@ -1,4 +1,3 @@
-import type { SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringEntityType, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type {
@@ -14,9 +13,10 @@ import type {
   WorkflowRun,
   WorkflowRuns,
   TABLE_NAMES,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import { MastraStorage } from '@mastra/core/storage';
-import type { StepResult, WorkflowRunState, WorkflowRunStatus } from '@mastra/core/workflows';
+import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 
 import type { ConvexAdminClientConfig } from './client';
 import { ConvexAdminClient } from './client';
@@ -206,13 +206,7 @@ export class ConvexStore extends MastraStorage {
   async updateWorkflowState(params: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: WorkflowRunStatus;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.workflows.updateWorkflowState(params);
   }

--- a/stores/convex/src/storage/index.ts
+++ b/stores/convex/src/storage/index.ts
@@ -1,3 +1,4 @@
+import type { SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringEntityType, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type {
@@ -208,7 +209,7 @@ export class ConvexStore extends MastraStorage {
     opts: {
       status: WorkflowRunStatus;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/dynamodb/src/storage/domains/workflows/index.ts
+++ b/stores/dynamodb/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import { createStorageErrorId, normalizePerPage, WorkflowsStorage } from '@mastra/core/storage';
 import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
@@ -62,7 +62,7 @@ export class WorkflowStorageDynamoDB extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/dynamodb/src/storage/domains/workflows/index.ts
+++ b/stores/dynamodb/src/storage/domains/workflows/index.ts
@@ -1,6 +1,11 @@
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { createStorageErrorId, normalizePerPage, WorkflowsStorage } from '@mastra/core/storage';
-import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
+import type {
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import type { Service } from 'electrodb';
 
@@ -59,13 +64,7 @@ export class WorkflowStorageDynamoDB extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new Error('Method not implemented.');

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType, MastraDBMessage } from '@mastra/core/memory';
 
@@ -16,6 +16,7 @@ import type {
   StorageDomains,
   StorageResourceType,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import type { Service } from 'electrodb';
@@ -327,13 +328,7 @@ export class DynamoDBStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType, MastraDBMessage } from '@mastra/core/memory';
 
@@ -330,7 +330,7 @@ export class DynamoDBStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/lance/src/storage/domains/workflows/index.ts
+++ b/stores/lance/src/storage/domains/workflows/index.ts
@@ -1,6 +1,11 @@
 import type { Connection } from '@lancedb/lancedb';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
-import type { WorkflowRun, StorageListWorkflowRunsInput, WorkflowRuns } from '@mastra/core/storage';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import type {
+  WorkflowRun,
+  StorageListWorkflowRunsInput,
+  WorkflowRuns,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import {
   createStorageErrorId,
   ensureDate,
@@ -63,13 +68,7 @@ export class StoreWorkflowsLance extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new Error('Method not implemented.');

--- a/stores/lance/src/storage/domains/workflows/index.ts
+++ b/stores/lance/src/storage/domains/workflows/index.ts
@@ -1,5 +1,5 @@
 import type { Connection } from '@lancedb/lancedb';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { WorkflowRun, StorageListWorkflowRunsInput, WorkflowRuns } from '@mastra/core/storage';
 import {
   createStorageErrorId,
@@ -66,7 +66,7 @@ export class StoreWorkflowsLance extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -1,7 +1,7 @@
 import { connect } from '@lancedb/lancedb';
 import type { Connection, ConnectionOptions } from '@lancedb/lancedb';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -365,7 +365,7 @@ export class LanceStorage extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -1,7 +1,7 @@
 import { connect } from '@lancedb/lancedb';
 import type { Connection, ConnectionOptions } from '@lancedb/lancedb';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -14,6 +14,7 @@ import type {
   StorageDomains,
   StorageResourceType,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import { StoreMemoryLance } from './domains/memory';
@@ -362,13 +363,7 @@ export class LanceStorage extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/libsql/src/storage/domains/workflows/index.ts
+++ b/stores/libsql/src/storage/domains/workflows/index.ts
@@ -1,6 +1,11 @@
 import type { Client, InValue } from '@libsql/client';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
-import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import type {
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import {
   createStorageErrorId,
   normalizePerPage,
@@ -211,13 +216,7 @@ export class WorkflowsLibSQL extends WorkflowsStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.executeWithRetry(async () => {
       // Use a transaction to ensure atomicity

--- a/stores/libsql/src/storage/domains/workflows/index.ts
+++ b/stores/libsql/src/storage/domains/workflows/index.ts
@@ -1,5 +1,5 @@
 import type { Client, InValue } from '@libsql/client';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
 import {
   createStorageErrorId,
@@ -214,7 +214,7 @@ export class WorkflowsLibSQL extends WorkflowsStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1,7 +1,6 @@
 import { createClient } from '@libsql/client';
 import type { Client } from '@libsql/client';
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
-import type { SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { MastraStorage } from '@mastra/core/storage';
@@ -18,6 +17,7 @@ import type {
   TraceRecord,
   TracesPaginatedArg,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
@@ -321,13 +321,7 @@ export class LibSQLStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@libsql/client';
 import type { Client } from '@libsql/client';
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
+import type { SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { MastraStorage } from '@mastra/core/storage';
@@ -323,7 +324,7 @@ export class LibSQLStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/mongodb/src/storage/domains/workflows/index.ts
+++ b/stores/mongodb/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorDomain, ErrorCategory, MastraError } from '@mastra/core/error';
+import { ErrorDomain, ErrorCategory, MastraError, type SerializedError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   WorkflowsStorage,
@@ -46,7 +46,7 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/mongodb/src/storage/domains/workflows/index.ts
+++ b/stores/mongodb/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorDomain, ErrorCategory, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorDomain, ErrorCategory, MastraError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   WorkflowsStorage,
@@ -6,7 +6,12 @@ import {
   safelyParseJSON,
   normalizePerPage,
 } from '@mastra/core/storage';
-import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/core/storage';
+import type {
+  WorkflowRun,
+  WorkflowRuns,
+  StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import type { StoreOperationsMongoDB } from '../operations';
 
@@ -43,13 +48,7 @@ export class WorkflowsStorageMongoDB extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new Error('Method not implemented.');

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type {
@@ -17,6 +17,7 @@ import type {
   CreateSpanRecord,
   UpdateSpanRecord,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
@@ -230,13 +231,7 @@ export class MongoDBStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type {
@@ -233,7 +233,7 @@ export class MongoDBStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/mssql/src/storage/domains/workflows/index.ts
+++ b/stores/mssql/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   WorkflowsStorage,
@@ -156,7 +156,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/mssql/src/storage/domains/workflows/index.ts
+++ b/stores/mssql/src/storage/domains/workflows/index.ts
@@ -1,11 +1,16 @@
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   WorkflowsStorage,
   TABLE_WORKFLOW_SNAPSHOT,
   normalizePerPage,
 } from '@mastra/core/storage';
-import type { StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
+import type {
+  StorageListWorkflowRunsInput,
+  WorkflowRun,
+  WorkflowRuns,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import sql from 'mssql';
 import type { StoreOperationsMSSQL } from '../operations';
@@ -153,13 +158,7 @@ export class WorkflowsMSSQL extends WorkflowsStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     const table = getTableName({ indexName: TABLE_WORKFLOW_SNAPSHOT, schemaName: getSchemaName(this.schema) });
     const transaction = this.pool.transaction();

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -343,7 +343,7 @@ export class MSSQLStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -22,6 +22,7 @@ import type {
   IndexInfo,
   StorageIndexStats,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import sql from 'mssql';
@@ -340,13 +341,7 @@ export class MSSQLStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -1,9 +1,10 @@
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   normalizePerPage,
   TABLE_WORKFLOW_SNAPSHOT,
   WorkflowsStorage,
   createStorageErrorId,
+  type UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
@@ -76,13 +77,7 @@ export class WorkflowsPG extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new Error('Method not implemented.');

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import {
   normalizePerPage,
   TABLE_WORKFLOW_SNAPSHOT,
@@ -79,7 +79,7 @@ export class WorkflowsPG extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -4,9 +4,13 @@ import {
   TABLE_WORKFLOW_SNAPSHOT,
   WorkflowsStorage,
   createStorageErrorId,
-  type UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
-import type { StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
+import type {
+  UpdateWorkflowStateOptions,
+  StorageListWorkflowRunsInput,
+  WorkflowRun,
+  WorkflowRuns,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import type { IDatabase } from 'pg-promise';
 import type { StoreOperationsPG } from '../operations';

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -16,6 +16,7 @@ import type {
   TraceRecord,
   TracesPaginatedArg,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import pgPromise from 'pg-promise';
@@ -313,13 +314,7 @@ export class PostgresStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
@@ -316,7 +316,7 @@ export class PostgresStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/upstash/src/storage/domains/workflows/index.ts
+++ b/stores/upstash/src/storage/domains/workflows/index.ts
@@ -1,11 +1,16 @@
-import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   normalizePerPage,
   TABLE_WORKFLOW_SNAPSHOT,
   WorkflowsStorage,
 } from '@mastra/core/storage';
-import type { StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/core/storage';
+import type {
+  StorageListWorkflowRunsInput,
+  WorkflowRun,
+  WorkflowRuns,
+  UpdateWorkflowStateOptions,
+} from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import type { Redis } from '@upstash/redis';
 import type { StoreOperationsUpstash } from '../operations';
@@ -66,13 +71,7 @@ export class WorkflowsUpstash extends WorkflowsStorage {
     }: {
       workflowName: string;
       runId: string;
-      opts: {
-        status: string;
-        result?: StepResult<any, any, any, any>;
-        error?: SerializedError;
-        suspendedPaths?: Record<string, number[]>;
-        waitingPaths?: Record<string, number[]>;
-      };
+      opts: UpdateWorkflowStateOptions;
     },
   ): Promise<WorkflowRunState | undefined> {
     throw new Error('Method not implemented.');

--- a/stores/upstash/src/storage/domains/workflows/index.ts
+++ b/stores/upstash/src/storage/domains/workflows/index.ts
@@ -1,4 +1,4 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { ErrorCategory, ErrorDomain, MastraError, type SerializedError } from '@mastra/core/error';
 import {
   createStorageErrorId,
   normalizePerPage,
@@ -69,7 +69,7 @@ export class WorkflowsUpstash extends WorkflowsStorage {
       opts: {
         status: string;
         result?: StepResult<any, any, any, any>;
-        error?: string;
+        error?: SerializedError;
         suspendedPaths?: Record<string, number[]>;
         waitingPaths?: Record<string, number[]>;
       };

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -1,4 +1,5 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
+import type { SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { MastraStorage } from '@mastra/core/storage';
@@ -183,7 +184,7 @@ export class UpstashStore extends MastraStorage {
     opts: {
       status: string;
       result?: StepResult<any, any, any, any>;
-      error?: string;
+      error?: SerializedError;
       suspendedPaths?: Record<string, number[]>;
       waitingPaths?: Record<string, number[]>;
     };

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -1,5 +1,4 @@
 import type { MastraMessageContentV2, MastraDBMessage } from '@mastra/core/agent';
-import type { SerializedError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import type { StorageThreadType } from '@mastra/core/memory';
 import { MastraStorage } from '@mastra/core/storage';
@@ -13,6 +12,7 @@ import type {
   StoragePagination,
   StorageDomains,
   StorageListWorkflowRunsInput,
+  UpdateWorkflowStateOptions,
 } from '@mastra/core/storage';
 
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
@@ -181,13 +181,7 @@ export class UpstashStore extends MastraStorage {
   }: {
     workflowName: string;
     runId: string;
-    opts: {
-      status: string;
-      result?: StepResult<any, any, any, any>;
-      error?: SerializedError;
-      suspendedPaths?: Record<string, number[]>;
-      waitingPaths?: Record<string, number[]>;
-    };
+    opts: UpdateWorkflowStateOptions;
   }): Promise<WorkflowRunState | undefined> {
     return this.stores.workflows.updateWorkflowState({ workflowName, runId, opts });
   }

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { getErrorFromUnknown } from '@mastra/core/error';
+import { getErrorFromUnknown, type SerializedError } from '@mastra/core/error';
 import type { Mastra } from '@mastra/core/mastra';
 import { DefaultExecutionEngine, createTimeTravelExecutionParams } from '@mastra/core/workflows';
 import type {
@@ -39,14 +39,17 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
    * Format errors while preserving Error instances and their custom properties.
    * Uses getErrorFromUnknown to ensure all error properties are preserved.
    */
-  protected formatResultError(error: Error | string | undefined, lastOutput: StepResult<any, any, any, any>): Error {
+  protected formatResultError(
+    error: Error | string | undefined,
+    lastOutput: StepResult<any, any, any, any>,
+  ): SerializedError {
     const outputError = (lastOutput as StepFailure<any, any, any, any>)?.error;
     const errorSource = error || outputError;
     const errorInstance = getErrorFromUnknown(errorSource, {
       serializeStack: true, // Include stack in JSON for better debugging in Inngest
       fallbackMessage: 'Unknown workflow error',
     });
-    return errorInstance;
+    return errorInstance.toJSON();
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
When errors are thrown from workflow steps, custom error properties (like `statusCode`, `responseHeaders`, `cause` chain, etc.) were being lost because `JSON.stringify(new Error())` produces `{}`.

This PR ensures error details are properly preserved by:

- Changing `WorkflowState.error` and `WorkflowRunState.error` types from `SerializedError | Error` to just `SerializedError`
- Updating `formatResultError` in execution engines to serialize errors immediately via `.toJSON()`
- Errors are now consistently serialized at workflow level for storage compatibility
- Step-level errors remain as `Error` instances; only workflow-level `result.error` is serialized
- Custom error properties (statusCode, responseHeaders, cause chain, etc.) are preserved through serialization

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
