### PR TITLE
.network() method ignores MASTRA_RESOURCE_ID_KEY from requestContext

### DIFF
--- a/.changeset/loud-mice-flow.md
+++ b/.changeset/loud-mice-flow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixes .network() method ignores MASTRA_RESOURCE_ID_KEY from requestContext

--- a/packages/core/src/agent/__tests__/request-context-reserved-keys.test.ts
+++ b/packages/core/src/agent/__tests__/request-context-reserved-keys.test.ts
@@ -385,4 +385,114 @@ describe('RequestContext reserved keys for resourceId and threadId', () => {
       expect(attackerThread).toBeNull();
     });
   });
+
+  describe('v2 - network', () => {
+    let dummyModel: MockLanguageModelV2;
+
+    beforeEach(() => {
+      dummyModel = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          text: {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: JSON.stringify({
+              isComplete: true,
+              completionReason: 'test',
+              finalResult: 'Reserved keys test response',
+            }),
+          },
+          content: [{ type: 'text', text: 'Reserved keys test response' }],
+          warnings: [],
+        }),
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 'text-1' },
+            {
+              type: 'text-delta',
+              id: 'text-1',
+              delta: JSON.stringify({
+                isComplete: true,
+                completionReason: 'test',
+                finalResult: 'Reserved keys test response',
+              }),
+            },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+          ]),
+        }),
+      });
+    });
+
+    it('should use mastra__resourceId and mastra__threadId from RequestContext', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'stream-context-user');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'stream-context-thread');
+
+      const streamResult = await agent.network('hello', {
+        requestContext,
+      });
+
+      for await (const _chunk of streamResult) {
+        // consume
+      }
+
+      const thread = await mockMemory.getThreadById({ threadId: 'stream-context-thread' });
+      expect(thread).toBeDefined();
+      expect(thread?.id).toBe('stream-context-thread');
+      expect(thread?.resourceId).toBe('stream-context-user');
+    });
+
+    it('RequestContext reserved keys should take precedence over memory option values', async () => {
+      const mockMemory = new MockMemory();
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'middleware-resource');
+      requestContext.set(MASTRA_THREAD_ID_KEY, 'middleware-thread');
+
+      const streamResult = await agent.network('hello', {
+        requestContext,
+        // Using the new memory option format - these should be overridden by RequestContext
+        memory: {
+          resource: 'body-resource-should-be-ignored',
+          thread: 'body-thread-should-be-ignored',
+        },
+      });
+
+      for await (const _chunk of streamResult) {
+        // consume
+      }
+
+      // The middleware values should win
+      const middlewareThread = await mockMemory.getThreadById({ threadId: 'middleware-thread' });
+      expect(middlewareThread).toBeDefined();
+      expect(middlewareThread?.id).toBe('middleware-thread');
+      expect(middlewareThread?.resourceId).toBe('middleware-resource');
+
+      // The body values should NOT be used
+      const bodyThread = await mockMemory.getThreadById({ threadId: 'body-thread-should-be-ignored' });
+      expect(bodyThread).toBeNull();
+    });
+  });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2906,6 +2906,17 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
     const runId = options?.runId || this.#mastra?.generateId() || randomUUID();
     const requestContextToUse = options?.requestContext || new RequestContext();
 
+    // Reserved keys from requestContext take precedence for security.
+    // This allows middleware to securely set resourceId/threadId based on authenticated user,
+    // preventing attackers from hijacking another user's memory by passing different values in the body.
+    const resourceIdFromContext = requestContextToUse.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+    const threadIdFromContext = requestContextToUse.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+
+    const threadId =
+      threadIdFromContext ||
+      (typeof options?.memory?.thread === 'string' ? options?.memory?.thread : options?.memory?.thread?.id);
+    const resourceId = resourceIdFromContext || options?.memory?.resource;
+
     return await networkLoop({
       networkName: this.name,
       requestContext: requestContextToUse,
@@ -2918,8 +2929,8 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
       generateId: () => this.#mastra?.generateId() || randomUUID(),
       maxIterations: options?.maxSteps || 1,
       messages,
-      threadId: typeof options?.memory?.thread === 'string' ? options?.memory?.thread : options?.memory?.thread?.id,
-      resourceId: options?.memory?.resource,
+      threadId,
+      resourceId,
     });
   }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
add MxASTRA_RESOURCE_ID_KEY from requestContext to nework

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes #11106

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a bug where network operations were ignoring request context identifiers, ensuring these values now correctly take precedence over memory-based configuration.

## Tests
* Added comprehensive test coverage validating that request context identifiers are properly used in both standard and streaming network operations with correct precedence rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->