### PR TITLE
feat(client-js): Add status parameter to workflow.runs() method

### DIFF
--- a/.changeset/strong-otters-beg.md
+++ b/.changeset/strong-otters-beg.md
@@ -1,0 +1,17 @@
+---
+'@mastra/client-js': patch
+---
+
+Add missing status parameter to workflow.runs() method
+
+The `status` parameter was supported by the server API but was missing from the TypeScript types in @mastra/client-js.
+
+Now you can filter workflow runs by status:
+
+```typescript
+// Get only running workflows
+const runningRuns = await workflow.runs({ status: 'running' });
+
+// Get completed workflows
+const completedRuns = await workflow.runs({ status: 'success' });
+```

--- a/client-sdks/client-js/src/resources/workflow.ts
+++ b/client-sdks/client-js/src/resources/workflow.ts
@@ -73,6 +73,9 @@ export class Workflow extends BaseResource {
     if (params?.resourceId) {
       searchParams.set('resourceId', params.resourceId);
     }
+    if (params?.status) {
+      searchParams.set('status', params.status);
+    }
     if (requestContextParam) {
       searchParams.set('requestContext', requestContextParam);
     }

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -34,7 +34,13 @@ import type {
 import type { OutputSchema } from '@mastra/core/stream';
 
 import type { QueryResult } from '@mastra/core/vector';
-import type { TimeTravelContext, Workflow, WorkflowResult, WorkflowState } from '@mastra/core/workflows';
+import type {
+  TimeTravelContext,
+  Workflow,
+  WorkflowResult,
+  WorkflowRunStatus,
+  WorkflowState,
+} from '@mastra/core/workflows';
 
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
@@ -172,6 +178,7 @@ export interface ListWorkflowRunsParams {
   page?: number;
   perPage?: number;
   resourceId?: string;
+  status?: WorkflowRunStatus;
   /** @deprecated Use page instead */
   offset?: number;
   /** @deprecated Use perPage instead */


### PR DESCRIPTION
## Description

This update introduces a new `status` parameter to the `workflow.runs()` method, allowing users to filter workflow runs by their status (e.g., 'running', 'success'). The TypeScript types in `@mastra/client-js` have been updated accordingly to reflect this change.

## Related Issue(s)

slack

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status parameter to filter workflow runs by their execution status (e.g., 'running', 'success').

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->