### PR TITLE
feat(github-workflows): add cron jobs for Discord to GitHub sync and …

### DIFF
--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -27,19 +27,19 @@ jobs:
       - name: Create and execute workflow run
         run: |
           set -e
-          
+
           WORKFLOW_NAME="${{ inputs.workflow_name }}"
           BASE_URL="${{ inputs.base_url }}"
-          
+
           # Validate workflow_name to prevent unsafe characters in URL paths
           if ! echo "$WORKFLOW_NAME" | grep -Eq '^[a-zA-Z0-9_-]+$'; then
             echo "Error: Invalid workflow_name '$WORKFLOW_NAME'"
             echo "Workflow name must contain only alphanumeric characters, underscores, and hyphens"
             exit 1
           fi
-          
+
           echo "Creating workflow run for: $WORKFLOW_NAME"
-          
+
           # Create the workflow run and capture the runId
           http_code=$(curl -w "%{http_code}" -o /tmp/create_response.json -s \
             --max-time 30 \
@@ -48,33 +48,33 @@ jobs:
             -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
             -H 'Referer: https://cloud.mastra.ai/' \
             -H 'User-Agent: Github Action')
-          
+
           create_response=$(cat /tmp/create_response.json)
-          
+
           # Check HTTP response code
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
             echo "Error: Create-run request failed with HTTP code $http_code"
             echo "Response: $create_response"
             exit 1
           fi
-          
+
           # Extract runId from the response
           runId=$(echo "$create_response" | jq -r '.runId')
-          
+
           if [ "$runId" = "null" ] || [ -z "$runId" ]; then
             echo "Error: Failed to extract runId from response"
             echo "Response: $create_response"
             exit 1
           fi
-          
+
           echo "Successfully created workflow run with ID: $runId"
-          
+
           # Start the workflow with the runId
           echo "Starting workflow with runId: $runId"
-          
+
           # Use jq to properly escape and validate the input data
           echo '${{ inputs.input_data }}' | jq -c . > /tmp/input_data.json
-          
+
           http_code=$(curl -w "%{http_code}" -o /tmp/start_response.json -s \
             --max-time 300 \
             "${BASE_URL}/${WORKFLOW_NAME}/start?runId=${runId}" \
@@ -84,18 +84,17 @@ jobs:
             -H 'User-Agent: Github Action' \
             -H 'Content-Type: application/json' \
             --data-binary @/tmp/input_data.json)
-          
+
           start_response=$(cat /tmp/start_response.json)
-          
+
           # Check HTTP response code
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
             echo "Error: Start workflow request failed with HTTP code $http_code"
             echo "Response: $start_response"
             exit 1
           fi
-          
+
           echo "Workflow start response (HTTP $http_code):"
           echo "$start_response" | jq .
-          
-          echo "Workflow execution completed successfully"
 
+          echo "Workflow execution completed successfully"

--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -1,0 +1,86 @@
+name: Call External Mastra Workflow
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        description: 'Name of the external workflow to execute'
+        required: true
+        type: string
+      input_data:
+        description: 'JSON input data for the workflow'
+        required: true
+        type: string
+    secrets:
+      MASTRA_TRIAGE_JWT_KEY:
+        required: true
+
+jobs:
+  execute-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create and execute workflow run
+        run: |
+          set -e
+          
+          WORKFLOW_NAME="${{ inputs.workflow_name }}"
+          BASE_URL="https://shrilling-scarce-finland.mastra.cloud/api/workflows"
+          
+          echo "Creating workflow run for: $WORKFLOW_NAME"
+          
+          # Create the workflow run and capture the runId
+          http_code=$(curl -w "%{http_code}" -o /tmp/create_response.json -s \
+            --max-time 30 \
+            "${BASE_URL}/${WORKFLOW_NAME}/create-run" \
+            -X 'POST' \
+            -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
+            -H 'Referer: https://cloud.mastra.ai/' \
+            -H 'User-Agent: Github Action')
+          
+          create_response=$(cat /tmp/create_response.json)
+          
+          # Check HTTP response code
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Error: Create-run request failed with HTTP code $http_code"
+            echo "Response: $create_response"
+            exit 1
+          fi
+          
+          # Extract runId from the response
+          runId=$(echo "$create_response" | jq -r '.runId')
+          
+          if [ "$runId" = "null" ] || [ -z "$runId" ]; then
+            echo "Error: Failed to extract runId from response"
+            echo "Response: $create_response"
+            exit 1
+          fi
+          
+          echo "Successfully created workflow run with ID: $runId"
+          
+          # Start the workflow with the runId
+          echo "Starting workflow with runId: $runId"
+          
+          http_code=$(curl -w "%{http_code}" -o /tmp/start_response.json -s \
+            --max-time 300 \
+            "${BASE_URL}/${WORKFLOW_NAME}/start?runId=${runId}" \
+            -X 'POST' \
+            -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
+            -H 'Referer: https://cloud.mastra.ai/' \
+            -H 'User-Agent: Github Action' \
+            -H 'Content-Type: application/json' \
+            --data-raw '${{ inputs.input_data }}')
+          
+          start_response=$(cat /tmp/start_response.json)
+          
+          # Check HTTP response code
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Error: Start workflow request failed with HTTP code $http_code"
+            echo "Response: $start_response"
+            exit 1
+          fi
+          
+          echo "Workflow start response (HTTP $http_code):"
+          echo "$start_response" | jq .
+          
+          echo "Workflow execution completed successfully"
+

