### PR TITLE
[Fix] isTopLevelSpan value on SpanScorring

### DIFF
--- a/.changeset/yellow-insects-raise.md
+++ b/.changeset/yellow-insects-raise.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'create-mastra': patch
+'mastra': patch
+---
+
+fix isTopLevelSpan value definition on SpanScoring to properly recognize lack of span?.parentSpanId value (null or empty string)

--- a/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
@@ -75,7 +75,7 @@ export function SpanTabs({
             </Section.Header>
             <SpanScoring
               traceId={trace?.traceId}
-              isTopLevelSpan={span?.parentSpanId === null}
+              isTopLevelSpan={!Boolean(span?.parentSpanId)}
               spanId={span?.spanId}
               entityType={entityType}
               scorers={scorers}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Fix value definition to properly recognise lack of  span?.parentSpanId no matter if it's null or empty string (Cloud case)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed incorrect identification of top-level spans in observability monitoring by improving the detection logic for spans without parent references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->