### PR TITLE
fix(storage): restrict message orderBy to only accept 'createdAt' in StorageListMessagesInput

### DIFF
--- a/.changeset/chatty-news-scream.md
+++ b/.changeset/chatty-news-scream.md
@@ -1,0 +1,9 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fix type safety for message ordering - restrict `orderBy` to only accept `'createdAt'` field
+
+Messages don't have an `updatedAt` field, but the previous type allowed ordering by it, which would return empty results. This change adds compile-time type safety by making `StorageOrderBy` generic and restricting `StorageListMessagesInput.orderBy` to only accept `'createdAt'`. The API validation schemas have also been updated to reject invalid orderBy values at runtime.
+

--- a/docs/src/components/ui/breadcrumbs.tsx
+++ b/docs/src/components/ui/breadcrumbs.tsx
@@ -3,41 +3,41 @@ import clsx from "clsx";
 import Link from "@docusaurus/Link";
 
 export function BreadcrumbsItemLink({
-    children,
-    href,
-    isLast,
+  children,
+  href,
+  isLast,
 }: {
-    children: ReactNode;
-    href: string | undefined;
-    isLast: boolean;
+  children: ReactNode;
+  href: string | undefined;
+  isLast: boolean;
 }): ReactNode {
-    const className = "breadcrumbs__link";
-    if (isLast) {
-        return <span className={className}>{children}</span>;
-    }
-    return href ? (
-        <Link className={className} href={href}>
-            <span>{children}</span>
-        </Link>
-    ) : (
-        <span className={className}>{children}</span>
-    );
+  const className = "breadcrumbs__link";
+  if (isLast) {
+    return <span className={className}>{children}</span>;
+  }
+  return href ? (
+    <Link className={className} href={href}>
+      <span>{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
 }
 
 export function BreadcrumbsItem({
-    children,
-    active,
+  children,
+  active,
 }: {
-    children: ReactNode;
-    active?: boolean;
+  children: ReactNode;
+  active?: boolean;
 }): ReactNode {
-    return (
-        <li
-            className={clsx("breadcrumbs__item", {
-                "breadcrumbs__item--active": active,
-            })}
-        >
-            {children}
-        </li>
-    );
+  return (
+    <li
+      className={clsx("breadcrumbs__item", {
+        "breadcrumbs__item--active": active,
+      })}
+    >
+      {children}
+    </li>
+  );
 }

--- a/docs/src/theme/DocBreadcrumbs/index.tsx
+++ b/docs/src/theme/DocBreadcrumbs/index.tsx
@@ -6,11 +6,12 @@ import { useHomePageRoute } from "@docusaurus/theme-common/internal";
 import { translate } from "@docusaurus/Translate";
 import HomeBreadcrumbItem from "@theme/DocBreadcrumbs/Items/Home";
 import DocBreadcrumbsStructuredData from "@theme/DocBreadcrumbs/StructuredData";
-import { BreadcrumbsItemLink, BreadcrumbsItem } from "@site/src/components/ui/breadcrumbs";
+import {
+  BreadcrumbsItemLink,
+  BreadcrumbsItem,
+} from "@site/src/components/ui/breadcrumbs";
 
 import styles from "./styles.module.css";
-
-
 
 export default function DocBreadcrumbs(): ReactNode {
   const breadcrumbs = useSidebarBreadcrumbs();

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -85,7 +85,7 @@ export type StorageListMessagesInput = {
       end?: Date;
     };
   };
-  orderBy?: StorageOrderBy;
+  orderBy?: StorageOrderBy<'createdAt'>;
 };
 
 export type StorageListMessagesOutput = PaginationInfo & {
@@ -149,8 +149,8 @@ export type StorageMessageType = {
   resourceId: string | null;
 };
 
-export interface StorageOrderBy {
-  field?: ThreadOrderBy;
+export interface StorageOrderBy<TField extends ThreadOrderBy = ThreadOrderBy> {
+  field?: TField;
   direction?: ThreadSortDirection;
 }
 

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -14,10 +14,18 @@ export const agentIdQuerySchema = z.object({
 });
 
 /**
- * Storage order by configuration
+ * Storage order by configuration for threads and agents (have both createdAt and updatedAt)
  */
 const storageOrderBySchema = z.object({
   field: z.enum(['createdAt', 'updatedAt']).optional(),
+  direction: z.enum(['ASC', 'DESC']).optional(),
+});
+
+/**
+ * Storage order by configuration for messages (only have createdAt)
+ */
+const messageOrderBySchema = z.object({
+  field: z.enum(['createdAt']).optional(),
   direction: z.enum(['ASC', 'DESC']).optional(),
 });
 
@@ -145,7 +153,7 @@ export const getThreadByIdQuerySchema = agentIdQuerySchema;
 export const listMessagesQuerySchema = createPagePaginationSchema(40).extend({
   agentId: z.string(),
   resourceId: z.string().optional(),
-  orderBy: storageOrderBySchema.optional(),
+  orderBy: messageOrderBySchema.optional(),
   include: includeSchema,
   filter: filterSchema,
 });
@@ -188,7 +196,7 @@ export const getThreadByIdNetworkQuerySchema = agentIdQuerySchema;
 export const listMessagesNetworkQuerySchema = createPagePaginationSchema(40).extend({
   agentId: z.string(),
   resourceId: z.string().optional(),
-  orderBy: storageOrderBySchema.optional(),
+  orderBy: messageOrderBySchema.optional(),
   include: includeSchema,
   filter: filterSchema,
 });


### PR DESCRIPTION
## Description

Messages don't have an updatedAt field, so ordering by it would return empty results. This change adds type safety by:

- Making StorageOrderBy generic with a default parameter
- Restricting StorageListMessagesInput to StorageOrderBy<'createdAt'>
- Adding messageOrderBySchema for API validation

This prevents runtime errors and provides better DX with compile-time type checking.

## Related Issue(s)

Slack

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Message ordering now strictly enforces ordering by creation date and rejects invalid order parameters at runtime for consistent results.

* **Refactor**
  - Enhanced type-safety around message ordering with compile-time constraints to prevent incorrect order fields.

* **Style**
  - Minor formatting and whitespace cleanups in breadcrumb UI components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->