--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -31,6 +31,13 @@ jobs:
           WORKFLOW_NAME="${{ inputs.workflow_name }}"
           BASE_URL="${{ inputs.base_url }}"
           
+          # Validate workflow_name to prevent unsafe characters in URL paths
+          if ! echo "$WORKFLOW_NAME" | grep -Eq '^[a-zA-Z0-9_-]+$'; then
+            echo "Error: Invalid workflow_name '$WORKFLOW_NAME'"
+            echo "Workflow name must contain only alphanumeric characters, underscores, and hyphens"
+            exit 1
+          fi
+          
           echo "Creating workflow run for: $WORKFLOW_NAME"
           
           # Create the workflow run and capture the runId

--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -11,6 +11,10 @@ on:
         description: 'JSON input data for the workflow'
         required: true
         type: string
+      base_url:
+        description: 'Base URL for the Mastra Cloud API'
+        required: true
+        type: string
     secrets:
       MASTRA_TRIAGE_JWT_KEY:
         required: true
@@ -25,7 +29,7 @@ jobs:
           set -e
           
           WORKFLOW_NAME="${{ inputs.workflow_name }}"
-          BASE_URL="https://shrilling-scarce-finland.mastra.cloud/api/workflows"
+          BASE_URL="${{ inputs.base_url }}"
           
           echo "Creating workflow run for: $WORKFLOW_NAME"
           
@@ -61,6 +65,9 @@ jobs:
           # Start the workflow with the runId
           echo "Starting workflow with runId: $runId"
           
+          # Use jq to properly escape and validate the input data
+          echo '${{ inputs.input_data }}' | jq -c . > /tmp/input_data.json
+          
           http_code=$(curl -w "%{http_code}" -o /tmp/start_response.json -s \
             --max-time 300 \
             "${BASE_URL}/${WORKFLOW_NAME}/start?runId=${runId}" \
@@ -69,7 +76,7 @@ jobs:
             -H 'Referer: https://cloud.mastra.ai/' \
             -H 'User-Agent: Github Action' \
             -H 'Content-Type: application/json' \
-            --data-raw '${{ inputs.input_data }}')
+            --data-binary @/tmp/input_data.json)
           
           start_response=$(cat /tmp/start_response.json)
           

--- a/.github/workflows/call-external-mastra-workflow.yml
+++ b/.github/workflows/call-external-mastra-workflow.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   execute-workflow:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: Create and execute workflow run

--- a/.github/workflows/cron-discord-github-sync.yml
+++ b/.github/workflows/cron-discord-github-sync.yml
@@ -1,4 +1,4 @@
-name: Discord Triage Cron
+name: Discord to GitHub Sync Cron
 permissions:
   contents: none
 
@@ -9,13 +9,13 @@ on:
   workflow_dispatch: # Allow manual triggering
 
 jobs:
-  discord-triage:
+  discord-github-sync:
     runs-on: ubuntu-latest
     steps:
       - name: Create workflow run and execute
         run: |
           # Create the workflow run and capture the runId
