### PR TITLE
fix: check running mastra instance with server.port OR 4111

### DIFF
--- a/.changeset/clean-maps-smash.md
+++ b/.changeset/clean-maps-smash.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Make sure to verify that a mastra instance is running on server.port OR 4111 by default

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -306,10 +306,12 @@ export async function createHonoServer(
       const port = serverOptions?.port ?? (Number(process.env.PORT) || 4111);
       const hideCloudCta = process.env.MASTRA_HIDE_CLOUD_CTA === 'true';
       const host = serverOptions?.host ?? 'localhost';
+      const protocol = serverOptions?.https ? 'https' : 'http';
 
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_HOST%%'`, `'${host}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PORT%%'`, `'${port}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_HIDE_CLOUD_CTA%%'`, `'${hideCloudCta}'`);
+      indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PROTOCOL%%'`, `'${protocol}'`);
       // Inject the base path for frontend routing
       // The <base href> tag uses this to resolve all relative URLs correctly
       indexHtml = indexHtml.replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', studioBasePath);

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -306,7 +306,13 @@ export async function createHonoServer(
       const port = serverOptions?.port ?? (Number(process.env.PORT) || 4111);
       const hideCloudCta = process.env.MASTRA_HIDE_CLOUD_CTA === 'true';
       const host = serverOptions?.host ?? 'localhost';
-      const protocol = serverOptions?.https ? 'https' : 'http';
+      const key =
+        serverOptions?.https?.key ??
+        (process.env.MASTRA_HTTPS_KEY ? Buffer.from(process.env.MASTRA_HTTPS_KEY, 'base64') : undefined);
+      const cert =
+        serverOptions?.https?.cert ??
+        (process.env.MASTRA_HTTPS_CERT ? Buffer.from(process.env.MASTRA_HTTPS_CERT, 'base64') : undefined);
+      const protocol = key && cert ? 'https' : 'http';
 
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_HOST%%'`, `'${host}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PORT%%'`, `'${port}'`);

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -12,6 +12,7 @@
       window.MASTRA_SERVER_PORT = '%%MASTRA_SERVER_PORT%%';
       window.MASTRA_HIDE_CLOUD_CTA = '%%MASTRA_HIDE_CLOUD_CTA%%';
       window.MASTRA_STUDIO_BASE_PATH = '%%MASTRA_STUDIO_BASE_PATH%%';
+      window.MASTRA_SERVER_PROTOCOL = '%%MASTRA_SERVER_PROTOCOL%%';
 
       function connectSSE() {
         const basePath = window.MASTRA_STUDIO_BASE_PATH || '';

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -197,7 +197,7 @@ function App() {
 export default function AppWrapper() {
   return (
     <PlaygroundQueryClient>
-      <StudioConfigProvider>
+      <StudioConfigProvider endpoint={`http://localhost:${window.MASTRA_SERVER_PORT || 4111}`}>
         <App />
       </StudioConfigProvider>
     </PlaygroundQueryClient>

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -11,6 +11,7 @@ declare global {
     MASTRA_SERVER_PORT: string;
     MASTRA_TELEMETRY_DISABLED?: string;
     MASTRA_HIDE_CLOUD_CTA: string;
+    MASTRA_SERVER_PROTOCOL: string;
   }
 }
 
@@ -195,9 +196,14 @@ function App() {
 }
 
 export default function AppWrapper() {
+  const protocol = window.MASTRA_SERVER_PROTOCOL || 'http';
+  const host = window.MASTRA_SERVER_HOST || 'localhost';
+  const port = window.MASTRA_SERVER_PORT || 4111;
+  const endpoint = `${protocol}://${host}:${port}`;
+
   return (
     <PlaygroundQueryClient>
-      <StudioConfigProvider endpoint={`http://localhost:${window.MASTRA_SERVER_PORT || 4111}`}>
+      <StudioConfigProvider endpoint={endpoint}>
         <App />
       </StudioConfigProvider>
     </PlaygroundQueryClient>


### PR DESCRIPTION
## Description

This pull request ensures that the application correctly connects to the appropriate `mastra` server port, defaulting to port 4111 if no custom port is specified. This change helps prevent connection issues by always providing a valid endpoint.

Configuration improvements:

* Updated the `StudioConfigProvider` in `App.tsx` to use the value of `window.MASTRA_SERVER_PORT` for the endpoint, defaulting to `4111` if not set.

Documentation update:

* Added a changeset note to clarify that a `mastra` instance should be running on the specified server port or on port `4111` by default.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playground now reads a configurable Mastra server endpoint (protocol, host, port); defaults keep port 4111.

* **Documentation**
  * Guidance added to verify a Mastra instance is running on the configured server endpoint/port.

* **Chores**
  * Added a changelog entry recording this change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->