### PR TITLE
feat(client-js): deserialize workflow errors on client side

### DIFF
--- a/.changeset/neat-baboons-throw.md
+++ b/.changeset/neat-baboons-throw.md
@@ -1,0 +1,17 @@
+---
+'@mastra/client-js': patch
+---
+
+Deserialize workflow errors on the client side
+
+When workflows fail, the server sends `SerializedError` (plain JSON object) over HTTP. This change deserializes those errors back to proper `Error` instances on the client, enabling:
+- `instanceof Error` checks
+- Access to `error.message`, `error.name`, `error.stack`
+- Preservation of custom error properties (e.g., `statusCode`, `responseHeaders`)
+- Proper cause chain reconstruction
+
+Affected methods:
+- `startAsync()`
+- `resumeAsync()`
+- `restartAsync()`
+- `timeTravelAsync()`

--- a/client-sdks/client-js/src/resources/workflow.test.ts
+++ b/client-sdks/client-js/src/resources/workflow.test.ts
@@ -142,6 +142,184 @@ describe('Workflow (fetch-mocked)', () => {
 // Mock fetch globally for client tests
 global.fetch = vi.fn();
 
+describe('Workflow error deserialization', () => {
+  let fetchMock: any;
+  let wf: Workflow;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+
+    const options: ClientOptions = { baseUrl: 'http://localhost', retries: 0 } as any;
+    wf = new Workflow(options, 'wf-1');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createJsonResponse = (data: any) => ({ ok: true, json: async () => data });
+
+  it('deserializes failed workflow error in startAsync', async () => {
+    const serializedError = {
+      name: 'StepError',
+      message: 'Step failed with validation error',
+      stack: 'Error: Step failed...\n    at ...',
+      statusCode: 400,
+      cause: {
+        name: 'ValidationError',
+        message: 'Invalid input',
+      },
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/start-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.startAsync({ inputData: {} })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Step failed with validation error');
+    expect(result.error?.name).toBe('StepError');
+    expect(result.error.statusCode).toBe(400);
+    expect(result.error?.cause).toBeDefined();
+    expect(result.error?.cause?.message).toBe('Invalid input');
+  });
+
+  it('deserializes failed workflow error in resumeAsync', async () => {
+    const serializedError = {
+      name: 'ResumeError',
+      message: 'Resume step failed',
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/resume-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.resumeAsync({ runId: 'r-123', step: 's1' })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Resume step failed');
+    expect(result.error?.name).toBe('ResumeError');
+  });
+
+  it('deserializes failed workflow error in restartAsync', async () => {
+    const serializedError = {
+      name: 'RestartError',
+      message: 'Restart failed',
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/restart-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.restartAsync({ runId: 'r-123' })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Restart failed');
+  });
+
+  it('deserializes failed workflow error in timeTravelAsync', async () => {
+    const serializedError = {
+      name: 'TimeTravelError',
+      message: 'Time travel failed',
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/time-travel-async')) {
+        return Promise.resolve(
+          createJsonResponse({
+            status: 'failed',
+            error: serializedError,
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.timeTravelAsync({ runId: 'r-123', step: 's1' })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Time travel failed');
+  });
+
+  it('passes through successful workflow result unchanged', async () => {
+    const successResult = {
+      status: 'success',
+      result: { data: 'test-output' },
+      steps: {},
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/start-async')) {
+        return Promise.resolve(createJsonResponse(successResult));
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.startAsync({ inputData: {} })) as any;
+
+    expect(result.status).toBe('success');
+    expect(result.result).toEqual({ data: 'test-output' });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('passes through suspended workflow result unchanged', async () => {
+    const suspendedResult = {
+      status: 'suspended',
+      steps: {
+        step1: { status: 'suspended', suspendPayload: { waitingFor: 'approval' } },
+      },
+    };
+
+    fetchMock.mockImplementation((input: any) => {
+      const url = String(input);
+      if (url.includes('/start-async')) {
+        return Promise.resolve(createJsonResponse(suspendedResult));
+      }
+      return Promise.reject(new Error(`Unhandled fetch to ${url}`));
+    });
+
+    const result = (await wf.startAsync({ inputData: {} })) as any;
+
+    expect(result.status).toBe('suspended');
+    expect(result.error).toBeUndefined();
+  });
+});
+
 describe('Workflow Client Methods', () => {
   let client: MastraClient;
   const clientOptions = {

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -1,3 +1,4 @@
+import { getErrorFromUnknown } from '@mastra/core/error';
 import type { TracingOptions } from '@mastra/core/observability';
 import type { RequestContext } from '@mastra/core/request-context';
 import type {
@@ -14,6 +15,20 @@ import type {
 
 import { parseClientRequestContext, base64RequestContext, requestContextQueryString } from '../utils';
 import { BaseResource } from './base';
+
+/**
+ * Deserializes the error property in a workflow result back to an Error instance.
+ * Server sends SerializedError (plain object), client converts to Error for instanceof checks.
+ */
+function deserializeWorkflowError<T extends WorkflowRunResult>(result: T): T {
+  if (result.status === 'failed' && result.error) {
+    result.error = getErrorFromUnknown(result.error, {
+      fallbackMessage: 'Unknown workflow error',
+      supportSerialization: false,
+    });
+  }
+  return result;
+}
 
 const RECORD_SEPARATOR = '\x1E';
 
@@ -347,7 +362,7 @@ export class Workflow extends BaseResource {
 
     const requestContext = parseClientRequestContext(params.requestContext);
 
-    return this.request(`/api/workflows/${this.workflowId}/start-async?${searchParams.toString()}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/start-async?${searchParams.toString()}`, {
       method: 'POST',
       body: {
         inputData: params.inputData,
@@ -355,7 +370,7 @@ export class Workflow extends BaseResource {
         requestContext,
         tracingOptions: params.tracingOptions,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**
@@ -652,7 +667,7 @@ export class Workflow extends BaseResource {
     tracingOptions?: TracingOptions;
   }): Promise<WorkflowRunResult> {
     const requestContext = parseClientRequestContext(params.requestContext);
-    return this.request(`/api/workflows/${this.workflowId}/resume-async?runId=${params.runId}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/resume-async?runId=${params.runId}`, {
       method: 'POST',
       body: {
         step: params.step,
@@ -660,7 +675,7 @@ export class Workflow extends BaseResource {
         requestContext,
         tracingOptions: params.tracingOptions,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**
@@ -792,13 +807,13 @@ export class Workflow extends BaseResource {
     tracingOptions?: TracingOptions;
   }): Promise<WorkflowRunResult> {
     const requestContext = parseClientRequestContext(params.requestContext);
-    return this.request(`/api/workflows/${this.workflowId}/restart-async?runId=${params.runId}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/restart-async?runId=${params.runId}`, {
       method: 'POST',
       body: {
         requestContext,
         tracingOptions: params.tracingOptions,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**
@@ -852,13 +867,13 @@ export class Workflow extends BaseResource {
     ...params
   }: TimeTravelParams): Promise<WorkflowRunResult> {
     const requestContext = parseClientRequestContext(paramsRequestContext);
-    return this.request(`/api/workflows/${this.workflowId}/time-travel-async?runId=${runId}`, {
+    return this.request<WorkflowRunResult>(`/api/workflows/${this.workflowId}/time-travel-async?runId=${runId}`, {
       method: 'POST',
       body: {
         ...params,
         requestContext,
       },
-    });
+    }).then(deserializeWorkflowError);
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- Deserialize `SerializedError` objects back to proper `Error` instances when workflows fail
- Enables `instanceof Error` checks on the client
- Preserves custom error properties (e.g., `statusCode`, `responseHeaders`) and cause chains


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
