### PR TITLE
feat(playground-ui): add message bookmarking with scrollbar indicators

### DIFF
--- a/packages/playground-ui/src/components/assistant-ui/bookmarks/bookmark-button.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/bookmarks/bookmark-button.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { BookmarkIcon, BookmarkPlusIcon } from 'lucide-react';
+import { useMessage } from '@assistant-ui/react';
+import { useBookmarks } from '@/domains/bookmarks/context/bookmark-context';
+import { BookmarkPopover } from './bookmark-popover';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export type BookmarkButtonProps = {
+  className?: string;
+  isPopoverOpen?: boolean;
+  onPopoverOpenChange?: (open: boolean) => void;
+};
+
+export function BookmarkButton({ className, isPopoverOpen = false, onPopoverOpenChange }: BookmarkButtonProps) {
+  const message = useMessage();
+  const messageId = message?.id;
+  const { getBookmarkByMessageId } = useBookmarks();
+
+  const existingBookmark = messageId ? getBookmarkByMessageId(messageId) : undefined;
+  const isBookmarked = Boolean(existingBookmark);
+
+  if (!messageId) return null;
+
+  const handleClick = () => {
+    onPopoverOpenChange?.(!isPopoverOpen);
+  };
+
+  return (
+    <BookmarkPopover
+      messageId={messageId}
+      existingBookmark={existingBookmark}
+      open={isPopoverOpen}
+      onOpenChange={onPopoverOpenChange ?? (() => {})}
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn('size-6 p-1', className)}
+        aria-label={isBookmarked ? 'Edit bookmark' : 'Add bookmark'}
+        title={isBookmarked ? 'Edit bookmark' : 'Add bookmark'}
+        onClick={handleClick}
+      >
+        {isBookmarked ? <BookmarkIcon className="fill-current" /> : <BookmarkPlusIcon />}
+      </Button>
+    </BookmarkPopover>
+  );
+}