-          response=$(curl -s 'https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordToGithubWorkflow/create-run' \
+          response=$(curl -s 'https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordSyncWorkflow/create-run' \
             -X 'POST' \
             -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
             -H 'Referer: https://cloud.mastra.ai/' \
@@ -29,13 +29,13 @@ jobs:
             
             # Follow-up request using the runId
             echo "Starting workflow with runId: $runId"
-            start_response=$(curl --max-time 300 "https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordToGithubWorkflow/start?runId=$runId" \
+            start_response=$(curl --max-time 300 "https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordSyncWorkflow/start?runId=$runId" \
               -X 'POST' \
               -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
               -H 'Referer: https://cloud.mastra.ai/' \
               -H 'User-Agent: Github Action' \
               -H 'Content-Type: application/json' \
-              --data-raw '{"inputData":{"forumChannelId":"1349006916902191125","fetchLimit":1},"requestContext":{}}')
+              --data-raw '{"inputData":{"owner":"mastra-ai","repo":"mastra"},"requestContext":{}}')
             
             echo "Workflow start response:"
             echo "$start_response" | jq .

--- a/.github/workflows/cron-discord-github-sync.yml
+++ b/.github/workflows/cron-discord-github-sync.yml
@@ -10,36 +10,9 @@ on:
 
 jobs:
   discord-github-sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create workflow run and execute
-        run: |
-          # Create the workflow run and capture the runId
-          response=$(curl -s 'https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordSyncWorkflow/create-run' \
-            -X 'POST' \
-            -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
-            -H 'Referer: https://cloud.mastra.ai/' \
-            -H 'User-Agent: Github Action')
-
-          # Extract runId from the response
-          runId=$(echo "$response" | jq -r '.runId')
-
-          if [ "$runId" != "null" ] && [ -n "$runId" ]; then
-            echo "Created workflow run with ID: $runId"
-            
-            # Follow-up request using the runId
-            echo "Starting workflow with runId: $runId"
-            start_response=$(curl --max-time 300 "https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordSyncWorkflow/start?runId=$runId" \
-              -X 'POST' \
-              -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
-              -H 'Referer: https://cloud.mastra.ai/' \
-              -H 'User-Agent: Github Action' \
-              -H 'Content-Type: application/json' \
-              --data-raw '{"inputData":{"owner":"mastra-ai","repo":"mastra"},"requestContext":{}}')
-            
-            echo "Workflow start response:"
-            echo "$start_response" | jq .
-          else
-            echo "Failed to get runId from response: $response"
-            exit 1
-          fi
+    uses: ./.github/workflows/call-external-mastra-workflow.yml
+    with:
+      workflow_name: discordSyncWorkflow
+      input_data: '{"inputData":{"owner":"mastra-ai","repo":"mastra"},"requestContext":{}}'
+    secrets:
+      MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}

--- a/.github/workflows/cron-discord-github-sync.yml
+++ b/.github/workflows/cron-discord-github-sync.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       workflow_name: discordSyncWorkflow
       input_data: '{"inputData":{"owner":"mastra-ai","repo":"mastra"},"requestContext":{}}'
+      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL }}
     secrets:
       MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}

--- a/.github/workflows/cron-discord-triage.yml
+++ b/.github/workflows/cron-discord-triage.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       workflow_name: discordToGithubWorkflow
       input_data: '{"inputData":{"forumChannelId":"1349006916902191125","fetchLimit":1},"requestContext":{}}'
+      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL }}
     secrets:
       MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}

--- a/.github/workflows/cron-discord-triage.yml
+++ b/.github/workflows/cron-discord-triage.yml
@@ -10,36 +10,9 @@ on:
 
 jobs:
   discord-triage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create workflow run and execute
-        run: |
-          # Create the workflow run and capture the runId
-          response=$(curl -s 'https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordToGithubWorkflow/create-run' \
-            -X 'POST' \
-            -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
-            -H 'Referer: https://cloud.mastra.ai/' \
-            -H 'User-Agent: Github Action')
-
-          # Extract runId from the response
-          runId=$(echo "$response" | jq -r '.runId')
-
-          if [ "$runId" != "null" ] && [ -n "$runId" ]; then
-            echo "Created workflow run with ID: $runId"
-            
-            # Follow-up request using the runId
-            echo "Starting workflow with runId: $runId"
-            start_response=$(curl --max-time 300 "https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordToGithubWorkflow/start?runId=$runId" \
-              -X 'POST' \
-              -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
-              -H 'Referer: https://cloud.mastra.ai/' \
-              -H 'User-Agent: Github Action' \
-              -H 'Content-Type: application/json' \
-              --data-raw '{"inputData":{"forumChannelId":"1349006916902191125","fetchLimit":1},"requestContext":{}}')
-            
-            echo "Workflow start response:"
-            echo "$start_response" | jq .
-          else
-            echo "Failed to get runId from response: $response"
-            exit 1
-          fi
+    uses: ./.github/workflows/call-external-mastra-workflow.yml
+    with:
+      workflow_name: discordToGithubWorkflow
+      input_data: '{"inputData":{"forumChannelId":"1349006916902191125","fetchLimit":1},"requestContext":{}}'
+    secrets:
+      MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}

--- a/.github/workflows/cron-github-issues-follow-up.yml
+++ b/.github/workflows/cron-github-issues-follow-up.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       workflow_name: githubIssueManagerWorkflow
       input_data: '{"inputData":{"owner":"mastra-ai","repo":"mastra","batchSize":100},"requestContext":{}}'
+      base_url: ${{ vars.MASTRA_CLOUD_BASE_URL }}
     secrets:
       MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}

