### PR TITLE
fix: studio command wrong playground path

### DIFF
--- a/.changeset/breezy-walls-grow.md
+++ b/.changeset/breezy-walls-grow.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Allow to run mastra studio from anywhere in the file system, and not necessarily inside a mastra project

--- a/packages/cli/src/commands/studio/studio.ts
+++ b/packages/cli/src/commands/studio/studio.ts
@@ -22,7 +22,7 @@ export async function studio(options: StudioOptions = {}) {
     const distPath = join(__dirname, 'playground');
 
     if (!existsSync(distPath)) {
-      logger.error(`Studio distribution not found at ${distPath}. Please run 'mastra build' first.`);
+      logger.error(`Studio distribution not found at ${distPath}.`);
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/studio/studio.ts
+++ b/packages/cli/src/commands/studio/studio.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import http from 'node:http';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { config } from 'dotenv';
 import handler from 'serve-handler';
 import { logger } from '../../utils/logger';
@@ -10,12 +11,15 @@ interface StudioOptions {
   port?: string | number;
 }
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 export async function studio(options: StudioOptions = {}) {
   // Load environment variables from .env files
   config({ path: [options.env || '.env.production', '.env'] });
 
   try {
-    const distPath = join(process.cwd(), '.mastra', 'output', 'playground');
+    const distPath = join(__dirname, 'playground');
 
     if (!existsSync(distPath)) {
       logger.error(`Studio distribution not found at ${distPath}. Please run 'mastra build' first.`);


### PR DESCRIPTION
## Description

This pull request updates the `mastra studio` command to make it more flexible and easier to use. Now, you can run the studio from any location in your file system, not just inside a mastra project directory. The main change is how the distribution path for the studio is resolved.

**Improvements to studio command usability:**

* Updated the studio distribution path resolution in `studio.ts` to use the directory of the command file itself (`__dirname`), allowing the studio to run from anywhere in the file system instead of requiring the current working directory to be a mastra project. [[1]](diffhunk://#diff-5bfa471042dfb7702bc45617ed2171946ead84b9907cf27c4d06fe887ec7612cL3-R4) [[2]](diffhunk://#diff-5bfa471042dfb7702bc45617ed2171946ead84b9907cf27c4d06fe887ec7612cR14-R22)
* Documented the change in `.changeset/breezy-walls-grow.md` to indicate that `mastra studio` can now be run from any location.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mastra Studio can now be launched from anywhere in the filesystem, not only from within a Mastra project directory.

* **Chores**
  * Prepared a patch release entry to version and publish this fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->