### PR TITLE
fix: dev playground experience

### DIFF
--- a/.changeset/salty-spiders-stop.md
+++ b/.changeset/salty-spiders-stop.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix the development experience of the studio. It was not able to resolve the running instance because the index.html variables were not replaced in the vite dev standalone config

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,9 +1,21 @@
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
-import { defineConfig } from 'vite';
+import { defineConfig, PluginOption, UserConfig } from 'vite';
+
+const studioStandalonePlugin = (targetPort: string, targetHost: string): PluginOption => ({
+  name: 'studio-standalone-plugin',
+  transformIndexHtml(html: string) {
+    return html
+      .replace(/%%MASTRA_SERVER_HOST%%/g, targetHost)
+      .replace(/%%MASTRA_SERVER_PORT%%/g, targetPort)
+      .replace(/%%MASTRA_HIDE_CLOUD_CTA%%/g, 'true')
+      .replace(/%%MASTRA_STUDIO_BASE_PATH%%/g, '')
+      .replace(/%%MASTRA_SERVER_PROTOCOL%%/g, 'http');
+  },
+});
 
 export default defineConfig(({ mode }) => {
-  const commonConfig = {
+  const commonConfig: UserConfig = {
     plugins: [react()],
     base: './',
     resolve: {
@@ -33,6 +45,10 @@ export default defineConfig(({ mode }) => {
     // Use environment variable for the target port, fallback to 4111
     const targetPort = process.env.PORT || '4111';
     const targetHost = process.env.HOST || 'localhost';
+
+    if (commonConfig.plugins) {
+      commonConfig.plugins.push(studioStandalonePlugin(targetPort, targetHost));
+    }
 
     return {
       ...commonConfig,


### PR DESCRIPTION
## Description

This pull request improves the development experience for the studio by ensuring that environment variables in `index.html` are correctly replaced when running the Vite development server in standalone mode. The main changes introduce a custom Vite plugin to handle variable substitution and update the Vite config to use this plugin.

Enhancements to development environment:

* Added a custom Vite plugin (`studioStandalonePlugin`) in `vite.config.ts` to replace placeholder variables (such as `%%MASTRA_SERVER_HOST%%`, `%%MASTRA_SERVER_PORT%%`, etc.) in `index.html` with the appropriate values during development.
* Updated the Vite configuration to include the new plugin when running in standalone mode, ensuring that the studio can resolve the running instance correctly.

Documentation:

* Added a changeset describing the fix for the studio development experience and the issue with unresolved variables in the Vite dev standalone config.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a development environment issue in the studio where the running instance failed to resolve properly when using standalone mode configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->