--- a/.github/workflows/cron-github-issues-follow-up.yml
+++ b/.github/workflows/cron-github-issues-follow-up.yml
@@ -1,4 +1,4 @@
-name: Discord Triage Cron
+name: GitHub Issues Follow-Up Cron
 permissions:
   contents: none
 
@@ -9,13 +9,13 @@ on:
   workflow_dispatch: # Allow manual triggering
 
 jobs:
-  discord-triage:
+  github-issues-follow-up:
     runs-on: ubuntu-latest
     steps:
       - name: Create workflow run and execute
         run: |
           # Create the workflow run and capture the runId
-          response=$(curl -s 'https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordToGithubWorkflow/create-run' \
+          response=$(curl -s 'https://shrilling-scarce-finland.mastra.cloud/api/workflows/githubIssueManagerWorkflow/create-run' \
             -X 'POST' \
             -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
             -H 'Referer: https://cloud.mastra.ai/' \
@@ -29,13 +29,13 @@ jobs:
             
             # Follow-up request using the runId
             echo "Starting workflow with runId: $runId"
-            start_response=$(curl --max-time 300 "https://shrilling-scarce-finland.mastra.cloud/api/workflows/discordToGithubWorkflow/start?runId=$runId" \
+            start_response=$(curl --max-time 300 "https://shrilling-scarce-finland.mastra.cloud/api/workflows/githubIssueManagerWorkflow/start?runId=$runId" \
               -X 'POST' \
               -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
               -H 'Referer: https://cloud.mastra.ai/' \
               -H 'User-Agent: Github Action' \
               -H 'Content-Type: application/json' \
-              --data-raw '{"inputData":{"forumChannelId":"1349006916902191125","fetchLimit":1},"requestContext":{}}')
+              --data-raw '{"inputData":{"owner":"mastra-ai","repo":"mastra","batchSize":100},"requestContext":{}}')
             
             echo "Workflow start response:"
             echo "$start_response" | jq .

--- a/.github/workflows/cron-github-issues-follow-up.yml
+++ b/.github/workflows/cron-github-issues-follow-up.yml
@@ -10,36 +10,9 @@ on:
 
 jobs:
   github-issues-follow-up:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create workflow run and execute
-        run: |
-          # Create the workflow run and capture the runId
-          response=$(curl -s 'https://shrilling-scarce-finland.mastra.cloud/api/workflows/githubIssueManagerWorkflow/create-run' \
-            -X 'POST' \
-            -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
-            -H 'Referer: https://cloud.mastra.ai/' \
-            -H 'User-Agent: Github Action')
-
-          # Extract runId from the response
-          runId=$(echo "$response" | jq -r '.runId')
-
-          if [ "$runId" != "null" ] && [ -n "$runId" ]; then
-            echo "Created workflow run with ID: $runId"
-            
-            # Follow-up request using the runId
-            echo "Starting workflow with runId: $runId"
-            start_response=$(curl --max-time 300 "https://shrilling-scarce-finland.mastra.cloud/api/workflows/githubIssueManagerWorkflow/start?runId=$runId" \
-              -X 'POST' \
-              -H 'Authorization: Bearer ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}' \
-              -H 'Referer: https://cloud.mastra.ai/' \
-              -H 'User-Agent: Github Action' \
-              -H 'Content-Type: application/json' \
-              --data-raw '{"inputData":{"owner":"mastra-ai","repo":"mastra","batchSize":100},"requestContext":{}}')
-            
-            echo "Workflow start response:"
-            echo "$start_response" | jq .
-          else
-            echo "Failed to get runId from response: $response"
-            exit 1
-          fi
+    uses: ./.github/workflows/call-external-mastra-workflow.yml
+    with:
+      workflow_name: githubIssueManagerWorkflow
+      input_data: '{"inputData":{"owner":"mastra-ai","repo":"mastra","batchSize":100},"requestContext":{}}'
+    secrets:
+      MASTRA_TRIAGE_JWT_KEY: ${{ secrets.MASTRA_TRIAGE_JWT_KEY }}


### PR DESCRIPTION
## Description

…GitHub issues follow-up

- the discord triage bots now runs every 2 hours
- I also added a cron that syncs discord messages to the github issue (when in waiting status or needs repro only for now
- added another cron jobs that mark GH issues as `status: needs follow up` when it was in waiting for answer or repro and an answer was provided

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added scheduled sync workflows for Discord→GitHub and GitHub issues follow-up, running every 2 hours with manual dispatch.
  * Updated Discord triage workflow to run every 2 hours and delegate execution to a reusable invocation.
  * Enhanced the reusable workflow invoker to accept a base URL, validate inputs, format and forward payloads, handle responses and errors more robustly, and centralize run creation/start logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->