### PR TITLE
feat(core): add support for passing custom `assistantMessageId`

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2701,6 +2701,7 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
       agentId: this.id,
       agentName: this.name,
       toolCallId: options.toolCallId,
+      assistantMessageId: options.assistantMessageId,
     });
 
     const run = await executionWorkflow.createRun();

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2701,7 +2701,7 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
       agentId: this.id,
       agentName: this.name,
       toolCallId: options.toolCallId,
-      assistantMessageId: options.assistantMessageId,
+      assistantMessageId: options.memory?.assistantMessageId,
     });
 
     const run = await executionWorkflow.createRun();

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -133,9 +133,6 @@ export type AgentExecutionOptions<
 
   /** Whether to include raw chunks in the stream output (not available on all model providers) */
   includeRawChunks?: boolean;
-
-  /** Custom ID to use for the assistant response message when saving to memory */
-  assistantMessageId?: string;
 };
 
 export type InnerAgentExecutionOptions<

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -133,6 +133,9 @@ export type AgentExecutionOptions<
 
   /** Whether to include raw chunks in the stream output (not available on all model providers) */
   includeRawChunks?: boolean;
+
+  /** Custom ID to use for the assistant response message when saving to memory */
+  assistantMessageId?: string;
 };
 
 export type InnerAgentExecutionOptions<

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -222,6 +222,8 @@ export type AgentMemoryOption = {
   resource: string;
   options?: MemoryConfig;
   readOnly?: boolean;
+  /** Custom ID to use for the assistant response message when saving to memory */
+  assistantMessageId?: string;
 };
 
 /**

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -43,6 +43,7 @@ interface CreatePrepareStreamWorkflowOptions<
   agentId: string;
   agentName?: string;
   toolCallId?: string;
+  assistantMessageId?: string;
 }
 
 export function createPrepareStreamWorkflow<
@@ -68,6 +69,7 @@ export function createPrepareStreamWorkflow<
   agentId,
   agentName,
   toolCallId,
+  assistantMessageId,
 }: CreatePrepareStreamWorkflowOptions<OUTPUT, FORMAT>) {
   const prepareToolsStep = createPrepareToolsStep({
     capabilities,
@@ -110,6 +112,7 @@ export function createPrepareStreamWorkflow<
     memoryConfig,
     memory,
     resourceId,
+    assistantMessageId,
   });
 
   const mapResultsStep = createMapResultsStep({

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -29,6 +29,7 @@ interface StreamStepOptions {
   memoryConfig?: MemoryConfig;
   memory?: MastraMemory;
   resourceId?: string;
+  assistantMessageId?: string;
 }
 
 export function createStreamStep<OUTPUT extends OutputSchema | undefined = undefined>({
@@ -46,6 +47,7 @@ export function createStreamStep<OUTPUT extends OutputSchema | undefined = undef
   memoryConfig,
   memory,
   resourceId,
+  assistantMessageId,
 }: StreamStepOptions) {
   return createStep({
     id: 'stream-text-step',
@@ -94,6 +96,7 @@ export function createStreamStep<OUTPUT extends OutputSchema | undefined = undef
         agentName,
         toolCallId,
         methodType: modelMethodType,
+        assistantMessageId,
       });
 
       return streamResult;

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -166,6 +166,7 @@ export class MastraLLMVNext extends MastraBase {
     methodType,
     includeRawChunks,
     maxProcessorRetries,
+    assistantMessageId,
   }: ModelLoopStreamArgs<Tools, OUTPUT>): MastraModelOutput<OUTPUT> {
     let stopWhenToUse;
 
@@ -238,6 +239,7 @@ export class MastraLLMVNext extends MastraBase {
         methodType,
         includeRawChunks,
         maxProcessorRetries,
+        assistantMessageId,
         options: {
           ...options,
           onStepFinish: async props => {

--- a/packages/core/src/llm/model/model.loop.types.ts
+++ b/packages/core/src/llm/model/model.loop.types.ts
@@ -44,6 +44,7 @@ export type ModelLoopStreamArgs<TOOLS extends ToolSet, OUTPUT extends OutputSche
   threadId?: string;
   returnScorerData?: boolean;
   messageList: MessageList;
-} & Omit<LoopOptions<TOOLS, OUTPUT>, 'models' | 'messageList'>;
+  assistantMessageId?: string;
+} & Omit<LoopOptions<TOOLS, OUTPUT>, 'models' | 'messageList' | 'assistantMessageId'>;
 
 export type ModelMethodType = 'generate' | 'stream';

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -24,6 +24,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
   requireToolApproval,
   agentId,
   toolCallConcurrency,
+  assistantMessageId,
   ...rest
 }: LoopOptions<Tools, OUTPUT>) {
   let loggerToUse =
@@ -65,7 +66,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
 
   let startTimestamp = internalToUse.now?.();
 
-  const messageId = rest.experimental_generateMessageId?.() || internalToUse.generateId?.();
+  const messageId = assistantMessageId || rest.experimental_generateMessageId?.() || internalToUse.generateId?.();
 
   let modelOutput: MastraModelOutput<OUTPUT> | undefined;
   const serializeStreamState = () => {

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -6917,4 +6917,61 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
       });
     });
   });
+
+  describe('options.assistantMessageId', () => {
+    it('should use provided assistantMessageId for the response message', async () => {
+      const messageList = createMessageListWithUserMessage();
+      const customMessageId = 'custom-assistant-message-id';
+
+      const result = loopFn({
+        methodType: 'stream',
+        runId,
+        messageList,
+        models: createTestModels(),
+        assistantMessageId: customMessageId,
+        agentId: 'agent-id',
+      });
+
+      expect(await convertReadableStreamToArray(result.aisdk.v5.toUIMessageStream())).toMatchInlineSnapshot(`
+        [
+          {
+            "messageId": "custom-assistant-message-id",
+            "type": "start",
+          },
+          {
+            "type": "start-step",
+          },
+          {
+            "id": "text-1",
+            "type": "text-start",
+          },
+          {
+            "delta": "Hello",
+            "id": "text-1",
+            "type": "text-delta",
+          },
+          {
+            "delta": ", ",
+            "id": "text-1",
+            "type": "text-delta",
+          },
+          {
+            "delta": "world!",
+            "id": "text-1",
+            "type": "text-delta",
+          },
+          {
+            "id": "text-1",
+            "type": "text-end",
+          },
+          {
+            "type": "finish-step",
+          },
+          {
+            "type": "finish",
+          },
+        ]
+      `);
+    });
+  });
 }

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -6923,6 +6923,8 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
       const messageList = createMessageListWithUserMessage();
       const customMessageId = 'custom-assistant-message-id';
 
+      // Note: at the loop level, assistantMessageId is a direct parameter.
+      // At the agent level, it's nested under memory.assistantMessageId
       const result = loopFn({
         methodType: 'stream',
         runId,

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -93,6 +93,7 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT extends OutputSc
   inputProcessors?: InputProcessorOrWorkflow[];
   tools?: TOOLS;
   experimental_generateMessageId?: () => string;
+  assistantMessageId?: string;
   stopWhen?: StopCondition<NoInfer<TOOLS>> | Array<StopCondition<NoInfer<TOOLS>>>;
   maxSteps?: number;
   _internal?: StreamInternal;


### PR DESCRIPTION
## Description

Adds support for passing a custom `assistantMessageId` when calling `agent.stream()` or `agent.generate()`. This allows you to specify the ID that will be used for the assistant response message when it's saved to memory.

```ts
const result = await agent.stream('Hello!', {
  memory: {
    thread: 'thread-123',
    resource: 'user-456',
    assistantMessageId: 'my-custom-id', // now works!
  },
});
```

This is useful when you need to know the assistant message ID upfront (e.g., for optimistic UI updates, offline mode reconciliation, or allowing users to interact with messages while they're still streaming).

Note: This only applies to the new message format used by `stream()` and `generate()`. The legacy methods are unaffected since they can split responses into multiple message records, making a single ID impractical.

## Related Issue(s)

Addresses #7222

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing an optional `assistantMessageId` through agent execution and streaming workflows, enabling better tracking and identification of assistant messages throughout the execution lifecycle.

* **Tests**
  * Added test coverage verifying that the `assistantMessageId` option is properly respected when streaming messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->