### PR TITLE
docs: add Text-to-SQL blog link

### DIFF
--- a/examples/txt-to-sql/README.md
+++ b/examples/txt-to-sql/README.md
@@ -8,5 +8,5 @@ Mastra Source code: [mastra-text-to-sql](https://github.com/mastra-ai/text-to-sq
 
 ## Blog Post
 
-Read the detailed walkthrough here:
-    [Text to SQL with Mastra](https://mastra.ai/blog/txt-to-sql)
+Detailed walkthrough:
+[Text to SQL with Mastra](https://mastra.ai/blog/txt-to-sql)

--- a/examples/txt-to-sql/README.md
+++ b/examples/txt-to-sql/README.md
@@ -6,4 +6,7 @@ Try the demo: [Text to SQL](https://mastra-text-to-sql.vercel.app/)
 
 Mastra Source code: [mastra-text-to-sql](https://github.com/mastra-ai/text-to-sql-example)
 
-// TODO: add blog post
+## Blog Post
+
+Read the detailed walkthrough here:
+    [Text to SQL with Mastra](https://mastra.ai/blog/txt-to-sql)


### PR DESCRIPTION
## Description

Adds a link to the official Mastra Text-to-SQL blog post in the example README and removes the TODO.

## Related Issue(s)

N/A

## Type of Change

- [x] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced a placeholder with a new "Blog Post" section in the example README, including a link to a detailed walkthrough and removing the prior TODO note.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->