### PR TITLE
fix: mastra-4244 focus textarea on click box

### DIFF
--- a/.changeset/major-memes-bake.md
+++ b/.changeset/major-memes-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Focus the textarea when clicking anywhere in the entire chat prompt input box

--- a/packages/playground-ui/src/components/assistant-ui/thread.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/thread.tsx
@@ -106,6 +106,7 @@ interface ComposerProps {
 
 const Composer = ({ hasMemory, agentId }: ComposerProps) => {
   const { setThreadInput } = useThreadInput();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   return (
     <div className="mx-4">
       <ComposerPrimitive.Root>
@@ -113,16 +114,22 @@ const Composer = ({ hasMemory, agentId }: ComposerProps) => {
           <ComposerAttachments />
         </div>
 
-        <div className="bg-surface3 rounded-lg border-sm border-border1 py-4 mt-auto max-w-[568px] w-full mx-auto px-4 focus-within:outline focus-within:outline-accent1 -outline-offset-2">
+        <div
+          className="bg-surface3 rounded-lg border-sm border-border1 py-4 mt-auto max-w-[568px] w-full mx-auto px-4 focus-within:outline focus-within:outline-accent1 -outline-offset-2"
+          onClick={() => {
+            textareaRef.current?.focus();
+          }}
+        >
           <ComposerPrimitive.Input asChild className="w-full">
             <textarea
+              ref={textareaRef}
               className="text-ui-lg leading-ui-lg placeholder:text-icon3 text-icon6 bg-transparent focus:outline-none resize-none outline-none"
               autoFocus={document.activeElement === document.body}
               placeholder="Enter your message..."
               name=""
               id=""
               onChange={e => setThreadInput?.(e.target.value)}
-            ></textarea>
+            />
           </ComposerPrimitive.Input>
           <div className="flex justify-end gap-2">
             <SpeechInput agentId={agentId} />


### PR DESCRIPTION
## Description

This pull request improves the user experience of the chat prompt input in the `@mastra/playground-ui` package by making it easier to focus the textarea. Now, clicking anywhere within the chat prompt input box will focus the textarea, not just the textarea itself.

User experience improvements:

* Modified the chat prompt input container in `thread.tsx` so that clicking anywhere in the input box focuses the textarea by using a `ref` and an `onClick` handler.
* Added a changeset entry documenting this enhancement for the `@mastra/playground-ui` package.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The textarea in the chat prompt input box now automatically focuses when clicking anywhere within the input area.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->