### PR TITLE
feat(qdrant): add support for payload index creation

### DIFF
--- a/.changeset/add-qdrant-payload-index-support.md
+++ b/.changeset/add-qdrant-payload-index-support.md
@@ -11,3 +11,18 @@ This release introduces a new `createPayloadIndex()` method on the `QdrantVector
 - `createPayloadIndex(indexName, fieldName, fieldSchema)` - Method to create payload indexes with idempotent behavior on conflicts
 
 This change aligns Mastra's abstraction with Qdrant's native client capabilities and ensures metadata filters work consistently across all Qdrant deployment environments.
+
+**Example usage:**
+
+```typescript
+// Create a payload index for a metadata field before filtering
+const qdrant = new QdrantVector(config);
+
+// Create an index for a 'category' field (keyword type)
+await qdrant.createPayloadIndex('category-idx', 'category', 'keyword');
+
+// Now metadata-based filtering will work in strict-mode environments
+const results = await qdrant.query({
+  vector: [/* ... */],
+  filter: { key: 'category', match: { value: 'electronics' } }
+});

--- a/.changeset/add-qdrant-payload-index-support.md
+++ b/.changeset/add-qdrant-payload-index-support.md
@@ -1,0 +1,13 @@
+---
+'@mastra/qdrant': minor
+---
+
+Add support for creating payload (metadata) indexes in Qdrant
+
+This release introduces a new `createPayloadIndex()` method on the `QdrantVector` class, enabling explicit creation of payload indexes for metadata fields. This feature addresses production environments (e.g., Qdrant Cloud or deployments with `strict_mode_config = true`) that require explicit payload indexes for metadata-based filtering operations.
+
+**New exports:**
+- `PayloadSchemaType` - Type representing Qdrant payload schema types ('keyword', 'integer', 'float', 'geo', 'text', 'bool', 'datetime', 'uuid')
+- `createPayloadIndex(indexName, fieldName, fieldSchema)` - Method to create payload indexes with idempotent behavior on conflicts
+
+This change aligns Mastra's abstraction with Qdrant's native client capabilities and ensures metadata filters work consistently across all Qdrant deployment environments.

--- a/stores/qdrant/src/vector/index.test.ts
+++ b/stores/qdrant/src/vector/index.test.ts
@@ -955,19 +955,23 @@ describe('QdrantVector', () => {
       console.log(`${numQueries} concurrent queries took ${duration}ms`);
     }, 50000);
   });
+});
 
-  describe('Payload Index Operations', () => {
-    beforeAll(async () => {
-      qdrant = new QdrantVector({ url: 'http://localhost:6333/', id: 'qdrant-test' });
-      await qdrant.createIndex({ indexName: testCollectionName, dimension });
-    });
+// Metadata filtering tests for Memory system
+describe('Qdrant Metadata Filtering', () => {
+  const qdrantVector = new QdrantVector({ url: 'http://localhost:6333/', id: 'qdrant-metadata-test' });
 
-    afterAll(async () => {
-      await qdrant.deleteIndex({ indexName: testCollectionName });
-    }, 50000);
-
-    it('should create payload index', async () => {
-      await expect(qdrant.createPayloadIndex(testCollectionName, 'test_field', 'keyword')).resolves.not.toThrow();
-    }, 50000);
+  createVectorTestSuite({
+    vector: qdrantVector,
+    createIndex: async (indexName: string) => {
+      await qdrantVector.createIndex({ indexName, dimension: 1536 });
+    },
+    deleteIndex: async (indexName: string) => {
+      await qdrantVector.deleteIndex({ indexName });
+    },
+    waitForIndexing: async () => {
+      // Qdrant indexes immediately
+      await new Promise(resolve => setTimeout(resolve, 100));
+    },
   });
 });

--- a/stores/qdrant/src/vector/index.test.ts
+++ b/stores/qdrant/src/vector/index.test.ts
@@ -955,6 +955,21 @@ describe('QdrantVector', () => {
       console.log(`${numQueries} concurrent queries took ${duration}ms`);
     }, 50000);
   });
+
+  describe('Payload Index Operations', () => {
+    beforeAll(async () => {
+      qdrant = new QdrantVector({ url: 'http://localhost:6333/', id: 'qdrant-test' });
+      await qdrant.createIndex({ indexName: testCollectionName, dimension });
+    });
+
+    afterAll(async () => {
+      await qdrant.deleteIndex({ indexName: testCollectionName });
+    }, 50000);
+
+    it('should create payload index', async () => {
+      await expect(qdrant.createPayloadIndex(testCollectionName, 'test_field', 'keyword')).resolves.not.toThrow();
+    }, 50000);
+  });
 });
 
 // Metadata filtering tests for Memory system

--- a/stores/qdrant/src/vector/index.test.ts
+++ b/stores/qdrant/src/vector/index.test.ts
@@ -971,22 +971,3 @@ describe('QdrantVector', () => {
     }, 50000);
   });
 });
