### PR TITLE
fix(core): disable validateInputs for processor workflows to fix Zod 4 compatibility

### DIFF
--- a/.changeset/fruity-eyes-raise.md
+++ b/.changeset/fruity-eyes-raise.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fix Zod 4 compatibility issue with structuredOutput in agent.generate()
+
+Users with Zod 4 installed would see `TypeError: undefined is not an object (evaluating 'def.valueType._zod')` when using `structuredOutput` with agent.generate(). This happened because ProcessorStepSchema contains `z.custom()` fields that hold user-provided Zod schemas, and the workflow validation was trying to deeply validate these schemas causing version conflicts.
+
+The fix disables input validation for processor workflows since `z.custom()` fields are meant to pass through arbitrary types without deep validation.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -372,11 +372,15 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
 
     // Create a single workflow with all processors chained
     // Mark it as a processor workflow type
+    // validateInputs is disabled because ProcessorStepSchema contains z.custom() fields
+    // that may hold user-provided Zod schemas. When users use Zod 4 schemas while Mastra
+    // uses Zod 3 internally, validation fails due to incompatible internal structures.
     let workflow = createWorkflow({
       id: workflowId,
       inputSchema: ProcessorStepSchema,
       outputSchema: ProcessorStepSchema,
       type: 'processor',
+      options: { validateInputs: false },
     });
 
     for (const processorOrWorkflow of validProcessors) {


### PR DESCRIPTION
## Summary

- Disables `validateInputs` for processor workflows to fix Zod 4 compatibility issue

## Context

`ProcessorStepSchema` contains `z.custom()` fields that may hold user-provided Zod schemas (e.g., `structuredOutput.schema`). When users install Zod 4 while Mastra uses Zod 3 internally (or vice versa), validation fails because Zod 4's internal structure (`._zod`) is incompatible with Zod 3's parser.

This fixes #11121 where users with Zod 4 would see:
```
TypeError: undefined is not an object (evaluating 'def.valueType._zod')
```

The fix disables input validation for processor workflows since they use `z.custom()` fields specifically to pass through arbitrary types without deep validation.

## Test plan

- [x] Tested with reproduction example from issue - structured output now works with Zod 4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a TypeError when using structured output with processor workflows by improving compatibility with Zod 4 custom schemas.

* **Documentation**
  * Added a changelog entry describing the Zod 4 compatibility patch for processor workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->