### PR TITLE
fix(examples): remove missing legacy-workflows import and add dev script to quick-start

### DIFF
--- a/examples/quick-start/package.json
+++ b/examples/quick-start/package.json
@@ -5,6 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "dev": "tsx src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/examples/quick-start/src/mastra/index.ts
+++ b/examples/quick-start/src/mastra/index.ts
@@ -1,14 +1,10 @@
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { catOne } from './agents/agent';
-import { logCatWorkflow as legacy_catWorkflow } from './legacy-workflows';
 import { logCatWorkflow } from './workflows';
 
 export const mastra = new Mastra({
   agents: { catOne },
-  legacy_workflows: {
-    legacy_catWorkflow,
-  },
   workflows: {
     logCatWorkflow,
   },


### PR DESCRIPTION
## Summary

- Removed import of non-existent `legacy-workflows` module that was causing `ERR_MODULE_NOT_FOUND` error
- Removed `legacy_workflows` configuration from Mastra instance
- Added `dev` script to `package.json` to enable running the example with `npm run dev` or `pnpm dev`

## Problem

The quick-start example was failing to run with the following error:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/.../mastra/examples/quick-start/src/mastra/legacy-workflows'
```

The `legacy-workflows` directory/file did not exist in the codebase, but was being imported in `src/mastra/index.ts`.

Additionally, there was no easy way to run the example as `package.json` had no dev script.

## Solution

1. Removed the import statement for `legacy-workflows` 
2. Removed the `legacy_workflows` property from the Mastra configuration
3. Added `"dev": "tsx src/index.ts"` script to enable easy execution

## Test plan

- [x] Verify the example runs without module not found errors
- [x] Verify `npm run dev` / `pnpm dev` executes the example successfully
- [x] Verify typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Added a dev script for running TypeScript examples in the quick-start project
  * Removed legacy workflow integration from the quick-start configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->