### PR TITLE
fix: CLOUD-609 adjust MCP details UI

### DIFF
--- a/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
@@ -60,114 +60,80 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
       </MainContentContent>
     );
 
+  const commandLineConfig = `npx -y mcp-remote ${sseUrl}`;
+
   return (
     <MainContentContent isDivided={true}>
-      <div className="px-8 py-20 mx-auto max-w-[604px] w-full">
+      <div className="px-8 py-12 mx-auto max-w-2xl w-full">
         <Txt as="h1" variant="header-md" className="text-icon6 font-medium pb-4">
           {server.name}
         </Txt>
 
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-1">
-            <Badge
-              icon={<span className="font-mono w-6 text-accent1 text-ui-xs font-medium">SSE</span>}
-              className="!text-icon4"
-            >
-              {sseUrl}
-            </Badge>
-            <CopyButton tooltip="Copy SSE URL" content={sseUrl} iconSize="sm" />
-          </div>
-
-          <div className="flex items-center gap-1">
-            <Badge
-              icon={<span className="font-mono w-6 text-accent1 text-ui-xs font-medium">HTTP</span>}
-              className="!text-icon4"
-            >
-              {httpStreamUrl}
-            </Badge>
-            <CopyButton tooltip="Copy HTTP Stream URL" content={httpStreamUrl} iconSize="sm" />
-          </div>
-        </div>
-
-        <div className="flex items-center gap-1 pt-3 pb-9">
+        <div className="flex items-center gap-1 pb-6">
           <Badge icon={<FolderIcon className="text-icon6" />} className="rounded-r-sm !text-icon4">
             Version
           </Badge>
-
           <Badge className="rounded-l-sm !text-icon4">{server.version_detail.version}</Badge>
         </div>
 
-        <McpSetupTabs sseUrl={sseUrl} serverName={server.name} />
+        <Txt className="text-icon3 pb-4">
+          This MCP server can be accessed through multiple transport methods. Choose the one that best fits your use
+          case.
+        </Txt>
+
+        <div className="flex flex-col gap-4">
+          {/* HTTP Stream */}
+          <div className="rounded-lg border-sm border-border1 bg-surface3 p-4">
+            <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">HTTP</span>}>
+              Regular HTTP Endpoint
+            </Badge>
+
+            <Txt className="text-icon3 pt-1 pb-2">Use for stateless HTTP transport with streamable responses.</Txt>
+
+            <div className="flex items-start gap-2">
+              <Txt className="px-2 py-1 bg-surface4 rounded-lg">{httpStreamUrl}</Txt>
+              <div className="pt-1">
+                <CopyButton tooltip="Copy HTTP Stream URL" content={httpStreamUrl} iconSize="sm" />
+              </div>
+            </div>
+          </div>
+
+          {/* SSE */}
+          <div className="rounded-lg border-sm border-border1 bg-surface3 p-4">
+            <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">SSE</span>}>
+              Server-Sent Events
+            </Badge>
+
+            <Txt className="text-icon3 pt-1 pb-2">Use for real-time communication via SSE.</Txt>
+
+            <div className="flex items-start gap-2">
+              <Txt className="px-2 py-1 bg-surface4 rounded-lg">{sseUrl}</Txt>
+              <div className="pt-1">
+                <CopyButton tooltip="Copy SSE URL" content={sseUrl} iconSize="sm" />
+              </div>
+            </div>
+          </div>
+
+          {/* Command Line */}
+          <div className="rounded-lg border-sm border-border1 bg-surface3 p-4">
+            <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">CLI</span>}>Command Line</Badge>
+
+            <Txt className="text-icon3 pt-1 pb-2">Use for local command-line access via npx and mcp-remote.</Txt>
+
+            <div className="flex items-start gap-2">
+              <Txt className="px-2 py-1 bg-surface4 rounded-lg">{commandLineConfig}</Txt>
+              <div className="pt-1">
+                <CopyButton tooltip="Copy Command Line Config" content={commandLineConfig} iconSize="sm" />
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div className="h-full overflow-y-scroll border-l-sm border-border1">
         <McpToolList server={server} />
       </div>
     </MainContentContent>
-  );
-};
-
-const McpSetupTabs = ({ sseUrl, serverName }: { sseUrl: string; serverName: string }) => {
-  const { Link } = useLinkComponent();
-  return (
-    <PlaygroundTabs defaultTab="cursor">
-      <TabList>
-        <Tab value="cursor">Cursor</Tab>
-        <Tab value="windsurf">Windsurf</Tab>
-      </TabList>
-
-      <TabContent value="cursor">
-        <Txt className="text-icon3 pb-4">
-          Cursor comes with built-in MCP Support.{' '}
-          <Link
-            href="https://docs.cursor.com/context/model-context-protocol"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-icon6"
-          >
-            Following the documentation
-          </Link>
-          , you can register an MCP server using SSE with the following configuration.
-        </Txt>
-
-        <CodeMirrorBlock
-          editable={false}
-          value={`{
-    "mcpServers": {
-      "${serverName}": {
-        "url": "${sseUrl}"
-      }
-    }
-  }`}
-        />
-      </TabContent>
-      <TabContent value="windsurf">
-        <Txt className="text-icon3 pb-4">
-          Windsurf comes with built-in MCP Support.{' '}
-          <Link
-            href="https://docs.windsurf.com/windsurf/cascade/mcp#mcp-config-json"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-icon6"
-          >
-            Following the documentation
-          </Link>
-          , you can register an MCP server using SSE with the following configuration.
-        </Txt>
-
-        <CodeMirrorBlock
-          editable={false}
-          value={`{
-    "mcpServers": {
-      "${serverName}": {
-        "command": "npx",
-        "args": ["-y", "mcp-remote", "${sseUrl}"]
-      }
-    }
-  }`}
-        />
-      </TabContent>
-    </PlaygroundTabs>
   );
 };
 


### PR DESCRIPTION
## Description

This pull request significantly improves the user experience and clarity of the `MCPDetail` component by redesigning how MCP server connection options are presented. The main focus is on making the available transport methods (HTTP, SSE, CLI) more discoverable and user-friendly, while removing the previous tabbed setup instructions for specific clients.

<img width="3840" height="2160" alt="CleanShot 2025-12-15 at 09 45 46@2x" src="https://github.com/user-attachments/assets/ee6ba2c8-58ee-4b97-a718-870e93a96507" />


Key UI/UX improvements:

* Redesigned the MCP connection options section to clearly display three distinct transport methods—HTTP Stream, Server-Sent Events (SSE), and Command Line (CLI)—each with descriptive badges, usage explanations, and copy-to-clipboard functionality for their respective connection strings.
* Added a new command line configuration string for easy CLI access using `npx mcp-remote`, and included a dedicated section for it in the UI.

Codebase simplification and cleanup:

* Removed the `McpSetupTabs` component, which previously provided tabbed setup instructions for Cursor and Windsurf clients, streamlining the code and focusing the UI on generic connection options.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version badge display
  * Expanded transport method sections with individual blocks for HTTP Endpoint, Server-Sent Events, and Command Line
  * Added copy buttons for transport methods and command-line snippets

* **Refactor**
  * Reorganized layout with larger container and improved spacing
  * Removed legacy configuration tabs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->