### PR TITLE
fix Invalid state: Controller is already closed

### DIFF
--- a/.changeset/chilly-tools-open.md
+++ b/.changeset/chilly-tools-open.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix invalid state: Controller is already closed
+
+Fixes #11005

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2589,7 +2589,10 @@ export class Run<
           unwatch();
 
           try {
-            controller.close();
+            // only close when not yet closed
+            if (controller.desiredSize !== null) {
+              controller.close();
+            }
           } catch (err) {
             console.error('Error closing stream:', err);
           }
@@ -2750,7 +2753,10 @@ export class Run<
           unwatch();
 
           try {
-            controller.close();
+            // only close when not yet closed
+            if (controller.desiredSize !== null) {
+              controller.close();
+            }
           } catch (err) {
             console.error('Error closing stream:', err);
           }
@@ -3396,7 +3402,10 @@ export class Run<
           unwatch();
 
           try {
-            controller.close();
+            // only close when not yet closed
+            if (controller.desiredSize !== null) {
+              controller.close();
+            }
           } catch (err) {
             console.error('Error closing stream:', err);
           }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fix bug when workflow controller alreayd closed - Invalid state: Controller is already closed


## Related Issue(s)

Fixes #11005
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an invalid state error that occurred when stream controllers were closed multiple times during workflow execution, ensuring stable stream termination and reliable error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->