### PR TITLE
docs: move Inngest deployment guide

### DIFF
--- a/docs/src/content/en/docs/deployment/overview.mdx
+++ b/docs/src/content/en/docs/deployment/overview.mdx
@@ -55,3 +55,10 @@ When Mastra is integrated with a web framework, it deploys alongside your applic
 We're building Mastra Cloud to be the easiest place to deploy and observe your Mastra agents. It's currently in beta.
 
 Learn more in the [Mastra Cloud docs](/docs/v1/mastra-cloud/overview).
+
+## Workflow Runners
+
+Mastra supports deploying workflows to specialized workflow execution platforms that handle orchestration, monitoring, and reliability. [Inngest](https://www.inngest.com) is a developer platform for running background workflows without managing infrastructure. Mastra workflows can be deployed to Inngest, which provides step memoization, automatic retries, real-time monitoring, and suspend/resume capabilities.
+
+- [Inngest deployment guide](/guides/v1/deployment/inngest)
+- [Inngest workflow example](https://github.com/mastra-ai/mastra/tree/main/examples/inngest)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -148,11 +148,6 @@ const sidebars = {
           id: "workflows/error-handling",
           label: "Error Handling",
         },
-        {
-          type: "doc",
-          id: "workflows/inngest-workflow",
-          label: "Inngest Workflow",
-        },
       ],
     },
     {

--- a/docs/src/content/en/examples/index.mdx
+++ b/docs/src/content/en/examples/index.mdx
@@ -11,16 +11,9 @@ The Examples section is a short list of example projects demonstrating basic AI 
 
 <CardItems
   titles={[
-    "Workflow",
     "Voice",
   ]}
   items={{
-    Workflow: [
-      {
-        title: "Inngest Workflow",
-        href: "/examples/v1/workflows/inngest-workflow",
-      },
-    ],
     Voice: [
       { title: "Text to Speech", href: "/examples/v1/voice/text-to-speech" },
       { title: "Speech to Text", href: "/examples/v1/voice/speech-to-text" },

--- a/docs/src/content/en/examples/sidebars.js
+++ b/docs/src/content/en/examples/sidebars.js
@@ -14,18 +14,6 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Workflows",
-      collapsed: true,
-      items: [
-        {
-          type: "doc",
-          id: "workflows/inngest-workflow",
-          label: "Inngest Workflow",
-        },
-      ],
-    },
-    {
-      type: "category",
       label: "Voice",
       collapsed: true,
       items: [

--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -21,8 +21,10 @@ Real-time monitoring, suspend/resume, and step-level observability are enabled v
 
 ## Setup
 
+Install the required Inngest package:
+
 ```sh
-npm install @mastra/inngest@beta @mastra/core@beta @mastra/deployer@beta
+npm install @mastra/inngest@beta
 ```
 
 ## Building an Inngest Workflow
@@ -33,7 +35,7 @@ This guide walks through creating a workflow with Inngest and Mastra, demonstrat
 
 Initialize the Inngest integration to obtain Mastra-compatible workflow helpers. The createWorkflow and createStep functions are used to create workflow and step objects that are compatible with Mastra and inngest.
 
-In development
+In development:
 
 ```ts title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
@@ -47,7 +49,7 @@ export const inngest = new Inngest({
 });
 ```
 
-In production
+In production:
 
 ```ts title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
@@ -159,131 +161,151 @@ export const mastra = new Mastra({
 
 ### Running the Workflow locally
 
-> **Prerequisites:**
->
-> - Docker installed and running
-> - Mastra project set up
-> - Dependencies installed (`npm install`)
+:::info[Prerequisites]
+
+- Docker installed and running
+- Mastra project set up
+- Dependencies installed (`npm install`)
+
+:::
 
 1. Run `npx mastra dev` to start the Mastra server on local to serve the server on port 4111.
 2. Start the Inngest Dev Server (via Docker)
    In a new terminal, run:
 
-```sh
-docker run --rm -p 8288:8288 \
-  inngest/inngest \
-  inngest dev -u http://host.docker.internal:4111/api/inngest
-```
+    ```sh
+    docker run --rm -p 8288:8288 \
+      inngest/inngest \
+      inngest dev -u http://host.docker.internal:4111/api/inngest
+    ```
 
-> **Note:** The URL after `-u` tells the Inngest dev server where to find your Mastra `/api/inngest` endpoint.
+    :::note
+
+    The URL after `-u` tells the Inngest dev server where to find your Mastra `/api/inngest` endpoint.
+
+    :::
 
 3. Open the Inngest Dashboard
 
-- Visit [http://localhost:8288](http://localhost:8288) in your browser.
-- Go to the **Apps** section in the sidebar.
-- You should see your Mastra workflow registered.
-  ![Inngest Dashboard](/img/inngest-apps-dashboard.png)
+    - Visit [http://localhost:8288](http://localhost:8288) in your browser.
+    - Go to the **Apps** section in the sidebar.
+    - You should see your Mastra workflow registered.
+
+    ![Inngest Dashboard](/img/inngest-apps-dashboard.png)
 
 4. Invoke the Workflow
 
-- Go to the **Functions** section in the sidebar.
-- Select your Mastra workflow.
-- Click **Invoke** and use the following input:
+    - Go to the **Functions** section in the sidebar.
+    - Select your Mastra workflow.
+    - Click **Invoke** and use the following input:
 
-```json
-{
-  "data": {
-    "inputData": {
-      "value": 5
+    ```json
+    {
+      "data": {
+        "inputData": {
+          "value": 5
+        }
+      }
     }
-  }
-}
-```
+    ```
 
-![Inngest Function](/img/inngest-function-dashboard.png)
+    ![Inngest Function](/img/inngest-function-dashboard.png)
 
 5. **Monitor the Workflow Execution**
 
-- Go to the **Runs** tab in the sidebar.
-- Click on the latest run to see step-by-step execution progress.
-  ![Inngest Function Run](/img/inngest-runs-dashboard.png)
+    - Go to the **Runs** tab in the sidebar.
+    - Click on the latest run to see step-by-step execution progress.
+
+    ![Inngest Function Run](/img/inngest-runs-dashboard.png)
 
 ### Running the Workflow in Production
 
-> **Prerequisites:**
->
-> - Vercel account and Vercel CLI installed (`npm i -g vercel`)
-> - Inngest account
-> - Vercel token (recommended: set as environment variable)
+:::info[Prerequisites]
+
+- Vercel account and Vercel CLI installed (`npm i -g vercel`)
+- Inngest account
+- Vercel token (recommended: set as environment variable)
+
+:::
 
 1. Add Vercel Deployer to Mastra instance
 
-```ts title="src/mastra/index.ts"
-import { VercelDeployer } from "@mastra/deployer-vercel";
+    ```ts title="src/mastra/index.ts"
+    import { VercelDeployer } from "@mastra/deployer-vercel";
 
-export const mastra = new Mastra({
-  // ...other config
-  deployer: new VercelDeployer({
-    teamSlug: "your_team_slug",
-    projectName: "your_project_name",
-    // you can get your vercel token from the vercel dashboard by clicking on the user icon in the top right corner
-    // and then clicking on "Account Settings" and then clicking on "Tokens" on the left sidebar.
-    token: "your_vercel_token",
-  }),
-});
-```
+    export const mastra = new Mastra({
+      // ...other config
+      deployer: new VercelDeployer({
+        teamSlug: "your_team_slug",
+        projectName: "your_project_name",
+        // you can get your vercel token from the vercel dashboard by clicking on the user icon in the top right corner
+        // and then clicking on "Account Settings" and then clicking on "Tokens" on the left sidebar.
+        token: "your_vercel_token",
+      }),
+    });
+    ```
 
-> **Note:** Set your Vercel token in your environment:
->
-> ```sh
-> export VERCEL_TOKEN=your_vercel_token
-> ```
+    :::note
+
+    Set your Vercel token in your environment:
+
+    ```sh
+    export VERCEL_TOKEN=your_vercel_token
+    ```
+
+    :::
 
 2. Build the mastra instance
 
-```sh
-npx mastra build
-```
+    ```sh
+    npx mastra build
+    ```
 
 3. Deploy to Vercel
 
-```sh
-cd .mastra/output
-vercel --prod
-```
+    ```sh
+    cd .mastra/output
+    vercel --prod
+    ```
 
-> **Tip:** If you haven't already, log in to Vercel CLI with `vercel login`.
+    :::tip
+
+    If you haven't already, log in to Vercel CLI with `vercel login`.
+
+    :::
 
 4. Sync with Inngest Dashboard
 
-- Go to the [Inngest dashboard](https://app.inngest.com/env/production/apps).
-- Click **Sync new app with Vercel** and follow the instructions.
-- You should see your Mastra workflow registered as an app.
-  ![Inngest Dashboard](/img/inngest-apps-dashboard-prod.png)
+    - Go to the [Inngest dashboard](https://app.inngest.com/env/production/apps).
+    - Click **Sync new app with Vercel** and follow the instructions.
+    - You should see your Mastra workflow registered as an app.
+
+    ![Inngest Dashboard](/img/inngest-apps-dashboard-prod.png)
 
 5. Invoke the Workflow
 
-- In the **Functions** section, select `workflow.increment-workflow`.
-- Click **All actions** (top right) > **Invoke**.
-- Provide the following input:
+    - In the **Functions** section, select `workflow.increment-workflow`.
+    - Click **All actions** (top right) > **Invoke**.
+    - Provide the following input:
 
-```json
-{
-  "data": {
-    "inputData": {
-      "value": 5
+    ```json
+    {
+      "data": {
+        "inputData": {
+          "value": 5
+        }
+      }
     }
-  }
-}
-```
+    ```
 
-![Inngest Function Run](/img/inngest-function-dashboard-prod.png)
+    ![Inngest Function Run](/img/inngest-function-dashboard-prod.png)
 
 6.  Monitor Execution
 
-- Go to the **Runs** tab.
-- Click the latest run to see step-by-step execution progress.
-  ![Inngest Function Run](/img/inngest-runs-dashboard-prod.png)
+    - Go to the **Runs** tab.
+    - Click the latest run to see step-by-step execution progress.
+
+        ![Inngest Function Run](/img/inngest-runs-dashboard-prod.png)
 
 ## Advanced Usage: Adding Custom Inngest Functions
 

--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -35,7 +35,7 @@ Initialize the Inngest integration to obtain Mastra-compatible workflow helpers.
 
 In development
 
-```ts showLineNumbers copy title="src/mastra/inngest/index.ts"
+```ts title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
 import { realtimeMiddleware } from "@inngest/realtime/middleware";
 
@@ -49,7 +49,7 @@ export const inngest = new Inngest({
 
 In production
 
-```ts showLineNumbers copy title="src/mastra/inngest/index.ts"
+```ts title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
 import { realtimeMiddleware } from "@inngest/realtime/middleware";
 
@@ -63,7 +63,7 @@ export const inngest = new Inngest({
 
 Define the individual steps that will compose your workflow:
 
-```ts showLineNumbers copy title="src/mastra/workflows/index.ts"
+```ts title="src/mastra/workflows/index.ts"
 import { z } from "zod";
 import { inngest } from "../inngest";
 import { init } from "@mastra/inngest";
@@ -90,7 +90,7 @@ const incrementStep = createStep({
 
 Compose the steps into a workflow using the `dountil` loop pattern. The createWorkflow function creates a function on inngest server that is invocable.
 
-```ts showLineNumbers copy title="src/mastra/workflows/index.ts"
+```ts title="src/mastra/workflows/index.ts"
 // workflow that is registered as a function on inngest server
 const workflow = createWorkflow({
   id: "increment-workflow",
@@ -111,7 +111,7 @@ export { workflow as incrementWorkflow };
 
 Register the workflow with Mastra and configure the Inngest API endpoint:
 
-```ts showLineNumbers copy title="src/mastra/index.ts"
+```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { incrementWorkflow } from "./workflows";
@@ -218,7 +218,7 @@ docker run --rm -p 8288:8288 \
 
 1. Add Vercel Deployer to Mastra instance
 
-```ts showLineNumbers copy title="src/mastra/index.ts"
+```ts title="src/mastra/index.ts"
 import { VercelDeployer } from "@mastra/deployer-vercel";
 
 export const mastra = new Mastra({
@@ -293,7 +293,7 @@ You can serve additional Inngest functions alongside your Mastra workflows by us
 
 First, create your custom Inngest functions:
 
-```ts showLineNumbers copy title="src/inngest/custom-functions.ts"
+```ts title="src/inngest/custom-functions.ts"
 import { inngest } from "./inngest";
 
 // Define custom Inngest functions
@@ -322,7 +322,7 @@ export const customWebhookFunction = inngest.createFunction(
 
 Update your Mastra configuration to include the custom functions:
 
-```ts showLineNumbers copy title="src/mastra/index.ts"
+```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { incrementWorkflow } from "./workflows";

--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -1,0 +1,365 @@
+---
+title: "Inngest | Deployment"
+description: "Deploy Mastra workflows with Inngest"
+---
+
+# Inngest Workflow
+
+[Inngest](https://www.inngest.com/docs) is a developer platform for building and running background workflows, without managing infrastructure.
+
+For a complete example with advanced flow control features, see the [Inngest workflow example](https://github.com/mastra-ai/mastra/tree/main/examples/inngest).
+
+## How Inngest Works with Mastra
+
+Inngest and Mastra integrate by aligning their workflow models: Inngest organizes logic into functions composed of steps, and Mastra workflows defined using `createWorkflow` and `createStep` map directly onto this paradigm. Each Mastra workflow becomes an Inngest function with a unique identifier, and each step within the workflow maps to an Inngest step.
+
+The `serve` function bridges the two systems by registering Mastra workflows as Inngest functions and setting up the necessary event handlers for execution and monitoring.
+
+When an event triggers a workflow, Inngest executes it step by step, memoizing each step's result. This means if a workflow is retried or resumed, completed steps are skipped, ensuring efficient and reliable execution. Control flow primitives in Mastra, such as loops, conditionals, and nested workflows are seamlessly translated into the same Inngest's function/step model, preserving advanced workflow features like composition, branching, and suspension.
+
+Real-time monitoring, suspend/resume, and step-level observability are enabled via Inngest's publish-subscribe system and dashboard. As each step executes, its state and output are tracked using Mastra storage and can be resumed as needed.
+
+## Setup
+
+```sh
+npm install @mastra/inngest@beta @mastra/core@beta @mastra/deployer@beta
+```
+
+## Building an Inngest Workflow
+
+This guide walks through creating a workflow with Inngest and Mastra, demonstrating a counter application that increments a value until it reaches 10.
+
+### Inngest Initialization
+
+Initialize the Inngest integration to obtain Mastra-compatible workflow helpers. The createWorkflow and createStep functions are used to create workflow and step objects that are compatible with Mastra and inngest.
+
+In development
+
+```ts showLineNumbers copy title="src/mastra/inngest/index.ts"
+import { Inngest } from "inngest";
+import { realtimeMiddleware } from "@inngest/realtime/middleware";
+
+export const inngest = new Inngest({
+  id: "mastra",
+  baseUrl: "http://localhost:8288",
+  isDev: true,
+  middleware: [realtimeMiddleware()],
+});
+```
+
+In production
+
+```ts showLineNumbers copy title="src/mastra/inngest/index.ts"
+import { Inngest } from "inngest";
+import { realtimeMiddleware } from "@inngest/realtime/middleware";
+
+export const inngest = new Inngest({
+  id: "mastra",
+  middleware: [realtimeMiddleware()],
+});
+```
+
+### Creating Steps
+
+Define the individual steps that will compose your workflow:
+
+```ts showLineNumbers copy title="src/mastra/workflows/index.ts"
+import { z } from "zod";
+import { inngest } from "../inngest";
+import { init } from "@mastra/inngest";
+
+// Initialize Inngest with Mastra, pointing to your local Inngest server
+const { createWorkflow, createStep } = init(inngest);
+
+// Step: Increment the counter value
+const incrementStep = createStep({
+  id: "increment",
+  inputSchema: z.object({
+    value: z.number(),
+  }),
+  outputSchema: z.object({
+    value: z.number(),
+  }),
+  execute: async ({ inputData }) => {
+    return { value: inputData.value + 1 };
+  },
+});
+```
+
+### Creating the Workflow
+
+Compose the steps into a workflow using the `dountil` loop pattern. The createWorkflow function creates a function on inngest server that is invocable.
+
+```ts showLineNumbers copy title="src/mastra/workflows/index.ts"
+// workflow that is registered as a function on inngest server
+const workflow = createWorkflow({
+  id: "increment-workflow",
+  inputSchema: z.object({
+    value: z.number(),
+  }),
+  outputSchema: z.object({
+    value: z.number(),
+  }),
+}).then(incrementStep);
+
+workflow.commit();
+
+export { workflow as incrementWorkflow };
+```
+
+### Configuring the Mastra Instance and Executing the Workflow
+
+Register the workflow with Mastra and configure the Inngest API endpoint:
+
+```ts showLineNumbers copy title="src/mastra/index.ts"
+import { Mastra } from "@mastra/core";
+import { serve as inngestServe } from "@mastra/inngest";
+import { incrementWorkflow } from "./workflows";
+import { inngest } from "./inngest";
+import { PinoLogger } from "@mastra/loggers";
+
+// Configure Mastra with the workflow and Inngest API endpoint
+export const mastra = new Mastra({
+  workflows: {
+    incrementWorkflow,
+  },
+  server: {
+    // The server configuration is required to allow local docker container can connect to the mastra server
+    host: "0.0.0.0",
+    apiRoutes: [
+      // This API route is used to register the Mastra workflow (inngest function) on the inngest server
+      {
+        path: "/api/inngest",
+        method: "ALL",
+        createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
+        // The inngestServe function integrates Mastra workflows with Inngest by:
+        // 1. Creating Inngest functions for each workflow with unique IDs (workflow.${workflowId})
+        // 2. Setting up event handlers that:
+        //    - Generate unique run IDs for each workflow execution
+        //    - Create an InngestExecutionEngine to manage step execution
+        //    - Handle workflow state persistence and real-time updates
+        // 3. Establishing a publish-subscribe system for real-time monitoring
+        //    through the workflow:${workflowId}:${runId} channel
+        //
+        // Optional: You can also pass additional Inngest functions to serve alongside workflows:
+        // createHandler: async ({ mastra }) => inngestServe({
+        //   mastra,
+        //   inngest,
+        //   functions: [customFunction1, customFunction2] // User-defined Inngest functions
+        // }),
+      },
+    ],
+  },
+  logger: new PinoLogger({
+    name: "Mastra",
+    level: "info",
+  }),
+});
+```
+
+### Running the Workflow locally
+
+> **Prerequisites:**
+>
+> - Docker installed and running
+> - Mastra project set up
+> - Dependencies installed (`npm install`)
+
+1. Run `npx mastra dev` to start the Mastra server on local to serve the server on port 4111.
+2. Start the Inngest Dev Server (via Docker)
+   In a new terminal, run:
+
+```sh
+docker run --rm -p 8288:8288 \
+  inngest/inngest \
+  inngest dev -u http://host.docker.internal:4111/api/inngest
+```
+
+> **Note:** The URL after `-u` tells the Inngest dev server where to find your Mastra `/api/inngest` endpoint.
+
+3. Open the Inngest Dashboard
+
+- Visit [http://localhost:8288](http://localhost:8288) in your browser.
+- Go to the **Apps** section in the sidebar.
+- You should see your Mastra workflow registered.
+  ![Inngest Dashboard](/img/inngest-apps-dashboard.png)
+
+4. Invoke the Workflow
+
+- Go to the **Functions** section in the sidebar.
+- Select your Mastra workflow.
+- Click **Invoke** and use the following input:
+
+```json
+{
+  "data": {
+    "inputData": {
+      "value": 5
+    }
+  }
+}
+```
+
+![Inngest Function](/img/inngest-function-dashboard.png)
+
+5. **Monitor the Workflow Execution**
+
+- Go to the **Runs** tab in the sidebar.
+- Click on the latest run to see step-by-step execution progress.
+  ![Inngest Function Run](/img/inngest-runs-dashboard.png)
+
+### Running the Workflow in Production
+
+> **Prerequisites:**
+>
+> - Vercel account and Vercel CLI installed (`npm i -g vercel`)
+> - Inngest account
+> - Vercel token (recommended: set as environment variable)
+
+1. Add Vercel Deployer to Mastra instance
+
+```ts showLineNumbers copy title="src/mastra/index.ts"
+import { VercelDeployer } from "@mastra/deployer-vercel";
+
+export const mastra = new Mastra({
+  // ...other config
+  deployer: new VercelDeployer({
+    teamSlug: "your_team_slug",
+    projectName: "your_project_name",
+    // you can get your vercel token from the vercel dashboard by clicking on the user icon in the top right corner
+    // and then clicking on "Account Settings" and then clicking on "Tokens" on the left sidebar.
+    token: "your_vercel_token",
+  }),
+});
+```
+
+> **Note:** Set your Vercel token in your environment:
+>
+> ```sh
+> export VERCEL_TOKEN=your_vercel_token
+> ```
+
+2. Build the mastra instance
+
+```sh
+npx mastra build
+```
+
+3. Deploy to Vercel
+
+```sh
+cd .mastra/output
+vercel --prod
+```
+
+> **Tip:** If you haven't already, log in to Vercel CLI with `vercel login`.
+
+4. Sync with Inngest Dashboard
+
+- Go to the [Inngest dashboard](https://app.inngest.com/env/production/apps).
+- Click **Sync new app with Vercel** and follow the instructions.
+- You should see your Mastra workflow registered as an app.
+  ![Inngest Dashboard](/img/inngest-apps-dashboard-prod.png)
+
+5. Invoke the Workflow
+
+- In the **Functions** section, select `workflow.increment-workflow`.
+- Click **All actions** (top right) > **Invoke**.
+- Provide the following input:
+
+```json
+{
+  "data": {
+    "inputData": {
+      "value": 5
+    }
+  }
+}
+```
+
+![Inngest Function Run](/img/inngest-function-dashboard-prod.png)
+
+6.  Monitor Execution
+
+- Go to the **Runs** tab.
+- Click the latest run to see step-by-step execution progress.
+  ![Inngest Function Run](/img/inngest-runs-dashboard-prod.png)
+
+## Advanced Usage: Adding Custom Inngest Functions
+
+You can serve additional Inngest functions alongside your Mastra workflows by using the optional `functions` parameter in `inngestServe`.
+
+### Creating Custom Functions
+
+First, create your custom Inngest functions:
+
+```ts showLineNumbers copy title="src/inngest/custom-functions.ts"
+import { inngest } from "./inngest";
+
+// Define custom Inngest functions
+export const customEmailFunction = inngest.createFunction(
+  { id: "send-welcome-email" },
+  { event: "user/registered" },
+  async ({ event }) => {
+    // Custom email logic here
+    console.log(`Sending welcome email to ${event.data.email}`);
+    return { status: "email_sent" };
+  },
+);
+
+export const customWebhookFunction = inngest.createFunction(
+  { id: "process-webhook" },
+  { event: "webhook/received" },
+  async ({ event }) => {
+    // Custom webhook processing
+    console.log(`Processing webhook: ${event.data.type}`);
+    return { processed: true };
+  },
+);
+```
+
+### Serving Custom Functions with Workflows
+
+Update your Mastra configuration to include the custom functions:
+
+```ts showLineNumbers copy title="src/mastra/index.ts"
+import { Mastra } from "@mastra/core";
+import { serve as inngestServe } from "@mastra/inngest";
+import { incrementWorkflow } from "./workflows";
+import { inngest } from "./inngest";
+import {
+  customEmailFunction,
+  customWebhookFunction,
+} from "./inngest/custom-functions";
+
+export const mastra = new Mastra({
+  workflows: {
+    incrementWorkflow,
+  },
+  server: {
+    host: "0.0.0.0",
+    apiRoutes: [
+      {
+        path: "/api/inngest",
+        method: "ALL",
+        createHandler: async ({ mastra }) =>
+          inngestServe({
+            mastra,
+            inngest,
+            functions: [customEmailFunction, customWebhookFunction], // Add your custom functions
+          }),
+      },
+    ],
+  },
+});
+```
+
+### Function Registration
+
+When you include custom functions:
+
+1. **Mastra workflows** are automatically converted to Inngest functions with IDs like `workflow.${workflowId}`
+2. **Custom functions** retain their specified IDs (e.g., `send-welcome-email`, `process-webhook`)
+3. **All functions** are served together on the same `/api/inngest` endpoint
+
+This allows you to combine Mastra's workflow orchestration with your existing Inngest functions seamlessly.

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -124,6 +124,11 @@ const sidebars = {
           id: "deployment/vercel-deployer",
           label: "Vercel",
         },
+        {
+          type: "doc",
+          id: "deployment/inngest",
+          label: "Inngest",
+        },
       ],
     },
     {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -439,6 +439,16 @@
       "source": "/docs/v1/deployment/building-mastra",
       "destination": "/docs/v1/deployment/mastra-server",
       "permanent": true
+    },
+    {
+      "source": "/docs/v1/workflows/inngest-workflow",
+      "destination": "/guides/v1/deployment/inngest",
+      "permanent": true
+    },
+    {
+      "source": "/examples/v1/workflows/inngest-workflow",
+      "destination": "https://github.com/mastra-ai/mastra/tree/main/examples/inngest",
+      "permanent": true
     }
   ]
 }

--- a/examples/inngest/README.md
+++ b/examples/inngest/README.md
@@ -20,13 +20,13 @@ Define a planning agent which leverages an LLM call to plan activities given a l
 
 ```ts
 // agents/planning-agent.ts
-import { Agent } from "@mastra/core/agent";
+import { Agent } from '@mastra/core/agent';
 
 // Create a new planning agent that uses the OpenAI model
 const planningAgent = new Agent({
-  id: "planning-agent",
-  name: "planningAgent",
-  model: "openai/gpt-5.1",
+  id: 'planning-agent',
+  name: 'planningAgent',
+  model: 'openai/gpt-5.1',
   instructions: `
         You are a local activities and travel expert who excels at weather-based planning. Analyze the weather data and provide practical activity recommendations.
 
@@ -79,13 +79,13 @@ Define the activity planner workflow with 3 steps: one to fetch the weather via 
 
 ```ts
 // workflows/inngest-workflow.ts
-import { init } from "@mastra/inngest";
-import { Inngest } from "inngest";
-import { z } from "zod";
+import { init } from '@mastra/inngest';
+import { Inngest } from 'inngest';
+import { z } from 'zod';
 
 const { createWorkflow, createStep } = init(
   new Inngest({
-    id: "mastra",
+    id: 'mastra',
     baseUrl: `http://localhost:8288`,
   }),
 );
@@ -93,24 +93,24 @@ const { createWorkflow, createStep } = init(
 // Helper function to convert weather codes to human-readable descriptions
 function getWeatherCondition(code: number): string {
   const conditions: Record<number, string> = {
-    0: "Clear sky",
-    1: "Mainly clear",
-    2: "Partly cloudy",
-    3: "Overcast",
-    45: "Foggy",
-    48: "Depositing rime fog",
-    51: "Light drizzle",
-    53: "Moderate drizzle",
-    55: "Dense drizzle",
-    61: "Slight rain",
-    63: "Moderate rain",
-    65: "Heavy rain",
-    71: "Slight snow fall",
-    73: "Moderate snow fall",
-    75: "Heavy snow fall",
-    95: "Thunderstorm",
+    0: 'Clear sky',
+    1: 'Mainly clear',
+    2: 'Partly cloudy',
+    3: 'Overcast',
+    45: 'Foggy',
+    48: 'Depositing rime fog',
+    51: 'Light drizzle',
+    53: 'Moderate drizzle',
+    55: 'Dense drizzle',
+    61: 'Slight rain',
+    63: 'Moderate rain',
+    65: 'Heavy rain',
+    71: 'Slight snow fall',
+    73: 'Moderate snow fall',
+    75: 'Heavy snow fall',
+    95: 'Thunderstorm',
   };
-  return conditions[code] || "Unknown";
+  return conditions[code] || 'Unknown';
 }
 
 const forecastSchema = z.object({
@@ -128,15 +128,15 @@ const forecastSchema = z.object({
 ```ts
 // workflows/inngest-workflow.ts
 const fetchWeather = createStep({
-  id: "fetch-weather",
-  description: "Fetches weather forecast for a given city",
+  id: 'fetch-weather',
+  description: 'Fetches weather forecast for a given city',
   inputSchema: z.object({
     city: z.string(),
   }),
   outputSchema: forecastSchema,
   execute: async ({ inputData }) => {
     if (!inputData) {
-      throw new Error("Trigger data not found");
+      throw new Error('Trigger data not found');
     }
 
     // Get latitude and longitude for the city
@@ -173,10 +173,7 @@ const fetchWeather = createStep({
       minTemp: Math.min(...data.hourly.temperature_2m),
       condition: getWeatherCondition(data.current.weathercode),
       location: name,
-      precipitationChance: data.hourly.precipitation_probability.reduce(
-        (acc, curr) => Math.max(acc, curr),
-        0,
-      ),
+      precipitationChance: data.hourly.precipitation_probability.reduce((acc, curr) => Math.max(acc, curr), 0),
     };
 
     return forecast;
@@ -189,8 +186,8 @@ const fetchWeather = createStep({
 ```ts
 // workflows/inngest-workflow.ts
 const planActivities = createStep({
-  id: "plan-activities",
-  description: "Suggests activities based on weather conditions",
+  id: 'plan-activities',
+  description: 'Suggests activities based on weather conditions',
   inputSchema: forecastSchema,
   outputSchema: z.object({
     activities: z.string(),
@@ -199,26 +196,26 @@ const planActivities = createStep({
     const forecast = inputData;
 
     if (!forecast) {
-      throw new Error("Forecast data not found");
+      throw new Error('Forecast data not found');
     }
 
     const prompt = `Based on the following weather forecast for ${forecast.location}, suggest appropriate activities:
       ${JSON.stringify(forecast, null, 2)}
       `;
 
-    const agent = mastra?.getAgent("planningAgent");
+    const agent = mastra?.getAgent('planningAgent');
     if (!agent) {
-      throw new Error("Planning agent not found");
+      throw new Error('Planning agent not found');
     }
 
     const response = await agent.stream([
       {
-        role: "user",
+        role: 'user',
         content: prompt,
       },
     ]);
 
-    let activitiesText = "";
+    let activitiesText = '';
 
     for await (const chunk of response.textStream) {
       process.stdout.write(chunk);
@@ -237,8 +234,8 @@ const planActivities = createStep({
 ```ts
 // workflows/inngest-workflow.ts
 const planIndoorActivities = createStep({
-  id: "plan-indoor-activities",
-  description: "Suggests indoor activities based on weather conditions",
+  id: 'plan-indoor-activities',
+  description: 'Suggests indoor activities based on weather conditions',
   inputSchema: forecastSchema,
   outputSchema: z.object({
     activities: z.string(),
@@ -247,24 +244,24 @@ const planIndoorActivities = createStep({
     const forecast = inputData;
 
     if (!forecast) {
-      throw new Error("Forecast data not found");
+      throw new Error('Forecast data not found');
     }
 
     const prompt = `In case it rains, plan indoor activities for ${forecast.location} on ${forecast.date}`;
 
-    const agent = mastra?.getAgent("planningAgent");
+    const agent = mastra?.getAgent('planningAgent');
     if (!agent) {
-      throw new Error("Planning agent not found");
+      throw new Error('Planning agent not found');
     }
 
     const response = await agent.stream([
       {
-        role: "user",
+        role: 'user',
         content: prompt,
       },
     ]);
 
-    let activitiesText = "";
+    let activitiesText = '';
 
     for await (const chunk of response.textStream) {
       process.stdout.write(chunk);
@@ -283,9 +280,9 @@ const planIndoorActivities = createStep({
 ```ts
 // workflows/inngest-workflow.ts
 const activityPlanningWorkflow = createWorkflow({
-  id: "activity-planning-workflow-step2-if-else",
+  id: 'activity-planning-workflow-step2-if-else',
   inputSchema: z.object({
-    city: z.string().describe("The city to get the weather for"),
+    city: z.string().describe('The city to get the weather for'),
   }),
   outputSchema: z.object({
     activities: z.string(),
@@ -320,17 +317,17 @@ Register the agents and workflow with the mastra instance. This allows access to
 
 ```ts
 // index.ts
-import { Mastra } from "@mastra/core";
-import { serve as inngestServe } from "@mastra/inngest";
-import { PinoLogger } from "@mastra/loggers";
-import { Inngest } from "inngest";
-import { activityPlanningWorkflow } from "./workflows/inngest-workflow";
-import { planningAgent } from "./agents/planning-agent";
-import { realtimeMiddleware } from "@inngest/realtime/middleware";
+import { Mastra } from '@mastra/core';
+import { serve as inngestServe } from '@mastra/inngest';
+import { PinoLogger } from '@mastra/loggers';
+import { Inngest } from 'inngest';
+import { activityPlanningWorkflow } from './workflows/inngest-workflow';
+import { planningAgent } from './agents/planning-agent';
+import { realtimeMiddleware } from '@inngest/realtime/middleware';
 
 // Create an Inngest instance for workflow orchestration and event handling
 const inngest = new Inngest({
-  id: "mastra",
+  id: 'mastra',
   baseUrl: `http://localhost:8288`, // URL of your local Inngest server
   isDev: true,
   middleware: [realtimeMiddleware()], // Enable real-time updates in the Inngest dashboard
@@ -345,18 +342,18 @@ export const mastra = new Mastra({
     planningAgent,
   },
   server: {
-    host: "0.0.0.0",
+    host: '0.0.0.0',
     apiRoutes: [
       {
-        path: "/api/inngest", // API endpoint for Inngest to send events to
-        method: "ALL",
+        path: '/api/inngest', // API endpoint for Inngest to send events to
+        method: 'ALL',
         createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
       },
     ],
   },
   logger: new PinoLogger({
-    name: "Mastra",
-    level: "info",
+    name: 'Mastra',
+    level: 'info',
   }),
 });
 ```
@@ -367,10 +364,10 @@ Here, we'll get the activity planner workflow from the mastra instance, then cre
 
 ```ts
 // exec.ts
-import { mastra } from "./";
-import { serve } from "@hono/node-server";
-import { createHonoServer, getToolExports } from "@mastra/deployer/server";
-import { tools } from "#tools";
+import { mastra } from './';
+import { serve } from '@hono/node-server';
+import { createHonoServer, getToolExports } from '@mastra/deployer/server';
+import { tools } from '#tools';
 
 const app = await createHonoServer(mastra, {
   tools: getToolExports(tools),
@@ -382,12 +379,12 @@ const srv = serve({
   port: 3000,
 });
 
-const workflow = mastra.getWorkflow("activityPlanningWorkflow");
+const workflow = mastra.getWorkflow('activityPlanningWorkflow');
 const run = await workflow.createRun();
 
 // Start the workflow with the required input data (city name)
 // This will trigger the workflow steps and stream the result to the console
-const result = await run.start({ inputData: { city: "New York" } });
+const result = await run.start({ inputData: { city: 'New York' } });
 console.dir(result, { depth: null });
 
 // Close the server after the workflow run is complete
@@ -406,14 +403,14 @@ Control how many workflow instances can run simultaneously:
 
 ```ts
 const workflow = createWorkflow({
-  id: "user-processing-workflow",
+  id: 'user-processing-workflow',
   inputSchema: z.object({ userId: z.string() }),
   outputSchema: z.object({ result: z.string() }),
   steps: [processUserStep],
   // Limit to 10 concurrent executions, scoped by user ID
   concurrency: {
     limit: 10,
-    key: "event.data.userId", // Per-user concurrency
+    key: 'event.data.userId', // Per-user concurrency
   },
 });
 ```
@@ -424,13 +421,13 @@ Limit the number of workflow executions within a time period:
 
 ```ts
 const workflow = createWorkflow({
-  id: "api-sync-workflow",
+  id: 'api-sync-workflow',
   inputSchema: z.object({ endpoint: z.string() }),
   outputSchema: z.object({ status: z.string() }),
   steps: [apiSyncStep],
   // Maximum 1000 executions per hour
   rateLimit: {
-    period: "1h",
+    period: '1h',
     limit: 1000,
   },
 });
@@ -442,15 +439,15 @@ Ensure minimum time between workflow executions:
 
 ```ts
 const workflow = createWorkflow({
-  id: "email-notification-workflow",
+  id: 'email-notification-workflow',
   inputSchema: z.object({ organizationId: z.string(), message: z.string() }),
   outputSchema: z.object({ sent: z.boolean() }),
   steps: [sendEmailStep],
   // Only one execution per 10 seconds per organization
   throttle: {
-    period: "10s",
+    period: '10s',
     limit: 1,
-    key: "event.data.organizationId",
+    key: 'event.data.organizationId',
   },
 });
 ```
@@ -461,14 +458,14 @@ Delay execution until no new events arrive within a time window:
 
 ```ts
 const workflow = createWorkflow({
-  id: "search-index-workflow",
+  id: 'search-index-workflow',
   inputSchema: z.object({ documentId: z.string() }),
   outputSchema: z.object({ indexed: z.boolean() }),
   steps: [indexDocumentStep],
   // Wait 5 seconds of no updates before indexing
   debounce: {
-    period: "5s",
-    key: "event.data.documentId",
+    period: '5s',
+    key: 'event.data.documentId',
   },
 });
 ```
@@ -479,7 +476,7 @@ Set execution priority for workflows:
 
 ```ts
 const workflow = createWorkflow({
-  id: "order-processing-workflow",
+  id: 'order-processing-workflow',
   inputSchema: z.object({
     orderId: z.string(),
     priority: z.number().optional(),
@@ -488,7 +485,7 @@ const workflow = createWorkflow({
   steps: [processOrderStep],
   // Higher priority orders execute first
   priority: {
-    run: "event.data.priority ?? 50", // Dynamic priority, default 50
+    run: 'event.data.priority ?? 50', // Dynamic priority, default 50
   },
 });
 ```
@@ -499,7 +496,7 @@ You can combine multiple flow control features:
 
 ```ts
 const workflow = createWorkflow({
-  id: "comprehensive-workflow",
+  id: 'comprehensive-workflow',
   inputSchema: z.object({
     userId: z.string(),
     organizationId: z.string(),
@@ -510,19 +507,19 @@ const workflow = createWorkflow({
   // Multiple flow control features
   concurrency: {
     limit: 5,
-    key: "event.data.userId",
+    key: 'event.data.userId',
   },
   rateLimit: {
-    period: "1m",
+    period: '1m',
     limit: 100,
   },
   throttle: {
-    period: "10s",
+    period: '10s',
     limit: 1,
-    key: "event.data.organizationId",
+    key: 'event.data.organizationId',
   },
   priority: {
-    run: "event.data.priority ?? 0",
+    run: 'event.data.priority ?? 0',
   },
 });
 ```

--- a/examples/inngest/README.md
+++ b/examples/inngest/README.md
@@ -1,0 +1,532 @@
+# Inngest Workflow
+
+This example demonstrates how to build an Inngest workflow with Mastra.
+
+## Setup
+
+```sh
+npm install @mastra/inngest@beta inngest @mastra/core@beta @mastra/deployer@beta @hono/node-server
+
+docker run --rm -p 8288:8288 \
+  inngest/inngest \
+  inngest dev -u http://host.docker.internal:3000/inngest/api
+```
+
+Alternatively, you can use the Inngest CLI for local development by following the official [Inngest Dev Server guide](https://www.inngest.com/docs/dev-server).
+
+## Define the Planning Agent
+
+Define a planning agent which leverages an LLM call to plan activities given a location and corresponding weather conditions.
+
+```ts
+// agents/planning-agent.ts
+import { Agent } from "@mastra/core/agent";
+
+// Create a new planning agent that uses the OpenAI model
+const planningAgent = new Agent({
+  id: "planning-agent",
+  name: "planningAgent",
+  model: "openai/gpt-5.1",
+  instructions: `
+        You are a local activities and travel expert who excels at weather-based planning. Analyze the weather data and provide practical activity recommendations.
+
+        📅 [Day, Month Date, Year]
+        ═══════════════════════════
+
+        🌡️ WEATHER SUMMARY
+        • Conditions: [brief description]
+        • Temperature: [X°C/Y°F to A°C/B°F]
+        • Precipitation: [X% chance]
+
+        🌅 MORNING ACTIVITIES
+        Outdoor:
+        • [Activity Name] - [Brief description including specific location/route]
+          Best timing: [specific time range]
+          Note: [relevant weather consideration]
+
+        🌞 AFTERNOON ACTIVITIES
+        Outdoor:
+        • [Activity Name] - [Brief description including specific location/route]
+          Best timing: [specific time range]
+          Note: [relevant weather consideration]
+
+        🏠 INDOOR ALTERNATIVES
+        • [Activity Name] - [Brief description including specific venue]
+          Ideal for: [weather condition that would trigger this alternative]
+
+        ⚠️ SPECIAL CONSIDERATIONS
+        • [Any relevant weather warnings, UV index, wind conditions, etc.]
+
+        Guidelines:
+        - Suggest 2-3 time-specific outdoor activities per day
+        - Include 1-2 indoor backup options
+        - For precipitation >50%, lead with indoor activities
+        - All activities must be specific to the location
+        - Include specific venues, trails, or locations
+        - Consider activity intensity based on temperature
+        - Keep descriptions concise but informative
+
+        Maintain this exact formatting for consistency, using the emoji and section headers as shown.
+      `,
+});
+
+export { planningAgent };
+```
+
+## Define the Activity Planner Workflow
+
+Define the activity planner workflow with 3 steps: one to fetch the weather via a network call, one to plan activities, and another to plan only indoor activities.
+
+```ts
+// workflows/inngest-workflow.ts
+import { init } from "@mastra/inngest";
+import { Inngest } from "inngest";
+import { z } from "zod";
+
+const { createWorkflow, createStep } = init(
+  new Inngest({
+    id: "mastra",
+    baseUrl: `http://localhost:8288`,
+  }),
+);
+
+// Helper function to convert weather codes to human-readable descriptions
+function getWeatherCondition(code: number): string {
+  const conditions: Record<number, string> = {
+    0: "Clear sky",
+    1: "Mainly clear",
+    2: "Partly cloudy",
+    3: "Overcast",
+    45: "Foggy",
+    48: "Depositing rime fog",
+    51: "Light drizzle",
+    53: "Moderate drizzle",
+    55: "Dense drizzle",
+    61: "Slight rain",
+    63: "Moderate rain",
+    65: "Heavy rain",
+    71: "Slight snow fall",
+    73: "Moderate snow fall",
+    75: "Heavy snow fall",
+    95: "Thunderstorm",
+  };
+  return conditions[code] || "Unknown";
+}
+
+const forecastSchema = z.object({
+  date: z.string(),
+  maxTemp: z.number(),
+  minTemp: z.number(),
+  precipitationChance: z.number(),
+  condition: z.string(),
+  location: z.string(),
+});
+```
+
+### Step 1: Fetch weather data for a given city
+
+```ts
+// workflows/inngest-workflow.ts
+const fetchWeather = createStep({
+  id: "fetch-weather",
+  description: "Fetches weather forecast for a given city",
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  outputSchema: forecastSchema,
+  execute: async ({ inputData }) => {
+    if (!inputData) {
+      throw new Error("Trigger data not found");
+    }
+
+    // Get latitude and longitude for the city
+    const geocodingUrl = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(inputData.city)}&count=1`;
+    const geocodingResponse = await fetch(geocodingUrl);
+    const geocodingData = (await geocodingResponse.json()) as {
+      results: { latitude: number; longitude: number; name: string }[];
+    };
+
+    if (!geocodingData.results?.[0]) {
+      throw new Error(`Location '${inputData.city}' not found`);
+    }
+
+    const { latitude, longitude, name } = geocodingData.results[0];
+
+    // Fetch weather data using the coordinates
+    const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=precipitation,weathercode&timezone=auto,&hourly=precipitation_probability,temperature_2m`;
+    const response = await fetch(weatherUrl);
+    const data = (await response.json()) as {
+      current: {
+        time: string;
+        precipitation: number;
+        weathercode: number;
+      };
+      hourly: {
+        precipitation_probability: number[];
+        temperature_2m: number[];
+      };
+    };
+
+    const forecast = {
+      date: new Date().toISOString(),
+      maxTemp: Math.max(...data.hourly.temperature_2m),
+      minTemp: Math.min(...data.hourly.temperature_2m),
+      condition: getWeatherCondition(data.current.weathercode),
+      location: name,
+      precipitationChance: data.hourly.precipitation_probability.reduce(
+        (acc, curr) => Math.max(acc, curr),
+        0,
+      ),
+    };
+
+    return forecast;
+  },
+});
+```
+
+### Step 2: Suggest activities (indoor or outdoor) based on weather
+
+```ts
+// workflows/inngest-workflow.ts
+const planActivities = createStep({
+  id: "plan-activities",
+  description: "Suggests activities based on weather conditions",
+  inputSchema: forecastSchema,
+  outputSchema: z.object({
+    activities: z.string(),
+  }),
+  execute: async ({ inputData, mastra }) => {
+    const forecast = inputData;
+
+    if (!forecast) {
+      throw new Error("Forecast data not found");
+    }
+
+    const prompt = `Based on the following weather forecast for ${forecast.location}, suggest appropriate activities:
+      ${JSON.stringify(forecast, null, 2)}
+      `;
+
+    const agent = mastra?.getAgent("planningAgent");
+    if (!agent) {
+      throw new Error("Planning agent not found");
+    }
+
+    const response = await agent.stream([
+      {
+        role: "user",
+        content: prompt,
+      },
+    ]);
+
+    let activitiesText = "";
+
+    for await (const chunk of response.textStream) {
+      process.stdout.write(chunk);
+      activitiesText += chunk;
+    }
+
+    return {
+      activities: activitiesText,
+    };
+  },
+});
+```
+
+### Step 3: Suggest indoor activities only (for rainy weather)
+
+```ts
+// workflows/inngest-workflow.ts
+const planIndoorActivities = createStep({
+  id: "plan-indoor-activities",
+  description: "Suggests indoor activities based on weather conditions",
+  inputSchema: forecastSchema,
+  outputSchema: z.object({
+    activities: z.string(),
+  }),
+  execute: async ({ inputData, mastra }) => {
+    const forecast = inputData;
+
+    if (!forecast) {
+      throw new Error("Forecast data not found");
+    }
+
+    const prompt = `In case it rains, plan indoor activities for ${forecast.location} on ${forecast.date}`;
+
+    const agent = mastra?.getAgent("planningAgent");
+    if (!agent) {
+      throw new Error("Planning agent not found");
+    }
+
+    const response = await agent.stream([
+      {
+        role: "user",
+        content: prompt,
+      },
+    ]);
+
+    let activitiesText = "";
+
+    for await (const chunk of response.textStream) {
+      process.stdout.write(chunk);
+      activitiesText += chunk;
+    }
+
+    return {
+      activities: activitiesText,
+    };
+  },
+});
+```
+
+## Define the activity planner workflow
+
+```ts
+// workflows/inngest-workflow.ts
+const activityPlanningWorkflow = createWorkflow({
+  id: "activity-planning-workflow-step2-if-else",
+  inputSchema: z.object({
+    city: z.string().describe("The city to get the weather for"),
+  }),
+  outputSchema: z.object({
+    activities: z.string(),
+  }),
+})
+  .then(fetchWeather)
+  .branch([
+    [
+      // If precipitation chance is greater than 50%, suggest indoor activities
+      async ({ inputData }) => {
+        return inputData?.precipitationChance > 50;
+      },
+      planIndoorActivities,
+    ],
+    [
+      // Otherwise, suggest a mix of activities
+      async ({ inputData }) => {
+        return inputData?.precipitationChance <= 50;
+      },
+      planActivities,
+    ],
+  ]);
+
+activityPlanningWorkflow.commit();
+
+export { activityPlanningWorkflow };
+```
+
+## Register Agent and Workflow instances with Mastra class
+
+Register the agents and workflow with the mastra instance. This allows access to the agents within the workflow.
+
+```ts
+// index.ts
+import { Mastra } from "@mastra/core";
+import { serve as inngestServe } from "@mastra/inngest";
+import { PinoLogger } from "@mastra/loggers";
+import { Inngest } from "inngest";
+import { activityPlanningWorkflow } from "./workflows/inngest-workflow";
+import { planningAgent } from "./agents/planning-agent";
+import { realtimeMiddleware } from "@inngest/realtime/middleware";
+
+// Create an Inngest instance for workflow orchestration and event handling
+const inngest = new Inngest({
+  id: "mastra",
+  baseUrl: `http://localhost:8288`, // URL of your local Inngest server
+  isDev: true,
+  middleware: [realtimeMiddleware()], // Enable real-time updates in the Inngest dashboard
+});
+
+// Create and configure the main Mastra instance
+export const mastra = new Mastra({
+  workflows: {
+    activityPlanningWorkflow,
+  },
+  agents: {
+    planningAgent,
+  },
+  server: {
+    host: "0.0.0.0",
+    apiRoutes: [
+      {
+        path: "/api/inngest", // API endpoint for Inngest to send events to
+        method: "ALL",
+        createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
+      },
+    ],
+  },
+  logger: new PinoLogger({
+    name: "Mastra",
+    level: "info",
+  }),
+});
+```
+
+## Execute the activity planner workflow
+
+Here, we'll get the activity planner workflow from the mastra instance, then create a run and execute the created run with the required inputData.
+
+```ts
+// exec.ts
+import { mastra } from "./";
+import { serve } from "@hono/node-server";
+import { createHonoServer, getToolExports } from "@mastra/deployer/server";
+import { tools } from "#tools";
+
+const app = await createHonoServer(mastra, {
+  tools: getToolExports(tools),
+});
+
+// Start the server on port 3000 so Inngest can send events to it
+const srv = serve({
+  fetch: app.fetch,
+  port: 3000,
+});
+
+const workflow = mastra.getWorkflow("activityPlanningWorkflow");
+const run = await workflow.createRun();
+
+// Start the workflow with the required input data (city name)
+// This will trigger the workflow steps and stream the result to the console
+const result = await run.start({ inputData: { city: "New York" } });
+console.dir(result, { depth: null });
+
+// Close the server after the workflow run is complete
+srv.close();
+```
+
+After running the workflow, you can view and monitor your workflow runs in real time using the Inngest dashboard at [http://localhost:8288](http://localhost:8288).
+
+## Inngest Flow Control Configuration
+
+Inngest workflows support advanced flow control features including concurrency limits, rate limiting, throttling, debouncing, and priority queuing. These features help manage workflow execution at scale and prevent resource overload.
+
+### Concurrency Control
+
+Control how many workflow instances can run simultaneously:
+
+```ts
+const workflow = createWorkflow({
+  id: "user-processing-workflow",
+  inputSchema: z.object({ userId: z.string() }),
+  outputSchema: z.object({ result: z.string() }),
+  steps: [processUserStep],
+  // Limit to 10 concurrent executions, scoped by user ID
+  concurrency: {
+    limit: 10,
+    key: "event.data.userId", // Per-user concurrency
+  },
+});
+```
+
+### Rate Limiting
+
+Limit the number of workflow executions within a time period:
+
+```ts
+const workflow = createWorkflow({
+  id: "api-sync-workflow",
+  inputSchema: z.object({ endpoint: z.string() }),
+  outputSchema: z.object({ status: z.string() }),
+  steps: [apiSyncStep],
+  // Maximum 1000 executions per hour
+  rateLimit: {
+    period: "1h",
+    limit: 1000,
+  },
+});
+```
+
+### Throttling
+
+Ensure minimum time between workflow executions:
+
+```ts
+const workflow = createWorkflow({
+  id: "email-notification-workflow",
+  inputSchema: z.object({ organizationId: z.string(), message: z.string() }),
+  outputSchema: z.object({ sent: z.boolean() }),
+  steps: [sendEmailStep],
+  // Only one execution per 10 seconds per organization
+  throttle: {
+    period: "10s",
+    limit: 1,
+    key: "event.data.organizationId",
+  },
+});
+```
+
+### Debouncing
+
+Delay execution until no new events arrive within a time window:
+
+```ts
+const workflow = createWorkflow({
+  id: "search-index-workflow",
+  inputSchema: z.object({ documentId: z.string() }),
+  outputSchema: z.object({ indexed: z.boolean() }),
+  steps: [indexDocumentStep],
+  // Wait 5 seconds of no updates before indexing
+  debounce: {
+    period: "5s",
+    key: "event.data.documentId",
+  },
+});
+```
+
+### Priority Queuing
+
+Set execution priority for workflows:
+
+```ts
+const workflow = createWorkflow({
+  id: "order-processing-workflow",
+  inputSchema: z.object({
+    orderId: z.string(),
+    priority: z.number().optional(),
+  }),
+  outputSchema: z.object({ processed: z.boolean() }),
+  steps: [processOrderStep],
+  // Higher priority orders execute first
+  priority: {
+    run: "event.data.priority ?? 50", // Dynamic priority, default 50
+  },
+});
+```
+
+### Combined Flow Control
+
+You can combine multiple flow control features:
+
+```ts
+const workflow = createWorkflow({
+  id: "comprehensive-workflow",
+  inputSchema: z.object({
+    userId: z.string(),
+    organizationId: z.string(),
+    priority: z.number().optional(),
+  }),
+  outputSchema: z.object({ result: z.string() }),
+  steps: [comprehensiveStep],
+  // Multiple flow control features
+  concurrency: {
+    limit: 5,
+    key: "event.data.userId",
+  },
+  rateLimit: {
+    period: "1m",
+    limit: 100,
+  },
+  throttle: {
+    period: "10s",
+    limit: 1,
+    key: "event.data.organizationId",
+  },
+  priority: {
+    run: "event.data.priority ?? 0",
+  },
+});
+```
+
+All flow control features are optional. If not specified, workflows run with Inngest's default behavior. Flow control configuration is validated by Inngest's native implementation, ensuring compatibility and correctness.
+
+For detailed information about flow control options and their behavior, see the [Inngest Flow Control documentation](https://www.inngest.com/docs/guides/flow-control).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Inngest deployment guide, an Inngest workflow example (with README), and a new "Workflow Runners" section in Deployment Overview describing orchestration, monitoring, retries, memoization, and suspend/resume.
  * Removed the standalone "Inngest Workflow" example entry from example cards and sidebar navigation to streamline docs.
* **Chores**
  * Added redirects to map previous Inngest workflow links to the new guide and example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->