### PR TITLE
refactor: cleanup DocBreadcrumbs component

### DIFF
--- a/docs/src/components/ui/breadcrumbs.tsx
+++ b/docs/src/components/ui/breadcrumbs.tsx
@@ -1,0 +1,43 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+
+export function BreadcrumbsItemLink({
+    children,
+    href,
+    isLast,
+}: {
+    children: ReactNode;
+    href: string | undefined;
+    isLast: boolean;
+}): ReactNode {
+    const className = "breadcrumbs__link";
+    if (isLast) {
+        return <span className={className}>{children}</span>;
+    }
+    return href ? (
+        <Link className={className} href={href}>
+            <span>{children}</span>
+        </Link>
+    ) : (
+        <span className={className}>{children}</span>
+    );
+}
+
+export function BreadcrumbsItem({
+    children,
+    active,
+}: {
+    children: ReactNode;
+    active?: boolean;
+}): ReactNode {
+    return (
+        <li
+            className={clsx("breadcrumbs__item", {
+                "breadcrumbs__item--active": active,
+            })}
+        >
+            {children}
+        </li>
+    );
+}

--- a/docs/src/theme/DocBreadcrumbs/index.tsx
+++ b/docs/src/theme/DocBreadcrumbs/index.tsx
@@ -3,54 +3,14 @@ import clsx from "clsx";
 import { ThemeClassNames } from "@docusaurus/theme-common";
 import { useSidebarBreadcrumbs } from "@docusaurus/plugin-content-docs/client";
 import { useHomePageRoute } from "@docusaurus/theme-common/internal";
-import Link from "@docusaurus/Link";
 import { translate } from "@docusaurus/Translate";
 import HomeBreadcrumbItem from "@theme/DocBreadcrumbs/Items/Home";
 import DocBreadcrumbsStructuredData from "@theme/DocBreadcrumbs/StructuredData";
+import { BreadcrumbsItemLink, BreadcrumbsItem } from "@site/src/components/ui/breadcrumbs";
 
 import styles from "./styles.module.css";
 
-// TODO move to design system folder
-function BreadcrumbsItemLink({
-  children,
-  href,
-  isLast,
-}: {
-  children: ReactNode;
-  href: string | undefined;
-  isLast: boolean;
-}): ReactNode {
-  const className = "breadcrumbs__link";
-  if (isLast) {
-    return <span className={className}>{children}</span>;
-  }
-  return href ? (
-    <Link className={className} href={href}>
-      <span>{children}</span>
-    </Link>
-  ) : (
-    <span className={className}>{children}</span>
-  );
-}
 
-// TODO move to design system folder
-function BreadcrumbsItem({
-  children,
-  active,
-}: {
-  children: ReactNode;
-  active?: boolean;
-}): ReactNode {
-  return (
-    <li
-      className={clsx("breadcrumbs__item", {
-        "breadcrumbs__item--active": active,
-      })}
-    >
-      {children}
-    </li>
-  );
-}
 
 export default function DocBreadcrumbs(): ReactNode {
   const breadcrumbs = useSidebarBreadcrumbs();


### PR DESCRIPTION

## Description

Refactored breadcrumb components by moving them to the design system folder. This improves code organization and makes the UI components reusable across the documentation site.

**Changes:**
- Extracted [BreadcrumbsItemLink][BreadcrumbsItem] elements into a dedicated breadcrumbs module in the UI design system
- Updated imports to reference the centralized components
- Resolved **TODO** comments requesting this refactoring
- Cleaned up unused imports

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works