### PR TITLE
fix: dark mode text and input styles

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -2,7 +2,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is([data-theme= "dark"] *));
+@custom-variant dark (&:is([data-theme="dark"] *));
 
 /* ==================== LIGHT MODE ==================== */
 :root {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -513,17 +513,6 @@ p {
   animation: slideDownAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-input:-webkit-autofill,
-input:-webkit-autofill:hover,
-input:-webkit-autofill:focus,
-textarea:-webkit-autofill,
-textarea:-webkit-autofill:hover,
-textarea:-webkit-autofill:focus {
-  -webkit-box-shadow: 0 0 0px 1000px var(--ifm-background-color) inset !important;
-  /* you might also set text-fill colour if needed */
-  -webkit-text-fill-color: #000 !important;
-}
-
 .menu,
 pre,
 [class*="tableOfContents"],


### PR DESCRIPTION
## Description

Fixed dark mode text color and input styles for the newsletter subscription form. Ensured `dark:text-white` works correctly and updated CSS variable syntax for Tailwind compatibility.

## Before
<img width="659" height="449" alt="Screenshot 2025-12-12 150645" src="https://github.com/user-attachments/assets/af837de7-1e7f-47d4-a558-e6576fc2537c" />
<img width="334" height="266" alt="Screenshot 2025-12-12 152502" src="https://github.com/user-attachments/assets/6400ff3e-21c5-404b-8135-8a4d7512305d" />


## After
<img width="634" height="416" alt="Screenshot 2025-12-12 151000" src="https://github.com/user-attachments/assets/786215ca-2df8-480a-8d67-4f0e0fc7fba2" />
<img width="334" height="266" alt="Screenshot 2025-12-12 152502" src="https://github.com/user-attachments/assets/5972f2bd-d458-4a8a-aa8f-2c8d3daea3a3" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Fixed CSS selector formatting for the dark-theme variant for consistency.
  * Removed a previous override of browser autofill styling so form fields now show the browser's native autofill appearance (no more light-mode visual override).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->