--- a/packages/playground-ui/src/components/assistant-ui/bookmarks/bookmark-indicators.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/bookmarks/bookmark-indicators.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useEffect, useState, RefObject, useCallback, useRef } from 'react';
+import { useBookmarks } from '@/domains/bookmarks/context/bookmark-context';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { Bookmark, BookmarkColor } from '@/types/bookmarks';
+
+const colorClasses: Record<BookmarkColor, string> = {
+  accent1: 'bg-accent1',
+  accent2: 'bg-accent2',
+  accent3: 'bg-accent3',
+  accent4: 'bg-accent4',
+  accent5: 'bg-accent5',
+  accent6: 'bg-accent6',
+};
+
+export type BookmarkIndicatorsProps = {
+  scrollContainerRef: RefObject<HTMLElement | null>;
+};
+
+type IndicatorPosition = {
+  bookmark: Bookmark;
+  absoluteTop: number;
+  messageHeight: number;
+};
+
+type VisualPosition = 'above' | 'visible' | 'below';
+
+const INDICATOR_SIZE = 12;
+const INDICATOR_GAP = 4;
+const TOP_PADDING = 8;
+const BOTTOM_PADDING = 8;
+
+export function BookmarkIndicators({ scrollContainerRef }: BookmarkIndicatorsProps) {
+  const { bookmarks, scrollToBookmark } = useBookmarks();
+  const [positions, setPositions] = useState<IndicatorPosition[]>([]);
+  const indicatorRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Calculate absolute positions of bookmarked messages (sorted by position)
+  const calculatePositions = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const newPositions: IndicatorPosition[] = [];
+
+    for (const bookmark of bookmarks) {
+      const messageElement = container.querySelector(`[data-message-id="${bookmark.messageId}"]`) as HTMLElement | null;
+      if (messageElement) {
+        newPositions.push({
+          bookmark,
+          absoluteTop: messageElement.offsetTop,
+          messageHeight: messageElement.offsetHeight,
+        });
+      }
+    }
+
+    newPositions.sort((a, b) => a.absoluteTop - b.absoluteTop);
+
+    // Only update state if positions actually changed
+    setPositions(prev => {
+      if (prev.length !== newPositions.length) return newPositions;
+      const changed = newPositions.some(
+        (pos, i) =>
+          prev[i]?.bookmark.id !== pos.bookmark.id ||
+          prev[i]?.absoluteTop !== pos.absoluteTop ||
+          prev[i]?.messageHeight !== pos.messageHeight,
+      );
+      return changed ? newPositions : prev;
+    });
+  }, [bookmarks, scrollContainerRef]);
+
+  // Find the actual scrolling ancestor (the element that has overflow scroll/auto and is scrolling)
+  const getScrollParent = useCallback((element: HTMLElement | null): HTMLElement | null => {
+    if (!element) return null;
+
+    let parent = element.parentElement;
+    while (parent) {
+      const style = getComputedStyle(parent);
+      const overflowY = style.overflowY;
+      // Check if this element is scrollable
+      if ((overflowY === 'auto' || overflowY === 'scroll') && parent.scrollHeight > parent.clientHeight) {
+        return parent;
+      }
+      parent = parent.parentElement;
+    }
+    return null;
+  }, []);
+
+  // Update indicator positions directly in DOM (called on scroll)
+  const updateIndicatorPositions = useCallback(() => {
+    const contentContainer = scrollContainerRef.current;
+    const indicatorContainer = containerRef.current;
+    if (!contentContainer || !indicatorContainer || positions.length === 0) return;
+
+    // Find the actual scroll container (might be a parent)
+    const container = getScrollParent(contentContainer) || contentContainer;
+    const containerRect = container.getBoundingClientRect();
+    const clientHeight = containerRect.height;
+
+    // Update container position - position it at the right edge of the scroll container
+    indicatorContainer.style.top = `${containerRect.top}px`;
+    indicatorContainer.style.left = `${containerRect.right - 20}px`; // 20px from right edge of container
+    indicatorContainer.style.height = `${clientHeight}px`;
+
+    // Calculate each message's position relative to the visible viewport
+    type MessageVisibility = {
+      pos: IndicatorPosition;
+      relativeTop: number; // position relative to container top (can be negative if above)
+      relativeBottom: number;
+    };
+
+    const messageVisibilities: MessageVisibility[] = positions.map(pos => {
+      const messageElement = contentContainer.querySelector(
+        `[data-message-id="${pos.bookmark.messageId}"]`,
+      ) as HTMLElement | null;
+      if (!messageElement) {
+        return { pos, relativeTop: -9999, relativeBottom: -9999 };
+      }
+      const messageRect = messageElement.getBoundingClientRect();
+      return {
+        pos,
+        relativeTop: messageRect.top - containerRect.top,
+        relativeBottom: messageRect.bottom - containerRect.top,
+      };
+    });
+
+    // Determine visual position for each bookmark based on viewport-relative position
+    const getVisualPosition = (mv: MessageVisibility): VisualPosition => {
+      if (mv.relativeBottom < 0) return 'above';
+      if (mv.relativeTop > clientHeight) return 'below';
+      return 'visible';
+    };
+
+    // Categorize bookmarks
+    const aboveBookmarks: MessageVisibility[] = [];
+    const visibleBookmarks: MessageVisibility[] = [];
+    const belowBookmarks: MessageVisibility[] = [];
+
+    for (const mv of messageVisibilities) {
+      const visualPos = getVisualPosition(mv);
+      if (visualPos === 'above') aboveBookmarks.push(mv);
+      else if (visualPos === 'below') belowBookmarks.push(mv);
+      else visibleBookmarks.push(mv);
+    }
+
+    // Calculate stack heights
+    const topStackHeight = aboveBookmarks.length * (INDICATOR_SIZE + INDICATOR_GAP) + TOP_PADDING;
+    const bottomStackHeight = belowBookmarks.length * (INDICATOR_SIZE + INDICATOR_GAP) + BOTTOM_PADDING;
+
+    // Update each indicator's position
+    for (const mv of messageVisibilities) {
+      const el = indicatorRefs.current.get(mv.pos.bookmark.id);
+      if (!el) continue;
+
+      const visualPos = getVisualPosition(mv);
+
+      // Reset styles
+      el.style.top = '';
+      el.style.bottom = '';
+
+      if (visualPos === 'above') {
+        const aboveIndex = aboveBookmarks.indexOf(mv);
+        const topValue = TOP_PADDING + aboveIndex * (INDICATOR_SIZE + INDICATOR_GAP);
+        el.style.top = `${topValue}px`;
+      } else if (visualPos === 'below') {
+        const belowIndex = belowBookmarks.indexOf(mv);
+        const fromBottom = belowBookmarks.length - 1 - belowIndex;
+        const bottomValue = BOTTOM_PADDING + fromBottom * (INDICATOR_SIZE + INDICATOR_GAP);
+        el.style.bottom = `${bottomValue}px`;
+      } else {
+        // Visible - position at same height as message, clamped to usable area
+        const visibleIndex = visibleBookmarks.indexOf(mv);
+        const idealTop = mv.relativeTop;
+
+        // Ensure minimum spacing from previous visible bookmark
+        let finalTop = idealTop;
+        if (visibleIndex > 0) {
+          const prevMv = visibleBookmarks[visibleIndex - 1];
+          const prevEl = indicatorRefs.current.get(prevMv.pos.bookmark.id);
+          if (prevEl) {
+            const prevTop = parseFloat(prevEl.style.top) || 0;
+            const minTop = prevTop + INDICATOR_SIZE + INDICATOR_GAP;
+            finalTop = Math.max(idealTop, minTop);
+          }
+        }
+
+        // Clamp to stay within usable area (between stacked bookmarks)
+        const clampedTop = Math.max(
+          topStackHeight,
+          Math.min(finalTop, clientHeight - bottomStackHeight - INDICATOR_SIZE),
+        );
+        el.style.top = `${clampedTop}px`;
+      }
+    }
+  }, [positions, scrollContainerRef, getScrollParent]);
+
+  // Set up event listeners
+  useEffect(() => {
+    calculatePositions();
+
+    const contentContainer = scrollContainerRef.current;
+    if (!contentContainer) return;
+
+    // Find the actual scroll container
+    const scrollContainer = getScrollParent(contentContainer) || contentContainer;
+
+    // Initial position update
+    requestAnimationFrame(updateIndicatorPositions);
+
+    // Scroll handler
+    const handleScroll = () => {
+      requestAnimationFrame(updateIndicatorPositions);
+    };
+
+    scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
+
+    const observer = new MutationObserver(() => {
+      calculatePositions();
+      requestAnimationFrame(updateIndicatorPositions);
+    });
+    observer.observe(contentContainer, { childList: true, subtree: true });
+
+    const resizeObserver = new ResizeObserver(() => {
+      calculatePositions();
+      requestAnimationFrame(updateIndicatorPositions);
+    });
+    resizeObserver.observe(scrollContainer);
+
+    // Also listen to window resize
+    const handleResize = () => requestAnimationFrame(updateIndicatorPositions);
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      scrollContainer.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+      observer.disconnect();
+      resizeObserver.disconnect();
+    };
+  }, [calculatePositions, updateIndicatorPositions, scrollContainerRef, getScrollParent]);
+
+  // Update positions when positions array changes
+  useEffect(() => {
+    requestAnimationFrame(updateIndicatorPositions);
+  }, [positions, updateIndicatorPositions]);
+
+  if (positions.length === 0) return null;
+
+  return (
+    <div ref={containerRef} className="fixed w-4 pointer-events-none z-50" style={{ top: 0, left: 0, height: '100%' }}>
+      <TooltipProvider>
+        {positions.map(pos => (
+          <Tooltip key={pos.bookmark.id}>
+            <TooltipTrigger asChild>
+              <button
+                ref={el => {
+                  if (el) indicatorRefs.current.set(pos.bookmark.id, el);
+                  else indicatorRefs.current.delete(pos.bookmark.id);
+                }}
+                type="button"
+                onClick={() => scrollToBookmark(pos.bookmark)}
+                className={cn(
+                  'absolute w-3 h-3 rounded-sm cursor-pointer pointer-events-auto hover:scale-150 shadow-md',
+                  colorClasses[pos.bookmark.color],
+                )}
+                aria-label={`Scroll to bookmark: ${pos.bookmark.title || 'Untitled'}`}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="left">{pos.bookmark.title || 'Untitled bookmark'}</TooltipContent>
+          </Tooltip>
+        ))}
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/packages/playground-ui/src/components/assistant-ui/bookmarks/bookmark-popover.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/bookmarks/bookmark-popover.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { ReactNode, useState, useEffect } from 'react';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { useBookmarks } from '@/domains/bookmarks/context/bookmark-context';
+import { Bookmark, BookmarkColor } from '@/types/bookmarks';
+import { cn } from '@/lib/utils';
+
+const BOOKMARK_COLORS: { value: BookmarkColor; label: string; className: string }[] = [
+  { value: 'accent1', label: 'Green', className: 'bg-accent1' },
+  { value: 'accent2', label: 'Red', className: 'bg-accent2' },
+  { value: 'accent3', label: 'Blue', className: 'bg-accent3' },
+  { value: 'accent4', label: 'Purple', className: 'bg-accent4' },
+  { value: 'accent5', label: 'Light Blue', className: 'bg-accent5' },
+  { value: 'accent6', label: 'Gold', className: 'bg-accent6' },
+];
+
+export type BookmarkPopoverProps = {
+  messageId: string;
+  existingBookmark?: Bookmark;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+};
+
+export function BookmarkPopover({ messageId, existingBookmark, open, onOpenChange, children }: BookmarkPopoverProps) {
+  const { addBookmark, updateBookmark, removeBookmark } = useBookmarks();
+  const [title, setTitle] = useState(existingBookmark?.title ?? '');
+  const [color, setColor] = useState<BookmarkColor>(existingBookmark?.color ?? 'accent1');
+
+  useEffect(() => {
+    if (open) {
+      setTitle(existingBookmark?.title ?? '');
+      setColor(existingBookmark?.color ?? 'accent1');
+    }
+  }, [open, existingBookmark]);
+
+  const handleSave = () => {
+    if (existingBookmark) {
+      updateBookmark(existingBookmark.id, { title, color });
+    } else {
+      addBookmark(messageId, title, color);
+    }
+    onOpenChange(false);
+  };
+
+  const handleDelete = () => {
+    if (existingBookmark) {
+      removeBookmark(existingBookmark.id);
+    }
+    onOpenChange(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange} modal>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="w-64 p-3" side="top" onOpenAutoFocus={e => e.preventDefault()}>
+        <div className="space-y-3">
+          <div className="grid gap-2">
+            <label htmlFor="bookmark-title" className="text-ui-sm text-icon3">
+              Bookmark title
+            </label>
+            <input
+              id="bookmark-title"
+              type="text"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="Enter a title..."
+              className={cn(
+                'flex grow items-center text-ui-md text-icon6 border border-border1 leading-none rounded-md bg-transparent h-8 px-3 w-full',
+                'focus:outline-none focus:shadow-[inset_0_0_0_1px_#18fb6f]',
+                'placeholder:text-icon3',
+              )}
+            />
+          </div>
+
+          <div>
+            <label className="text-ui-sm text-icon3 mb-2 block">Color</label>
+            <div className="flex gap-2">
+              {BOOKMARK_COLORS.map(c => (
+                <button
+                  key={c.value}
+                  type="button"
+                  onClick={() => setColor(c.value)}
+                  className={cn('w-6 h-6 rounded-full transition-all', c.className, {
+                    'ring-2 ring-white ring-offset-2 ring-offset-surface3': color === c.value,
+                  })}
+                  title={c.label}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            {existingBookmark && (
+              <Button variant="destructive" size="sm" onClick={handleDelete}>
+                Delete
+              </Button>
+            )}
+            <Button variant="default" size="sm" onClick={handleSave} className="ml-auto">
+              {existingBookmark ? 'Update' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/playground-ui/src/components/assistant-ui/bookmarks/index.ts
+++ b/packages/playground-ui/src/components/assistant-ui/bookmarks/index.ts
@@ -1,0 +1,3 @@
+export { BookmarkButton } from './bookmark-button';
+export { BookmarkPopover } from './bookmark-popover';
+export { BookmarkIndicators } from './bookmark-indicators';

--- a/packages/playground-ui/src/components/assistant-ui/messages/assistant-message.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/messages/assistant-message.tsx
@@ -1,5 +1,6 @@
 import { ActionBarPrimitive, MessagePrimitive, useMessage } from '@assistant-ui/react';
 import { AudioLinesIcon, CheckIcon, CopyIcon, StopCircleIcon } from 'lucide-react';
+import { useState } from 'react';
 
 import { ErrorAwareText } from './error-aware-text';
 import { TooltipIconButton } from '../tooltip-icon-button';
@@ -7,6 +8,7 @@ import { ToolFallback } from '@/components/assistant-ui/tools/tool-fallback';
 import { Reasoning } from './reasoning';
 import { cn } from '@/lib/utils';
 import { ProviderLogo } from '@/domains/agents/components/agent-metadata/provider-logo';
+import { BookmarkButton } from '../bookmarks/bookmark-button';
 
 export interface AssistantMessageProps {
   hasModelList?: boolean;
@@ -51,10 +53,12 @@ export const AssistantMessage = ({ hasModelList }: AssistantMessageProps) => {
 };
 
 const AssistantActionBar = () => {
+  const [isBookmarkPopoverOpen, setIsBookmarkPopoverOpen] = useState(false);
+
   return (
     <ActionBarPrimitive.Root
       hideWhenRunning
-      autohide="always"
+      autohide={isBookmarkPopoverOpen ? 'never' : 'always'}
       autohideFloat="single-branch"
       className="flex gap-1 items-center transition-all relative"
     >
@@ -82,11 +86,11 @@ const AssistantActionBar = () => {
           </MessagePrimitive.If>
         </TooltipIconButton>
       </ActionBarPrimitive.Copy>
-      {/* <ActionBarPrimitive.Reload asChild>
-        <TooltipIconButton tooltip="Refresh">
-          <RefreshCwIcon />
-        </TooltipIconButton>
-      </ActionBarPrimitive.Reload> */}
+      <BookmarkButton
+        className="bg-transparent text-icon3 hover:text-icon6"
+        isPopoverOpen={isBookmarkPopoverOpen}
+        onPopoverOpenChange={setIsBookmarkPopoverOpen}
+      />
     </ActionBarPrimitive.Root>
   );
 };

--- a/packages/playground-ui/src/components/assistant-ui/messages/user-messages.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/messages/user-messages.tsx
@@ -1,12 +1,21 @@
 'use client';
 
-import { AttachmentPrimitive, MessagePrimitive, TextMessagePart, useAttachment, useMessage } from '@assistant-ui/react';
+import { useState } from 'react';
+import {
+  ActionBarPrimitive,
+  AttachmentPrimitive,
+  MessagePrimitive,
+  TextMessagePart,
+  useAttachment,
+  useMessage,
+} from '@assistant-ui/react';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 import { useAttachmentSrc } from '../hooks/use-attachment-src';
 import { ImageEntry, PdfEntry, TxtEntry } from '../attachments/attachment-preview-dialog';
+import { BookmarkButton } from '../bookmarks/bookmark-button';
 
 export interface InMessageAttachmentProps {
   type: string;
@@ -38,13 +47,30 @@ const InMessageAttachment = ({ type, contentType, nameSlot, src, data }: InMessa
   );
 };
 
+const UserActionBar = () => {
+  const [isBookmarkPopoverOpen, setIsBookmarkPopoverOpen] = useState(false);
+
+  return (
+    <ActionBarPrimitive.Root
+      hideWhenRunning
+      autohide={isBookmarkPopoverOpen ? 'never' : 'always'}
+      className="flex gap-1 items-center"
+    >
+      <BookmarkButton
+        className="bg-transparent text-icon3 hover:text-icon6"
+        isPopoverOpen={isBookmarkPopoverOpen}
+        onPopoverOpenChange={setIsBookmarkPopoverOpen}
+      />
+    </ActionBarPrimitive.Root>
+  );
+};
+
 export const UserMessage = () => {
   const message = useMessage();
   const messageId = message?.id;
 
   return (
     <MessagePrimitive.Root className="w-full flex items-end pb-4 flex-col" data-message-id={messageId}>
-      {/* <UserActionBar /> */}
       <div className="max-w-[366px] px-5 py-3 text-icon6 text-ui-lg leading-ui-lg rounded-lg bg-surface3">
         <MessagePrimitive.Parts
           components={{
@@ -83,8 +109,9 @@ export const UserMessage = () => {
           }}
         />
       </div>
-
-      {/* <BranchPicker className="col-span-full col-start-1 row-start-3 -mr-1 justify-end" /> */}
+      <div className="h-6 pt-2">
+        <UserActionBar />
+      </div>
     </MessagePrimitive.Root>
   );
 };

--- a/packages/playground-ui/src/components/assistant-ui/thread.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/thread.tsx
@@ -20,15 +20,18 @@ import { useSpeechRecognition } from '@/domains/voice/hooks/use-speech-recogniti
 import { ComposerAttachments } from './attachments/attachment';
 import { AttachFileDialog } from './attachments/attach-file-dialog';
 import { useThreadInput } from '@/domains/conversation';
+import { BookmarkProvider } from '@/domains/bookmarks/context/bookmark-context';
+import { BookmarkIndicators } from './bookmarks/bookmark-indicators';
 
 export interface ThreadProps {
   agentName?: string;
   agentId?: string;
   hasMemory?: boolean;
   hasModelList?: boolean;
+  threadId?: string;
 }
 
-export const Thread = ({ agentName, agentId, hasMemory, hasModelList }: ThreadProps) => {
+export const Thread = ({ agentName, agentId, hasMemory, hasModelList, threadId }: ThreadProps) => {
   const areaRef = useRef<HTMLDivElement>(null);
   useAutoscroll(areaRef, { enabled: true });
 
@@ -36,29 +39,38 @@ export const Thread = ({ agentName, agentId, hasMemory, hasModelList }: ThreadPr
     return <AssistantMessage {...props} hasModelList={hasModelList} />;
   };
 
-  return (
+  const content = (
     <ThreadWrapper>
-      <ThreadPrimitive.Viewport ref={areaRef} autoScroll={false} className="overflow-y-scroll scroll-smooth h-full">
-        <ThreadWelcome agentName={agentName} />
+      <div className="relative h-full">
+        <ThreadPrimitive.Viewport ref={areaRef} autoScroll={false} className="overflow-y-scroll scroll-smooth h-full">
+          <ThreadWelcome agentName={agentName} />
 
-        <div className="max-w-[568px] w-full mx-auto px-4 pb-7">
-          <ThreadPrimitive.Messages
-            components={{
-              UserMessage: UserMessage,
-              EditComposer: EditComposer,
-              AssistantMessage: WrappedAssistantMessage,
-            }}
-          />
-        </div>
+          <div className="max-w-[568px] w-full mx-auto px-4 pb-7">
+            <ThreadPrimitive.Messages
+              components={{
+                UserMessage: UserMessage,
+                EditComposer: EditComposer,
+                AssistantMessage: WrappedAssistantMessage,
+              }}
+            />
+          </div>
 
-        <ThreadPrimitive.If empty={false}>
-          <div />
-        </ThreadPrimitive.If>
-      </ThreadPrimitive.Viewport>
+          <ThreadPrimitive.If empty={false}>
+            <div />
+          </ThreadPrimitive.If>
+        </ThreadPrimitive.Viewport>
+        <BookmarkIndicators scrollContainerRef={areaRef} />
+      </div>
 
       <Composer hasMemory={hasMemory} agentId={agentId} />
     </ThreadWrapper>
   );
+
+  if (threadId) {
+    return <BookmarkProvider threadId={threadId}>{content}</BookmarkProvider>;
+  }
+
+  return content;
 };
 
 const ThreadWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
@@ -62,7 +62,13 @@ export const AgentChat = ({
       settings={settings}
       requestContext={requestContext}
     >
-      <Thread agentName={agentName ?? ''} hasMemory={memory} agentId={agentId} hasModelList={Boolean(modelList)} />
+      <Thread
+        agentName={agentName ?? ''}
+        hasMemory={memory}
+        agentId={agentId}
+        hasModelList={Boolean(modelList)}
+        threadId={threadId}
+      />
     </MastraRuntimeProvider>
   );
 };

--- a/packages/playground-ui/src/domains/bookmarks/context/bookmark-context.tsx
+++ b/packages/playground-ui/src/domains/bookmarks/context/bookmark-context.tsx
@@ -1,0 +1,29 @@
+import { createContext, ReactNode, useContext } from 'react';
+import { BookmarkContextType } from '@/types/bookmarks';
+import { useBookmarksState } from '@/domains/bookmarks/hooks/use-bookmarks-state';
+
+const defaultContextValue: BookmarkContextType = {
+  bookmarks: [],
+  addBookmark: () => {},
+  updateBookmark: () => {},
+  removeBookmark: () => {},
+  getBookmarkByMessageId: () => undefined,
+  scrollToBookmark: () => {},
+};
+
+export const BookmarkContext = createContext<BookmarkContextType>(defaultContextValue);
+
+export type BookmarkProviderProps = {
+  children: ReactNode;
+  threadId: string;
+};
+
+export function BookmarkProvider({ children, threadId }: BookmarkProviderProps) {
+  const bookmarkState = useBookmarksState({ threadId });
+
+  return <BookmarkContext.Provider value={bookmarkState}>{children}</BookmarkContext.Provider>;
+}
+
+export const useBookmarks = () => {
+  return useContext(BookmarkContext);
+};

--- a/packages/playground-ui/src/domains/bookmarks/hooks/use-bookmarks-state.ts
+++ b/packages/playground-ui/src/domains/bookmarks/hooks/use-bookmarks-state.ts
@@ -1,0 +1,89 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Bookmark, BookmarkColor, BookmarkContextType } from '@/types/bookmarks';
+
+export type UseBookmarksStateProps = {
+  threadId: string;
+};
+
+export function useBookmarksState({ threadId }: UseBookmarksStateProps): BookmarkContextType {
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
+
+  const LOCAL_STORAGE_KEY = `mastra-bookmarks-${threadId}`;
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (stored) {
+        setBookmarks(JSON.parse(stored));
+      } else {
+        setBookmarks([]);
+      }
+    } catch {
+      setBookmarks([]);
+    }
+  }, [LOCAL_STORAGE_KEY]);
+
+  const persistBookmarks = useCallback(
+    (newBookmarks: Bookmark[]) => {
+      setBookmarks(newBookmarks);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newBookmarks));
+    },
+    [LOCAL_STORAGE_KEY],
+  );
+
+  const addBookmark = useCallback(
+    (messageId: string, title: string, color: BookmarkColor) => {
+      const newBookmark: Bookmark = {
+        id: crypto.randomUUID(),
+        messageId,
+        title,
+        color,
+        createdAt: Date.now(),
+      };
+      persistBookmarks([...bookmarks, newBookmark]);
+    },
+    [bookmarks, persistBookmarks],
+  );
+
+  const updateBookmark = useCallback(
+    (id: string, updates: Partial<Pick<Bookmark, 'title' | 'color'>>) => {
+      const updated = bookmarks.map(b => (b.id === id ? { ...b, ...updates } : b));
+      persistBookmarks(updated);
+    },
+    [bookmarks, persistBookmarks],
+  );
+
+  const removeBookmark = useCallback(
+    (id: string) => {
+      persistBookmarks(bookmarks.filter(b => b.id !== id));
+    },
+    [bookmarks, persistBookmarks],
+  );
+
+  const getBookmarkByMessageId = useCallback(
+    (messageId: string) => {
+      return bookmarks.find(b => b.messageId === messageId);
+    },
+    [bookmarks],
+  );
+
+  const scrollToBookmark = useCallback((bookmark: Bookmark) => {
+    const messageElement = document.querySelector(`[data-message-id="${bookmark.messageId}"]`);
+    if (messageElement) {
+      messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      messageElement.classList.add('bg-surface4');
+      setTimeout(() => {
+        messageElement.classList.remove('bg-surface4');
+      }, 2000);
+    }
+  }, []);
+
+  return {
+    bookmarks,
+    addBookmark,
+    updateBookmark,
+    removeBookmark,
+    getBookmarkByMessageId,
+    scrollToBookmark,
+  };
+}

--- a/packages/playground-ui/src/types/bookmarks.ts
+++ b/packages/playground-ui/src/types/bookmarks.ts
@@ -1,0 +1,18 @@
+export type BookmarkColor = 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6';
+
+export type Bookmark = {
+  id: string;
+  messageId: string;
+  title: string;
+  color: BookmarkColor;
+  createdAt: number;
+};
+
+export type BookmarkContextType = {
+  bookmarks: Bookmark[];
+  addBookmark: (messageId: string, title: string, color: BookmarkColor) => void;
+  updateBookmark: (id: string, updates: Partial<Pick<Bookmark, 'title' | 'color'>>) => void;
+  removeBookmark: (id: string) => void;
+  getBookmarkByMessageId: (messageId: string) => Bookmark | undefined;
+  scrollToBookmark: (bookmark: Bookmark) => void;
+};


### PR DESCRIPTION
Adds ability to bookmark messages in threads. Bookmarks show as colored indicators along the scrollbar - hover to see title, click to scroll to the message.

Usage:
```tsx
// Hover over any message and click the bookmark icon
// Set a title and pick a color (6 accent options)
// Bookmarks persist per-thread in localStorage
```

The indicators are sticky - they stack at top when you scroll past them, stack at bottom for messages below the viewport, and align with the message when visible.

Known issue: message IDs from assistant-ui may change on page refresh when loaded from thread storage, which can cause bookmarks to not match their messages.


https://github.com/user-attachments/assets/d87eb927-3813-4964-85cc-10db98b96399



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bookmark functionality to conversations
  * Bookmark messages with custom titles and color-coded labels
  * Visual indicators show all bookmarked messages in the conversation
  * Quick navigation and scrolling to bookmarked content
  * Edit or remove bookmarks directly from messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->