-
-// Metadata filtering tests for Memory system
-describe('Qdrant Metadata Filtering', () => {
-  const qdrantVector = new QdrantVector({ url: 'http://localhost:6333/', id: 'qdrant-metadata-test' });
-
-  createVectorTestSuite({
-    vector: qdrantVector,
-    createIndex: async (indexName: string) => {
-      await qdrantVector.createIndex({ indexName, dimension: 1536 });
-    },
-    deleteIndex: async (indexName: string) => {
-      await qdrantVector.deleteIndex({ indexName });
-    },
-    waitForIndexing: async () => {
-      // Qdrant indexes immediately
-      await new Promise(resolve => setTimeout(resolve, 100));
-    },
-  });
-});

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -131,19 +131,15 @@ export class QdrantVector extends MastraVector {
   }
 
   /**
- * Creates a payload index on a Qdrant collection to enable efficient filtering on metadata fields.
- *
- * @param indexName - The name of the collection (index) to create the payload index on.
- * @param fieldName - The name of the payload field to index.
- * @param fieldSchema - The schema type for the field (e.g., 'keyword', 'integer', 'text').
- * @returns A promise that resolves when the index is created (idempotent if the index already exists).
- * @throws Will throw a MastraError if arguments are invalid or if the operation fails.
- */
-  async createPayloadIndex(
-    indexName: string,
-    fieldName: string,
-    fieldSchema: PayloadSchemaType,
-  ): Promise<void> {
+   * Creates a payload index on a Qdrant collection to enable efficient filtering on metadata fields.
+   *
+   * @param indexName - The name of the collection (index) to create the payload index on.
+   * @param fieldName - The name of the payload field to index.
+   * @param fieldSchema - The schema type for the field (e.g., 'keyword', 'integer', 'text').
+   * @returns A promise that resolves when the index is created (idempotent if the index already exists).
+   * @throws Will throw a MastraError if arguments are invalid or if the operation fails.
+   */
+  async createPayloadIndex(indexName: string, fieldName: string, fieldSchema: PayloadSchemaType): Promise<void> {
     if (!indexName?.trim() || !fieldName?.trim()) {
       throw new MastraError({
         id: createVectorErrorId('QDRANT', 'CREATE_PAYLOAD_INDEX', 'INVALID_ARGS'),

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -28,6 +28,8 @@ const DISTANCE_MAPPING: Record<string, Schemas['Distance']> = {
 
 type QdrantQueryVectorParams = QueryVectorParams<QdrantVectorFilter>;
 
+export type PayloadSchemaType = 'keyword' | 'integer' | 'float' | 'geo' | 'text' | 'bool' | 'datetime' | 'uuid';
+
 export class QdrantVector extends MastraVector {
   private client: QdrantClient;
 
@@ -118,6 +120,30 @@ export class QdrantVector extends MastraVector {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: { indexName, dimension, metric },
+        },
+        error,
+      );
+    }
+  }
+
+  async createPayloadIndex(
+    indexName: string,
+    fieldName: string,
+    fieldSchema: PayloadSchemaType,
+  ): Promise<void> {
+    try {
+      await this.client.createPayloadIndex(indexName, {
+        field_name: fieldName,
+        field_schema: fieldSchema,
+        wait: true,
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createVectorErrorId('QDRANT', 'CREATE_PAYLOAD_INDEX', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, fieldName, fieldSchema },
         },
         error,
       );

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -130,6 +130,15 @@ export class QdrantVector extends MastraVector {
     }
   }
 
+  /**
+ * Creates a payload index on a Qdrant collection to enable efficient filtering on metadata fields.
+ *
+ * @param indexName - The name of the collection (index) to create the payload index on.
+ * @param fieldName - The name of the payload field to index.
+ * @param fieldSchema - The schema type for the field (e.g., 'keyword', 'integer', 'text').
+ * @returns A promise that resolves when the index is created (idempotent if the index already exists).
+ * @throws Will throw a MastraError if arguments are invalid or if the operation fails.
+ */
   async createPayloadIndex(
     indexName: string,
     fieldName: string,


### PR DESCRIPTION
## Description

This PR adds support for creating **payload (metadata) indexes** in the `@mastra/qdrant` integration.

Qdrant Cloud and other deployments with `strict_mode_config = true` require explicit payload indexes in order to perform metadata-based filtering. Until now, Mastra only created vector (collection) indexes, which caused metadata filters to work locally but fail in production environments.

This change exposes a dedicated `createPayloadIndex()` API on `QdrantVector`, aligning Mastra’s abstraction with Qdrant’s native client and enabling users to explicitly index metadata fields when required.

## Related Issue(s)

- #8923

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to create and configure payload (metadata) indexes for vector storage.
  * Supports eight payload schema types: keyword, integer, float, geo, text, bool, datetime, uuid.
  * Index creation is idempotent — creating an existing index will not fail.
  * Errors returned on failures include contextual information to aid debugging and retries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->