### PR TITLE
fix(core): prevent agent loop from stopping after Workers AI tool cal…

### DIFF
--- a/.changeset/polite-trees-juggle.md
+++ b/.changeset/polite-trees-juggle.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+What Changed:
+Tool calls information from Cloudflare Workers ai now get properly processed and sent back to the model for final response geneartion.
+
+How:
+Step-result's finishReason from Cloudflare Workers ai is marked as stop when there are further tool calls involved, causing workflows to terminate without generating the final response with the tool call result. Now the field gets normalized to tool-calls when there are toolcalls left to execute. This fix makes so that even when the finishReason is stop, the workflow would resume, providing the final response.


### PR DESCRIPTION
…ls #8471

## Description

The finishReason from Cloudflare workers ai tool call information response is changed from `stop` to `tool-calls` so that workflows would resume instead of being terminated.

Before the fix, `finishReason` from workers ai would be `stop` even when the step is generating tool call information. This makes so that the workflow gets terminated, causing the final response not being produced. After the fix, `finishReason` gets normalized to `tool-calls` when toolcalls list is not empty and `finishReason` is `stop`. The final tool call response now gets properly generated and returned.

NOTE:
1. There are still some issues with how workers ai streaming tool call responses when using certain models.
`llama-4-scout-17b-16e-instruct` would not copy over the tool results into the final response, while `llama-3.3-70b-instruct-fp8-fast` consistently does it without any issues.
2. When using `generate` mode, the final result gets returned consistently, even for `llama-4-scout-17b-16e-instruct`. Therefore we recommend using generate mode if you would like to stick with `llama-4-scout-17b-16e-instruct`.


## Related Issue(s)

[#8471](https://github.com/mastra-ai/mastra/issues/8471)

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved finish-reason handling in agentic execution so workflows consistently account for tool call results, preventing premature "stop" conclusions and ensuring correct step result propagation.
* **Documentation**
  * Added a changeset documenting the finish-reason normalization behavior for cloud worker tool calls to clarify runtime behavior and resumption of workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->