### PR TITLE
fix: let docusaurus handle the hreflang generation v0.x

### DIFF
--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -42,12 +42,6 @@ export default function Layout(props: Props): ReactNode {
 
       <Head>
         <link rel="canonical" href={canonicalUrl} />
-        <link rel="alternate" hrefLang="en" href={canonicalUrl} />
-        <link
-          rel="alternate"
-          hrefLang="ja"
-          href={`${siteConfig.url}/ja${cleanPath}`}
-        />
       </Head>
 
       <SkipToContent />


### PR DESCRIPTION
With this change, we will avoid having hreflang set twice with different values.