### PR TITLE
fix: let docusaurus handle the hreflang generation

### DIFF
--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -44,7 +44,6 @@ export default function Layout(props: Props): ReactNode {
 
       <Head>
         <link rel="canonical" href={canonicalUrl} />
-        <link rel="alternate" hrefLang="en" href={canonicalUrl} />
         <meta name="x-docs-origin" content="v1" />
       </Head>
 


### PR DESCRIPTION
With this change, we will avoid having hreflang set twice with different values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Removed alternate language link metadata from documentation pages, while preserving canonical URL and origin metadata references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->