### PR TITLE
fix(core/workflows): Correctly handle resourceId in workflows

### DIFF
--- a/.changeset/olive-hands-tell.md
+++ b/.changeset/olive-hands-tell.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+---
+
+Fix workflow createRun() to properly handle resourceId parameter and read from RequestContext
+
+Workflows now correctly handle the `resourceId` parameter, matching the behavior of agents:
+
+- `EventedWorkflow.createRun({ resourceId })` now passes resourceId to the run and persists it in storage
+- Workflows read `MASTRA_RESOURCE_ID_KEY` from RequestContext, allowing middleware to securely set resourceId
+- RequestContext values take precedence over parameters for security (prevents resourceId hijacking)
+- resourceId persists through workflow suspend/resume cycles
+
+This fixes issue #11082 where the resourceId column in `mastra_workflow_snapshot` remained empty.

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -125,8 +125,9 @@ export class WorkflowEventProcessor extends EventProcessor {
     stepResults,
     requestContext,
   }: ProcessorArgs) {
-    // Extract resourceId from requestContext
-    const resourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined;
+    // Extract resourceId from requestContext with type validation
+    const contextValue = requestContext?.[MASTRA_RESOURCE_ID_KEY];
+    const resourceId = typeof contextValue === 'string' ? contextValue : undefined;
 
     await this.mastra.getStorage()?.persistWorkflowSnapshot({
       workflowName: workflow.id,

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -4,7 +4,7 @@ import { ErrorCategory, ErrorDomain, MastraError, getErrorFromUnknown } from '..
 import { EventProcessor } from '../../../events/processor';
 import type { Event } from '../../../events/types';
 import type { Mastra } from '../../../mastra';
-import { RequestContext } from '../../../request-context/';
+import { RequestContext, MASTRA_RESOURCE_ID_KEY } from '../../../request-context/';
 import type { StepFlowEntry, StepResult, TimeTravelExecutionParams, WorkflowRunState } from '../../../workflows/types';
 import type { Workflow } from '../../../workflows/workflow';
 import { createTimeTravelExecutionParams, validateStepResumeData } from '../../utils';
@@ -125,9 +125,13 @@ export class WorkflowEventProcessor extends EventProcessor {
     stepResults,
     requestContext,
   }: ProcessorArgs) {
+    // Extract resourceId from requestContext
+    const resourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined;
+
     await this.mastra.getStorage()?.persistWorkflowSnapshot({
       workflowName: workflow.id,
       runId,
+      resourceId,
       snapshot: {
         activePaths: [],
         suspendedPaths: {},

--- a/packages/core/src/workflows/evented/workflow-resourceId.test.ts
+++ b/packages/core/src/workflows/evented/workflow-resourceId.test.ts
@@ -10,12 +10,18 @@ import { createStep, createWorkflow } from '.';
 const testStorage = new MockStore();
 
 describe('Workflow resourceId', () => {
+  let mastra: Mastra | null = null;
+
   beforeEach(() => {
     vi.resetAllMocks();
     testStorage.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (mastra) {
+      await mastra.stopEventEngine();
+      mastra = null;
+    }
     testStorage.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
   });
 
@@ -35,7 +41,7 @@ describe('Workflow resourceId', () => {
     });
     workflow.then(step1).commit();
 
-    const mastra = new Mastra({
+    mastra = new Mastra({
       workflows: { 'test-workflow': workflow },
       storage: testStorage,
       pubsub: new EventEmitterPubSub(),
@@ -85,7 +91,7 @@ describe('Workflow resourceId', () => {
     });
     workflow.then(step1).commit();
 
-    const mastra = new Mastra({
+    mastra = new Mastra({
       workflows: { 'test-workflow': workflow },
       storage: testStorage,
       pubsub: new EventEmitterPubSub(),
@@ -131,7 +137,7 @@ describe('Workflow resourceId', () => {
     });
     workflow.then(step1).commit();
 
-    const mastra = new Mastra({
+    mastra = new Mastra({
       workflows: { 'test-workflow': workflow },
       storage: testStorage,
       pubsub: new EventEmitterPubSub(),
@@ -185,7 +191,7 @@ describe('Workflow resourceId', () => {
     });
     workflow.then(step1).commit();
 
-    const mastra = new Mastra({
+    mastra = new Mastra({
       workflows: { 'test-workflow': workflow },
       storage: testStorage,
       pubsub: new EventEmitterPubSub(),

--- a/packages/core/src/workflows/evented/workflow-resourceId.test.ts
+++ b/packages/core/src/workflows/evented/workflow-resourceId.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { RequestContext, MASTRA_RESOURCE_ID_KEY } from '../../di';
+import { EventEmitterPubSub } from '../../events/event-emitter';
+import { Mastra } from '../../mastra';
+import { TABLE_WORKFLOW_SNAPSHOT } from '../../storage';
+import { MockStore } from '../../storage/mock';
+import { createStep, createWorkflow } from '.';
+
+const testStorage = new MockStore();
+
+describe('Workflow resourceId', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    testStorage.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
+  });
+
+  afterEach(() => {
+    testStorage.clearTable({ tableName: TABLE_WORKFLOW_SNAPSHOT });
+  });
+
+  it('should persist resourceId passed to createRun()', async () => {
+    const step1 = createStep({
+      id: 'step1',
+      execute: async () => ({ result: 'success' }),
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'test-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      steps: [step1],
+    });
+    workflow.then(step1).commit();
+
+    const mastra = new Mastra({
+      workflows: { 'test-workflow': workflow },
+      storage: testStorage,
+      pubsub: new EventEmitterPubSub(),
+    });
+    await mastra.startEventEngine();
+
+    const runId = 'test-run-id';
+    const resourceId = 'user-123';
+
+    const run = await workflow.createRun({
+      runId,
+      resourceId,
+    });
+
+    await run.start({ inputData: {} });
+
+    // Check if resourceId was persisted
+    const snapshot = await testStorage.loadWorkflowSnapshot({
+      workflowName: 'test-workflow',
+      runId,
+    });
+
+    expect(snapshot).toBeTruthy();
+
+    // Get the stored workflow run to check resourceId
+    const workflowRun = await testStorage.getWorkflowRunById({
+      runId,
+      workflowName: 'test-workflow',
+    });
+
+    expect(workflowRun?.resourceId).toBe(resourceId);
+  });
+
+  it('should read resourceId from RequestContext', async () => {
+    const step1 = createStep({
+      id: 'step1',
+      execute: async () => ({ result: 'success' }),
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'test-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      steps: [step1],
+    });
+    workflow.then(step1).commit();
+
+    const mastra = new Mastra({
+      workflows: { 'test-workflow': workflow },
+      storage: testStorage,
+      pubsub: new EventEmitterPubSub(),
+    });
+    await mastra.startEventEngine();
+
+    const runId = 'test-run-id';
+    const resourceId = 'user-from-context-456';
+
+    const run = await workflow.createRun({ runId });
+
+    // Set resourceId in RequestContext (like middleware would do)
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceId);
+
+    await run.start({
+      inputData: {},
+      requestContext,
+    });
+
+    // Get the stored workflow run to check resourceId
+    const workflowRun = await testStorage.getWorkflowRunById({
+      runId,
+      workflowName: 'test-workflow',
+    });
+
+    expect(workflowRun?.resourceId).toBe(resourceId);
+  });
+
+  it('should prioritize RequestContext resourceId over parameter (for security)', async () => {
+    const step1 = createStep({
+      id: 'step1',
+      execute: async () => ({ result: 'success' }),
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'test-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      steps: [step1],
+    });
+    workflow.then(step1).commit();
+
+    const mastra = new Mastra({
+      workflows: { 'test-workflow': workflow },
+      storage: testStorage,
+      pubsub: new EventEmitterPubSub(),
+    });
+    await mastra.startEventEngine();
+
+    const runId = 'test-run-id';
+    const resourceIdFromParam = 'malicious-user-999'; // Attacker trying to hijack
+    const resourceIdFromContext = 'authenticated-user-123'; // Set by secure middleware
+
+    const run = await workflow.createRun({
+      runId,
+      resourceId: resourceIdFromParam,
+    });
+
+    // Middleware sets authenticated user's resourceId
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceIdFromContext);
+
+    await run.start({
+      inputData: {},
+      requestContext,
+    });
+
+    const workflowRun = await testStorage.getWorkflowRunById({
+      runId,
+      workflowName: 'test-workflow',
+    });
+
+    expect(workflowRun?.resourceId).toBe(resourceIdFromContext);
+    expect(workflowRun?.resourceId).not.toBe(resourceIdFromParam);
+  });
+
+  it('should persist resourceId on workflow resume', async () => {
+    const step1 = createStep({
+      id: 'step1',
+      execute: async ({ suspend }) => {
+        return suspend({ reason: 'waiting' });
+      },
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+      suspendSchema: z.object({ reason: z.string() }),
+      resumeSchema: z.object({ approved: z.boolean() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'test-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      steps: [step1],
+    });
+    workflow.then(step1).commit();
+
+    const mastra = new Mastra({
+      workflows: { 'test-workflow': workflow },
+      storage: testStorage,
+      pubsub: new EventEmitterPubSub(),
+    });
+    await mastra.startEventEngine();
+
+    const runId = 'test-run-id';
+    const resourceId = 'user-789';
+
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceId);
+
+    const run = await workflow.createRun({ runId });
+    const result = await run.start({
+      inputData: {},
+      requestContext,
+    });
+
+    expect(result.status).toBe('suspended');
+
+    // Resume with same resourceId in context
+    await run.resume({
+      step: step1,
+      resumeData: { approved: true },
+      requestContext,
+    });
+
+    // Check resourceId is still persisted after resume
+    const workflowRun = await testStorage.getWorkflowRunById({
+      runId,
+      workflowName: 'test-workflow',
+    });
+
+    expect(workflowRun?.resourceId).toBe(resourceId);
+  });
+});

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -464,11 +464,13 @@ export class EventedRun<
 
     // Extract resourceId from RequestContext with precedence over constructor parameter
     // This matches agent behavior for security (prevents attackers from hijacking another user's memory)
-    const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+    const contextValue = requestContext.get(MASTRA_RESOURCE_ID_KEY);
+    const resourceIdFromContext = typeof contextValue === 'string' ? contextValue : undefined;
     const resourceId = resourceIdFromContext || this.resourceId;
 
     // If we have a resourceId, ensure it's in the RequestContext so it's available throughout execution
-    if (resourceId && !resourceIdFromContext) {
+    // Only set if it's a valid string value
+    if (resourceId && typeof resourceId === 'string' && !resourceIdFromContext) {
       requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceId);
     }
 
@@ -552,11 +554,13 @@ export class EventedRun<
     requestContext = requestContext ?? new RequestContext();
 
     // Extract resourceId from RequestContext with precedence over constructor parameter
-    const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+    const contextValue = requestContext.get(MASTRA_RESOURCE_ID_KEY);
+    const resourceIdFromContext = typeof contextValue === 'string' ? contextValue : undefined;
     const resourceId = resourceIdFromContext || this.resourceId;
 
     // If we have a resourceId, ensure it's in the RequestContext so it's available throughout execution
-    if (resourceId && !resourceIdFromContext) {
+    // Only set if it's a valid string value
+    if (resourceId && typeof resourceId === 'string' && !resourceIdFromContext) {
       requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceId);
     }
 

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import z from 'zod';
 import type { Agent } from '../../agent';
-import { RequestContext, MASTRA_RESOURCE_ID_KEY } from '../../request-context';
 import type { Event } from '../../events';
 import type { Mastra } from '../../mastra';
+import { RequestContext, MASTRA_RESOURCE_ID_KEY } from '../../request-context';
 import { Tool } from '../../tools';
 import type { ToolExecutionContext } from '../../tools/types';
 import { Workflow, Run } from '../../workflows';

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import z from 'zod';
 import type { Agent } from '../../agent';
-import { RequestContext, MASTRA_RESOURCE_ID_KEY } from '../../di';
+import { RequestContext, MASTRA_RESOURCE_ID_KEY } from '../../request-context';
 import type { Event } from '../../events';
 import type { Mastra } from '../../mastra';
 import { Tool } from '../../tools';


### PR DESCRIPTION
## Description

This PR addresses issue by ensuring that the `resourceId` parameter is properly utilized in the `EventedWorkflow.createRun()` method. The changes include:

- Updated `createRun()` to accept and pass `resourceId` to the `EventedRun` constructor.
- Enhanced `EventedRun` methods to extract `resourceId` from `RequestContext`, prioritizing it for security.
- Ensured `resourceId` is persisted in the `mastra_workflow_snapshot` table during workflow execution and resume cycles.

Comprehensive tests have been added to verify the correct handling of `resourceId` in various scenarios, ensuring backward compatibility and adherence to security practices.

## Related Issue(s)

Fix #11082

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs can accept an optional resourceId at creation to enable per-resource scoping.

* **Bug Fixes**
  * Persisted workflow snapshots now include resourceId.
  * resourceId is preserved across suspend/resume cycles.
  * resourceId from the request context takes precedence over supplied parameters for execution.

* **Tests**
  * Added tests covering resourceId persistence and precedence across create/start/resume flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->