### PR TITLE
fix(core): Fix OpenRouter type incompatibility by adding ai-v5 to devDependencies

### DIFF
--- a/.changeset/gentle-geese-kneel.md
+++ b/.changeset/gentle-geese-kneel.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fix OpenRouter type incompatibility by adding ai-v5 to devDependencies
+
+When `ai-v5` was removed from dependencies in PR #10989, pnpm started resolving `@openrouter/ai-sdk-provider`'s peer dependency on `ai` to v6 beta instead of v5. This caused a type mismatch because v6 beta uses `@ai-sdk/provider@3.0.0-beta.26` (with `type: "provider"`) while v5 uses `@ai-sdk/provider@2.0.0` (with `type: "provider-defined"`).
+
+Adding `ai-v5` as a devDependency ensures pnpm resolves OpenRouter's peer dependency to the stable v5 version.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -245,6 +245,7 @@
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "eslint": "^9.37.0",
+    "ai-v5": "npm:ai@5.0.97",
     "fast-deep-equal": "^3.1.3",
     "globby": "^14.1.0",
     "rollup": "^4.50.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2074,6 +2074,9 @@ importers:
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.12(vitest@4.0.12)
+      ai-v5:
+        specifier: npm:ai@5.0.97
+        version: ai@5.0.97(zod@3.25.76)
       eslint:
         specifier: ^9.37.0
         version: 9.38.0(jiti@2.6.1)
@@ -26305,15 +26308,6 @@ snapshots:
       msw: 2.12.4(@types/node@22.13.17)(typescript@5.9.3)
       vite: 7.1.11(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
 
-  '@vitest/mocker@4.0.12(msw@2.12.4(@types/node@22.13.17)(typescript@5.9.3))(vite@7.1.11(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 4.0.12
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.12.4(@types/node@22.13.17)(typescript@5.9.3)
-      vite: 7.1.11(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
-
   '@vitest/mocker@4.0.12(msw@2.12.4(@types/node@22.13.17)(typescript@5.9.3))(vite@7.1.11(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.12
@@ -34207,7 +34201,7 @@ snapshots:
   vitest@4.0.12(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@22.13.17)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.4(@types/node@22.13.17)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.12
-      '@vitest/mocker': 4.0.12(msw@2.12.4(@types/node@22.13.17)(typescript@5.9.3))(vite@7.1.11(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.12(msw@2.12.4(@types/node@22.13.17)(typescript@5.9.3))(vite@7.1.11(@types/node@22.13.17)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.12
       '@vitest/runner': 4.0.12
       '@vitest/snapshot': 4.0.12


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fix OpenRouter build failure caused by type incompatibility between AI SDK v5 and v6 beta.

When `ai-v5` was removed from dependencies in #10989, pnpm started resolving `@openrouter/ai-sdk-provider`'s peer dependency on `ai` to v6 beta instead of v5 stable. This caused a type mismatch:

- v5 stable uses `@ai-sdk/provider@2.0.0` with `type: "provider-defined"`
- v6 beta uses `@ai-sdk/provider@3.0.0-beta.26` with `type: "provider"`

The fix adds `ai-v5` back as a devDependency so pnpm resolves OpenRouter's peer dependency to the stable v5 version.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved type incompatibility issues by adding ai-v5 as a devDependency, ensuring correct peer dependency resolution for OpenRouter integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->