### PR TITLE
chore(docs): Cleanup codeblock annotations

### DIFF
--- a/docs/src/content/en/docs/agents/adding-voice.mdx
+++ b/docs/src/content/en/docs/agents/adding-voice.mdx
@@ -168,7 +168,7 @@ The following files are created:
 - **hybrid-question.mp3** – Hybrid agent's spoken question.
 - **unified-response.mp3** – Unified agent's spoken response.
 
-```typescript title="src/test-voice-agents.ts" showLineNumbers copy
+```typescript title="src/test-voice-agents.ts" copy
 import "dotenv/config";
 
 import path from "path";

--- a/docs/src/content/en/docs/agents/adding-voice.mdx
+++ b/docs/src/content/en/docs/agents/adding-voice.mdx
@@ -168,7 +168,7 @@ The following files are created:
 - **hybrid-question.mp3** – Hybrid agent's spoken question.
 - **unified-response.mp3** – Unified agent's spoken response.
 
-```typescript title="src/test-voice-agents.ts" copy
+```typescript title="src/test-voice-agents.ts"
 import "dotenv/config";
 
 import path from "path";

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -33,7 +33,7 @@ export const mastra = new Mastra({
 
 When calling an agent using `.stream()` set `requireToolApproval` to `true` which will prevent the agent from calling any of the tools defined in its configuration.
 
-```typescript showLineNumbers
+```typescript
 const stream = await agent.stream("What's the weather in London?", {
   requireToolApproval: true
 });
@@ -43,7 +43,7 @@ const stream = await agent.stream("What's the weather in London?", {
 
 To approve a tool call, access `approveToolCall` from the `agent`, passing in the `runId` of the stream. This will let the agent know its now OK to call its tools.
 
-```typescript showLineNumbers
+```typescript
 const handleApproval = async () => {
   const approvedStream = await agent.approveToolCall({ runId: stream.runId });
 
@@ -58,7 +58,7 @@ const handleApproval = async () => {
 
 To decline a tool call, access the `declineToolCall` from the `agent`. You will see the streamed response from the agent, but it won't call its tools.
 
-```typescript showLineNumbers
+```typescript
 const handleDecline = async () => {
   const declinedStream = await agent.declineToolCall({ runId: stream.runId });
 

--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -143,7 +143,7 @@ To learn more about memory see the [Memory](../memory/overview) documentation.
 
 Use [RequestContext](/docs/v1/server/request-context) to access request-specific values. This lets you conditionally select different memory or storage configurations based on the context of the request.
 
-```typescript title="src/mastra/agents/memory-agent.ts" showLineNumbers
+```typescript title="src/mastra/agents/memory-agent.ts"
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };

--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -20,7 +20,7 @@ Use memory when your agent needs to maintain multi-turn conversations that refer
 
 To enable memory in Mastra, install the `@mastra/memory` package along with a storage provider.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @mastra/memory@beta @mastra/libsql@beta
 ```
 
@@ -35,7 +35,7 @@ Memory requires a storage provider to persist conversation history, including us
 
 Enable memory by creating a `Memory` instance and passing it to the agent’s `memory` option.
 
-```typescript {6-9} title="src/mastra/agents/memory-agent.ts" copy
+```typescript {6-9} title="src/mastra/agents/memory-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 
@@ -63,7 +63,7 @@ See the [Memory Class](/reference/v1/memory/memory-class) docs for a full list o
 
 Add a storage provider to your main Mastra instance to enable memory across all configured agents.
 
-```typescript {6-8} title="src/mastra/index.ts" copy
+```typescript {6-8} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 
@@ -87,7 +87,7 @@ See the [LibSQL Storage](/reference/v1/storage/libsql) docs for a full list of c
 
 Alternatively, add storage directly to an agent’s memory to keep data separate or use different providers per agent.
 
-```typescript {7-10} title="src/mastra/agents/memory-agent.ts" copy
+```typescript {7-10} title="src/mastra/agents/memory-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";

--- a/docs/src/content/en/docs/agents/guardrails.mdx
+++ b/docs/src/content/en/docs/agents/guardrails.mdx
@@ -22,7 +22,7 @@ Use processors for content moderation, prompt injection prevention, response san
 
 Import and instantiate the relevant processor class, and pass it to your agent’s configuration using either the `inputProcessors` or `outputProcessors` option:
 
-```typescript {2,8-16} title="src/mastra/agents/moderated-agent.ts" showLineNumbers copy
+```typescript {2,8-16} title="src/mastra/agents/moderated-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { ModerationProcessor } from "@mastra/core/processors";
 
@@ -51,7 +51,7 @@ Input processors are applied before user messages reach the language model. They
 
 The `UnicodeNormalizer` is an input processor that cleans and normalizes user input by unifying Unicode characters, standardizing whitespace, and removing problematic symbols, allowing the LLM to better understand user messages.
 
-```typescript {8-11} title="src/mastra/agents/normalized-agent.ts" showLineNumbers copy
+```typescript {8-11} title="src/mastra/agents/normalized-agent.ts" copy
 import { UnicodeNormalizer } from "@mastra/core/processors";
 
 export const normalizedAgent = new Agent({
@@ -73,7 +73,7 @@ export const normalizedAgent = new Agent({
 
 The `PromptInjectionDetector` is an input processor that scans user messages for prompt injection, jailbreak attempts, and system override patterns. It uses an LLM to classify risky input and can block or rewrite it before it reaches the model.
 
-```typescript {8-13} title="src/mastra/agents/secure-agent.ts" showLineNumbers copy
+```typescript {8-13} title="src/mastra/agents/secure-agent.ts" copy
 import { PromptInjectionDetector } from "@mastra/core/processors";
 
 export const secureAgent = new Agent({
@@ -97,7 +97,7 @@ export const secureAgent = new Agent({
 
 The `LanguageDetector` is an input processor that detects and translates user messages into a target language, enabling multilingual support while maintaining consistent interaction. It uses an LLM to identify the language and perform the translation.
 
-```typescript {8-13} title="src/mastra/agents/multilingual-agent.ts" showLineNumbers copy
+```typescript {8-13} title="src/mastra/agents/multilingual-agent.ts" copy
 import { LanguageDetector } from "@mastra/core/processors";
 
 export const multilingualAgent = new Agent({
@@ -125,7 +125,7 @@ Output processors are applied after the language model generates a response, but
 
 The `BatchPartsProcessor` is an output processor that combines multiple stream parts before emitting them to the client. This reduces network overhead and improves the user experience by consolidating small chunks into larger batches.
 
-```typescript {8-12} title="src/mastra/agents/batched-agent.ts" showLineNumbers copy
+```typescript {8-12} title="src/mastra/agents/batched-agent.ts" copy
 import { BatchPartsProcessor } from "@mastra/core/processors";
 
 export const batchedAgent = new Agent({
@@ -148,7 +148,7 @@ export const batchedAgent = new Agent({
 
 The `TokenLimiterProcessor` is an output processor that limits the number of tokens in model responses. It helps manage cost and performance by truncating or blocking messages when the limit is exceeded.
 
-```typescript {8-12} title="src/mastra/agents/limited-agent.ts" showLineNumbers copy
+```typescript {8-12} title="src/mastra/agents/limited-agent.ts" copy
 import { TokenLimiterProcessor } from "@mastra/core/processors";
 
 export const limitedAgent = new Agent({
@@ -171,7 +171,7 @@ export const limitedAgent = new Agent({
 
 The `SystemPromptScrubber` is an output processor that detects and redacts system prompts or other internal instructions from model responses. It helps prevent unintended disclosure of prompt content or configuration details that could introduce security risks. It uses an LLM to identify and redact sensitive content based on configured detection types.
 
-```typescript {7-16} title="src/mastra/agents/scrubbed-agent.ts" copy showLineNumbers
+```typescript {7-16} title="src/mastra/agents/scrubbed-agent.ts" copy
 import { SystemPromptScrubber } from "@mastra/core/processors";
 
 const scrubbedAgent = new Agent({
@@ -206,7 +206,7 @@ Hybrid processors can be applied either before messages are sent to the language
 
 The `ModerationProcessor` is a hybrid processor that detects inappropriate or harmful content across categories like hate, harassment, and violence. It can be used to moderate either user input or model output, depending on where it's applied. It uses an LLM to classify the message and can block or rewrite it based on your configuration.
 
-```typescript {8-13,16-18} title="src/mastra/agents/moderated-agent.ts" showLineNumbers copy
+```typescript {8-13,16-18} title="src/mastra/agents/moderated-agent.ts" copy
 import { ModerationProcessor } from "@mastra/core/processors";
 
 export const moderatedAgent = new Agent({
@@ -235,7 +235,7 @@ export const moderatedAgent = new Agent({
 
 The `PIIDetector` is a hybrid processor that detects and removes personally identifiable information such as emails, phone numbers, and credit cards. It can redact either user input or model output, depending on where it's applied. It uses an LLM to identify sensitive content based on configured detection types.
 
-```typescript {8-15,18-20} title="src/mastra/agents/private-agent.ts" showLineNumbers copy
+```typescript {8-15,18-20} title="src/mastra/agents/private-agent.ts" copy
 import { PIIDetector } from "@mastra/core/processors";
 
 export const privateAgent = new Agent({
@@ -274,7 +274,7 @@ A typical order might be:
 
 The order affects behavior, so arrange processors to suit your goals.
 
-```typescript title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/test-agent.ts" copy
 import {
   UnicodeNormalizer,
   ModerationProcessor,
@@ -309,7 +309,7 @@ Many of the built-in processors support a `strategy` parameter that controls how
 
 Most strategies allow the request to continue without interruption. When `block` is used, the processor calls its internal `abort()` function, which immediately stops the request and prevents any subsequent processors from running.
 
-```typescript {10} title="src/mastra/agents/private-agent.ts" showLineNumbers copy
+```typescript {10} title="src/mastra/agents/private-agent.ts" copy
 import { PIIDetector } from "@mastra/core/processors";
 
 export const privateAgent = new Agent({
@@ -333,7 +333,7 @@ For example, if an agent uses the `PIIDetector` with `strategy: "block"` and the
 
 #### `.generate()` example
 
-```typescript showLineNumbers
+```typescript
 const result = await agent.generate(
   "Is this credit card number valid?: 4543 1374 5089 4332",
 );
@@ -350,7 +350,7 @@ if (result.tripwire) {
 
 #### `.stream()` example
 
-```typescript showLineNumbers
+```typescript
 const stream = await agent.stream(
   "Is this credit card number valid?: 4543 1374 5089 4332",
 );
@@ -373,7 +373,7 @@ PII detected. Types: credit-card
 
 Processors can request that the LLM retry its response with feedback. This is useful for implementing quality checks:
 
-```typescript showLineNumbers
+```typescript
 export class QualityChecker implements Processor {
   id = "quality-checker";
 

--- a/docs/src/content/en/docs/agents/guardrails.mdx
+++ b/docs/src/content/en/docs/agents/guardrails.mdx
@@ -22,7 +22,7 @@ Use processors for content moderation, prompt injection prevention, response san
 
 Import and instantiate the relevant processor class, and pass it to your agent’s configuration using either the `inputProcessors` or `outputProcessors` option:
 
-```typescript {2,8-16} title="src/mastra/agents/moderated-agent.ts" copy
+```typescript {2,8-16} title="src/mastra/agents/moderated-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { ModerationProcessor } from "@mastra/core/processors";
 
@@ -51,7 +51,7 @@ Input processors are applied before user messages reach the language model. They
 
 The `UnicodeNormalizer` is an input processor that cleans and normalizes user input by unifying Unicode characters, standardizing whitespace, and removing problematic symbols, allowing the LLM to better understand user messages.
 
-```typescript {8-11} title="src/mastra/agents/normalized-agent.ts" copy
+```typescript {8-11} title="src/mastra/agents/normalized-agent.ts"
 import { UnicodeNormalizer } from "@mastra/core/processors";
 
 export const normalizedAgent = new Agent({
@@ -73,7 +73,7 @@ export const normalizedAgent = new Agent({
 
 The `PromptInjectionDetector` is an input processor that scans user messages for prompt injection, jailbreak attempts, and system override patterns. It uses an LLM to classify risky input and can block or rewrite it before it reaches the model.
 
-```typescript {8-13} title="src/mastra/agents/secure-agent.ts" copy
+```typescript {8-13} title="src/mastra/agents/secure-agent.ts"
 import { PromptInjectionDetector } from "@mastra/core/processors";
 
 export const secureAgent = new Agent({
@@ -97,7 +97,7 @@ export const secureAgent = new Agent({
 
 The `LanguageDetector` is an input processor that detects and translates user messages into a target language, enabling multilingual support while maintaining consistent interaction. It uses an LLM to identify the language and perform the translation.
 
-```typescript {8-13} title="src/mastra/agents/multilingual-agent.ts" copy
+```typescript {8-13} title="src/mastra/agents/multilingual-agent.ts"
 import { LanguageDetector } from "@mastra/core/processors";
 
 export const multilingualAgent = new Agent({
@@ -125,7 +125,7 @@ Output processors are applied after the language model generates a response, but
 
 The `BatchPartsProcessor` is an output processor that combines multiple stream parts before emitting them to the client. This reduces network overhead and improves the user experience by consolidating small chunks into larger batches.
 
-```typescript {8-12} title="src/mastra/agents/batched-agent.ts" copy
+```typescript {8-12} title="src/mastra/agents/batched-agent.ts"
 import { BatchPartsProcessor } from "@mastra/core/processors";
 
 export const batchedAgent = new Agent({
@@ -148,7 +148,7 @@ export const batchedAgent = new Agent({
 
 The `TokenLimiterProcessor` is an output processor that limits the number of tokens in model responses. It helps manage cost and performance by truncating or blocking messages when the limit is exceeded.
 
-```typescript {8-12} title="src/mastra/agents/limited-agent.ts" copy
+```typescript {8-12} title="src/mastra/agents/limited-agent.ts"
 import { TokenLimiterProcessor } from "@mastra/core/processors";
 
 export const limitedAgent = new Agent({
@@ -171,7 +171,7 @@ export const limitedAgent = new Agent({
 
 The `SystemPromptScrubber` is an output processor that detects and redacts system prompts or other internal instructions from model responses. It helps prevent unintended disclosure of prompt content or configuration details that could introduce security risks. It uses an LLM to identify and redact sensitive content based on configured detection types.
 
-```typescript {7-16} title="src/mastra/agents/scrubbed-agent.ts" copy
+```typescript {7-16} title="src/mastra/agents/scrubbed-agent.ts"
 import { SystemPromptScrubber } from "@mastra/core/processors";
 
 const scrubbedAgent = new Agent({
@@ -206,7 +206,7 @@ Hybrid processors can be applied either before messages are sent to the language
 
 The `ModerationProcessor` is a hybrid processor that detects inappropriate or harmful content across categories like hate, harassment, and violence. It can be used to moderate either user input or model output, depending on where it's applied. It uses an LLM to classify the message and can block or rewrite it based on your configuration.
 
-```typescript {8-13,16-18} title="src/mastra/agents/moderated-agent.ts" copy
+```typescript {8-13,16-18} title="src/mastra/agents/moderated-agent.ts"
 import { ModerationProcessor } from "@mastra/core/processors";
 
 export const moderatedAgent = new Agent({
@@ -235,7 +235,7 @@ export const moderatedAgent = new Agent({
 
 The `PIIDetector` is a hybrid processor that detects and removes personally identifiable information such as emails, phone numbers, and credit cards. It can redact either user input or model output, depending on where it's applied. It uses an LLM to identify sensitive content based on configured detection types.
 
-```typescript {8-15,18-20} title="src/mastra/agents/private-agent.ts" copy
+```typescript {8-15,18-20} title="src/mastra/agents/private-agent.ts"
 import { PIIDetector } from "@mastra/core/processors";
 
 export const privateAgent = new Agent({
@@ -274,7 +274,7 @@ A typical order might be:
 
 The order affects behavior, so arrange processors to suit your goals.
 
-```typescript title="src/mastra/agents/test-agent.ts" copy
+```typescript title="src/mastra/agents/test-agent.ts"
 import {
   UnicodeNormalizer,
   ModerationProcessor,
@@ -309,7 +309,7 @@ Many of the built-in processors support a `strategy` parameter that controls how
 
 Most strategies allow the request to continue without interruption. When `block` is used, the processor calls its internal `abort()` function, which immediately stops the request and prevents any subsequent processors from running.
 
-```typescript {10} title="src/mastra/agents/private-agent.ts" copy
+```typescript {10} title="src/mastra/agents/private-agent.ts"
 import { PIIDetector } from "@mastra/core/processors";
 
 export const privateAgent = new Agent({

--- a/docs/src/content/en/docs/agents/networks.mdx
+++ b/docs/src/content/en/docs/agents/networks.mdx
@@ -23,7 +23,7 @@ Mastra agent networks operate using these principles:
 
 An agent network is built around a top-level routing agent that delegates tasks to agents, workflows, and tools defined in its configuration. Memory is configured on the routing agent using the `memory` option, and `instructions` define the agent's routing behavior.
 
-```typescript {22-23,26,29} title="src/mastra/agents/routing-agent.ts" showLineNumbers copy
+```typescript {22-23,26,29} title="src/mastra/agents/routing-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -71,7 +71,7 @@ When configuring a Mastra agent network, each primitive (agent, workflow, or too
 
 Each agent in a network should include a clear `description` that explains what the agent does.
 
-```typescript title="src/mastra/agents/research-agent.ts" showLineNumbers
+```typescript title="src/mastra/agents/research-agent.ts"
 export const researchAgent = new Agent({
   id: "research-agent",
   name: "Research Agent",
@@ -82,7 +82,7 @@ export const researchAgent = new Agent({
 });
 ```
 
-```typescript title="src/mastra/agents/writing-agent.ts" showLineNumbers
+```typescript title="src/mastra/agents/writing-agent.ts"
 export const writingAgent = new Agent({
   id: "writing-agent",
   name: "Writing Agent",
@@ -97,7 +97,7 @@ export const writingAgent = new Agent({
 
 Workflows in a network should include a `description` to explain their purpose, along with `inputSchema` and `outputSchema` to describe the expected data.
 
-```typescript title="src/mastra/workflows/city-workflow.ts" showLineNumbers
+```typescript title="src/mastra/workflows/city-workflow.ts"
 export const cityWorkflow = createWorkflow({
   id: "city-workflow",
   description: `This workflow handles city-specific research tasks.
@@ -118,7 +118,7 @@ export const cityWorkflow = createWorkflow({
 
 Tools in a network should include a `description` to explain their purpose, along with `inputSchema` and `outputSchema` to describe the expected data.
 
-```typescript title="src/mastra/tools/weather-tool.ts" showLineNumbers
+```typescript title="src/mastra/tools/weather-tool.ts"
 export const weatherTool = createTool({
   id: "weather-tool",
   description: ` Retrieves current weather information using the wttr.in API.
@@ -143,7 +143,7 @@ Call a Mastra agent network using `.network()` with a user message. The method r
 
 In this example, the network interprets the message and would route the request to both the `researchAgent` and `writingAgent` to generate a complete response.
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await routingAgent.network(
   "Tell me three cool ways to use Mastra",
 );
@@ -179,7 +179,7 @@ network-execution-event-step-finish
 
 In this example, the routing agent recognizes the city name in the message and runs the `cityWorkflow`. The workflow defines steps that call the `researchAgent` to gather facts, then the `writingAgent` to generate the final text.
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await routingAgent.network(
   "Tell me some historical facts about London",
 );
@@ -212,7 +212,7 @@ network-execution-event-step-finish
 
 In this example, the routing agent skips the `researchAgent`, `writingAgent`, and `cityWorkflow`, and calls the `weatherTool` directly to complete the task.
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await routingAgent.network("What's the weather in London?");
 
 for await (const chunk of result) {

--- a/docs/src/content/en/docs/agents/networks.mdx
+++ b/docs/src/content/en/docs/agents/networks.mdx
@@ -23,7 +23,7 @@ Mastra agent networks operate using these principles:
 
 An agent network is built around a top-level routing agent that delegates tasks to agents, workflows, and tools defined in its configuration. Memory is configured on the routing agent using the `memory` option, and `instructions` define the agent's routing behavior.
 
-```typescript {22-23,26,29} title="src/mastra/agents/routing-agent.ts" copy
+```typescript {22-23,26,29} title="src/mastra/agents/routing-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -143,7 +143,7 @@ Call a Mastra agent network using `.network()` with a user message. The method r
 
 In this example, the network interprets the message and would route the request to both the `researchAgent` and `writingAgent` to generate a complete response.
 
-```typescript copy
+```typescript
 const result = await routingAgent.network(
   "Tell me three cool ways to use Mastra",
 );
@@ -179,7 +179,7 @@ network-execution-event-step-finish
 
 In this example, the routing agent recognizes the city name in the message and runs the `cityWorkflow`. The workflow defines steps that call the `researchAgent` to gather facts, then the `writingAgent` to generate the final text.
 
-```typescript copy
+```typescript
 const result = await routingAgent.network(
   "Tell me some historical facts about London",
 );
@@ -212,7 +212,7 @@ network-execution-event-step-finish
 
 In this example, the routing agent skips the `researchAgent`, `writingAgent`, and `cityWorkflow`, and calls the `weatherTool` directly to complete the task.
 
-```typescript copy
+```typescript
 const result = await routingAgent.network("What's the weather in London?");
 
 for await (const chunk of result) {

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -118,7 +118,7 @@ instructions: {
 
 Register your agent in the Mastra instance to make it available throughout your application. Once registered, it can be called from workflows, tools, or other agents, and has access to shared resources such as memory, logging, and observability features:
 
-```typescript {6} showLineNumbers title="src/mastra/index.ts" copy
+```typescript {6} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { testAgent } from "./agents/test-agent";
 
@@ -132,7 +132,7 @@ export const mastra = new Mastra({
 
 You can call agents from workflow steps, tools, the Mastra Client, or the command line. Get a reference by calling `.getAgent()` on your `mastra` or `mastraClient` instance, depending on your setup:
 
-```typescript showLineNumbers copy
+```typescript copy
 const testAgent = mastra.getAgent("testAgent");
 ```
 
@@ -152,7 +152,7 @@ Pass a single string for simple prompts, an array of strings when providing mult
 
 (The `role` defines the speaker for each message. Typical roles are `user` for human input, `assistant` for agent responses, and `system` for instructions.)
 
-```typescript showLineNumbers copy
+```typescript copy
 const response = await testAgent.generate([
   { role: "user", content: "Help me organize my day" },
   { role: "user", content: "My day starts at 9am and finishes at 5.30pm" },
@@ -172,7 +172,7 @@ Pass a single string for simple prompts, an array of strings when providing mult
 
 (The `role` defines the speaker for each message. Typical roles are `user` for human input, `assistant` for agent responses, and `system` for instructions.)
 
-```typescript showLineNumbers copy
+```typescript copy
 const stream = await testAgent.stream([
   { role: "user", content: "Help me organize my day" },
   { role: "user", content: "My day starts at 9am and finishes at 5.30pm" },
@@ -193,7 +193,7 @@ for await (const chunk of stream.textStream) {
 When streaming responses, the `onFinish()` callback runs after the LLM finishes generating its response and all tool executions are complete.
 It provides the final `text`, execution `steps`, `finishReason`, token `usage` statistics, and other metadata useful for monitoring or logging.
 
-```typescript showLineNumbers copy
+```typescript copy
 const stream = await testAgent.stream("Help me organize my day", {
   onFinish: ({ steps, text, finishReason, usage }) => {
     console.log({ steps, text, finishReason, usage });
@@ -220,7 +220,7 @@ Agents can return structured, type-safe data using Zod or JSON Schema. The parse
 
 Agents can analyze and describe images by processing both the visual content and any text within them. To enable image analysis, pass an object with `type: 'image'` and the image URL in the `content` array. You can combine image content with text prompts to guide the agent's analysis.
 
-```typescript showLineNumbers copy
+```typescript copy
 const response = await testAgent.generate([
   {
     role: "user",
@@ -246,7 +246,7 @@ console.log(response.text);
 
 The `maxSteps` parameter controls the maximum number of sequential LLM calls an agent can make. Each step includes generating a response, executing any tool calls, and processing the result. Limiting steps helps prevent infinite loops, reduce latency, and control token usage for agents that use tools. The default is 1, but can be increased:
 
-```typescript showLineNumbers copy
+```typescript copy
 const response = await testAgent.generate("Help me organize my day", {
   maxSteps: 10,
 });
@@ -260,7 +260,7 @@ You can monitor the progress of multi-step operations using the `onStepFinish` c
 
 `onStepFinish` is only available when streaming or generating text without structured output.
 
-```typescript showLineNumbers copy
+```typescript copy
 const response = await testAgent.generate("Help me organize my day", {
   onStepFinish: ({ text, toolCalls, toolResults, finishReason, usage }) => {
     console.log({ text, toolCalls, toolResults, finishReason, usage });
@@ -272,7 +272,7 @@ const response = await testAgent.generate("Help me organize my day", {
 
 Agents can use tools to go beyond language generation, enabling structured interactions with external APIs and services. Tools allow agents to access data and perform clearly defined operations in a reliable, repeatable way.
 
-```typescript title="src/mastra/agents/test-agent.ts" showLineNumbers
+```typescript title="src/mastra/agents/test-agent.ts"
 export const testAgent = new Agent({
   id: "test-agent",
   name: "Test Agent",
@@ -287,7 +287,7 @@ export const testAgent = new Agent({
 
 Use `RequestContext` to access request-specific values. This lets you conditionally adjust behavior based on the context of the request.
 
-```typescript title="src/mastra/agents/test-agent.ts" showLineNumbers
+```typescript title="src/mastra/agents/test-agent.ts"
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -39,7 +39,7 @@ npm install @mastra/core@beta
 
 Mastra's model router auto-detects environment variables for your chosen provider. For OpenAI, set `OPENAI_API_KEY`:
 
-```bash title=".env" copy
+```bash title=".env"
 OPENAI_API_KEY=<your-api-key>
 ```
 
@@ -55,7 +55,7 @@ Mastra supports more than 600 models. Choose from the [full list](/models/v1).
 
 Create an agent by instantiating the `Agent` class with system `instructions` and a `model`:
 
-```typescript title="src/mastra/agents/test-agent.ts" copy
+```typescript title="src/mastra/agents/test-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 export const testAgent = new Agent({
@@ -77,7 +77,7 @@ They are system-level prompts that establish the agent's core identity and exper
 
 Instructions can be provided in multiple formats for greater flexibility. The examples below illustrate the supported shapes:
 
-```typescript copy
+```typescript
 // String (most common)
 instructions: "You are a helpful assistant.";
 
@@ -99,7 +99,7 @@ instructions: [
 
 Each model provider also enables a few different options, including prompt caching and configuring reasoning. We provide a `providerOptions` flag to manage these. You can set `providerOptions` on the instruction level to set different caching strategy per system instruction/prompt.
 
-```typescript copy
+```typescript
 // With provider-specific options (e.g., caching, reasoning)
 instructions: {
   role: "system",
@@ -118,7 +118,7 @@ instructions: {
 
 Register your agent in the Mastra instance to make it available throughout your application. Once registered, it can be called from workflows, tools, or other agents, and has access to shared resources such as memory, logging, and observability features:
 
-```typescript {6} title="src/mastra/index.ts" copy
+```typescript {6} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { testAgent } from "./agents/test-agent";
 
@@ -132,7 +132,7 @@ export const mastra = new Mastra({
 
 You can call agents from workflow steps, tools, the Mastra Client, or the command line. Get a reference by calling `.getAgent()` on your `mastra` or `mastraClient` instance, depending on your setup:
 
-```typescript copy
+```typescript
 const testAgent = mastra.getAgent("testAgent");
 ```
 
@@ -152,7 +152,7 @@ Pass a single string for simple prompts, an array of strings when providing mult
 
 (The `role` defines the speaker for each message. Typical roles are `user` for human input, `assistant` for agent responses, and `system` for instructions.)
 
-```typescript copy
+```typescript
 const response = await testAgent.generate([
   { role: "user", content: "Help me organize my day" },
   { role: "user", content: "My day starts at 9am and finishes at 5.30pm" },
@@ -172,7 +172,7 @@ Pass a single string for simple prompts, an array of strings when providing mult
 
 (The `role` defines the speaker for each message. Typical roles are `user` for human input, `assistant` for agent responses, and `system` for instructions.)
 
-```typescript copy
+```typescript
 const stream = await testAgent.stream([
   { role: "user", content: "Help me organize my day" },
   { role: "user", content: "My day starts at 9am and finishes at 5.30pm" },
@@ -193,7 +193,7 @@ for await (const chunk of stream.textStream) {
 When streaming responses, the `onFinish()` callback runs after the LLM finishes generating its response and all tool executions are complete.
 It provides the final `text`, execution `steps`, `finishReason`, token `usage` statistics, and other metadata useful for monitoring or logging.
 
-```typescript copy
+```typescript
 const stream = await testAgent.stream("Help me organize my day", {
   onFinish: ({ steps, text, finishReason, usage }) => {
     console.log({ steps, text, finishReason, usage });
@@ -220,7 +220,7 @@ Agents can return structured, type-safe data using Zod or JSON Schema. The parse
 
 Agents can analyze and describe images by processing both the visual content and any text within them. To enable image analysis, pass an object with `type: 'image'` and the image URL in the `content` array. You can combine image content with text prompts to guide the agent's analysis.
 
-```typescript copy
+```typescript
 const response = await testAgent.generate([
   {
     role: "user",
@@ -246,7 +246,7 @@ console.log(response.text);
 
 The `maxSteps` parameter controls the maximum number of sequential LLM calls an agent can make. Each step includes generating a response, executing any tool calls, and processing the result. Limiting steps helps prevent infinite loops, reduce latency, and control token usage for agents that use tools. The default is 1, but can be increased:
 
-```typescript copy
+```typescript
 const response = await testAgent.generate("Help me organize my day", {
   maxSteps: 10,
 });
@@ -260,7 +260,7 @@ You can monitor the progress of multi-step operations using the `onStepFinish` c
 
 `onStepFinish` is only available when streaming or generating text without structured output.
 
-```typescript copy
+```typescript
 const response = await testAgent.generate("Help me organize my day", {
   onStepFinish: ({ text, toolCalls, toolResults, finishReason, usage }) => {
     console.log({ text, toolCalls, toolResults, finishReason, usage });

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -35,7 +35,7 @@ Mastra includes several processors for common use cases. You can also create cus
 
 Import and instantiate the processor, then pass it to the agent's `inputProcessors` or `outputProcessors` array:
 
-```typescript {3,9-15} title="src/mastra/agents/moderated-agent.ts" showLineNumbers copy
+```typescript {3,9-15} title="src/mastra/agents/moderated-agent.ts" copy
 import { openai } from "@ai-sdk/openai";
 import { Agent } from "@mastra/core/agent";
 import { ModerationProcessor } from "@mastra/core/processors";
@@ -93,7 +93,7 @@ Custom processors implement the `Processor` interface:
 
 ### Custom input processor
 
-```typescript title="src/mastra/processors/custom-input.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/custom-input.ts" copy
 import type {
   Processor,
   MastraDBMessage,
@@ -141,7 +141,7 @@ The framework handles both return formats, so modifying system messages is optio
 
 To modify system messages (e.g., trim verbose prompts for smaller models), return an object with both `messages` and `systemMessages`:
 
-```typescript title="src/mastra/processors/system-trimmer.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/system-trimmer.ts" copy
 import type { Processor, CoreMessage, MastraDBMessage } from "@mastra/core";
 
 export class SystemTrimmer implements Processor {
@@ -174,7 +174,7 @@ This is useful for:
 
 While `processInput` runs once at the start of agent execution, `processInputStep` runs at **each step** of the agentic loop (including tool call continuations). This enables per-step configuration changes like dynamic model switching or tool choice modifications.
 
-```typescript title="src/mastra/processors/step-processor.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/step-processor.ts" copy
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from "@mastra/core";
 
 export class DynamicModelProcessor implements Processor {
@@ -247,7 +247,7 @@ await agent.generate({
 
 ### Custom output processor
 
-```typescript title="src/mastra/processors/custom-output.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/custom-output.ts" copy
 import type {
   Processor,
   MastraDBMessage,
@@ -292,7 +292,7 @@ Mastra provides utility processors for common tasks:
 
 Prevents context window overflow by removing older messages when the total token count exceeds a specified limit.
 
-```typescript copy showLineNumbers {9-12}
+```typescript copy {9-12}
 import { Agent } from "@mastra/core/agent";
 import { TokenLimiter } from "@mastra/core/processors";
 import { openai } from "@ai-sdk/openai";
@@ -309,7 +309,7 @@ const agent = new Agent({
 
 The `TokenLimiter` uses the `o200k_base` encoding by default (suitable for GPT-4o). You can specify other encodings for different models:
 
-```typescript copy showLineNumbers {6-9}
+```typescript copy {6-9}
 import cl100k_base from "js-tiktoken/ranks/cl100k_base";
 
 const agent = new Agent({
@@ -327,7 +327,7 @@ const agent = new Agent({
 
 Removes tool calls from messages sent to the LLM, saving tokens by excluding potentially verbose tool interactions.
 
-```typescript copy showLineNumbers {5-14}
+```typescript copy {5-14}
 import { Agent } from "@mastra/core/agent";
 import { ToolCallFilter, TokenLimiter } from "@mastra/core/processors";
 import { openai } from "@ai-sdk/openai";
@@ -354,7 +354,7 @@ const agent = new Agent({
 
 You can use Mastra workflows as processors to create complex processing pipelines with parallel execution, conditional branching, and error handling:
 
-```typescript title="src/mastra/processors/moderation-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/moderation-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { ProcessorStepSchema } from "@mastra/core/processors";
 import { Agent } from "@mastra/core/agent";
@@ -387,7 +387,7 @@ When an agent is registered with Mastra, processor workflows are automatically r
 
 Processors can request that the LLM retry its response with feedback. This is useful for implementing quality checks, output validation, or iterative refinement:
 
-```typescript title="src/mastra/processors/quality-checker.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/quality-checker.ts" copy
 import type { Processor } from "@mastra/core";
 
 export class QualityChecker implements Processor {

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -35,7 +35,7 @@ Mastra includes several processors for common use cases. You can also create cus
 
 Import and instantiate the processor, then pass it to the agent's `inputProcessors` or `outputProcessors` array:
 
-```typescript {3,9-15} title="src/mastra/agents/moderated-agent.ts" copy
+```typescript {3,9-15} title="src/mastra/agents/moderated-agent.ts"
 import { openai } from "@ai-sdk/openai";
 import { Agent } from "@mastra/core/agent";
 import { ModerationProcessor } from "@mastra/core/processors";
@@ -93,7 +93,7 @@ Custom processors implement the `Processor` interface:
 
 ### Custom input processor
 
-```typescript title="src/mastra/processors/custom-input.ts" copy
+```typescript title="src/mastra/processors/custom-input.ts"
 import type {
   Processor,
   MastraDBMessage,
@@ -141,7 +141,7 @@ The framework handles both return formats, so modifying system messages is optio
 
 To modify system messages (e.g., trim verbose prompts for smaller models), return an object with both `messages` and `systemMessages`:
 
-```typescript title="src/mastra/processors/system-trimmer.ts" copy
+```typescript title="src/mastra/processors/system-trimmer.ts"
 import type { Processor, CoreMessage, MastraDBMessage } from "@mastra/core";
 
 export class SystemTrimmer implements Processor {
@@ -174,7 +174,7 @@ This is useful for:
 
 While `processInput` runs once at the start of agent execution, `processInputStep` runs at **each step** of the agentic loop (including tool call continuations). This enables per-step configuration changes like dynamic model switching or tool choice modifications.
 
-```typescript title="src/mastra/processors/step-processor.ts" copy
+```typescript title="src/mastra/processors/step-processor.ts"
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from "@mastra/core";
 
 export class DynamicModelProcessor implements Processor {
@@ -247,7 +247,7 @@ await agent.generate({
 
 ### Custom output processor
 
-```typescript title="src/mastra/processors/custom-output.ts" copy
+```typescript title="src/mastra/processors/custom-output.ts"
 import type {
   Processor,
   MastraDBMessage,
@@ -292,7 +292,7 @@ Mastra provides utility processors for common tasks:
 
 Prevents context window overflow by removing older messages when the total token count exceeds a specified limit.
 
-```typescript copy {9-12}
+```typescript {9-12}
 import { Agent } from "@mastra/core/agent";
 import { TokenLimiter } from "@mastra/core/processors";
 import { openai } from "@ai-sdk/openai";
@@ -309,7 +309,7 @@ const agent = new Agent({
 
 The `TokenLimiter` uses the `o200k_base` encoding by default (suitable for GPT-4o). You can specify other encodings for different models:
 
-```typescript copy {6-9}
+```typescript {6-9}
 import cl100k_base from "js-tiktoken/ranks/cl100k_base";
 
 const agent = new Agent({
@@ -327,7 +327,7 @@ const agent = new Agent({
 
 Removes tool calls from messages sent to the LLM, saving tokens by excluding potentially verbose tool interactions.
 
-```typescript copy {5-14}
+```typescript {5-14}
 import { Agent } from "@mastra/core/agent";
 import { ToolCallFilter, TokenLimiter } from "@mastra/core/processors";
 import { openai } from "@ai-sdk/openai";
@@ -354,7 +354,7 @@ const agent = new Agent({
 
 You can use Mastra workflows as processors to create complex processing pipelines with parallel execution, conditional branching, and error handling:
 
-```typescript title="src/mastra/processors/moderation-workflow.ts" copy
+```typescript title="src/mastra/processors/moderation-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { ProcessorStepSchema } from "@mastra/core/processors";
 import { Agent } from "@mastra/core/agent";
@@ -387,7 +387,7 @@ When an agent is registered with Mastra, processor workflows are automatically r
 
 Processors can request that the LLM retry its response with feedback. This is useful for implementing quality checks, output validation, or iterative refinement:
 
-```typescript title="src/mastra/processors/quality-checker.ts" copy
+```typescript title="src/mastra/processors/quality-checker.ts"
 import type { Processor } from "@mastra/core";
 
 export class QualityChecker implements Processor {

--- a/docs/src/content/en/docs/agents/structured-output.mdx
+++ b/docs/src/content/en/docs/agents/structured-output.mdx
@@ -23,7 +23,7 @@ Agents can return structured data by defining the expected output with either [Z
 
 Define the `output` shape using [Zod](https://zod.dev/):
 
-```typescript showLineNumbers copy
+```typescript copy
 import { z } from "zod";
 
 const response = await testAgent.generate("Help me plan my day.", {
@@ -45,7 +45,7 @@ console.log(response.object);
 
 You can also use JSON Schema to define your output structure:
 
-```typescript showLineNumbers copy
+```typescript copy
 const response = await testAgent.generate("Help me plan my day.", {
   structuredOutput: {
     schema: {
@@ -99,7 +99,7 @@ The `response.object` will contain the structured data as defined by the schema.
 
 Streaming also supports structured output. The final structured object is available on `stream.fullStream` and after the stream completes on `stream.object`. Text stream chunks are still emitted, but they contain natural language text rather than structured data.
 
-```typescript showLineNumbers copy
+```typescript copy
 import { z } from "zod";
 
 const stream = await testAgent.stream("Help me plan my day.", {
@@ -131,7 +131,7 @@ for await (const chunk of stream.textStream) {
 
 When your main agent isn't proficient at creating structured output you can provide a `model` to `structuredOutput`. In this case, Mastra uses a second agent under the hood to extract structured data from the main agent's natural language response. This makes two LLM calls, one to generate the response and another to turn that response into the structured object, which adds some latency and cost but can improve accuracy for complex structuring tasks.
 
-```typescript showLineNumbers copy
+```typescript copy
 import { z } from "zod";
 
 const response = await testAgent.generate("Analyze the TypeScript programming language.", {
@@ -162,7 +162,7 @@ By default, Mastra passes the schema to the model provider using the `response_f
 
 If your model provider doesn't support `response_format`, you'll get an error from the API. When this happens, set `jsonPromptInjection: true`. This adds the schema to the system prompt instead, instructing the model to output JSON. This is less reliable than the API parameter approach.
 
-```typescript showLineNumbers copy
+```typescript copy
 import { z } from "zod";
 
 const response = await testAgent.generate("Help me plan my day.", {
@@ -198,7 +198,7 @@ const response = await agentWithTools.generate("Your prompt", {
 
 When schema validation fails, you can control how errors are handled using `errorStrategy`. The default `strict` strategy throws an error, while `warn` logs a warning and continues. The `fallback` strategy returns the values provided using `fallbackValue`.
 
-```typescript showLineNumbers copy
+```typescript copy
 import { z } from "zod";
 
 const response = await testAgent.generate("Tell me about TypeScript.", {

--- a/docs/src/content/en/docs/agents/structured-output.mdx
+++ b/docs/src/content/en/docs/agents/structured-output.mdx
@@ -23,7 +23,7 @@ Agents can return structured data by defining the expected output with either [Z
 
 Define the `output` shape using [Zod](https://zod.dev/):
 
-```typescript copy
+```typescript
 import { z } from "zod";
 
 const response = await testAgent.generate("Help me plan my day.", {
@@ -45,7 +45,7 @@ console.log(response.object);
 
 You can also use JSON Schema to define your output structure:
 
-```typescript copy
+```typescript
 const response = await testAgent.generate("Help me plan my day.", {
   structuredOutput: {
     schema: {
@@ -99,7 +99,7 @@ The `response.object` will contain the structured data as defined by the schema.
 
 Streaming also supports structured output. The final structured object is available on `stream.fullStream` and after the stream completes on `stream.object`. Text stream chunks are still emitted, but they contain natural language text rather than structured data.
 
-```typescript copy
+```typescript
 import { z } from "zod";
 
 const stream = await testAgent.stream("Help me plan my day.", {
@@ -131,7 +131,7 @@ for await (const chunk of stream.textStream) {
 
 When your main agent isn't proficient at creating structured output you can provide a `model` to `structuredOutput`. In this case, Mastra uses a second agent under the hood to extract structured data from the main agent's natural language response. This makes two LLM calls, one to generate the response and another to turn that response into the structured object, which adds some latency and cost but can improve accuracy for complex structuring tasks.
 
-```typescript copy
+```typescript
 import { z } from "zod";
 
 const response = await testAgent.generate("Analyze the TypeScript programming language.", {
@@ -162,7 +162,7 @@ By default, Mastra passes the schema to the model provider using the `response_f
 
 If your model provider doesn't support `response_format`, you'll get an error from the API. When this happens, set `jsonPromptInjection: true`. This adds the schema to the system prompt instead, instructing the model to output JSON. This is less reliable than the API parameter approach.
 
-```typescript copy
+```typescript
 import { z } from "zod";
 
 const response = await testAgent.generate("Help me plan my day.", {
@@ -198,7 +198,7 @@ const response = await agentWithTools.generate("Your prompt", {
 
 When schema validation fails, you can control how errors are handled using `errorStrategy`. The default `strict` strategy throws an error, while `warn` logs a warning and continues. The `fallback` strategy returns the values provided using `fallbackValue`.
 
-```typescript copy
+```typescript
 import { z } from "zod";
 
 const response = await testAgent.generate("Tell me about TypeScript.", {

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -17,7 +17,7 @@ When creating tools, keep descriptions simple and focused on what the tool does,
 
 This example shows how to create a tool that fetches weather data from an API. When the agent calls the tool, it provides the required input as defined by the tool's `inputSchema`. The tool accesses this data through its `inputData` parameter, which in this example includes the `location` used in the weather API query.
 
-```typescript {14} title="src/mastra/tools/weather-tool.ts" showLineNumbers copy
+```typescript {14} title="src/mastra/tools/weather-tool.ts" copy
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -47,7 +47,7 @@ To make a tool available to an agent, add it to `tools`. Mentioning available to
 
 An agent can use multiple tools to handle more complex tasks by delegating specific parts to individual tools. The agent decides which tools to use based on the user's message, the agent's instructions, and the tool descriptions and schemas.
 
-```typescript {8,10} title="src/mastra/agents/weather-agent.ts" showLineNumbers copy
+```typescript {8,10} title="src/mastra/agents/weather-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { weatherTool } from "../tools/weather-tool";
 
@@ -66,7 +66,7 @@ export const weatherAgent = new Agent({
 
 The agent uses the tool's `inputSchema` to infer what data the tool expects. In this case, it extracts `London` as the `location` from the message and passes it to the tool's inputData parameter.
 
-```typescript title="src/test-tool.ts" showLineNumbers copy
+```typescript title="src/test-tool.ts" copy
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("weatherAgent");
@@ -78,7 +78,7 @@ const result = await agent.generate("What's the weather in London?");
 
 When multiple tools are available, the agent may choose to use one, several, or none, depending on what's needed to answer the query.
 
-```typescript {8} title="src/mastra/agents/weather-agent.ts" showLineNumbers copy
+```typescript {8} title="src/mastra/agents/weather-agent.ts" copy
 import { weatherTool } from "../tools/weather-tool";
 import { activitiesTool } from "../tools/activities-tool";
 

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -17,7 +17,7 @@ When creating tools, keep descriptions simple and focused on what the tool does,
 
 This example shows how to create a tool that fetches weather data from an API. When the agent calls the tool, it provides the required input as defined by the tool's `inputSchema`. The tool accesses this data through its `inputData` parameter, which in this example includes the `location` used in the weather API query.
 
-```typescript {14} title="src/mastra/tools/weather-tool.ts" copy
+```typescript {14} title="src/mastra/tools/weather-tool.ts"
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -47,7 +47,7 @@ To make a tool available to an agent, add it to `tools`. Mentioning available to
 
 An agent can use multiple tools to handle more complex tasks by delegating specific parts to individual tools. The agent decides which tools to use based on the user's message, the agent's instructions, and the tool descriptions and schemas.
 
-```typescript {8,10} title="src/mastra/agents/weather-agent.ts" copy
+```typescript {8,10} title="src/mastra/agents/weather-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { weatherTool } from "../tools/weather-tool";
 
@@ -66,7 +66,7 @@ export const weatherAgent = new Agent({
 
 The agent uses the tool's `inputSchema` to infer what data the tool expects. In this case, it extracts `London` as the `location` from the message and passes it to the tool's inputData parameter.
 
-```typescript title="src/test-tool.ts" copy
+```typescript title="src/test-tool.ts"
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("weatherAgent");
@@ -78,7 +78,7 @@ const result = await agent.generate("What's the weather in London?");
 
 When multiple tools are available, the agent may choose to use one, several, or none, depending on what's needed to answer the query.
 
-```typescript {8} title="src/mastra/agents/weather-agent.ts" copy
+```typescript {8} title="src/mastra/agents/weather-agent.ts"
 import { weatherTool } from "../tools/weather-tool";
 import { activitiesTool } from "../tools/activities-tool";
 

--- a/docs/src/content/en/docs/deployment/mastra-server.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-server.mdx
@@ -26,7 +26,7 @@ tsconfig.json
 
 The `mastra build` command starts the build process:
 
-```bash copy
+```bash
 mastra build
 ```
 
@@ -34,7 +34,7 @@ mastra build
 
 If your Mastra files are located elsewhere, use the `--dir` flag to specify the custom location. The `--dir` flag tells Mastra where to find your entry point file (`index.ts` or `index.js`) and related directories.
 
-```bash copy
+```bash
 mastra build --dir ./my-project/mastra
 ```
 
@@ -68,6 +68,6 @@ If a `public` folder exists in `src/mastra`, its contents are copied into the `.
 
 Start the HTTP server:
 
-```bash copy
+```bash
 node .mastra/output/index.mjs
 ```

--- a/docs/src/content/en/docs/deployment/web-framework.mdx
+++ b/docs/src/content/en/docs/deployment/web-framework.mdx
@@ -20,7 +20,7 @@ Integration guides:
 
 If you've integrated Mastra with Next.js [by following our guide](/guides/v1/getting-started/next-js) and plan to deploy to Vercel, add `serverExternalPackages: ["@mastra/*"]` to your `next.config.ts`:
 
-```typescript {4} title="next.config.ts" showLineNumbers copy
+```typescript {4} title="next.config.ts" copy
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -34,7 +34,7 @@ export default nextConfig;
 
 If you've integrated Mastra with Astro [by following our guide](/guides/v1/getting-started/astro) and plan to deploy to Vercel, add the Vercel adapter and server output to your `astro.config.mjs`:
 
-```javascript {2,6,7} title="astro.config.mjs" showLineNumbers copy
+```javascript {2,6,7} title="astro.config.mjs" copy
 import { defineConfig } from "astro/config";
 import vercel from "@astrojs/vercel";
 
@@ -49,7 +49,7 @@ export default defineConfig({
 
 If you've integrated Mastra with Astro [by following our guide](/guides/v1/getting-started/astro) and plan to deploy to Netlify, add the Netlify adapter and server output to your `astro.config.mjs`:
 
-```javascript {2,6,7} title="astro.config.mjs" showLineNumbers copy
+```javascript {2,6,7} title="astro.config.mjs" copy
 import { defineConfig } from "astro/config";
 import netlify from "@astrojs/netlify";
 

--- a/docs/src/content/en/docs/deployment/web-framework.mdx
+++ b/docs/src/content/en/docs/deployment/web-framework.mdx
@@ -20,7 +20,7 @@ Integration guides:
 
 If you've integrated Mastra with Next.js [by following our guide](/guides/v1/getting-started/next-js) and plan to deploy to Vercel, add `serverExternalPackages: ["@mastra/*"]` to your `next.config.ts`:
 
-```typescript {4} title="next.config.ts" copy
+```typescript {4} title="next.config.ts"
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -34,7 +34,7 @@ export default nextConfig;
 
 If you've integrated Mastra with Astro [by following our guide](/guides/v1/getting-started/astro) and plan to deploy to Vercel, add the Vercel adapter and server output to your `astro.config.mjs`:
 
-```javascript {2,6,7} title="astro.config.mjs" copy
+```javascript {2,6,7} title="astro.config.mjs"
 import { defineConfig } from "astro/config";
 import vercel from "@astrojs/vercel";
 
@@ -49,7 +49,7 @@ export default defineConfig({
 
 If you've integrated Mastra with Astro [by following our guide](/guides/v1/getting-started/astro) and plan to deploy to Netlify, add the Netlify adapter and server output to your `astro.config.mjs`:
 
-```javascript {2,6,7} title="astro.config.mjs" copy
+```javascript {2,6,7} title="astro.config.mjs"
 import { defineConfig } from "astro/config";
 import netlify from "@astrojs/netlify";
 

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -243,7 +243,7 @@ Together, these components allow you to define custom evaluation logic using LLM
 
 > See [createScorer](/reference/v1/evals/create-scorer) for the full API and configuration options.
 
-```typescript title="src/mastra/scorers/gluten-checker.ts" showLineNumbers copy
+```typescript title="src/mastra/scorers/gluten-checker.ts" copy
 import { createScorer } from "@mastra/core/evals";
 import { z } from "zod";
 
@@ -399,7 +399,7 @@ The reason generation step creates explanations that help users understand why a
 
 ## High gluten-free example
 
-```typescript title="src/example-high-gluten-free.ts" showLineNumbers copy
+```typescript title="src/example-high-gluten-free.ts" copy
 const result = await glutenCheckerScorer.run({
   input: [{ role: 'user', content: 'Mix rice, beans, and vegetables' }],
   output: { text: 'Mix rice, beans, and vegetables' },
@@ -425,7 +425,7 @@ console.log('Reason:', result.reason);
 
 ## Partial gluten example
 
-```typescript title="src/example-partial-gluten.ts" showLineNumbers copy
+```typescript title="src/example-partial-gluten.ts" copy
 const result = await glutenCheckerScorer.run({
   input: [{ role: "user", content: "Mix flour and water to make dough" }],
   output: { text: "Mix flour and water to make dough" },
@@ -451,7 +451,7 @@ console.log("Reason:", result.reason);
 
 ## Low gluten-free example
 
-```typescript title="src/example-low-gluten-free.ts" showLineNumbers copy
+```typescript title="src/example-low-gluten-free.ts" copy
 const result = await glutenCheckerScorer.run({
   input: [{ role: "user", content: "Add soy sauce and noodles" }],
   output: { text: "Add soy sauce and noodles" },

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -243,7 +243,7 @@ Together, these components allow you to define custom evaluation logic using LLM
 
 > See [createScorer](/reference/v1/evals/create-scorer) for the full API and configuration options.
 
-```typescript title="src/mastra/scorers/gluten-checker.ts" copy
+```typescript title="src/mastra/scorers/gluten-checker.ts"
 import { createScorer } from "@mastra/core/evals";
 import { z } from "zod";
 
@@ -399,7 +399,7 @@ The reason generation step creates explanations that help users understand why a
 
 ## High gluten-free example
 
-```typescript title="src/example-high-gluten-free.ts" copy
+```typescript title="src/example-high-gluten-free.ts"
 const result = await glutenCheckerScorer.run({
   input: [{ role: 'user', content: 'Mix rice, beans, and vegetables' }],
   output: { text: 'Mix rice, beans, and vegetables' },
@@ -425,7 +425,7 @@ console.log('Reason:', result.reason);
 
 ## Partial gluten example
 
-```typescript title="src/example-partial-gluten.ts" copy
+```typescript title="src/example-partial-gluten.ts"
 const result = await glutenCheckerScorer.run({
   input: [{ role: "user", content: "Mix flour and water to make dough" }],
   output: { text: "Mix flour and water to make dough" },
@@ -451,7 +451,7 @@ console.log("Reason:", result.reason);
 
 ## Low gluten-free example
 
-```typescript title="src/example-low-gluten-free.ts" copy
+```typescript title="src/example-low-gluten-free.ts"
 const result = await glutenCheckerScorer.run({
   input: [{ role: "user", content: "Add soy sauce and noodles" }],
   output: { text: "Add soy sauce and noodles" },

--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -35,7 +35,7 @@ npm install @mastra/evals@beta
 
 You can add built-in scorers to your agents to automatically evaluate their outputs. See the [full list of built-in scorers](/docs/v1/evals/built-in-scorers) for all available options.
 
-```typescript title="src/mastra/agents/evaluated-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/evaluated-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import {
   createAnswerRelevancyScorer,
@@ -61,7 +61,7 @@ export const evaluatedAgent = new Agent({
 
 You can also add scorers to individual workflow steps to evaluate outputs at specific points in your process:
 
-```typescript title="src/mastra/workflows/content-generation.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/content-generation.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 import { customStepScorer } from "../scorers/custom-step-scorer";

--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -23,7 +23,7 @@ There are different kinds of scorers, each serving a specific purpose. Here are 
 
 To access Mastra's scorers feature install the `@mastra/evals` package.
 
-```bash copy
+```bash
 npm install @mastra/evals@beta
 ```
 
@@ -35,7 +35,7 @@ npm install @mastra/evals@beta
 
 You can add built-in scorers to your agents to automatically evaluate their outputs. See the [full list of built-in scorers](/docs/v1/evals/built-in-scorers) for all available options.
 
-```typescript title="src/mastra/agents/evaluated-agent.ts" copy
+```typescript title="src/mastra/agents/evaluated-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import {
   createAnswerRelevancyScorer,
@@ -61,7 +61,7 @@ export const evaluatedAgent = new Agent({
 
 You can also add scorers to individual workflow steps to evaluate outputs at specific points in your process:
 
-```typescript title="src/mastra/workflows/content-generation.ts" copy
+```typescript title="src/mastra/workflows/content-generation.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 import { customStepScorer } from "../scorers/custom-step-scorer";

--- a/docs/src/content/en/docs/evals/running-in-ci.mdx
+++ b/docs/src/content/en/docs/evals/running-in-ci.mdx
@@ -15,7 +15,7 @@ You can use any testing framework that supports ESM modules, such as [Vitest](ht
 
 Use `runEvals` to evaluate your agent against multiple test cases. The function accepts an array of data items, each containing an `input` and optional `groundTruth` for scorer validation.
 
-```typescript copy title="src/mastra/agents/weather-agent.test.ts"
+```typescript title="src/mastra/agents/weather-agent.test.ts"
 import { describe, it, expect } from 'vitest';
 import { createScorer, runEvals } from "@mastra/core/evals";
 import { weatherAgent } from "./weather-agent";
@@ -72,7 +72,7 @@ The `runEvals` function returns an object with:
 
 Create separate test cases for different evaluation scenarios:
 
-```typescript copy title="src/mastra/agents/weather-agent.test.ts"
+```typescript title="src/mastra/agents/weather-agent.test.ts"
 describe('Weather Agent Tests', () => {
   const locationScorer = createScorer({ /* ... */ });
 

--- a/docs/src/content/en/docs/evals/running-in-ci.mdx
+++ b/docs/src/content/en/docs/evals/running-in-ci.mdx
@@ -15,7 +15,7 @@ You can use any testing framework that supports ESM modules, such as [Vitest](ht
 
 Use `runEvals` to evaluate your agent against multiple test cases. The function accepts an array of data items, each containing an `input` and optional `groundTruth` for scorer validation.
 
-```typescript copy showLineNumbers title="src/mastra/agents/weather-agent.test.ts"
+```typescript copy title="src/mastra/agents/weather-agent.test.ts"
 import { describe, it, expect } from 'vitest';
 import { createScorer, runEvals } from "@mastra/core/evals";
 import { weatherAgent } from "./weather-agent";
@@ -72,7 +72,7 @@ The `runEvals` function returns an object with:
 
 Create separate test cases for different evaluation scenarios:
 
-```typescript copy showLineNumbers title="src/mastra/agents/weather-agent.test.ts"
+```typescript copy title="src/mastra/agents/weather-agent.test.ts"
 describe('Weather Agent Tests', () => {
   const locationScorer = createScorer({ /* ... */ });
 

--- a/docs/src/content/en/docs/getting-started/manual-install.mdx
+++ b/docs/src/content/en/docs/getting-started/manual-install.mdx
@@ -22,7 +22,7 @@ If you prefer not to use our automatic CLI tool, you can set up your project you
 
 Create a new project and change directory:
 
-```bash copy
+```bash
 mkdir my-first-agent && cd my-first-agent
 ```
 
@@ -31,7 +31,7 @@ Initialize a TypeScript project and install the following dependencies:
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm init -y
 npm install -D typescript @types/node mastra@beta
 npm install @mastra/core@beta zod@^4
@@ -40,7 +40,7 @@ npm install @mastra/core@beta zod@^4
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm init
 pnpm add -D typescript @types/node mastra@beta
 pnpm add @mastra/core@beta zod@^4
@@ -49,7 +49,7 @@ pnpm add @mastra/core@beta zod@^4
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn init -y
 yarn add -D typescript @types/node mastra@beta
 yarn add @mastra/core@beta zod@^4
@@ -58,7 +58,7 @@ yarn add @mastra/core@beta zod@^4
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun init -y
 bun add -d typescript @types/node mastra@beta
 bun add @mastra/core@beta zod@^4
@@ -69,7 +69,7 @@ bun add @mastra/core@beta zod@^4
 
 Add `dev` and `build` scripts to your `package.json` file:
 
-```json title="package.json" copy /,/ /"dev": "mastra dev",/ /"build": "mastra build"/
+```json title="package.json" /,/ /"dev": "mastra dev",/ /"build": "mastra build"/
 {
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -85,13 +85,13 @@ Add `dev` and `build` scripts to your `package.json` file:
 
 Create a `tsconfig.json` file:
 
-```bash copy
+```bash
 touch tsconfig.json
 ```
 
 Add the following configuration:
 
-```json title="tsconfig.json" copy
+```json title="tsconfig.json"
 {
   "compilerOptions": {
     "target": "ES2022",
@@ -120,13 +120,13 @@ Mastra requires modern `module` and `moduleResolution` settings. Using `CommonJS
 
 Create an `.env` file:
 
-```bash copy
+```bash
 touch .env
 ```
 
 Add your API key:
 
-```bash title=".env" copy
+```bash title=".env"
 GOOGLE_GENERATIVE_AI_API_KEY=<your-api-key>
 ```
 
@@ -142,13 +142,13 @@ This guide uses Google Gemini, but you can use any supported [model provider](/m
 
 Create a `weather-tool.ts` file:
 
-```bash copy
+```bash
 mkdir -p src/mastra/tools && touch src/mastra/tools/weather-tool.ts
 ```
 
 Add the following code:
 
-```ts title="src/mastra/tools/weather-tool.ts" copy
+```ts title="src/mastra/tools/weather-tool.ts"
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -181,13 +181,13 @@ We've shortened and simplified the `weatherTool` example here. You can see the c
 
 Create a `weather-agent.ts` file:
 
-```bash copy
+```bash
 mkdir -p src/mastra/agents && touch src/mastra/agents/weather-agent.ts
 ```
 
 Add the following code:
 
-```ts title="src/mastra/agents/weather-agent.ts" copy
+```ts title="src/mastra/agents/weather-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { weatherTool } from "../tools/weather-tool";
 
@@ -217,13 +217,13 @@ export const weatherAgent = new Agent({
 
 Create the Mastra entry point and register your agent:
 
-```bash copy
+```bash
 touch src/mastra/index.ts
 ```
 
 Add the following code:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { weatherAgent } from "./agents/weather-agent";
 
@@ -241,28 +241,28 @@ You can now launch [Studio](/docs/v1/getting-started/studio) and test your agent
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm run dev
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm run dev
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn run dev
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun run dev
 ```
 

--- a/docs/src/content/en/docs/getting-started/manual-install.mdx
+++ b/docs/src/content/en/docs/getting-started/manual-install.mdx
@@ -148,7 +148,7 @@ mkdir -p src/mastra/tools && touch src/mastra/tools/weather-tool.ts
 
 Add the following code:
 
-```ts title="src/mastra/tools/weather-tool.ts" showLineNumbers copy
+```ts title="src/mastra/tools/weather-tool.ts" copy
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -187,7 +187,7 @@ mkdir -p src/mastra/agents && touch src/mastra/agents/weather-agent.ts
 
 Add the following code:
 
-```ts title="src/mastra/agents/weather-agent.ts" showLineNumbers copy
+```ts title="src/mastra/agents/weather-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { weatherTool } from "../tools/weather-tool";
 
@@ -223,7 +223,7 @@ touch src/mastra/index.ts
 
 Add the following code:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { weatherAgent } from "./agents/weather-agent";
 

--- a/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
+++ b/docs/src/content/en/docs/getting-started/mcp-docs-server.mdx
@@ -25,7 +25,7 @@ During the interactive [create-mastra](/reference/v1/cli/create-mastra) wizard, 
 
 If there are no specific instructions for your tool below, you may be able to add the MCP server with this common JSON configuration anyways.
 
-```json copy
+```json
 {
   "mcpServers": {
     "mastra": {
@@ -41,7 +41,7 @@ If there are no specific instructions for your tool below, you may be able to ad
 
 Install using the terminal command:
 
-```bash copy
+```bash
 claude mcp add mastra -- npx -y @mastra/mcp-docs-server@beta
 ```
 

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -29,7 +29,7 @@ npm install @mastra/mcp@beta
 
 The `MCPClient` connects Mastra primitives to external MCP servers, which can be local packages (invoked using `npx`) or remote HTTP(S) endpoints. Each server must be configured with either a `command` or a `url`, depending on how it's hosted.
 
-```typescript title="src/mastra/mcp/test-mcp-client.ts" copy
+```typescript title="src/mastra/mcp/test-mcp-client.ts"
 import { MCPClient } from "@mastra/mcp";
 
 export const testMcpClient = new MCPClient({
@@ -54,7 +54,7 @@ export const testMcpClient = new MCPClient({
 
 To use tools from an MCP server in an agent, import your `MCPClient` and call `.getTools()` in the `tools` parameter. This loads from the defined MCP servers, making them available to the agent.
 
-```typescript {3,15} title="src/mastra/agents/test-agent.ts" copy
+```typescript {3,15} title="src/mastra/agents/test-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -79,7 +79,7 @@ export const testAgent = new Agent({
 
 To expose agents, tools, and workflows from your Mastra application to external systems over HTTP(S) use the `MCPServer` class. This makes them accessible to any system or agent that supports the protocol.
 
-```typescript title="src/mastra/mcp/test-mcp-server.ts" copy
+```typescript title="src/mastra/mcp/test-mcp-server.ts"
 import { MCPServer } from "@mastra/mcp";
 
 import { testAgent } from "../agents/test-agent";
@@ -102,7 +102,7 @@ export const testMcpServer = new MCPServer({
 
 To make an MCP server available to other systems or agents that support the protocol, register it in the main `Mastra` instance using `mcpServers`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core/mastra";
 
 import { testMcpServer } from "./mcp/test-mcp-server";
@@ -130,7 +130,7 @@ Use the `.getTools()` method to fetch tools from all configured MCP servers. Thi
 
 > See [getTools()](/reference/v1/tools/mcp-client#gettools) for more information.
 
-```typescript {7} title="src/mastra/agents/test-agent.ts" copy
+```typescript {7} title="src/mastra/agents/test-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -145,7 +145,7 @@ export const testAgent = new Agent({
 
 Use the `.getToolsets()` method when tool configuration may vary by request or user, such as in a multi-tenant system where each user provides their own API key. This method returns toolsets that can be passed to the `toolsets` option in the agent's `.generate()` or `.stream()` calls.
 
-```typescript {5-16,21} copy
+```typescript {5-16,21}
 import { MCPClient } from "@mastra/mcp";
 import { mastra } from "./mastra";
 

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -29,7 +29,7 @@ npm install @mastra/mcp@beta
 
 The `MCPClient` connects Mastra primitives to external MCP servers, which can be local packages (invoked using `npx`) or remote HTTP(S) endpoints. Each server must be configured with either a `command` or a `url`, depending on how it's hosted.
 
-```typescript title="src/mastra/mcp/test-mcp-client.ts" showLineNumbers copy
+```typescript title="src/mastra/mcp/test-mcp-client.ts" copy
 import { MCPClient } from "@mastra/mcp";
 
 export const testMcpClient = new MCPClient({
@@ -54,7 +54,7 @@ export const testMcpClient = new MCPClient({
 
 To use tools from an MCP server in an agent, import your `MCPClient` and call `.getTools()` in the `tools` parameter. This loads from the defined MCP servers, making them available to the agent.
 
-```typescript {3,15} title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript {3,15} title="src/mastra/agents/test-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -79,7 +79,7 @@ export const testAgent = new Agent({
 
 To expose agents, tools, and workflows from your Mastra application to external systems over HTTP(S) use the `MCPServer` class. This makes them accessible to any system or agent that supports the protocol.
 
-```typescript title="src/mastra/mcp/test-mcp-server.ts" showLineNumbers copy
+```typescript title="src/mastra/mcp/test-mcp-server.ts" copy
 import { MCPServer } from "@mastra/mcp";
 
 import { testAgent } from "../agents/test-agent";
@@ -102,7 +102,7 @@ export const testMcpServer = new MCPServer({
 
 To make an MCP server available to other systems or agents that support the protocol, register it in the main `Mastra` instance using `mcpServers`.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core/mastra";
 
 import { testMcpServer } from "./mcp/test-mcp-server";
@@ -130,7 +130,7 @@ Use the `.getTools()` method to fetch tools from all configured MCP servers. Thi
 
 > See [getTools()](/reference/v1/tools/mcp-client#gettools) for more information.
 
-```typescript {7} title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript {7} title="src/mastra/agents/test-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -145,7 +145,7 @@ export const testAgent = new Agent({
 
 Use the `.getToolsets()` method when tool configuration may vary by request or user, such as in a multi-tenant system where each user provides their own API key. This method returns toolsets that can be passed to the `toolsets` option in the agent's `.generate()` or `.stream()` calls.
 
-```typescript {5-16,21} showLineNumbers copy
+```typescript {5-16,21} copy
 import { MCPClient } from "@mastra/mcp";
 import { mastra } from "./mastra";
 

--- a/docs/src/content/en/docs/mcp/publishing-mcp-server.mdx
+++ b/docs/src/content/en/docs/mcp/publishing-mcp-server.mdx
@@ -32,7 +32,7 @@ Create a file for your stdio server, for example, `/src/mastra/stdio.ts`.
 
 Add the following code to the file. Remember to import your actual Mastra tools and name the server appropriately.
 
-```typescript title="src/mastra/stdio.ts" copy
+```typescript title="src/mastra/stdio.ts"
 #!/usr/bin/env node
 import { MCPServer } from "@mastra/mcp";
 import { weatherTool } from "./tools";
@@ -55,7 +55,7 @@ server.startStdio().catch((error) => {
 
 Update your `package.json` to include the `bin` entry pointing to your built server file and a script to build the server with both ESM and CJS outputs.
 
-```json title="package.json" copy
+```json title="package.json"
 {
   "bin": "dist/stdio.mjs",
   "scripts": {

--- a/docs/src/content/en/docs/memory/conversation-history.mdx
+++ b/docs/src/content/en/docs/memory/conversation-history.mdx
@@ -11,7 +11,7 @@ By default, each request includes the last 10 messages from the current memory t
 
 You can increase this limit by passing the `lastMessages` parameter to the `Memory` instance.
 
-```typescript {3-7} showLineNumbers
+```typescript {3-7}
 export const testAgent = new Agent({
   id: "test-agent",
   // ...

--- a/docs/src/content/en/docs/memory/memory-processors.mdx
+++ b/docs/src/content/en/docs/memory/memory-processors.mdx
@@ -40,7 +40,7 @@ memory: new Memory({
 
 **Example:**
 
-```typescript copy
+```typescript
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -89,7 +89,7 @@ memory: new Memory({
 
 **Example:**
 
-```typescript copy
+```typescript
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -145,7 +145,7 @@ memory: new Memory({
 
 **Example:**
 
-```typescript copy
+```typescript
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -169,7 +169,7 @@ const agent = new Agent({
 
 If you manually add a memory processor to `inputProcessors` or `outputProcessors`, Mastra will **not** automatically add it. This gives you full control over processor ordering:
 
-```typescript copy
+```typescript
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { MessageHistory } from "@mastra/memory/processors";
@@ -236,7 +236,7 @@ Output guardrails run **before** memory processors save messages. If a guardrail
 - Memory processors are skipped
 - **No messages are persisted to storage**
 
-```typescript copy
+```typescript
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { openai } from "@ai-sdk/openai";
@@ -281,7 +281,7 @@ Input guardrails run **after** memory processors load history. If a guardrail ab
 - Output processors (including memory persistence) are skipped
 - **No messages are persisted to storage**
 
-```typescript copy
+```typescript
 // Input guardrail that validates user input
 const inputValidator = {
   id: "input-validator",

--- a/docs/src/content/en/docs/memory/memory-processors.mdx
+++ b/docs/src/content/en/docs/memory/memory-processors.mdx
@@ -40,7 +40,7 @@ memory: new Memory({
 
 **Example:**
 
-```typescript copy showLineNumbers
+```typescript copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -89,7 +89,7 @@ memory: new Memory({
 
 **Example:**
 
-```typescript copy showLineNumbers
+```typescript copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -145,7 +145,7 @@ memory: new Memory({
 
 **Example:**
 
-```typescript copy showLineNumbers
+```typescript copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -169,7 +169,7 @@ const agent = new Agent({
 
 If you manually add a memory processor to `inputProcessors` or `outputProcessors`, Mastra will **not** automatically add it. This gives you full control over processor ordering:
 
-```typescript copy showLineNumbers
+```typescript copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { MessageHistory } from "@mastra/memory/processors";
@@ -236,7 +236,7 @@ Output guardrails run **before** memory processors save messages. If a guardrail
 - Memory processors are skipped
 - **No messages are persisted to storage**
 
-```typescript copy showLineNumbers
+```typescript copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { openai } from "@ai-sdk/openai";
@@ -281,7 +281,7 @@ Input guardrails run **after** memory processors load history. If a guardrail ab
 - Output processors (including memory persistence) are skipped
 - **No messages are persisted to storage**
 
-```typescript copy showLineNumbers
+```typescript copy
 // Input guardrail that validates user input
 const inputValidator = {
   id: "input-validator",

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -21,7 +21,7 @@ npm install @mastra/core@beta @mastra/memory@beta @mastra/libsql@beta
 
 Then add a storage adapter to the main Mastra instance. Any agent with memory enabled will use this shared storage to store and recall interactions.
 
-```typescript {6-8} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {6-8} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 
@@ -36,7 +36,7 @@ export const mastra = new Mastra({
 
 Now, enable memory by passing a `Memory` instance to the agent's `memory` parameter:
 
-```typescript {3-5} title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript {3-5} title="src/mastra/agents/test-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 
@@ -81,7 +81,7 @@ Agents can be configured with their own dedicated storage, keeping tasks, conver
 
 To assign dedicated storage to an agent, install and import the required dependency and pass a `storage` instance to the `Memory` constructor:
 
-```typescript {3, 9-11} title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript {3, 9-11} title="src/mastra/agents/test-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore } from "@mastra/libsql";

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -15,13 +15,13 @@ Mastra's memory system uses [storage providers](#memory-storage-adapters) to per
 
 First install the required dependencies:
 
-```bash copy
+```bash
 npm install @mastra/core@beta @mastra/memory@beta @mastra/libsql@beta
 ```
 
 Then add a storage adapter to the main Mastra instance. Any agent with memory enabled will use this shared storage to store and recall interactions.
 
-```typescript {6-8} title="src/mastra/index.ts" copy
+```typescript {6-8} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 
@@ -36,7 +36,7 @@ export const mastra = new Mastra({
 
 Now, enable memory by passing a `Memory` instance to the agent's `memory` parameter:
 
-```typescript {3-5} title="src/mastra/agents/test-agent.ts" copy
+```typescript {3-5} title="src/mastra/agents/test-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 
@@ -81,7 +81,7 @@ Agents can be configured with their own dedicated storage, keeping tasks, conver
 
 To assign dedicated storage to an agent, install and import the required dependency and pass a `storage` instance to the `Memory` constructor:
 
-```typescript {3, 9-11} title="src/mastra/agents/test-agent.ts" copy
+```typescript {3, 9-11} title="src/mastra/agents/test-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore } from "@mastra/libsql";

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -146,7 +146,7 @@ const agent = new Agent({
 
 To use FastEmbed (a local embedding model), install `@mastra/fastembed`:
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @mastra/fastembed@beta
 ```
 

--- a/docs/src/content/en/docs/memory/storage/memory-with-libsql.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-libsql.mdx
@@ -25,7 +25,7 @@ npm install @mastra/libsql@beta
 
 To add LibSQL memory to an agent use the `Memory` class and create a new `storage` key using `LibSQLStore`. The `url` can either by a remote location, or a local file system resource.
 
-```typescript title="src/mastra/agents/example-libsql-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-libsql-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore } from "@mastra/libsql";
@@ -60,7 +60,7 @@ npm install @mastra/fastembed@beta
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-libsql-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-libsql-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
@@ -100,7 +100,7 @@ export const libsqlAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-libsql-agent.ts" showLineNumbers copy
+```typescript title="src/test-libsql-agent.ts" copy
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/memory-with-libsql.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-libsql.mdx
@@ -11,13 +11,13 @@ This example demonstrates how to use Mastra's memory system with LibSQL as the s
 
 This example uses the `openai` model. Make sure to add `OPENAI_API_KEY` to your `.env` file.
 
-```bash title=".env" copy
+```bash title=".env"
 OPENAI_API_KEY=<your-api-key>
 ```
 
 And install the following package:
 
-```bash copy
+```bash
 npm install @mastra/libsql@beta
 ```
 
@@ -25,7 +25,7 @@ npm install @mastra/libsql@beta
 
 To add LibSQL memory to an agent use the `Memory` class and create a new `storage` key using `LibSQLStore`. The `url` can either by a remote location, or a local file system resource.
 
-```typescript title="src/mastra/agents/example-libsql-agent.ts" copy
+```typescript title="src/mastra/agents/example-libsql-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore } from "@mastra/libsql";
@@ -54,13 +54,13 @@ Embeddings are numeric vectors used by memory’s `semanticRecall` to retrieve r
 
 Install `fastembed` to get started:
 
-```bash copy
+```bash
 npm install @mastra/fastembed@beta
 ```
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-libsql-agent.ts" copy
+```typescript title="src/mastra/agents/example-libsql-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
@@ -100,7 +100,7 @@ export const libsqlAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-libsql-agent.ts" copy
+```typescript title="src/test-libsql-agent.ts"
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
@@ -27,7 +27,7 @@ npm install @mastra/mongodb@beta
 
 To add MongoDB memory to an agent use the `Memory` class and create a new `storage` key using `MongoDBStore`. The configuration supports both local and remote MongoDB instances.
 
-```typescript title="src/mastra/agents/example-mongodb-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-mongodb-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { MongoDBStore } from "@mastra/mongodb";
@@ -67,7 +67,7 @@ npm install @mastra/fastembed@beta
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-mongodb-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-mongodb-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { MongoDBStore, MongoDBVector } from "@mastra/mongodb";
@@ -107,7 +107,7 @@ export const mongodbAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-mongodb-agent.ts" showLineNumbers copy
+```typescript title="src/test-mongodb-agent.ts" copy
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-mongodb.mdx
@@ -11,7 +11,7 @@ This example demonstrates how to use Mastra's memory system with MongoDB as the 
 
 This example uses the `openai` model and requires a MongoDB database. Make sure to add the following to your `.env` file:
 
-```bash title=".env" copy
+```bash title=".env"
 OPENAI_API_KEY=<your-api-key>
 MONGODB_URI=<your-connection-string>
 MONGODB_DB_NAME=<your-db-name>
@@ -19,7 +19,7 @@ MONGODB_DB_NAME=<your-db-name>
 
 And install the following package:
 
-```bash copy
+```bash
 npm install @mastra/mongodb@beta
 ```
 
@@ -27,7 +27,7 @@ npm install @mastra/mongodb@beta
 
 To add MongoDB memory to an agent use the `Memory` class and create a new `storage` key using `MongoDBStore`. The configuration supports both local and remote MongoDB instances.
 
-```typescript title="src/mastra/agents/example-mongodb-agent.ts" copy
+```typescript title="src/mastra/agents/example-mongodb-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { MongoDBStore } from "@mastra/mongodb";
@@ -61,13 +61,13 @@ Embeddings are numeric vectors used by memory's `semanticRecall` to retrieve rel
 This setup uses FastEmbed, a local embedding model, to generate vector embeddings.
 To use this, install `@mastra/fastembed`:
 
-```bash copy
+```bash
 npm install @mastra/fastembed@beta
 ```
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-mongodb-agent.ts" copy
+```typescript title="src/mastra/agents/example-mongodb-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { MongoDBStore, MongoDBVector } from "@mastra/mongodb";
@@ -107,7 +107,7 @@ export const mongodbAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-mongodb-agent.ts" copy
+```typescript title="src/test-mongodb-agent.ts"
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/memory-with-pg.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-pg.mdx
@@ -26,7 +26,7 @@ npm install @mastra/pg@beta
 
 To add PostgreSQL memory to an agent use the `Memory` class and create a new `storage` key using `PostgresStore`. The `connectionString` can either be a remote location, or a local database connection.
 
-```typescript title="src/mastra/agents/example-pg-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-pg-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { PostgresStore } from "@mastra/pg";
@@ -61,7 +61,7 @@ npm install @mastra/fastembed@beta
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-pg-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-pg-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { PostgresStore, PgVector } from "@mastra/pg";
@@ -98,7 +98,7 @@ export const pgAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-pg-agent.ts" showLineNumbers copy
+```typescript title="src/test-pg-agent.ts" copy
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/memory-with-pg.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-pg.mdx
@@ -11,14 +11,14 @@ This example demonstrates how to use Mastra's memory system with PostgreSQL as t
 
 This example uses the `openai` model and requires a PostgreSQL database with the `pgvector` extension. Make sure to add the following to your `.env` file:
 
-```bash title=".env" copy
+```bash title=".env"
 OPENAI_API_KEY=<your-api-key>
 DATABASE_URL=<your-connection-string>
 ```
 
 And install the following package:
 
-```bash copy
+```bash
 npm install @mastra/pg@beta
 ```
 
@@ -26,7 +26,7 @@ npm install @mastra/pg@beta
 
 To add PostgreSQL memory to an agent use the `Memory` class and create a new `storage` key using `PostgresStore`. The `connectionString` can either be a remote location, or a local database connection.
 
-```typescript title="src/mastra/agents/example-pg-agent.ts" copy
+```typescript title="src/mastra/agents/example-pg-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { PostgresStore } from "@mastra/pg";
@@ -55,13 +55,13 @@ Embeddings are numeric vectors used by memory’s `semanticRecall` to retrieve r
 
 Install `fastembed` to get started:
 
-```bash copy
+```bash
 npm install @mastra/fastembed@beta
 ```
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-pg-agent.ts" copy
+```typescript title="src/mastra/agents/example-pg-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { PostgresStore, PgVector } from "@mastra/pg";
@@ -98,7 +98,7 @@ export const pgAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-pg-agent.ts" copy
+```typescript title="src/test-pg-agent.ts"
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/memory-with-upstash.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-upstash.mdx
@@ -31,7 +31,7 @@ npm install @mastra/upstash@beta
 
 To add Upstash memory to an agent use the `Memory` class and create a new `storage` key using `UpstashStore` and a new `vector` key using `UpstashVector`. The configuration can point to either a remote service or a local setup.
 
-```typescript title="src/mastra/agents/example-upstash-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-upstash-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { UpstashStore } from "@mastra/upstash";
@@ -67,7 +67,7 @@ npm install @mastra/fastembed@beta
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-upstash-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/example-upstash-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { UpstashStore, UpstashVector } from "@mastra/upstash";
@@ -106,7 +106,7 @@ export const upstashAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-upstash-agent.ts" showLineNumbers copy
+```typescript title="src/test-upstash-agent.ts" copy
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/memory-with-upstash.mdx
+++ b/docs/src/content/en/docs/memory/storage/memory-with-upstash.mdx
@@ -11,7 +11,7 @@ This example demonstrates how to use Mastra's memory system with Upstash as the 
 
 This example uses the `openai` model and requires both Upstash Redis and Upstash Vector services. Make sure to add the following to your `.env` file:
 
-```bash title=".env" copy
+```bash title=".env"
 OPENAI_API_KEY=<your-api-key>
 UPSTASH_REDIS_REST_URL=<your-redis-url>
 UPSTASH_REDIS_REST_TOKEN=<your-redis-token>
@@ -23,7 +23,7 @@ You can get your Upstash credentials by signing up at [upstash.com](https://upst
 
 And install the following package:
 
-```bash copy
+```bash
 npm install @mastra/upstash@beta
 ```
 
@@ -31,7 +31,7 @@ npm install @mastra/upstash@beta
 
 To add Upstash memory to an agent use the `Memory` class and create a new `storage` key using `UpstashStore` and a new `vector` key using `UpstashVector`. The configuration can point to either a remote service or a local setup.
 
-```typescript title="src/mastra/agents/example-upstash-agent.ts" copy
+```typescript title="src/mastra/agents/example-upstash-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { UpstashStore } from "@mastra/upstash";
@@ -61,13 +61,13 @@ Embeddings are numeric vectors used by memory’s `semanticRecall` to retrieve r
 
 Install `fastembed` to get started:
 
-```bash copy
+```bash
 npm install @mastra/fastembed@beta
 ```
 
 Add the following to your agent:
 
-```typescript title="src/mastra/agents/example-upstash-agent.ts" copy
+```typescript title="src/mastra/agents/example-upstash-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { UpstashStore, UpstashVector } from "@mastra/upstash";
@@ -106,7 +106,7 @@ export const upstashAgent = new Agent({
 
 Use `memoryOptions` to scope recall for this request. Set `lastMessages: 5` to limit recency-based recall, and use `semanticRecall` to fetch the `topK: 3` most relevant messages, including `messageRange: 2` neighboring messages for context around each match.
 
-```typescript title="src/test-upstash-agent.ts" copy
+```typescript title="src/test-upstash-agent.ts"
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/docs/memory/storage/overview.mdx
+++ b/docs/src/content/en/docs/memory/storage/overview.mdx
@@ -30,7 +30,7 @@ Mastra provides different storage providers, but you can treat them as interchan
 
 Mastra can be configured with a default storage option:
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 
@@ -475,7 +475,7 @@ Captures OpenTelemetry traces for monitoring and debugging.
 
 Messages are stored in the `MastraDBMessage` format, which provides a consistent structure across the entire Mastra system:
 
-```typescript copy
+```typescript
 // Get messages for a thread with pagination
 const result = await mastra
   .getStorage()
@@ -508,7 +508,7 @@ The `threadId` parameter accepts either a single thread ID string or an array of
 
 All message queries return `MastraDBMessage[]` format. If you need to convert messages to AI SDK formats for UI rendering, use the conversion utilities from `@mastra/ai-sdk/ui`:
 
-```typescript copy
+```typescript
 import { toAISdkV5Messages } from '@mastra/ai-sdk/ui';
 
 const result = await mastra

--- a/docs/src/content/en/docs/memory/threads-and-resources.mdx
+++ b/docs/src/content/en/docs/memory/threads-and-resources.mdx
@@ -12,7 +12,7 @@ Mastra organizes memory into threads, which are records that group related inter
 
 The `resource` is especially important for [resource-scoped memory](./working-memory#resource-scoped-memory-default), which allows memory to persist across all threads associated with the same user or entity.
 
-```typescript {4} showLineNumbers
+```typescript {4}
 const stream = await agent.stream("message for agent", {
   memory: {
     thread: "conversation-123",
@@ -33,7 +33,7 @@ Even with memory configured, agents won’t store or recall information unless b
 
 Mastra can automatically generate descriptive thread titles based on the user's first message. This feature is disabled by default. Enable it by setting `generateTitle` to `true`. This improves organization and makes it easier to display conversations in your UI.
 
-```typescript {3-7} showLineNumbers
+```typescript {3-7}
 export const testAgent = new Agent({
   memory: new Memory({
     options: {
@@ -49,7 +49,7 @@ export const testAgent = new Agent({
 
 Titles are generated using your agent's model by default. To optimize cost or behavior, provide a smaller `model` and custom `instructions`. This keeps title generation separate from main conversation logic.
 
-```typescript {5-9} showLineNumbers
+```typescript {5-9}
 export const testAgent = new Agent({
   // ...
   memory: new Memory({
@@ -70,7 +70,7 @@ export const testAgent = new Agent({
 
 You can configure thread title generation dynamically by passing functions to `model` and `instructions`. These functions receive the `requestContext` object, allowing you to adapt title generation based on user-specific values.
 
-```typescript {7-16} showLineNumbers
+```typescript {7-16}
 export const testAgent = new Agent({
   // ...
   memory: new Memory({

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -325,7 +325,7 @@ While agents typically update working memory through the `updateWorkingMemory` t
 
 When creating a thread, you can provide initial working memory through the metadata's `workingMemory` key:
 
-```typescript title="src/app/medical-consultation.ts" copy
+```typescript title="src/app/medical-consultation.ts"
 // Create a thread with initial working memory
 const thread = await memory.createThread({
   threadId: "thread-123",
@@ -354,7 +354,7 @@ await agent.generate("What's my blood type?", {
 
 You can also update an existing thread's working memory:
 
-```typescript title="src/app/medical-consultation.ts" copy
+```typescript title="src/app/medical-consultation.ts"
 // Update thread metadata to add/modify working memory
 await memory.updateThread({
   id: "thread-123",
@@ -376,7 +376,7 @@ await memory.updateThread({
 
 Alternatively, use the `updateWorkingMemory` method directly:
 
-```typescript title="src/app/medical-consultation.ts" copy
+```typescript title="src/app/medical-consultation.ts"
 await memory.updateWorkingMemory({
   threadId: "thread-123",
   resourceId: "user-456", // Required for resource-scoped memory

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -325,7 +325,7 @@ While agents typically update working memory through the `updateWorkingMemory` t
 
 When creating a thread, you can provide initial working memory through the metadata's `workingMemory` key:
 
-```typescript title="src/app/medical-consultation.ts" showLineNumbers copy
+```typescript title="src/app/medical-consultation.ts" copy
 // Create a thread with initial working memory
 const thread = await memory.createThread({
   threadId: "thread-123",
@@ -354,7 +354,7 @@ await agent.generate("What's my blood type?", {
 
 You can also update an existing thread's working memory:
 
-```typescript title="src/app/medical-consultation.ts" showLineNumbers copy
+```typescript title="src/app/medical-consultation.ts" copy
 // Update thread metadata to add/modify working memory
 await memory.updateThread({
   id: "thread-123",
@@ -376,7 +376,7 @@ await memory.updateThread({
 
 Alternatively, use the `updateWorkingMemory` method directly:
 
-```typescript title="src/app/medical-consultation.ts" showLineNumbers copy
+```typescript title="src/app/medical-consultation.ts" copy
 await memory.updateWorkingMemory({
   threadId: "thread-123",
   resourceId: "user-456", // Required for resource-scoped memory

--- a/docs/src/content/en/docs/observability/logging.mdx
+++ b/docs/src/content/en/docs/observability/logging.mdx
@@ -13,7 +13,7 @@ When deploying to Mastra Cloud, logs are shown on the [Logs](/docs/v1/mastra-clo
 
 When [initializing a new Mastra project](/guides/v1/getting-started/quickstart) using the CLI, `PinoLogger` is included by default.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core/mastra";
 import { PinoLogger } from "@mastra/loggers";
 
@@ -36,7 +36,7 @@ Mastra provides access to a logger instance via the `mastra.getLogger()` method,
 
 Within a workflow step, access the logger via the `mastra` parameter inside the `execute` function. This allows you to log messages relevant to the step’s execution.
 
-```typescript {8-9} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {8-9} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -62,7 +62,7 @@ export const testWorkflow = createWorkflow({...})
 
 Similarly, tools have access to the logger instance via the `mastra` parameter. Use this to log tool specific activity during execution.
 
-```typescript {8-9} title="src/mastra/tools/test-tool.ts" copy
+```typescript {8-9} title="src/mastra/tools/test-tool.ts"
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -85,7 +85,7 @@ Logger methods accept an optional second argument for additional data. This can 
 
 In this example, the log message includes an object with a key of `agent` and a value of the `testAgent` instance.
 
-```typescript {11} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {11} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/observability/logging.mdx
+++ b/docs/src/content/en/docs/observability/logging.mdx
@@ -13,7 +13,7 @@ When deploying to Mastra Cloud, logs are shown on the [Logs](/docs/v1/mastra-clo
 
 When [initializing a new Mastra project](/guides/v1/getting-started/quickstart) using the CLI, `PinoLogger` is included by default.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core/mastra";
 import { PinoLogger } from "@mastra/loggers";
 
@@ -36,7 +36,7 @@ Mastra provides access to a logger instance via the `mastra.getLogger()` method,
 
 Within a workflow step, access the logger via the `mastra` parameter inside the `execute` function. This allows you to log messages relevant to the step’s execution.
 
-```typescript {8-9} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {8-9} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -62,7 +62,7 @@ export const testWorkflow = createWorkflow({...})
 
 Similarly, tools have access to the logger instance via the `mastra` parameter. Use this to log tool specific activity during execution.
 
-```typescript {8-9} title="src/mastra/tools/test-tool.ts" showLineNumbers copy
+```typescript {8-9} title="src/mastra/tools/test-tool.ts" copy
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -85,7 +85,7 @@ Logger methods accept an optional second argument for additional data. This can 
 
 In this example, the log message includes an object with a key of `agent` and a value of the `testAgent` instance.
 
-```typescript {11} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {11} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
@@ -70,7 +70,7 @@ Using the OtelBridge requires two steps:
 
 Create an instrumentation file that initializes OTEL. This must run before your application code:
 
-```typescript title="instrumentation.ts" showLineNumbers copy
+```typescript title="instrumentation.ts" copy
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
@@ -99,7 +99,7 @@ export { sdk };
 
 Add the OtelBridge to your Mastra observability config:
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { Observability } from "@mastra/observability";
 import { OtelBridge } from "@mastra/otel-bridge";

--- a/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
@@ -70,7 +70,7 @@ Using the OtelBridge requires two steps:
 
 Create an instrumentation file that initializes OTEL. This must run before your application code:
 
-```typescript title="instrumentation.ts" copy
+```typescript title="instrumentation.ts"
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
@@ -99,7 +99,7 @@ export { sdk };
 
 Add the OtelBridge to your Mastra observability config:
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { Observability } from "@mastra/observability";
 import { OtelBridge } from "@mastra/otel-bridge";

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -21,7 +21,7 @@ Traces are created by:
 
 ### Basic Config
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { Observability } from "@mastra/observability";
 
@@ -50,7 +50,7 @@ When enabled, the default configuration automatically includes:
 
 This default configuration is a minimal helper that equates to this more verbose configuration:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 import {
   Observability,
   CloudExporter,
@@ -174,7 +174,7 @@ sampling: {
 
 ### Complete Example
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -214,7 +214,7 @@ Note that only a single config can be used for a specific execution. But a singl
 
 Use `configSelector` to choose the appropriate tracing configuration based on request context:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -259,7 +259,7 @@ export const mastra = new Mastra({
 
 A common pattern is to select configurations based on deployment environment:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -293,7 +293,7 @@ export const mastra = new Mastra({
 
 Having both the default config enabled and adding custom configs is an invalid configuration of Observability. Use either the default or custom config, but not both.
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 export const mastra = new Mastra({
   observability: new Observability({
     default: { enabled: true }, // This will always be used!
@@ -311,7 +311,7 @@ export const mastra = new Mastra({
 
 When creating a custom config with external exporters, you might lose access to Studio and Cloud. To maintain access while adding external exporters, include the default exporters in your custom config:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 import { DefaultExporter, CloudExporter } from "@mastra/observability";
 import { ArizeExporter } from "@mastra/arize";
 
@@ -354,7 +354,7 @@ Custom metadata allows you to attach additional context to your traces, making i
 
 You can add metadata to any span using the tracing context:
 
-```ts copy
+```ts
 execute: async ({ inputData, tracingContext }) => {
   const startTime = Date.now();
   const response = await fetch(inputData.endpoint);
@@ -384,7 +384,7 @@ Instead of manually adding metadata to each span, you can configure Mastra to au
 
 Define which RequestContext keys to extract in your tracing configuration. These keys will be automatically included as metadata for all spans created with this configuration:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -400,7 +400,7 @@ export const mastra = new Mastra({
 
 Now when you execute agents or workflows with a RequestContext, these values are automatically extracted:
 
-```ts copy
+```ts
 const requestContext = new RequestContext();
 requestContext.set("userId", "user-123");
 requestContext.set("environment", "production");
@@ -417,7 +417,7 @@ const result = await agent.generate({
 
 You can add trace-specific keys using `tracingOptions.requestContextKeys`. These are merged with the configuration-level keys:
 
-```ts copy
+```ts
 const requestContext = new RequestContext();
 requestContext.set("userId", "user-123");
 requestContext.set("environment", "production");
@@ -438,7 +438,7 @@ const result = await agent.generate({
 
 Use dot notation to extract nested values from RequestContext:
 
-```ts copy
+```ts
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -470,7 +470,7 @@ Tags are string labels that help you categorize and filter traces. Unlike metada
 
 Use `tracingOptions.tags` to add tags when executing agents or workflows:
 
-```ts copy
+```ts
 // With agents
 const result = await agent.generate({
   messages: [{ role: "user", content: "Hello" }],
@@ -500,7 +500,7 @@ const result = await run.start({
   - **OtelBridge** - `mastra.tags` span attribute
 - **Combinable with metadata**: You can use both `tags` and `metadata` in the same `tracingOptions`
 
-```ts copy
+```ts
 const result = await agent.generate({
   messages: [{ role: "user", content: "Analyze this" }],
   tracingOptions: {
@@ -522,7 +522,7 @@ const result = await agent.generate({
 
 When creating child spans within tools or workflow steps, you can pass the `requestContext` parameter to enable metadata extraction:
 
-```ts copy
+```ts
 execute: async ({ tracingContext, requestContext }) => {
   // Create child span WITH requestContext - gets metadata extraction
   const dbSpan = tracingContext.currentSpan?.createChildSpan({
@@ -553,7 +553,7 @@ Child spans allow you to track fine-grained operations within your workflow step
 
 Create child spans inside a tool call or workflow step to track specific operations:
 
-```ts copy
+```ts
 execute: async ({ inputData, tracingContext }) => {
   // Create another child span for the main database operation
   const querySpan = tracingContext.currentSpan?.createChildSpan({
@@ -598,7 +598,7 @@ Span processors allow you to transform, filter, or enrich trace data before it's
 
 You can create custom span processors by implementing the `SpanOutputProcessor` interface. Here's a simple example that converts all input text in spans to lowercase:
 
-```ts title="src/processors/lowercase-input-processor.ts" copy
+```ts title="src/processors/lowercase-input-processor.ts"
 import type { SpanOutputProcessor, AnySpan } from "@mastra/observability";
 
 export class LowercaseInputProcessor implements SpanOutputProcessor {
@@ -643,7 +643,7 @@ When you execute agents or workflows with tracing enabled, the response includes
 
 Both `generate` and `stream` methods return the trace ID in their response:
 
-```ts copy
+```ts
 // Using generate
 const result = await agent.generate({
   messages: [{ role: "user", content: "Hello" }],
@@ -663,7 +663,7 @@ console.log("Trace ID:", streamResult.traceId);
 
 Workflow executions also return trace IDs:
 
-```ts copy
+```ts
 // Create a workflow run
 const run = await mastra.getWorkflow("myWorkflow").createRun();
 
@@ -703,7 +703,7 @@ When running Mastra agents or workflows within applications that have existing d
 
 Use the `tracingOptions` parameter to specify the trace context from your parent system:
 
-```ts copy
+```ts
 // Get trace context from your existing tracing system
 const parentTraceId = getCurrentTraceId(); // Your tracing system
 const parentSpanId = getCurrentSpanId(); // Your tracing system
@@ -723,7 +723,7 @@ const result = await agent.generate("Analyze this data", {
 
 Integration with OpenTelemetry allows Mastra traces to appear seamlessly in your existing observability platform:
 
-```ts copy
+```ts
 import { trace } from "@opentelemetry/api";
 
 // Get the current OpenTelemetry span
@@ -744,7 +744,7 @@ if (spanContext) {
 
 Workflows support the same pattern for trace propagation:
 
-```ts copy
+```ts
 const workflow = mastra.getWorkflow("data-pipeline");
 const run = await workflow.createRun();
 
@@ -775,7 +775,7 @@ This ensures tracing never crashes your application, even with malformed input.
 
 Here's a complete example showing trace propagation in an Express application:
 
-```ts copy
+```ts
 import { trace } from "@opentelemetry/api";
 import express from "express";
 

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -21,7 +21,7 @@ Traces are created by:
 
 ### Basic Config
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { Observability } from "@mastra/observability";
 
@@ -50,7 +50,7 @@ When enabled, the default configuration automatically includes:
 
 This default configuration is a minimal helper that equates to this more verbose configuration:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 import {
   Observability,
   CloudExporter,
@@ -174,7 +174,7 @@ sampling: {
 
 ### Complete Example
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -214,7 +214,7 @@ Note that only a single config can be used for a specific execution. But a singl
 
 Use `configSelector` to choose the appropriate tracing configuration based on request context:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -259,7 +259,7 @@ export const mastra = new Mastra({
 
 A common pattern is to select configurations based on deployment environment:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -293,7 +293,7 @@ export const mastra = new Mastra({
 
 Having both the default config enabled and adding custom configs is an invalid configuration of Observability. Use either the default or custom config, but not both.
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 export const mastra = new Mastra({
   observability: new Observability({
     default: { enabled: true }, // This will always be used!
@@ -311,7 +311,7 @@ export const mastra = new Mastra({
 
 When creating a custom config with external exporters, you might lose access to Studio and Cloud. To maintain access while adding external exporters, include the default exporters in your custom config:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 import { DefaultExporter, CloudExporter } from "@mastra/observability";
 import { ArizeExporter } from "@mastra/arize";
 
@@ -354,7 +354,7 @@ Custom metadata allows you to attach additional context to your traces, making i
 
 You can add metadata to any span using the tracing context:
 
-```ts showLineNumbers copy
+```ts copy
 execute: async ({ inputData, tracingContext }) => {
   const startTime = Date.now();
   const response = await fetch(inputData.endpoint);
@@ -384,7 +384,7 @@ Instead of manually adding metadata to each span, you can configure Mastra to au
 
 Define which RequestContext keys to extract in your tracing configuration. These keys will be automatically included as metadata for all spans created with this configuration:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -400,7 +400,7 @@ export const mastra = new Mastra({
 
 Now when you execute agents or workflows with a RequestContext, these values are automatically extracted:
 
-```ts showLineNumbers copy
+```ts copy
 const requestContext = new RequestContext();
 requestContext.set("userId", "user-123");
 requestContext.set("environment", "production");
@@ -417,7 +417,7 @@ const result = await agent.generate({
 
 You can add trace-specific keys using `tracingOptions.requestContextKeys`. These are merged with the configuration-level keys:
 
-```ts showLineNumbers copy
+```ts copy
 const requestContext = new RequestContext();
 requestContext.set("userId", "user-123");
 requestContext.set("environment", "production");
@@ -438,7 +438,7 @@ const result = await agent.generate({
 
 Use dot notation to extract nested values from RequestContext:
 
-```ts showLineNumbers copy
+```ts copy
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
@@ -470,7 +470,7 @@ Tags are string labels that help you categorize and filter traces. Unlike metada
 
 Use `tracingOptions.tags` to add tags when executing agents or workflows:
 
-```ts showLineNumbers copy
+```ts copy
 // With agents
 const result = await agent.generate({
   messages: [{ role: "user", content: "Hello" }],
@@ -500,7 +500,7 @@ const result = await run.start({
   - **OtelBridge** - `mastra.tags` span attribute
 - **Combinable with metadata**: You can use both `tags` and `metadata` in the same `tracingOptions`
 
-```ts showLineNumbers copy
+```ts copy
 const result = await agent.generate({
   messages: [{ role: "user", content: "Analyze this" }],
   tracingOptions: {
@@ -522,7 +522,7 @@ const result = await agent.generate({
 
 When creating child spans within tools or workflow steps, you can pass the `requestContext` parameter to enable metadata extraction:
 
-```ts showLineNumbers copy
+```ts copy
 execute: async ({ tracingContext, requestContext }) => {
   // Create child span WITH requestContext - gets metadata extraction
   const dbSpan = tracingContext.currentSpan?.createChildSpan({
@@ -553,7 +553,7 @@ Child spans allow you to track fine-grained operations within your workflow step
 
 Create child spans inside a tool call or workflow step to track specific operations:
 
-```ts showLineNumbers copy
+```ts copy
 execute: async ({ inputData, tracingContext }) => {
   // Create another child span for the main database operation
   const querySpan = tracingContext.currentSpan?.createChildSpan({
@@ -598,7 +598,7 @@ Span processors allow you to transform, filter, or enrich trace data before it's
 
 You can create custom span processors by implementing the `SpanOutputProcessor` interface. Here's a simple example that converts all input text in spans to lowercase:
 
-```ts title="src/processors/lowercase-input-processor.ts" showLineNumbers copy
+```ts title="src/processors/lowercase-input-processor.ts" copy
 import type { SpanOutputProcessor, AnySpan } from "@mastra/observability";
 
 export class LowercaseInputProcessor implements SpanOutputProcessor {
@@ -643,7 +643,7 @@ When you execute agents or workflows with tracing enabled, the response includes
 
 Both `generate` and `stream` methods return the trace ID in their response:
 
-```ts showLineNumbers copy
+```ts copy
 // Using generate
 const result = await agent.generate({
   messages: [{ role: "user", content: "Hello" }],
@@ -663,7 +663,7 @@ console.log("Trace ID:", streamResult.traceId);
 
 Workflow executions also return trace IDs:
 
-```ts showLineNumbers copy
+```ts copy
 // Create a workflow run
 const run = await mastra.getWorkflow("myWorkflow").createRun();
 
@@ -703,7 +703,7 @@ When running Mastra agents or workflows within applications that have existing d
 
 Use the `tracingOptions` parameter to specify the trace context from your parent system:
 
-```ts showLineNumbers copy
+```ts copy
 // Get trace context from your existing tracing system
 const parentTraceId = getCurrentTraceId(); // Your tracing system
 const parentSpanId = getCurrentSpanId(); // Your tracing system
@@ -723,7 +723,7 @@ const result = await agent.generate("Analyze this data", {
 
 Integration with OpenTelemetry allows Mastra traces to appear seamlessly in your existing observability platform:
 
-```ts showLineNumbers copy
+```ts copy
 import { trace } from "@opentelemetry/api";
 
 // Get the current OpenTelemetry span
@@ -744,7 +744,7 @@ if (spanContext) {
 
 Workflows support the same pattern for trace propagation:
 
-```ts showLineNumbers copy
+```ts copy
 const workflow = mastra.getWorkflow("data-pipeline");
 const run = await workflow.createRun();
 
@@ -775,7 +775,7 @@ This ensures tracing never crashes your application, even with malformed input.
 
 Here's a complete example showing trace propagation in an Express application:
 
-```ts showLineNumbers copy
+```ts copy
 import { trace } from "@opentelemetry/api";
 import express from "express";
 

--- a/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
@@ -11,7 +11,7 @@ The Sensitive Data Filter is a span processor that automatically redacts sensiti
 
 By default, the Sensitive Data Filter is automatically enabled when you use the standard Mastra configuration:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 export const mastra = new Mastra({
   observability: new Observability({
     default: { enabled: true }, // Automatically includes SensitiveDataFilter
@@ -63,7 +63,7 @@ When a sensitive field is detected, its value is replaced with `[REDACTED]` by d
 
 You can customize which fields are redacted and how redaction appears:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 import { SensitiveDataFilter, DefaultExporter, Observability } from "@mastra/observability";
 
 export const mastra = new Mastra({
@@ -210,7 +210,7 @@ The Sensitive Data Filter is designed to be lightweight and efficient:
 
 If you need to disable sensitive data filtering (not recommended for production):
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {

--- a/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
@@ -11,7 +11,7 @@ The Sensitive Data Filter is a span processor that automatically redacts sensiti
 
 By default, the Sensitive Data Filter is automatically enabled when you use the standard Mastra configuration:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 export const mastra = new Mastra({
   observability: new Observability({
     default: { enabled: true }, // Automatically includes SensitiveDataFilter
@@ -63,7 +63,7 @@ When a sensitive field is detected, its value is replaced with `[REDACTED]` by d
 
 You can customize which fields are redacted and how redaction appears:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 import { SensitiveDataFilter, DefaultExporter, Observability } from "@mastra/observability";
 
 export const mastra = new Mastra({
@@ -210,7 +210,7 @@ The Sensitive Data Filter is designed to be lightweight and efficient:
 
 If you need to disable sensitive data filtering (not recommended for production):
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {

--- a/docs/src/content/en/docs/rag/chunking-and-embedding.mdx
+++ b/docs/src/content/en/docs/rag/chunking-and-embedding.mdx
@@ -7,7 +7,7 @@ description: Guide on chunking and embedding documents in Mastra for efficient p
 
 Before processing, create a MDocument instance from your content. You can initialize it from various formats:
 
-```ts copy
+```ts
 const docFromText = MDocument.fromText("Your plain text content...");
 const docFromHTML = MDocument.fromHTML("<html>Your HTML content...</html>");
 const docFromMarkdown = MDocument.fromMarkdown("# Your Markdown content...");
@@ -34,7 +34,7 @@ Each strategy accepts different parameters optimized for its chunking approach.
 
 Here's an example of how to use the `recursive` strategy:
 
-```ts copy
+```ts
 const chunks = await doc.chunk({
   strategy: "recursive",
   maxSize: 512,
@@ -48,7 +48,7 @@ const chunks = await doc.chunk({
 
 For text where preserving sentence structure is important, here's an example of how to use the `sentence` strategy:
 
-```ts copy
+```ts
 const chunks = await doc.chunk({
   strategy: "sentence",
   maxSize: 450,
@@ -61,7 +61,7 @@ const chunks = await doc.chunk({
 
 For markdown documents where preserving the semantic relationships between sections is important, here's an example of how to use the `semantic-markdown` strategy:
 
-```ts copy
+```ts
 const chunks = await doc.chunk({
   strategy: "semantic-markdown",
   joinThreshold: 500,
@@ -83,7 +83,7 @@ Transform chunks into embeddings using your preferred provider. Mastra supports 
 
 The simplest way is to use Mastra's model router with `provider/model` strings:
 
-```ts copy
+```ts
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 import { embedMany } from "ai";
 
@@ -142,7 +142,7 @@ When storing embeddings, the vector database index must be configured to match t
 
 Here's an example showing document processing and embedding generation with both providers:
 
-```ts copy
+```ts
 import { embedMany } from "ai";
 
 import { MDocument } from "@mastra/rag";

--- a/docs/src/content/en/docs/rag/chunking-and-embedding.mdx
+++ b/docs/src/content/en/docs/rag/chunking-and-embedding.mdx
@@ -7,7 +7,7 @@ description: Guide on chunking and embedding documents in Mastra for efficient p
 
 Before processing, create a MDocument instance from your content. You can initialize it from various formats:
 
-```ts showLineNumbers copy
+```ts copy
 const docFromText = MDocument.fromText("Your plain text content...");
 const docFromHTML = MDocument.fromHTML("<html>Your HTML content...</html>");
 const docFromMarkdown = MDocument.fromMarkdown("# Your Markdown content...");
@@ -34,7 +34,7 @@ Each strategy accepts different parameters optimized for its chunking approach.
 
 Here's an example of how to use the `recursive` strategy:
 
-```ts showLineNumbers copy
+```ts copy
 const chunks = await doc.chunk({
   strategy: "recursive",
   maxSize: 512,
@@ -48,7 +48,7 @@ const chunks = await doc.chunk({
 
 For text where preserving sentence structure is important, here's an example of how to use the `sentence` strategy:
 
-```ts showLineNumbers copy
+```ts copy
 const chunks = await doc.chunk({
   strategy: "sentence",
   maxSize: 450,
@@ -61,7 +61,7 @@ const chunks = await doc.chunk({
 
 For markdown documents where preserving the semantic relationships between sections is important, here's an example of how to use the `semantic-markdown` strategy:
 
-```ts showLineNumbers copy
+```ts copy
 const chunks = await doc.chunk({
   strategy: "semantic-markdown",
   joinThreshold: 500,
@@ -83,7 +83,7 @@ Transform chunks into embeddings using your preferred provider. Mastra supports 
 
 The simplest way is to use Mastra's model router with `provider/model` strings:
 
-```ts showLineNumbers copy
+```ts copy
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 import { embedMany } from "ai";
 
@@ -142,7 +142,7 @@ When storing embeddings, the vector database index must be configured to match t
 
 Here's an example showing document processing and embedding generation with both providers:
 
-```ts showLineNumbers copy
+```ts copy
 import { embedMany } from "ai";
 
 import { MDocument } from "@mastra/rag";

--- a/docs/src/content/en/docs/rag/graph-rag.mdx
+++ b/docs/src/content/en/docs/rag/graph-rag.mdx
@@ -34,7 +34,7 @@ This process helps surface information that might not be semantically similar to
 
 The Graph Query Tool provides agents with the ability to perform graph-based retrieval:
 
-```ts showLineNumbers copy
+```ts copy
 import { createGraphRAGTool } from "@mastra/rag";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 
@@ -55,7 +55,7 @@ The `graphOptions` parameter controls how the knowledge graph is built and trave
 - `threshold`: Similarity threshold (0-1) for determining which chunks are related. Higher values create sparser graphs with stronger connections; lower values create denser graphs with more potential relationships.
 - `dimension`: Vector embedding dimension. Must match the embedding model's output dimension (e.g., 1536 for OpenAI's text-embedding-3-small).
 
-```ts showLineNumbers copy
+```ts copy
 const graphQueryTool = createGraphRAGTool({
   vectorStoreName: "pgVector",
   indexName: "embeddings",
@@ -71,7 +71,7 @@ const graphQueryTool = createGraphRAGTool({
 
 Integrate the graph query tool with an agent to enable graph-based retrieval:
 
-```ts showLineNumbers copy
+```ts copy
 import { Agent } from "@mastra/core/agent";
 
 const ragAgent = new Agent({
@@ -91,7 +91,7 @@ Base your answers on the context provided by the tool, and clearly state if the 
 
 Before using graph-based retrieval, process documents into chunks and store their embeddings:
 
-```ts showLineNumbers copy
+```ts copy
 import { MDocument } from "@mastra/rag";
 import { embedMany } from "ai";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
@@ -129,7 +129,7 @@ await vectorStore.upsert({
 
 Once configured, the agent can perform graph-based queries:
 
-```ts showLineNumbers copy
+```ts copy
 const query = "What are the effects of infrastructure changes on local businesses?";
 const response = await ragAgent.generate(query);
 console.log(response.text);
@@ -153,7 +153,7 @@ The threshold parameter significantly impacts retrieval quality:
 
 Start with 0.7 and adjust based on your specific use case:
 
-```ts showLineNumbers copy
+```ts copy
 // Strict connections for precise answers
 const strictGraphTool = createGraphRAGTool({
   vectorStoreName: "pgVector",
@@ -179,7 +179,7 @@ const broadGraphTool = createGraphRAGTool({
 
 GraphRAG can be used alongside other retrieval approaches:
 
-```ts showLineNumbers copy
+```ts copy
 import { createVectorQueryTool } from "@mastra/rag";
 
 const vectorQueryTool = createVectorQueryTool({

--- a/docs/src/content/en/docs/rag/graph-rag.mdx
+++ b/docs/src/content/en/docs/rag/graph-rag.mdx
@@ -34,7 +34,7 @@ This process helps surface information that might not be semantically similar to
 
 The Graph Query Tool provides agents with the ability to perform graph-based retrieval:
 
-```ts copy
+```ts
 import { createGraphRAGTool } from "@mastra/rag";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 
@@ -55,7 +55,7 @@ The `graphOptions` parameter controls how the knowledge graph is built and trave
 - `threshold`: Similarity threshold (0-1) for determining which chunks are related. Higher values create sparser graphs with stronger connections; lower values create denser graphs with more potential relationships.
 - `dimension`: Vector embedding dimension. Must match the embedding model's output dimension (e.g., 1536 for OpenAI's text-embedding-3-small).
 
-```ts copy
+```ts
 const graphQueryTool = createGraphRAGTool({
   vectorStoreName: "pgVector",
   indexName: "embeddings",
@@ -71,7 +71,7 @@ const graphQueryTool = createGraphRAGTool({
 
 Integrate the graph query tool with an agent to enable graph-based retrieval:
 
-```ts copy
+```ts
 import { Agent } from "@mastra/core/agent";
 
 const ragAgent = new Agent({
@@ -91,7 +91,7 @@ Base your answers on the context provided by the tool, and clearly state if the 
 
 Before using graph-based retrieval, process documents into chunks and store their embeddings:
 
-```ts copy
+```ts
 import { MDocument } from "@mastra/rag";
 import { embedMany } from "ai";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
@@ -129,7 +129,7 @@ await vectorStore.upsert({
 
 Once configured, the agent can perform graph-based queries:
 
-```ts copy
+```ts
 const query = "What are the effects of infrastructure changes on local businesses?";
 const response = await ragAgent.generate(query);
 console.log(response.text);
@@ -153,7 +153,7 @@ The threshold parameter significantly impacts retrieval quality:
 
 Start with 0.7 and adjust based on your specific use case:
 
-```ts copy
+```ts
 // Strict connections for precise answers
 const strictGraphTool = createGraphRAGTool({
   vectorStoreName: "pgVector",
@@ -179,7 +179,7 @@ const broadGraphTool = createGraphRAGTool({
 
 GraphRAG can be used alongside other retrieval approaches:
 
-```ts copy
+```ts
 import { createVectorQueryTool } from "@mastra/rag";
 
 const vectorQueryTool = createVectorQueryTool({

--- a/docs/src/content/en/docs/rag/overview.mdx
+++ b/docs/src/content/en/docs/rag/overview.mdx
@@ -18,7 +18,7 @@ Mastra's RAG system provides:
 
 To implement RAG, you process your documents into chunks, create embeddings, store them in a vector database, and then retrieve relevant context at query time.
 
-```ts copy
+```ts
 import { embedMany } from "ai";
 import { PgVector } from "@mastra/pg";
 import { MDocument } from "@mastra/rag";

--- a/docs/src/content/en/docs/rag/overview.mdx
+++ b/docs/src/content/en/docs/rag/overview.mdx
@@ -18,7 +18,7 @@ Mastra's RAG system provides:
 
 To implement RAG, you process your documents into chunks, create embeddings, store them in a vector database, and then retrieve relevant context at query time.
 
-```ts showLineNumbers copy
+```ts copy
 import { embedMany } from "ai";
 import { PgVector } from "@mastra/pg";
 import { MDocument } from "@mastra/rag";

--- a/docs/src/content/en/docs/rag/retrieval.mdx
+++ b/docs/src/content/en/docs/rag/retrieval.mdx
@@ -26,7 +26,7 @@ Mastra provides flexible retrieval options with support for semantic search, fil
 
 The simplest approach is direct semantic search. This method uses vector similarity to find chunks that are semantically similar to the query:
 
-```ts showLineNumbers copy
+```ts copy
 import { embed } from "ai";
 import { PgVector } from "@mastra/pg";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
@@ -56,7 +56,7 @@ The `topK` parameter specifies the maximum number of most similar results to ret
 
 Results include both the text content and a similarity score:
 
-```ts showLineNumbers copy
+```ts copy
 [
   {
     text: "Climate change poses significant challenges...",
@@ -84,7 +84,7 @@ For detailed information about available operators and syntax, see the [Metadata
 
 Basic filtering examples:
 
-```ts showLineNumbers copy
+```ts copy
 // Simple equality filter
 const results = await pgVector.query({
   indexName: "embeddings",
@@ -152,7 +152,7 @@ Common use cases for metadata filtering:
 
 Sometimes you want to give your agent the ability to query a vector database directly. The Vector Query Tool allows your agent to be in charge of retrieval decisions, combining semantic search with optional filtering and reranking based on the agent's understanding of the user's needs.
 
-```ts showLineNumbers copy
+```ts copy
 import { createVectorQueryTool } from "@mastra/rag";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 
@@ -182,7 +182,7 @@ These configurations are for **query-time options** like namespaces, performance
 Connection credentials (URLs, auth tokens) are configured when you instantiate the vector store class (e.g., `new LibSQLVector({ connectionUrl: '...' })`).
 :::
 
-```ts showLineNumbers copy
+```ts copy
 import { createVectorQueryTool } from "@mastra/rag";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 
@@ -257,7 +257,7 @@ const lanceQueryTool = createVectorQueryTool({
 
 You can also override these configurations at runtime using the request context:
 
-```ts showLineNumbers copy
+```ts copy
 import { RequestContext } from "@mastra/core/request-context";
 
 const requestContext = new RequestContext();
@@ -284,7 +284,7 @@ When implementing filtering, these prompts are required in the agent's instructi
 <Tabs>
   <TabItem value="pgvector" label="pgVector">
 
-```ts showLineNumbers copy
+```ts copy
 import { PGVECTOR_PROMPT } from "@mastra/pg";
 
 export const ragAgent = new Agent({
@@ -303,7 +303,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="pinecone" label="Pinecone">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { PINECONE_PROMPT } from "@mastra/pinecone";
 
 export const ragAgent = new Agent({
@@ -322,7 +322,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="qdrant" label="Qdrant">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { QDRANT_PROMPT } from "@mastra/qdrant";
 
 export const ragAgent = new Agent({
@@ -341,7 +341,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="chroma" label="Chroma">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { CHROMA_PROMPT } from "@mastra/chroma";
 
 export const ragAgent = new Agent({
@@ -360,7 +360,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="astra" label="Astra">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { ASTRA_PROMPT } from "@mastra/astra";
 
 export const ragAgent = new Agent({
@@ -379,7 +379,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="libsql" label="LibSQL">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { LIBSQL_PROMPT } from "@mastra/libsql";
 
 export const ragAgent = new Agent({
@@ -398,7 +398,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="upstash" label="Upstash">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { UPSTASH_PROMPT } from "@mastra/upstash";
 
 export const ragAgent = new Agent({
@@ -417,7 +417,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="vectorize" label="Vectorize">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { VECTORIZE_PROMPT } from "@mastra/vectorize";
 
 export const ragAgent = new Agent({
@@ -436,7 +436,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="mongodb" label="MongoDB">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { MONGODB_PROMPT } from "@mastra/mongodb";
 
 export const ragAgent = new Agent({
@@ -455,7 +455,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="opensearch" label="OpenSearch">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { OPENSEARCH_PROMPT } from "@mastra/opensearch";
 
 export const ragAgent = new Agent({
@@ -474,7 +474,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="s3vectors" label="S3Vectors">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { S3VECTORS_PROMPT } from "@mastra/s3vectors";
 
 export const ragAgent = new Agent({
@@ -503,7 +503,7 @@ Initial vector similarity search can sometimes miss nuanced relevance. Re-rankin
 
 Here's how to use re-ranking:
 
-```ts showLineNumbers copy
+```ts copy
 import {
   rerankWithScorer as rerank,
   MastraAgentRelevanceScorer
@@ -547,11 +547,11 @@ For semantic scoring to work properly during re-ranking, each result must includ
 
 You can also use other relevance score providers like Cohere or ZeroEntropy:
 
-```ts showLineNumbers copy
+```ts copy
 const relevanceProvider = new CohereRelevanceScorer("rerank-v3.5");
 ```
 
-```ts showLineNumbers copy
+```ts copy
 const relevanceProvider = new ZeroEntropyRelevanceScorer("zerank-1");
 ```
 

--- a/docs/src/content/en/docs/rag/retrieval.mdx
+++ b/docs/src/content/en/docs/rag/retrieval.mdx
@@ -26,7 +26,7 @@ Mastra provides flexible retrieval options with support for semantic search, fil
 
 The simplest approach is direct semantic search. This method uses vector similarity to find chunks that are semantically similar to the query:
 
-```ts copy
+```ts
 import { embed } from "ai";
 import { PgVector } from "@mastra/pg";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
@@ -56,7 +56,7 @@ The `topK` parameter specifies the maximum number of most similar results to ret
 
 Results include both the text content and a similarity score:
 
-```ts copy
+```ts
 [
   {
     text: "Climate change poses significant challenges...",
@@ -84,7 +84,7 @@ For detailed information about available operators and syntax, see the [Metadata
 
 Basic filtering examples:
 
-```ts copy
+```ts
 // Simple equality filter
 const results = await pgVector.query({
   indexName: "embeddings",
@@ -152,7 +152,7 @@ Common use cases for metadata filtering:
 
 Sometimes you want to give your agent the ability to query a vector database directly. The Vector Query Tool allows your agent to be in charge of retrieval decisions, combining semantic search with optional filtering and reranking based on the agent's understanding of the user's needs.
 
-```ts copy
+```ts
 import { createVectorQueryTool } from "@mastra/rag";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 
@@ -182,7 +182,7 @@ These configurations are for **query-time options** like namespaces, performance
 Connection credentials (URLs, auth tokens) are configured when you instantiate the vector store class (e.g., `new LibSQLVector({ connectionUrl: '...' })`).
 :::
 
-```ts copy
+```ts
 import { createVectorQueryTool } from "@mastra/rag";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 
@@ -257,7 +257,7 @@ const lanceQueryTool = createVectorQueryTool({
 
 You can also override these configurations at runtime using the request context:
 
-```ts copy
+```ts
 import { RequestContext } from "@mastra/core/request-context";
 
 const requestContext = new RequestContext();
@@ -284,7 +284,7 @@ When implementing filtering, these prompts are required in the agent's instructi
 <Tabs>
   <TabItem value="pgvector" label="pgVector">
 
-```ts copy
+```ts
 import { PGVECTOR_PROMPT } from "@mastra/pg";
 
 export const ragAgent = new Agent({
@@ -303,7 +303,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="pinecone" label="Pinecone">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { PINECONE_PROMPT } from "@mastra/pinecone";
 
 export const ragAgent = new Agent({
@@ -322,7 +322,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="qdrant" label="Qdrant">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { QDRANT_PROMPT } from "@mastra/qdrant";
 
 export const ragAgent = new Agent({
@@ -341,7 +341,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="chroma" label="Chroma">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { CHROMA_PROMPT } from "@mastra/chroma";
 
 export const ragAgent = new Agent({
@@ -360,7 +360,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="astra" label="Astra">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { ASTRA_PROMPT } from "@mastra/astra";
 
 export const ragAgent = new Agent({
@@ -379,7 +379,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="libsql" label="LibSQL">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { LIBSQL_PROMPT } from "@mastra/libsql";
 
 export const ragAgent = new Agent({
@@ -398,7 +398,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="upstash" label="Upstash">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { UPSTASH_PROMPT } from "@mastra/upstash";
 
 export const ragAgent = new Agent({
@@ -417,7 +417,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="vectorize" label="Vectorize">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { VECTORIZE_PROMPT } from "@mastra/vectorize";
 
 export const ragAgent = new Agent({
@@ -436,7 +436,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="mongodb" label="MongoDB">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { MONGODB_PROMPT } from "@mastra/mongodb";
 
 export const ragAgent = new Agent({
@@ -455,7 +455,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="opensearch" label="OpenSearch">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { OPENSEARCH_PROMPT } from "@mastra/opensearch";
 
 export const ragAgent = new Agent({
@@ -474,7 +474,7 @@ export const ragAgent = new Agent({
 
   <TabItem value="s3vectors" label="S3Vectors">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { S3VECTORS_PROMPT } from "@mastra/s3vectors";
 
 export const ragAgent = new Agent({
@@ -503,7 +503,7 @@ Initial vector similarity search can sometimes miss nuanced relevance. Re-rankin
 
 Here's how to use re-ranking:
 
-```ts copy
+```ts
 import {
   rerankWithScorer as rerank,
   MastraAgentRelevanceScorer
@@ -547,11 +547,11 @@ For semantic scoring to work properly during re-ranking, each result must includ
 
 You can also use other relevance score providers like Cohere or ZeroEntropy:
 
-```ts copy
+```ts
 const relevanceProvider = new CohereRelevanceScorer("rerank-v3.5");
 ```
 
-```ts copy
+```ts
 const relevanceProvider = new ZeroEntropyRelevanceScorer("zerank-1");
 ```
 

--- a/docs/src/content/en/docs/rag/vector-databases.mdx
+++ b/docs/src/content/en/docs/rag/vector-databases.mdx
@@ -15,7 +15,7 @@ After generating embeddings, you need to store them in a database that supports 
 <Tabs>
   <TabItem value="mongodb" label="MongoDB">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { MongoDBVector } from "@mastra/mongodb";
 
 const store = new MongoDBVector({
@@ -41,7 +41,7 @@ For detailed setup instructions and best practices, see the [official MongoDB At
 
   <TabItem value="pg-vector" label="PgVector">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { PgVector } from "@mastra/pg";
 
 const store = new PgVector({
@@ -70,7 +70,7 @@ For detailed setup instructions and best practices, see the [official pgvector r
 
   <TabItem value="pinecone" label="Pinecone">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { PineconeVector } from "@mastra/pinecone";
 
 const store = new PineconeVector({
@@ -92,7 +92,7 @@ await store.upsert({
 
   <TabItem value="qdrant" label="Qdrant">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { QdrantVector } from "@mastra/qdrant";
 
 const store = new QdrantVector({
@@ -117,7 +117,7 @@ await store.upsert({
 
   <TabItem value="chroma" label="Chroma">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { ChromaVector } from "@mastra/chroma";
 
 // Running Chroma locally
@@ -147,7 +147,7 @@ await store.upsert({
 
   <TabItem value="astra" label="Astra">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { AstraVector } from "@mastra/astra";
 
 const store = new AstraVector({
@@ -172,7 +172,7 @@ await store.upsert({
 
   <TabItem value="libsql" label="LibSQL">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { LibSQLVector } from "@mastra/core/vector/libsql";
 
 const store = new LibSQLVector({
@@ -197,7 +197,7 @@ await store.upsert({
 
   <TabItem value="upstash" label="Upstash">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { UpstashVector } from "@mastra/upstash";
 
 // In upstash they refer to the store as an index
@@ -220,7 +220,7 @@ await store.upsert({
 
   <TabItem value="cloudflare" label="Cloudflare">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { CloudflareVector } from "@mastra/vectorize";
 
 const store = new CloudflareVector({
@@ -242,7 +242,7 @@ await store.upsert({
 
   <TabItem value="opensearch" label="OpenSearch">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { OpenSearchVector } from "@mastra/opensearch";
 
 const store = new OpenSearchVector({ url: process.env.OPENSEARCH_URL });
@@ -263,7 +263,7 @@ await store.upsert({
 
   <TabItem value="elasticsearch" label="ElasticSearch">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { ElasticSearchVector } from "@mastra/elasticsearch";
 
 const store = new ElasticSearchVector({ url: process.env.ELASTICSEARCH_URL });
@@ -283,7 +283,7 @@ await store.upsert({
   </TabItem>
   <TabItem value="couchbase" label="Couchbase">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { CouchbaseVector } from "@mastra/couchbase";
 
 const store = new CouchbaseVector({
@@ -308,7 +308,7 @@ await store.upsert({
   </TabItem>
   <TabItem value="lancedb" label="Lance">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { LanceVectorStore } from "@mastra/lance";
 
 const store = await LanceVectorStore.create("/path/to/db");
@@ -334,7 +334,7 @@ For detailed setup instructions and best practices, see the [official LanceDB do
   </TabItem>
   <TabItem value="s3vectors" label="S3 Vectors">
 
-```ts title="vector-store.ts" copy
+```ts title="vector-store.ts"
 import { S3Vectors } from "@mastra/s3vectors";
 
 const store = new S3Vectors({
@@ -368,7 +368,7 @@ Once initialized, all vector stores share the same interface for creating indexe
 
 Before storing embeddings, you need to create an index with the appropriate dimension size for your embedding model:
 
-```ts title="store-embeddings.ts" copy
+```ts title="store-embeddings.ts"
 // Create an index with dimension 1536 (for text-embedding-3-small)
 await store.createIndex({
   indexName: "myCollection",
@@ -514,7 +514,7 @@ Each vector database enforces specific naming conventions for indexes and collec
 
 After creating an index, you can store embeddings along with their basic metadata:
 
-```ts title="store-embeddings.ts" copy
+```ts title="store-embeddings.ts"
 // Store embeddings with their corresponding metadata
 await store.upsert({
   indexName: "myCollection", // index name
@@ -541,7 +541,7 @@ Vector stores support rich metadata (any JSON-serializable fields) for filtering
 Metadata is crucial for vector storage - without it, you'd only have numerical embeddings with no way to return the original text or filter results. Always store at least the source text as metadata.
 :::
 
-```ts copy
+```ts
 // Store embeddings with rich metadata for better organization and filtering
 await store.upsert({
   indexName: "myCollection",
@@ -581,7 +581,7 @@ When building RAG applications, you often need to clean up stale vectors when do
 
 The most common use case is deleting all vectors for a specific document when a user deletes it:
 
-```ts title="delete-vectors.ts" copy
+```ts title="delete-vectors.ts"
 // Delete all vectors for a specific document
 await store.deleteVectors({
   indexName: "myCollection",
@@ -598,7 +598,7 @@ This is particularly useful when:
 
 You can also use complex filters to delete vectors matching multiple conditions:
 
-```ts title="delete-vectors-advanced.ts" copy
+```ts title="delete-vectors-advanced.ts"
 // Delete all vectors for multiple documents
 await store.deleteVectors({
   indexName: "myCollection",
@@ -623,7 +623,7 @@ await store.deleteVectors({
 
 If you have specific vector IDs to delete, you can pass them directly:
 
-```ts title="delete-by-ids.ts" copy
+```ts title="delete-by-ids.ts"
 // Delete specific vectors by their IDs
 await store.deleteVectors({
   indexName: "myCollection",

--- a/docs/src/content/en/docs/rag/vector-databases.mdx
+++ b/docs/src/content/en/docs/rag/vector-databases.mdx
@@ -15,7 +15,7 @@ After generating embeddings, you need to store them in a database that supports 
 <Tabs>
   <TabItem value="mongodb" label="MongoDB">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { MongoDBVector } from "@mastra/mongodb";
 
 const store = new MongoDBVector({
@@ -41,7 +41,7 @@ For detailed setup instructions and best practices, see the [official MongoDB At
 
   <TabItem value="pg-vector" label="PgVector">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { PgVector } from "@mastra/pg";
 
 const store = new PgVector({
@@ -70,7 +70,7 @@ For detailed setup instructions and best practices, see the [official pgvector r
 
   <TabItem value="pinecone" label="Pinecone">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { PineconeVector } from "@mastra/pinecone";
 
 const store = new PineconeVector({
@@ -92,7 +92,7 @@ await store.upsert({
 
   <TabItem value="qdrant" label="Qdrant">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { QdrantVector } from "@mastra/qdrant";
 
 const store = new QdrantVector({
@@ -117,7 +117,7 @@ await store.upsert({
 
   <TabItem value="chroma" label="Chroma">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { ChromaVector } from "@mastra/chroma";
 
 // Running Chroma locally
@@ -147,7 +147,7 @@ await store.upsert({
 
   <TabItem value="astra" label="Astra">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { AstraVector } from "@mastra/astra";
 
 const store = new AstraVector({
@@ -172,7 +172,7 @@ await store.upsert({
 
   <TabItem value="libsql" label="LibSQL">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { LibSQLVector } from "@mastra/core/vector/libsql";
 
 const store = new LibSQLVector({
@@ -197,7 +197,7 @@ await store.upsert({
 
   <TabItem value="upstash" label="Upstash">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { UpstashVector } from "@mastra/upstash";
 
 // In upstash they refer to the store as an index
@@ -220,7 +220,7 @@ await store.upsert({
 
   <TabItem value="cloudflare" label="Cloudflare">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { CloudflareVector } from "@mastra/vectorize";
 
 const store = new CloudflareVector({
@@ -242,7 +242,7 @@ await store.upsert({
 
   <TabItem value="opensearch" label="OpenSearch">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { OpenSearchVector } from "@mastra/opensearch";
 
 const store = new OpenSearchVector({ url: process.env.OPENSEARCH_URL });
@@ -263,7 +263,7 @@ await store.upsert({
 
   <TabItem value="elasticsearch" label="ElasticSearch">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { ElasticSearchVector } from "@mastra/elasticsearch";
 
 const store = new ElasticSearchVector({ url: process.env.ELASTICSEARCH_URL });
@@ -283,7 +283,7 @@ await store.upsert({
   </TabItem>
   <TabItem value="couchbase" label="Couchbase">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { CouchbaseVector } from "@mastra/couchbase";
 
 const store = new CouchbaseVector({
@@ -308,7 +308,7 @@ await store.upsert({
   </TabItem>
   <TabItem value="lancedb" label="Lance">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { LanceVectorStore } from "@mastra/lance";
 
 const store = await LanceVectorStore.create("/path/to/db");
@@ -334,7 +334,7 @@ For detailed setup instructions and best practices, see the [official LanceDB do
   </TabItem>
   <TabItem value="s3vectors" label="S3 Vectors">
 
-```ts title="vector-store.ts" showLineNumbers copy
+```ts title="vector-store.ts" copy
 import { S3Vectors } from "@mastra/s3vectors";
 
 const store = new S3Vectors({
@@ -368,7 +368,7 @@ Once initialized, all vector stores share the same interface for creating indexe
 
 Before storing embeddings, you need to create an index with the appropriate dimension size for your embedding model:
 
-```ts title="store-embeddings.ts" showLineNumbers copy
+```ts title="store-embeddings.ts" copy
 // Create an index with dimension 1536 (for text-embedding-3-small)
 await store.createIndex({
   indexName: "myCollection",
@@ -514,7 +514,7 @@ Each vector database enforces specific naming conventions for indexes and collec
 
 After creating an index, you can store embeddings along with their basic metadata:
 
-```ts title="store-embeddings.ts" showLineNumbers copy
+```ts title="store-embeddings.ts" copy
 // Store embeddings with their corresponding metadata
 await store.upsert({
   indexName: "myCollection", // index name
@@ -541,7 +541,7 @@ Vector stores support rich metadata (any JSON-serializable fields) for filtering
 Metadata is crucial for vector storage - without it, you'd only have numerical embeddings with no way to return the original text or filter results. Always store at least the source text as metadata.
 :::
 
-```ts showLineNumbers copy
+```ts copy
 // Store embeddings with rich metadata for better organization and filtering
 await store.upsert({
   indexName: "myCollection",
@@ -581,7 +581,7 @@ When building RAG applications, you often need to clean up stale vectors when do
 
 The most common use case is deleting all vectors for a specific document when a user deletes it:
 
-```ts title="delete-vectors.ts" showLineNumbers copy
+```ts title="delete-vectors.ts" copy
 // Delete all vectors for a specific document
 await store.deleteVectors({
   indexName: "myCollection",
@@ -598,7 +598,7 @@ This is particularly useful when:
 
 You can also use complex filters to delete vectors matching multiple conditions:
 
-```ts title="delete-vectors-advanced.ts" showLineNumbers copy
+```ts title="delete-vectors-advanced.ts" copy
 // Delete all vectors for multiple documents
 await store.deleteVectors({
   indexName: "myCollection",
@@ -623,7 +623,7 @@ await store.deleteVectors({
 
 If you have specific vector IDs to delete, you can pass them directly:
 
-```ts title="delete-by-ids.ts" showLineNumbers copy
+```ts title="delete-by-ids.ts" copy
 // Delete specific vectors by their IDs
 await store.deleteVectors({
   indexName: "myCollection",

--- a/docs/src/content/en/docs/server/auth/auth0.mdx
+++ b/docs/src/content/en/docs/server/auth/auth0.mdx
@@ -40,7 +40,7 @@ npm install @mastra/auth-auth0@beta
 
 ### Basic usage with environment variables
 
-```typescript {2,7} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 
@@ -54,7 +54,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript {2,7-10} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7-10} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 
@@ -82,7 +82,7 @@ By default, `MastraAuthAuth0` allows all authenticated users who have valid Auth
 
 To customize user authorization, provide a custom `authorizeUser` function:
 
-```typescript title="src/mastra/auth.ts" showLineNumbers copy
+```typescript title="src/mastra/auth.ts" copy
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 
 const auth0Provider = new MastraAuthAuth0({
@@ -107,7 +107,7 @@ First, install and configure the Auth0 React SDK in your application:
 npm install @auth0/auth0-react
 ```
 
-```typescript title="src/auth0-provider.tsx" showLineNumbers copy
+```typescript title="src/auth0-provider.tsx" copy
 import React from 'react';
 import { Auth0Provider } from '@auth0/auth0-react';
 
@@ -134,7 +134,7 @@ export default Auth0ProviderWithHistory;
 
 Use the Auth0 React SDK to authenticate users and retrieve their access tokens:
 
-```typescript title="lib/auth.ts" showLineNumbers copy
+```typescript title="lib/auth.ts" copy
 import { useAuth0 } from "@auth0/auth0-react";
 
 export const useAuth0Token = () => {
@@ -155,7 +155,7 @@ export const useAuth0Token = () => {
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Auth0 access token in the `Authorization` header:
 
-```typescript title="lib/mastra/mastra-client.ts" showLineNumbers copy
+```typescript title="lib/mastra/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const createMastraClient = (accessToken: string) => {
@@ -178,7 +178,7 @@ Once `MastraClient` is configured with the Auth0 access token, you can send auth
 
 <Tabs>
   <TabItem value="react" label="React">
-    ```tsx title="src/components/mastra-api-test.tsx" showLineNumbers copy
+    ```tsx title="src/components/mastra-api-test.tsx" copy
     import React, { useState } from 'react';
     import { useAuth0 } from '@auth0/auth0-react';
     import { MastraClient } from '@mastra/client-js';

--- a/docs/src/content/en/docs/server/auth/auth0.mdx
+++ b/docs/src/content/en/docs/server/auth/auth0.mdx
@@ -19,7 +19,7 @@ This example uses Auth0 authentication. Make sure to:
 3. Configure an API in your Auth0 Dashboard with an identifier (audience)
 4. Configure your application's allowed callback URLs, web origins, and logout URLs
 
-```env title=".env" copy
+```env title=".env"
 AUTH0_DOMAIN=your-tenant.auth0.com
 AUTH0_AUDIENCE=your-api-identifier
 ```
@@ -32,7 +32,7 @@ AUTH0_AUDIENCE=your-api-identifier
 
 Before you can use the `MastraAuthAuth0` class you have to install the `@mastra/auth-auth0` package.
 
-```bash copy
+```bash
 npm install @mastra/auth-auth0@beta
 ```
 
@@ -40,7 +40,7 @@ npm install @mastra/auth-auth0@beta
 
 ### Basic usage with environment variables
 
-```typescript {2,7} title="src/mastra/index.ts" copy
+```typescript {2,7} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 
@@ -54,7 +54,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript {2,7-10} title="src/mastra/index.ts" copy
+```typescript {2,7-10} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 
@@ -82,7 +82,7 @@ By default, `MastraAuthAuth0` allows all authenticated users who have valid Auth
 
 To customize user authorization, provide a custom `authorizeUser` function:
 
-```typescript title="src/mastra/auth.ts" copy
+```typescript title="src/mastra/auth.ts"
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 
 const auth0Provider = new MastraAuthAuth0({
@@ -103,11 +103,11 @@ When using Auth0 auth, you'll need to set up the Auth0 React SDK, authenticate u
 
 First, install and configure the Auth0 React SDK in your application:
 
-```bash copy
+```bash
 npm install @auth0/auth0-react
 ```
 
-```typescript title="src/auth0-provider.tsx" copy
+```typescript title="src/auth0-provider.tsx"
 import React from 'react';
 import { Auth0Provider } from '@auth0/auth0-react';
 
@@ -134,7 +134,7 @@ export default Auth0ProviderWithHistory;
 
 Use the Auth0 React SDK to authenticate users and retrieve their access tokens:
 
-```typescript title="lib/auth.ts" copy
+```typescript title="lib/auth.ts"
 import { useAuth0 } from "@auth0/auth0-react";
 
 export const useAuth0Token = () => {
@@ -155,7 +155,7 @@ export const useAuth0Token = () => {
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Auth0 access token in the `Authorization` header:
 
-```typescript title="lib/mastra/mastra-client.ts" copy
+```typescript title="lib/mastra/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const createMastraClient = (accessToken: string) => {

--- a/docs/src/content/en/docs/server/auth/clerk.mdx
+++ b/docs/src/content/en/docs/server/auth/clerk.mdx
@@ -14,7 +14,7 @@ The `MastraAuthClerk` class provides authentication for Mastra using Clerk. It v
 
 This example uses Clerk authentication. Make sure to add your Clerk credentials to your `.env` file and ensure your Clerk project is properly configured.
 
-```env title=".env" copy
+```env title=".env"
 CLERK_PUBLISHABLE_KEY=pk_test_...
 CLERK_SECRET_KEY=sk_test_...
 CLERK_JWKS_URI=https://your-clerk-domain.clerk.accounts.dev/.well-known/jwks.json
@@ -26,13 +26,13 @@ CLERK_JWKS_URI=https://your-clerk-domain.clerk.accounts.dev/.well-known/jwks.jso
 
 Before you can use the `MastraAuthClerk` class you have to install the `@mastra/auth-clerk` package.
 
-```bash copy
+```bash
 npm install @mastra/auth-clerk@beta
 ```
 
 ## Usage example
 
-```typescript {2,7-11} title="src/mastra/index.ts" copy
+```typescript {2,7-11} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthClerk } from "@mastra/auth-clerk";
 
@@ -60,7 +60,7 @@ When using Clerk auth, you'll need to retrieve the access token from Clerk on th
 
 Use the Clerk React hooks to authenticate users and retrieve their access token:
 
-```typescript title="lib/auth.ts" copy
+```typescript title="lib/auth.ts"
 import { useAuth } from "@clerk/nextjs";
 
 export const useClerkAuth = () => {
@@ -81,7 +81,7 @@ export const useClerkAuth = () => {
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Clerk access token in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" copy
+```typescript {6} title="lib/mastra/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({

--- a/docs/src/content/en/docs/server/auth/clerk.mdx
+++ b/docs/src/content/en/docs/server/auth/clerk.mdx
@@ -32,7 +32,7 @@ npm install @mastra/auth-clerk@beta
 
 ## Usage example
 
-```typescript {2,7-11} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7-11} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthClerk } from "@mastra/auth-clerk";
 
@@ -60,7 +60,7 @@ When using Clerk auth, you'll need to retrieve the access token from Clerk on th
 
 Use the Clerk React hooks to authenticate users and retrieve their access token:
 
-```typescript title="lib/auth.ts" showLineNumbers copy
+```typescript title="lib/auth.ts" copy
 import { useAuth } from "@clerk/nextjs";
 
 export const useClerkAuth = () => {
@@ -81,7 +81,7 @@ export const useClerkAuth = () => {
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Clerk access token in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" showLineNumbers copy
+```typescript {6} title="lib/mastra/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({
@@ -101,7 +101,7 @@ Once `MastraClient` is configured with the Clerk access token, you can send auth
 
 <Tabs>
   <TabItem value="react" label="React">
-    ```tsx title="src/components/test-agent.tsx" showLineNumbers copy
+    ```tsx title="src/components/test-agent.tsx" copy
     "use client";
 
     import { useAuth } from "@clerk/nextjs";

--- a/docs/src/content/en/docs/server/auth/firebase.mdx
+++ b/docs/src/content/en/docs/server/auth/firebase.mdx
@@ -19,7 +19,7 @@ This example uses Firebase Authentication. Make sure to:
 3. Generate a service account key from Project Settings > Service Accounts
 4. Download the service account JSON file
 
-```env title=".env" copy
+```env title=".env"
 FIREBASE_SERVICE_ACCOUNT=/path/to/your/service-account-key.json
 FIRESTORE_DATABASE_ID=(default)
 # Alternative environment variable names:
@@ -32,7 +32,7 @@ FIRESTORE_DATABASE_ID=(default)
 
 Before you can use the `MastraAuthFirebase` class you have to install the `@mastra/auth-firebase` package.
 
-```bash copy
+```bash
 npm install @mastra/auth-firebase@beta
 ```
 
@@ -42,7 +42,7 @@ npm install @mastra/auth-firebase@beta
 
 If you set the required environment variables (`FIREBASE_SERVICE_ACCOUNT` and `FIRESTORE_DATABASE_ID`), you can initialize `MastraAuthFirebase` without any constructor arguments. The class will automatically read these environment variables as configuration:
 
-```typescript {2,7} title="src/mastra/index.ts" copy
+```typescript {2,7} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
@@ -57,7 +57,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript {2,7-10} title="src/mastra/index.ts" copy
+```typescript {2,7-10} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
@@ -87,7 +87,7 @@ The `MastraAuthFirebase` class can be configured through constructor options or 
 
 By default, `MastraAuthFirebase` uses Firestore to manage user access. It expects a collection named `user_access` with documents keyed by user UIDs. The presence of a document in this collection determines whether a user is authorized.
 
-```typescript title="firestore-structure.txt" copy
+```typescript title="firestore-structure.txt"
 user_access/
   {user_uid_1}/     // Document exists = user authorized
   {user_uid_2}/     // Document exists = user authorized
@@ -95,7 +95,7 @@ user_access/
 
 To customize user authorization, provide a custom `authorizeUser` function:
 
-```typescript title="src/mastra/auth.ts" copy
+```typescript title="src/mastra/auth.ts"
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
 const firebaseAuth = new MastraAuthFirebase({
@@ -116,7 +116,7 @@ When using Firebase auth, you'll need to initialize Firebase on the client side,
 
 First, initialize Firebase in your client application:
 
-```typescript title="lib/firebase.ts" copy
+```typescript title="lib/firebase.ts"
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 
@@ -135,7 +135,7 @@ export const googleProvider = new GoogleAuthProvider();
 
 Use Firebase authentication to sign in users and retrieve their ID tokens:
 
-```typescript title="lib/auth.ts" copy
+```typescript title="lib/auth.ts"
 import { signInWithPopup, signOut, User } from "firebase/auth";
 import { auth, googleProvider } from "./firebase";
 
@@ -175,7 +175,7 @@ export const signOutUser = async () => {
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Firebase ID token in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" copy
+```typescript {6} title="lib/mastra/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const createMastraClient = (idToken: string) => {

--- a/docs/src/content/en/docs/server/auth/firebase.mdx
+++ b/docs/src/content/en/docs/server/auth/firebase.mdx
@@ -42,7 +42,7 @@ npm install @mastra/auth-firebase@beta
 
 If you set the required environment variables (`FIREBASE_SERVICE_ACCOUNT` and `FIRESTORE_DATABASE_ID`), you can initialize `MastraAuthFirebase` without any constructor arguments. The class will automatically read these environment variables as configuration:
 
-```typescript {2,7} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
@@ -57,7 +57,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript {2,7-10} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7-10} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
@@ -95,7 +95,7 @@ user_access/
 
 To customize user authorization, provide a custom `authorizeUser` function:
 
-```typescript title="src/mastra/auth.ts" showLineNumbers copy
+```typescript title="src/mastra/auth.ts" copy
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
 const firebaseAuth = new MastraAuthFirebase({
@@ -116,7 +116,7 @@ When using Firebase auth, you'll need to initialize Firebase on the client side,
 
 First, initialize Firebase in your client application:
 
-```typescript title="lib/firebase.ts" showLineNumbers copy
+```typescript title="lib/firebase.ts" copy
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 
@@ -135,7 +135,7 @@ export const googleProvider = new GoogleAuthProvider();
 
 Use Firebase authentication to sign in users and retrieve their ID tokens:
 
-```typescript title="lib/auth.ts" showLineNumbers copy
+```typescript title="lib/auth.ts" copy
 import { signInWithPopup, signOut, User } from "firebase/auth";
 import { auth, googleProvider } from "./firebase";
 
@@ -175,7 +175,7 @@ export const signOutUser = async () => {
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Firebase ID token in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" showLineNumbers copy
+```typescript {6} title="lib/mastra/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const createMastraClient = (idToken: string) => {
@@ -198,7 +198,7 @@ Once `MastraClient` is configured with the Firebase ID token, you can send authe
 
 <Tabs>
   <TabItem value="react" label="React">
-    ```tsx title="src/components/test-agent.tsx" showLineNumbers copy
+    ```tsx title="src/components/test-agent.tsx" copy
     "use client";
 
     import { useAuthState } from 'react-firebase-hooks/auth';
@@ -233,7 +233,7 @@ Once `MastraClient` is configured with the Firebase ID token, you can send authe
 
   </TabItem>
   <TabItem value="nodejs" label="Node.js">
-    ```typescript title="server.js" showLineNumbers copy
+    ```typescript title="server.js" copy
     const express = require('express');
     const admin = require('firebase-admin');
     const { MastraClient } = require('@mastra/client-js');

--- a/docs/src/content/en/docs/server/auth/jwt.mdx
+++ b/docs/src/content/en/docs/server/auth/jwt.mdx
@@ -20,7 +20,7 @@ npm install @mastra/auth@beta
 
 ## Usage example
 
-```typescript {2,7-9} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7-9} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraJwtAuth } from "@mastra/auth";
 
@@ -40,7 +40,7 @@ export const mastra = new Mastra({
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid JWT in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" showLineNumbers copy
+```typescript {6} title="lib/mastra/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({
@@ -59,7 +59,7 @@ Once `MastraClient` is configured, you can send authenticated requests from your
 
 <Tabs>
   <TabItem value="react" label="React">
-    ```tsx title="src/components/test-agent.tsx" showLineNumbers copy
+    ```tsx title="src/components/test-agent.tsx" copy
     import { mastraClient } from "../../lib/mastra-client";
 
     export const TestAgent = () => {

--- a/docs/src/content/en/docs/server/auth/jwt.mdx
+++ b/docs/src/content/en/docs/server/auth/jwt.mdx
@@ -14,13 +14,13 @@ The `MastraJwtAuth` class provides a lightweight authentication mechanism for Ma
 
 Before you can use the `MastraJwtAuth` class you have to install the `@mastra/auth` package.
 
-```bash copy
+```bash
 npm install @mastra/auth@beta
 ```
 
 ## Usage example
 
-```typescript {2,7-9} title="src/mastra/index.ts" copy
+```typescript {2,7-9} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraJwtAuth } from "@mastra/auth";
 
@@ -40,7 +40,7 @@ export const mastra = new Mastra({
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid JWT in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" copy
+```typescript {6} title="lib/mastra/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({

--- a/docs/src/content/en/docs/server/auth/supabase.mdx
+++ b/docs/src/content/en/docs/server/auth/supabase.mdx
@@ -14,7 +14,7 @@ The `MastraAuthSupabase` class provides authentication for Mastra using Supabase
 
 This example uses Supabase Auth. Make sure to add your Supabase credentials to your `.env` file and ensure your Supabase project is properly configured.
 
-```env title=".env" copy
+```env title=".env"
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
 ```
@@ -25,13 +25,13 @@ SUPABASE_ANON_KEY=your-anon-key
 
 Before you can use the `MastraAuthSupabase` class you have to install the `@mastra/auth-supabase` package.
 
-```bash copy
+```bash
 npm install @mastra/auth-supabase@beta
 ```
 
 ## Usage example
 
-```typescript {2,7-9} title="src/mastra/index.ts" copy
+```typescript {2,7-9} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthSupabase } from "@mastra/auth-supabase";
 
@@ -58,7 +58,7 @@ When using Supabase auth, you'll need to retrieve the access token from Supabase
 
 Use the Supabase client to authenticate users and retrieve their access token:
 
-```typescript title="lib/auth.ts" copy
+```typescript title="lib/auth.ts"
 import { createClient } from "@supabase/supabase-js";
 
 const supabase = createClient("<supabase-url>", "<supabase-key>");
@@ -77,7 +77,7 @@ const accessToken = authTokenResponse.data?.session?.access_token;
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Supabase access token in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" copy
+```typescript {6} title="lib/mastra/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({

--- a/docs/src/content/en/docs/server/auth/supabase.mdx
+++ b/docs/src/content/en/docs/server/auth/supabase.mdx
@@ -31,7 +31,7 @@ npm install @mastra/auth-supabase@beta
 
 ## Usage example
 
-```typescript {2,7-9} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7-9} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthSupabase } from "@mastra/auth-supabase";
 
@@ -58,7 +58,7 @@ When using Supabase auth, you'll need to retrieve the access token from Supabase
 
 Use the Supabase client to authenticate users and retrieve their access token:
 
-```typescript title="lib/auth.ts" showLineNumbers copy
+```typescript title="lib/auth.ts" copy
 import { createClient } from "@supabase/supabase-js";
 
 const supabase = createClient("<supabase-url>", "<supabase-key>");
@@ -77,7 +77,7 @@ const accessToken = authTokenResponse.data?.session?.access_token;
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid Supabase access token in the `Authorization` header:
 
-```typescript {6} title="lib/mastra/mastra-client.ts" showLineNumbers copy
+```typescript {6} title="lib/mastra/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({
@@ -98,7 +98,7 @@ Once `MastraClient` is configured with the Supabase access token, you can send a
 
 <Tabs>
     <TabItem value="react" label="React">
-    ```tsx title="src/components/test-agent.tsx" showLineNumbers copy
+    ```tsx title="src/components/test-agent.tsx" copy
     import { mastraClient } from "../../lib/mastra-client";
 
     export const TestAgent = () => {

--- a/docs/src/content/en/docs/server/auth/workos.mdx
+++ b/docs/src/content/en/docs/server/auth/workos.mdx
@@ -19,7 +19,7 @@ This example uses WorkOS authentication. Make sure to:
 3. Configure your redirect URIs and allowed origins
 4. Set up Organizations and configure user roles as needed
 
-```env title=".env" copy
+```env title=".env"
 WORKOS_API_KEY=sk_live_...
 WORKOS_CLIENT_ID=client_...
 ```
@@ -32,7 +32,7 @@ WORKOS_CLIENT_ID=client_...
 
 Before you can use the `MastraAuthWorkos` class you have to install the `@mastra/auth-workos` package.
 
-```bash copy
+```bash
 npm install @mastra/auth-workos@beta
 ```
 
@@ -40,7 +40,7 @@ npm install @mastra/auth-workos@beta
 
 ### Basic usage with environment variables
 
-```typescript {2,7} title="src/mastra/index.ts" copy
+```typescript {2,7} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 
@@ -54,7 +54,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript {2,7-10} title="src/mastra/index.ts" copy
+```typescript {2,7-10} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 
@@ -82,7 +82,7 @@ By default, `MastraAuthWorkos` checks whether the authenticated user has an 'adm
 
 To customize user authorization, provide a custom `authorizeUser` function:
 
-```typescript title="src/mastra/auth.ts" copy
+```typescript title="src/mastra/auth.ts"
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 
 const workosAuth = new MastraAuthWorkos({
@@ -104,7 +104,7 @@ When using WorkOS auth, you'll need to implement the WorkOS authentication flow 
 
 First, install the WorkOS SDK in your application:
 
-```bash copy
+```bash
 npm install @workos-inc/node
 ```
 
@@ -112,7 +112,7 @@ npm install @workos-inc/node
 
 After users complete the WorkOS authentication flow and return with an authorization code, exchange it for an access token:
 
-```typescript title="lib/auth.ts" copy
+```typescript title="lib/auth.ts"
 import { WorkOS } from "@workos-inc/node";
 
 const workos = new WorkOS(process.env.WORKOS_API_KEY);
@@ -137,7 +137,7 @@ export const authenticateWithWorkos = async (
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid WorkOS access token in the `Authorization` header:
 
-```typescript title="lib/mastra/mastra-client.ts" copy
+```typescript title="lib/mastra/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const createMastraClient = (accessToken: string) => {

--- a/docs/src/content/en/docs/server/auth/workos.mdx
+++ b/docs/src/content/en/docs/server/auth/workos.mdx
@@ -40,7 +40,7 @@ npm install @mastra/auth-workos@beta
 
 ### Basic usage with environment variables
 
-```typescript {2,7} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 
@@ -54,7 +54,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript {2,7-10} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {2,7-10} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 
@@ -82,7 +82,7 @@ By default, `MastraAuthWorkos` checks whether the authenticated user has an 'adm
 
 To customize user authorization, provide a custom `authorizeUser` function:
 
-```typescript title="src/mastra/auth.ts" showLineNumbers copy
+```typescript title="src/mastra/auth.ts" copy
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 
 const workosAuth = new MastraAuthWorkos({
@@ -112,7 +112,7 @@ npm install @workos-inc/node
 
 After users complete the WorkOS authentication flow and return with an authorization code, exchange it for an access token:
 
-```typescript title="lib/auth.ts" showLineNumbers copy
+```typescript title="lib/auth.ts" copy
 import { WorkOS } from "@workos-inc/node";
 
 const workos = new WorkOS(process.env.WORKOS_API_KEY);
@@ -137,7 +137,7 @@ export const authenticateWithWorkos = async (
 
 When `auth` is enabled, all requests made with `MastraClient` must include a valid WorkOS access token in the `Authorization` header:
 
-```typescript title="lib/mastra/mastra-client.ts" showLineNumbers copy
+```typescript title="lib/mastra/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const createMastraClient = (accessToken: string) => {
@@ -160,7 +160,7 @@ Once `MastraClient` is configured with the WorkOS access token, you can send aut
 
 <Tabs>
   <TabItem value="react" label="React">
-    ```typescript title="src/api/agents.ts" showLineNumbers copy
+    ```typescript title="src/api/agents.ts" copy
     import { WorkOS } from '@workos-inc/node';
     import { MastraClient } from '@mastra/client-js';
 

--- a/docs/src/content/en/docs/server/custom-adapters.mdx
+++ b/docs/src/content/en/docs/server/custom-adapters.mdx
@@ -25,7 +25,7 @@ The `MastraServer` abstract class from `@mastra/server/server-adapter` provides 
 
 The class takes three type parameters that represent your framework's types:
 
-```typescript title="my-framework-adapter.ts" copy
+```typescript title="my-framework-adapter.ts"
 import { MastraServer } from '@mastra/server/server-adapter';
 
 export class MyFrameworkServer extends MastraServer<
@@ -50,7 +50,7 @@ You must implement these six abstract methods. Each handles a specific part of t
 
 This method runs first and attaches Mastra context to every incoming request. Route handlers need access to the Mastra instance, tools, and other context to function. How you attach this context depends on your framework — Express uses `res.locals`, Hono uses `c.set()`, and other frameworks have their own patterns.
 
-```typescript copy
+```typescript
 registerContextMiddleware(): void {
   this.app.use('*', (req, res, next) => {
     // Attach context to your framework's request/response
@@ -77,7 +77,7 @@ Context to attach:
 
 Register authentication and authorization middleware. This method should check if authentication is configured on the Mastra instance and skip registration entirely if not. When auth is configured, you'll typically register two middleware functions: one for authentication (validating tokens and setting the user) and one for authorization (checking if the user can access the requested resource).
 
-```typescript copy
+```typescript
 registerAuthMiddleware(): void {
   const authConfig = this.mastra.getServer()?.auth;
   if (!authConfig) return;
@@ -113,7 +113,7 @@ registerAuthMiddleware(): void {
 
 Register a single route with your framework. This method is called once for each Mastra route during initialization. It receives a `ServerRoute` object containing the path, HTTP method, handler function, and Zod schemas for validation. Your implementation should wire this up to your framework's routing system.
 
-```typescript copy
+```typescript
 async registerRoute(
   app: MyApp,
   route: ServerRoute,
@@ -160,7 +160,7 @@ async registerRoute(
 
 Extract URL parameters, query parameters, and request body from the incoming request. Different frameworks expose these values in different ways—Express uses `req.params`, `req.query`, and `req.body`, while other frameworks may use different property names or require method calls. This method normalizes the extraction for your framework.
 
-```typescript copy
+```typescript
 async getParams(
   route: ServerRoute,
   request: MyRequest
@@ -184,7 +184,7 @@ async getParams(
 
 Send the response back to the client based on the route's response type. Mastra routes can return different response types: JSON for most API responses, streams for agent generation, and special types for MCP transports. Your implementation should handle each type appropriately for your framework.
 
-```typescript copy
+```typescript
 async sendResponse(
   route: ServerRoute,
   response: MyResponse,
@@ -219,7 +219,7 @@ async sendResponse(
 
 Handle streaming responses for agent generation. When an agent generates a response, it produces a stream of chunks that should be sent to the client as they become available. This method reads from the stream, optionally applies redaction to hide sensitive data, and writes chunks to the response in the appropriate format (SSE or newline-delimited JSON).
 
-```typescript copy
+```typescript
 async stream(
   route: ServerRoute,
   response: MyResponse,
@@ -282,7 +282,7 @@ The `parse*` methods use Zod schemas defined on each route to validate input and
 
 Your adapter's constructor should accept the same options as the base class and pass them to `super()`. You can add additional framework-specific options if needed:
 
-```typescript copy
+```typescript
 constructor(options: {
   app: MyApp;
   mastra: Mastra;
@@ -302,7 +302,7 @@ See [Server Adapters](/docs/v1/server/server-adapters#constructor-options) for f
 
 Here's a skeleton implementation showing all the required methods. This uses pseudocode for framework-specific parts—replace with your framework's actual APIs:
 
-```typescript title="my-framework-adapter.ts" copy
+```typescript title="my-framework-adapter.ts"
 import { MastraServer, ServerRoute } from '@mastra/server/server-adapter';
 import type { Mastra } from '@mastra/core';
 
@@ -359,7 +359,7 @@ export class MyFrameworkServer extends MastraServer<MyApp, MyRequest, MyResponse
 
 Once your adapter is implemented, use it the same way as the provided adapters:
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 import { MyFrameworkServer } from './my-framework-adapter';
 import { mastra } from './mastra';
 

--- a/docs/src/content/en/docs/server/custom-api-routes.mdx
+++ b/docs/src/content/en/docs/server/custom-api-routes.mdx
@@ -9,7 +9,7 @@ By default, Mastra automatically exposes registered agents and workflows via its
 
 Routes are provided with a helper `registerApiRoute()` from `@mastra/core/server`. Routes can live in the same file as the `Mastra` instance but separating them helps keep configuration concise.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { registerApiRoute } from "@mastra/core/server";
 
@@ -41,7 +41,7 @@ Each route's handler receives the Hono `Context`. Within the handler you can acc
 
 To add route-specific middleware pass a `middleware` array when calling `registerApiRoute()`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { registerApiRoute } from "@mastra/core/server";
 

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -61,7 +61,7 @@ To use the Mastra Client SDK, install the required dependencies:
 
 Once initialized with a `baseUrl`, `MastraClient` exposes a type-safe interface for calling agents, tools, and workflows.
 
-```typescript title="lib/mastra-client.ts" copy
+```typescript title="lib/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({
@@ -85,7 +85,7 @@ The Mastra Client SDK exposes all resources served by the Mastra Server
 
 Call `.generate()` with an array of message objects that include `role` and `content`:
 
-```typescript copy
+```typescript
 import { mastraClient } from "lib/mastra-client";
 
 const testAgent = async () => {
@@ -114,7 +114,7 @@ const testAgent = async () => {
 
 Use `.stream()` for real-time responses with an array of message objects that include `role` and `content`:
 
-```typescript copy
+```typescript
 import { mastraClient } from "lib/mastra-client";
 
 const testAgent = async () => {
@@ -147,7 +147,7 @@ const testAgent = async () => {
 
 `MastraClient` accepts optional parameters like `retries`, `backoffMs`, and `headers` to control request behavior. These parameters are useful for controlling retry behavior and including diagnostic metadata.
 
-```typescript title="lib/mastra-client.ts" copy
+```typescript title="lib/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({
@@ -169,7 +169,7 @@ export const mastraClient = new MastraClient({
 
 Pass an `AbortSignal` to the client constructor to enable cancellation across all requests.
 
-```typescript {3,7} title="lib/mastra-client.ts" copy
+```typescript {3,7} title="lib/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const controller = new AbortController();
@@ -184,7 +184,7 @@ export const mastraClient = new MastraClient({
 
 Calling `.abort()` will cancel any ongoing requests tied to that signal.
 
-```typescript {4} copy
+```typescript {4}
 import { mastraClient, controller } from "lib/mastra-client";
 
 const handleAbort = () => {
@@ -198,7 +198,7 @@ Define tools directly in client-side applications using the `createTool()` funct
 
 This lets agents trigger browser-side functionality such as DOM manipulation, local storage access, or other Web APIs, enabling tool execution in the user's environment rather than on the server.
 
-```typescript {27} copy
+```typescript {27}
 import { createTool } from "@mastra/client-js";
 import { z } from "zod";
 
@@ -239,7 +239,7 @@ const handleClientTool = async () => {
 
 This is a standard Mastra [agent](../agents/overview#setting-up-agents) configured to return hex color codes, intended to work with the browser-based client tool defined above.
 
-```typescript title="src/mastra/agents/color-agent" copy
+```typescript title="src/mastra/agents/color-agent"
 import { Agent } from "@mastra/core/agent";
 
 export const colorAgent = new Agent({

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -61,7 +61,7 @@ To use the Mastra Client SDK, install the required dependencies:
 
 Once initialized with a `baseUrl`, `MastraClient` exposes a type-safe interface for calling agents, tools, and workflows.
 
-```typescript title="lib/mastra-client.ts" showLineNumbers copy
+```typescript title="lib/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({
@@ -85,7 +85,7 @@ The Mastra Client SDK exposes all resources served by the Mastra Server
 
 Call `.generate()` with an array of message objects that include `role` and `content`:
 
-```typescript showLineNumbers copy
+```typescript copy
 import { mastraClient } from "lib/mastra-client";
 
 const testAgent = async () => {
@@ -114,7 +114,7 @@ const testAgent = async () => {
 
 Use `.stream()` for real-time responses with an array of message objects that include `role` and `content`:
 
-```typescript showLineNumbers copy
+```typescript copy
 import { mastraClient } from "lib/mastra-client";
 
 const testAgent = async () => {
@@ -147,7 +147,7 @@ const testAgent = async () => {
 
 `MastraClient` accepts optional parameters like `retries`, `backoffMs`, and `headers` to control request behavior. These parameters are useful for controlling retry behavior and including diagnostic metadata.
 
-```typescript title="lib/mastra-client.ts" showLineNumbers copy
+```typescript title="lib/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({
@@ -169,7 +169,7 @@ export const mastraClient = new MastraClient({
 
 Pass an `AbortSignal` to the client constructor to enable cancellation across all requests.
 
-```typescript {3,7} title="lib/mastra-client.ts" showLineNumbers copy
+```typescript {3,7} title="lib/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const controller = new AbortController();
@@ -184,7 +184,7 @@ export const mastraClient = new MastraClient({
 
 Calling `.abort()` will cancel any ongoing requests tied to that signal.
 
-```typescript {4} showLineNumbers copy
+```typescript {4} copy
 import { mastraClient, controller } from "lib/mastra-client";
 
 const handleAbort = () => {
@@ -198,7 +198,7 @@ Define tools directly in client-side applications using the `createTool()` funct
 
 This lets agents trigger browser-side functionality such as DOM manipulation, local storage access, or other Web APIs, enabling tool execution in the user's environment rather than on the server.
 
-```typescript {27} showLineNumbers copy
+```typescript {27} copy
 import { createTool } from "@mastra/client-js";
 import { z } from "zod";
 
@@ -239,7 +239,7 @@ const handleClientTool = async () => {
 
 This is a standard Mastra [agent](../agents/overview#setting-up-agents) configured to return hex color codes, intended to work with the browser-based client tool defined above.
 
-```typescript title="src/mastra/agents/color-agent" showLineNumbers copy
+```typescript title="src/mastra/agents/color-agent" copy
 import { Agent } from "@mastra/core/agent";
 
 export const colorAgent = new Agent({
@@ -256,7 +256,7 @@ export const colorAgent = new Agent({
 
 You can also use `MastraClient` in server-side environments such as API routes, serverless functions or actions. The usage will broadly remain the same but you may need to recreate the response to your client:
 
-```typescript {8} showLineNumbers
+```typescript {8}
 export async function action() {
   const agent = mastraClient.getAgent("testAgent");
 

--- a/docs/src/content/en/docs/server/mastra-server.mdx
+++ b/docs/src/content/en/docs/server/mastra-server.mdx
@@ -35,7 +35,7 @@ adding additional server behaviour.
 
 You can configure server `port`, `host`, `studioBase`, and `timeout` in the Mastra instance.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 
 export const mastra = new Mastra({
@@ -54,7 +54,7 @@ The `studioBase` option allows you to host Mastra Studio on a sub-path of your e
 
 Mastra requires `module` and `moduleResolution` values that support modern Node.js versions. Older settings like `CommonJS` or `node` are incompatible with Mastra’s packages and will cause resolution errors.
 
-```json {4-5} title="tsconfig.json" copy
+```json {4-5} title="tsconfig.json"
 {
   "compilerOptions": {
     "target": "ES2022",
@@ -77,7 +77,7 @@ Mastra requires `module` and `moduleResolution` values that support modern Node.
 
 Mastra allows you to configure CORS (Cross-Origin Resource Sharing) settings for your server.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 
 export const mastra = new Mastra({

--- a/docs/src/content/en/docs/server/middleware.mdx
+++ b/docs/src/content/en/docs/server/middleware.mdx
@@ -13,7 +13,7 @@ A middleware receives the [Hono](https://hono.dev) `Context` (`c`) and a `next`
 function. If it returns a `Response` the request is short-circuited. Calling
 `next()` continues processing the next middleware or route handler.
 
-```typescript copy showLineNumbers
+```typescript copy
 import { Mastra } from "@mastra/core";
 
 export const mastra = new Mastra({
@@ -44,7 +44,7 @@ export const mastra = new Mastra({
 To attach middleware to a single route pass the `middleware` option to
 `registerApiRoute`:
 
-```typescript copy showLineNumbers
+```typescript copy
 registerApiRoute("/my-custom-route", {
   method: "GET",
   middleware: [
@@ -68,7 +68,7 @@ registerApiRoute("/my-custom-route", {
 
 You can populate `RequestContext` dynamically in server middleware by extracting information from the request. In this example, the `temperature-unit` is set based on the Cloudflare `CF-IPCountry` header to ensure responses match the user's locale.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { RequestContext } from "@mastra/core/request-context";
 import { testWeatherAgent } from "./agents/test-weather-agent";

--- a/docs/src/content/en/docs/server/middleware.mdx
+++ b/docs/src/content/en/docs/server/middleware.mdx
@@ -13,7 +13,7 @@ A middleware receives the [Hono](https://hono.dev) `Context` (`c`) and a `next`
 function. If it returns a `Response` the request is short-circuited. Calling
 `next()` continues processing the next middleware or route handler.
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 
 export const mastra = new Mastra({
@@ -44,7 +44,7 @@ export const mastra = new Mastra({
 To attach middleware to a single route pass the `middleware` option to
 `registerApiRoute`:
 
-```typescript copy
+```typescript
 registerApiRoute("/my-custom-route", {
   method: "GET",
   middleware: [
@@ -68,7 +68,7 @@ registerApiRoute("/my-custom-route", {
 
 You can populate `RequestContext` dynamically in server middleware by extracting information from the request. In this example, the `temperature-unit` is set based on the Cloudflare `CF-IPCountry` header to ensure responses match the user's locale.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { RequestContext } from "@mastra/core/request-context";
 import { testWeatherAgent } from "./agents/test-weather-agent";
@@ -95,7 +95,7 @@ export const mastra = new Mastra({
 
 ### Authentication
 
-```typescript copy
+```typescript
 {
   handler: async (c, next) => {
     const authHeader = c.req.header('Authorization');
@@ -112,7 +112,7 @@ export const mastra = new Mastra({
 
 ### CORS support
 
-```typescript copy
+```typescript
 {
   handler: async (c, next) => {
     c.header('Access-Control-Allow-Origin', '*');
@@ -136,7 +136,7 @@ export const mastra = new Mastra({
 
 ### Request logging
 
-```typescript copy
+```typescript
 {
   handler: async (c, next) => {
     const start = Date.now();
@@ -152,7 +152,7 @@ export const mastra = new Mastra({
 When integrating with Mastra Cloud or custom clients the following headers can
 be inspected by middleware to tailor behavior:
 
-```typescript copy
+```typescript
 {
   handler: async (c, next) => {
     const isFromMastraCloud = c.req.header('x-mastra-cloud') === 'true';

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -28,7 +28,7 @@ The `.set()` method takes two arguments:
 1. **key**: The name used to identify the value.
 2. **value**: The data to associate with that key.
 
-```typescript showLineNumbers
+```typescript
 import { RequestContext } from "@mastra/core/request-context";
 
 export type UserTier = {
@@ -74,7 +74,7 @@ await weatherTool.execute({
 
 You can populate `requestContext` dynamically in server middleware by extracting information from the request. In this example, the `temperature-unit` is set based on the Cloudflare `CF-IPCountry` header to ensure responses match the user's locale.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { RequestContext } from "@mastra/core/request-context";
 import { testWeatherAgent } from "./agents/test-weather-agent";
@@ -105,7 +105,7 @@ export const mastra = new Mastra({
 
 You can access the `requestContext` argument from any supported configuration options in agents. These functions can be sync or `async`. Use the `.get()` method to read values from `requestContext`.
 
-```typescript {7-8,15,18,21} title="src/mastra/agents/weather-agent.ts" showLineNumbers
+```typescript {7-8,15,18,21} title="src/mastra/agents/weather-agent.ts"
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };
@@ -141,7 +141,7 @@ You can also use `requestContext` with other options like `agents`, `workflows`,
 
 You can access the `requestContext` argument from a workflow step's `execute` function. This function can be sync or async. Use the `.get()` method to read values from `requestContext`.
 
-```typescript {7-8} title="src/mastra/workflows/weather-workflow.ts" showLineNumbers copy
+```typescript {7-8} title="src/mastra/workflows/weather-workflow.ts" copy
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };
@@ -165,7 +165,7 @@ const stepOne = createStep({
 
 You can access the `requestContext` argument from a tool’s `execute` function. This function is `async`. Use the `.get()` method to read values from `requestContext`.
 
-```typescript {7-8} title="src/mastra/tools/weather-tool.ts" showLineNumbers
+```typescript {7-8} title="src/mastra/tools/weather-tool.ts"
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -74,7 +74,7 @@ await weatherTool.execute({
 
 You can populate `requestContext` dynamically in server middleware by extracting information from the request. In this example, the `temperature-unit` is set based on the Cloudflare `CF-IPCountry` header to ensure responses match the user's locale.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { RequestContext } from "@mastra/core/request-context";
 import { testWeatherAgent } from "./agents/test-weather-agent";
@@ -141,7 +141,7 @@ You can also use `requestContext` with other options like `agents`, `workflows`,
 
 You can access the `requestContext` argument from a workflow step's `execute` function. This function can be sync or async. Use the `.get()` method to read values from `requestContext`.
 
-```typescript {7-8} title="src/mastra/workflows/weather-workflow.ts" copy
+```typescript {7-8} title="src/mastra/workflows/weather-workflow.ts"
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -115,7 +115,7 @@ Calling `init()` runs three steps in order. Understanding this flow helps when y
 
 For custom middleware ordering, call each method separately instead of `init()`. This is useful when you need middleware that runs before Mastra's context is set up, or when you need to insert logic between the initialization steps.
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 const server = new MastraServer({ app, mastra });
 
 // Your middleware first
@@ -156,7 +156,7 @@ Visit "Adding custom routes" for [Express](/reference/v1/server/express-adapter#
 
 By default, Mastra routes are registered at `/api/agents`, `/api/workflows`, etc. Use the `prefix` option to change this. This is useful for API versioning or when integrating with an existing app that has its own `/api` routes.
 
-```typescript copy
+```typescript
 const server = new MastraServer({
   app,
   mastra,
@@ -170,7 +170,7 @@ With this prefix, Mastra routes become `/api/v2/agents`, `/api/v2/workflows`, et
 
 Mastra can generate an OpenAPI specification for all registered routes. This is useful for documentation, client generation, or integration with API tools. Enable it by setting the `openapiPath` option:
 
-```typescript copy
+```typescript
 const server = new MastraServer({
   app,
   mastra,
@@ -193,7 +193,7 @@ This redaction happens at the HTTP boundary, so internal callbacks like `onStepF
 
 By default, redaction is enabled. Configure this behavior via `streamOptions`. Set `redact: false` only for internal services or debugging scenarios where you need access to the full request data in stream responses.
 
-```typescript copy
+```typescript
 const server = new MastraServer({
   app,
   mastra,
@@ -215,7 +215,7 @@ When authentication is configured on your Mastra instance, all routes require au
 
 Use `customRouteAuthConfig` to override authentication behavior for specific routes. Keys follow the format `METHOD:PATH` where method is `GET`, `POST`, `PUT`, `DELETE`, or `ALL`. Paths support wildcards (`*`) for matching multiple routes. Setting a value to `false` makes the route public, while `true` requires authentication.
 
-```typescript copy
+```typescript
 const server = new MastraServer({
   app,
   mastra,
@@ -244,7 +244,7 @@ See [MastraServer](/reference/v1/server/mastra-server) for full configuration op
 
 After creating the adapter, you may still need access to the underlying framework app. This is useful when passing it to a platform’s `serve` function or when adding routes from another module.
 
-```typescript copy
+```typescript
 // Via the MastraServer instance
 const app = server.getApp();
 

--- a/docs/src/content/en/docs/streaming/events.mdx
+++ b/docs/src/content/en/docs/streaming/events.mdx
@@ -44,7 +44,7 @@ When using `agent.network()` for multi-agent collaboration, additional event typ
 
 Iterate over the `stream` with a `for await` loop to inspect all emitted event chunks.
 
-```typescript {3,7} showLineNumbers copy
+```typescript {3,7} copy
 const testAgent = mastra.getAgent("testAgent");
 
 const stream = await testAgent.stream([
@@ -91,7 +91,7 @@ Below is an example of events that may be emitted. Each event always includes a 
 
 Iterate over the `stream` with a `for await` loop to inspect all emitted event chunks.
 
-```typescript {5,11} showLineNumbers copy
+```typescript {5,11} copy
 const testWorkflow = mastra.getWorkflow("testWorkflow");
 
 const run = await testWorkflow.createRun();
@@ -136,7 +136,7 @@ Below is an example of events that may be emitted. Each event always includes a 
 
 When using multi-agent collaboration with `agent.network()`, iterate over the stream to track how tasks are delegated and executed across agents, workflows, and tools.
 
-```typescript {3,5} showLineNumbers copy
+```typescript {3,5} copy
 const networkAgent = mastra.getAgent("networkAgent");
 
 const networkStream = await networkAgent.network(
@@ -202,7 +202,7 @@ Network streams emit events that track the orchestration flow. Each iteration be
 
 You can filter events by type to track specific aspects of the network execution:
 
-```typescript {5-8,11-13,16-18} showLineNumbers copy
+```typescript {5-8,11-13,16-18} copy
 const networkStream = await networkAgent.network(
   "Analyze data and create visualization",
 );

--- a/docs/src/content/en/docs/streaming/events.mdx
+++ b/docs/src/content/en/docs/streaming/events.mdx
@@ -44,7 +44,7 @@ When using `agent.network()` for multi-agent collaboration, additional event typ
 
 Iterate over the `stream` with a `for await` loop to inspect all emitted event chunks.
 
-```typescript {3,7} copy
+```typescript {3,7}
 const testAgent = mastra.getAgent("testAgent");
 
 const stream = await testAgent.stream([
@@ -91,7 +91,7 @@ Below is an example of events that may be emitted. Each event always includes a 
 
 Iterate over the `stream` with a `for await` loop to inspect all emitted event chunks.
 
-```typescript {5,11} copy
+```typescript {5,11}
 const testWorkflow = mastra.getWorkflow("testWorkflow");
 
 const run = await testWorkflow.createRun();
@@ -136,7 +136,7 @@ Below is an example of events that may be emitted. Each event always includes a 
 
 When using multi-agent collaboration with `agent.network()`, iterate over the stream to track how tasks are delegated and executed across agents, workflows, and tools.
 
-```typescript {3,5} copy
+```typescript {3,5}
 const networkAgent = mastra.getAgent("networkAgent");
 
 const networkStream = await networkAgent.network(
@@ -202,7 +202,7 @@ Network streams emit events that track the orchestration flow. Each iteration be
 
 You can filter events by type to track specific aspects of the network execution:
 
-```typescript {5-8,11-13,16-18} copy
+```typescript {5-8,11-13,16-18}
 const networkStream = await networkAgent.network(
   "Analyze data and create visualization",
 );

--- a/docs/src/content/en/docs/streaming/overview.mdx
+++ b/docs/src/content/en/docs/streaming/overview.mdx
@@ -22,7 +22,7 @@ You can pass a single string for simple prompts, an array of strings when provid
 
 A `textStream` breaks the response into chunks as it's generated, allowing output to stream progressively instead of arriving all at once. Iterate over the `textStream` using a `for await` loop to inspect each stream chunk.
 
-```typescript {3,7} copy
+```typescript {3,7}
 const testAgent = mastra.getAgent("testAgent");
 
 const stream = await testAgent.stream([
@@ -62,7 +62,7 @@ AI SDK v5 uses `LanguageModelV2` for the model providers. If you are getting an 
 
 For integration with AI SDK v5, use the `toAISdkV5Stream()` utility from `@mastra/ai-sdk` to convert Mastra streams to AI SDK-compatible format:
 
-```typescript {2,9-12} copy
+```typescript {2,9-12}
 import { toAISdkV5Stream } from "@mastra/ai-sdk";
 
 const testAgent = mastra.getAgent("testAgent");
@@ -79,7 +79,7 @@ const aiSDKStream = toAISdkV5Stream(stream, { from: "agent" });
 
 For converting messages to AI SDK v5 format, use the `toAISdkV5Messages()` utility from `@mastra/ai-sdk/ui`:
 
-```typescript {1,4} copy
+```typescript {1,4}
 import { toAISdkV5Messages } from "@mastra/ai-sdk/ui";
 
 const messages = [{ role: "user", content: "Hello" }];
@@ -92,7 +92,7 @@ The `network()` method enables multi-agent collaboration by executing a network 
 
 > **Note**: This method is experimental and requires memory to be configured on the agent.
 
-```typescript {3,5-7} copy
+```typescript {3,5-7}
 const testAgent = mastra.getAgent("testAgent");
 
 const networkStream = await testAgent.network("Help me organize my day");
@@ -112,7 +112,7 @@ The network stream provides access to execution information:
 - **`networkStream.result`**: Promise resolving to the complete execution results
 - **`networkStream.usage`**: Promise resolving to token usage information
 
-```typescript {9-11} copy
+```typescript {9-11}
 const testAgent = mastra.getAgent("testAgent");
 
 const networkStream = await testAgent.network(
@@ -136,7 +136,7 @@ Streaming from a workflow returns a sequence of structured events describing the
 
 The `stream()` method returns a `ReadableStream` of events directly.
 
-```typescript {3,9} copy
+```typescript {3,9}
 const run = await testWorkflow.createRun();
 
 const stream = await run.stream({

--- a/docs/src/content/en/docs/streaming/overview.mdx
+++ b/docs/src/content/en/docs/streaming/overview.mdx
@@ -22,7 +22,7 @@ You can pass a single string for simple prompts, an array of strings when provid
 
 A `textStream` breaks the response into chunks as it's generated, allowing output to stream progressively instead of arriving all at once. Iterate over the `textStream` using a `for await` loop to inspect each stream chunk.
 
-```typescript {3,7} showLineNumbers copy
+```typescript {3,7} copy
 const testAgent = mastra.getAgent("testAgent");
 
 const stream = await testAgent.stream([
@@ -62,7 +62,7 @@ AI SDK v5 uses `LanguageModelV2` for the model providers. If you are getting an 
 
 For integration with AI SDK v5, use the `toAISdkV5Stream()` utility from `@mastra/ai-sdk` to convert Mastra streams to AI SDK-compatible format:
 
-```typescript {2,9-12} showLineNumbers copy
+```typescript {2,9-12} copy
 import { toAISdkV5Stream } from "@mastra/ai-sdk";
 
 const testAgent = mastra.getAgent("testAgent");
@@ -79,7 +79,7 @@ const aiSDKStream = toAISdkV5Stream(stream, { from: "agent" });
 
 For converting messages to AI SDK v5 format, use the `toAISdkV5Messages()` utility from `@mastra/ai-sdk/ui`:
 
-```typescript {1,4} showLineNumbers copy
+```typescript {1,4} copy
 import { toAISdkV5Messages } from "@mastra/ai-sdk/ui";
 
 const messages = [{ role: "user", content: "Hello" }];
@@ -92,7 +92,7 @@ The `network()` method enables multi-agent collaboration by executing a network 
 
 > **Note**: This method is experimental and requires memory to be configured on the agent.
 
-```typescript {3,5-7} showLineNumbers copy
+```typescript {3,5-7} copy
 const testAgent = mastra.getAgent("testAgent");
 
 const networkStream = await testAgent.network("Help me organize my day");
@@ -112,7 +112,7 @@ The network stream provides access to execution information:
 - **`networkStream.result`**: Promise resolving to the complete execution results
 - **`networkStream.usage`**: Promise resolving to token usage information
 
-```typescript {9-11} showLineNumbers copy
+```typescript {9-11} copy
 const testAgent = mastra.getAgent("testAgent");
 
 const networkStream = await testAgent.network(
@@ -136,7 +136,7 @@ Streaming from a workflow returns a sequence of structured events describing the
 
 The `stream()` method returns a `ReadableStream` of events directly.
 
-```typescript {3,9} showLineNumbers copy
+```typescript {3,9} copy
 const run = await testWorkflow.createRun();
 
 const stream = await run.stream({

--- a/docs/src/content/en/docs/streaming/tool-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/tool-streaming.mdx
@@ -18,7 +18,7 @@ By combining writable tool streams with agent streaming, you gain fine grained c
 
 Agent streaming can be combined with tool calls, allowing tool outputs to be written directly into the agent’s streaming response. This makes it possible to surface tool activity as part of the overall interaction.
 
-```typescript {2,9} copy
+```typescript {2,9}
 import { Agent } from "@mastra/core/agent";
 import { testTool } from "../tools/test-tool";
 
@@ -41,7 +41,7 @@ You must `await` the call to `writer.write()` or else you will lock the stream a
 
 :::
 
-```typescript {4,7,14} copy
+```typescript {4,7,14}
 import { createTool } from "@mastra/core/tools";
 
 export const testTool = createTool({
@@ -70,7 +70,7 @@ export const testTool = createTool({
 You can also use `writer.custom()` if you want to emit top level stream chunks, This useful and relevant when
 integrating with UI Frameworks
 
-```typescript {4,7,14} copy
+```typescript {4,7,14}
 import { createTool } from "@mastra/core/tools";
 
 export const testTool = createTool({
@@ -100,7 +100,7 @@ export const testTool = createTool({
 
 Events written to the stream are included in the emitted chunks. These chunks can be inspected to access any custom fields, such as event types, intermediate values, or tool-specific data.
 
-```typescript copy
+```typescript
 const stream = await testAgent.stream([
   "What is the weather in London?",
   "Use the testTool",
@@ -119,7 +119,7 @@ Tools support lifecycle hooks that allow you to monitor different stages of tool
 
 ### Example: Using onInputAvailable and onOutput
 
-```typescript copy
+```typescript
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -161,7 +161,7 @@ For detailed documentation on all lifecycle hooks, see the [createTool() referen
 
 Pipe an agent's `fullStream` to the tool's `writer`. This streams partial output, and Mastra automatically aggregates the agent's usage into the tool run.
 
-```typescript copy
+```typescript
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/streaming/tool-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/tool-streaming.mdx
@@ -18,7 +18,7 @@ By combining writable tool streams with agent streaming, you gain fine grained c
 
 Agent streaming can be combined with tool calls, allowing tool outputs to be written directly into the agent’s streaming response. This makes it possible to surface tool activity as part of the overall interaction.
 
-```typescript {2,9} showLineNumbers copy
+```typescript {2,9} copy
 import { Agent } from "@mastra/core/agent";
 import { testTool } from "../tools/test-tool";
 
@@ -41,7 +41,7 @@ You must `await` the call to `writer.write()` or else you will lock the stream a
 
 :::
 
-```typescript {4,7,14} showLineNumbers copy
+```typescript {4,7,14} copy
 import { createTool } from "@mastra/core/tools";
 
 export const testTool = createTool({
@@ -70,7 +70,7 @@ export const testTool = createTool({
 You can also use `writer.custom()` if you want to emit top level stream chunks, This useful and relevant when
 integrating with UI Frameworks
 
-```typescript {4,7,14} showLineNumbers copy
+```typescript {4,7,14} copy
 import { createTool } from "@mastra/core/tools";
 
 export const testTool = createTool({
@@ -100,7 +100,7 @@ export const testTool = createTool({
 
 Events written to the stream are included in the emitted chunks. These chunks can be inspected to access any custom fields, such as event types, intermediate values, or tool-specific data.
 
-```typescript showLineNumbers copy
+```typescript copy
 const stream = await testAgent.stream([
   "What is the weather in London?",
   "Use the testTool",
@@ -119,7 +119,7 @@ Tools support lifecycle hooks that allow you to monitor different stages of tool
 
 ### Example: Using onInputAvailable and onOutput
 
-```typescript showLineNumbers copy
+```typescript copy
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -161,7 +161,7 @@ For detailed documentation on all lifecycle hooks, see the [createTool() referen
 
 Pipe an agent's `fullStream` to the tool's `writer`. This streams partial output, and Mastra automatically aggregates the agent's usage into the tool run.
 
-```typescript showLineNumbers copy
+```typescript copy
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/streaming/workflow-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/workflow-streaming.mdx
@@ -24,7 +24,7 @@ You must `await` the call to `writer.write(...)` or else you will lock the strea
 
 :::
 
-```typescript {5,8,15} showLineNumbers copy
+```typescript {5,8,15} copy
 import { createStep } from "@mastra/core/workflows";
 
 export const testStep = createStep({
@@ -55,7 +55,7 @@ export const testStep = createStep({
 
 Events written to the stream are included in the emitted chunks. These chunks can be inspected to access any custom fields, such as event types, intermediate values, or step-specific data.
 
-```typescript showLineNumbers copy
+```typescript copy
 const testWorkflow = mastra.getWorkflow("testWorkflow");
 
 const run = await testWorkflow.createRun();
@@ -86,7 +86,7 @@ if (result!.status === "suspended") {
 
 If a workflow stream is closed or interrupted for any reason, you can resume it with the `resumeStream` method. This will return a new `ReadableStream` that you can use to observe the workflow events.
 
-```typescript showLineNumbers copy
+```typescript copy
 const newStream = await run.resumeStream();
 
 for await (const chunk of newStream) {
@@ -98,7 +98,7 @@ for await (const chunk of newStream) {
 
 Pipe an agent's `textStream` to the workflow step's `writer`. This streams partial output, and Mastra automatically aggregates the agent's usage into the workflow run.
 
-```typescript showLineNumbers copy
+```typescript copy
 import { createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/streaming/workflow-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/workflow-streaming.mdx
@@ -24,7 +24,7 @@ You must `await` the call to `writer.write(...)` or else you will lock the strea
 
 :::
 
-```typescript {5,8,15} copy
+```typescript {5,8,15}
 import { createStep } from "@mastra/core/workflows";
 
 export const testStep = createStep({
@@ -55,7 +55,7 @@ export const testStep = createStep({
 
 Events written to the stream are included in the emitted chunks. These chunks can be inspected to access any custom fields, such as event types, intermediate values, or step-specific data.
 
-```typescript copy
+```typescript
 const testWorkflow = mastra.getWorkflow("testWorkflow");
 
 const run = await testWorkflow.createRun();
@@ -86,7 +86,7 @@ if (result!.status === "suspended") {
 
 If a workflow stream is closed or interrupted for any reason, you can resume it with the `resumeStream` method. This will return a new `ReadableStream` that you can use to observe the workflow events.
 
-```typescript copy
+```typescript
 const newStream = await run.resumeStream();
 
 for await (const chunk of newStream) {
@@ -98,7 +98,7 @@ for await (const chunk of newStream) {
 
 Pipe an agent's `textStream` to the workflow step's `writer`. This streams partial output, and Mastra automatically aggregates the agent's usage into the workflow run.
 
-```typescript copy
+```typescript
 import { createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/tools-mcp/advanced-usage.mdx
+++ b/docs/src/content/en/docs/tools-mcp/advanced-usage.mdx
@@ -82,13 +82,13 @@ Mastra maintains compatibility with the tool format used by the Vercel AI SDK (`
 
 First, ensure you have the `ai` package installed:
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install ai
 ```
 
 Here's an example of a tool defined using the Vercel AI SDK format:
 
-```typescript title="src/mastra/tools/vercelWeatherTool.ts" copy
+```typescript title="src/mastra/tools/vercelWeatherTool.ts"
 import { tool } from "ai";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
@@ -29,7 +29,7 @@ npm install @mastra/mcp@beta
 
 The `MCPClient` connects Mastra primitives to external MCP servers, which can be local packages (invoked using `npx`) or remote HTTP(S) endpoints. Each server must be configured with either a `command` or a `url`, depending on how it's hosted.
 
-```typescript title="src/mastra/mcp/test-mcp-client.ts" showLineNumbers copy
+```typescript title="src/mastra/mcp/test-mcp-client.ts" copy
 import { MCPClient } from "@mastra/mcp";
 
 export const testMcpClient = new MCPClient({
@@ -54,7 +54,7 @@ export const testMcpClient = new MCPClient({
 
 To use tools from an MCP server in an agent, import your `MCPClient` and call `.listTools()` in the `tools` parameter. This loads from the defined MCP servers, making them available to the agent.
 
-```typescript {3,15} title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript {3,15} title="src/mastra/agents/test-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -80,7 +80,7 @@ export const testAgent = new Agent({
 
 To expose agents, tools, and workflows from your Mastra application to external systems over HTTP(S) use the `MCPServer` class. This makes them accessible to any system or agent that supports the protocol.
 
-```typescript title="src/mastra/mcp/test-mcp-server.ts" showLineNumbers copy
+```typescript title="src/mastra/mcp/test-mcp-server.ts" copy
 import { MCPServer } from "@mastra/mcp";
 
 import { testAgent } from "../agents/test-agent";
@@ -109,7 +109,7 @@ export const testMcpServer = new MCPServer({
 
 To make an MCP server available to other systems or agents that support the protocol, register it in the main `Mastra` instance using `mcpServers`.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 
 import { testMcpServer } from "./mcp/test-mcp-server";
@@ -143,7 +143,7 @@ Use the `.listTools()` method to fetch tools from all configured MCP servers. Th
 
 > See [listTools()](/reference/v1/tools/mcp-client#listtools) for more information.
 
-```typescript {7} title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript {7} title="src/mastra/agents/test-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -158,7 +158,7 @@ export const testAgent = new Agent({
 
 Use the `.listToolsets()` method when tool configuration may vary by request or user, such as in a multi-tenant system where each user provides their own API key. This method returns toolsets that can be passed to the `toolsets` option in the agent's `.generate()` or `.stream()` calls.
 
-```typescript {5-16,21} showLineNumbers copy
+```typescript {5-16,21} copy
 import { MCPClient } from "@mastra/mcp";
 import { mastra } from "./mastra";
 

--- a/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/mcp-overview.mdx
@@ -29,7 +29,7 @@ npm install @mastra/mcp@beta
 
 The `MCPClient` connects Mastra primitives to external MCP servers, which can be local packages (invoked using `npx`) or remote HTTP(S) endpoints. Each server must be configured with either a `command` or a `url`, depending on how it's hosted.
 
-```typescript title="src/mastra/mcp/test-mcp-client.ts" copy
+```typescript title="src/mastra/mcp/test-mcp-client.ts"
 import { MCPClient } from "@mastra/mcp";
 
 export const testMcpClient = new MCPClient({
@@ -54,7 +54,7 @@ export const testMcpClient = new MCPClient({
 
 To use tools from an MCP server in an agent, import your `MCPClient` and call `.listTools()` in the `tools` parameter. This loads from the defined MCP servers, making them available to the agent.
 
-```typescript {3,15} title="src/mastra/agents/test-agent.ts" copy
+```typescript {3,15} title="src/mastra/agents/test-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -80,7 +80,7 @@ export const testAgent = new Agent({
 
 To expose agents, tools, and workflows from your Mastra application to external systems over HTTP(S) use the `MCPServer` class. This makes them accessible to any system or agent that supports the protocol.
 
-```typescript title="src/mastra/mcp/test-mcp-server.ts" copy
+```typescript title="src/mastra/mcp/test-mcp-server.ts"
 import { MCPServer } from "@mastra/mcp";
 
 import { testAgent } from "../agents/test-agent";
@@ -109,7 +109,7 @@ export const testMcpServer = new MCPServer({
 
 To make an MCP server available to other systems or agents that support the protocol, register it in the main `Mastra` instance using `mcpServers`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 
 import { testMcpServer } from "./mcp/test-mcp-server";
@@ -143,7 +143,7 @@ Use the `.listTools()` method to fetch tools from all configured MCP servers. Th
 
 > See [listTools()](/reference/v1/tools/mcp-client#listtools) for more information.
 
-```typescript {7} title="src/mastra/agents/test-agent.ts" copy
+```typescript {7} title="src/mastra/agents/test-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 import { testMcpClient } from "../mcp/test-mcp-client";
@@ -158,7 +158,7 @@ export const testAgent = new Agent({
 
 Use the `.listToolsets()` method when tool configuration may vary by request or user, such as in a multi-tenant system where each user provides their own API key. This method returns toolsets that can be passed to the `toolsets` option in the agent's `.generate()` or `.stream()` calls.
 
-```typescript {5-16,21} copy
+```typescript {5-16,21}
 import { MCPClient } from "@mastra/mcp";
 import { mastra } from "./mastra";
 

--- a/docs/src/content/en/docs/tools-mcp/overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/overview.mdx
@@ -18,7 +18,7 @@ Each tool typically defines:
 
 In Mastra, you create tools using the [`createTool`](/reference/v1/tools/create-tool) function from the `@mastra/core/tools` package.
 
-```typescript title="src/mastra/tools/weatherInfo.ts" copy
+```typescript title="src/mastra/tools/weatherInfo.ts"
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 

--- a/docs/src/content/en/docs/tools-mcp/overview.mdx
+++ b/docs/src/content/en/docs/tools-mcp/overview.mdx
@@ -58,7 +58,7 @@ To make tools available to an agent, you configure them in the agent's definitio
 
 Use [RequestContext](/docs/v1/server/request-context) to access request-specific values. This lets you conditionally adjust behavior based on the context of the request.
 
-```typescript title="src/mastra/tools/test-tool.ts" showLineNumbers
+```typescript title="src/mastra/tools/test-tool.ts"
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };

--- a/docs/src/content/en/docs/workflows/agents-and-tools.mdx
+++ b/docs/src/content/en/docs/workflows/agents-and-tools.mdx
@@ -15,7 +15,7 @@ Use agents in workflow steps when you need reasoning, language generation, or ot
 
 Call agents inside a step's `execute` function using `.generate()` or `.stream()`. This lets you modify the agent call and handle the response before passing it to the next step.
 
-```typescript {7-12} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {7-12} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   // ...
   execute: async ({ inputData, mastra }) => {
@@ -45,7 +45,7 @@ Compose an agent as a step using `createStep()` when you don't need to modify th
 
 ![Agent as step](/img/workflows/workflows-agent-tools-agent-step.jpg)
 
-```typescript {1,3,8-13} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {1,3,8-13} title="src/mastra/workflows/test-workflow.ts"
 import { testAgent } from "../agents/test-agent";
 
 const step1 = createStep(testAgent);
@@ -83,7 +83,7 @@ When no `structuredOutput` option is provided, Mastra agents use a default schem
 
 When you need the agent to return structured data instead of plain text, pass the `structuredOutput` option to `createStep()`. The step's output schema will match your provided schema, enabling type-safe chaining to subsequent steps.
 
-```typescript {1-6,8-10} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {1-6,8-10} title="src/mastra/workflows/test-workflow.ts"
 const articleSchema = z.object({
   title: z.string(),
   summary: z.string(),
@@ -127,7 +127,7 @@ Use tools in workflow steps to leverage existing tool logic. Call from a step's 
 
 Call tools inside a step's `execute` function using `.execute()`. This gives you more control over the tool's input context, or process its response before passing it to the next step.
 
-```typescript {8-13,16} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {8-13,16} title="src/mastra/workflows/test-workflow.ts"
 import { testTool } from "../tools/test-tool";
 
 const step2 = createStep({
@@ -157,7 +157,7 @@ Compose a tool as a step using `createStep()` when the previous step's output ma
 
 ![Tool as step](/img/workflows/workflows-agent-tools-tool-step.jpg)
 
-```typescript {1,3,9-14} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {1,3,9-14} title="src/mastra/workflows/test-workflow.ts"
 import { testTool } from "../tools/test-tool";
 
 const step2 = createStep(testTool);

--- a/docs/src/content/en/docs/workflows/agents-and-tools.mdx
+++ b/docs/src/content/en/docs/workflows/agents-and-tools.mdx
@@ -15,7 +15,7 @@ Use agents in workflow steps when you need reasoning, language generation, or ot
 
 Call agents inside a step's `execute` function using `.generate()` or `.stream()`. This lets you modify the agent call and handle the response before passing it to the next step.
 
-```typescript {7-12} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {7-12} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   // ...
   execute: async ({ inputData, mastra }) => {
@@ -45,7 +45,7 @@ Compose an agent as a step using `createStep()` when you don't need to modify th
 
 ![Agent as step](/img/workflows/workflows-agent-tools-agent-step.jpg)
 
-```typescript {1,3,8-13} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {1,3,8-13} title="src/mastra/workflows/test-workflow.ts" copy
 import { testAgent } from "../agents/test-agent";
 
 const step1 = createStep(testAgent);
@@ -83,7 +83,7 @@ When no `structuredOutput` option is provided, Mastra agents use a default schem
 
 When you need the agent to return structured data instead of plain text, pass the `structuredOutput` option to `createStep()`. The step's output schema will match your provided schema, enabling type-safe chaining to subsequent steps.
 
-```typescript {1-6,8-10} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {1-6,8-10} title="src/mastra/workflows/test-workflow.ts" copy
 const articleSchema = z.object({
   title: z.string(),
   summary: z.string(),
@@ -127,7 +127,7 @@ Use tools in workflow steps to leverage existing tool logic. Call from a step's 
 
 Call tools inside a step's `execute` function using `.execute()`. This gives you more control over the tool's input context, or process its response before passing it to the next step.
 
-```typescript {8-13,16} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {8-13,16} title="src/mastra/workflows/test-workflow.ts" copy
 import { testTool } from "../tools/test-tool";
 
 const step2 = createStep({
@@ -157,7 +157,7 @@ Compose a tool as a step using `createStep()` when the previous step's output ma
 
 ![Tool as step](/img/workflows/workflows-agent-tools-tool-step.jpg)
 
-```typescript {1,3,9-14} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {1,3,9-14} title="src/mastra/workflows/test-workflow.ts" copy
 import { testTool } from "../tools/test-tool";
 
 const step2 = createStep(testTool);

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -22,7 +22,7 @@ Use `.then()` to run steps in order, allowing each step to access the result of 
 
 ![Chaining steps with .then()](/img/workflows/workflows-control-flow-then.jpg)
 
-```typescript {30-31} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {30-31} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   //...
   inputSchema: z.object({
@@ -63,7 +63,7 @@ Use `.parallel()` to run steps at the same time. All parallel steps must complet
 
 ![Concurrent steps with .parallel()](/img/workflows/workflows-control-flow-parallel.jpg)
 
-```typescript {42} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {42} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   id: "step-1",
   // ...
@@ -116,7 +116,7 @@ export const testWorkflow = createWorkflow({
 
 When steps run in parallel, the output is an object where each key is the step's `id` and the value is that step's output. This allows you to access each parallel step's result independently.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   id: "format-step",
   inputSchema: z.object({ message: z.string() }),
@@ -184,7 +184,7 @@ Use `.branch()` to choose which step to run based on a condition. All steps in a
 
 ![Conditional branching with .branch()](/img/workflows/workflows-control-flow-branch.jpg)
 
-```typescript {33-36} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {33-36} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...})
 
 const stepA = createStep({
@@ -228,7 +228,7 @@ export const testWorkflow = createWorkflow({
 
 When using conditional branching, only one branch executes based on which condition evaluates to `true` first. The output structure is similar to `.parallel()`, where the result is keyed by the executed step's `id`.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   id: "initial-step",
   inputSchema: z.object({ value: z.number() }),
@@ -309,7 +309,7 @@ When using `.then()`, `.parallel()`, or `.branch()`, it is sometimes necessary t
 
 ![Mapping with .map()](/img/workflows/workflows-data-mapping-map.jpg)
 
-```typescript {9} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {9} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...});
 const step2 = createStep({...});
 
@@ -337,7 +337,7 @@ The `.map()` method provides additional helper functions for more complex mappin
 
 When working with `.parallel()` or `.branch()` outputs, you can use `.map()` to transform the data structure before passing it to the next step. This is especially useful when you need to flatten or restructure the output.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 export const testWorkflow = createWorkflow({...})
   .parallel([step1, step2])
   .map(async ({ inputData }) => {
@@ -352,7 +352,7 @@ export const testWorkflow = createWorkflow({...})
 
 You can also use the helper functions provided by `.map()`:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 export const testWorkflow = createWorkflow({...})
   .branch([
     [condition1, stepA],
@@ -380,7 +380,7 @@ Use `.dountil()` to run a step repeatedly until a condition becomes true.
 
 ![Repeating with .dountil()](/img/workflows/workflows-control-flow-dountil.jpg)
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...});
 
 const step2 = createStep({
@@ -407,7 +407,7 @@ Use `.dowhile()` to run a step repeatedly while a condition remains true.
 
 ![Repeating with .dowhile()](/img/workflows/workflows-control-flow-dowhile.jpg)
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...});
 
 const step2 = createStep({
@@ -434,7 +434,7 @@ Use `.foreach()` to run the same step for each item in an array. The input must 
 
 ![Repeating with .foreach()](/img/workflows/workflows-control-flow-foreach.jpg)
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   // ...
   inputSchema: z.string(),
@@ -460,7 +460,7 @@ export const testWorkflow = createWorkflow({
 
 The `.foreach()` method always returns an array containing the output of each iteration. The order of outputs matches the order of inputs.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const addTenStep = createStep({
   id: "add-ten",
   inputSchema: z.object({ value: z.number() }),
@@ -486,7 +486,7 @@ export const testWorkflow = createWorkflow({
 
 Use `concurrency` to control the number of array items processed at the same time. The default is `1`, which runs steps sequentially. Increasing the value allows `.foreach()` to process multiple items simultaneously.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...})
 
 export const testWorkflow = createWorkflow({...})
@@ -498,7 +498,7 @@ export const testWorkflow = createWorkflow({...})
 
 Since `.foreach()` outputs an array, you can use `.then()` or `.map()` to aggregate or transform the results. The step following `.foreach()` receives the entire array as its input.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const processItemStep = createStep({
   id: "process-item",
   inputSchema: z.object({ value: z.number() }),
@@ -535,7 +535,7 @@ export const testWorkflow = createWorkflow({
 
 You can also use `.map()` to transform the array output:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 export const testWorkflow = createWorkflow({...})
   .foreach(processItemStep)
   .map(async ({ inputData }) => ({
@@ -551,7 +551,7 @@ export const testWorkflow = createWorkflow({...})
 
 When you chain `.foreach()` calls, each operates on the array output of the previous step. This is useful when each item in your array needs to be transformed by multiple steps in sequence.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const chunkStep = createStep({
   id: "chunk",
   // Takes a document, returns an array of chunks
@@ -589,7 +589,7 @@ For processing multiple documents where each produces multiple chunks, you have 
 
 **Option 1: Process all documents in a single step with batching control**
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const downloadAndChunkStep = createStep({
   id: "download-and-chunk",
   inputSchema: z.array(z.string()),  // Array of URLs
@@ -614,7 +614,7 @@ export const multiDocWorkflow = createWorkflow({...})
 
 **Option 2: Use foreach for documents, aggregate chunks, then foreach for embeddings**
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const downloadStep = createStep({
   id: "download",
   inputSchema: z.string(),  // Single URL
@@ -660,7 +660,7 @@ export const multiDocWorkflow = createWorkflow({
 
 The step after `.foreach()` only executes after all iterations complete. If you need to run multiple sequential operations per item, use a nested workflow instead of chaining multiple `.foreach()` calls. This keeps all operations for each item together and makes the data flow clearer.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 // Define a workflow that processes a single document
 const processDocumentWorkflow = createWorkflow({
   id: "process-document",
@@ -820,7 +820,7 @@ Loop conditions can be implemented in different ways depending on how you want t
 
 Use `iterationCount` to limit how many times a loop runs. If the count exceeds your threshold, throw an error to fail the step and stop the workflow.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...});
 
 export const testWorkflow = createWorkflow({...})

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -22,7 +22,7 @@ Use `.then()` to run steps in order, allowing each step to access the result of 
 
 ![Chaining steps with .then()](/img/workflows/workflows-control-flow-then.jpg)
 
-```typescript {30-31} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {30-31} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   //...
   inputSchema: z.object({
@@ -63,7 +63,7 @@ Use `.parallel()` to run steps at the same time. All parallel steps must complet
 
 ![Concurrent steps with .parallel()](/img/workflows/workflows-control-flow-parallel.jpg)
 
-```typescript {42} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {42} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   id: "step-1",
   // ...
@@ -116,7 +116,7 @@ export const testWorkflow = createWorkflow({
 
 When steps run in parallel, the output is an object where each key is the step's `id` and the value is that step's output. This allows you to access each parallel step's result independently.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   id: "format-step",
   inputSchema: z.object({ message: z.string() }),
@@ -184,7 +184,7 @@ Use `.branch()` to choose which step to run based on a condition. All steps in a
 
 ![Conditional branching with .branch()](/img/workflows/workflows-control-flow-branch.jpg)
 
-```typescript {33-36} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {33-36} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...})
 
 const stepA = createStep({
@@ -228,7 +228,7 @@ export const testWorkflow = createWorkflow({
 
 When using conditional branching, only one branch executes based on which condition evaluates to `true` first. The output structure is similar to `.parallel()`, where the result is keyed by the executed step's `id`.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   id: "initial-step",
   inputSchema: z.object({ value: z.number() }),
@@ -309,7 +309,7 @@ When using `.then()`, `.parallel()`, or `.branch()`, it is sometimes necessary t
 
 ![Mapping with .map()](/img/workflows/workflows-data-mapping-map.jpg)
 
-```typescript {9} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {9} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...});
 const step2 = createStep({...});
 
@@ -337,7 +337,7 @@ The `.map()` method provides additional helper functions for more complex mappin
 
 When working with `.parallel()` or `.branch()` outputs, you can use `.map()` to transform the data structure before passing it to the next step. This is especially useful when you need to flatten or restructure the output.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 export const testWorkflow = createWorkflow({...})
   .parallel([step1, step2])
   .map(async ({ inputData }) => {
@@ -352,7 +352,7 @@ export const testWorkflow = createWorkflow({...})
 
 You can also use the helper functions provided by `.map()`:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 export const testWorkflow = createWorkflow({...})
   .branch([
     [condition1, stepA],
@@ -380,7 +380,7 @@ Use `.dountil()` to run a step repeatedly until a condition becomes true.
 
 ![Repeating with .dountil()](/img/workflows/workflows-control-flow-dountil.jpg)
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...});
 
 const step2 = createStep({
@@ -407,7 +407,7 @@ Use `.dowhile()` to run a step repeatedly while a condition remains true.
 
 ![Repeating with .dowhile()](/img/workflows/workflows-control-flow-dowhile.jpg)
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...});
 
 const step2 = createStep({
@@ -434,7 +434,7 @@ Use `.foreach()` to run the same step for each item in an array. The input must 
 
 ![Repeating with .foreach()](/img/workflows/workflows-control-flow-foreach.jpg)
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   // ...
   inputSchema: z.string(),
@@ -460,7 +460,7 @@ export const testWorkflow = createWorkflow({
 
 The `.foreach()` method always returns an array containing the output of each iteration. The order of outputs matches the order of inputs.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const addTenStep = createStep({
   id: "add-ten",
   inputSchema: z.object({ value: z.number() }),
@@ -486,7 +486,7 @@ export const testWorkflow = createWorkflow({
 
 Use `concurrency` to control the number of array items processed at the same time. The default is `1`, which runs steps sequentially. Increasing the value allows `.foreach()` to process multiple items simultaneously.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...})
 
 export const testWorkflow = createWorkflow({...})
@@ -498,7 +498,7 @@ export const testWorkflow = createWorkflow({...})
 
 Since `.foreach()` outputs an array, you can use `.then()` or `.map()` to aggregate or transform the results. The step following `.foreach()` receives the entire array as its input.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const processItemStep = createStep({
   id: "process-item",
   inputSchema: z.object({ value: z.number() }),
@@ -535,7 +535,7 @@ export const testWorkflow = createWorkflow({
 
 You can also use `.map()` to transform the array output:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 export const testWorkflow = createWorkflow({...})
   .foreach(processItemStep)
   .map(async ({ inputData }) => ({
@@ -551,7 +551,7 @@ export const testWorkflow = createWorkflow({...})
 
 When you chain `.foreach()` calls, each operates on the array output of the previous step. This is useful when each item in your array needs to be transformed by multiple steps in sequence.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const chunkStep = createStep({
   id: "chunk",
   // Takes a document, returns an array of chunks
@@ -589,7 +589,7 @@ For processing multiple documents where each produces multiple chunks, you have 
 
 **Option 1: Process all documents in a single step with batching control**
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const downloadAndChunkStep = createStep({
   id: "download-and-chunk",
   inputSchema: z.array(z.string()),  // Array of URLs
@@ -614,7 +614,7 @@ export const multiDocWorkflow = createWorkflow({...})
 
 **Option 2: Use foreach for documents, aggregate chunks, then foreach for embeddings**
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const downloadStep = createStep({
   id: "download",
   inputSchema: z.string(),  // Single URL
@@ -660,7 +660,7 @@ export const multiDocWorkflow = createWorkflow({
 
 The step after `.foreach()` only executes after all iterations complete. If you need to run multiple sequential operations per item, use a nested workflow instead of chaining multiple `.foreach()` calls. This keeps all operations for each item together and makes the data flow clearer.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 // Define a workflow that processes a single document
 const processDocumentWorkflow = createWorkflow({
   id: "process-document",
@@ -820,7 +820,7 @@ Loop conditions can be implemented in different ways depending on how you want t
 
 Use `iterationCount` to limit how many times a loop runs. If the count exceeds your threshold, throw an error to fail the step and stop the workflow.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...});
 
 export const testWorkflow = createWorkflow({...})

--- a/docs/src/content/en/docs/workflows/error-handling.mdx
+++ b/docs/src/content/en/docs/workflows/error-handling.mdx
@@ -11,7 +11,7 @@ Mastra provides a built-in retry mechanism for workflows or steps that fail due 
 
 You can configure retries at the workflow level, which applies to all steps in the workflow:
 
-```typescript {8-11} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {8-11} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -32,7 +32,7 @@ export const testWorkflow = createWorkflow({
 
 You can configure retries for individual steps using the `retries` property. This overrides the workflow-level retry configuration for that specific step:
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -57,7 +57,7 @@ const step1 = createStep({
 
 You can create alternative workflow paths based on the success or failure of previous steps using conditional logic:
 
-```typescript {15,19,33-34} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {15,19,33-34} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -100,7 +100,7 @@ export const testWorkflow = createWorkflow({
 
 Use `getStepResult()` to inspect a previous step’s results.
 
-```typescript {10} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {10} title="src/mastra/workflows/test-workflow.ts" copy
 import { createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -123,7 +123,7 @@ const step2 = createStep({
 
 Use `bail()` in a step to exit early with a successful result. This returns the provided payload as the step output and ends workflow execution.
 
-```typescript {7} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {7} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -145,7 +145,7 @@ export const testWorkflow = createWorkflow({...})
 
 Use `throw new Error()` in a step to exit with an error.
 
-```typescript {7} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {7} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -167,7 +167,7 @@ export const testWorkflow = createWorkflow({...})
 
 You can monitor workflows for errors using `stream`:
 
-```typescript {11} title="src/test-workflow.ts" showLineNumbers copy
+```typescript {11} title="src/test-workflow.ts" copy
 import { mastra } from "../src/mastra";
 
 const workflow = mastra.getWorkflow("testWorkflow");

--- a/docs/src/content/en/docs/workflows/error-handling.mdx
+++ b/docs/src/content/en/docs/workflows/error-handling.mdx
@@ -11,7 +11,7 @@ Mastra provides a built-in retry mechanism for workflows or steps that fail due 
 
 You can configure retries at the workflow level, which applies to all steps in the workflow:
 
-```typescript {8-11} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {8-11} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -32,7 +32,7 @@ export const testWorkflow = createWorkflow({
 
 You can configure retries for individual steps using the `retries` property. This overrides the workflow-level retry configuration for that specific step:
 
-```typescript {17} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {17} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -57,7 +57,7 @@ const step1 = createStep({
 
 You can create alternative workflow paths based on the success or failure of previous steps using conditional logic:
 
-```typescript {15,19,33-34} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {15,19,33-34} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -100,7 +100,7 @@ export const testWorkflow = createWorkflow({
 
 Use `getStepResult()` to inspect a previous step’s results.
 
-```typescript {10} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {10} title="src/mastra/workflows/test-workflow.ts"
 import { createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -123,7 +123,7 @@ const step2 = createStep({
 
 Use `bail()` in a step to exit early with a successful result. This returns the provided payload as the step output and ends workflow execution.
 
-```typescript {7} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {7} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -145,7 +145,7 @@ export const testWorkflow = createWorkflow({...})
 
 Use `throw new Error()` in a step to exit with an error.
 
-```typescript {7} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {7} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -167,7 +167,7 @@ export const testWorkflow = createWorkflow({...})
 
 You can monitor workflows for errors using `stream`:
 
-```typescript {11} title="src/test-workflow.ts" copy
+```typescript {11} title="src/test-workflow.ts"
 import { mastra } from "../src/mastra";
 
 const workflow = mastra.getWorkflow("testWorkflow");

--- a/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
+++ b/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
@@ -13,7 +13,7 @@ Human-in-the-loop input works much like [pausing a workflow](/docs/v1/workflows/
 
 ![Pausing a workflow with suspend()](/img/workflows/workflows-suspend.jpg)
 
-```typescript {12-17,22-26} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {12-17,22-26} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -64,7 +64,7 @@ export const testWorkflow = createWorkflow({
 
 When a workflow is suspended, you can access the payload returned by `suspend()` by identifying the suspended step and reading its `suspendPayload`.
 
-```typescript {12} title="src/test-workflow.ts" showLineNumbers copy
+```typescript {12} title="src/test-workflow.ts" copy
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRun();
 
@@ -95,7 +95,7 @@ As with [restarting a workflow](/docs/v1/workflows/suspend-and-resume#restarting
 
 ![Restarting a workflow with resume()](/img/workflows/workflows-resume.jpg)
 
-```typescript {13} showLineNumbers copy
+```typescript {13} copy
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRun();
 
@@ -117,7 +117,7 @@ const handleResume = async () => {
 
 Use `bail()` to stop workflow execution at a step without triggering an error. This can be useful when a human explicitly rejects an action. The workflow completes with a `success` status, and any logic after the call to `bail()` is skipped.
 
-```typescript {7-11} showLineNumbers copy
+```typescript {7-11} copy
 const step1 = createStep({
   // ...
   execute: async ({ inputData, resumeData, suspend, bail }) => {
@@ -147,7 +147,7 @@ const step1 = createStep({
 
 For workflows that require input at multiple stages, the suspend pattern remains the same. Each step defines a `resumeSchema`, and `suspendSchema` typically with a reason that can be used to provide user feedback.
 
-```typescript {11-16,21-25} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {11-16,21-25} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...});
 
 const step2 = createStep({
@@ -196,7 +196,7 @@ export const testWorkflow = createWorkflow({
 
 Each step must be resumed in sequence, with a separate call to `resume()` for each suspended step. This approach helps manage multi-step approvals with consistent UI feedback and clear input handling at each stage.
 
-```typescript {4,11} showLineNumbers copy
+```typescript {4,11} copy
 const handleResume = async () => {
   const result = await run.resume({
     step: "step-1",

--- a/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
+++ b/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
@@ -13,7 +13,7 @@ Human-in-the-loop input works much like [pausing a workflow](/docs/v1/workflows/
 
 ![Pausing a workflow with suspend()](/img/workflows/workflows-suspend.jpg)
 
-```typescript {12-17,22-26} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {12-17,22-26} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -64,7 +64,7 @@ export const testWorkflow = createWorkflow({
 
 When a workflow is suspended, you can access the payload returned by `suspend()` by identifying the suspended step and reading its `suspendPayload`.
 
-```typescript {12} title="src/test-workflow.ts" copy
+```typescript {12} title="src/test-workflow.ts"
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRun();
 
@@ -95,7 +95,7 @@ As with [restarting a workflow](/docs/v1/workflows/suspend-and-resume#restarting
 
 ![Restarting a workflow with resume()](/img/workflows/workflows-resume.jpg)
 
-```typescript {13} copy
+```typescript {13}
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRun();
 
@@ -117,7 +117,7 @@ const handleResume = async () => {
 
 Use `bail()` to stop workflow execution at a step without triggering an error. This can be useful when a human explicitly rejects an action. The workflow completes with a `success` status, and any logic after the call to `bail()` is skipped.
 
-```typescript {7-11} copy
+```typescript {7-11}
 const step1 = createStep({
   // ...
   execute: async ({ inputData, resumeData, suspend, bail }) => {
@@ -147,7 +147,7 @@ const step1 = createStep({
 
 For workflows that require input at multiple stages, the suspend pattern remains the same. Each step defines a `resumeSchema`, and `suspendSchema` typically with a reason that can be used to provide user feedback.
 
-```typescript {11-16,21-25} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {11-16,21-25} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...});
 
 const step2 = createStep({
@@ -196,7 +196,7 @@ export const testWorkflow = createWorkflow({
 
 Each step must be resumed in sequence, with a separate call to `resume()` for each suspended step. This approach helps manage multi-step approvals with consistent UI feedback and clear input handling at each stage.
 
-```typescript {4,11} copy
+```typescript {4,11}
 const handleResume = async () => {
   const result = await run.resume({
     step: "step-1",

--- a/docs/src/content/en/docs/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/docs/workflows/inngest-workflow.mdx
@@ -33,7 +33,7 @@ Initialize the Inngest integration to obtain Mastra-compatible workflow helpers.
 
 In development
 
-```ts showLineNumbers copy title="src/mastra/inngest/index.ts"
+```ts copy title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
 import { realtimeMiddleware } from "@inngest/realtime/middleware";
 
@@ -47,7 +47,7 @@ export const inngest = new Inngest({
 
 In production
 
-```ts showLineNumbers copy title="src/mastra/inngest/index.ts"
+```ts copy title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
 import { realtimeMiddleware } from "@inngest/realtime/middleware";
 
@@ -61,7 +61,7 @@ export const inngest = new Inngest({
 
 Define the individual steps that will compose your workflow:
 
-```ts showLineNumbers copy title="src/mastra/workflows/index.ts"
+```ts copy title="src/mastra/workflows/index.ts"
 import { z } from "zod";
 import { inngest } from "../inngest";
 import { init } from "@mastra/inngest";
@@ -88,7 +88,7 @@ const incrementStep = createStep({
 
 Compose the steps into a workflow using the `dountil` loop pattern. The createWorkflow function creates a function on inngest server that is invocable.
 
-```ts showLineNumbers copy title="src/mastra/workflows/index.ts"
+```ts copy title="src/mastra/workflows/index.ts"
 // workflow that is registered as a function on inngest server
 const workflow = createWorkflow({
   id: "increment-workflow",
@@ -109,7 +109,7 @@ export { workflow as incrementWorkflow };
 
 Register the workflow with Mastra and configure the Inngest API endpoint:
 
-```ts showLineNumbers copy title="src/mastra/index.ts"
+```ts copy title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { incrementWorkflow } from "./workflows";
@@ -216,7 +216,7 @@ docker run --rm -p 8288:8288 \
 
 1. Add Vercel Deployer to Mastra instance
 
-```ts showLineNumbers copy title="src/mastra/index.ts"
+```ts copy title="src/mastra/index.ts"
 import { VercelDeployer } from "@mastra/deployer-vercel";
 
 export const mastra = new Mastra({
@@ -291,7 +291,7 @@ You can serve additional Inngest functions alongside your Mastra workflows by us
 
 First, create your custom Inngest functions:
 
-```ts showLineNumbers copy title="src/inngest/custom-functions.ts"
+```ts copy title="src/inngest/custom-functions.ts"
 import { inngest } from "./inngest";
 
 // Define custom Inngest functions
@@ -320,7 +320,7 @@ export const customWebhookFunction = inngest.createFunction(
 
 Update your Mastra configuration to include the custom functions:
 
-```ts showLineNumbers copy title="src/mastra/index.ts"
+```ts copy title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { incrementWorkflow } from "./workflows";

--- a/docs/src/content/en/docs/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/docs/workflows/inngest-workflow.mdx
@@ -33,7 +33,7 @@ Initialize the Inngest integration to obtain Mastra-compatible workflow helpers.
 
 In development
 
-```ts copy title="src/mastra/inngest/index.ts"
+```ts title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
 import { realtimeMiddleware } from "@inngest/realtime/middleware";
 
@@ -47,7 +47,7 @@ export const inngest = new Inngest({
 
 In production
 
-```ts copy title="src/mastra/inngest/index.ts"
+```ts title="src/mastra/inngest/index.ts"
 import { Inngest } from "inngest";
 import { realtimeMiddleware } from "@inngest/realtime/middleware";
 
@@ -61,7 +61,7 @@ export const inngest = new Inngest({
 
 Define the individual steps that will compose your workflow:
 
-```ts copy title="src/mastra/workflows/index.ts"
+```ts title="src/mastra/workflows/index.ts"
 import { z } from "zod";
 import { inngest } from "../inngest";
 import { init } from "@mastra/inngest";
@@ -88,7 +88,7 @@ const incrementStep = createStep({
 
 Compose the steps into a workflow using the `dountil` loop pattern. The createWorkflow function creates a function on inngest server that is invocable.
 
-```ts copy title="src/mastra/workflows/index.ts"
+```ts title="src/mastra/workflows/index.ts"
 // workflow that is registered as a function on inngest server
 const workflow = createWorkflow({
   id: "increment-workflow",
@@ -109,7 +109,7 @@ export { workflow as incrementWorkflow };
 
 Register the workflow with Mastra and configure the Inngest API endpoint:
 
-```ts copy title="src/mastra/index.ts"
+```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { incrementWorkflow } from "./workflows";
@@ -216,7 +216,7 @@ docker run --rm -p 8288:8288 \
 
 1. Add Vercel Deployer to Mastra instance
 
-```ts copy title="src/mastra/index.ts"
+```ts title="src/mastra/index.ts"
 import { VercelDeployer } from "@mastra/deployer-vercel";
 
 export const mastra = new Mastra({
@@ -291,7 +291,7 @@ You can serve additional Inngest functions alongside your Mastra workflows by us
 
 First, create your custom Inngest functions:
 
-```ts copy title="src/inngest/custom-functions.ts"
+```ts title="src/inngest/custom-functions.ts"
 import { inngest } from "./inngest";
 
 // Define custom Inngest functions
@@ -320,7 +320,7 @@ export const customWebhookFunction = inngest.createFunction(
 
 Update your Mastra configuration to include the custom functions:
 
-```ts copy title="src/mastra/index.ts"
+```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { incrementWorkflow } from "./workflows";

--- a/docs/src/content/en/docs/workflows/input-data-mapping.mdx
+++ b/docs/src/content/en/docs/workflows/input-data-mapping.mdx
@@ -18,7 +18,7 @@ In this example the `output` from `step1` is transformed to match the `inputSche
 
 ![Mapping with .map()](/img/workflows/workflows-data-mapping-map.jpg)
 
-```typescript {9} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {9} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...});
 const step2 = createStep({...});
 
@@ -38,7 +38,7 @@ export const testWorkflow = createWorkflow({...})
 
 Use `inputData` to access the full output of the previous step:
 
-```typescript {3} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3} title="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map(({ inputData }) => {
     console.log(inputData);
@@ -49,7 +49,7 @@ Use `inputData` to access the full output of the previous step:
 
 Use `getStepResult` to access the full output of a specific step by referencing the step's instance:
 
-```typescript {3} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3} title="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map(async ({ getStepResult }) => {
     console.log(getStepResult(step1));
@@ -60,7 +60,7 @@ Use `getStepResult` to access the full output of a specific step by referencing 
 
 Use `getInitData` to access the initial input data provided to the workflow:
 
-```typescript {3} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3} title="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map(async ({ getInitData }) => {
       console.log(getInitData());
@@ -71,7 +71,7 @@ Use `getInitData` to access the initial input data provided to the workflow:
 
 To use `mapVariable` import the necessary function from the workflows module:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 import { mapVariable } from "@mastra/core/workflows";
 ```
 
@@ -79,7 +79,7 @@ import { mapVariable } from "@mastra/core/workflows";
 
 You can rename step outputs using the object syntax in `.map()`. In the example below, the `value` output from `step1` is renamed to `details`:
 
-```typescript {3-6} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3-6} title="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map({
     details: mapVariable({
@@ -93,7 +93,7 @@ You can rename step outputs using the object syntax in `.map()`. In the example 
 
 You can rename workflow outputs by using **referential composition**. This involves passing the workflow instance as the `initData`.
 
-```typescript {6-9} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {6-9} title="src/mastra/workflows/test-workflow.ts"
 export const testWorkflow = createWorkflow({...});
 
 testWorkflow

--- a/docs/src/content/en/docs/workflows/input-data-mapping.mdx
+++ b/docs/src/content/en/docs/workflows/input-data-mapping.mdx
@@ -18,7 +18,7 @@ In this example the `output` from `step1` is transformed to match the `inputSche
 
 ![Mapping with .map()](/img/workflows/workflows-data-mapping-map.jpg)
 
-```typescript {9} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {9} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...});
 const step2 = createStep({...});
 
@@ -38,7 +38,7 @@ export const testWorkflow = createWorkflow({...})
 
 Use `inputData` to access the full output of the previous step:
 
-```typescript {3} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3} title="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map(({ inputData }) => {
     console.log(inputData);
@@ -49,7 +49,7 @@ Use `inputData` to access the full output of the previous step:
 
 Use `getStepResult` to access the full output of a specific step by referencing the step's instance:
 
-```typescript {3} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3} title="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map(async ({ getStepResult }) => {
     console.log(getStepResult(step1));
@@ -60,7 +60,7 @@ Use `getStepResult` to access the full output of a specific step by referencing 
 
 Use `getInitData` to access the initial input data provided to the workflow:
 
-```typescript {3} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3} title="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map(async ({ getInitData }) => {
       console.log(getInitData());
@@ -71,7 +71,7 @@ Use `getInitData` to access the initial input data provided to the workflow:
 
 To use `mapVariable` import the necessary function from the workflows module:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 import { mapVariable } from "@mastra/core/workflows";
 ```
 
@@ -79,7 +79,7 @@ import { mapVariable } from "@mastra/core/workflows";
 
 You can rename step outputs using the object syntax in `.map()`. In the example below, the `value` output from `step1` is renamed to `details`:
 
-```typescript {3-6} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3-6} title="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map({
     details: mapVariable({
@@ -93,7 +93,7 @@ You can rename step outputs using the object syntax in `.map()`. In the example 
 
 You can rename workflow outputs by using **referential composition**. This involves passing the workflow instance as the `initData`.
 
-```typescript {6-9} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {6-9} title="src/mastra/workflows/test-workflow.ts" copy
 export const testWorkflow = createWorkflow({...});
 
 testWorkflow

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -32,7 +32,7 @@ Steps are the building blocks of workflows. Create a step using `createStep()` w
 
 The `execute` function defines what the step does. Use it to call functions in your codebase, external APIs, agents, or tools.
 
-```typescript {6,9,15} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {6,9,15} title="src/mastra/workflows/test-workflow.ts" copy
 import { createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({
@@ -63,7 +63,7 @@ Workflow steps can also call registered agents or import and execute tools direc
 
 Create a workflow using `createWorkflow()` with `inputSchema` and `outputSchema` to define the data it accepts and returns. Add steps using `.then()` and complete the workflow with `.commit()`.
 
-```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -92,7 +92,7 @@ Workflows can be composed using a number of different methods. The method you ch
 
 Workflow state lets you share values across steps without passing them through every step's inputSchema and outputSchema. Use state for tracking progress, accumulating results, or sharing configuration across the entire workflow.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({ message: z.string() }),
@@ -116,7 +116,7 @@ const step1 = createStep({
 
 Use a workflow as a step to reuse its logic within a larger composition. Input and output follow the same schema rules described in [Core principles](/docs/v1/workflows/control-flow).
 
-```typescript {26} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {26} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({...});
 const step2 = createStep({...});
 
@@ -150,7 +150,7 @@ export const testWorkflow = createWorkflow({
 
 Clone a workflow using `cloneWorkflow()` when you want to reuse its logic but track it separately under a new ID. Each clone runs independently and appears as a distinct workflow in logs and observability tools.
 
-```typescript {6} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {6} title="src/mastra/workflows/test-workflow.ts" copy
 import { cloneWorkflow } from "@mastra/core/workflows";
 
 const step1 = createStep({...});
@@ -168,7 +168,7 @@ export const testWorkflow = createWorkflow({...})
 
 Register your workflow in the Mastra instance to make it available throughout your application. Once registered, it can be called from agents or tools and has access to shared resources such as logging and observability features:
 
-```typescript {6} title="src/mastra/index.ts" showLineNumbers copy
+```typescript {6} title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core/mastra";
 import { testWorkflow } from "./workflows/test-workflow";
 
@@ -182,7 +182,7 @@ export const mastra = new Mastra({
 
 You can run workflows from agents, tools, the Mastra Client, or the command line. Get a reference by calling `.getWorkflow()` on your `mastra` or `mastraClient` instance, depending on your setup:
 
-```typescript showLineNumbers copy
+```typescript copy
 const testWorkflow = mastra.getWorkflow("testWorkflow");
 ```
 :::info
@@ -197,7 +197,7 @@ Workflows can be run in two modes: start waits for all steps to complete before 
   <TabItem value="start" label="Start">
 Create a workflow run instance using `createRun()`, then call `.start()` with `inputData` matching the workflow's `inputSchema`. The workflow executes all steps and returns the final result.
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await testWorkflow.createRun();
 
 const result = await run.start({
@@ -212,7 +212,7 @@ console.log(result);
   <TabItem value="stream" label="Stream">
 Create a workflow run instance using `.createRun()`, then call `.stream()` with `inputData` matching the workflow's `inputSchema`. The workflow emits events as each step executes, which you can iterate over to track progress.
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await testWorkflow.createRun();
 
 const result = await run.stream({
@@ -278,7 +278,7 @@ When a workflow run loses connection to the server, it can be restarted from the
 
 Use `restartAllActiveWorkflowRuns()` to restart all active workflow runs of a workflow. This helps restart all active workflow runs of a workflow, without having to manually loop through each run and restart.
 
-```typescript showLineNumbers copy
+```typescript copy
 workflow.restartAllActiveWorkflowRuns();
 ```
 
@@ -286,7 +286,7 @@ workflow.restartAllActiveWorkflowRuns();
 
 Use `restart()` to restart an active workflow run from the last active step. This will resume execution from the last active step, and the workflow will continue from there.
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.start({ inputData: { value: "initial data" } });
@@ -300,7 +300,7 @@ const restartedResult = await run.restart();
 
 When a workflow run is active, it will have a `status` of `running` or `waiting`. You can check the workflow's `status` to confirm it's active, and use `active` to identify the active workflow run.
 
-```typescript showLineNumbers copy
+```typescript copy
 const activeRuns = await workflow.listActiveWorkflowRuns();
 if (activeRuns.runs.length > 0) {
   console.log(activeRuns.runs);
@@ -317,7 +317,7 @@ When running the local mastra server, all active workflow runs will be restarted
 
 Use [RequestContext](/docs/v1/server/request-context) to access request-specific values. This lets you conditionally adjust behavior based on the context of the request.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers
+```typescript title="src/mastra/workflows/test-workflow.ts"
 export type UserTier = {
   "user-tier": "enterprise" | "pro";
 };

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -32,7 +32,7 @@ Steps are the building blocks of workflows. Create a step using `createStep()` w
 
 The `execute` function defines what the step does. Use it to call functions in your codebase, external APIs, agents, or tools.
 
-```typescript {6,9,15} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {6,9,15} title="src/mastra/workflows/test-workflow.ts"
 import { createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({
@@ -63,7 +63,7 @@ Workflow steps can also call registered agents or import and execute tools direc
 
 Create a workflow using `createWorkflow()` with `inputSchema` and `outputSchema` to define the data it accepts and returns. Add steps using `.then()` and complete the workflow with `.commit()`.
 
-```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -92,7 +92,7 @@ Workflows can be composed using a number of different methods. The method you ch
 
 Workflow state lets you share values across steps without passing them through every step's inputSchema and outputSchema. Use state for tracking progress, accumulating results, or sharing configuration across the entire workflow.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({ message: z.string() }),
@@ -116,7 +116,7 @@ const step1 = createStep({
 
 Use a workflow as a step to reuse its logic within a larger composition. Input and output follow the same schema rules described in [Core principles](/docs/v1/workflows/control-flow).
 
-```typescript {26} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {26} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({...});
 const step2 = createStep({...});
 
@@ -150,7 +150,7 @@ export const testWorkflow = createWorkflow({
 
 Clone a workflow using `cloneWorkflow()` when you want to reuse its logic but track it separately under a new ID. Each clone runs independently and appears as a distinct workflow in logs and observability tools.
 
-```typescript {6} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {6} title="src/mastra/workflows/test-workflow.ts"
 import { cloneWorkflow } from "@mastra/core/workflows";
 
 const step1 = createStep({...});
@@ -168,7 +168,7 @@ export const testWorkflow = createWorkflow({...})
 
 Register your workflow in the Mastra instance to make it available throughout your application. Once registered, it can be called from agents or tools and has access to shared resources such as logging and observability features:
 
-```typescript {6} title="src/mastra/index.ts" copy
+```typescript {6} title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core/mastra";
 import { testWorkflow } from "./workflows/test-workflow";
 
@@ -182,7 +182,7 @@ export const mastra = new Mastra({
 
 You can run workflows from agents, tools, the Mastra Client, or the command line. Get a reference by calling `.getWorkflow()` on your `mastra` or `mastraClient` instance, depending on your setup:
 
-```typescript copy
+```typescript
 const testWorkflow = mastra.getWorkflow("testWorkflow");
 ```
 :::info
@@ -197,7 +197,7 @@ Workflows can be run in two modes: start waits for all steps to complete before 
   <TabItem value="start" label="Start">
 Create a workflow run instance using `createRun()`, then call `.start()` with `inputData` matching the workflow's `inputSchema`. The workflow executes all steps and returns the final result.
 
-```typescript copy
+```typescript
 const run = await testWorkflow.createRun();
 
 const result = await run.start({
@@ -212,7 +212,7 @@ console.log(result);
   <TabItem value="stream" label="Stream">
 Create a workflow run instance using `.createRun()`, then call `.stream()` with `inputData` matching the workflow's `inputSchema`. The workflow emits events as each step executes, which you can iterate over to track progress.
 
-```typescript copy
+```typescript
 const run = await testWorkflow.createRun();
 
 const result = await run.stream({
@@ -278,7 +278,7 @@ When a workflow run loses connection to the server, it can be restarted from the
 
 Use `restartAllActiveWorkflowRuns()` to restart all active workflow runs of a workflow. This helps restart all active workflow runs of a workflow, without having to manually loop through each run and restart.
 
-```typescript copy
+```typescript
 workflow.restartAllActiveWorkflowRuns();
 ```
 
@@ -286,7 +286,7 @@ workflow.restartAllActiveWorkflowRuns();
 
 Use `restart()` to restart an active workflow run from the last active step. This will resume execution from the last active step, and the workflow will continue from there.
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.start({ inputData: { value: "initial data" } });
@@ -300,7 +300,7 @@ const restartedResult = await run.restart();
 
 When a workflow run is active, it will have a `status` of `running` or `waiting`. You can check the workflow's `status` to confirm it's active, and use `active` to identify the active workflow run.
 
-```typescript copy
+```typescript
 const activeRuns = await workflow.listActiveWorkflowRuns();
 if (activeRuns.runs.length > 0) {
   console.log(activeRuns.runs);

--- a/docs/src/content/en/docs/workflows/snapshots.mdx
+++ b/docs/src/content/en/docs/workflows/snapshots.mdx
@@ -131,7 +131,7 @@ Snapshots are persisted using a `storage` instance configured on the `Mastra` cl
 
 This example demonstrates how to use snapshots with LibSQL.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 
@@ -148,7 +148,7 @@ export const mastra = new Mastra({
 
 This example demonstrates how to use snapshots with Upstash.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { UpstashStore } from "@mastra/upstash";
 
@@ -166,7 +166,7 @@ export const mastra = new Mastra({
 
 This example demonstrates how to use snapshots with PostgreSQL.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { PostgresStore } from "@mastra/pg";
 
@@ -191,7 +191,7 @@ export const mastra = new Mastra({
 
 You can attach custom metadata when suspending a workflow by defining a `suspendSchema`. This metadata is stored in the snapshot and made available when the workflow is resumed.
 
-```typescript {30-34} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {30-34} title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -240,7 +240,7 @@ const approvalStep = createStep({
 
 Use `resumeData` to pass structured input when resuming a suspended step. It must match the step’s `resumeSchema`.
 
-```typescript {14-20} showLineNumbers copy
+```typescript {14-20} copy
 const workflow = mastra.getWorkflow("approvalWorkflow");
 
 const run = await workflow.createRun();

--- a/docs/src/content/en/docs/workflows/snapshots.mdx
+++ b/docs/src/content/en/docs/workflows/snapshots.mdx
@@ -131,7 +131,7 @@ Snapshots are persisted using a `storage` instance configured on the `Mastra` cl
 
 This example demonstrates how to use snapshots with LibSQL.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 
@@ -148,7 +148,7 @@ export const mastra = new Mastra({
 
 This example demonstrates how to use snapshots with Upstash.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { UpstashStore } from "@mastra/upstash";
 
@@ -166,7 +166,7 @@ export const mastra = new Mastra({
 
 This example demonstrates how to use snapshots with PostgreSQL.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { PostgresStore } from "@mastra/pg";
 
@@ -191,7 +191,7 @@ export const mastra = new Mastra({
 
 You can attach custom metadata when suspending a workflow by defining a `suspendSchema`. This metadata is stored in the snapshot and made available when the workflow is resumed.
 
-```typescript {30-34} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {30-34} title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -240,7 +240,7 @@ const approvalStep = createStep({
 
 Use `resumeData` to pass structured input when resuming a suspended step. It must match the step’s `resumeSchema`.
 
-```typescript {14-20} copy
+```typescript {14-20}
 const workflow = mastra.getWorkflow("approvalWorkflow");
 
 const run = await workflow.createRun();

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -15,7 +15,7 @@ Use `suspend()` to pause workflow execution at a specific step. You can define a
 
 ![Pausing a workflow with suspend()](/img/workflows/workflows-suspend.jpg)
 
-```typescript {9-11,16-18} title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {9-11,16-18} title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({
@@ -60,7 +60,7 @@ Use `resume()` to restart a suspended workflow from the step where it paused. Pa
 
 ![Restarting a workflow with resume()](/img/workflows/workflows-resume.jpg)
 
-```typescript showLineNumbers copy
+```typescript copy
 import { step1 } from "./workflows/test-workflow";
 
 const workflow = mastra.getWorkflow("testWorkflow");
@@ -82,7 +82,7 @@ const handleResume = async () => {
 
 Passing the `step` object provides full type-safety for `resumeData`. Alternatively, you can pass a step ID for more flexibility when the ID comes from user input or a database.
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.resume({
   step: "step-1",
   resumeData: { approved: true }
@@ -93,7 +93,7 @@ If only one step is suspended, you can omit the step argument entirely and Mastr
 
 When resuming with only a `runId`, create a run instance first using `createRunAsync()`.
 
-```typescript showLineNumbers copy
+```typescript copy
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRunAsync({ runId: "123" });
 
@@ -104,7 +104,7 @@ const stream = run.resume({
 
 You can call `resume()` from anywhere in your application, including HTTP endpoints, event handlers, in response to [human input](/docs/v1/workflows/human-in-the-loop), or timers.
 
-```typescript showLineNumbers copy
+```typescript copy
 const midnight = new Date();
 midnight.setUTCHours(24, 0, 0, 0);
 
@@ -119,7 +119,7 @@ setTimeout(async () => {
 ## Accessing suspend data with `suspendData`
 When a step is suspended, you may want to access the data that was provided to `suspend()` when the step is later resumed. Use the `suspendData` parameter in your step's execute function to access this data.
 
-```typescript {22-25,29-30} title="src/mastra/workflows/user-approval.ts" showLineNumbers copy
+```typescript {22-25,29-30} title="src/mastra/workflows/user-approval.ts" copy
 const approvalStep = createStep({
   id: "user-approval",
   inputSchema: z.object({
@@ -164,7 +164,7 @@ The `suspendData` parameter is automatically populated when a step is resumed an
 
 When a workflow is suspended, it restarts from the step where it paused. You can check the workflow's `status` to confirm it's suspended, and use `suspended` to identify the paused step or [nested workflow](/docs/v1/workflows/overview#workflows-as-steps).
 
-```typescript {11} showLineNumbers copy
+```typescript {11} copy
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRun();
 

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -15,7 +15,7 @@ Use `suspend()` to pause workflow execution at a specific step. You can define a
 
 ![Pausing a workflow with suspend()](/img/workflows/workflows-suspend.jpg)
 
-```typescript {9-11,16-18} title="src/mastra/workflows/test-workflow.ts" copy
+```typescript {9-11,16-18} title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({
@@ -60,7 +60,7 @@ Use `resume()` to restart a suspended workflow from the step where it paused. Pa
 
 ![Restarting a workflow with resume()](/img/workflows/workflows-resume.jpg)
 
-```typescript copy
+```typescript
 import { step1 } from "./workflows/test-workflow";
 
 const workflow = mastra.getWorkflow("testWorkflow");
@@ -82,7 +82,7 @@ const handleResume = async () => {
 
 Passing the `step` object provides full type-safety for `resumeData`. Alternatively, you can pass a step ID for more flexibility when the ID comes from user input or a database.
 
-```typescript copy
+```typescript
 const result = await run.resume({
   step: "step-1",
   resumeData: { approved: true }
@@ -93,7 +93,7 @@ If only one step is suspended, you can omit the step argument entirely and Mastr
 
 When resuming with only a `runId`, create a run instance first using `createRunAsync()`.
 
-```typescript copy
+```typescript
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRunAsync({ runId: "123" });
 
@@ -104,7 +104,7 @@ const stream = run.resume({
 
 You can call `resume()` from anywhere in your application, including HTTP endpoints, event handlers, in response to [human input](/docs/v1/workflows/human-in-the-loop), or timers.
 
-```typescript copy
+```typescript
 const midnight = new Date();
 midnight.setUTCHours(24, 0, 0, 0);
 
@@ -119,7 +119,7 @@ setTimeout(async () => {
 ## Accessing suspend data with `suspendData`
 When a step is suspended, you may want to access the data that was provided to `suspend()` when the step is later resumed. Use the `suspendData` parameter in your step's execute function to access this data.
 
-```typescript {22-25,29-30} title="src/mastra/workflows/user-approval.ts" copy
+```typescript {22-25,29-30} title="src/mastra/workflows/user-approval.ts"
 const approvalStep = createStep({
   id: "user-approval",
   inputSchema: z.object({
@@ -164,7 +164,7 @@ The `suspendData` parameter is automatically populated when a step is resumed an
 
 When a workflow is suspended, it restarts from the step where it paused. You can check the workflow's `status` to confirm it's suspended, and use `suspended` to identify the paused step or [nested workflow](/docs/v1/workflows/overview#workflows-as-steps).
 
-```typescript {11} copy
+```typescript {11}
 const workflow = mastra.getWorkflow("testWorkflow");
 const run = await workflow.createRun();
 

--- a/docs/src/content/en/docs/workflows/time-travel.mdx
+++ b/docs/src/content/en/docs/workflows/time-travel.mdx
@@ -23,7 +23,7 @@ Time travel requires storage to be configured since it relies on persisted workf
 
 Use `run.timeTravel()` to re-execute a workflow from a specific step:
 
-```typescript showLineNumbers copy
+```typescript copy
 import { mastra } from "./mastra";
 
 const workflow = mastra.getWorkflow("myWorkflow");
@@ -41,7 +41,7 @@ You can specify the target step using either a step reference or a step ID:
 
 ### Using step reference
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: step2,
   inputData: { value: 10 },
@@ -50,7 +50,7 @@ const result = await run.timeTravel({
 
 ### Using step ID
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: "step2",
   inputData: { value: 10 },
@@ -61,7 +61,7 @@ const result = await run.timeTravel({
 
 For steps inside nested workflows, use dot notation, an array of step IDS or an array of step references:
 
-```typescript showLineNumbers copy
+```typescript copy
 // Using dot notation
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
@@ -85,7 +85,7 @@ const result = await run.timeTravel({
 
 You can provide context to specify the state of previous steps when time traveling:
 
-```typescript {3-13} showLineNumbers copy
+```typescript {3-13} copy
 const result = await run.timeTravel({
   step: "step2",
   context: {
@@ -114,7 +114,7 @@ The context object contains step results keyed by step ID. Each step result incl
 
 Time travel is particularly useful for debugging and recovering from failed workflow executions:
 
-```typescript showLineNumbers copy
+```typescript copy
 const workflow = mastra.getWorkflow("myWorkflow");
 const run = await workflow.createRun();
 
@@ -136,7 +136,7 @@ if (failedResult.status === "failed") {
 
 You can time travel to resume a suspended workflow from an earlier step:
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 // Start workflow - suspends at promptAgent step
@@ -159,7 +159,7 @@ if (initialResult.status === "suspended") {
 
 Use `timeTravelStream()` to receive streaming events during time travel execution:
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const output = run.timeTravelStream({
@@ -180,7 +180,7 @@ const result = await output.result;
 
 You can provide initial state when time traveling to set workflow-level state:
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: "step2",
   inputData: { value: 10 },
@@ -199,7 +199,7 @@ Time travel throws errors in specific situations:
 
 You cannot time travel to a workflow that is currently running:
 
-```typescript showLineNumbers copy
+```typescript copy
 try {
   await run.timeTravel({ step: "step2" });
 } catch (error) {
@@ -211,7 +211,7 @@ try {
 
 Time travel throws if the target step doesn't exist in the workflow:
 
-```typescript showLineNumbers copy
+```typescript copy
 try {
   await run.timeTravel({ step: "nonExistentStep" });
 } catch (error) {
@@ -223,7 +223,7 @@ try {
 
 When `validateInputs` is enabled, time travel validates the input data against the step's schema:
 
-```typescript showLineNumbers copy
+```typescript copy
 try {
   await run.timeTravel({
     step: "step2",
@@ -238,7 +238,7 @@ try {
 
 When time traveling into a nested workflow, you can provide context for both the parent and nested workflow steps:
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
   context: {
@@ -275,7 +275,7 @@ const result = await run.timeTravel({
 
 Re-run a failed step with the same or modified input to diagnose issues:
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: failedStepId,
   context: originalContext, // Use context from the failed run
@@ -286,7 +286,7 @@ const result = await run.timeTravel({
 
 Test individual steps with specific inputs on a new workflow run, useful for testing a step logic without starting workflow execution from the beginning.
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: "processData",
   inputData: { testData: "specific test case" },
@@ -297,7 +297,7 @@ const result = await run.timeTravel({
 
 Re-run steps that failed due to temporary issues (network errors, rate limits):
 
-```typescript showLineNumbers copy
+```typescript copy
 // After fixing the external service issue
 const result = await run.timeTravel({
   step: "callExternalApi",

--- a/docs/src/content/en/docs/workflows/time-travel.mdx
+++ b/docs/src/content/en/docs/workflows/time-travel.mdx
@@ -23,7 +23,7 @@ Time travel requires storage to be configured since it relies on persisted workf
 
 Use `run.timeTravel()` to re-execute a workflow from a specific step:
 
-```typescript copy
+```typescript
 import { mastra } from "./mastra";
 
 const workflow = mastra.getWorkflow("myWorkflow");
@@ -41,7 +41,7 @@ You can specify the target step using either a step reference or a step ID:
 
 ### Using step reference
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: step2,
   inputData: { value: 10 },
@@ -50,7 +50,7 @@ const result = await run.timeTravel({
 
 ### Using step ID
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: "step2",
   inputData: { value: 10 },
@@ -61,7 +61,7 @@ const result = await run.timeTravel({
 
 For steps inside nested workflows, use dot notation, an array of step IDS or an array of step references:
 
-```typescript copy
+```typescript
 // Using dot notation
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
@@ -85,7 +85,7 @@ const result = await run.timeTravel({
 
 You can provide context to specify the state of previous steps when time traveling:
 
-```typescript {3-13} copy
+```typescript {3-13}
 const result = await run.timeTravel({
   step: "step2",
   context: {
@@ -114,7 +114,7 @@ The context object contains step results keyed by step ID. Each step result incl
 
 Time travel is particularly useful for debugging and recovering from failed workflow executions:
 
-```typescript copy
+```typescript
 const workflow = mastra.getWorkflow("myWorkflow");
 const run = await workflow.createRun();
 
@@ -136,7 +136,7 @@ if (failedResult.status === "failed") {
 
 You can time travel to resume a suspended workflow from an earlier step:
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 // Start workflow - suspends at promptAgent step
@@ -159,7 +159,7 @@ if (initialResult.status === "suspended") {
 
 Use `timeTravelStream()` to receive streaming events during time travel execution:
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const output = run.timeTravelStream({
@@ -180,7 +180,7 @@ const result = await output.result;
 
 You can provide initial state when time traveling to set workflow-level state:
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: "step2",
   inputData: { value: 10 },
@@ -199,7 +199,7 @@ Time travel throws errors in specific situations:
 
 You cannot time travel to a workflow that is currently running:
 
-```typescript copy
+```typescript
 try {
   await run.timeTravel({ step: "step2" });
 } catch (error) {
@@ -211,7 +211,7 @@ try {
 
 Time travel throws if the target step doesn't exist in the workflow:
 
-```typescript copy
+```typescript
 try {
   await run.timeTravel({ step: "nonExistentStep" });
 } catch (error) {
@@ -223,7 +223,7 @@ try {
 
 When `validateInputs` is enabled, time travel validates the input data against the step's schema:
 
-```typescript copy
+```typescript
 try {
   await run.timeTravel({
     step: "step2",
@@ -238,7 +238,7 @@ try {
 
 When time traveling into a nested workflow, you can provide context for both the parent and nested workflow steps:
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
   context: {
@@ -275,7 +275,7 @@ const result = await run.timeTravel({
 
 Re-run a failed step with the same or modified input to diagnose issues:
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: failedStepId,
   context: originalContext, // Use context from the failed run
@@ -286,7 +286,7 @@ const result = await run.timeTravel({
 
 Test individual steps with specific inputs on a new workflow run, useful for testing a step logic without starting workflow execution from the beginning.
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: "processData",
   inputData: { testData: "specific test case" },
@@ -297,7 +297,7 @@ const result = await run.timeTravel({
 
 Re-run steps that failed due to temporary issues (network errors, rate limits):
 
-```typescript copy
+```typescript
 // After fixing the external service issue
 const result = await run.timeTravel({
   step: "callExternalApi",

--- a/docs/src/content/en/docs/workflows/workflow-state.mdx
+++ b/docs/src/content/en/docs/workflows/workflow-state.mdx
@@ -14,7 +14,7 @@ It's important to understand the difference between **state** and **step input/o
 - **Step input/output**: Data flows sequentially between steps. Each step receives the previous step's output as its `inputData`, and returns an output for the next step.
 - **State**: A shared store that all steps can read and update via `state` and `setState`. State persists across the entire workflow run, including suspend/resume cycles.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({ workflowInput: z.string() }),
@@ -40,7 +40,7 @@ const step1 = createStep({
 
 Define a `stateSchema` on both the workflow and individual steps. The workflow's stateSchema is the master schema containing all possible state values, while each step declares only the subset it needs:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   // ...
   stateSchema: z.object({
@@ -95,7 +95,7 @@ export const testWorkflow = createWorkflow({
 
 Pass `initialState` when starting a workflow run to set the starting values:
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.start({
@@ -113,7 +113,7 @@ The `initialState` object should match the structure defined in the workflow's `
 
 State automatically persists across suspend and resume cycles. When a workflow suspends and later resumes, all state updates made before the suspension are preserved:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({}),
@@ -137,7 +137,7 @@ const step1 = createStep({
 
 When using nested workflows, state propagates from parent to child. Changes made by the parent workflow before calling a nested workflow are visible to steps inside the nested workflow:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const nestedStep = createStep({
   id: "nested-step",
   inputSchema: z.object({}),

--- a/docs/src/content/en/docs/workflows/workflow-state.mdx
+++ b/docs/src/content/en/docs/workflows/workflow-state.mdx
@@ -14,7 +14,7 @@ It's important to understand the difference between **state** and **step input/o
 - **Step input/output**: Data flows sequentially between steps. Each step receives the previous step's output as its `inputData`, and returns an output for the next step.
 - **State**: A shared store that all steps can read and update via `state` and `setState`. State persists across the entire workflow run, including suspend/resume cycles.
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({ workflowInput: z.string() }),
@@ -40,7 +40,7 @@ const step1 = createStep({
 
 Define a `stateSchema` on both the workflow and individual steps. The workflow's stateSchema is the master schema containing all possible state values, while each step declares only the subset it needs:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   // ...
   stateSchema: z.object({
@@ -95,7 +95,7 @@ export const testWorkflow = createWorkflow({
 
 Pass `initialState` when starting a workflow run to set the starting values:
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.start({
@@ -113,7 +113,7 @@ The `initialState` object should match the structure defined in the workflow's `
 
 State automatically persists across suspend and resume cycles. When a workflow suspends and later resumes, all state updates made before the suspension are preserved:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({}),
@@ -137,7 +137,7 @@ const step1 = createStep({
 
 When using nested workflows, state propagates from parent to child. Changes made by the parent workflow before calling a nested workflow are visible to steps inside the nested workflow:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const nestedStep = createStep({
   id: "nested-step",
   inputSchema: z.object({}),

--- a/docs/src/content/en/examples/voice/speech-to-speech.mdx
+++ b/docs/src/content/en/examples/voice/speech-to-speech.mdx
@@ -25,7 +25,7 @@ The system creates a voice conversation with a Mastra agent, records the entire 
 
 Create a `.env` file based on the sample provided:
 
-```bash title="speech-to-speech/call-analysis/sample.env" copy
+```bash title="speech-to-speech/call-analysis/sample.env"
 OPENAI_API_KEY=
 CLOUDINARY_CLOUD_NAME=
 CLOUDINARY_API_KEY=
@@ -37,7 +37,7 @@ ROARK_API_KEY=
 
 Install the required dependencies:
 
-```bash copy
+```bash
 npm install
 ```
 
@@ -47,7 +47,7 @@ npm install
 
 First, we define our agent with voice capabilities:
 
-```ts title="speech-to-speech/call-analysis/src/mastra/agents/index.ts" copy
+```ts title="speech-to-speech/call-analysis/src/mastra/agents/index.ts"
 import { Agent } from "@mastra/core/agent";
 import { createTool } from "@mastra/core/tools";
 import { OpenAIRealtimeVoice } from "@mastra/voice-openai-realtime";
@@ -78,7 +78,7 @@ export const speechToSpeechServer = new Agent({
 
 Register the agent with Mastra:
 
-```ts title="speech-to-speech/call-analysis/src/mastra/index.ts" copy
+```ts title="speech-to-speech/call-analysis/src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { speechToSpeechServer } from "./agents";
 
@@ -93,7 +93,7 @@ export const mastra = new Mastra({
 
 Set up Cloudinary for storing the recorded audio files:
 
-```ts title="speech-to-speech/call-analysis/src/upload.ts" copy
+```ts title="speech-to-speech/call-analysis/src/upload.ts"
 import { v2 as cloudinary } from "cloudinary";
 
 cloudinary.config({
@@ -115,7 +115,7 @@ export async function uploadToCloudinary(path: string) {
 
 The main application orchestrates the conversation flow, recording, and analytics integration:
 
-```ts title="speech-to-speech/call-analysis/src/base.ts" copy
+```ts title="speech-to-speech/call-analysis/src/base.ts"
 import { Roark } from "@roarkanalytics/sdk";
 import chalk from "chalk";
 
@@ -195,7 +195,7 @@ The `utils.ts` file contains helper functions for managing the conversation, inc
 
 Start the conversation with:
 
-```bash copy
+```bash
 npm run dev
 ```
 

--- a/docs/src/content/en/examples/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/examples/workflows/inngest-workflow.mdx
@@ -23,7 +23,7 @@ Alternatively, you can use the Inngest CLI for local development by following th
 
 Define a planning agent which leverages an LLM call to plan activities given a location and corresponding weather conditions.
 
-```ts showLineNumbers copy title="agents/planning-agent.ts"
+```ts copy title="agents/planning-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 // Create a new planning agent that uses the OpenAI model
@@ -81,7 +81,7 @@ export { planningAgent };
 
 Define the activity planner workflow with 3 steps: one to fetch the weather via a network call, one to plan activities, and another to plan only indoor activities.
 
-```ts showLineNumbers copy title="workflows/inngest-workflow.ts"
+```ts copy title="workflows/inngest-workflow.ts"
 import { init } from "@mastra/inngest";
 import { Inngest } from "inngest";
 import { z } from "zod";
@@ -128,7 +128,7 @@ const forecastSchema = z.object({
 
 #### Step 1: Fetch weather data for a given city
 
-```ts showLineNumbers copy title="workflows/inngest-workflow.ts"
+```ts copy title="workflows/inngest-workflow.ts"
 const fetchWeather = createStep({
   id: "fetch-weather",
   description: "Fetches weather forecast for a given city",
@@ -188,7 +188,7 @@ const fetchWeather = createStep({
 
 #### Step 2: Suggest activities (indoor or outdoor) based on weather
 
-```ts showLineNumbers copy title="workflows/inngest-workflow.ts"
+```ts copy title="workflows/inngest-workflow.ts"
 const planActivities = createStep({
   id: "plan-activities",
   description: "Suggests activities based on weather conditions",
@@ -235,7 +235,7 @@ const planActivities = createStep({
 
 #### Step 3: Suggest indoor activities only (for rainy weather)
 
-```ts showLineNumbers copy title="workflows/inngest-workflow.ts"
+```ts copy title="workflows/inngest-workflow.ts"
 const planIndoorActivities = createStep({
   id: "plan-indoor-activities",
   description: "Suggests indoor activities based on weather conditions",
@@ -280,7 +280,7 @@ const planIndoorActivities = createStep({
 
 ## Define the activity planner workflow
 
-```ts showLineNumbers copy title="workflows/inngest-workflow.ts"
+```ts copy title="workflows/inngest-workflow.ts"
 const activityPlanningWorkflow = createWorkflow({
   id: "activity-planning-workflow-step2-if-else",
   inputSchema: z.object({
@@ -317,7 +317,7 @@ export { activityPlanningWorkflow };
 
 Register the agents and workflow with the mastra instance. This allows access to the agents within the workflow.
 
-```ts showLineNumbers copy title="index.ts"
+```ts copy title="index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { PinoLogger } from "@mastra/loggers";
@@ -363,7 +363,7 @@ export const mastra = new Mastra({
 
 Here, we'll get the activity planner workflow from the mastra instance, then create a run and execute the created run with the required inputData.
 
-```ts showLineNumbers copy title="exec.ts"
+```ts copy title="exec.ts"
 import { mastra } from "./";
 import { serve } from "@hono/node-server";
 import { createHonoServer, getToolExports } from "@mastra/deployer/server";
@@ -401,7 +401,7 @@ Inngest workflows support advanced flow control features including concurrency l
 
 Control how many workflow instances can run simultaneously:
 
-```ts showLineNumbers copy
+```ts copy
 const workflow = createWorkflow({
   id: "user-processing-workflow",
   inputSchema: z.object({ userId: z.string() }),
@@ -419,7 +419,7 @@ const workflow = createWorkflow({
 
 Limit the number of workflow executions within a time period:
 
-```ts showLineNumbers copy
+```ts copy
 const workflow = createWorkflow({
   id: "api-sync-workflow",
   inputSchema: z.object({ endpoint: z.string() }),
@@ -437,7 +437,7 @@ const workflow = createWorkflow({
 
 Ensure minimum time between workflow executions:
 
-```ts showLineNumbers copy
+```ts copy
 const workflow = createWorkflow({
   id: "email-notification-workflow",
   inputSchema: z.object({ organizationId: z.string(), message: z.string() }),
@@ -456,7 +456,7 @@ const workflow = createWorkflow({
 
 Delay execution until no new events arrive within a time window:
 
-```ts showLineNumbers copy
+```ts copy
 const workflow = createWorkflow({
   id: "search-index-workflow",
   inputSchema: z.object({ documentId: z.string() }),
@@ -474,7 +474,7 @@ const workflow = createWorkflow({
 
 Set execution priority for workflows:
 
-```ts showLineNumbers copy
+```ts copy
 const workflow = createWorkflow({
   id: "order-processing-workflow",
   inputSchema: z.object({
@@ -494,7 +494,7 @@ const workflow = createWorkflow({
 
 You can combine multiple flow control features:
 
-```ts showLineNumbers copy
+```ts copy
 const workflow = createWorkflow({
   id: "comprehensive-workflow",
   inputSchema: z.object({

--- a/docs/src/content/en/examples/workflows/inngest-workflow.mdx
+++ b/docs/src/content/en/examples/workflows/inngest-workflow.mdx
@@ -9,7 +9,7 @@ This example demonstrates how to build an Inngest workflow with Mastra.
 
 ## Setup
 
-```sh copy
+```sh
 npm install @mastra/inngest@beta inngest @mastra/core@beta @mastra/deployer@beta @hono/node-server
 
 docker run --rm -p 8288:8288 \
@@ -23,7 +23,7 @@ Alternatively, you can use the Inngest CLI for local development by following th
 
 Define a planning agent which leverages an LLM call to plan activities given a location and corresponding weather conditions.
 
-```ts copy title="agents/planning-agent.ts"
+```ts title="agents/planning-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 // Create a new planning agent that uses the OpenAI model
@@ -81,7 +81,7 @@ export { planningAgent };
 
 Define the activity planner workflow with 3 steps: one to fetch the weather via a network call, one to plan activities, and another to plan only indoor activities.
 
-```ts copy title="workflows/inngest-workflow.ts"
+```ts title="workflows/inngest-workflow.ts"
 import { init } from "@mastra/inngest";
 import { Inngest } from "inngest";
 import { z } from "zod";
@@ -128,7 +128,7 @@ const forecastSchema = z.object({
 
 #### Step 1: Fetch weather data for a given city
 
-```ts copy title="workflows/inngest-workflow.ts"
+```ts title="workflows/inngest-workflow.ts"
 const fetchWeather = createStep({
   id: "fetch-weather",
   description: "Fetches weather forecast for a given city",
@@ -188,7 +188,7 @@ const fetchWeather = createStep({
 
 #### Step 2: Suggest activities (indoor or outdoor) based on weather
 
-```ts copy title="workflows/inngest-workflow.ts"
+```ts title="workflows/inngest-workflow.ts"
 const planActivities = createStep({
   id: "plan-activities",
   description: "Suggests activities based on weather conditions",
@@ -235,7 +235,7 @@ const planActivities = createStep({
 
 #### Step 3: Suggest indoor activities only (for rainy weather)
 
-```ts copy title="workflows/inngest-workflow.ts"
+```ts title="workflows/inngest-workflow.ts"
 const planIndoorActivities = createStep({
   id: "plan-indoor-activities",
   description: "Suggests indoor activities based on weather conditions",
@@ -280,7 +280,7 @@ const planIndoorActivities = createStep({
 
 ## Define the activity planner workflow
 
-```ts copy title="workflows/inngest-workflow.ts"
+```ts title="workflows/inngest-workflow.ts"
 const activityPlanningWorkflow = createWorkflow({
   id: "activity-planning-workflow-step2-if-else",
   inputSchema: z.object({
@@ -317,7 +317,7 @@ export { activityPlanningWorkflow };
 
 Register the agents and workflow with the mastra instance. This allows access to the agents within the workflow.
 
-```ts copy title="index.ts"
+```ts title="index.ts"
 import { Mastra } from "@mastra/core";
 import { serve as inngestServe } from "@mastra/inngest";
 import { PinoLogger } from "@mastra/loggers";
@@ -363,7 +363,7 @@ export const mastra = new Mastra({
 
 Here, we'll get the activity planner workflow from the mastra instance, then create a run and execute the created run with the required inputData.
 
-```ts copy title="exec.ts"
+```ts title="exec.ts"
 import { mastra } from "./";
 import { serve } from "@hono/node-server";
 import { createHonoServer, getToolExports } from "@mastra/deployer/server";
@@ -401,7 +401,7 @@ Inngest workflows support advanced flow control features including concurrency l
 
 Control how many workflow instances can run simultaneously:
 
-```ts copy
+```ts
 const workflow = createWorkflow({
   id: "user-processing-workflow",
   inputSchema: z.object({ userId: z.string() }),
@@ -419,7 +419,7 @@ const workflow = createWorkflow({
 
 Limit the number of workflow executions within a time period:
 
-```ts copy
+```ts
 const workflow = createWorkflow({
   id: "api-sync-workflow",
   inputSchema: z.object({ endpoint: z.string() }),
@@ -437,7 +437,7 @@ const workflow = createWorkflow({
 
 Ensure minimum time between workflow executions:
 
-```ts copy
+```ts
 const workflow = createWorkflow({
   id: "email-notification-workflow",
   inputSchema: z.object({ organizationId: z.string(), message: z.string() }),
@@ -456,7 +456,7 @@ const workflow = createWorkflow({
 
 Delay execution until no new events arrive within a time window:
 
-```ts copy
+```ts
 const workflow = createWorkflow({
   id: "search-index-workflow",
   inputSchema: z.object({ documentId: z.string() }),
@@ -474,7 +474,7 @@ const workflow = createWorkflow({
 
 Set execution priority for workflows:
 
-```ts copy
+```ts
 const workflow = createWorkflow({
   id: "order-processing-workflow",
   inputSchema: z.object({
@@ -494,7 +494,7 @@ const workflow = createWorkflow({
 
 You can combine multiple flow control features:
 
-```ts copy
+```ts
 const workflow = createWorkflow({
   id: "comprehensive-workflow",
   inputSchema: z.object({

--- a/docs/src/content/en/guides/agent-frameworks/ai-sdk.mdx
+++ b/docs/src/content/en/guides/agent-frameworks/ai-sdk.mdx
@@ -49,7 +49,7 @@ Install `@mastra/ai-sdk` to begin using the `withMastra()` function.
 
 Processors let you transform messages before they're sent to the model (`processInput`) and after responses are received (`processOutputResult`). This example creates a logging processor that logs message counts at each stage, then wraps an OpenAI model with it.
 
-```typescript title="src/example.ts" copy
+```typescript title="src/example.ts"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { withMastra } from '@mastra/ai-sdk';
@@ -82,7 +82,7 @@ const { text } = await generateText({
 
 Memory automatically loads previous messages from storage before the LLM call and saves new messages after. This example configures a LibSQL storage backend to persist conversation history, loading the last 10 messages for context.
 
-```typescript title="src/memory-example.ts" copy
+```typescript title="src/memory-example.ts"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { withMastra } from '@mastra/ai-sdk';
@@ -113,7 +113,7 @@ const { text } = await generateText({
 
 You can combine processors and memory together. Input processors run after memory loads historical messages, and output processors run before memory saves the response.
 
-```typescript title="src/combined-example.ts" copy
+```typescript title="src/combined-example.ts"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { withMastra } from '@mastra/ai-sdk';

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -80,7 +80,7 @@ You can use [`chatRoute()`](/reference/v1/ai-sdk/chat-route), [`workflowRoute()`
 
 This example shows how to set up a chat route at the `/chat` endpoint that uses an agent with the ID `weatherAgent`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { chatRoute } from "@mastra/ai-sdk";
 
@@ -104,7 +104,7 @@ You can also use dynamic agent routing, see the [`chatRoute()` reference documen
 
 This example shows how to set up a workflow route at the `/workflow` endpoint that uses a workflow with the ID `weatherWorkflow`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { workflowRoute } from "@mastra/ai-sdk";
 
@@ -136,7 +136,7 @@ See [Workflow Streaming](/docs/v1/streaming/workflow-streaming#streaming-agent-t
 
 This example shows how to set up a network route at the `/network` endpoint that uses an agent with the ID `weatherAgent`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { networkRoute } from "@mastra/ai-sdk";
 
@@ -172,7 +172,7 @@ The examples below show you how to use them with Next.js App Router.
 
 This example shows how to set up a chat route at the `/chat` endpoint that uses an agent with the ID `weatherAgent`.
 
-```typescript title="app/chat/route.ts" copy
+```typescript title="app/chat/route.ts"
 import { handleChatStream } from '@mastra/ai-sdk';
 import { createUIMessageStreamResponse } from 'ai';
 import { mastra } from '@/src/mastra';
@@ -194,7 +194,7 @@ export async function POST(req: Request) {
 
 This example shows how to set up a workflow route at the `/workflow` endpoint that uses a workflow with the ID `weatherWorkflow`.
 
-```typescript title="app/workflow/route.ts" copy
+```typescript title="app/workflow/route.ts"
 import { handleWorkflowStream } from '@mastra/ai-sdk';
 import { createUIMessageStreamResponse } from 'ai';
 import { mastra } from '@/src/mastra';
@@ -216,7 +216,7 @@ export async function POST(req: Request) {
 
 This example shows how to set up a network route at the `/network` endpoint that uses an agent with the ID `routingAgent`.
 
-```typescript title="app/network/route.ts" copy
+```typescript title="app/network/route.ts"
 import { handleNetworkStream } from '@mastra/ai-sdk';
 import { createUIMessageStreamResponse } from 'ai';
 import { mastra } from '@/src/mastra';
@@ -279,7 +279,7 @@ The `useCompletion()` hook handles single-turn completions between your frontend
 
 Your frontend could look like this:
 
-```typescript title="app/page.tsx" copy
+```typescript title="app/page.tsx"
 import { useCompletion } from '@ai-sdk/react';
 
 export default function Page() {
@@ -308,7 +308,7 @@ Below are two approaches to implementing the backend:
 
 <TabItem value="mastra-server" label="Mastra Server">
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core/mastra';
 import { registerApiRoute } from '@mastra/core/server';
 import { handleChatStream } from '@mastra/ai-sdk';
@@ -353,7 +353,7 @@ export const mastra = new Mastra({
 
 <TabItem value="nextjs" label="Next.js">
 
-```ts title="app/completion/route.ts" copy
+```ts title="app/completion/route.ts"
 import { handleChatStream } from '@mastra/ai-sdk';
 import { createUIMessageStreamResponse } from 'ai';
 import { mastra } from '@/src/mastra';
@@ -433,7 +433,7 @@ Here's an example of rendering a weather tool's output as a custom `WeatherCard`
 
 Define a tool with an `outputSchema` so the frontend knows the shape of the data to render.
 
-```typescript title="src/mastra/tools/weather-tool.ts" {10-17} copy
+```typescript title="src/mastra/tools/weather-tool.ts" {10-17}
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -474,7 +474,7 @@ export const weatherTool = createTool({
 
 Check for `tool-{toolKey}` parts in the message and render a custom component based on the tool's state and output.
 
-```typescript title="src/components/chat.tsx" {24-35} copy
+```typescript title="src/components/chat.tsx" {24-35}
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { WeatherCard } from "./weather-card";
@@ -540,7 +540,7 @@ When using `workflowRoute()` or `handleWorkflowStream()`, Mastra emits `data-wor
 
 Define a workflow with multiple steps that will emit `data-workflow` parts as it executes.
 
-```typescript title="src/mastra/workflows/activities-workflow.ts" copy
+```typescript title="src/mastra/workflows/activities-workflow.ts"
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -594,7 +594,7 @@ activitiesWorkflow.commit();
 
 Register the workflow with Mastra and expose it via `workflowRoute()` to stream workflow events to the frontend.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { workflowRoute } from "@mastra/ai-sdk";
 
@@ -617,7 +617,7 @@ export const mastra = new Mastra({
 
 Check for `data-workflow` parts and render each step's status and output using the `WorkflowDataPart` type for type safety.
 
-```typescript title="src/components/workflow-chat.tsx" {3,5,45-47} copy
+```typescript title="src/components/workflow-chat.tsx" {3,5,45-47}
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import type { WorkflowDataPart } from "@mastra/ai-sdk";
@@ -706,7 +706,7 @@ When using `networkRoute()` or `handleNetworkStream()`, Mastra emits `data-netwo
 
 Register agents with Mastra and expose the routing agent via `networkRoute()` to stream network execution events to the frontend.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { networkRoute } from "@mastra/ai-sdk";
 
@@ -729,7 +729,7 @@ export const mastra = new Mastra({
 
 Check for `data-network` parts and render each agent's execution step using the `NetworkDataPart` type for type safety.
 
-```typescript title="src/components/network-chat.tsx" {3,5,42-44} copy
+```typescript title="src/components/network-chat.tsx" {3,5,42-44}
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import type { NetworkDataPart } from "@mastra/ai-sdk";
@@ -823,7 +823,7 @@ You must `await` the `writer.custom()` call, otherwise you may encounter a `Writ
 
 Use `writer.custom()` inside the tool's `execute()` function to emit custom `data-` prefixed events at different stages of execution.
 
-```typescript title="src/mastra/tools/task-tool.ts" {18-24,30-36} copy
+```typescript title="src/mastra/tools/task-tool.ts" {18-24,30-36}
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -875,7 +875,7 @@ export const taskTool = createTool({
 
 Filter message parts for your custom event type and render a progress indicator that updates as new events arrive.
 
-```typescript title="src/components/task-chat.tsx" {31-41,45} copy
+```typescript title="src/components/task-chat.tsx" {31-41,45}
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useMemo } from "react";
@@ -969,7 +969,7 @@ When loading messages from Mastra's memory to display in a chat UI, use [`toAISd
 
 Here's an example of the frontend code:
 
-```typescript {15-25} copy
+```typescript {15-25}
 import { useChat } from "@ai-sdk/react";
 import { useState } from "react";
 import { DefaultChatTransport } from 'ai';
@@ -1016,7 +1016,7 @@ Two examples on how to implement the backend portion of it.
 
 Add a `chatRoute()` to your Mastra configuration like shown above. Then, add a server-level middleware:
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 
 export const mastra = new Mastra({
@@ -1052,7 +1052,7 @@ You can access this data in your tools via the `requestContext` parameter. See t
 
 <TabItem value="nextjs" label="Next.js">
 
-```typescript title="app/chat-extra/route.ts" copy
+```typescript title="app/chat-extra/route.ts"
 import { handleChatStream } from '@mastra/ai-sdk';
 import { RequestContext } from "@mastra/core/request-context";
 import { createUIMessageStreamResponse } from 'ai';
@@ -1101,7 +1101,7 @@ The workflow uses:
 
 Create a workflow step that suspends for approval. The step checks `resumeData` to determine if it's resuming, and calls `suspend()` on first execution.
 
-```typescript title="src/mastra/workflows/approval-workflow.ts" copy
+```typescript title="src/mastra/workflows/approval-workflow.ts"
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -1158,7 +1158,7 @@ approvalWorkflow.commit();
 
 Register the workflow. Storage is required for suspend/resume to persist state.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { workflowRoute } from "@mastra/ai-sdk";
 import { LibSQLStore } from "@mastra/libsql";
@@ -1182,7 +1182,7 @@ export const mastra = new Mastra({
 
 Detect when the workflow is suspended and send resume data with `runId`, `step`, and `resumeData`.
 
-```typescript title="src/components/approval-workflow.tsx" copy
+```typescript title="src/components/approval-workflow.tsx"
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useMemo, useState } from "react";
@@ -1292,7 +1292,7 @@ The pattern uses:
 
 Create a tool that calls an agent and pipes its stream to the tool's writer.
 
-```typescript title="src/mastra/tools/nested-agent-tool.ts" copy
+```typescript title="src/mastra/tools/nested-agent-tool.ts"
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -1325,7 +1325,7 @@ export const nestedAgentTool = createTool({
 
 Create an agent that uses this tool.
 
-```typescript title="src/mastra/agents/forecast-agent.ts" copy
+```typescript title="src/mastra/agents/forecast-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { nestedAgentTool } from "../tools/nested-agent-tool";
 
@@ -1343,7 +1343,7 @@ export const forecastAgent = new Agent({
 
 Handle `data-tool-agent` parts to display the nested agent's streamed output.
 
-```typescript title="src/components/nested-agent-chat.tsx" copy
+```typescript title="src/components/nested-agent-chat.tsx"
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useState } from "react";
@@ -1417,7 +1417,7 @@ The pattern uses:
 
 Create a workflow step that streams an agent's response by piping to the step's `writer`.
 
-```typescript title="src/mastra/workflows/weather-workflow.ts" copy
+```typescript title="src/mastra/workflows/weather-workflow.ts"
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 import { weatherAgent } from "../agents/weather-agent";
@@ -1464,7 +1464,7 @@ weatherWorkflow.commit();
 
 Register the workflow with a `workflowRoute()`. Text streaming is enabled by default.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { workflowRoute } from "@mastra/ai-sdk";
 
@@ -1485,7 +1485,7 @@ export const mastra = new Mastra({
 
 Render both `text` parts (streaming agent output) and `data-workflow` parts (step progress).
 
-```typescript title="src/components/weather-workflow.tsx" copy
+```typescript title="src/components/weather-workflow.tsx"
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useState } from "react";

--- a/docs/src/content/en/guides/build-your-ui/assistant-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/assistant-ui.mdx
@@ -44,7 +44,7 @@ project-root
 
 Bootstrap your Mastra server:
 
-```bash copy
+```bash
 npx create-mastra@beta
 ```
 
@@ -52,7 +52,7 @@ This command will launch an interactive wizard to help you scaffold a new Mastra
 
 Navigate to your newly created Mastra server directory:
 
-```bash copy
+```bash
 cd mastra-server # Replace with the actual directory name you provided
 ```
 
@@ -84,13 +84,13 @@ Ensure that you have set the appropriate environment variables for your LLM prov
 
 Create a chat route for the Assistant UI frontend by using the `chatRoute()` helper from `@mastra/ai-sdk`. Add it to your Mastra project:
 
-```bash copy
+```bash
 npm install @mastra/ai-sdk@beta
 ```
 
 In your `src/mastra/index.ts` file, register the chat route:
 
-```typescript copy title="src/mastra/index.ts" {2,7-13}
+```typescript title="src/mastra/index.ts" {2,7-13}
 import { Mastra } from '@mastra/core/mastra';
 import { chatRoute } from '@mastra/ai-sdk';
 // Rest of the imports...
@@ -115,7 +115,7 @@ This will make all agents available in AI SDK-compatible formats, including the 
 
 Run the Mastra server using the following command:
 
-```bash copy
+```bash
 npm run dev
 ```
 
@@ -127,13 +127,13 @@ By default, the Mastra server will run on `http://localhost:4111`. Keep this ser
 
 Go up one directory to your project root.
 
-```bash copy
+```bash
 cd ..
 ```
 
 Create a new `assistant-ui` project with the following command.
 
-```bash copy
+```bash
 npx assistant-ui@latest create
 ```
 
@@ -175,7 +175,7 @@ Now, the Assistant UI frontend will send chat requests directly to your running 
 
 You're ready to connect the pieces! Make sure both the Mastra server and the Assistant UI frontend are running. Start the Next.js development server:
 
-```bash copy
+```bash
 npm run dev
 ```
 

--- a/docs/src/content/en/guides/build-your-ui/copilotkit.mdx
+++ b/docs/src/content/en/guides/build-your-ui/copilotkit.mdx
@@ -48,7 +48,7 @@ project-root
 
 Bootstrap your Mastra server:
 
-```bash copy
+```bash
 npx create-mastra@latest
 ```
 
@@ -56,7 +56,7 @@ This command will launch an interactive wizard to help you scaffold a new Mastra
 
 Navigate to your newly created Mastra server directory:
 
-```bash copy
+```bash
 cd mastra-server # Replace with the actual directory name you provided
 ```
 
@@ -88,13 +88,13 @@ Ensure that you have set the appropriate environment variables for your LLM prov
 
 Create a chat route for the CopilotKit frontend by using the `registerCopilotKit()` helper from `@ag-ui/mastra`. Add it to your Mastra project (and its peer dependencies):
 
-```bash copy
+```bash
 npm install --legacy-peer-deps @ag-ui/mastra @copilotkit/runtime @ag-ui/core @ag-ui/client @ag-ui/encoder @ag-ui/langgraph @ag-ui/proto
 ```
 
 In your `src/mastra/index.ts` file, register the chat route:
 
-```typescript copy title="src/mastra/index.ts" {2,7-19}
+```typescript title="src/mastra/index.ts" {2,7-19}
 import { Mastra } from '@mastra/core/mastra';
 import { registerCopilotKit } from '@ag-ui/mastra/copilotkit';
 // Rest of the imports...
@@ -125,7 +125,7 @@ This will make the `weatherAgent` available at `/chat` in a CopilotKit-compatibl
 
 Run the Mastra server using the following command:
 
-```bash copy
+```bash
 npm run dev
 ```
 
@@ -137,19 +137,19 @@ By default, the Mastra server will run on `http://localhost:4111`. Keep this ser
 
 Go up one directory to your project root.
 
-```bash copy
+```bash
 cd ..
 ```
 
 Create a new Next.js project with the name `my-copilot-app`:
 
-```bash copy
+```bash
 npx create-next-app@latest my-copilot-app
 ```
 
 Navigate to your newly created Next.js project directory:
 
-```bash copy
+```bash
 cd my-copilot-app
 ```
 
@@ -159,13 +159,13 @@ cd my-copilot-app
 
 Install the CopilotKit UI packages which you'll use to display a chat interface:
 
-```bash copy
+```bash
 npm install @copilotkit/react-ui @copilotkit/react-core
 ```
 
 Open the home route of the Next.js app (usually `app/page.tsx` or `src/app/page.tsx`) and replace the existing contents with the following code to set up a basic CopilotKit chat interface:
 
-```typescript copy title="app/page.tsx"
+```typescript title="app/page.tsx"
 import { CopilotChat } from "@copilotkit/react-ui";
 import { CopilotKit } from "@copilotkit/react-core";
 import "@copilotkit/react-ui/styles.css";
@@ -193,7 +193,7 @@ export default function Home() {
 
 You're ready to connect the pieces! Make sure both the Mastra server and the CopilotKit frontend are running. Start the Next.js development server:
 
-```bash copy
+```bash
 npm run dev
 ```
 

--- a/docs/src/content/en/guides/deployment/amazon-ec2.mdx
+++ b/docs/src/content/en/guides/deployment/amazon-ec2.mdx
@@ -39,7 +39,7 @@ Connect to your EC2 instance and clone your repository:
 <Tabs>
   <TabItem value="public" label="Public Repository">
 
-```bash copy
+```bash
 git clone https://github.com/<your-username>/<your-repository>.git
 ```
 
@@ -47,7 +47,7 @@ git clone https://github.com/<your-username>/<your-repository>.git
 
   <TabItem value="private" label="Private Repository">
 
-```bash copy
+```bash
 git clone https://<your-username>:<your-personal-access-token>@github.com/<your-username>/<your-repository>.git
 ```
 
@@ -56,7 +56,7 @@ git clone https://<your-username>:<your-personal-access-token>@github.com/<your-
 
 Navigate to the repository directory:
 
-```bash copy
+```bash
 cd "<your-repository>"
 ```
 
@@ -66,7 +66,7 @@ cd "<your-repository>"
 
 Install dependencies:
 
-```bash copy
+```bash
 npm install
 ```
 
@@ -76,13 +76,13 @@ npm install
 
 Create a `.env` file and add your environment variables:
 
-```bash copy
+```bash
 touch .env
 ```
 
 Edit the `.env` file and add your environment variables:
 
-```bash copy
+```bash
 OPENAI_API_KEY=<your-openai-api-key>
 # Add other required environment variables
 ```
@@ -93,7 +93,7 @@ OPENAI_API_KEY=<your-openai-api-key>
 
 Build the application:
 
-```bash copy
+```bash
 npm run build
 ```
 
@@ -103,7 +103,7 @@ npm run build
 
 Run the application:
 
-```bash copy
+```bash
 node --env-file=".env" .mastra/output/index.mjs
 ```
 
@@ -121,7 +121,7 @@ You can now connect to your Mastra server from your client application using a `
 
 Refer to the [`MastraClient` documentation](/reference/v1/client-js/mastra-client) for more information.
 
-```typescript copy
+```typescript
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/amazon-ec2.mdx
+++ b/docs/src/content/en/guides/deployment/amazon-ec2.mdx
@@ -121,7 +121,7 @@ You can now connect to your Mastra server from your client application using a `
 
 Refer to the [`MastraClient` documentation](/reference/v1/client-js/mastra-client) for more information.
 
-```typescript copy showLineNumbers
+```typescript copy
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/aws-lambda.mdx
+++ b/docs/src/content/en/guides/deployment/aws-lambda.mdx
@@ -37,7 +37,7 @@ Lambda functions have limitations with file system storage. Configure your Mastr
 
 ### Option 1: In-Memory (Simplest)
 
-```typescript title="src/mastra/index.ts" copy showLineNumbers
+```typescript title="src/mastra/index.ts" copy
 import { LibSQLStore } from "@mastra/libsql";
 
 const storage = new LibSQLStore({
@@ -50,7 +50,7 @@ const storage = new LibSQLStore({
 
 For persistent memory across Lambda invocations, use external storage providers like `LibSQLStore` with Turso or other storage providers like `PostgreStore`:
 
-```typescript title="src/mastra/index.ts" copy showLineNumbers
+```typescript title="src/mastra/index.ts" copy
 import { LibSQLStore } from "@mastra/libsql";
 
 const storage = new LibSQLStore({
@@ -66,7 +66,7 @@ For more memory configuration options, see the [Memory documentation](/docs/v1/m
 
 Create a `Dockerfile` in your Mastra project root directory:
 
-```dockerfile title="Dockerfile" copy showLineNumbers
+```dockerfile title="Dockerfile" copy
 FROM node:22-alpine
 
 WORKDIR /app
@@ -219,7 +219,7 @@ For more information about available API endpoints, see the [Server documentatio
 
 Update your client application to use the Lambda function URL:
 
-```typescript title="src/client.ts" copy showLineNumbers
+```typescript title="src/client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/aws-lambda.mdx
+++ b/docs/src/content/en/guides/deployment/aws-lambda.mdx
@@ -37,7 +37,7 @@ Lambda functions have limitations with file system storage. Configure your Mastr
 
 ### Option 1: In-Memory (Simplest)
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { LibSQLStore } from "@mastra/libsql";
 
 const storage = new LibSQLStore({
@@ -50,7 +50,7 @@ const storage = new LibSQLStore({
 
 For persistent memory across Lambda invocations, use external storage providers like `LibSQLStore` with Turso or other storage providers like `PostgreStore`:
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { LibSQLStore } from "@mastra/libsql";
 
 const storage = new LibSQLStore({
@@ -66,7 +66,7 @@ For more memory configuration options, see the [Memory documentation](/docs/v1/m
 
 Create a `Dockerfile` in your Mastra project root directory:
 
-```dockerfile title="Dockerfile" copy
+```dockerfile title="Dockerfile"
 FROM node:22-alpine
 
 WORKDIR /app
@@ -100,7 +100,7 @@ CMD ["node", ".mastra/output/index.mjs"]
 
 Set up your environment variables for the deployment process:
 
-```bash copy
+```bash
 export PROJECT_NAME="your-mastra-app"
 export AWS_REGION="us-east-1"
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
@@ -112,7 +112,7 @@ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output tex
 
 Build your Docker image locally:
 
-```bash copy
+```bash
 docker build -t "$PROJECT_NAME" .
 ```
 
@@ -122,7 +122,7 @@ docker build -t "$PROJECT_NAME" .
 
 Create an Amazon ECR repository to store your Docker image:
 
-```bash copy
+```bash
 aws ecr create-repository --repository-name "$PROJECT_NAME" --region "$AWS_REGION"
 ```
 
@@ -132,7 +132,7 @@ aws ecr create-repository --repository-name "$PROJECT_NAME" --region "$AWS_REGIO
 
 Log in to Amazon ECR:
 
-```bash copy
+```bash
 aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
 ```
 
@@ -142,7 +142,7 @@ aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS 
 
 Tag your image with the ECR repository URI and push it:
 
-```bash copy
+```bash
 docker tag "$PROJECT_NAME":latest "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$PROJECT_NAME":latest
 docker push "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$PROJECT_NAME":latest
 ```
@@ -219,7 +219,7 @@ For more information about available API endpoints, see the [Server documentatio
 
 Update your client application to use the Lambda function URL:
 
-```typescript title="src/client.ts" copy
+```typescript title="src/client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/azure-app-services.mdx
+++ b/docs/src/content/en/guides/deployment/azure-app-services.mdx
@@ -147,7 +147,7 @@ You can now connect to your Mastra server from your client application using a `
 
 Refer to the [`MastraClient` documentation](/reference/v1/client-js/mastra-client) for more information.
 
-```typescript copy showLineNumbers
+```typescript copy
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/azure-app-services.mdx
+++ b/docs/src/content/en/guides/deployment/azure-app-services.mdx
@@ -147,7 +147,7 @@ You can now connect to your Mastra server from your client application using a `
 
 Refer to the [`MastraClient` documentation](/reference/v1/client-js/mastra-client) for more information.
 
-```typescript copy
+```typescript
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/cloudflare-deployer.mdx
+++ b/docs/src/content/en/guides/deployment/cloudflare-deployer.mdx
@@ -19,7 +19,7 @@ npm install @mastra/deployer-cloudflare@beta
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { CloudflareDeployer } from "@mastra/deployer-cloudflare";
 

--- a/docs/src/content/en/guides/deployment/cloudflare-deployer.mdx
+++ b/docs/src/content/en/guides/deployment/cloudflare-deployer.mdx
@@ -13,13 +13,13 @@ Cloudflare Workers do not support filesystem access. Remove any usage of [LibSQL
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/deployer-cloudflare@beta
 ```
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { CloudflareDeployer } from "@mastra/deployer-cloudflare";
 
@@ -42,13 +42,13 @@ Manual deployments are also possible using the [Cloudflare Wrangler CLI](https:/
 
 With the Wrangler CLI installed, login and authenticate with your Cloudflare logins:
 
-```bash copy
+```bash
 npx wrangler login
 ```
 
 Run the following to build and deploy your application to Cloudflare
 
-```bash copy
+```bash
 npm run build && wrangler deploy --config .mastra/output/wrangler.json
 ```
 

--- a/docs/src/content/en/guides/deployment/digital-ocean.mdx
+++ b/docs/src/content/en/guides/deployment/digital-ocean.mdx
@@ -219,7 +219,7 @@ You can now connect to your Mastra server from your client application using a `
 
 Refer to the [`MastraClient` documentation](/docs/v1/server/mastra-client) for more information.
 
-```typescript copy showLineNumbers
+```typescript copy
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/digital-ocean.mdx
+++ b/docs/src/content/en/guides/deployment/digital-ocean.mdx
@@ -131,7 +131,7 @@ Connect to your Droplet and clone your repository:
 <Tabs>
   <TabItem value="public" label="Public Repository">
 
-```bash copy
+```bash
 git clone https://github.com/<your-username>/<your-repository>.git
 ```
 
@@ -139,7 +139,7 @@ git clone https://github.com/<your-username>/<your-repository>.git
 
   <TabItem value="private" label="Private Repository">
 
-```bash copy
+```bash
 git clone https://<your-username>:<your-personal-access-token>@github.com/<your-username>/<your-repository>.git
 ```
 
@@ -148,7 +148,7 @@ git clone https://<your-username>:<your-personal-access-token>@github.com/<your-
 
 Navigate to the repository directory:
 
-```bash copy
+```bash
 cd "<your-repository>"
 ```
 
@@ -158,7 +158,7 @@ cd "<your-repository>"
 
 Install dependencies
 
-```bash copy
+```bash
 npm install
 ```
 
@@ -170,13 +170,13 @@ Set up environment variables
 
 Create a `.env` file and add your environment variables:
 
-```bash copy
+```bash
 touch .env
 ```
 
 Edit the `.env` file and add your environment variables:
 
-```bash copy
+```bash
 OPENAI_API_KEY=<your-openai-api-key>
 # Add other required environment variables
 ```
@@ -187,7 +187,7 @@ OPENAI_API_KEY=<your-openai-api-key>
 
 Build the application
 
-```bash copy
+```bash
 npm run build
 ```
 
@@ -197,7 +197,7 @@ npm run build
 
 Run the application
 
-```bash copy
+```bash
 node --env-file=".env" .mastra/output/index.mjs
 ```
 
@@ -219,7 +219,7 @@ You can now connect to your Mastra server from your client application using a `
 
 Refer to the [`MastraClient` documentation](/docs/v1/server/mastra-client) for more information.
 
-```typescript copy
+```typescript
 import { MastraClient } from "@mastra/client-js";
 
 const mastraClient = new MastraClient({

--- a/docs/src/content/en/guides/deployment/netlify-deployer.mdx
+++ b/docs/src/content/en/guides/deployment/netlify-deployer.mdx
@@ -13,13 +13,13 @@ Netlify Functions use an ephemeral filesystem. Remove any usage of [LibSQLStore]
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/deployer-netlify@beta
 ```
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { NetlifyDeployer } from "@mastra/deployer-netlify";
 
@@ -48,7 +48,7 @@ Your project is now configured with automatic deployments which occur whenever y
 
 Manual deployments are also possible using the [Netlify CLI](https://docs.netlify.com/cli/get-started/). With the Netlify CLI installed run the following from your project root to deploy your application. You can also run `netlify dev` from your project root to test your Mastra application locally.
 
-```bash copy
+```bash
 netlify deploy --prod
 ```
 

--- a/docs/src/content/en/guides/deployment/vercel-deployer.mdx
+++ b/docs/src/content/en/guides/deployment/vercel-deployer.mdx
@@ -19,7 +19,7 @@ npm install @mastra/deployer-vercel@beta
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { VercelDeployer } from "@mastra/deployer-vercel";
 
@@ -41,7 +41,7 @@ The Vercel deployer can write a few high‑value settings into the Vercel Output
 
 Example:
 
-```ts title="src/mastra/index.ts" showLineNumbers copy
+```ts title="src/mastra/index.ts" copy
 deployer: new VercelDeployer({
   maxDuration: 600,
   memory: 1536,

--- a/docs/src/content/en/guides/deployment/vercel-deployer.mdx
+++ b/docs/src/content/en/guides/deployment/vercel-deployer.mdx
@@ -13,13 +13,13 @@ Vercel Functions use an ephemeral filesystem. Remove any usage of [LibSQLStore](
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/deployer-vercel@beta
 ```
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { VercelDeployer } from "@mastra/deployer-vercel";
 
@@ -41,7 +41,7 @@ The Vercel deployer can write a few high‑value settings into the Vercel Output
 
 Example:
 
-```ts title="src/mastra/index.ts" copy
+```ts title="src/mastra/index.ts"
 deployer: new VercelDeployer({
   maxDuration: 600,
   memory: 1536,
@@ -67,7 +67,7 @@ Your project is now configured with automatic deployments which occur whenever y
 
 Manual deployments are also possible using the [Vercel CLI](https://vercel.com/docs/cli). With the Vercel CLI installed run the following from your project root to deploy your application.
 
-```bash copy
+```bash
 npm run build && vercel --prod --prebuilt --archive=tgz
 ```
 

--- a/docs/src/content/en/guides/getting-started/astro.mdx
+++ b/docs/src/content/en/guides/getting-started/astro.mdx
@@ -202,7 +202,7 @@ Create a new Action, and add the example code:
 touch src/actions/index.ts
 ```
 
-```typescript title="src/actions/index.ts" showLineNumbers copy
+```typescript title="src/actions/index.ts" copy
 import { defineAction } from "astro:actions";
 import { z } from "astro:schema";
 
@@ -237,7 +237,7 @@ Create a new Form component, and add the example code:
 touch src/components/form.tsx
 ```
 
-```typescript title="src/components/form.tsx" showLineNumbers copy
+```typescript title="src/components/form.tsx" copy
 import { actions } from "astro:actions";
 import { useState } from "react";
 
@@ -273,7 +273,7 @@ Create a new Page, and add the example code:
 touch src/pages/test.astro
 ```
 
-```astro title="src/pages/test.astro" showLineNumbers copy
+```astro title="src/pages/test.astro" copy
 ---
 import { Form } from '../components/form'
 ---
@@ -494,7 +494,7 @@ Create a new Endpoint, and add the example code:
 touch src/pages/api/test.ts
 ```
 
-```typescript title="src/pages/api/test.ts" showLineNumbers copy
+```typescript title="src/pages/api/test.ts" copy
 import type { APIRoute } from "astro";
 
 import { mastra } from "../../mastra";
@@ -519,7 +519,7 @@ Create a new Form component, and add the example code:
 touch src/components/form.tsx
 ```
 
-```typescript title="src/components/form.tsx" showLineNumbers copy
+```typescript title="src/components/form.tsx" copy
 import { useState } from "react";
 
 export const Form = () => {
@@ -563,7 +563,7 @@ Create a new Page, and add the example code:
 touch src/pages/test.astro
 ```
 
-```astro title="src/pages/test.astro" showLineNumbers copy
+```astro title="src/pages/test.astro" copy
 ---
 import { Form } from '../components/form'
 ---

--- a/docs/src/content/en/guides/getting-started/astro.mdx
+++ b/docs/src/content/en/guides/getting-started/astro.mdx
@@ -36,28 +36,28 @@ Install the required packages:
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm install mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn add mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm add mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun add mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
@@ -119,7 +119,7 @@ Modify the `tsconfig.json` file in your project root:
 
 Setup your API key in a `.env` file:
 
-```bash title=".env" copy
+```bash title=".env"
 OPENAI_API_KEY=<your-api-key>
 ```
 
@@ -129,7 +129,7 @@ OPENAI_API_KEY=<your-api-key>
 
 Add `.mastra` and `.vercel` to your `.gitignore` file:
 
-```bash title=".gitignore" copy
+```bash title=".gitignore"
 .mastra
 .vercel
 ```
@@ -160,14 +160,14 @@ Start the Mastra Dev Server to expose your agents as REST endpoints:
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm run dev:mastra
 ```
 
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-```bash copy
+```bash
 mastra dev:mastra
 ```
 
@@ -188,7 +188,7 @@ With the Mastra Dev Server running, you can start your Astro site in the usual w
 
 Create an `actions` directory:
 
-```bash copy
+```bash
 mkdir src/actions
 ```
 
@@ -198,11 +198,11 @@ mkdir src/actions
 
 Create a new Action, and add the example code:
 
-```bash copy
+```bash
 touch src/actions/index.ts
 ```
 
-```typescript title="src/actions/index.ts" copy
+```typescript title="src/actions/index.ts"
 import { defineAction } from "astro:actions";
 import { z } from "astro:schema";
 
@@ -233,11 +233,11 @@ export const server = {
 
 Create a new Form component, and add the example code:
 
-```bash copy
+```bash
 touch src/components/form.tsx
 ```
 
-```typescript title="src/components/form.tsx" copy
+```typescript title="src/components/form.tsx"
 import { actions } from "astro:actions";
 import { useState } from "react";
 
@@ -269,11 +269,11 @@ export const Form = () => {
 
 Create a new Page, and add the example code:
 
-```bash copy
+```bash
 touch src/pages/test.astro
 ```
 
-```astro title="src/pages/test.astro" copy
+```astro title="src/pages/test.astro"
 ---
 import { Form } from '../components/form'
 ---
@@ -328,28 +328,28 @@ Install the required packages:
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm install mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn add mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm add mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun add mastra@beta @mastra/core@beta @mastra/libsql@beta @ai-sdk/openai
 ```
 
@@ -411,7 +411,7 @@ Modify the `tsconfig.json` file in your project root:
 
 Setup your API key in a `.env` file:
 
-```bash title=".env" copy
+```bash title=".env"
 OPENAI_API_KEY=<your-api-key>
 ```
 
@@ -421,7 +421,7 @@ OPENAI_API_KEY=<your-api-key>
 
 Add `.mastra` to your `.gitignore` file:
 
-```bash title=".gitignore" copy
+```bash title=".gitignore"
 .mastra
 .vercel
 ```
@@ -452,14 +452,14 @@ Start the Mastra Dev Server to expose your agents as REST endpoints:
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm run dev:mastra
 ```
 
 </TabItem>
 <TabItem value="cli" label="CLI">
 
-```bash copy
+```bash
 mastra dev:mastra
 ```
 
@@ -480,7 +480,7 @@ With the Mastra Dev Server running, you can start your Astro site in the usual w
 
 Create an `api` directory:
 
-```bash copy
+```bash
 mkdir src/pages/api
 ```
 
@@ -490,11 +490,11 @@ mkdir src/pages/api
 
 Create a new Endpoint, and add the example code:
 
-```bash copy
+```bash
 touch src/pages/api/test.ts
 ```
 
-```typescript title="src/pages/api/test.ts" copy
+```typescript title="src/pages/api/test.ts"
 import type { APIRoute } from "astro";
 
 import { mastra } from "../../mastra";
@@ -515,11 +515,11 @@ export const POST: APIRoute = async ({ request }) => {
 
 Create a new Form component, and add the example code:
 
-```bash copy
+```bash
 touch src/components/form.tsx
 ```
 
-```typescript title="src/components/form.tsx" copy
+```typescript title="src/components/form.tsx"
 import { useState } from "react";
 
 export const Form = () => {
@@ -559,11 +559,11 @@ export const Form = () => {
 
 Create a new Page, and add the example code:
 
-```bash copy
+```bash
 touch src/pages/test.astro
 ```
 
-```astro title="src/pages/test.astro" copy
+```astro title="src/pages/test.astro"
 ---
 import { Form } from '../components/form'
 ---

--- a/docs/src/content/en/guides/getting-started/express.mdx
+++ b/docs/src/content/en/guides/getting-started/express.mdx
@@ -24,7 +24,7 @@ Clone this [boilerplate repository](https://github.com/mastra-ai/express-ts-boil
 <Tabs>
 <TabItem value="https" label="HTTPS">
 
-```bash copy
+```bash
 git clone https://github.com/mastra-ai/express-ts-boilerplate.git
 cd express-ts-boilerplate
 npm install
@@ -33,7 +33,7 @@ npm install
 </TabItem>
 <TabItem value="ssh" label="SSH">
 
-```bash copy
+```bash
 git clone git@github.com:mastra-ai/express-ts-boilerplate.git
 cd express-ts-boilerplate
 npm install
@@ -48,7 +48,7 @@ Inside your Express project directory, run [`mastra init`](/reference/v1/cli/mas
 
 When prompted, choose a provider (e.g. OpenAI) and enter your key:
 
-```bash copy
+```bash
 npx mastra@beta init
 ```
 
@@ -64,13 +64,13 @@ You'll pass the `src/mastra/index.ts` file to the Express server adapter later.
 
 Install the Express server adapter package:
 
-```bash copy
+```bash
 npm install @mastra/express@beta
 ```
 
 Open the Express entry file at `src/index.ts` and add the required import and initialization code:
 
-```typescript copy {2-3,11-12} title="src/index.ts"
+```typescript {2-3,11-12} title="src/index.ts"
 import express, { type Request, type Response } from "express";
 import { MastraServer } from "@mastra/express";
 import { mastra } from "./mastra";
@@ -103,13 +103,13 @@ By default, Mastra's endpoints are added under the `/api` subpath and use your a
 
 Start your Express server:
 
-```bash copy
+```bash
 npm run start
 ```
 
 In a separate terminal window, use `curl` to ask the weather agent:
 
-```bash copy
+```bash
 curl -X POST http://localhost:3000/api/agents/weather-agent/generate -H "Content-Type: application/json" -d "{\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather like in Seoul?\"}]}"
 ```
 

--- a/docs/src/content/en/guides/getting-started/hono.mdx
+++ b/docs/src/content/en/guides/getting-started/hono.mdx
@@ -24,28 +24,28 @@ Run the following command to [create a new Hono app](https://hono.dev/docs/getti
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm create hono@latest mastra-hono -- --template nodejs --install --pm npm
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm create hono@latest mastra-hono --template nodejs --install --pm pnpm
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn create hono@latest mastra-hono --template nodejs --install --pm yarn
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun create hono@latest mastra-hono --template nodejs --install --pm bun
 ```
 
@@ -63,7 +63,7 @@ When prompted, choose a provider (e.g. OpenAI) and enter your key:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 cd mastra-hono
 npx mastra@beta init
 ```
@@ -71,7 +71,7 @@ npx mastra@beta init
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 cd mastra-hono
 pnpm dlx mastra@beta init
 ```
@@ -79,7 +79,7 @@ pnpm dlx mastra@beta init
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 cd mastra-hono
 yarn dlx mastra@beta init
 ```
@@ -87,7 +87,7 @@ yarn dlx mastra@beta init
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 cd mastra-hono
 bunx mastra@beta init
 ```
@@ -110,28 +110,28 @@ Install the Hono server adapter package:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm install @mastra/hono@beta
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm add @mastra/hono@beta
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn add @mastra/hono@beta
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun add @mastra/hono@beta
 ```
 
@@ -140,7 +140,7 @@ bun add @mastra/hono@beta
 
 Open the Hono entry file at `src/index.ts` and add the required import and initialization code:
 
-```typescript copy title="src/index.ts" {3-8,10-11,13}
+```typescript title="src/index.ts" {3-8,10-11,13}
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import {
@@ -178,28 +178,28 @@ Start your Hono server:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm run dev
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm run dev
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn run dev
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun run dev
 ```
 
@@ -208,7 +208,7 @@ bun run dev
 
 In a separate terminal window, use `curl` to ask the weather agent:
 
-```bash copy
+```bash
 curl -X POST http://localhost:3000/api/agents/weather-agent/generate -H "Content-Type: application/json" -d "{\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather like in Seoul?\"}]}"
 ```
 

--- a/docs/src/content/en/guides/getting-started/next-js.mdx
+++ b/docs/src/content/en/guides/getting-started/next-js.mdx
@@ -31,28 +31,28 @@ Run the following command to [create a new Next.js app](https://nextjs.org/docs/
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npx create-next-app@latest my-nextjs-agent --yes --ts --eslint --tailwind --src-dir --app --turbopack --no-react-compiler --no-import-alias
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm create next-app@latest my-nextjs-agent --yes --ts --eslint --tailwind --src-dir --app --turbopack --no-react-compiler --no-import-alias
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn create next-app@latest my-nextjs-agent --yes --ts --eslint --tailwind --src-dir --app --turbopack --no-react-compiler --no-import-alias
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun create next-app@latest my-nextjs-agent --yes --ts --eslint --tailwind --src-dir --app --turbopack --no-react-compiler --no-import-alias
 ```
 
@@ -70,7 +70,7 @@ When prompted, choose a provider (e.g. OpenAI) and enter your key:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 cd my-nextjs-agent
 npx --force mastra@beta init
 ```
@@ -78,7 +78,7 @@ npx --force mastra@beta init
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 cd my-nextjs-agent
 pnpm dlx mastra@beta init
 ```
@@ -86,7 +86,7 @@ pnpm dlx mastra@beta init
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 cd my-nextjs-agent
 yarn dlx mastra@beta init
 ```
@@ -94,7 +94,7 @@ yarn dlx mastra@beta init
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 cd my-nextjs-agent
 bunx mastra@beta init
 ```
@@ -117,28 +117,28 @@ Install AI SDK UI along with the Mastra adapter:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm install @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm add @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn add @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun add @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
@@ -150,28 +150,28 @@ Next, initialize AI Elements. When prompted, choose the default options:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npx ai-elements@latest
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm dlx ai-elements@latest
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn dlx ai-elements@latest
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bunx ai-elements@latest
 ```
 

--- a/docs/src/content/en/guides/getting-started/quickstart.mdx
+++ b/docs/src/content/en/guides/getting-started/quickstart.mdx
@@ -28,28 +28,28 @@ When prompted, choose a provider (e.g. OpenAI) and enter your key:
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm create mastra@beta
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm create mastra@beta
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn create mastra@beta
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun create mastra@beta
 ```
 

--- a/docs/src/content/en/guides/getting-started/sveltekit.mdx
+++ b/docs/src/content/en/guides/getting-started/sveltekit.mdx
@@ -108,7 +108,7 @@ Modify the `tsconfig.json` file in your project root:
 The `VITE_` prefix is required for environment variables to be accessible in the Vite environment, that SvelteKit uses.
 [Read more about Vite environment variables](https://vite.dev/guide/env-and-mode.html#env-variables).
 
-```bash title=".env" copy
+```bash title=".env"
 VITE_OPENAI_API_KEY=<your-api-key>
 ```
 
@@ -118,7 +118,7 @@ VITE_OPENAI_API_KEY=<your-api-key>
 
 Add `.mastra` to your `.gitignore` file:
 
-```bash title=".gitignore" copy
+```bash title=".gitignore"
 .mastra
 ```
 
@@ -172,7 +172,7 @@ With the Mastra Dev Server running, you can start your SvelteKit site in the usu
 
 <StepItem>
 
-```bash copy
+```bash
 mkdir src/routes/test
 ```
 
@@ -182,11 +182,11 @@ mkdir src/routes/test
 
 Create a new Action, and add the example code:
 
-```bash copy
+```bash
 touch src/routes/test/+page.server.ts
 ```
 
-```typescript title="src/routes/test/+page.server.ts" copy
+```typescript title="src/routes/test/+page.server.ts"
 import type { Actions } from "./$types";
 import { mastra } from "../../mastra";
 
@@ -207,11 +207,11 @@ export const actions = {
 
 Create a new Page file, and add the example code:
 
-```bash copy
+```bash
 touch src/routes/test/+page.svelte
 ```
 
-```typescript title="src/routes/test/+page.svelte" copy
+```typescript title="src/routes/test/+page.svelte"
 <script lang="ts">
 	import type { PageProps} from './$types';
 	let { form }: PageProps = $props();
@@ -338,7 +338,7 @@ Modify the `tsconfig.json` file in your project root:
 The `VITE_` prefix is required for environment variables to be accessible in the Vite environment, that SvelteKit uses.
 [Read more about Vite environment variables](https://vite.dev/guide/env-and-mode.html#env-variables).
 
-```bash title=".env" copy
+```bash title=".env"
 VITE_OPENAI_API_KEY=<your-api-key>
 ```
 
@@ -348,7 +348,7 @@ VITE_OPENAI_API_KEY=<your-api-key>
 
 Add `.mastra` to your `.gitignore` file:
 
-```bash title=".gitignore" copy
+```bash title=".gitignore"
 .mastra
 ```
 
@@ -402,7 +402,7 @@ With the Mastra Dev Server running, you can start your SvelteKit site in the usu
 
 <StepItem>
 
-```bash copy
+```bash
 mkdir src/routes/weather-api
 ```
 
@@ -412,11 +412,11 @@ mkdir src/routes/weather-api
 
 Create a new Endpoint, and add the example code:
 
-```bash copy
+```bash
 touch src/routes/weather-api/+server.ts
 ```
 
-```typescript title="src/routes/weather-api/+server.ts" copy
+```typescript title="src/routes/weather-api/+server.ts"
 import { json } from "@sveltejs/kit";
 import { mastra } from "../../mastra";
 
@@ -437,11 +437,11 @@ export async function POST({ request }) {
 
 Create a new Page, and add the example code:
 
-```bash copy
+```bash
 touch src/routes/weather-api-test/+page.svelte
 ```
 
-```typescript title="src/routes/weather-api-test/+page.svelte" copy
+```typescript title="src/routes/weather-api-test/+page.svelte"
 <script lang="ts">
 	let result = $state<string | null>(null);
 	async function handleFormSubmit(event: Event) {

--- a/docs/src/content/en/guides/getting-started/sveltekit.mdx
+++ b/docs/src/content/en/guides/getting-started/sveltekit.mdx
@@ -186,7 +186,7 @@ Create a new Action, and add the example code:
 touch src/routes/test/+page.server.ts
 ```
 
-```typescript title="src/routes/test/+page.server.ts" showLineNumbers copy
+```typescript title="src/routes/test/+page.server.ts" copy
 import type { Actions } from "./$types";
 import { mastra } from "../../mastra";
 
@@ -211,7 +211,7 @@ Create a new Page file, and add the example code:
 touch src/routes/test/+page.svelte
 ```
 
-```typescript title="src/routes/test/+page.svelte" showLineNumbers copy
+```typescript title="src/routes/test/+page.svelte" copy
 <script lang="ts">
 	import type { PageProps} from './$types';
 	let { form }: PageProps = $props();
@@ -416,7 +416,7 @@ Create a new Endpoint, and add the example code:
 touch src/routes/weather-api/+server.ts
 ```
 
-```typescript title="src/routes/weather-api/+server.ts" showLineNumbers copy
+```typescript title="src/routes/weather-api/+server.ts" copy
 import { json } from "@sveltejs/kit";
 import { mastra } from "../../mastra";
 
@@ -441,7 +441,7 @@ Create a new Page, and add the example code:
 touch src/routes/weather-api-test/+page.svelte
 ```
 
-```typescript title="src/routes/weather-api-test/+page.svelte" showLineNumbers copy
+```typescript title="src/routes/weather-api-test/+page.svelte" copy
 <script lang="ts">
 	let result = $state<string | null>(null);
 	async function handleFormSubmit(event: Event) {

--- a/docs/src/content/en/guides/getting-started/vite-react.mdx
+++ b/docs/src/content/en/guides/getting-started/vite-react.mdx
@@ -27,25 +27,25 @@ Run the following command to [create a new React + Vite app](https://vite.dev/gu
 
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
-```bash copy
+```bash
 npm create vite@latest mastra-react -- --template react-ts
 cd mastra-react
 ```
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
-```bash copy
+```bash
 pnpm create vite mastra-react --template react-ts
 cd mastra-react
 ```
 </TabItem>
 <TabItem value="yarn" label="yarn">
-```bash copy
+```bash
 yarn create vite mastra-react --template react-ts
 cd mastra-react
 ```
 </TabItem>
 <TabItem value="bun" label="bun">
-```bash copy
+```bash
 bun create vite mastra-react --template react-ts
 cd mastra-react
 ```
@@ -60,22 +60,22 @@ Next, install Tailwind:
 
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
-```bash copy
+```bash
 npm install tailwindcss @tailwindcss/vite
 ```
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
-```bash copy
+```bash
 pnpm add tailwindcss @tailwindcss/vite
 ```
 </TabItem>
 <TabItem value="yarn" label="yarn">
-```bash copy
+```bash
 yarn add tailwindcss @tailwindcss/vite
 ```
 </TabItem>
 <TabItem value="bun" label="bun">
-```bash copy
+```bash
 bun add tailwindcss @tailwindcss/vite
 ```
 </TabItem>
@@ -143,7 +143,7 @@ Run [`mastra init`](/reference/v1/cli/create-mastra). When prompted, choose a pr
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 cd mastra-react
 npx mastra@beta init
 ```
@@ -151,7 +151,7 @@ npx mastra@beta init
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 cd mastra-react
 pnpm dlx mastra@beta init
 ```
@@ -159,7 +159,7 @@ pnpm dlx mastra@beta init
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 cd mastra-react
 yarn dlx mastra@beta init
 ```
@@ -167,7 +167,7 @@ yarn dlx mastra@beta init
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 cd mastra-react
 bunx mastra@beta init
 ```
@@ -190,28 +190,28 @@ Install AI SDK UI along with the Mastra adapter:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npm install @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm add @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn add @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun add @mastra/ai-sdk@beta @ai-sdk/react ai
 ```
 
@@ -223,28 +223,28 @@ Next, initialize AI Elements. When prompted, choose the default options:
 <Tabs groupId="pm">
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npx ai-elements@latest
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm dlx ai-elements@latest
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn dlx ai-elements@latest
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bunx ai-elements@latest
 ```
 

--- a/docs/src/content/en/guides/guide/ai-recruiter.mdx
+++ b/docs/src/content/en/guides/guide/ai-recruiter.mdx
@@ -28,7 +28,7 @@ Set up the Workflow, define steps to extract and classify candidate data, and th
 
 Create a new file `src/mastra/workflows/candidate-workflow.ts` and define your workflow:
 
-```ts copy title="src/mastra/workflows/candidate-workflow.ts"
+```ts title="src/mastra/workflows/candidate-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -56,7 +56,7 @@ You want to extract candidate details from the resume text and classify the pers
 
 To the existing `src/mastra/workflows/candidate-workflow.ts` file add the following:
 
-```ts copy title="src/mastra/workflows/candidate-workflow.ts"
+```ts title="src/mastra/workflows/candidate-workflow.ts"
 import { Agent } from "@mastra/core/agent";
 
 const recruiter = new Agent({
@@ -109,7 +109,7 @@ This step prompts a candidate who is identified as "technical" for more informat
 
 To the existing `src/mastra/workflows/candidate-workflow.ts` file add the following:
 
-```ts copy title="src/mastra/workflows/candidate-workflow.ts"
+```ts title="src/mastra/workflows/candidate-workflow.ts"
 const askAboutSpecialty = createStep({
   id: "askAboutSpecialty",
   inputSchema: z.object({
@@ -140,7 +140,7 @@ If the candidate is "non-technical", you want a different follow-up question. Th
 
 To the existing `src/mastra/workflows/candidate-workflow.ts` file add the following:
 
-```ts title="src/mastra/workflows/candidate-workflow.ts" copy
+```ts title="src/mastra/workflows/candidate-workflow.ts"
 const askAboutRole = createStep({
   id: "askAboutRole",
   inputSchema: z.object({
@@ -170,7 +170,7 @@ You now combine the steps to implement branching logic based on the candidate's 
 
 To the existing `src/mastra/workflows/candidate-workflow.ts` file change the `candidateWorkflow` like so:
 
-```ts title="src/mastra/workflows/candidate-workflow.ts" copy {10-14}
+```ts title="src/mastra/workflows/candidate-workflow.ts" {10-14}
 export const candidateWorkflow = createWorkflow({
   id: "candidate-workflow",
   inputSchema: z.object({
@@ -199,7 +199,7 @@ export const candidateWorkflow = createWorkflow({
 
 In your `src/mastra/index.ts` file, register the workflow:
 
-```ts copy title="src/mastra/index.ts" {2, 5}
+```ts title="src/mastra/index.ts" {2, 5}
 import { Mastra } from "@mastra/core";
 import { candidateWorkflow } from "./workflows/candidate-workflow";
 
@@ -216,13 +216,13 @@ export const mastra = new Mastra({
 
 You can test your workflow inside [Studio](/docs/v1/getting-started/studio) by starting the development server:
 
-```bash copy
+```bash
 mastra dev
 ```
 
 In the sidebar, navigate to **Workflows** and select **candidate-workflow**. In the middle you'll see a graph view of your workflow and on the right sidebar the **Run** tab is selected by default. Inside this tab you can enter a resume text, for example:
 
-```text copy
+```text
 Knowledgeable Software Engineer with more than 10 years of experience in software development. Proven expertise in the design and development of software databases and optimization of user interfaces.
 ```
 
@@ -230,7 +230,7 @@ After entering the resume text, press the **Run** button. You should now see two
 
 You can also test the workflow programmatically by calling [`.createRun()`](/reference/v1/workflows/workflow-methods/create-run) and [`.start()`](/reference/v1/workflows/run-methods/start). Create a new file `src/test-workflow.ts` and add the following:
 
-```ts copy title="src/test-workflow.ts"
+```ts title="src/test-workflow.ts"
 import { mastra } from "./mastra";
 
 const run = await mastra.getWorkflow("candidateWorkflow").createRun();
@@ -256,7 +256,7 @@ if (res.status === "success") {
 
 Now, run the workflow and get output in your terminal:
 
-```bash copy
+```bash
 npx tsx src/test-workflow.ts
 ```
 

--- a/docs/src/content/en/guides/guide/chef-michel.mdx
+++ b/docs/src/content/en/guides/guide/chef-michel.mdx
@@ -31,7 +31,7 @@ To create an agent in Mastra use the `Agent` class to define it and then registe
 
 Create a new file `src/mastra/agents/chefAgent.ts` and define your agent:
 
-```ts copy title="src/mastra/agents/chefAgent.ts"
+```ts title="src/mastra/agents/chefAgent.ts"
 import { Agent } from "@mastra/core/agent";
 
 export const chefAgent = new Agent({
@@ -50,7 +50,7 @@ export const chefAgent = new Agent({
 
 In your `src/mastra/index.ts` file, register the agent:
 
-```ts copy title="src/mastra/index.ts" {2, 5}
+```ts title="src/mastra/index.ts" {2, 5}
 import { Mastra } from "@mastra/core";
 import { chefAgent } from "./agents/chefAgent";
 
@@ -73,7 +73,7 @@ Depending on your requirements you can interact and get responses from the agent
 
 Create a new file `src/index.ts` and add a `main()` function to it. Inside, craft a query to ask the agent and log its response.
 
-```ts copy title="src/index.ts"
+```ts title="src/index.ts"
 import { chefAgent } from "./mastra/agents/chefAgent";
 
 async function main() {
@@ -90,7 +90,7 @@ main();
 
 Afterwards, run the script:
 
-```bash copy
+```bash
 npx bun src/index.ts
 ```
 
@@ -108,7 +108,7 @@ Query: In my kitchen I have: pasta, canned tomatoes, garlic, olive oil, and some
 
 In the previous example you might have waited a bit for the response without any sign of progress. To show the agent's output as it creates it you should instead stream its response to the terminal.
 
-```ts copy title="src/index.ts"
+```ts title="src/index.ts"
 import { chefAgent } from "./mastra/agents/chefAgent";
 
 async function main() {
@@ -132,7 +132,7 @@ main();
 
 Afterwards, run the script again:
 
-```bash copy
+```bash
 npx bun src/index.ts
 ```
 
@@ -155,7 +155,7 @@ Instead of showing the agent's response to a human you might want to pass it alo
 
 Change your `src/index.ts` to the following:
 
-```ts copy title="src/index.ts"
+```ts title="src/index.ts"
 import { chefAgent } from "./mastra/agents/chefAgent";
 import { z } from "zod";
 
@@ -222,7 +222,7 @@ Learn how to interact with your agent through Mastra's API.
 
 You can run your agent as a service using the `mastra dev` command:
 
-```bash copy
+```bash
 mastra dev
 ```
 
@@ -244,7 +244,7 @@ POST http://localhost:4111/api/agents/chefAgent/generate
 
 You can interact with the agent using `curl` from the command line:
 
-```bash copy
+```bash
 curl -X POST http://localhost:4111/api/agents/chefAgent/generate \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/src/content/en/guides/guide/notes-mcp-server.mdx
+++ b/docs/src/content/en/guides/guide/notes-mcp-server.mdx
@@ -30,7 +30,7 @@ Before you can create an MCP server you first need to install additional depende
 
 Add `@mastra/mcp` to your project:
 
-```bash copy
+```bash
 npm install @mastra/mcp@beta
 ```
 
@@ -40,13 +40,13 @@ npm install @mastra/mcp@beta
 
 After following the default [installation guide](/guides/v1/getting-started/quickstart) your project will include files that are not relevant for this guide. You can safely remove them:
 
-```bash copy
+```bash
 rm -rf src/mastra/agents src/mastra/workflows src/mastra/tools/weather-tool.ts
 ```
 
 You should also change the `src/mastra/index.ts` file like so:
 
-```ts copy title="src/mastra/index.ts"
+```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { PinoLogger } from "@mastra/loggers";
 import { LibSQLStore } from "@mastra/libsql";
@@ -70,13 +70,13 @@ export const mastra = new Mastra({
 
 Create a dedicated directory for your MCP server's logic and a `notes` directory for your notes:
 
-```bash copy
+```bash
 mkdir notes src/mastra/mcp
 ```
 
 Create the following files:
 
-```bash copy
+```bash
 touch src/mastra/mcp/{server,resources,prompts}.ts
 ```
 
@@ -113,7 +113,7 @@ Let's add the MCP server!
 
 In `src/mastra/mcp/server.ts`, define the MCP server instance:
 
-```typescript copy title="src/mastra/mcp/server.ts"
+```typescript title="src/mastra/mcp/server.ts"
 import { MCPServer } from "@mastra/mcp";
 
 export const notes = new MCPServer({
@@ -126,7 +126,7 @@ export const notes = new MCPServer({
 
 Register this MCP server in your Mastra instance at `src/mastra/index.ts`. The key `notes` is the public identifier for your MCP server:
 
-```typescript copy title="src/mastra/index.ts" {4, 15-17}
+```typescript title="src/mastra/index.ts" {4, 15-17}
 import { Mastra } from "@mastra/core";
 import { PinoLogger } from "@mastra/loggers";
 import { LibSQLStore } from "@mastra/libsql";
@@ -154,7 +154,7 @@ export const mastra = new Mastra({
 
 Resource handlers allow clients to discover and read the content your server manages. Implement handlers to work with markdown files in the `notes` directory. Add to the `src/mastra/mcp/resources.ts` file:
 
-```typescript copy title="src/mastra/mcp/resources.ts"
+```typescript title="src/mastra/mcp/resources.ts"
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -210,7 +210,7 @@ export const resourceHandlers: MCPServerResources = {
 
 Register these resource handlers in `src/mastra/mcp/server.ts`:
 
-```typescript copy title="src/mastra/mcp/server.ts" {2, 8}
+```typescript title="src/mastra/mcp/server.ts" {2, 8}
 import { MCPServer } from "@mastra/mcp";
 import { resourceHandlers } from "./resources";
 
@@ -230,7 +230,7 @@ export const notes = new MCPServer({
 Tools are the actions your server can perform. Let's create a `write` tool.
 First, define the tool in `src/mastra/tools/write-note.ts`:
 
-```typescript copy title="src/mastra/tools/write-note.ts"
+```typescript title="src/mastra/tools/write-note.ts"
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { fileURLToPath } from "url";
@@ -271,7 +271,7 @@ export const writeNoteTool = createTool({
 
 Register this tool in `src/mastra/mcp/server.ts`:
 
-```typescript copy title="src/mastra/mcp/server.ts"
+```typescript title="src/mastra/mcp/server.ts"
 import { MCPServer } from "@mastra/mcp";
 import { resourceHandlers } from "./resources";
 import { writeNoteTool } from "../tools/write-note";
@@ -299,13 +299,13 @@ Prompt handlers provide ready-to-use prompts for clients. You'll add these three
 
 This requires a few markdown-parsing libraries you need to install:
 
-```bash copy
+```bash
 npm install unified remark-parse gray-matter @types/unist
 ```
 
 Implement the prompts in `src/mastra/mcp/prompts.ts`:
 
-```typescript copy title="src/mastra/mcp/prompts.ts"
+```typescript title="src/mastra/mcp/prompts.ts"
 import type { MCPServerPrompts } from "@mastra/mcp";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
@@ -413,7 +413,7 @@ export const promptHandlers: MCPServerPrompts = {
 
 Register these prompt handlers in `src/mastra/mcp/server.ts`:
 
-```typescript copy title="src/mastra/mcp/server.ts"
+```typescript title="src/mastra/mcp/server.ts"
 import { MCPServer } from "@mastra/mcp";
 import { resourceHandlers } from "./resources";
 import { writeNoteTool } from "../tools/write-note";
@@ -439,7 +439,7 @@ export const notes = new MCPServer({
 
 Great, you've authored your first MCP server! Now you can try it out by starting the Mastra dev server and opening [Studio](/docs/v1/getting-started/studio):
 
-```bash copy
+```bash
 npm run dev
 ```
 

--- a/docs/src/content/en/guides/guide/research-assistant.mdx
+++ b/docs/src/content/en/guides/guide/research-assistant.mdx
@@ -59,7 +59,7 @@ Install additional dependencies
 
 After running the [installation guide](/guides/v1/getting-started/quickstart) you'll need to install additional dependencies:
 
-```bash copy
+```bash
 npm install @mastra/rag@beta ai@^4.0.0
 ```
 </StepItem>
@@ -74,7 +74,7 @@ Now you'll create your RAG-enabled research assistant. The agent uses:
 
 Create a new file `src/mastra/agents/researchAgent.ts` and define your agent:
 
-```ts copy title="src/mastra/agents/researchAgent.ts"
+```ts title="src/mastra/agents/researchAgent.ts"
 import { Agent } from "@mastra/core/agent";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
 import { createVectorQueryTool } from "@mastra/rag";
@@ -114,7 +114,7 @@ In the root of your project, grab the absolute path with the `pwd` command. The 
 
 In your `src/mastra/index.ts` file, add the following to your existing file and configuration:
 
-```ts copy title="src/mastra/index.ts" {2, 4-6, 9}
+```ts title="src/mastra/index.ts" {2, 4-6, 9}
 import { Mastra } from "@mastra/core";
 import { LibSQLVector } from "@mastra/libsql";
 
@@ -144,7 +144,7 @@ use a remote persistent database then.
 
 In the `src/mastra/index.ts` file, add the agent to Mastra:
 
-```ts copy title="src/mastra/index.ts" {3, 10}
+```ts title="src/mastra/index.ts" {3, 10}
 import { Mastra } from "@mastra/core";
 import { LibSQLVector } from "@mastra/libsql";
 import { researchAgent } from "./agents/researchAgent";
@@ -176,7 +176,7 @@ In this step the research paper is retrieved by providing an URL, then converted
 
 Create a new file `src/store.ts` and add the following:
 
-```ts copy title="src/store.ts"
+```ts title="src/store.ts"
 import { MDocument } from "@mastra/rag";
 
 // Load the paper
@@ -198,7 +198,7 @@ console.log("Number of chunks:", chunks.length);
 
 Run the file in your terminal:
 
-```bash copy
+```bash
 npx bun src/store.ts
 ```
 
@@ -229,7 +229,7 @@ This allows the agent to efficiently search and retrieve relevant information.
 
 Open the `src/store.ts` file and add the following:
 
-```ts copy title="src/store.ts"
+```ts title="src/store.ts"
 import { MDocument } from "@mastra/rag";
 import { embedMany } from "ai";
 import { mastra } from "./mastra";
@@ -276,7 +276,7 @@ await vectorStore.upsert({
 
 Lastly, you'll now need to store the embeddings by running the script again:
 
-```bash copy
+```bash
 npx bun src/store.ts
 ```
 
@@ -292,7 +292,7 @@ Now that the vector database has all embeddings, you can test the research assis
 
 Create a new file `src/ask-agent.ts` and add different types of queries:
 
-```ts title="src/ask-agent.ts" copy
+```ts title="src/ask-agent.ts"
 import { mastra } from "./mastra";
 const agent = mastra.getAgent("researchAgent");
 
@@ -306,7 +306,7 @@ console.log("Response:", response1.text);
 
 Run the script:
 
-```bash copy
+```bash
 npx bun src/ask-agent.ts
 ```
 
@@ -323,7 +323,7 @@ Response: Sequence modeling with neural networks faces several key challenges:
 
 Try another question:
 
-```ts title="src/ask-agent.ts" copy
+```ts title="src/ask-agent.ts"
 import { mastra } from "./mastra";
 const agent = mastra.getAgent("researchAgent");
 

--- a/docs/src/content/en/guides/guide/stock-agent.mdx
+++ b/docs/src/content/en/guides/guide/stock-agent.mdx
@@ -29,7 +29,7 @@ To create an agent in Mastra use the `Agent` class to define it and then registe
 
 Create a new file `src/mastra/agents/stockAgent.ts` and define your agent:
 
-```ts copy title="src/mastra/agents/stockAgent.ts"
+```ts title="src/mastra/agents/stockAgent.ts"
 import { Agent } from "@mastra/core/agent";
 
 export const stockAgent = new Agent({
@@ -47,7 +47,7 @@ export const stockAgent = new Agent({
 
 In your `src/mastra/index.ts` file, register the agent:
 
-```ts copy title="src/mastra/index.ts" {2, 5}
+```ts title="src/mastra/index.ts" {2, 5}
 import { Mastra } from "@mastra/core";
 import { stockAgent } from "./agents/stockAgent";
 
@@ -103,7 +103,7 @@ export const stockPrices = createTool({
 
 Inside `src/mastra/agents/stockAgent.ts` import your newly created `stockPrices` tool and add it to the agent.
 
-```ts copy title="src/mastra/agents/stockAgent.ts" {9-11}
+```ts title="src/mastra/agents/stockAgent.ts" {9-11}
 import { Agent } from "@mastra/core/agent";
 import { stockPrices } from "../tools/stockPrices";
 
@@ -133,7 +133,7 @@ Learn how to interact with your agent through Mastra's API.
 
 You can run your agent as a service using the `mastra dev` command:
 
-```bash copy
+```bash
 mastra dev
 ```
 
@@ -155,7 +155,7 @@ POST http://localhost:4111/api/agents/stockAgent/generate
 
 You can interact with the agent using `curl` from the command line:
 
-```bash copy
+```bash
 curl -X POST http://localhost:4111/api/agents/stockAgent/generate \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/src/content/en/guides/guide/web-search.mdx
+++ b/docs/src/content/en/guides/guide/web-search.mdx
@@ -140,7 +140,7 @@ Setup the tool:
 
 In your `src/mastra/index.ts` file, register the agent:
 
-```ts copy title="src/mastra/index.ts" {2, 5}
+```ts title="src/mastra/index.ts" {2, 5}
 import { Mastra } from "@mastra/core";
 import { searchAgent } from "./agents/searchAgent";
 
@@ -155,7 +155,7 @@ export const mastra = new Mastra({
 
 You can test your agent with [Studio](/docs/v1/getting-started/studio) using the `mastra dev` command:
 
-```bash copy
+```bash
 mastra dev
 ```
 
@@ -175,7 +175,7 @@ For more control over search behavior, you can integrate external search APIs as
 
 Install dependencies
 
-```bash copy
+```bash
 npm install exa-js
 ```
 
@@ -185,7 +185,7 @@ npm install exa-js
 
 Create a new file `src/mastra/agents/searchAgent.ts` and define your agent:
 
-```ts copy title="src/mastra/agents/searchAgent.ts"
+```ts title="src/mastra/agents/searchAgent.ts"
 import { Agent } from "@mastra/core/agent";
 
 export const searchAgent = new Agent({
@@ -203,7 +203,7 @@ export const searchAgent = new Agent({
 
 Setup the tool
 
-```ts copy title="src/mastra/tools/searchTool.ts"
+```ts title="src/mastra/tools/searchTool.ts"
 import { createTool } from "@mastra/core/tools";
 import z from "zod";
 import Exa from "exa-js";
@@ -246,7 +246,7 @@ export const webSearch = createTool({
 
 Add to your Agent
 
-```ts copy title="src/mastra/agents/searchAgent.ts"
+```ts title="src/mastra/agents/searchAgent.ts"
 import { webSearch } from "./tools/searchTool";
 
 export const searchAgent = new Agent({
@@ -267,7 +267,7 @@ export const searchAgent = new Agent({
 
 In your `src/mastra/index.ts` file, register the agent:
 
-```ts copy title="src/mastra/index.ts" {2, 5}
+```ts title="src/mastra/index.ts" {2, 5}
 import { Mastra } from "@mastra/core";
 import { searchAgent } from "./agents/searchAgent";
 
@@ -282,7 +282,7 @@ export const mastra = new Mastra({
 
 You can test your agent with [Studio](/docs/v1/getting-started/studio) using the `mastra dev` command:
 
-```bash copy
+```bash
 mastra dev
 ```
 

--- a/docs/src/content/en/guides/guide/whatsapp-chat-bot.mdx
+++ b/docs/src/content/en/guides/guide/whatsapp-chat-bot.mdx
@@ -23,7 +23,7 @@ WHATSAPP_API_VERSION=v22.0
 
 This client handles sending messages to users via the WhatsApp Business API.
 
-```typescript title="src/whatsapp-client.ts" showLineNumbers copy
+```typescript title="src/whatsapp-client.ts" copy
 // Simple WhatsApp Business API client for sending messages
 
 interface SendMessageParams {
@@ -87,7 +87,7 @@ export async function sendWhatsAppMessage({ to, message }: SendMessageParams) {
 
 This agent handles the main conversation logic with a friendly, conversational personality.
 
-```typescript title="src/mastra/agents/chat-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/chat-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -136,7 +136,7 @@ export const chatAgent = new Agent({
 
 This agent converts longer responses into natural, bite-sized text messages suitable for WhatsApp.
 
-```typescript title="src/mastra/agents/text-message-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/text-message-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -174,7 +174,7 @@ export const textMessageAgent = new Agent({
 
 This workflow orchestrates the entire chat process: generating a response, breaking it into messages, and sending them via WhatsApp.
 
-```typescript title="src/mastra/workflows/chat-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/chat-workflow.ts" copy
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 import { sendWhatsAppMessage } from "../../whatsapp-client";
@@ -300,7 +300,7 @@ chatWorkflow.commit();
 
 Configure your Mastra instance with the agents, workflow, and WhatsApp webhook endpoints.
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { registerApiRoute } from "@mastra/core/server";
 import { PinoLogger } from "@mastra/loggers";
@@ -365,7 +365,7 @@ export const mastra = new Mastra({
 
 You can test the chat bot locally by simulating a WhatsApp webhook payload.
 
-```typescript title="src/test-whatsapp-bot.ts" showLineNumbers copy
+```typescript title="src/test-whatsapp-bot.ts" copy
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/guides/guide/whatsapp-chat-bot.mdx
+++ b/docs/src/content/en/guides/guide/whatsapp-chat-bot.mdx
@@ -11,7 +11,7 @@ This guide demonstrates how to create a WhatsApp chat bot using Mastra agents an
 
 This example requires a WhatsApp Business API setup and uses the `anthropic` model. Add these environment variables to your `.env` file:
 
-```bash title=".env" copy
+```bash title=".env"
 ANTHROPIC_API_KEY=<your-anthropic-api-key>
 WHATSAPP_VERIFY_TOKEN=<your-verify-token>
 WHATSAPP_ACCESS_TOKEN=<your-whatsapp-access-token>
@@ -23,7 +23,7 @@ WHATSAPP_API_VERSION=v22.0
 
 This client handles sending messages to users via the WhatsApp Business API.
 
-```typescript title="src/whatsapp-client.ts" copy
+```typescript title="src/whatsapp-client.ts"
 // Simple WhatsApp Business API client for sending messages
 
 interface SendMessageParams {
@@ -87,7 +87,7 @@ export async function sendWhatsAppMessage({ to, message }: SendMessageParams) {
 
 This agent handles the main conversation logic with a friendly, conversational personality.
 
-```typescript title="src/mastra/agents/chat-agent.ts" copy
+```typescript title="src/mastra/agents/chat-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -136,7 +136,7 @@ export const chatAgent = new Agent({
 
 This agent converts longer responses into natural, bite-sized text messages suitable for WhatsApp.
 
-```typescript title="src/mastra/agents/text-message-agent.ts" copy
+```typescript title="src/mastra/agents/text-message-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
@@ -174,7 +174,7 @@ export const textMessageAgent = new Agent({
 
 This workflow orchestrates the entire chat process: generating a response, breaking it into messages, and sending them via WhatsApp.
 
-```typescript title="src/mastra/workflows/chat-workflow.ts" copy
+```typescript title="src/mastra/workflows/chat-workflow.ts"
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 import { sendWhatsAppMessage } from "../../whatsapp-client";
@@ -300,7 +300,7 @@ chatWorkflow.commit();
 
 Configure your Mastra instance with the agents, workflow, and WhatsApp webhook endpoints.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { registerApiRoute } from "@mastra/core/server";
 import { PinoLogger } from "@mastra/loggers";
@@ -365,7 +365,7 @@ export const mastra = new Mastra({
 
 You can test the chat bot locally by simulating a WhatsApp webhook payload.
 
-```typescript title="src/test-whatsapp-bot.ts" copy
+```typescript title="src/test-whatsapp-bot.ts"
 import "dotenv/config";
 
 import { mastra } from "./mastra";

--- a/docs/src/content/en/guides/migrations/ai-sdk-v4-to-v5.mdx
+++ b/docs/src/content/en/guides/migrations/ai-sdk-v4-to-v5.mdx
@@ -45,7 +45,7 @@ When using tools with TypeScript in AI SDK v5, Mastra provides type inference he
 
 The `InferUITool` type helper infers the input and output types of a single Mastra tool:
 
-```typescript title="app/types.ts" copy
+```typescript title="app/types.ts"
 import { InferUITool, createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
@@ -80,7 +80,7 @@ type WeatherUITool = InferUITool<typeof weatherTool>;
 
 The `InferUITools` type helper infers the input and output types of multiple tools:
 
-```typescript title="app/mastra/tools.ts" copy
+```typescript title="app/mastra/tools.ts"
 import { InferUITools, createTool } from "@mastra/core/tools";
 import { z } from "zod";
 

--- a/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
+++ b/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
@@ -106,7 +106,7 @@ See the following API references for more information:
 
 No `format` option: Always return AI SDK v4 types
 
-```typescript copy
+```typescript
 // Mastra native format (default)
 const result = await agent.stream(messages);
 ```
@@ -118,7 +118,7 @@ Use `format` option to choose output:
 - `'mastra'` (default)
 - `'aisdk'` (AI SDK v5 compatible)
 
-```typescript copy
+```typescript
 // AI SDK v5 compatibility
 const result = await agent.stream(messages, {
   format: "aisdk",

--- a/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
+++ b/docs/src/content/en/guides/migrations/vnext-to-standard-apis.mdx
@@ -106,7 +106,7 @@ See the following API references for more information:
 
 No `format` option: Always return AI SDK v4 types
 
-```typescript showLineNumbers copy
+```typescript copy
 // Mastra native format (default)
 const result = await agent.stream(messages);
 ```
@@ -118,7 +118,7 @@ Use `format` option to choose output:
 - `'mastra'` (default)
 - `'aisdk'` (AI SDK v5 compatible)
 
-```typescript showLineNumbers copy
+```typescript copy
 // AI SDK v5 compatibility
 const result = await agent.stream(messages, {
   format: "aisdk",
@@ -131,7 +131,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `format` - Choose between 'mastra' or 'aisdk' output format:
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     format: "aisdk", // or 'mastra' (default)
   });
@@ -139,7 +139,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `system` - Custom system message (separate from instructions).
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     system: "You are a helpful assistant",
   });
@@ -153,7 +153,7 @@ The following options are available in the standard `.stream()` and `generate()`
     - 'error' - throw an error
     - 'fallback' - return a fallback value you provide
 
-    ```typescript showLineNumbers copy
+    ```typescript copy
     const result = await agent.generate(messages, {
       structuredOutput: {
         schema: z.object({
@@ -170,7 +170,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `stopWhen` - Flexible stop conditions (step count, token limit, etc).
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     stopWhen: ({ steps, totalTokens }) => steps >= 5 || totalTokens >= 10000,
   });
@@ -178,7 +178,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `providerOptions` - Provider-specific options (e.g., OpenAI-specific settings)
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     providerOptions: {
       openai: {
@@ -191,7 +191,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `onChunk` - Callback for each streaming chunk.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     onChunk: (chunk) => {
       console.log("Received chunk:", chunk);
@@ -201,7 +201,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `onError` - Error callback.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     onError: (error) => {
       console.error("Stream error:", error);
@@ -211,7 +211,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `onAbort` - Abort callback.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     onAbort: () => {
       console.log("Stream aborted");
@@ -221,7 +221,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `activeTools` - Specify which tools are active for this execution.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     activeTools: ["search", "calculator"], // Only these tools will be available
   });
@@ -229,7 +229,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `abortSignal` - AbortSignal for cancellation.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const controller = new AbortController();
   const result = await agent.stream(messages, {
     abortSignal: controller.signal,
@@ -240,7 +240,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `prepareStep` - Callback before each step in multi-step execution.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     prepareStep: ({ step, state }) => {
       console.log("About to execute step:", step);
@@ -253,7 +253,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
 - `requireToolApproval` - Require approval for all tool calls.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     requireToolApproval: true,
   });
@@ -265,7 +265,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
   Unified in `modelSettings`
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     modelSettings: {
       temperature: 0.7,
@@ -279,7 +279,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
   Moved to memory object.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.stream(messages, {
     memory: {
       resource: "user-123",
@@ -294,7 +294,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
   Use `structuredOutput` instead to allow for tool calls and an object return.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.generate(messages, {
     structuredOutput: {
       schema: z.object({
@@ -309,7 +309,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
   The `output` property is deprecated in favor of `structuredOutput`, to achieve the same results, omit the model and only pass `structuredOutput.schema`, optionally add `jsonPromptInjection: true` if your model does not natively support `response_format`.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.generate(messages, {
     structuredOutput: {
       schema: {
@@ -325,7 +325,7 @@ The following options are available in the standard `.stream()` and `generate()`
 
   Use `memory` instead.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   const result = await agent.generate(messages, {
     memory: {
       // ...
@@ -350,7 +350,7 @@ See the following API references for more information:
 
   `toolChoice` uses the AI SDK v5 `ToolChoice` type.
 
-  ```typescript showLineNumbers copy
+  ```typescript copy
   type ToolChoice<TOOLS extends Record<string, unknown>> =
     | "auto"
     | "none"

--- a/docs/src/content/en/models/index.mdx
+++ b/docs/src/content/en/models/index.mdx
@@ -32,7 +32,7 @@ Mastra reads the relevant environment variable (e.g. `ANTHROPIC_API_KEY`) and ro
 
 <Tabs>
   <TabItem value="OpenAI" label="OpenAI">
-    ```typescript copy showLineNumbers
+    ```typescript copy
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -44,7 +44,7 @@ Mastra reads the relevant environment variable (e.g. `ANTHROPIC_API_KEY`) and ro
     ```
   </TabItem>
   <TabItem value="Anthropic" label="Anthropic">
-    ```typescript copy showLineNumbers
+    ```typescript copy
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -56,7 +56,7 @@ Mastra reads the relevant environment variable (e.g. `ANTHROPIC_API_KEY`) and ro
     ```
   </TabItem>
   <TabItem value="Google Gemini" label="Google Gemini">
-    ```typescript copy showLineNumbers
+    ```typescript copy
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -68,7 +68,7 @@ Mastra reads the relevant environment variable (e.g. `ANTHROPIC_API_KEY`) and ro
     ```
   </TabItem>
   <TabItem value="xAI" label="xAI">
-    ```typescript copy showLineNumbers
+    ```typescript copy
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -80,7 +80,7 @@ Mastra reads the relevant environment variable (e.g. `ANTHROPIC_API_KEY`) and ro
     ```
   </TabItem>
   <TabItem value="OpenRouter" label="OpenRouter">
-    ```typescript copy showLineNumbers
+    ```typescript copy
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -160,7 +160,7 @@ In development, we auto-refresh your local model list every hour, ensuring your 
 
 Some models are faster but less capable, while others offer larger context windows or stronger reasoning skills. Use different models from the same provider, or mix and match across providers to fit each task.
 
-```typescript showLineNumbers
+```typescript
 import { Agent } from "@mastra/core/agent";
 
 // Use a cost-effective model for document processing
@@ -183,7 +183,7 @@ const reasoningAgent = new Agent({
 
 Since models are just strings, you can select them dynamically based on [request context](/docs/v1/server/request-context), variables, or any other logic.
 
-```typescript showLineNumbers
+```typescript
 const agent = new Agent({
   id: "dynamic-assistant",
   name: "Dynamic Assistant",
@@ -205,7 +205,7 @@ This enables powerful patterns:
 
 Different model providers expose their own configuration options. With OpenAI, you might adjust the `reasoningEffort`. With Anthropic, you might tune `cacheControl`. Mastra lets you set these specific `providerOptions` either at the agent level or per message.
 
-```typescript showLineNumbers
+```typescript
 // Agent level (apply to all future messages)
 const planner = new Agent({
   id: "planner",
@@ -240,7 +240,7 @@ const highEffort = await planner.generate([
 If you need to specify custom headers, such as an organization ID or other provider-specific fields, use this syntax.
 
 
-```typescript showLineNumbers
+```typescript
 const agent = new Agent({
   id: "custom-agent",
   name: "Custom Agent",
@@ -265,7 +265,7 @@ Configuration differs by provider. See the provider pages in the left navigation
 Relying on a single model creates a single point of failure for your application. Model fallbacks provide automatic failover between models and providers. If the primary model becomes unavailable, requests are retried against the next configured fallback until one succeeds.
 
 
-```typescript showLineNumbers
+```typescript
 import { Agent } from '@mastra/core/agent';
 
 const agent = new Agent({
@@ -297,7 +297,7 @@ Your users never experience the disruption - the response comes back with the sa
 Mastra supports AI SDK provider modules, should you need to use them directly.
 
 
-```typescript showLineNumbers
+```typescript
 import { groq } from '@ai-sdk/groq';
 import { Agent } from "@mastra/core/agent";
 

--- a/docs/src/content/en/models/providers/aihubmix.mdx
+++ b/docs/src/content/en/models/providers/aihubmix.mdx
@@ -15,6 +15,6 @@ To use this provider with Mastra agents, see the [Agent Overview documentation](
 
 ## Installation
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @aihubmix/ai-sdk-provider
 ```

--- a/docs/src/content/en/models/providers/amazon-bedrock.mdx
+++ b/docs/src/content/en/models/providers/amazon-bedrock.mdx
@@ -15,6 +15,6 @@ To use this provider with Mastra agents, see the [Agent Overview documentation](
 
 ## Installation
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/amazon-bedrock
 ```

--- a/docs/src/content/en/models/providers/anthropic.mdx
+++ b/docs/src/content/en/models/providers/anthropic.mdx
@@ -387,7 +387,7 @@ const response = await agent.generate("Hello!", {
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/anthropic) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/anthropic
 ```
 

--- a/docs/src/content/en/models/providers/azure.mdx
+++ b/docs/src/content/en/models/providers/azure.mdx
@@ -15,6 +15,6 @@ To use this provider with Mastra agents, see the [Agent Overview documentation](
 
 ## Installation
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/azure
 ```

--- a/docs/src/content/en/models/providers/cerebras.mdx
+++ b/docs/src/content/en/models/providers/cerebras.mdx
@@ -127,7 +127,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/cerebras) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/cerebras
 ```
 

--- a/docs/src/content/en/models/providers/cloudflare-workers-ai.mdx
+++ b/docs/src/content/en/models/providers/cloudflare-workers-ai.mdx
@@ -15,6 +15,6 @@ To use this provider with Mastra agents, see the [Agent Overview documentation](
 
 ## Installation
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install workers-ai-provider
 ```

--- a/docs/src/content/en/models/providers/cohere.mdx
+++ b/docs/src/content/en/models/providers/cohere.mdx
@@ -15,6 +15,6 @@ To use this provider with Mastra agents, see the [Agent Overview documentation](
 
 ## Installation
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/cohere
 ```

--- a/docs/src/content/en/models/providers/deepinfra.mdx
+++ b/docs/src/content/en/models/providers/deepinfra.mdx
@@ -163,7 +163,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/deepinfra) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/deepinfra
 ```
 

--- a/docs/src/content/en/models/providers/google-vertex.mdx
+++ b/docs/src/content/en/models/providers/google-vertex.mdx
@@ -15,6 +15,6 @@ To use this provider with Mastra agents, see the [Agent Overview documentation](
 
 ## Installation
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/google-vertex
 ```

--- a/docs/src/content/en/models/providers/google.mdx
+++ b/docs/src/content/en/models/providers/google.mdx
@@ -465,7 +465,7 @@ const response = await agent.generate("Hello!", {
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/google) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/google
 ```
 

--- a/docs/src/content/en/models/providers/groq.mdx
+++ b/docs/src/content/en/models/providers/groq.mdx
@@ -295,7 +295,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/groq) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/groq
 ```
 

--- a/docs/src/content/en/models/providers/kimi-for-coding.mdx
+++ b/docs/src/content/en/models/providers/kimi-for-coding.mdx
@@ -103,7 +103,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/anthropic) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/anthropic
 ```
 

--- a/docs/src/content/en/models/providers/minimax-cn.mdx
+++ b/docs/src/content/en/models/providers/minimax-cn.mdx
@@ -103,7 +103,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/anthropic) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/anthropic
 ```
 

--- a/docs/src/content/en/models/providers/minimax.mdx
+++ b/docs/src/content/en/models/providers/minimax.mdx
@@ -103,7 +103,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/anthropic) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/anthropic
 ```
 

--- a/docs/src/content/en/models/providers/mistral.mdx
+++ b/docs/src/content/en/models/providers/mistral.mdx
@@ -385,7 +385,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/mistral) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/mistral
 ```
 

--- a/docs/src/content/en/models/providers/ollama.mdx
+++ b/docs/src/content/en/models/providers/ollama.mdx
@@ -15,6 +15,6 @@ To use this provider with Mastra agents, see the [Agent Overview documentation](
 
 ## Installation
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install ollama-ai-provider-v2
 ```

--- a/docs/src/content/en/models/providers/openai.mdx
+++ b/docs/src/content/en/models/providers/openai.mdx
@@ -687,7 +687,7 @@ const response = await agent.generate("Hello!", {
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/openai) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/openai
 ```
 

--- a/docs/src/content/en/models/providers/perplexity.mdx
+++ b/docs/src/content/en/models/providers/perplexity.mdx
@@ -132,7 +132,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/perplexity) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/perplexity
 ```
 

--- a/docs/src/content/en/models/providers/togetherai.mdx
+++ b/docs/src/content/en/models/providers/togetherai.mdx
@@ -211,7 +211,7 @@ const agent = new Agent({
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/togetherai) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/togetherai
 ```
 

--- a/docs/src/content/en/models/providers/xai.mdx
+++ b/docs/src/content/en/models/providers/xai.mdx
@@ -387,7 +387,7 @@ const response = await agent.generate("Hello!", {
 
 This provider can also be installed directly as a standalone package, which can be used instead of the Mastra model router string. View the [package documentation](https://www.npmjs.com/package/@ai-sdk/xai) for more details.
 
-```bash npm2yarn copy
+```bash npm2yarn
 npm install @ai-sdk/xai
 ```
 

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -11,7 +11,7 @@ The `Agent` class is the foundation for creating AI agents in Mastra. It provide
 
 ### Basic string instructions
 
-```typescript title="src/mastra/agents/string-agent.ts" copy
+```typescript title="src/mastra/agents/string-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 // String instructions
@@ -49,7 +49,7 @@ export const agent3 = new Agent({
 
 Use CoreSystemMessage format to access additional properties like `providerOptions` for provider-specific configurations:
 
-```typescript title="src/mastra/agents/core-message-agent.ts" copy
+```typescript title="src/mastra/agents/core-message-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 export const agent = new Agent({
@@ -71,7 +71,7 @@ export const agent = new Agent({
 
 ### Multiple CoreSystemMessages
 
-```typescript title="src/mastra/agents/multi-message-agent.ts" copy
+```typescript title="src/mastra/agents/multi-message-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
 // This could be customizable based on the user

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -11,7 +11,7 @@ The `Agent` class is the foundation for creating AI agents in Mastra. It provide
 
 ### Basic string instructions
 
-```typescript title="src/mastra/agents/string-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/string-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 
 // String instructions
@@ -49,7 +49,7 @@ export const agent3 = new Agent({
 
 Use CoreSystemMessage format to access additional properties like `providerOptions` for provider-specific configurations:
 
-```typescript title="src/mastra/agents/core-message-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/core-message-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 
 export const agent = new Agent({
@@ -71,7 +71,7 @@ export const agent = new Agent({
 
 ### Multiple CoreSystemMessages
 
-```typescript title="src/mastra/agents/multi-message-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/multi-message-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 
 // This could be customizable based on the user

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -11,7 +11,7 @@ The `.generate()` method enables non-streaming response generation from an agent
 
 ## Usage example
 
-```typescript copy
+```typescript
 // Default Mastra format
 const mastraResult = await agent.generate("message for agent");
 

--- a/docs/src/content/en/reference/agents/generateLegacy.mdx
+++ b/docs/src/content/en/reference/agents/generateLegacy.mdx
@@ -546,7 +546,7 @@ const result = await agent.generate("message", {
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { z } from "zod";
 import {
   ModerationProcessor,

--- a/docs/src/content/en/reference/agents/generateLegacy.mdx
+++ b/docs/src/content/en/reference/agents/generateLegacy.mdx
@@ -15,7 +15,7 @@ The `.generateLegacy()` method is the legacy version of the agent generation API
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.generateLegacy("message for agent");
 ```
 
@@ -546,7 +546,7 @@ const result = await agent.generate("message", {
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 import { z } from "zod";
 import {
   ModerationProcessor,

--- a/docs/src/content/en/reference/agents/getDefaultGenerateOptions.mdx
+++ b/docs/src/content/en/reference/agents/getDefaultGenerateOptions.mdx
@@ -15,7 +15,7 @@ Agents can be configured with default generation options for controlling model b
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getDefaultGenerateOptionsLegacy();
 ```
 
@@ -48,7 +48,7 @@ await agent.getDefaultGenerateOptionsLegacy();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getDefaultGenerateOptionsLegacy({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/getDefaultOptions.mdx
+++ b/docs/src/content/en/reference/agents/getDefaultOptions.mdx
@@ -9,7 +9,7 @@ Agents can be configured with default options for memory usage, output format, a
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getDefaultOptions();
 ```
 
@@ -42,7 +42,7 @@ await agent.getDefaultOptions();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getDefaultOptions({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/getDefaultStreamOptions.mdx
+++ b/docs/src/content/en/reference/agents/getDefaultStreamOptions.mdx
@@ -15,7 +15,7 @@ Agents can be configured with default streaming options for memory usage, output
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getDefaultStreamOptionsLegacy();
 ```
 
@@ -48,7 +48,7 @@ await agent.getDefaultStreamOptionsLegacy();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getDefaultStreamOptionsLegacy({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/getDescription.mdx
+++ b/docs/src/content/en/reference/agents/getDescription.mdx
@@ -9,7 +9,7 @@ The `.getDescription()` method retrieves the description configured for an agent
 
 ## Usage example
 
-```typescript copy
+```typescript
 agent.getDescription();
 ```
 

--- a/docs/src/content/en/reference/agents/getInstructions.mdx
+++ b/docs/src/content/en/reference/agents/getInstructions.mdx
@@ -9,7 +9,7 @@ The `.getInstructions()` method retrieves the instructions configured for an age
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getInstructions();
 ```
 
@@ -42,7 +42,7 @@ await agent.getInstructions();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getInstructions({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/getLLM.mdx
+++ b/docs/src/content/en/reference/agents/getLLM.mdx
@@ -9,7 +9,7 @@ The `.getLLM()` method retrieves the language model instance configured for an a
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getLLM();
 ```
 
@@ -43,7 +43,7 @@ await agent.getLLM();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getLLM({
   requestContext: new RequestContext(),
   model: "openai/gpt-5.1",

--- a/docs/src/content/en/reference/agents/getMemory.mdx
+++ b/docs/src/content/en/reference/agents/getMemory.mdx
@@ -9,7 +9,7 @@ The `.getMemory()` method retrieves the memory system associated with an agent. 
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getMemory();
 ```
 
@@ -42,7 +42,7 @@ await agent.getMemory();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getMemory({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/getModel.mdx
+++ b/docs/src/content/en/reference/agents/getModel.mdx
@@ -9,7 +9,7 @@ The `.getModel()` method retrieves the language model configured for an agent, r
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getModel();
 ```
 
@@ -42,7 +42,7 @@ await agent.getModel();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getModel({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/getTools.mdx
+++ b/docs/src/content/en/reference/agents/getTools.mdx
@@ -9,7 +9,7 @@ The `.getTools()` method retrieves the tools configured for an agent, resolving 
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getTools();
 ```
 
@@ -42,7 +42,7 @@ await agent.getTools();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getTools({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/getVoice.mdx
+++ b/docs/src/content/en/reference/agents/getVoice.mdx
@@ -9,7 +9,7 @@ The `.getVoice()` method retrieves the voice provider configured for an agent, r
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.getVoice();
 ```
 
@@ -42,7 +42,7 @@ await agent.getVoice();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.getVoice({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/listAgents.mdx
+++ b/docs/src/content/en/reference/agents/listAgents.mdx
@@ -9,7 +9,7 @@ The `.listAgents()` method retrieves the sub-agents configured for an agent, res
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.listAgents();
 ```
 
@@ -42,7 +42,7 @@ await agent.listAgents();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 import { RequestContext } from "@mastra/core/request-context";
 
 await agent.listAgents({

--- a/docs/src/content/en/reference/agents/listScorers.mdx
+++ b/docs/src/content/en/reference/agents/listScorers.mdx
@@ -9,7 +9,7 @@ The `.listScorers()` method retrieves the scoring configuration configured for a
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.listScorers();
 ```
 
@@ -42,7 +42,7 @@ await agent.listScorers();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.listScorers({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/listTools.mdx
+++ b/docs/src/content/en/reference/agents/listTools.mdx
@@ -9,7 +9,7 @@ The `.listTools()` method retrieves the tools configured for an agent, resolving
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.listTools();
 ```
 
@@ -42,7 +42,7 @@ await agent.listTools();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.listTools({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/listWorkflows.mdx
+++ b/docs/src/content/en/reference/agents/listWorkflows.mdx
@@ -9,7 +9,7 @@ The `.listWorkflows()` method retrieves the workflows configured for an agent, r
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.listWorkflows();
 ```
 
@@ -42,7 +42,7 @@ await agent.listWorkflows();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.listWorkflows({
   requestContext: new RequestContext(),
 });

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -15,7 +15,7 @@ The `.network()` method enables multi-agent collaboration and routing. This meth
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { Agent } from "@mastra/core/agent";
 import { agent1, agent2 } from "./agents";
 import { workflow1 } from "./workflows";

--- a/docs/src/content/en/reference/ai-sdk/chat-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/chat-route.mdx
@@ -15,7 +15,7 @@ Use [`handleChatStream()`](/reference/v1/ai-sdk/handle-chat-stream) if you need 
 
 This example shows how to set up a chat route at the `/chat` endpoint that uses an agent with the ID `weatherAgent`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { chatRoute } from "@mastra/ai-sdk";
 
@@ -33,7 +33,7 @@ export const mastra = new Mastra({
 
 You can also use dynamic agent routing based on an `agentId`. The URL `/chat/weatherAgent` will resolve to the agent with the ID `weatherAgent`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { chatRoute } from "@mastra/ai-sdk";
 

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -17,7 +17,7 @@ Use [`chatRoute()`](/reference/v1/ai-sdk/chat-route) if you want to create a cha
 
 Next.js App Router example:
 
-```typescript title="app/api/chat/route.ts" copy
+```typescript title="app/api/chat/route.ts"
 import { handleChatStream } from '@mastra/ai-sdk';
 import { createUIMessageStreamResponse } from 'ai';
 import { mastra } from '@/src/mastra';

--- a/docs/src/content/en/reference/ai-sdk/handle-network-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-network-stream.mdx
@@ -16,7 +16,7 @@ Use [`networkRoute()`](/reference/v1/ai-sdk/network-route) if you want to create
 
 Next.js App Router example:
 
-```typescript title="app/api/network/route.ts" copy
+```typescript title="app/api/network/route.ts"
 import { handleNetworkStream } from '@mastra/ai-sdk';
 import { createUIMessageStreamResponse } from 'ai';
 import { mastra } from '@/src/mastra';

--- a/docs/src/content/en/reference/ai-sdk/handle-workflow-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-workflow-stream.mdx
@@ -25,7 +25,7 @@ See [Workflow Streaming](/docs/v1/streaming/workflow-streaming#streaming-agent-t
 
 Next.js App Router example:
 
-```typescript title="app/api/workflow/route.ts" copy
+```typescript title="app/api/workflow/route.ts"
 import { handleWorkflowStream } from '@mastra/ai-sdk';
 import { createUIMessageStreamResponse } from 'ai';
 import { mastra } from '@/src/mastra';

--- a/docs/src/content/en/reference/ai-sdk/network-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/network-route.mdx
@@ -15,7 +15,7 @@ Use [`handleNetworkStream()`](/reference/v1/ai-sdk/handle-network-stream) if you
 
 This example shows how to set up a network route at the `/network` endpoint that uses an agent with the ID `weatherAgent`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { networkRoute } from "@mastra/ai-sdk";
 
@@ -33,7 +33,7 @@ export const mastra = new Mastra({
 
 You can also use dynamic agent routing based on an `agentId`. The URL `/network/weatherAgent` will resolve to the agent with the ID `weatherAgent`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { networkRoute } from "@mastra/ai-sdk";
 

--- a/docs/src/content/en/reference/ai-sdk/to-ai-sdk-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/to-ai-sdk-stream.mdx
@@ -15,7 +15,7 @@ This is useful when building custom streaming endpoints outside Mastra's provide
 
 Next.js App Router example:
 
-```typescript title="app/api/chat/route.ts" copy
+```typescript title="app/api/chat/route.ts"
 import { mastra } from "../../mastra";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
@@ -124,7 +124,7 @@ The second parameter is an options object:
 
 ### Converting a workflow stream
 
-```typescript title="app/api/workflow/route.ts" copy {13}
+```typescript title="app/api/workflow/route.ts" {13}
 import { mastra } from "../../mastra";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
@@ -151,7 +151,7 @@ export async function POST(req: Request) {
 
 ### Converting a network stream
 
-```typescript title="app/api/network/route.ts" copy {12}
+```typescript title="app/api/network/route.ts" {12}
 import { mastra } from "../../mastra";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
@@ -177,7 +177,7 @@ export async function POST(req: Request) {
 
 ### Converting an agent stream with reasoning enabled
 
-```typescript title="app/api/reasoning/route.ts" copy {8-12,17-20}
+```typescript title="app/api/reasoning/route.ts" {8-12,17-20}
 import { mastra } from "../../mastra";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
@@ -211,7 +211,7 @@ export async function POST(req: Request) {
 
 ### Using messageMetadata
 
-```typescript title="app/api/chat-with-metadata/route.ts" copy {13-19}
+```typescript title="app/api/chat-with-metadata/route.ts" {13-19}
 import { mastra } from "../../mastra";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
@@ -246,7 +246,7 @@ export async function POST(req: Request) {
 
 If you're using the Mastra client SDK (`@mastra/client-js`) on the client side and want to convert streams to AI SDK format:
 
-```typescript title="client-stream-to-ai-sdk.ts" copy {14-23,25-35}
+```typescript title="client-stream-to-ai-sdk.ts" {14-23,25-35}
 import { MastraClient } from "@mastra/client-js";
 import { createUIMessageStream } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";

--- a/docs/src/content/en/reference/ai-sdk/to-ai-sdk-v4-messages.mdx
+++ b/docs/src/content/en/reference/ai-sdk/to-ai-sdk-v4-messages.mdx
@@ -11,7 +11,7 @@ Converts messages from various input formats to AI SDK V4 UI message format. Thi
 
 ## Usage example
 
-```typescript title="app/chat/page.tsx" copy
+```typescript title="app/chat/page.tsx"
 import { toAISdkV4Messages } from "@mastra/ai-sdk";
 import { useChat } from "ai/react"; // AI SDK V4
 
@@ -107,7 +107,7 @@ Returns an array of AI SDK V4 `UIMessage` objects with the following structure:
 
 ### Converting simple text messages
 
-```typescript copy
+```typescript
 import { toAISdkV4Messages } from "@mastra/ai-sdk";
 
 const messages = toAISdkV4Messages(["Hello", "How can I help you today?"]);
@@ -116,7 +116,7 @@ const messages = toAISdkV4Messages(["Hello", "How can I help you today?"]);
 
 ### Loading messages with Mastra client
 
-```typescript copy
+```typescript
 import { MastraClient } from "@mastra/client-js";
 import { toAISdkV4Messages } from "@mastra/ai-sdk";
 

--- a/docs/src/content/en/reference/ai-sdk/to-ai-sdk-v5-messages.mdx
+++ b/docs/src/content/en/reference/ai-sdk/to-ai-sdk-v5-messages.mdx
@@ -11,7 +11,7 @@ Converts messages from various input formats to AI SDK V5 UI message format. Thi
 
 ## Usage example
 
-```typescript title="app/chat/page.tsx" copy
+```typescript title="app/chat/page.tsx"
 import { toAISdkV5Messages } from "@mastra/ai-sdk";
 import { useChat } from "ai/react";
 
@@ -87,7 +87,7 @@ Returns an array of AI SDK V5 `UIMessage` objects with the following structure:
 
 ### Converting simple text messages
 
-```typescript copy
+```typescript
 import { toAISdkV5Messages } from "@mastra/ai-sdk";
 
 const messages = toAISdkV5Messages(["Hello", "How can I help you today?"]);
@@ -96,7 +96,7 @@ const messages = toAISdkV5Messages(["Hello", "How can I help you today?"]);
 
 ### Loading messages with Mastra client
 
-```typescript copy
+```typescript
 import { MastraClient } from "@mastra/client-js";
 import { toAISdkV5Messages } from "@mastra/ai-sdk";
 

--- a/docs/src/content/en/reference/ai-sdk/with-mastra.mdx
+++ b/docs/src/content/en/reference/ai-sdk/with-mastra.mdx
@@ -11,7 +11,7 @@ Wraps an AI SDK model with Mastra processors and/or memory.
 
 ## Usage example
 
-```typescript title="src/example.ts" copy
+```typescript title="src/example.ts"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { withMastra } from '@mastra/ai-sdk';

--- a/docs/src/content/en/reference/ai-sdk/workflow-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/workflow-route.mdx
@@ -23,7 +23,7 @@ See [Workflow Streaming](/docs/v1/streaming/workflow-streaming#streaming-agent-t
 
 This example shows how to set up a workflow route at the `/workflow` endpoint that uses a workflow with the ID `weatherWorkflow`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { workflowRoute } from "@mastra/ai-sdk";
 
@@ -41,7 +41,7 @@ export const mastra = new Mastra({
 
 You can also use dynamic workflow routing based on a `workflowId`. The URL `/workflow/weatherWorkflow` will resolve to the workflow with the ID `weatherWorkflow`.
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { workflowRoute } from "@mastra/ai-sdk";
 

--- a/docs/src/content/en/reference/auth/auth0.mdx
+++ b/docs/src/content/en/reference/auth/auth0.mdx
@@ -9,7 +9,7 @@ The `MastraAuthAuth0` class provides authentication for Mastra using Auth0. It v
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 

--- a/docs/src/content/en/reference/auth/auth0.mdx
+++ b/docs/src/content/en/reference/auth/auth0.mdx
@@ -9,7 +9,7 @@ The `MastraAuthAuth0` class provides authentication for Mastra using Auth0. It v
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthAuth0 } from "@mastra/auth-auth0";
 

--- a/docs/src/content/en/reference/auth/clerk.mdx
+++ b/docs/src/content/en/reference/auth/clerk.mdx
@@ -9,7 +9,7 @@ The `MastraAuthClerk` class provides authentication for Mastra applications usin
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthClerk } from "@mastra/auth-clerk";
 

--- a/docs/src/content/en/reference/auth/clerk.mdx
+++ b/docs/src/content/en/reference/auth/clerk.mdx
@@ -9,7 +9,7 @@ The `MastraAuthClerk` class provides authentication for Mastra applications usin
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthClerk } from "@mastra/auth-clerk";
 

--- a/docs/src/content/en/reference/auth/firebase.mdx
+++ b/docs/src/content/en/reference/auth/firebase.mdx
@@ -11,7 +11,7 @@ The `MastraAuthFirebase` class provides authentication for Mastra using Firebase
 
 ### Basic usage with environment variables
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
@@ -26,7 +26,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 

--- a/docs/src/content/en/reference/auth/firebase.mdx
+++ b/docs/src/content/en/reference/auth/firebase.mdx
@@ -11,7 +11,7 @@ The `MastraAuthFirebase` class provides authentication for Mastra using Firebase
 
 ### Basic usage with environment variables
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 
@@ -26,7 +26,7 @@ export const mastra = new Mastra({
 
 ### Custom configuration
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthFirebase } from "@mastra/auth-firebase";
 

--- a/docs/src/content/en/reference/auth/jwt.mdx
+++ b/docs/src/content/en/reference/auth/jwt.mdx
@@ -9,7 +9,7 @@ The `MastraJwtAuth` class provides a lightweight authentication mechanism for Ma
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraJwtAuth } from "@mastra/auth";
 

--- a/docs/src/content/en/reference/auth/jwt.mdx
+++ b/docs/src/content/en/reference/auth/jwt.mdx
@@ -9,7 +9,7 @@ The `MastraJwtAuth` class provides a lightweight authentication mechanism for Ma
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraJwtAuth } from "@mastra/auth";
 

--- a/docs/src/content/en/reference/auth/supabase.mdx
+++ b/docs/src/content/en/reference/auth/supabase.mdx
@@ -9,7 +9,7 @@ The `MastraAuthSupabase` class provides authentication for Mastra using Supabase
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthSupabase } from "@mastra/auth-supabase";
 

--- a/docs/src/content/en/reference/auth/supabase.mdx
+++ b/docs/src/content/en/reference/auth/supabase.mdx
@@ -9,7 +9,7 @@ The `MastraAuthSupabase` class provides authentication for Mastra using Supabase
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthSupabase } from "@mastra/auth-supabase";
 

--- a/docs/src/content/en/reference/auth/workos.mdx
+++ b/docs/src/content/en/reference/auth/workos.mdx
@@ -9,7 +9,7 @@ The `MastraAuthWorkos` class provides authentication for Mastra using WorkOS. It
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 

--- a/docs/src/content/en/reference/auth/workos.mdx
+++ b/docs/src/content/en/reference/auth/workos.mdx
@@ -9,7 +9,7 @@ The `MastraAuthWorkos` class provides authentication for Mastra using WorkOS. It
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { MastraAuthWorkos } from "@mastra/auth-workos";
 

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -15,28 +15,28 @@ The `create-mastra` command **creates** a new standalone Mastra project. Use thi
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npx create-mastra@beta
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn dlx create-mastra@beta
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm create mastra@beta
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun create mastra@beta
 ```
 
@@ -48,28 +48,28 @@ bun create mastra@beta
 <Tabs>
 <TabItem value="npm" label="npm">
 
-```bash copy
+```bash
 npx create-mastra@beta my-mastra-project -- --template coding-agent
 ```
 
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-```bash copy
+```bash
 yarn dlx create-mastra@beta --template coding-agent
 ```
 
 </TabItem>
 <TabItem value="pnpm" label="pnpm">
 
-```bash copy
+```bash
 pnpm create mastra@beta --template coding-agent
 ```
 
 </TabItem>
 <TabItem value="bun" label="bun">
 
-```bash copy
+```bash
 bun create mastra@beta --template coding-agent
 ```
 
@@ -183,12 +183,12 @@ By default, Mastra collects anonymous information about your project like your O
 
 You can opt out of the CLI analytics by setting an environment variable:
 
-```bash copy
+```bash
 MASTRA_TELEMETRY_DISABLED=1
 ```
 
 You can also set this while using other `mastra` commands:
 
-```bash copy
+```bash
 MASTRA_TELEMETRY_DISABLED=1 npx create-mastra@beta
 ```

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -41,7 +41,7 @@ You can set certain environment variables to modify the behavior of `mastra dev`
 
 Set `MASTRA_DEV_NO_CACHE=1` to force a full rebuild rather than using the cached assets under `.mastra/`:
 
-```bash copy
+```bash
 MASTRA_DEV_NO_CACHE=1 mastra dev
 ```
 
@@ -51,7 +51,7 @@ This helps when you are debugging bundler plugins or suspect stale output.
 
 `MASTRA_CONCURRENCY` caps how many expensive operations run in parallel (primarily build and evaluation steps). For example:
 
-```bash copy
+```bash
 MASTRA_CONCURRENCY=4 mastra dev
 ```
 
@@ -61,7 +61,7 @@ Leave it unset to let the CLI pick a sensible default for the machine.
 
 When using providers supported by the Vercel AI SDK you can redirect requests through proxies or internal gateways by setting a base URL. For OpenAI:
 
-```bash copy
+```bash
 OPENAI_API_KEY=<your-api-key> \
 OPENAI_BASE_URL=https://openrouter.example/v1 \
 mastra dev
@@ -69,7 +69,7 @@ mastra dev
 
 For Anthropic:
 
-```bash copy
+```bash
 ANTHROPIC_API_KEY=<your-api-key> \
 ANTHROPIC_BASE_URL=https://anthropic.internal \
 mastra dev
@@ -98,7 +98,7 @@ You can set certain environment variables to modify the behavior of `mastra buil
 
 For CI or when running in resource constrained environments you can cap how many expensive tasks run at once by setting `MASTRA_CONCURRENCY`.
 
-```bash copy
+```bash
 MASTRA_CONCURRENCY=2 mastra build
 ```
 
@@ -152,13 +152,13 @@ Read the [Scorers overview](/docs/v1/evals/overview) to learn more.
 
 Add a new scorer to your project. You can use an interactive prompt:
 
-```bash copy
+```bash
 mastra scorers add
 ```
 
 Or provide a scorer name directly:
 
-```bash copy
+```bash
 mastra scorers add answer-relevancy
 ```
 
@@ -258,13 +258,13 @@ By default, Mastra collects anonymous information about your project like your O
 
 You can opt out of the CLI analytics by setting an environment variable:
 
-```bash copy
+```bash
 MASTRA_TELEMETRY_DISABLED=1
 ```
 
 You can also set this while using other `mastra` commands:
 
-```bash copy
+```bash
 MASTRA_TELEMETRY_DISABLED=1 mastra dev
 ```
 

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -123,7 +123,7 @@ while (true) {
 
 To stream AI SDK-formatted parts on the client from an `agent.stream(...)` response, wrap `response.processDataStream` into a `ReadableStream<ChunkType>` and use `toAISdkStream`:
 
-```typescript title="client-ai-sdk-transform.ts" copy
+```typescript title="client-ai-sdk-transform.ts"
 import { createUIMessageStream } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
 import type { ChunkType, MastraModelOutput } from "@mastra/core/stream";

--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -9,7 +9,7 @@ The Mastra Client SDK provides a simple and type-safe interface for interacting 
 
 ## Usage example
 
-```typescript title="lib/mastra/mastra-client.ts" showLineNumbers copy
+```typescript title="lib/mastra/mastra-client.ts" copy
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({

--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -9,7 +9,7 @@ The Mastra Client SDK provides a simple and type-safe interface for interacting 
 
 ## Usage example
 
-```typescript title="lib/mastra/mastra-client.ts" copy
+```typescript title="lib/mastra/mastra-client.ts"
 import { MastraClient } from "@mastra/client-js";
 
 export const mastraClient = new MastraClient({

--- a/docs/src/content/en/reference/core/getAgent.mdx
+++ b/docs/src/content/en/reference/core/getAgent.mdx
@@ -9,7 +9,7 @@ The `.getAgent()` method is used to retrieve an agent. The method accepts a sing
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getAgent("testAgent");
 ```
 

--- a/docs/src/content/en/reference/core/getAgentById.mdx
+++ b/docs/src/content/en/reference/core/getAgentById.mdx
@@ -9,7 +9,7 @@ The `.getAgentById()` method is used to retrieve an agent by its ID. The method 
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getAgentById("test-agent-123");
 ```
 

--- a/docs/src/content/en/reference/core/getDeployer.mdx
+++ b/docs/src/content/en/reference/core/getDeployer.mdx
@@ -9,7 +9,7 @@ The `.getDeployer()` method is used to retrieve the deployer instance that has b
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getDeployer();
 ```
 

--- a/docs/src/content/en/reference/core/getLogger.mdx
+++ b/docs/src/content/en/reference/core/getLogger.mdx
@@ -9,7 +9,7 @@ The `.getLogger()` method is used to retrieve the logger instance that has been 
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getLogger();
 ```
 

--- a/docs/src/content/en/reference/core/getMCPServer.mdx
+++ b/docs/src/content/en/reference/core/getMCPServer.mdx
@@ -9,7 +9,7 @@ The `.getMCPServer()` method retrieves an MCP server instance by its registry ke
 
 ## Usage example
 
-```typescript copy
+```typescript
 // Register an MCP server with a registry key
 const myServer = new MCPServer({
   id: 'my-mcp-server',

--- a/docs/src/content/en/reference/core/getMCPServerById.mdx
+++ b/docs/src/content/en/reference/core/getMCPServerById.mdx
@@ -9,7 +9,7 @@ The `.getMCPServerById()` method retrieves an MCP server instance by its intrins
 
 ## Usage example
 
-```typescript copy
+```typescript
 // Register an MCP server with a registry key
 const myServer = new MCPServer({
   id: 'my-mcp-server',

--- a/docs/src/content/en/reference/core/getMemory.mdx
+++ b/docs/src/content/en/reference/core/getMemory.mdx
@@ -9,7 +9,7 @@ The `.getMemory()` method retrieves a memory instance from the Mastra registry b
 
 ## Usage example
 
-```typescript copy
+```typescript
 const memory = mastra.getMemory("conversationMemory");
 
 // Use the memory instance
@@ -47,7 +47,7 @@ const thread = await memory.createThread({
 
 ## Example: Registering and Retrieving Memory
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";

--- a/docs/src/content/en/reference/core/getServer.mdx
+++ b/docs/src/content/en/reference/core/getServer.mdx
@@ -9,7 +9,7 @@ The `.getServer()` method is used to retrieve the server configuration that has 
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getServer();
 ```
 

--- a/docs/src/content/en/reference/core/getStorage.mdx
+++ b/docs/src/content/en/reference/core/getStorage.mdx
@@ -9,7 +9,7 @@ The `.getStorage()` method is used to retrieve the storage instance that has bee
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getStorage();
 ```
 

--- a/docs/src/content/en/reference/core/getStoredAgentById.mdx
+++ b/docs/src/content/en/reference/core/getStoredAgentById.mdx
@@ -9,7 +9,7 @@ The `.getStoredAgentById()` method retrieves an agent configuration from storage
 
 ## Usage example
 
-```typescript copy
+```typescript
 // Get an Agent instance from storage
 const agent = await mastra.getStoredAgentById("my-stored-agent");
 
@@ -19,7 +19,7 @@ if (agent) {
 }
 ```
 
-```typescript copy
+```typescript
 // Get the raw storage data instead of an Agent instance
 const storedConfig = await mastra.getStoredAgentById("my-stored-agent", { raw: true });
 

--- a/docs/src/content/en/reference/core/getTelemetry.mdx
+++ b/docs/src/content/en/reference/core/getTelemetry.mdx
@@ -9,7 +9,7 @@ The `.getTelemetry()` method is used to retrieve the telemetry instance that has
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getTelemetry();
 ```
 

--- a/docs/src/content/en/reference/core/getVector.mdx
+++ b/docs/src/content/en/reference/core/getVector.mdx
@@ -9,7 +9,7 @@ The `.getVector()` method is used to retrieve a vector store by its name. The me
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getVector("testVectorStore");
 ```
 

--- a/docs/src/content/en/reference/core/getWorkflow.mdx
+++ b/docs/src/content/en/reference/core/getWorkflow.mdx
@@ -9,7 +9,7 @@ The `.getWorkflow()` method is used to retrieve a workflow by its ID. The method
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.getWorkflow("testWorkflow");
 ```
 

--- a/docs/src/content/en/reference/core/listAgents.mdx
+++ b/docs/src/content/en/reference/core/listAgents.mdx
@@ -9,7 +9,7 @@ The `.listAgents()` method is used to retrieve all agents that have been configu
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.listAgents();
 ```
 

--- a/docs/src/content/en/reference/core/listLogs.mdx
+++ b/docs/src/content/en/reference/core/listLogs.mdx
@@ -9,7 +9,7 @@ The `.listLogs()` method is used to retrieve all logs for a specific transport I
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.listLogs("456");
 ```
 

--- a/docs/src/content/en/reference/core/listLogsByRunId.mdx
+++ b/docs/src/content/en/reference/core/listLogsByRunId.mdx
@@ -9,7 +9,7 @@ The `.listLogsByRunId()` method is used to retrieve logs for a specific run ID a
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.listLogsByRunId({ runId: "123", transportId: "456" });
 ```
 

--- a/docs/src/content/en/reference/core/listMCPServers.mdx
+++ b/docs/src/content/en/reference/core/listMCPServers.mdx
@@ -9,7 +9,7 @@ The `.listMCPServers()` method is used to retrieve all MCP server instances that
 
 ## Usage example
 
-```typescript copy
+```typescript
 // Register MCP servers
 const server1 = new MCPServer({
   id: 'server-one',

--- a/docs/src/content/en/reference/core/listMemory.mdx
+++ b/docs/src/content/en/reference/core/listMemory.mdx
@@ -9,7 +9,7 @@ The `.listMemory()` method returns all memory instances registered with the Mast
 
 ## Usage example
 
-```typescript copy
+```typescript
 const memoryInstances = mastra.listMemory();
 
 for (const [key, memory] of Object.entries(memoryInstances)) {
@@ -36,7 +36,7 @@ This method takes no parameters.
 
 ## Example: Checking Registered Memory
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";

--- a/docs/src/content/en/reference/core/listStoredAgents.mdx
+++ b/docs/src/content/en/reference/core/listStoredAgents.mdx
@@ -9,7 +9,7 @@ The `.listStoredAgents()` method retrieves a paginated list of agent configurati
 
 ## Usage example
 
-```typescript copy
+```typescript
 // Get Agent instances from storage
 const { agents, total, hasMore } = await mastra.listStoredAgents();
 
@@ -20,7 +20,7 @@ for (const agent of agents) {
 }
 ```
 
-```typescript copy
+```typescript
 // Get paginated results with raw storage data
 const result = await mastra.listStoredAgents({
   page: 0,
@@ -127,7 +127,7 @@ If a referenced primitive is not found, a warning is logged but the agent is sti
 
 ## Example: Iterating Through All Stored Agents
 
-```typescript copy
+```typescript
 async function getAllStoredAgents(mastra: Mastra) {
   const allAgents: Agent[] = [];
   let page = 0;

--- a/docs/src/content/en/reference/core/listVectors.mdx
+++ b/docs/src/content/en/reference/core/listVectors.mdx
@@ -9,7 +9,7 @@ The `.listVectors()` method is used to retrieve all vector stores that have been
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.listVectors();
 ```
 

--- a/docs/src/content/en/reference/core/listWorkflows.mdx
+++ b/docs/src/content/en/reference/core/listWorkflows.mdx
@@ -9,7 +9,7 @@ The `.listWorkflows()` method is used to retrieve all workflows that have been c
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.listWorkflows();
 ```
 

--- a/docs/src/content/en/reference/core/setLogger.mdx
+++ b/docs/src/content/en/reference/core/setLogger.mdx
@@ -9,7 +9,7 @@ The `.setLogger()` method is used to set the logger for all components (agents, 
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.setLogger({ logger: new PinoLogger({ name: "testLogger" }) });
 ```
 

--- a/docs/src/content/en/reference/core/setStorage.mdx
+++ b/docs/src/content/en/reference/core/setStorage.mdx
@@ -9,7 +9,7 @@ The `.setStorage()` method is used to set the storage instance for the Mastra in
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.setStorage(
   new LibSQLStore({
     id: 'mastra-storage',

--- a/docs/src/content/en/reference/core/setTelemetry.mdx
+++ b/docs/src/content/en/reference/core/setTelemetry.mdx
@@ -9,7 +9,7 @@ The `.setTelemetry()` method is used to set the telemetry configuration for all 
 
 ## Usage example
 
-```typescript copy
+```typescript
 mastra.setTelemetry({ export: { type: "console" } });
 ```
 

--- a/docs/src/content/en/reference/deployer/cloudflare.mdx
+++ b/docs/src/content/en/reference/deployer/cloudflare.mdx
@@ -9,7 +9,7 @@ The `CloudflareDeployer` class handles deployment of standalone Mastra applicati
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { CloudflareDeployer } from "@mastra/deployer-cloudflare";
 

--- a/docs/src/content/en/reference/deployer/cloudflare.mdx
+++ b/docs/src/content/en/reference/deployer/cloudflare.mdx
@@ -9,7 +9,7 @@ The `CloudflareDeployer` class handles deployment of standalone Mastra applicati
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { CloudflareDeployer } from "@mastra/deployer-cloudflare";
 

--- a/docs/src/content/en/reference/deployer/netlify.mdx
+++ b/docs/src/content/en/reference/deployer/netlify.mdx
@@ -9,7 +9,7 @@ The `NetlifyDeployer` class handles deployment of standalone Mastra applications
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { NetlifyDeployer } from "@mastra/deployer-netlify";
 

--- a/docs/src/content/en/reference/deployer/vercel.mdx
+++ b/docs/src/content/en/reference/deployer/vercel.mdx
@@ -9,7 +9,7 @@ The `VercelDeployer` class handles deployment of standalone Mastra applications 
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { VercelDeployer } from "@mastra/deployer-vercel";
 
@@ -31,7 +31,7 @@ These options are merged into `.vercel/output/functions/index.func/.vc-config.js
 
 ### Example with overrides
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { VercelDeployer } from "@mastra/deployer-vercel";
 

--- a/docs/src/content/en/reference/deployer/vercel.mdx
+++ b/docs/src/content/en/reference/deployer/vercel.mdx
@@ -9,7 +9,7 @@ The `VercelDeployer` class handles deployment of standalone Mastra applications 
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { VercelDeployer } from "@mastra/deployer-vercel";
 
@@ -31,7 +31,7 @@ These options are merged into `.vercel/output/functions/index.func/.vc-config.js
 
 ### Example with overrides
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { VercelDeployer } from "@mastra/deployer-vercel";
 

--- a/docs/src/content/en/reference/evals/answer-relevancy.mdx
+++ b/docs/src/content/en/reference/evals/answer-relevancy.mdx
@@ -116,7 +116,7 @@ A relevancy score between 0 and 1:
 
 Evaluate agent responses for relevancy across different scenarios:
 
-```typescript title="src/example-answer-relevancy.ts" copy
+```typescript title="src/example-answer-relevancy.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createAnswerRelevancyScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/answer-relevancy.mdx
+++ b/docs/src/content/en/reference/evals/answer-relevancy.mdx
@@ -116,7 +116,7 @@ A relevancy score between 0 and 1:
 
 Evaluate agent responses for relevancy across different scenarios:
 
-```typescript title="src/example-answer-relevancy.ts" showLineNumbers copy
+```typescript title="src/example-answer-relevancy.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createAnswerRelevancyScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/answer-similarity.mdx
+++ b/docs/src/content/en/reference/evals/answer-similarity.mdx
@@ -153,7 +153,7 @@ Score calculation: `max(0, base_score - contradiction_penalty - missing_penalty 
 
 Evaluate agent responses for similarity to ground truth across different scenarios:
 
-```typescript title="src/example-answer-similarity.ts" showLineNumbers copy
+```typescript title="src/example-answer-similarity.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createAnswerSimilarityScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/answer-similarity.mdx
+++ b/docs/src/content/en/reference/evals/answer-similarity.mdx
@@ -153,7 +153,7 @@ Score calculation: `max(0, base_score - contradiction_penalty - missing_penalty 
 
 Evaluate agent responses for similarity to ground truth across different scenarios:
 
-```typescript title="src/example-answer-similarity.ts" copy
+```typescript title="src/example-answer-similarity.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createAnswerSimilarityScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/bias.mdx
+++ b/docs/src/content/en/reference/evals/bias.mdx
@@ -127,7 +127,7 @@ A bias score between 0 and 1:
 
 Evaluate agent responses for bias across different types of questions:
 
-```typescript title="src/example-bias.ts" copy
+```typescript title="src/example-bias.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createBiasScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/bias.mdx
+++ b/docs/src/content/en/reference/evals/bias.mdx
@@ -127,7 +127,7 @@ A bias score between 0 and 1:
 
 Evaluate agent responses for bias across different types of questions:
 
-```typescript title="src/example-bias.ts" showLineNumbers copy
+```typescript title="src/example-bias.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createBiasScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/completeness.mdx
+++ b/docs/src/content/en/reference/evals/completeness.mdx
@@ -109,7 +109,7 @@ A completeness score between 0 and 1:
 
 Evaluate agent responses for completeness across different query complexities:
 
-```typescript title="src/example-completeness.ts" showLineNumbers copy
+```typescript title="src/example-completeness.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createCompletenessScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/completeness.mdx
+++ b/docs/src/content/en/reference/evals/completeness.mdx
@@ -109,7 +109,7 @@ A completeness score between 0 and 1:
 
 Evaluate agent responses for completeness across different query complexities:
 
-```typescript title="src/example-completeness.ts" copy
+```typescript title="src/example-completeness.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createCompletenessScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/content-similarity.mdx
+++ b/docs/src/content/en/reference/evals/content-similarity.mdx
@@ -82,7 +82,7 @@ Final score: `similarity_value * scale`
 
 Evaluate textual similarity between expected and actual agent outputs:
 
-```typescript title="src/example-content-similarity.ts" copy
+```typescript title="src/example-content-similarity.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createContentSimilarityScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/content-similarity.mdx
+++ b/docs/src/content/en/reference/evals/content-similarity.mdx
@@ -82,7 +82,7 @@ Final score: `similarity_value * scale`
 
 Evaluate textual similarity between expected and actual agent outputs:
 
-```typescript title="src/example-content-similarity.ts" showLineNumbers copy
+```typescript title="src/example-content-similarity.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createContentSimilarityScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/context-precision.mdx
+++ b/docs/src/content/en/reference/evals/context-precision.mdx
@@ -190,7 +190,7 @@ const scorer = createContextPrecisionScorer({
 
 Evaluate RAG system context retrieval precision for different queries:
 
-```typescript title="src/example-context-precision.ts" showLineNumbers copy
+```typescript title="src/example-context-precision.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createContextPrecisionScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/context-precision.mdx
+++ b/docs/src/content/en/reference/evals/context-precision.mdx
@@ -190,7 +190,7 @@ const scorer = createContextPrecisionScorer({
 
 Evaluate RAG system context retrieval precision for different queries:
 
-```typescript title="src/example-context-precision.ts" copy
+```typescript title="src/example-context-precision.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createContextPrecisionScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/faithfulness.mdx
+++ b/docs/src/content/en/reference/evals/faithfulness.mdx
@@ -126,7 +126,7 @@ A faithfulness score between 0 and 1:
 
 Evaluate agent responses for faithfulness to provided context:
 
-```typescript title="src/example-faithfulness.ts" copy
+```typescript title="src/example-faithfulness.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createFaithfulnessScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/faithfulness.mdx
+++ b/docs/src/content/en/reference/evals/faithfulness.mdx
@@ -126,7 +126,7 @@ A faithfulness score between 0 and 1:
 
 Evaluate agent responses for faithfulness to provided context:
 
-```typescript title="src/example-faithfulness.ts" showLineNumbers copy
+```typescript title="src/example-faithfulness.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createFaithfulnessScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/hallucination.mdx
+++ b/docs/src/content/en/reference/evals/hallucination.mdx
@@ -135,7 +135,7 @@ A hallucination score between 0 and 1:
 
 Evaluate agent responses for hallucinations against provided context:
 
-```typescript title="src/example-hallucination.ts" showLineNumbers copy
+```typescript title="src/example-hallucination.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createHallucinationScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/hallucination.mdx
+++ b/docs/src/content/en/reference/evals/hallucination.mdx
@@ -135,7 +135,7 @@ A hallucination score between 0 and 1:
 
 Evaluate agent responses for hallucinations against provided context:
 
-```typescript title="src/example-hallucination.ts" copy
+```typescript title="src/example-hallucination.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createHallucinationScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/keyword-coverage.mdx
+++ b/docs/src/content/en/reference/evals/keyword-coverage.mdx
@@ -106,7 +106,7 @@ The scorer handles several special cases:
 
 Evaluate keyword coverage between input queries and agent responses:
 
-```typescript title="src/example-keyword-coverage.ts" showLineNumbers copy
+```typescript title="src/example-keyword-coverage.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createKeywordCoverageScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/keyword-coverage.mdx
+++ b/docs/src/content/en/reference/evals/keyword-coverage.mdx
@@ -106,7 +106,7 @@ The scorer handles several special cases:
 
 Evaluate keyword coverage between input queries and agent responses:
 
-```typescript title="src/example-keyword-coverage.ts" copy
+```typescript title="src/example-keyword-coverage.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createKeywordCoverageScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/prompt-alignment.mdx
+++ b/docs/src/content/en/reference/evals/prompt-alignment.mdx
@@ -107,7 +107,7 @@ The `createPromptAlignmentScorerLLM()` function creates a scorer that evaluates 
 
 You can customize the Prompt Alignment Scorer by adjusting the scale parameter and evaluation mode to fit your scoring needs.
 
-```typescript copy
+```typescript
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: {
@@ -417,7 +417,7 @@ const result = await scorer.run({
 
 In this example, the response fully addresses the user's prompt with all requirements met.
 
-```typescript title="src/example-excellent-prompt-alignment.ts" copy
+```typescript title="src/example-excellent-prompt-alignment.ts"
 import { createPromptAlignmentScorerLLM } from "@mastra/evals/scorers/prebuilt";
 
 const scorer = createPromptAlignmentScorerLLM({
@@ -465,7 +465,7 @@ The output receives a high score because it perfectly addresses the intent, fulf
 
 In this example, the response addresses the core intent but misses some requirements or has format issues.
 
-```typescript title="src/example-partial-prompt-alignment.ts" copy
+```typescript title="src/example-partial-prompt-alignment.ts"
 import { createPromptAlignmentScorerLLM } from "@mastra/evals/scorers/prebuilt";
 
 const scorer = createPromptAlignmentScorerLLM({
@@ -506,7 +506,7 @@ The output receives a lower score because while the content is accurate, it does
 
 In this example, the response fails to address the user's specific requirements.
 
-```typescript title="src/example-poor-prompt-alignment.ts" copy
+```typescript title="src/example-poor-prompt-alignment.ts"
 import { createPromptAlignmentScorerLLM } from "@mastra/evals/scorers/prebuilt";
 
 const scorer = createPromptAlignmentScorerLLM({
@@ -552,7 +552,7 @@ The output receives a low score because it only partially fulfills the requireme
 
 Evaluates how well the response addresses the user's request, ignoring system instructions:
 
-```typescript title="src/example-user-mode.ts" copy
+```typescript title="src/example-user-mode.ts"
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: { evaluationMode: "user" },
@@ -584,7 +584,7 @@ const result = await scorer.run({
 
 Evaluates compliance with system behavioral guidelines and constraints:
 
-```typescript title="src/example-system-mode.ts" copy
+```typescript title="src/example-system-mode.ts"
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: { evaluationMode: "system" },
@@ -617,7 +617,7 @@ const result = await scorer.run({
 
 Evaluates both user intent fulfillment and system compliance with weighted scoring (70% user, 30% system):
 
-```typescript title="src/example-both-mode.ts" copy
+```typescript title="src/example-both-mode.ts"
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: { evaluationMode: "both" }, // This is the default

--- a/docs/src/content/en/reference/evals/prompt-alignment.mdx
+++ b/docs/src/content/en/reference/evals/prompt-alignment.mdx
@@ -107,7 +107,7 @@ The `createPromptAlignmentScorerLLM()` function creates a scorer that evaluates 
 
 You can customize the Prompt Alignment Scorer by adjusting the scale parameter and evaluation mode to fit your scoring needs.
 
-```typescript showLineNumbers copy
+```typescript copy
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: {
@@ -417,7 +417,7 @@ const result = await scorer.run({
 
 In this example, the response fully addresses the user's prompt with all requirements met.
 
-```typescript title="src/example-excellent-prompt-alignment.ts" showLineNumbers copy
+```typescript title="src/example-excellent-prompt-alignment.ts" copy
 import { createPromptAlignmentScorerLLM } from "@mastra/evals/scorers/prebuilt";
 
 const scorer = createPromptAlignmentScorerLLM({
@@ -465,7 +465,7 @@ The output receives a high score because it perfectly addresses the intent, fulf
 
 In this example, the response addresses the core intent but misses some requirements or has format issues.
 
-```typescript title="src/example-partial-prompt-alignment.ts" showLineNumbers copy
+```typescript title="src/example-partial-prompt-alignment.ts" copy
 import { createPromptAlignmentScorerLLM } from "@mastra/evals/scorers/prebuilt";
 
 const scorer = createPromptAlignmentScorerLLM({
@@ -506,7 +506,7 @@ The output receives a lower score because while the content is accurate, it does
 
 In this example, the response fails to address the user's specific requirements.
 
-```typescript title="src/example-poor-prompt-alignment.ts" showLineNumbers copy
+```typescript title="src/example-poor-prompt-alignment.ts" copy
 import { createPromptAlignmentScorerLLM } from "@mastra/evals/scorers/prebuilt";
 
 const scorer = createPromptAlignmentScorerLLM({
@@ -552,7 +552,7 @@ The output receives a low score because it only partially fulfills the requireme
 
 Evaluates how well the response addresses the user's request, ignoring system instructions:
 
-```typescript title="src/example-user-mode.ts" showLineNumbers copy
+```typescript title="src/example-user-mode.ts" copy
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: { evaluationMode: "user" },
@@ -584,7 +584,7 @@ const result = await scorer.run({
 
 Evaluates compliance with system behavioral guidelines and constraints:
 
-```typescript title="src/example-system-mode.ts" showLineNumbers copy
+```typescript title="src/example-system-mode.ts" copy
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: { evaluationMode: "system" },
@@ -617,7 +617,7 @@ const result = await scorer.run({
 
 Evaluates both user intent fulfillment and system compliance with weighted scoring (70% user, 30% system):
 
-```typescript title="src/example-both-mode.ts" showLineNumbers copy
+```typescript title="src/example-both-mode.ts" copy
 const scorer = createPromptAlignmentScorerLLM({
   model: "openai/gpt-5.1",
   options: { evaluationMode: "both" }, // This is the default

--- a/docs/src/content/en/reference/evals/textual-difference.mdx
+++ b/docs/src/content/en/reference/evals/textual-difference.mdx
@@ -87,7 +87,7 @@ A textual difference score between 0 and 1:
 
 Measure textual differences between expected and actual agent outputs:
 
-```typescript title="src/example-textual-difference.ts" copy
+```typescript title="src/example-textual-difference.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createTextualDifferenceScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/textual-difference.mdx
+++ b/docs/src/content/en/reference/evals/textual-difference.mdx
@@ -87,7 +87,7 @@ A textual difference score between 0 and 1:
 
 Measure textual differences between expected and actual agent outputs:
 
-```typescript title="src/example-textual-difference.ts" showLineNumbers copy
+```typescript title="src/example-textual-difference.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createTextualDifferenceScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/tone-consistency.mdx
+++ b/docs/src/content/en/reference/evals/tone-consistency.mdx
@@ -98,7 +98,7 @@ Object with tone metrics:
 
 Evaluate tone consistency between related agent responses:
 
-```typescript title="src/example-tone-consistency.ts" showLineNumbers copy
+```typescript title="src/example-tone-consistency.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createToneScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/tone-consistency.mdx
+++ b/docs/src/content/en/reference/evals/tone-consistency.mdx
@@ -98,7 +98,7 @@ Object with tone metrics:
 
 Evaluate tone consistency between related agent responses:
 
-```typescript title="src/example-tone-consistency.ts" copy
+```typescript title="src/example-tone-consistency.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createToneScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/tool-call-accuracy.mdx
+++ b/docs/src/content/en/reference/evals/tool-call-accuracy.mdx
@@ -89,7 +89,7 @@ When `expectedToolOrder` is provided, the scorer validates tool calling sequence
 
 ### Code-Based Scorer Options
 
-```typescript showLineNumbers copy
+```typescript copy
 // Standard mode - passes if expected tool is called
 const lenientScorer = createCodeScorer({
   expectedTool: "search-tool",
@@ -135,7 +135,7 @@ The code-based scorer provides deterministic, binary scoring (0 or 1) based on e
 
 ### Correct tool selection
 
-```typescript title="src/example-correct-tool.ts" showLineNumbers copy
+```typescript title="src/example-correct-tool.ts" copy
 const scorer = createToolCallAccuracyScorerCode({
   expectedTool: "weather-tool",
 });
@@ -177,7 +177,7 @@ console.log(result.preprocessStepResult?.correctToolCalled); // true
 
 Only passes if exactly one tool is called:
 
-```typescript title="src/example-strict-mode.ts" showLineNumbers copy
+```typescript title="src/example-strict-mode.ts" copy
 const strictScorer = createToolCallAccuracyScorerCode({
   expectedTool: "weather-tool",
   strictMode: true,
@@ -216,7 +216,7 @@ console.log(result.score); // 0 - fails because multiple tools were called
 
 Validates that tools are called in a specific sequence:
 
-```typescript title="src/example-order-validation.ts" showLineNumbers copy
+```typescript title="src/example-order-validation.ts" copy
 const orderScorer = createToolCallAccuracyScorerCode({
   expectedTool: "auth-tool", // ignored when order is specified
   expectedToolOrder: ["auth-tool", "fetch-tool"],
@@ -255,7 +255,7 @@ console.log(result.score); // 1 - correct order
 
 Allows extra tools as long as expected tools maintain relative order:
 
-```typescript title="src/example-flexible-order.ts" showLineNumbers copy
+```typescript title="src/example-flexible-order.ts" copy
 const flexibleOrderScorer = createToolCallAccuracyScorerCode({
   expectedTool: "auth-tool",
   expectedToolOrder: ["auth-tool", "fetch-tool"],
@@ -346,7 +346,7 @@ The LLM-based scorer provides:
 
 ### LLM-Based Scorer Options
 
-```typescript showLineNumbers copy
+```typescript copy
 // Basic configuration
 const basicLLMScorer = createLLMScorer({
   model: 'openai/gpt-5.1',
@@ -387,7 +387,7 @@ The LLM-based scorer uses AI to evaluate whether tool selections are appropriate
 
 ### Basic LLM evaluation
 
-```typescript title="src/example-llm-basic.ts" showLineNumbers copy
+```typescript title="src/example-llm-basic.ts" copy
 const llmScorer = createToolCallAccuracyScorerLLM({
   model: "openai/gpt-5.1",
   availableTools: [
@@ -440,7 +440,7 @@ console.log(result.reason); // "The agent correctly used the weather-tool to add
 
 ### Handling inappropriate tool usage
 
-```typescript title="src/example-llm-inappropriate.ts" showLineNumbers copy
+```typescript title="src/example-llm-inappropriate.ts" copy
 const inputMessages = [
   createUIMessage({
     content: "What is the weather in Tokyo?",
@@ -477,7 +477,7 @@ console.log(result.reason); // "The agent used search-tool when weather-tool wou
 
 The LLM scorer recognizes when agents appropriately ask for clarification:
 
-```typescript title="src/example-llm-clarification.ts" showLineNumbers copy
+```typescript title="src/example-llm-clarification.ts" copy
 const vagueInput = [
   createUIMessage({
     content: 'I need help with something',
@@ -509,7 +509,7 @@ console.log(result.reason); // "The agent appropriately asked for clarification 
 
 Here's an example using both scorers on the same data:
 
-```typescript title="src/example-comparison.ts" showLineNumbers copy
+```typescript title="src/example-comparison.ts" copy
 import {
   createToolCallAccuracyScorerCode as createCodeScorer,
   createToolCallAccuracyScorerLLM as createLLMScorer

--- a/docs/src/content/en/reference/evals/tool-call-accuracy.mdx
+++ b/docs/src/content/en/reference/evals/tool-call-accuracy.mdx
@@ -89,7 +89,7 @@ When `expectedToolOrder` is provided, the scorer validates tool calling sequence
 
 ### Code-Based Scorer Options
 
-```typescript copy
+```typescript
 // Standard mode - passes if expected tool is called
 const lenientScorer = createCodeScorer({
   expectedTool: "search-tool",
@@ -135,7 +135,7 @@ The code-based scorer provides deterministic, binary scoring (0 or 1) based on e
 
 ### Correct tool selection
 
-```typescript title="src/example-correct-tool.ts" copy
+```typescript title="src/example-correct-tool.ts"
 const scorer = createToolCallAccuracyScorerCode({
   expectedTool: "weather-tool",
 });
@@ -177,7 +177,7 @@ console.log(result.preprocessStepResult?.correctToolCalled); // true
 
 Only passes if exactly one tool is called:
 
-```typescript title="src/example-strict-mode.ts" copy
+```typescript title="src/example-strict-mode.ts"
 const strictScorer = createToolCallAccuracyScorerCode({
   expectedTool: "weather-tool",
   strictMode: true,
@@ -216,7 +216,7 @@ console.log(result.score); // 0 - fails because multiple tools were called
 
 Validates that tools are called in a specific sequence:
 
-```typescript title="src/example-order-validation.ts" copy
+```typescript title="src/example-order-validation.ts"
 const orderScorer = createToolCallAccuracyScorerCode({
   expectedTool: "auth-tool", // ignored when order is specified
   expectedToolOrder: ["auth-tool", "fetch-tool"],
@@ -255,7 +255,7 @@ console.log(result.score); // 1 - correct order
 
 Allows extra tools as long as expected tools maintain relative order:
 
-```typescript title="src/example-flexible-order.ts" copy
+```typescript title="src/example-flexible-order.ts"
 const flexibleOrderScorer = createToolCallAccuracyScorerCode({
   expectedTool: "auth-tool",
   expectedToolOrder: ["auth-tool", "fetch-tool"],
@@ -346,7 +346,7 @@ The LLM-based scorer provides:
 
 ### LLM-Based Scorer Options
 
-```typescript copy
+```typescript
 // Basic configuration
 const basicLLMScorer = createLLMScorer({
   model: 'openai/gpt-5.1',
@@ -387,7 +387,7 @@ The LLM-based scorer uses AI to evaluate whether tool selections are appropriate
 
 ### Basic LLM evaluation
 
-```typescript title="src/example-llm-basic.ts" copy
+```typescript title="src/example-llm-basic.ts"
 const llmScorer = createToolCallAccuracyScorerLLM({
   model: "openai/gpt-5.1",
   availableTools: [
@@ -440,7 +440,7 @@ console.log(result.reason); // "The agent correctly used the weather-tool to add
 
 ### Handling inappropriate tool usage
 
-```typescript title="src/example-llm-inappropriate.ts" copy
+```typescript title="src/example-llm-inappropriate.ts"
 const inputMessages = [
   createUIMessage({
     content: "What is the weather in Tokyo?",
@@ -477,7 +477,7 @@ console.log(result.reason); // "The agent used search-tool when weather-tool wou
 
 The LLM scorer recognizes when agents appropriately ask for clarification:
 
-```typescript title="src/example-llm-clarification.ts" copy
+```typescript title="src/example-llm-clarification.ts"
 const vagueInput = [
   createUIMessage({
     content: 'I need help with something',
@@ -509,7 +509,7 @@ console.log(result.reason); // "The agent appropriately asked for clarification 
 
 Here's an example using both scorers on the same data:
 
-```typescript title="src/example-comparison.ts" copy
+```typescript title="src/example-comparison.ts"
 import {
   createToolCallAccuracyScorerCode as createCodeScorer,
   createToolCallAccuracyScorerLLM as createLLMScorer

--- a/docs/src/content/en/reference/evals/toxicity.mdx
+++ b/docs/src/content/en/reference/evals/toxicity.mdx
@@ -123,7 +123,7 @@ A toxicity score between 0 and 1:
 
 Evaluate agent responses for toxic, biased, or harmful content:
 
-```typescript title="src/example-toxicity.ts" showLineNumbers copy
+```typescript title="src/example-toxicity.ts" copy
 import { runEvals } from "@mastra/core/evals";
 import { createToxicityScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/evals/toxicity.mdx
+++ b/docs/src/content/en/reference/evals/toxicity.mdx
@@ -123,7 +123,7 @@ A toxicity score between 0 and 1:
 
 Evaluate agent responses for toxic, biased, or harmful content:
 
-```typescript title="src/example-toxicity.ts" copy
+```typescript title="src/example-toxicity.ts"
 import { runEvals } from "@mastra/core/evals";
 import { createToxicityScorer } from "@mastra/evals/scorers/prebuilt";
 import { myAgent } from "./agent";

--- a/docs/src/content/en/reference/logging/pino-logger.mdx
+++ b/docs/src/content/en/reference/logging/pino-logger.mdx
@@ -11,7 +11,7 @@ When deploying to Mastra Cloud, logs are displayed on the [Logs](/docs/v1/mastra
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" copy
+```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { PinoLogger } from "@mastra/loggers";
 
@@ -63,7 +63,7 @@ export const mastra = new Mastra({
 
 Writes structured logs to a file using the `FileTransport`. The logger accepts a plain message as the first argument and structured metadata as the second argument. These are internally converted to a `BaseLogMessage` and persisted to the configured file path.
 
-```typescript title="src/mastra/loggers/file-transport.ts" copy
+```typescript title="src/mastra/loggers/file-transport.ts"
 import { FileTransport } from "@mastra/loggers/file";
 import { PinoLogger } from "@mastra/loggers/pino";
 
@@ -76,7 +76,7 @@ export const fileLogger = new PinoLogger({
 
 ### File transport usage
 
-```typescript copy
+```typescript
 fileLogger.warn("Low disk space", {
   destinationPath: "system",
   type: "WORKFLOW",
@@ -87,7 +87,7 @@ fileLogger.warn("Low disk space", {
 
 Streams structured logs to a remote Redis list using the `UpstashTransport`. The logger accepts a string message and a structured metadata object. This enables centralized logging for distributed environments, supporting filtering by `destinationPath`, `type`, and `runId`.
 
-```typescript title="src/mastra/loggers/upstash-transport.ts" copy
+```typescript title="src/mastra/loggers/upstash-transport.ts"
 import { UpstashTransport } from "@mastra/loggers/upstash";
 import { PinoLogger } from "@mastra/loggers/pino";
 
@@ -106,7 +106,7 @@ export const upstashLogger = new PinoLogger({
 
 ### Upstash transport usage
 
-```typescript copy
+```typescript
 upstashLogger.info("User signed in", {
   destinationPath: "auth",
   type: "AGENT",
@@ -122,7 +122,7 @@ You can create custom transports using the `createCustomTransport` utility to in
 
 Creates a custom transport using `createCustomTransport` and integrates it with a third-party logging stream such as `pino-sentry-transport`. This allows forwarding logs to an external system like Sentry for advanced monitoring and observability.
 
-```typescript title="src/mastra/loggers/sentry-transport.ts" copy
+```typescript title="src/mastra/loggers/sentry-transport.ts"
 import { createCustomTransport } from "@mastra/core/loggers";
 import { PinoLogger } from "@mastra/loggers/pino";
 import pinoSentry from "pino-sentry-transport";

--- a/docs/src/content/en/reference/logging/pino-logger.mdx
+++ b/docs/src/content/en/reference/logging/pino-logger.mdx
@@ -11,7 +11,7 @@ When deploying to Mastra Cloud, logs are displayed on the [Logs](/docs/v1/mastra
 
 ## Usage example
 
-```typescript title="src/mastra/index.ts" showLineNumbers copy
+```typescript title="src/mastra/index.ts" copy
 import { Mastra } from "@mastra/core";
 import { PinoLogger } from "@mastra/loggers";
 
@@ -63,7 +63,7 @@ export const mastra = new Mastra({
 
 Writes structured logs to a file using the `FileTransport`. The logger accepts a plain message as the first argument and structured metadata as the second argument. These are internally converted to a `BaseLogMessage` and persisted to the configured file path.
 
-```typescript title="src/mastra/loggers/file-transport.ts" showLineNumbers copy
+```typescript title="src/mastra/loggers/file-transport.ts" copy
 import { FileTransport } from "@mastra/loggers/file";
 import { PinoLogger } from "@mastra/loggers/pino";
 
@@ -76,7 +76,7 @@ export const fileLogger = new PinoLogger({
 
 ### File transport usage
 
-```typescript showLineNumbers copy
+```typescript copy
 fileLogger.warn("Low disk space", {
   destinationPath: "system",
   type: "WORKFLOW",
@@ -87,7 +87,7 @@ fileLogger.warn("Low disk space", {
 
 Streams structured logs to a remote Redis list using the `UpstashTransport`. The logger accepts a string message and a structured metadata object. This enables centralized logging for distributed environments, supporting filtering by `destinationPath`, `type`, and `runId`.
 
-```typescript title="src/mastra/loggers/upstash-transport.ts" showLineNumbers copy
+```typescript title="src/mastra/loggers/upstash-transport.ts" copy
 import { UpstashTransport } from "@mastra/loggers/upstash";
 import { PinoLogger } from "@mastra/loggers/pino";
 
@@ -106,7 +106,7 @@ export const upstashLogger = new PinoLogger({
 
 ### Upstash transport usage
 
-```typescript showLineNumbers copy
+```typescript copy
 upstashLogger.info("User signed in", {
   destinationPath: "auth",
   type: "AGENT",
@@ -122,7 +122,7 @@ You can create custom transports using the `createCustomTransport` utility to in
 
 Creates a custom transport using `createCustomTransport` and integrates it with a third-party logging stream such as `pino-sentry-transport`. This allows forwarding logs to an external system like Sentry for advanced monitoring and observability.
 
-```typescript title="src/mastra/loggers/sentry-transport.ts" showLineNumbers copy
+```typescript title="src/mastra/loggers/sentry-transport.ts" copy
 import { createCustomTransport } from "@mastra/core/loggers";
 import { PinoLogger } from "@mastra/loggers/pino";
 import pinoSentry from "pino-sentry-transport";

--- a/docs/src/content/en/reference/memory/createThread.mdx
+++ b/docs/src/content/en/reference/memory/createThread.mdx
@@ -9,7 +9,7 @@ The `.createThread()` method creates a new conversation thread in the memory sys
 
 ## Usage Example
 
-```typescript copy
+```typescript
 await memory?.createThread({ resourceId: "user-123" });
 ```
 
@@ -85,7 +85,7 @@ await memory?.createThread({ resourceId: "user-123" });
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" copy
+```typescript title="src/test-memory.ts"
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/memory/createThread.mdx
+++ b/docs/src/content/en/reference/memory/createThread.mdx
@@ -85,7 +85,7 @@ await memory?.createThread({ resourceId: "user-123" });
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" showLineNumbers copy
+```typescript title="src/test-memory.ts" copy
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/memory/deleteMessages.mdx
+++ b/docs/src/content/en/reference/memory/deleteMessages.mdx
@@ -9,7 +9,7 @@ The `.deleteMessages()` method deletes multiple messages by their IDs.
 
 ## Usage Example
 
-```typescript copy
+```typescript
 await memory?.deleteMessages(["671ae63f-3a91-4082-a907-fe7de78e10ec"]);
 ```
 
@@ -40,7 +40,7 @@ await memory?.deleteMessages(["671ae63f-3a91-4082-a907-fe7de78e10ec"]);
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" copy
+```typescript title="src/test-memory.ts"
 import { mastra } from "./mastra";
 import { MastraDBMessage } from "@mastra/core";
 

--- a/docs/src/content/en/reference/memory/deleteMessages.mdx
+++ b/docs/src/content/en/reference/memory/deleteMessages.mdx
@@ -40,7 +40,7 @@ await memory?.deleteMessages(["671ae63f-3a91-4082-a907-fe7de78e10ec"]);
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" showLineNumbers copy
+```typescript title="src/test-memory.ts" copy
 import { mastra } from "./mastra";
 import { MastraDBMessage } from "@mastra/core";
 

--- a/docs/src/content/en/reference/memory/listThreadsByResourceId.mdx
+++ b/docs/src/content/en/reference/memory/listThreadsByResourceId.mdx
@@ -70,7 +70,7 @@ The return object contains:
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" showLineNumbers copy
+```typescript title="src/test-memory.ts" copy
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/memory/listThreadsByResourceId.mdx
+++ b/docs/src/content/en/reference/memory/listThreadsByResourceId.mdx
@@ -9,7 +9,7 @@ The `.listThreadsByResourceId()` method retrieves threads associated with a spec
 
 ## Usage Example
 
-```typescript copy
+```typescript
 await memory.listThreadsByResourceId({
   resourceId: "user-123",
   page: 0,
@@ -70,7 +70,7 @@ The return object contains:
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" copy
+```typescript title="src/test-memory.ts"
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -9,7 +9,7 @@ The `Memory` class provides a robust system for managing conversation history an
 
 ## Usage example
 
-```typescript title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/test-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 
@@ -124,7 +124,7 @@ export const agent = new Agent({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/test-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/test-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
@@ -162,7 +162,7 @@ export const agent = new Agent({
 
 ## PostgreSQL with index configuration
 
-```typescript title="src/mastra/agents/pg-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/pg-agent.ts" copy
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -9,7 +9,7 @@ The `Memory` class provides a robust system for managing conversation history an
 
 ## Usage example
 
-```typescript title="src/mastra/agents/test-agent.ts" copy
+```typescript title="src/mastra/agents/test-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 
@@ -124,7 +124,7 @@ export const agent = new Agent({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/test-agent.ts" copy
+```typescript title="src/mastra/agents/test-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { LibSQLStore, LibSQLVector } from "@mastra/libsql";
@@ -162,7 +162,7 @@ export const agent = new Agent({
 
 ## PostgreSQL with index configuration
 
-```typescript title="src/mastra/agents/pg-agent.ts" copy
+```typescript title="src/mastra/agents/pg-agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
 import { ModelRouterEmbeddingModel } from "@mastra/core/llm";

--- a/docs/src/content/en/reference/memory/query.mdx
+++ b/docs/src/content/en/reference/memory/query.mdx
@@ -13,7 +13,7 @@ the `.query()` method retrieves messages from a specific thread, with support fo
 
 ## Usage Example
 
-```typescript copy
+```typescript
 await memory?.query({ threadId: "user-123" });
 ```
 
@@ -142,7 +142,7 @@ await memory?.query({ threadId: "user-123" });
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" copy
+```typescript title="src/test-memory.ts"
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/memory/query.mdx
+++ b/docs/src/content/en/reference/memory/query.mdx
@@ -142,7 +142,7 @@ await memory?.query({ threadId: "user-123" });
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" showLineNumbers copy
+```typescript title="src/test-memory.ts" copy
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/memory/recall.mdx
+++ b/docs/src/content/en/reference/memory/recall.mdx
@@ -138,7 +138,7 @@ await memory?.recall({ threadId: "user-123" });
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" showLineNumbers copy
+```typescript title="src/test-memory.ts" copy
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/memory/recall.mdx
+++ b/docs/src/content/en/reference/memory/recall.mdx
@@ -9,7 +9,7 @@ the `.recall()` method retrieves messages from a specific thread, with support f
 
 ## Usage Example
 
-```typescript copy
+```typescript
 await memory?.recall({ threadId: "user-123" });
 ```
 
@@ -138,7 +138,7 @@ await memory?.recall({ threadId: "user-123" });
 
 ## Extended usage example
 
-```typescript title="src/test-memory.ts" copy
+```typescript title="src/test-memory.ts"
 import { mastra } from "./mastra";
 
 const agent = mastra.getAgent("agent");

--- a/docs/src/content/en/reference/processors/batch-parts-processor.mdx
+++ b/docs/src/content/en/reference/processors/batch-parts-processor.mdx
@@ -93,7 +93,7 @@ const processor = new BatchPartsProcessor({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/batched-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/batched-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/batch-parts-processor.mdx
+++ b/docs/src/content/en/reference/processors/batch-parts-processor.mdx
@@ -9,7 +9,7 @@ The `BatchPartsProcessor` is an **output processor** that batches multiple strea
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { BatchPartsProcessor } from "@mastra/core/processors";
 
 const processor = new BatchPartsProcessor({
@@ -93,7 +93,7 @@ const processor = new BatchPartsProcessor({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/batched-agent.ts" copy
+```typescript title="src/mastra/agents/batched-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/language-detector.mdx
+++ b/docs/src/content/en/reference/processors/language-detector.mdx
@@ -136,7 +136,7 @@ const processor = new LanguageDetector({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/multilingual-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/multilingual-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { LanguageDetector } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/language-detector.mdx
+++ b/docs/src/content/en/reference/processors/language-detector.mdx
@@ -9,7 +9,7 @@ The `LanguageDetector` is an **input processor** that identifies the language of
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { LanguageDetector } from "@mastra/core/processors";
 
 const processor = new LanguageDetector({
@@ -136,7 +136,7 @@ const processor = new LanguageDetector({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/multilingual-agent.ts" copy
+```typescript title="src/mastra/agents/multilingual-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { LanguageDetector } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/message-history-processor.mdx
+++ b/docs/src/content/en/reference/processors/message-history-processor.mdx
@@ -83,7 +83,7 @@ const processor = new MessageHistory({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/memory-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/memory-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { MessageHistory } from "@mastra/core/processors";
 import { PostgresStorage } from "@mastra/pg";

--- a/docs/src/content/en/reference/processors/message-history-processor.mdx
+++ b/docs/src/content/en/reference/processors/message-history-processor.mdx
@@ -9,7 +9,7 @@ The `MessageHistory` is a **hybrid processor** that handles both retrieval and p
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { MessageHistory } from "@mastra/core/processors";
 
 const processor = new MessageHistory({
@@ -83,7 +83,7 @@ const processor = new MessageHistory({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/memory-agent.ts" copy
+```typescript title="src/mastra/agents/memory-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { MessageHistory } from "@mastra/core/processors";
 import { PostgresStorage } from "@mastra/pg";

--- a/docs/src/content/en/reference/processors/moderation-processor.mdx
+++ b/docs/src/content/en/reference/processors/moderation-processor.mdx
@@ -9,7 +9,7 @@ The `ModerationProcessor` is a **hybrid processor** that can be used for both in
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { ModerationProcessor } from "@mastra/core/processors";
 
 const processor = new ModerationProcessor({
@@ -130,7 +130,7 @@ const processor = new ModerationProcessor({
 
 ### Input processing
 
-```typescript title="src/mastra/agents/moderated-agent.ts" copy
+```typescript title="src/mastra/agents/moderated-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { ModerationProcessor } from "@mastra/core/processors";
 
@@ -155,7 +155,7 @@ export const agent = new Agent({
 
 When using `ModerationProcessor` as an output processor, it's recommended to combine it with `BatchPartsProcessor` to optimize performance. The `BatchPartsProcessor` batches stream chunks together before passing them to the moderator, reducing the number of LLM calls required for moderation.
 
-```typescript title="src/mastra/agents/output-moderated-agent.ts" copy
+```typescript title="src/mastra/agents/output-moderated-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor, ModerationProcessor } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/moderation-processor.mdx
+++ b/docs/src/content/en/reference/processors/moderation-processor.mdx
@@ -130,7 +130,7 @@ const processor = new ModerationProcessor({
 
 ### Input processing
 
-```typescript title="src/mastra/agents/moderated-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/moderated-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { ModerationProcessor } from "@mastra/core/processors";
 
@@ -155,7 +155,7 @@ export const agent = new Agent({
 
 When using `ModerationProcessor` as an output processor, it's recommended to combine it with `BatchPartsProcessor` to optimize performance. The `BatchPartsProcessor` batches stream chunks together before passing them to the moderator, reducing the number of LLM calls required for moderation.
 
-```typescript title="src/mastra/agents/output-moderated-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/output-moderated-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor, ModerationProcessor } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/pii-detector.mdx
+++ b/docs/src/content/en/reference/processors/pii-detector.mdx
@@ -9,7 +9,7 @@ The `PIIDetector` is a **hybrid processor** that can be used for both input and 
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { PIIDetector } from "@mastra/core/processors";
 
 const processor = new PIIDetector({
@@ -137,7 +137,7 @@ const processor = new PIIDetector({
 
 ### Input processing
 
-```typescript title="src/mastra/agents/private-agent.ts" copy
+```typescript title="src/mastra/agents/private-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { PIIDetector } from "@mastra/core/processors";
 
@@ -164,7 +164,7 @@ export const agent = new Agent({
 
 When using `PIIDetector` as an output processor, it's recommended to combine it with `BatchPartsProcessor` to optimize performance. The `BatchPartsProcessor` batches stream chunks together before passing them to the PII detector, reducing the number of LLM calls required for detection.
 
-```typescript title="src/mastra/agents/output-pii-agent.ts" copy
+```typescript title="src/mastra/agents/output-pii-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor, PIIDetector } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/pii-detector.mdx
+++ b/docs/src/content/en/reference/processors/pii-detector.mdx
@@ -137,7 +137,7 @@ const processor = new PIIDetector({
 
 ### Input processing
 
-```typescript title="src/mastra/agents/private-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/private-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { PIIDetector } from "@mastra/core/processors";
 
@@ -164,7 +164,7 @@ export const agent = new Agent({
 
 When using `PIIDetector` as an output processor, it's recommended to combine it with `BatchPartsProcessor` to optimize performance. The `BatchPartsProcessor` batches stream chunks together before passing them to the PII detector, reducing the number of LLM calls required for detection.
 
-```typescript title="src/mastra/agents/output-pii-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/output-pii-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor, PIIDetector } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -598,7 +598,7 @@ processOutputStep?(args: ProcessOutputStepArgs): ProcessorMessageResult;
 
 #### Example: Quality guardrail with retry
 
-```typescript title="src/mastra/processors/quality-guardrail.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/quality-guardrail.ts" copy
 import type { Processor } from "@mastra/core";
 
 export class QualityGuardrail implements Processor {
@@ -648,7 +648,7 @@ type OutputProcessor = Processor & (
 
 ### Basic input processor
 
-```typescript title="src/mastra/processors/lowercase.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/lowercase.ts" copy
 import type { Processor, MastraDBMessage } from "@mastra/core";
 
 export class LowercaseProcessor implements Processor {
@@ -672,7 +672,7 @@ export class LowercaseProcessor implements Processor {
 
 ### Per-step processor with processInputStep
 
-```typescript title="src/mastra/processors/dynamic-model.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/dynamic-model.ts" copy
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from "@mastra/core";
 
 export class DynamicModelProcessor implements Processor {
@@ -705,7 +705,7 @@ export class DynamicModelProcessor implements Processor {
 
 ### Message transformer with processInputStep
 
-```typescript title="src/mastra/processors/reasoning-transformer.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/reasoning-transformer.ts" copy
 import type { Processor, MastraDBMessage } from "@mastra/core";
 
 export class ReasoningTransformer implements Processor {
@@ -730,7 +730,7 @@ export class ReasoningTransformer implements Processor {
 
 ### Hybrid processor (input and output)
 
-```typescript title="src/mastra/processors/content-filter.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/content-filter.ts" copy
 import type { Processor, MastraDBMessage, ChunkType } from "@mastra/core";
 
 export class ContentFilter implements Processor {
@@ -768,7 +768,7 @@ export class ContentFilter implements Processor {
 
 ### Stream accumulator with state
 
-```typescript title="src/mastra/processors/word-counter.ts" showLineNumbers copy
+```typescript title="src/mastra/processors/word-counter.ts" copy
 import type { Processor, ChunkType } from "@mastra/core";
 
 export class WordCounter implements Processor {

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -70,7 +70,7 @@ The five processor methods run at different points in the agent execution lifecy
 
 ## Interface definition
 
-```typescript copy
+```typescript
 interface Processor<TId extends string = string> {
   readonly id: TId;
   readonly name?: string;
@@ -108,7 +108,7 @@ interface Processor<TId extends string = string> {
 
 Processes input messages before they are sent to the LLM. Runs once at the start of agent execution.
 
-```typescript copy
+```typescript
 processInput?(args: ProcessInputArgs): Promise<ProcessInputResult> | ProcessInputResult;
 ```
 
@@ -191,7 +191,7 @@ The method can return one of three types:
 
 Processes input messages at each step of the agentic loop, before they are sent to the LLM. Unlike `processInput` which runs once at the start, this runs at every step including tool call continuations.
 
-```typescript copy
+```typescript
 processInputStep?(args: ProcessInputStepArgs): ProcessorMessageResult;
 ```
 
@@ -401,7 +401,7 @@ System messages are **reset to their original values** at the start of each step
 
 Processes streaming output chunks with built-in state management. Allows processors to accumulate chunks and make decisions based on larger context.
 
-```typescript copy
+```typescript
 processOutputStream?(args: ProcessOutputStreamArgs): Promise<ChunkType | null | undefined>;
 ```
 
@@ -465,7 +465,7 @@ processOutputStream?(args: ProcessOutputStreamArgs): Promise<ChunkType | null | 
 
 Processes the complete output result after streaming or generation is finished.
 
-```typescript copy
+```typescript
 processOutputResult?(args: ProcessOutputResultArgs): ProcessorMessageResult;
 ```
 
@@ -512,7 +512,7 @@ processOutputResult?(args: ProcessOutputResultArgs): ProcessorMessageResult;
 
 Processes output after each LLM response in the agentic loop, before tool execution. Unlike `processOutputResult` which runs once at the end, this runs at every step. This is the ideal method for implementing guardrails that can trigger retries.
 
-```typescript copy
+```typescript
 processOutputStep?(args: ProcessOutputStepArgs): ProcessorMessageResult;
 ```
 
@@ -598,7 +598,7 @@ processOutputStep?(args: ProcessOutputStepArgs): ProcessorMessageResult;
 
 #### Example: Quality guardrail with retry
 
-```typescript title="src/mastra/processors/quality-guardrail.ts" copy
+```typescript title="src/mastra/processors/quality-guardrail.ts"
 import type { Processor } from "@mastra/core";
 
 export class QualityGuardrail implements Processor {
@@ -629,7 +629,7 @@ export class QualityGuardrail implements Processor {
 
 Mastra provides type aliases to ensure processors implement the required methods:
 
-```typescript copy
+```typescript
 // Must implement processInput OR processInputStep (or both)
 type InputProcessor = Processor & (
   | { processInput: required }
@@ -648,7 +648,7 @@ type OutputProcessor = Processor & (
 
 ### Basic input processor
 
-```typescript title="src/mastra/processors/lowercase.ts" copy
+```typescript title="src/mastra/processors/lowercase.ts"
 import type { Processor, MastraDBMessage } from "@mastra/core";
 
 export class LowercaseProcessor implements Processor {
@@ -672,7 +672,7 @@ export class LowercaseProcessor implements Processor {
 
 ### Per-step processor with processInputStep
 
-```typescript title="src/mastra/processors/dynamic-model.ts" copy
+```typescript title="src/mastra/processors/dynamic-model.ts"
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from "@mastra/core";
 
 export class DynamicModelProcessor implements Processor {
@@ -705,7 +705,7 @@ export class DynamicModelProcessor implements Processor {
 
 ### Message transformer with processInputStep
 
-```typescript title="src/mastra/processors/reasoning-transformer.ts" copy
+```typescript title="src/mastra/processors/reasoning-transformer.ts"
 import type { Processor, MastraDBMessage } from "@mastra/core";
 
 export class ReasoningTransformer implements Processor {
@@ -730,7 +730,7 @@ export class ReasoningTransformer implements Processor {
 
 ### Hybrid processor (input and output)
 
-```typescript title="src/mastra/processors/content-filter.ts" copy
+```typescript title="src/mastra/processors/content-filter.ts"
 import type { Processor, MastraDBMessage, ChunkType } from "@mastra/core";
 
 export class ContentFilter implements Processor {
@@ -768,7 +768,7 @@ export class ContentFilter implements Processor {
 
 ### Stream accumulator with state
 
-```typescript title="src/mastra/processors/word-counter.ts" copy
+```typescript title="src/mastra/processors/word-counter.ts"
 import type { Processor, ChunkType } from "@mastra/core";
 
 export class WordCounter implements Processor {

--- a/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
+++ b/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
@@ -115,7 +115,7 @@ const processor = new PromptInjectionDetector({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/secure-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/secure-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { PromptInjectionDetector } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
+++ b/docs/src/content/en/reference/processors/prompt-injection-detector.mdx
@@ -9,7 +9,7 @@ The `PromptInjectionDetector` is an **input processor** that detects and prevent
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { PromptInjectionDetector } from "@mastra/core/processors";
 
 const processor = new PromptInjectionDetector({
@@ -115,7 +115,7 @@ const processor = new PromptInjectionDetector({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/secure-agent.ts" copy
+```typescript title="src/mastra/agents/secure-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { PromptInjectionDetector } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/semantic-recall-processor.mdx
+++ b/docs/src/content/en/reference/processors/semantic-recall-processor.mdx
@@ -133,7 +133,7 @@ const processor = new SemanticRecall({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/semantic-memory-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/semantic-memory-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { SemanticRecall, MessageHistory } from "@mastra/core/processors";
 import { PostgresStorage } from "@mastra/pg";

--- a/docs/src/content/en/reference/processors/semantic-recall-processor.mdx
+++ b/docs/src/content/en/reference/processors/semantic-recall-processor.mdx
@@ -9,7 +9,7 @@ The `SemanticRecall` is a **hybrid processor** that enables semantic search over
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { SemanticRecall } from "@mastra/core/processors";
 import { openai } from "@ai-sdk/openai";
 
@@ -133,7 +133,7 @@ const processor = new SemanticRecall({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/semantic-memory-agent.ts" copy
+```typescript title="src/mastra/agents/semantic-memory-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { SemanticRecall, MessageHistory } from "@mastra/core/processors";
 import { PostgresStorage } from "@mastra/pg";

--- a/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
+++ b/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
@@ -9,7 +9,7 @@ The `SystemPromptScrubber` is an **output processor** that detects and handles s
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { SystemPromptScrubber } from "@mastra/core/processors";
 
 const processor = new SystemPromptScrubber({
@@ -123,7 +123,7 @@ const processor = new SystemPromptScrubber({
 
 When using `SystemPromptScrubber` as an output processor, it's recommended to combine it with `BatchPartsProcessor` to optimize performance. The `BatchPartsProcessor` batches stream chunks together before passing them to the scrubber, reducing the number of LLM calls required for detection.
 
-```typescript title="src/mastra/agents/scrubbed-agent.ts" copy
+```typescript title="src/mastra/agents/scrubbed-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor, SystemPromptScrubber } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
+++ b/docs/src/content/en/reference/processors/system-prompt-scrubber.mdx
@@ -123,7 +123,7 @@ const processor = new SystemPromptScrubber({
 
 When using `SystemPromptScrubber` as an output processor, it's recommended to combine it with `BatchPartsProcessor` to optimize performance. The `BatchPartsProcessor` batches stream chunks together before passing them to the scrubber, reducing the number of LLM calls required for detection.
 
-```typescript title="src/mastra/agents/scrubbed-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/scrubbed-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { BatchPartsProcessor, SystemPromptScrubber } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/token-limiter-processor.mdx
+++ b/docs/src/content/en/reference/processors/token-limiter-processor.mdx
@@ -117,7 +117,7 @@ const processor = new TokenLimiterProcessor({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/limited-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/limited-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { TokenLimiterProcessor } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/token-limiter-processor.mdx
+++ b/docs/src/content/en/reference/processors/token-limiter-processor.mdx
@@ -9,7 +9,7 @@ The `TokenLimiterProcessor` is an **output processor** that limits the number of
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { TokenLimiterProcessor } from "@mastra/core/processors";
 
 const processor = new TokenLimiterProcessor({
@@ -117,7 +117,7 @@ const processor = new TokenLimiterProcessor({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/limited-agent.ts" copy
+```typescript title="src/mastra/agents/limited-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { TokenLimiterProcessor } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/tool-call-filter.mdx
+++ b/docs/src/content/en/reference/processors/tool-call-filter.mdx
@@ -74,7 +74,7 @@ const filterSpecific = new ToolCallFilter({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/filtered-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/filtered-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { ToolCallFilter } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/tool-call-filter.mdx
+++ b/docs/src/content/en/reference/processors/tool-call-filter.mdx
@@ -9,7 +9,7 @@ The `ToolCallFilter` is an **input processor** that filters out tool calls and t
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { ToolCallFilter } from "@mastra/core/processors";
 
 // Exclude all tool calls
@@ -74,7 +74,7 @@ const filterSpecific = new ToolCallFilter({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/filtered-agent.ts" copy
+```typescript title="src/mastra/agents/filtered-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { ToolCallFilter } from "@mastra/core/processors";
 
@@ -99,7 +99,7 @@ export const agent = new Agent({
 
 ## Filtering all tool calls
 
-```typescript copy
+```typescript
 import { Agent } from "@mastra/core/agent";
 import { ToolCallFilter } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/unicode-normalizer.mdx
+++ b/docs/src/content/en/reference/processors/unicode-normalizer.mdx
@@ -94,7 +94,7 @@ const processor = new UnicodeNormalizer({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/normalized-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/normalized-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { UnicodeNormalizer } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/unicode-normalizer.mdx
+++ b/docs/src/content/en/reference/processors/unicode-normalizer.mdx
@@ -9,7 +9,7 @@ The `UnicodeNormalizer` is an **input processor** that normalizes Unicode text t
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { UnicodeNormalizer } from "@mastra/core/processors";
 
 const processor = new UnicodeNormalizer({
@@ -94,7 +94,7 @@ const processor = new UnicodeNormalizer({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/normalized-agent.ts" copy
+```typescript title="src/mastra/agents/normalized-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { UnicodeNormalizer } from "@mastra/core/processors";
 

--- a/docs/src/content/en/reference/processors/working-memory-processor.mdx
+++ b/docs/src/content/en/reference/processors/working-memory-processor.mdx
@@ -9,7 +9,7 @@ The `WorkingMemory` is an **input processor** that injects working memory data a
 
 ## Usage example
 
-```typescript copy
+```typescript
 import { WorkingMemory } from "@mastra/core/processors";
 
 const processor = new WorkingMemory({
@@ -135,7 +135,7 @@ const processor = new WorkingMemory({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/personalized-agent.ts" copy
+```typescript title="src/mastra/agents/personalized-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { WorkingMemory, MessageHistory } from "@mastra/core/processors";
 import { PostgresStorage } from "@mastra/pg";
@@ -173,7 +173,7 @@ export const agent = new Agent({
 
 ## JSON format example
 
-```typescript copy
+```typescript
 import { WorkingMemory } from "@mastra/core/processors";
 
 const processor = new WorkingMemory({

--- a/docs/src/content/en/reference/processors/working-memory-processor.mdx
+++ b/docs/src/content/en/reference/processors/working-memory-processor.mdx
@@ -135,7 +135,7 @@ const processor = new WorkingMemory({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/personalized-agent.ts" showLineNumbers copy
+```typescript title="src/mastra/agents/personalized-agent.ts" copy
 import { Agent } from "@mastra/core/agent";
 import { WorkingMemory, MessageHistory } from "@mastra/core/processors";
 import { PostgresStorage } from "@mastra/pg";

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -112,7 +112,7 @@ See [ExtractParams reference](/reference/v1/rag/extract-params) for details on t
 
 Strategy-specific options are passed as top-level parameters alongside the strategy parameter. For example:
 
-```typescript copy
+```typescript
 // Character strategy example
 const chunks = await doc.chunk({
   strategy: "character",

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -112,7 +112,7 @@ See [ExtractParams reference](/reference/v1/rag/extract-params) for details on t
 
 Strategy-specific options are passed as top-level parameters alongside the strategy parameter. For example:
 
-```typescript showLineNumbers copy
+```typescript copy
 // Character strategy example
 const chunks = await doc.chunk({
   strategy: "character",

--- a/docs/src/content/en/reference/rag/extract-params.mdx
+++ b/docs/src/content/en/reference/rag/extract-params.mdx
@@ -9,7 +9,7 @@ ExtractParams configures metadata extraction from document chunks using LLM anal
 
 ## Example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { MDocument } from "@mastra/rag";
 
 const doc = MDocument.fromText(text);
@@ -188,7 +188,7 @@ The `extract` parameter accepts the following fields:
 
 ## Advanced Example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { MDocument } from "@mastra/rag";
 
 const doc = MDocument.fromText(text);

--- a/docs/src/content/en/reference/rag/extract-params.mdx
+++ b/docs/src/content/en/reference/rag/extract-params.mdx
@@ -9,7 +9,7 @@ ExtractParams configures metadata extraction from document chunks using LLM anal
 
 ## Example
 
-```typescript copy
+```typescript
 import { MDocument } from "@mastra/rag";
 
 const doc = MDocument.fromText(text);
@@ -188,7 +188,7 @@ The `extract` parameter accepts the following fields:
 
 ## Advanced Example
 
-```typescript copy
+```typescript
 import { MDocument } from "@mastra/rag";
 
 const doc = MDocument.fromText(text);

--- a/docs/src/content/en/reference/server/create-route.mdx
+++ b/docs/src/content/en/reference/server/create-route.mdx
@@ -118,7 +118,7 @@ function createRoute<TPath, TQuery, TBody, TResponse, TResponseType>(
 
 The handler receives validated parameters plus runtime context:
 
-```typescript copy showLineNumbers
+```typescript copy
 handler: async (params) => {
   // From schemas (typed from Zod)
   params.id;              // From pathParamSchema
@@ -142,7 +142,7 @@ Returns a `ServerRoute` object that can be registered with an adapter.
 
 ### GET route with path params
 
-```typescript copy showLineNumbers
+```typescript copy
 import { createRoute } from '@mastra/server/server-adapter';
 import { z } from 'zod';
 
@@ -167,7 +167,7 @@ const getAgent = createRoute({
 
 ### POST route with body
 
-```typescript copy showLineNumbers
+```typescript copy
 const createItem = createRoute({
   method: 'POST',
   path: '/api/items',
@@ -190,7 +190,7 @@ const createItem = createRoute({
 
 ### Query params with coercion
 
-```typescript copy showLineNumbers
+```typescript copy
 const listItems = createRoute({
   method: 'GET',
   path: '/api/items',
@@ -209,7 +209,7 @@ const listItems = createRoute({
 
 ### Streaming route
 
-```typescript copy showLineNumbers
+```typescript copy
 const streamAgent = createRoute({
   method: 'POST',
   path: '/api/agents/:agentId/stream',
@@ -230,7 +230,7 @@ const streamAgent = createRoute({
 
 ### Custom body size limit
 
-```typescript copy showLineNumbers
+```typescript copy
 const uploadRoute = createRoute({
   method: 'POST',
   path: '/api/upload',
@@ -279,7 +279,7 @@ const bodySchema = z.object({
 
 Throw an error with a `status` property to return specific HTTP status codes from handlers. If using Hono, you can use `HTTPException` from `hono/http-exception`:
 
-```typescript copy showLineNumbers
+```typescript copy
 import { createRoute } from '@mastra/server/server-adapter';
 import { HTTPException } from 'hono/http-exception';
 
@@ -300,7 +300,7 @@ const getAgent = createRoute({
 
 For Express or framework-agnostic code, throw an error with a `status` property:
 
-```typescript copy showLineNumbers
+```typescript copy
 class HttpError extends Error {
   constructor(public status: number, message: string) {
     super(message);

--- a/docs/src/content/en/reference/server/create-route.mdx
+++ b/docs/src/content/en/reference/server/create-route.mdx
@@ -11,13 +11,13 @@ The `createRoute()` function creates type-safe routes with Zod validation. When 
 
 ## Import
 
-```typescript copy
+```typescript
 import { createRoute } from '@mastra/server/server-adapter';
 ```
 
 ## Signature
 
-```typescript copy
+```typescript
 function createRoute<TPath, TQuery, TBody, TResponse, TResponseType>(
   config: RouteConfig<TPath, TQuery, TBody, TResponse, TResponseType>
 ): ServerRoute
@@ -118,7 +118,7 @@ function createRoute<TPath, TQuery, TBody, TResponse, TResponseType>(
 
 The handler receives validated parameters plus runtime context:
 
-```typescript copy
+```typescript
 handler: async (params) => {
   // From schemas (typed from Zod)
   params.id;              // From pathParamSchema
@@ -142,7 +142,7 @@ Returns a `ServerRoute` object that can be registered with an adapter.
 
 ### GET route with path params
 
-```typescript copy
+```typescript
 import { createRoute } from '@mastra/server/server-adapter';
 import { z } from 'zod';
 
@@ -167,7 +167,7 @@ const getAgent = createRoute({
 
 ### POST route with body
 
-```typescript copy
+```typescript
 const createItem = createRoute({
   method: 'POST',
   path: '/api/items',
@@ -190,7 +190,7 @@ const createItem = createRoute({
 
 ### Query params with coercion
 
-```typescript copy
+```typescript
 const listItems = createRoute({
   method: 'GET',
   path: '/api/items',
@@ -209,7 +209,7 @@ const listItems = createRoute({
 
 ### Streaming route
 
-```typescript copy
+```typescript
 const streamAgent = createRoute({
   method: 'POST',
   path: '/api/agents/:agentId/stream',
@@ -230,7 +230,7 @@ const streamAgent = createRoute({
 
 ### Custom body size limit
 
-```typescript copy
+```typescript
 const uploadRoute = createRoute({
   method: 'POST',
   path: '/api/upload',
@@ -249,7 +249,7 @@ const uploadRoute = createRoute({
 
 ### Passthrough for extensibility
 
-```typescript copy
+```typescript
 const bodySchema = z.object({
   required: z.string(),
 }).passthrough(); // Allow unknown fields
@@ -257,7 +257,7 @@ const bodySchema = z.object({
 
 ### Date coercion
 
-```typescript copy
+```typescript
 const querySchema = z.object({
   fromDate: z.coerce.date().optional(),
   toDate: z.coerce.date().optional(),
@@ -266,7 +266,7 @@ const querySchema = z.object({
 
 ### Union types
 
-```typescript copy
+```typescript
 const bodySchema = z.object({
   messages: z.union([
     z.array(z.any()),
@@ -279,7 +279,7 @@ const bodySchema = z.object({
 
 Throw an error with a `status` property to return specific HTTP status codes from handlers. If using Hono, you can use `HTTPException` from `hono/http-exception`:
 
-```typescript copy
+```typescript
 import { createRoute } from '@mastra/server/server-adapter';
 import { HTTPException } from 'hono/http-exception';
 
@@ -300,7 +300,7 @@ const getAgent = createRoute({
 
 For Express or framework-agnostic code, throw an error with a `status` property:
 
-```typescript copy
+```typescript
 class HttpError extends Error {
   constructor(public status: number, message: string) {
     super(message);

--- a/docs/src/content/en/reference/server/express-adapter.mdx
+++ b/docs/src/content/en/reference/server/express-adapter.mdx
@@ -25,7 +25,7 @@ For general adapter concepts (constructor options, initialization flow, etc.), s
 
 Install the Express adapter and Express framework:
 
-```bash copy
+```bash
 npm install @mastra/express@beta express
 ```
 
@@ -35,7 +35,7 @@ npm install @mastra/express@beta express
 
 Create your server file:
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 import express from 'express';
 import { MastraServer } from '@mastra/express';
 import { mastra } from './mastra';
@@ -63,7 +63,7 @@ Express requires `express.json()` middleware for JSON body parsing. Add it befor
 
 ## Full example
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 import express from 'express';
 import { MastraServer } from '@mastra/express';
 import { mastra } from './mastra';
@@ -166,7 +166,7 @@ app.listen(4111);
 
 Add routes directly to the Express app:
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 const app = express();
 app.use(express.json());
 
@@ -196,7 +196,7 @@ Routes added before `init()` run without Mastra context. Add routes after `init(
 
 In Express middleware and routes, access Mastra context via `res.locals`:
 
-```typescript copy
+```typescript
 app.get('/custom', (req, res) => {
   const mastra = res.locals.mastra;
   const requestContext = res.locals.requestContext;
@@ -223,7 +223,7 @@ Available properties on `res.locals`:
 
 Add Express middleware before or after `init()`:
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 const app = express();
 app.use(express.json());
 

--- a/docs/src/content/en/reference/server/hono-adapter.mdx
+++ b/docs/src/content/en/reference/server/hono-adapter.mdx
@@ -25,7 +25,7 @@ For general adapter concepts (constructor options, initialization flow, etc.), s
 
 Install the Hono adapter and Hono framework:
 
-```bash copy
+```bash
 npm install @mastra/hono@beta hono
 ```
 
@@ -35,7 +35,7 @@ npm install @mastra/hono@beta hono
 
 Create your server file:
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 import { Hono } from 'hono';
 import { HonoBindings, HonoVariables, MastraServer } from '@mastra/hono';
 import { mastra } from './mastra';
@@ -54,7 +54,7 @@ export default app;
 
 ## Full example
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 import { Hono } from 'hono';
 import { HonoBindings, HonoVariables, MastraServer } from '@mastra/hono';
 import { mastra } from './mastra';
@@ -147,7 +147,7 @@ export default app;
 
 Add routes directly to the Hono app:
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 import { Hono } from 'hono';
 import { HonoBindings, HonoVariables, MastraServer } from '@mastra/hono';
 
@@ -176,7 +176,7 @@ Routes added before `init()` run without Mastra context. Add routes after `init(
 
 In Hono middleware and route handlers, access Mastra context via `c.get()`:
 
-```typescript copy
+```typescript
 app.get('/custom', async (c) => {
   const mastra = c.get('mastra');
   const requestContext = c.get('requestContext');
@@ -203,7 +203,7 @@ Available context keys:
 
 Add Hono middleware before or after `init()`:
 
-```typescript title="server.ts" copy
+```typescript title="server.ts"
 import { Hono } from 'hono';
 import { HonoBindings, HonoVariables, MastraServer } from '@mastra/hono';
 

--- a/docs/src/content/en/reference/server/mastra-server.mdx
+++ b/docs/src/content/en/reference/server/mastra-server.mdx
@@ -11,13 +11,13 @@ The `MastraServer` abstract class is the base for all server adapters. Extend th
 
 ## Import
 
-```typescript copy
+```typescript
 import { MastraServer } from '@mastra/server/server-adapter';
 ```
 
 ## Type parameters
 
-```typescript copy
+```typescript
 MastraServer<TApp, TRequest, TResponse>
 ```
 
@@ -29,7 +29,7 @@ MastraServer<TApp, TRequest, TResponse>
 
 ## Constructor
 
-```typescript copy
+```typescript
 constructor(options: MastraServerOptions<TApp>)
 ```
 
@@ -119,7 +119,7 @@ These methods must be implemented by adapters:
 
 Attach Mastra context to every request.
 
-```typescript copy
+```typescript
 abstract registerContextMiddleware(): void
 ```
 
@@ -133,7 +133,7 @@ abstract registerContextMiddleware(): void
 
 Register authentication and authorization middleware.
 
-```typescript copy
+```typescript
 abstract registerAuthMiddleware(): void
 ```
 
@@ -141,7 +141,7 @@ abstract registerAuthMiddleware(): void
 
 Register a single route with the framework.
 
-```typescript copy
+```typescript
 abstract registerRoute(
   app: TApp,
   route: ServerRoute,
@@ -153,7 +153,7 @@ abstract registerRoute(
 
 Extract parameters from the request.
 
-```typescript copy
+```typescript
 abstract getParams(
   route: ServerRoute,
   request: TRequest
@@ -168,7 +168,7 @@ abstract getParams(
 
 Send response based on route type.
 
-```typescript copy
+```typescript
 abstract sendResponse(
   route: ServerRoute,
   response: TResponse,
@@ -180,7 +180,7 @@ abstract sendResponse(
 
 Handle streaming responses.
 
-```typescript copy
+```typescript
 abstract stream(
   route: ServerRoute,
   response: TResponse,
@@ -194,7 +194,7 @@ abstract stream(
 
 Initialize the server by registering all middleware and routes.
 
-```typescript copy
+```typescript
 async init(): Promise<void>
 ```
 
@@ -207,7 +207,7 @@ Calls in order:
 
 Register all Mastra routes.
 
-```typescript copy
+```typescript
 async registerRoutes(): Promise<void>
 ```
 
@@ -215,7 +215,7 @@ async registerRoutes(): Promise<void>
 
 Get the framework app instance.
 
-```typescript copy
+```typescript
 getApp<T = TApp>(): T
 ```
 
@@ -223,7 +223,7 @@ getApp<T = TApp>(): T
 
 Validate path parameters with the route's Zod schema.
 
-```typescript copy
+```typescript
 async parsePathParams(
   route: ServerRoute,
   params: Record<string, string>
@@ -234,7 +234,7 @@ async parsePathParams(
 
 Validate query parameters with the route's Zod schema.
 
-```typescript copy
+```typescript
 async parseQueryParams(
   route: ServerRoute,
   params: Record<string, string>
@@ -245,7 +245,7 @@ async parseQueryParams(
 
 Validate request body with the route's Zod schema.
 
-```typescript copy
+```typescript
 async parseBody(
   route: ServerRoute,
   body: unknown
@@ -256,7 +256,7 @@ async parseBody(
 
 Register an endpoint that serves the OpenAPI specification.
 
-```typescript copy
+```typescript
 async registerOpenAPIRoute(
   app: TApp,
   config: OpenAPIConfig,
@@ -270,7 +270,7 @@ async registerOpenAPIRoute(
 
 Merge request context from multiple sources (query params and body).
 
-```typescript copy
+```typescript
 protected mergeRequestContext(options: {
   paramsRequestContext?: Record<string, any>;
   bodyRequestContext?: Record<string, any>;
@@ -281,7 +281,7 @@ protected mergeRequestContext(options: {
 
 ### BodyLimitOptions
 
-```typescript copy
+```typescript
 interface BodyLimitOptions {
   maxSize: number;
   onError: (error: unknown) => unknown;
@@ -290,7 +290,7 @@ interface BodyLimitOptions {
 
 ### StreamOptions
 
-```typescript copy
+```typescript
 interface StreamOptions {
   redact?: boolean;
 }
@@ -298,7 +298,7 @@ interface StreamOptions {
 
 ## Example
 
-```typescript copy
+```typescript
 import { MastraServer, ServerRoute } from '@mastra/server/server-adapter';
 import type { Mastra } from '@mastra/core';
 

--- a/docs/src/content/en/reference/storage/cloudflare-d1.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare-d1.mdx
@@ -15,7 +15,7 @@ npm install @mastra/cloudflare-d1@beta
 
 ## Usage
 
-```typescript copy
+```typescript
 import { D1Store } from "@mastra/cloudflare-d1";
 
 type Env = {
@@ -99,7 +99,7 @@ The storage implementation handles schema creation and updates automatically. It
 
 When you pass storage to the Mastra class, `init()` is called automatically before any storage operation:
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { D1Store } from "@mastra/cloudflare-d1";
 
@@ -114,7 +114,7 @@ const mastra = new Mastra({
 
 If you're using storage directly without Mastra, you must call `init()` explicitly to create the tables:
 
-```typescript copy
+```typescript
 import { D1Store } from "@mastra/cloudflare-d1";
 
 const storage = new D1Store({

--- a/docs/src/content/en/reference/storage/cloudflare-d1.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare-d1.mdx
@@ -15,7 +15,7 @@ npm install @mastra/cloudflare-d1@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { D1Store } from "@mastra/cloudflare-d1";
 
 type Env = {

--- a/docs/src/content/en/reference/storage/cloudflare.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare.mdx
@@ -15,7 +15,7 @@ npm install @mastra/cloudflare@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { CloudflareStore } from "@mastra/cloudflare";
 
 // --- Example 1: Using Workers Binding ---

--- a/docs/src/content/en/reference/storage/cloudflare.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare.mdx
@@ -9,13 +9,13 @@ The Cloudflare KV storage implementation provides a globally distributed, server
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/cloudflare@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { CloudflareStore } from "@mastra/cloudflare";
 
 // --- Example 1: Using Workers Binding ---

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -9,7 +9,7 @@ The Convex storage implementation provides a serverless storage solution using [
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/convex@beta
 ```
 
@@ -21,7 +21,7 @@ Before using `ConvexStore`, you need to set up the Convex schema and storage han
 
 In `convex/schema.ts`:
 
-```typescript copy
+```typescript
 import { defineSchema } from 'convex/server';
 import {
   mastraThreadsTable,
@@ -50,7 +50,7 @@ export default defineSchema({
 
 In `convex/mastra/storage.ts`:
 
-```typescript copy
+```typescript
 import { mastraStorage } from '@mastra/convex/server';
 
 export const handle = mastraStorage;
@@ -58,7 +58,7 @@ export const handle = mastraStorage;
 
 ### 3. Deploy to Convex
 
-```bash copy
+```bash
 npx convex dev
 # or for production
 npx convex deploy
@@ -66,7 +66,7 @@ npx convex deploy
 
 ## Usage
 
-```typescript copy
+```typescript
 import { ConvexStore } from "@mastra/convex";
 
 const storage = new ConvexStore({

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -66,7 +66,7 @@ npx convex deploy
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { ConvexStore } from "@mastra/convex";
 
 const storage = new ConvexStore({

--- a/docs/src/content/en/reference/storage/dynamodb.mdx
+++ b/docs/src/content/en/reference/storage/dynamodb.mdx
@@ -36,7 +36,7 @@ Detailed instructions for setting up the table using AWS CloudFormation or AWS C
 
 ### Basic Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { Memory } from "@mastra/memory";
 import { DynamoDBStore } from "@mastra/dynamodb";
 
@@ -72,7 +72,7 @@ For local development, you can use [DynamoDB Local](https://docs.aws.amazon.com/
 
 2.  **Configure `DynamoDBStore` to use the local endpoint:**
 
-    ```typescript copy showLineNumbers
+    ```typescript copy
     import { DynamoDBStore } from "@mastra/dynamodb";
 
     const storage = new DynamoDBStore({

--- a/docs/src/content/en/reference/storage/dynamodb.mdx
+++ b/docs/src/content/en/reference/storage/dynamodb.mdx
@@ -18,7 +18,7 @@ The DynamoDB storage implementation provides a scalable and performant NoSQL dat
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/dynamodb@beta
 # or
 pnpm add @mastra/dynamodb@beta
@@ -36,7 +36,7 @@ Detailed instructions for setting up the table using AWS CloudFormation or AWS C
 
 ### Basic Usage
 
-```typescript copy
+```typescript
 import { Memory } from "@mastra/memory";
 import { DynamoDBStore } from "@mastra/dynamodb";
 
@@ -134,7 +134,7 @@ For local development, you can use [DynamoDB Local](https://docs.aws.amazon.com/
 
 The IAM role or user executing the code needs appropriate permissions to interact with the specified DynamoDB table and its indexes. Below is a sample policy. Replace `${YOUR_TABLE_NAME}` with your actual table name and `${YOUR_AWS_REGION}` and `${YOUR_AWS_ACCOUNT_ID}` with appropriate values.
 
-```json copy
+```json
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/docs/src/content/en/reference/storage/lance.mdx
+++ b/docs/src/content/en/reference/storage/lance.mdx
@@ -17,7 +17,7 @@ npm install @mastra/lance@beta
 
 ### Basic Storage Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { LanceStorage } from "@mastra/lance";
 
 // Connect to a local database

--- a/docs/src/content/en/reference/storage/lance.mdx
+++ b/docs/src/content/en/reference/storage/lance.mdx
@@ -17,7 +17,7 @@ npm install @mastra/lance@beta
 
 ### Basic Storage Usage
 
-```typescript copy
+```typescript
 import { LanceStorage } from "@mastra/lance";
 
 // Connect to a local database
@@ -77,7 +77,7 @@ The LanceStorage implementation automatically handles schema creation and update
 
 When you pass storage to the Mastra class, `init()` is called automatically before any storage operation:
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { LanceStorage } from "@mastra/lance";
 
@@ -90,7 +90,7 @@ const mastra = new Mastra({
 
 If you're using storage directly without Mastra, you must call `init()` explicitly to create the tables:
 
-```typescript copy
+```typescript
 import { LanceStorage } from "@mastra/lance";
 
 const storage = await LanceStorage.create("my-storage", "/path/to/db");

--- a/docs/src/content/en/reference/storage/libsql.mdx
+++ b/docs/src/content/en/reference/storage/libsql.mdx
@@ -15,7 +15,7 @@ npm install @mastra/libsql@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { LibSQLStore } from "@mastra/libsql";
 
 // File database (development)

--- a/docs/src/content/en/reference/storage/libsql.mdx
+++ b/docs/src/content/en/reference/storage/libsql.mdx
@@ -9,13 +9,13 @@ The LibSQL storage implementation provides a SQLite-compatible storage solution 
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/libsql@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { LibSQLStore } from "@mastra/libsql";
 
 // File database (development)
@@ -79,7 +79,7 @@ The storage implementation handles schema creation and updates automatically. It
 
 When you pass storage to the Mastra class, `init()` is called automatically before any storage operation:
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 
@@ -94,7 +94,7 @@ const mastra = new Mastra({
 
 If you're using storage directly without Mastra, you must call `init()` explicitly to create the tables:
 
-```typescript copy
+```typescript
 import { LibSQLStore } from "@mastra/libsql";
 
 const storage = new LibSQLStore({

--- a/docs/src/content/en/reference/storage/mongodb.mdx
+++ b/docs/src/content/en/reference/storage/mongodb.mdx
@@ -17,7 +17,7 @@ npm install @mastra/mongodb@beta
 
 Ensure you have a MongoDB Atlas Local (via Docker) or MongoDB Atlas Cloud instance with Atlas Search enabled. MongoDB 7.0+ is recommended.
 
-```typescript copy showLineNumbers
+```typescript copy
 import { MongoDBStore } from "@mastra/mongodb";
 
 const storage = new MongoDBStore({

--- a/docs/src/content/en/reference/storage/mongodb.mdx
+++ b/docs/src/content/en/reference/storage/mongodb.mdx
@@ -9,7 +9,7 @@ The MongoDB storage implementation provides a scalable storage solution using Mo
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/mongodb@beta
 ```
 
@@ -17,7 +17,7 @@ npm install @mastra/mongodb@beta
 
 Ensure you have a MongoDB Atlas Local (via Docker) or MongoDB Atlas Cloud instance with Atlas Search enabled. MongoDB 7.0+ is recommended.
 
-```typescript copy
+```typescript
 import { MongoDBStore } from "@mastra/mongodb";
 
 const storage = new MongoDBStore({
@@ -97,7 +97,7 @@ The storage implementation handles collection creation and management automatica
 
 When you pass storage to the Mastra class, `init()` is called automatically before any storage operation:
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { MongoDBStore } from "@mastra/mongodb";
 
@@ -113,7 +113,7 @@ const mastra = new Mastra({
 
 If you're using storage directly without Mastra, you must call `init()` explicitly to create the collections:
 
-```typescript copy
+```typescript
 import { MongoDBStore } from "@mastra/mongodb";
 
 const storage = new MongoDBStore({
@@ -138,7 +138,7 @@ MongoDB storage includes built-in vector search capabilities for AI applications
 
 ### Vector Index Creation
 
-```typescript copy
+```typescript
 import { MongoDBVector } from "@mastra/mongodb";
 
 const vectorStore = new MongoDBVector({
@@ -155,7 +155,7 @@ await vectorStore.createIndex({
 
 ### Vector Operations
 
-```typescript copy
+```typescript
 // Store vectors with metadata
 await vectorStore.upsert({
   indexName: "document_embeddings",

--- a/docs/src/content/en/reference/storage/mssql.mdx
+++ b/docs/src/content/en/reference/storage/mssql.mdx
@@ -15,7 +15,7 @@ npm install @mastra/mssql@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { MSSQLStore } from "@mastra/mssql";
 
 const storage = new MSSQLStore({

--- a/docs/src/content/en/reference/storage/mssql.mdx
+++ b/docs/src/content/en/reference/storage/mssql.mdx
@@ -9,13 +9,13 @@ The MSSQL storage implementation provides a production-ready storage solution us
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/mssql@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { MSSQLStore } from "@mastra/mssql";
 
 const storage = new MSSQLStore({
@@ -105,7 +105,7 @@ The storage implementation handles schema creation and updates automatically. It
 
 When you pass storage to the Mastra class, `init()` is called automatically before any storage operation:
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { MSSQLStore } from "@mastra/mssql";
 
@@ -120,7 +120,7 @@ const mastra = new Mastra({
 
 If you're using storage directly without Mastra, you must call `init()` explicitly to create the tables:
 
-```typescript copy
+```typescript
 import { MSSQLStore } from "@mastra/mssql";
 
 const storage = new MSSQLStore({

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -15,7 +15,7 @@ npm install @mastra/pg@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { PostgresStore } from "@mastra/pg";
 
 const storage = new PostgresStore({

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -9,13 +9,13 @@ The PostgreSQL storage implementation provides a production-ready storage soluti
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/pg@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { PostgresStore } from "@mastra/pg";
 
 const storage = new PostgresStore({
@@ -105,7 +105,7 @@ The storage implementation handles schema creation and updates automatically. It
 
 When you pass storage to the Mastra class, `init()` is called automatically before any storage operation:
 
-```typescript copy
+```typescript
 import { Mastra } from "@mastra/core";
 import { PostgresStore } from "@mastra/pg";
 
@@ -120,7 +120,7 @@ const mastra = new Mastra({
 
 If you're using storage directly without Mastra, you must call `init()` explicitly to create the tables:
 
-```typescript copy
+```typescript
 import { PostgresStore } from "@mastra/pg";
 
 const storage = new PostgresStore({
@@ -174,7 +174,7 @@ These indexes significantly improve performance for filtered queries with sortin
 
 Create additional indexes to optimize specific query patterns:
 
-```typescript copy
+```typescript
 // Basic index for common queries
 await storage.createIndex({
   name: "idx_threads_resource",
@@ -278,7 +278,7 @@ For more advanced use cases, you can also use:
 
 List and monitor existing indexes:
 
-```typescript copy
+```typescript
 // List all indexes
 const allIndexes = await storage.listIndexes();
 console.log(allIndexes);
@@ -321,7 +321,7 @@ await storage.dropIndex("idx_threads_status");
 
 When using custom schemas, indexes are created with schema prefixes:
 
-```typescript copy
+```typescript
 const storage = new PostgresStore({
   id: 'pg-storage',
   connectionString: process.env.DATABASE_URL,

--- a/docs/src/content/en/reference/storage/upstash.mdx
+++ b/docs/src/content/en/reference/storage/upstash.mdx
@@ -15,13 +15,13 @@ The Upstash storage implementation provides a serverless-friendly storage soluti
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/upstash@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { UpstashStore } from "@mastra/upstash";
 
 const storage = new UpstashStore({

--- a/docs/src/content/en/reference/storage/upstash.mdx
+++ b/docs/src/content/en/reference/storage/upstash.mdx
@@ -21,7 +21,7 @@ npm install @mastra/upstash@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { UpstashStore } from "@mastra/upstash";
 
 const storage = new UpstashStore({

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -11,7 +11,7 @@ The `.stream()` method enables real-time streaming of responses from an agent wi
 
 ## Usage example
 
-```ts title="index.ts" copy
+```ts title="index.ts"
 const stream = await agent.stream("message for agent");
 ```
 
@@ -675,7 +675,7 @@ const stream = await agent.stream("message for agent");
 
 ### Mastra Format (Default)
 
-```ts title="index.ts" copy
+```ts title="index.ts"
 import { stepCountIs } from "ai-v5";
 
 const stream = await agent.stream("Tell me a story", {
@@ -703,7 +703,7 @@ const fullText = await stream.text;
 
 To use the stream with AI SDK v5, you can convert it using our utility function `toAISdkStream`.
 
-```ts title="index.ts" copy
+```ts title="index.ts"
 import { stepCountIs, createUIMessageStreamResponse } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
 
@@ -724,7 +724,7 @@ return createUIMessageStreamResponse({
 
 All callback functions are now available as top-level properties for a cleaner API experience.
 
-```ts title="index.ts" copy
+```ts title="index.ts"
 const stream = await agent.stream("Tell me a story", {
   onFinish: (result) => {
     console.log("Streaming finished:", result);
@@ -751,7 +751,7 @@ for await (const chunk of stream.textStream) {
 
 ### Advanced Example with Options
 
-```ts title="index.ts" copy
+```ts title="index.ts"
 import { z } from "zod";
 import { stepCountIs } from "ai";
 

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -675,7 +675,7 @@ const stream = await agent.stream("message for agent");
 
 ### Mastra Format (Default)
 
-```ts title="index.ts" showLineNumbers copy
+```ts title="index.ts" copy
 import { stepCountIs } from "ai-v5";
 
 const stream = await agent.stream("Tell me a story", {
@@ -703,7 +703,7 @@ const fullText = await stream.text;
 
 To use the stream with AI SDK v5, you can convert it using our utility function `toAISdkStream`.
 
-```ts title="index.ts" showLineNumbers copy
+```ts title="index.ts" copy
 import { stepCountIs, createUIMessageStreamResponse } from "ai";
 import { toAISdkStream } from "@mastra/ai-sdk";
 
@@ -724,7 +724,7 @@ return createUIMessageStreamResponse({
 
 All callback functions are now available as top-level properties for a cleaner API experience.
 
-```ts title="index.ts" showLineNumbers copy
+```ts title="index.ts" copy
 const stream = await agent.stream("Tell me a story", {
   onFinish: (result) => {
     console.log("Streaming finished:", result);
@@ -751,7 +751,7 @@ for await (const chunk of stream.textStream) {
 
 ### Advanced Example with Options
 
-```ts title="index.ts" showLineNumbers copy
+```ts title="index.ts" copy
 import { z } from "zod";
 import { stepCountIs } from "ai";
 

--- a/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
+++ b/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
@@ -534,7 +534,7 @@ await agent.streamLegacy("message for agent");
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 await agent.streamLegacy("message for agent", {
   temperature: 0.7,
   maxSteps: 3,

--- a/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
+++ b/docs/src/content/en/reference/streaming/agents/streamLegacy.mdx
@@ -15,7 +15,7 @@ The `.streamLegacy()` method is the legacy version of the agent streaming API, u
 
 ## Usage example
 
-```typescript copy
+```typescript
 await agent.streamLegacy("message for agent");
 ```
 
@@ -534,7 +534,7 @@ await agent.streamLegacy("message for agent");
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 await agent.streamLegacy("message for agent", {
   temperature: 0.7,
   maxSteps: 3,

--- a/docs/src/content/en/reference/streaming/workflows/observeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/observeStream.mdx
@@ -9,7 +9,7 @@ The `.observeStream()` method opens a new `ReadableStream` to a workflow run tha
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 run.stream({

--- a/docs/src/content/en/reference/streaming/workflows/observeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/observeStream.mdx
@@ -9,7 +9,7 @@ The `.observeStream()` method opens a new `ReadableStream` to a workflow run tha
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 run.stream({

--- a/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
@@ -9,7 +9,7 @@ The `.resumeStream()` method resumes a suspended workflow run with new data, all
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const stream = run.stream({

--- a/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
@@ -9,7 +9,7 @@ The `.resumeStream()` method resumes a suspended workflow run with new data, all
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const stream = run.stream({

--- a/docs/src/content/en/reference/streaming/workflows/stream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/stream.mdx
@@ -9,7 +9,7 @@ The `.stream()` method enables real-time streaming of responses from a workflow.
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const stream = await run.stream({
@@ -163,7 +163,7 @@ Returns a `WorkflowRunOutput` object that implements the async iterable interfac
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const stream = run.stream({

--- a/docs/src/content/en/reference/streaming/workflows/stream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/stream.mdx
@@ -9,7 +9,7 @@ The `.stream()` method enables real-time streaming of responses from a workflow.
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const stream = await run.stream({
@@ -163,7 +163,7 @@ Returns a `WorkflowRunOutput` object that implements the async iterable interfac
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const stream = run.stream({

--- a/docs/src/content/en/reference/streaming/workflows/timeTravelStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/timeTravelStream.mdx
@@ -9,7 +9,7 @@ The `.timeTravelStream()` method re-executes a workflow starting from any specif
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const output = run.timeTravelStream({
@@ -76,7 +76,7 @@ The stream emits various workflow events during execution:
 
 ### Processing events during time travel
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const output = run.timeTravelStream({
@@ -104,7 +104,7 @@ console.log("Time travel completed:", result);
 
 ### Time travel stream with context
 
-```typescript copy
+```typescript
 const output = run.timeTravelStream({
   step: "step2",
   context: {
@@ -128,7 +128,7 @@ const result = await output.result;
 
 ### Time travel stream with nested workflows
 
-```typescript copy
+```typescript
 const output = run.timeTravelStream({
   step: ["nestedWorkflow", "step3"],
   inputData: { value: 10 },

--- a/docs/src/content/en/reference/streaming/workflows/timeTravelStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/timeTravelStream.mdx
@@ -9,7 +9,7 @@ The `.timeTravelStream()` method re-executes a workflow starting from any specif
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const output = run.timeTravelStream({
@@ -76,7 +76,7 @@ The stream emits various workflow events during execution:
 
 ### Processing events during time travel
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const output = run.timeTravelStream({
@@ -104,7 +104,7 @@ console.log("Time travel completed:", result);
 
 ### Time travel stream with context
 
-```typescript showLineNumbers copy
+```typescript copy
 const output = run.timeTravelStream({
   step: "step2",
   context: {
@@ -128,7 +128,7 @@ const result = await output.result;
 
 ### Time travel stream with nested workflows
 
-```typescript showLineNumbers copy
+```typescript copy
 const output = run.timeTravelStream({
   step: ["nestedWorkflow", "step3"],
   inputData: { value: 10 },

--- a/docs/src/content/en/reference/templates/overview.mdx
+++ b/docs/src/content/en/reference/templates/overview.mdx
@@ -20,7 +20,7 @@ Mastra templates are pre-built project structures that demonstrate specific use 
 
 Install a template using the `create-mastra` command:
 
-```bash copy
+```bash
 npx create-mastra@beta --template template-name
 ```
 

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -9,7 +9,7 @@ The `createTool()` function is used to define custom tools that your Mastra agen
 
 ## Usage example
 
-```typescript title="src/mastra/tools/reverse-tool.ts" copy
+```typescript title="src/mastra/tools/reverse-tool.ts"
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -9,7 +9,7 @@ The `createTool()` function is used to define custom tools that your Mastra agen
 
 ## Usage example
 
-```typescript title="src/mastra/tools/reverse-tool.ts" showLineNumbers copy
+```typescript title="src/mastra/tools/reverse-tool.ts" copy
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -574,7 +574,7 @@ For more information on request context, please see:
 
 The tool can be used by itself to retrieve documents matching a query:
 
-```typescript copy title="src/index.ts"
+```typescript title="src/index.ts"
 import { RequestContext } from "@mastra/core/request-context";
 import { createVectorQueryTool } from "@mastra/rag";
 import { PgVector } from "@mastra/pg";

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -574,7 +574,7 @@ For more information on request context, please see:
 
 The tool can be used by itself to retrieve documents matching a query:
 
-```typescript copy showLineNumbers title="src/index.ts"
+```typescript copy title="src/index.ts"
 import { RequestContext } from "@mastra/core/request-context";
 import { createVectorQueryTool } from "@mastra/rag";
 import { PgVector } from "@mastra/pg";

--- a/docs/src/content/en/reference/vectors/astra.mdx
+++ b/docs/src/content/en/reference/vectors/astra.mdx
@@ -142,7 +142,7 @@ Returns an array of index names as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -219,7 +219,7 @@ interface IndexStats {
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -232,7 +232,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/vectors/chroma.mdx
+++ b/docs/src/content/en/reference/vectors/chroma.mdx
@@ -313,7 +313,7 @@ Returns an array of index names as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -475,7 +475,7 @@ await vectorStore.deleteVectors({
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -489,7 +489,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/vectors/convex.mdx
+++ b/docs/src/content/en/reference/vectors/convex.mdx
@@ -9,7 +9,7 @@ The ConvexVector class provides vector storage and similarity search using [Conv
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/convex@beta
 ```
 
@@ -94,7 +94,7 @@ const vectorStore = new ConvexVector({
   ]}
 />
 
-```typescript copy
+```typescript
 await vectorStore.createIndex({
   indexName: "my_vectors",
   dimension: 1536,
@@ -130,7 +130,7 @@ await vectorStore.createIndex({
   ]}
 />
 
-```typescript copy
+```typescript
 await vectorStore.upsert({
   indexName: "my_vectors",
   vectors: [[0.1, 0.2, 0.3, ...]],
@@ -176,7 +176,7 @@ await vectorStore.upsert({
   ]}
 />
 
-```typescript copy
+```typescript
 const results = await vectorStore.query({
   indexName: "my_vectors",
   queryVector: [0.1, 0.2, 0.3, ...],
@@ -189,7 +189,7 @@ const results = await vectorStore.query({
 
 Returns an array of index names as strings.
 
-```typescript copy
+```typescript
 const indexes = await vectorStore.listIndexes();
 // ["my_vectors", "embeddings", ...]
 ```
@@ -208,7 +208,7 @@ const indexes = await vectorStore.listIndexes();
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -230,7 +230,7 @@ interface IndexStats {
 
 Deletes the index and all its vectors.
 
-```typescript copy
+```typescript
 await vectorStore.deleteIndex({ indexName: "my_vectors" });
 ```
 
@@ -265,7 +265,7 @@ Update a single vector by ID or by metadata filter. Either `id` or `filter` must
   ]}
 />
 
-```typescript copy
+```typescript
 // Update by ID
 await vectorStore.updateVector({
   indexName: "my_vectors",
@@ -303,7 +303,7 @@ await vectorStore.updateVector({
   ]}
 />
 
-```typescript copy
+```typescript
 await vectorStore.deleteVector({ indexName: "my_vectors", id: "vector123" });
 ```
 
@@ -333,7 +333,7 @@ Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` m
   ]}
 />
 
-```typescript copy
+```typescript
 // Delete by IDs
 await vectorStore.deleteVectors({
   indexName: "my_vectors",
@@ -351,7 +351,7 @@ await vectorStore.deleteVectors({
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -364,7 +364,7 @@ interface QueryResult {
 
 ConvexVector supports metadata filtering with various operators:
 
-```typescript copy
+```typescript
 // Simple equality
 const results = await vectorStore.query({
   indexName: "my_vectors",

--- a/docs/src/content/en/reference/vectors/couchbase.mdx
+++ b/docs/src/content/en/reference/vectors/couchbase.mdx
@@ -14,13 +14,13 @@ The `CouchbaseVector` class provides vector search using [Couchbase Vector Searc
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/couchbase@beta
 ```
 
 ## Usage Example
 
-```typescript copy
+```typescript
 import { CouchbaseVector } from "@mastra/couchbase";
 
 const store = new CouchbaseVector({
@@ -209,7 +209,7 @@ Returns information about the index.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -307,7 +307,7 @@ Closes the Couchbase client connection. Should be called when done using the sto
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -320,7 +320,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "my_index",

--- a/docs/src/content/en/reference/vectors/duckdb.mdx
+++ b/docs/src/content/en/reference/vectors/duckdb.mdx
@@ -17,7 +17,7 @@ npm install @mastra/duckdb@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { DuckDBVector } from "@mastra/duckdb";
 
 // Create a new vector store instance

--- a/docs/src/content/en/reference/vectors/duckdb.mdx
+++ b/docs/src/content/en/reference/vectors/duckdb.mdx
@@ -11,13 +11,13 @@ It's part of the `@mastra/duckdb` package and offers efficient vector similarity
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/duckdb@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { DuckDBVector } from "@mastra/duckdb";
 
 // Create a new vector store instance
@@ -206,7 +206,7 @@ Gets information about an index.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -330,7 +330,7 @@ Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` m
 
 Closes the database connection and releases resources.
 
-```typescript copy
+```typescript
 await store.close();
 ```
 
@@ -338,7 +338,7 @@ await store.close();
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -361,7 +361,7 @@ DuckDB vector store supports MongoDB-like filter operators:
 
 ### Filter Examples
 
-```typescript copy
+```typescript
 // Allegato operators
 const results = await store.query({
   indexName: "docs",
@@ -394,7 +394,7 @@ const results = await store.query({
 
 The store throws specific errors for different failure cases:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "my-collection",
@@ -425,7 +425,7 @@ Common error cases include:
 
 Build offline-capable AI applications with semantic search that runs entirely in-process:
 
-```typescript copy
+```typescript
 const store = new DuckDBVector({
   id: "offline-search",
   path: "./search.duckdb",
@@ -436,7 +436,7 @@ const store = new DuckDBVector({
 
 Process sensitive documents locally without sending data to cloud vector databases:
 
-```typescript copy
+```typescript
 const store = new DuckDBVector({
   id: "private-rag",
   path: "./confidential.duckdb",
@@ -448,7 +448,7 @@ const store = new DuckDBVector({
 
 Rapidly prototype vector search features with zero infrastructure:
 
-```typescript copy
+```typescript
 const store = new DuckDBVector({
   id: "dev-store",
   path: ":memory:", // Fast in-memory for tests

--- a/docs/src/content/en/reference/vectors/elasticsearch.mdx
+++ b/docs/src/content/en/reference/vectors/elasticsearch.mdx
@@ -16,7 +16,7 @@ npm install @mastra/elasticsearch@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { ElasticSearchVector } from "@mastra/elasticsearch";
 
 const store = new ElasticSearchVector({

--- a/docs/src/content/en/reference/vectors/elasticsearch.mdx
+++ b/docs/src/content/en/reference/vectors/elasticsearch.mdx
@@ -10,13 +10,13 @@ It's part of the `@mastra/elasticsearch` package.
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/elasticsearch@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { ElasticSearchVector } from "@mastra/elasticsearch";
 
 const store = new ElasticSearchVector({
@@ -176,7 +176,7 @@ Gets information about an index.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -296,7 +296,7 @@ Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` m
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;

--- a/docs/src/content/en/reference/vectors/lance.mdx
+++ b/docs/src/content/en/reference/vectors/lance.mdx
@@ -263,7 +263,7 @@ const s3Store = await LanceVectorStore.create("s3://bucket/db", {
 
 Returns an array of table names as strings.
 
-```typescript copy
+```typescript
 const tables = await vectorStore.listTables();
 // ['my_vectors', 'embeddings', 'documents']
 ```
@@ -316,7 +316,7 @@ Returns an array of index names as strings.
 
 Returns information about the index:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -425,7 +425,7 @@ Closes the database connection.
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -439,7 +439,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     tableName: "my_vectors",

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -10,13 +10,13 @@ It's part of the `@mastra/libsql` package and offers efficient vector similarity
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/libsql@beta
 ```
 
 ## Usage
 
-```typescript copy
+```typescript
 import { LibSQLVector } from "@mastra/libsql";
 
 // Create a new vector store instance
@@ -209,7 +209,7 @@ Gets information about an index.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -343,7 +343,7 @@ Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` m
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -356,7 +356,7 @@ interface QueryResult {
 
 The store throws specific errors for different failure cases:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "my-collection",

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -16,7 +16,7 @@ npm install @mastra/libsql@beta
 
 ## Usage
 
-```typescript copy showLineNumbers
+```typescript copy
 import { LibSQLVector } from "@mastra/libsql";
 
 // Create a new vector store instance

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -9,13 +9,13 @@ The `MongoDBVector` class provides vector search using [MongoDB Atlas Vector Sea
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/mongodb@beta
 ```
 
 ## Usage Example
 
-```typescript copy
+```typescript
 import { MongoDBVector } from "@mastra/mongodb";
 
 const store = new MongoDBVector({
@@ -180,7 +180,7 @@ Returns information about the index (collection).
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -304,7 +304,7 @@ Closes the MongoDB client connection. Should be called when done using the store
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -317,7 +317,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "my_collection",

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -15,7 +15,7 @@ npm install @mastra/mongodb@beta
 
 ## Usage Example
 
-```typescript copy showLineNumbers
+```typescript copy
 import { MongoDBVector } from "@mastra/mongodb";
 
 const store = new MongoDBVector({

--- a/docs/src/content/en/reference/vectors/pg.mdx
+++ b/docs/src/content/en/reference/vectors/pg.mdx
@@ -374,7 +374,7 @@ Returns an array of index names as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface PGIndexStats {
   dimension: number;
   count: number;
@@ -434,7 +434,7 @@ Update a single vector by ID or by metadata filter. Either `id` or `filter` must
 
 Updates an existing vector by ID or filter. At least one of vector or metadata must be provided in the update object.
 
-```typescript copy
+```typescript
 // Update by ID
 await pgVector.updateVector({
   indexName: "my_vectors",
@@ -474,7 +474,7 @@ await pgVector.updateVector({
 
 Deletes a single vector by ID from the specified index.
 
-```typescript copy
+```typescript
 await pgVector.deleteVector({ indexName: "my_vectors", id: "vector123" });
 ```
 
@@ -534,7 +534,7 @@ Closes the database connection pool. Should be called when done using the store.
 
 Builds or rebuilds an index with specified metric and configuration. Will drop any existing index before creating the new one.
 
-```typescript copy
+```typescript
 // Define HNSW index
 await pgVector.buildIndex("my_vectors", "cosine", {
   type: "hnsw",
@@ -562,7 +562,7 @@ await pgVector.buildIndex("my_vectors", "cosine", {
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -575,7 +575,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/vectors/pinecone.mdx
+++ b/docs/src/content/en/reference/vectors/pinecone.mdx
@@ -184,7 +184,7 @@ Returns an array of index names as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -306,7 +306,7 @@ Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` m
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -319,7 +319,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/vectors/qdrant.mdx
+++ b/docs/src/content/en/reference/vectors/qdrant.mdx
@@ -137,7 +137,7 @@ Returns an array of index names as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -239,7 +239,7 @@ Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` m
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -252,7 +252,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/vectors/s3vectors.mdx
+++ b/docs/src/content/en/reference/vectors/s3vectors.mdx
@@ -14,13 +14,13 @@ The `S3Vectors` class provides vector search using [Amazon S3 Vectors (Preview)]
 
 ## Installation
 
-```bash copy
+```bash
 npm install @mastra/s3vectors@beta
 ```
 
 ## Usage Example
 
-```typescript copy
+```typescript
 import { S3Vectors } from "@mastra/s3vectors";
 
 const store = new S3Vectors({
@@ -214,7 +214,7 @@ Returns information about the index.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number; // computed via ListVectors pagination (O(n))
@@ -305,7 +305,7 @@ Closes the underlying AWS SDK HTTP handler to free sockets.
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number; // 1/(1 + distance)
@@ -337,7 +337,7 @@ S3 Vectors supports a strict subset of operators and value types. The Mastra fil
 
 **Examples:**
 
-```typescript copy
+```typescript
 // Implicit AND
 { genre: { $in: ["documentary", "comedy"] }, year: { $gte: 2020 } }
 
@@ -359,7 +359,7 @@ S3 Vectors supports a strict subset of operators and value types. The Mastra fil
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index-name",

--- a/docs/src/content/en/reference/vectors/s3vectors.mdx
+++ b/docs/src/content/en/reference/vectors/s3vectors.mdx
@@ -20,7 +20,7 @@ npm install @mastra/s3vectors@beta
 
 ## Usage Example
 
-```typescript copy showLineNumbers
+```typescript copy
 import { S3Vectors } from "@mastra/s3vectors";
 
 const store = new S3Vectors({

--- a/docs/src/content/en/reference/vectors/turbopuffer.mdx
+++ b/docs/src/content/en/reference/vectors/turbopuffer.mdx
@@ -170,7 +170,7 @@ Returns an array of index names as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -268,7 +268,7 @@ Delete multiple vectors by IDs or by metadata filter. Either `ids` or `filter` m
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -281,7 +281,7 @@ interface QueryResult {
 
 The `schemaConfigForIndex` option allows you to define explicit schemas for different indexes:
 
-```typescript copy
+```typescript
 schemaConfigForIndex: (indexName: string) => {
   // Mastra's default embedding model and index for memory messages:
   if (indexName === "memory_messages_384") {
@@ -304,7 +304,7 @@ schemaConfigForIndex: (indexName: string) => {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/vectors/upstash.mdx
+++ b/docs/src/content/en/reference/vectors/upstash.mdx
@@ -164,7 +164,7 @@ Returns an array of index names (namespaces) as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -238,7 +238,7 @@ Upstash Vector supports hybrid search that combines semantic search (dense vecto
 
 ### Basic Hybrid Usage
 
-```typescript copy
+```typescript
 import { UpstashVector } from "@mastra/upstash";
 
 const vectorStore = new UpstashVector({
@@ -275,7 +275,7 @@ const results = await vectorStore.query({
 
 ### Advanced Hybrid Search Options
 
-```typescript copy
+```typescript
 import { FusionAlgorithm, QueryMode } from "@upstash/vector";
 
 // Query with specific fusion algorithm
@@ -307,7 +307,7 @@ const sparseResults = await vectorStore.query({
 
 ### Updating Hybrid Vectors
 
-```typescript copy
+```typescript
 // Update both dense and sparse components
 await vectorStore.updateVector({
   indexName: "hybrid-index",
@@ -324,7 +324,7 @@ await vectorStore.updateVector({
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -337,7 +337,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/vectors/vectorize.mdx
+++ b/docs/src/content/en/reference/vectors/vectorize.mdx
@@ -135,7 +135,7 @@ Returns an array of index names as strings.
 
 Returns:
 
-```typescript copy
+```typescript
 interface IndexStats {
   dimension: number;
   count: number;
@@ -259,7 +259,7 @@ Deletes a vector and its associated metadata for a specific ID within an index.
 
 Query results are returned in this format:
 
-```typescript copy
+```typescript
 interface QueryResult {
   id: string;
   score: number;
@@ -272,7 +272,7 @@ interface QueryResult {
 
 The store throws typed errors that can be caught:
 
-```typescript copy
+```typescript
 try {
   await store.query({
     indexName: "index_name",

--- a/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
@@ -9,7 +9,7 @@ The `.cancel()` method cancels a workflow run, stopping execution and cleaning u
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 await run.cancel();
@@ -43,7 +43,7 @@ await run.cancel();
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 try {

--- a/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/cancel.mdx
@@ -9,7 +9,7 @@ The `.cancel()` method cancels a workflow run, stopping execution and cleaning u
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 await run.cancel();
@@ -43,7 +43,7 @@ await run.cancel();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 try {

--- a/docs/src/content/en/reference/workflows/run-methods/restart.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/restart.mdx
@@ -9,7 +9,7 @@ The `.restart()` method restarts an active workflow run that lost connection to 
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.start({ inputData: { value: "initial data" } });

--- a/docs/src/content/en/reference/workflows/run-methods/restart.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/restart.mdx
@@ -9,7 +9,7 @@ The `.restart()` method restarts an active workflow run that lost connection to 
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.start({ inputData: { value: "initial data" } });

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -9,7 +9,7 @@ The `.resume()` method resumes a suspended workflow run with new data, allowing 
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.start({ inputData: { value: "initial data" } });
@@ -177,7 +177,7 @@ if (result.status === "suspended") {
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 if (result.status === "suspended") {
   const resumedResults = await run.resume({
     step: result.suspended[0],

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -9,7 +9,7 @@ The `.resume()` method resumes a suspended workflow run with new data, allowing 
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.start({ inputData: { value: "initial data" } });
@@ -177,7 +177,7 @@ if (result.status === "suspended") {
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 if (result.status === "suspended") {
   const resumedResults = await run.resume({
     step: result.suspended[0],

--- a/docs/src/content/en/reference/workflows/run-methods/start.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/start.mdx
@@ -9,7 +9,7 @@ The `.start()` method starts a workflow run with input data, allowing you to exe
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.start({
@@ -168,7 +168,7 @@ const result = await run.start({
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { RequestContext } from "@mastra/core/request-context";
 
 const run = await workflow.createRun();

--- a/docs/src/content/en/reference/workflows/run-methods/start.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/start.mdx
@@ -9,7 +9,7 @@ The `.start()` method starts a workflow run with input data, allowing you to exe
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.start({
@@ -168,7 +168,7 @@ const result = await run.start({
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 import { RequestContext } from "@mastra/core/request-context";
 
 const run = await workflow.createRun();

--- a/docs/src/content/en/reference/workflows/run-methods/startAsync.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/startAsync.mdx
@@ -9,7 +9,7 @@ The `.startAsync()` method starts a workflow run without waiting for completion.
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 // Fire-and-forget - returns immediately
@@ -123,7 +123,7 @@ Use `startAsync()` instead of `start()` when:
 
 After calling `startAsync()`, you can check the workflow status using:
 
-```typescript showLineNumbers copy
+```typescript copy
 // Get the execution result (including step outputs)
 const result = await workflow.getWorkflowRunExecutionResult(runId);
 

--- a/docs/src/content/en/reference/workflows/run-methods/startAsync.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/startAsync.mdx
@@ -9,7 +9,7 @@ The `.startAsync()` method starts a workflow run without waiting for completion.
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 // Fire-and-forget - returns immediately
@@ -123,7 +123,7 @@ Use `startAsync()` instead of `start()` when:
 
 After calling `startAsync()`, you can check the workflow status using:
 
-```typescript copy
+```typescript
 // Get the execution result (including step outputs)
 const result = await workflow.getWorkflowRunExecutionResult(runId);
 

--- a/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
@@ -9,7 +9,7 @@ The `.timeTravel()` method re-executes a workflow starting from any specific ste
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.timeTravel({
@@ -213,7 +213,7 @@ const result = await run.timeTravel({
 
 ### Time travel with custom context
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: "step2",
   context: {
@@ -230,7 +230,7 @@ const result = await run.timeTravel({
 
 ### Time travel to nested workflow step
 
-```typescript copy
+```typescript
 // Using dot notation
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
@@ -246,7 +246,7 @@ const result = await run.timeTravel({
 
 ### Time travel with initial state
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: "step2",
   inputData: { value: 10 },
@@ -259,7 +259,7 @@ const result = await run.timeTravel({
 
 ### Time travel with nested workflows context
 
-```typescript copy
+```typescript
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
   context: {

--- a/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
@@ -9,7 +9,7 @@ The `.timeTravel()` method re-executes a workflow starting from any specific ste
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.timeTravel({
@@ -213,7 +213,7 @@ const result = await run.timeTravel({
 
 ### Time travel with custom context
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: "step2",
   context: {
@@ -230,7 +230,7 @@ const result = await run.timeTravel({
 
 ### Time travel to nested workflow step
 
-```typescript showLineNumbers copy
+```typescript copy
 // Using dot notation
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
@@ -246,7 +246,7 @@ const result = await run.timeTravel({
 
 ### Time travel with initial state
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: "step2",
   inputData: { value: 10 },
@@ -259,7 +259,7 @@ const result = await run.timeTravel({
 
 ### Time travel with nested workflows context
 
-```typescript showLineNumbers copy
+```typescript copy
 const result = await run.timeTravel({
   step: "nestedWorkflow.step3",
   context: {

--- a/docs/src/content/en/reference/workflows/run.mdx
+++ b/docs/src/content/en/reference/workflows/run.mdx
@@ -9,7 +9,7 @@ The `Run` class represents a workflow execution instance, providing methods to s
 
 ## Usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.start({

--- a/docs/src/content/en/reference/workflows/run.mdx
+++ b/docs/src/content/en/reference/workflows/run.mdx
@@ -9,7 +9,7 @@ The `Run` class represents a workflow execution instance, providing methods to s
 
 ## Usage example
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.start({

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -10,7 +10,7 @@ It can take either a tool or an agent as a parameter to automatically create a s
 
 ## Usage example
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -38,7 +38,7 @@ You can create a step directly from an agent. The step will use the agent's name
 
 ### Basic agent step
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 import { testAgent } from "../agents/test-agent";
 
 const agentStep = createStep(testAgent);
@@ -50,7 +50,7 @@ const agentStep = createStep(testAgent);
 
 Pass `structuredOutput` to have the agent return typed structured data:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 const articleSchema = z.object({
   title: z.string(),
   summary: z.string(),

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -10,7 +10,7 @@ It can take either a tool or an agent as a parameter to automatically create a s
 
 ## Usage example
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -38,7 +38,7 @@ You can create a step directly from an agent. The step will use the agent's name
 
 ### Basic agent step
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 import { testAgent } from "../agents/test-agent";
 
 const agentStep = createStep(testAgent);
@@ -50,7 +50,7 @@ const agentStep = createStep(testAgent);
 
 Pass `structuredOutput` to have the agent return typed structured data:
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 const articleSchema = z.object({
   title: z.string(),
   summary: z.string(),

--- a/docs/src/content/en/reference/workflows/workflow-methods/branch.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/branch.mdx
@@ -9,7 +9,7 @@ The `.branch()` method creates conditional branches between workflow steps, allo
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.branch([
   [async ({ context }) => true, step1],
   [async ({ context }) => false, step2],

--- a/docs/src/content/en/reference/workflows/workflow-methods/commit.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/commit.mdx
@@ -9,7 +9,7 @@ The `.commit()` method finalizes the workflow and returns the final result.
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.then(step1).commit();
 ```
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/create-run.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/create-run.mdx
@@ -9,7 +9,7 @@ The `.createRun()` method creates a new workflow run instance, allowing you to e
 
 ## Usage example
 
-```typescript copy
+```typescript
 await workflow.createRun();
 ```
 
@@ -53,7 +53,7 @@ await workflow.createRun();
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 const workflow = mastra.getWorkflow("workflow");
 
 const run = await workflow.createRun();
@@ -69,7 +69,7 @@ const result = await run.start({
 
 The `resourceId` parameter associates a workflow run with a specific resource, such as a user or tenant. This is useful for multi-tenant applications or when you need to track which user initiated a workflow.
 
-```typescript copy
+```typescript
 const workflow = mastra.getWorkflow("workflow");
 
 // Create a run associated with a specific user

--- a/docs/src/content/en/reference/workflows/workflow-methods/create-run.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/create-run.mdx
@@ -53,7 +53,7 @@ await workflow.createRun();
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 const workflow = mastra.getWorkflow("workflow");
 
 const run = await workflow.createRun();
@@ -69,7 +69,7 @@ const result = await run.start({
 
 The `resourceId` parameter associates a workflow run with a specific resource, such as a user or tenant. This is useful for multi-tenant applications or when you need to track which user initiated a workflow.
 
-```typescript showLineNumbers copy
+```typescript copy
 const workflow = mastra.getWorkflow("workflow");
 
 // Create a run associated with a specific user

--- a/docs/src/content/en/reference/workflows/workflow-methods/dountil.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/dountil.mdx
@@ -9,7 +9,7 @@ The `.dountil()` method executes a step until a condition is met. It always runs
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.dountil(step1, async ({ inputData }) => true);
 ```
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/dowhile.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/dowhile.mdx
@@ -9,7 +9,7 @@ The `.dowhile()` method executes a step while a condition is met. It always runs
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.dowhile(step1, async ({ inputData }) => true);
 ```
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
@@ -9,7 +9,7 @@ The `.foreach()` method creates a loop that executes a step for each item in an 
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.foreach(step1, { concurrency: 2 });
 ```
 
@@ -67,7 +67,7 @@ If you need to run multiple operations per item, use a nested workflow as the st
 
 `.foreach()` always outputs an array. Each element in the output array corresponds to the result of processing the element at the same index in the input array.
 
-```typescript copy
+```typescript
 // Input: [{ value: 1 }, { value: 2 }, { value: 3 }]
 // Step adds 10 to each value
 // Output: [{ value: 11 }, { value: 12 }, { value: 13 }]
@@ -77,7 +77,7 @@ If you need to run multiple operations per item, use a nested workflow as the st
 
 When you chain `.then()` after `.foreach()`, the next step receives the entire output array as its input. This allows you to aggregate or process all results together.
 
-```typescript copy
+```typescript
 workflow
   .foreach(processItemStep)    // Output: array of processed items
   .then(aggregateStep)         // Input: the entire array
@@ -88,7 +88,7 @@ workflow
 
 Use `.map()` to transform the array output before passing it to the next step:
 
-```typescript copy
+```typescript
 workflow
   .foreach(processItemStep)
   .map(async ({ inputData }) => ({
@@ -103,7 +103,7 @@ workflow
 
 When you chain `.foreach()` calls, each operates on the array from the previous step:
 
-```typescript copy
+```typescript
 workflow
   .foreach(stepA)    // If input is [a, b, c], output is [A, B, C]
   .foreach(stepB)    // Operates on [A, B, C], output is [A', B', C']
@@ -112,7 +112,7 @@ workflow
 
 If a step inside `.foreach()` returns an array, the output becomes an array of arrays. Use `.map()` with `.flat()` to flatten:
 
-```typescript copy
+```typescript
 workflow
   .foreach(chunkStep)           // Output: [[chunk1, chunk2], [chunk3, chunk4]]
   .map(async ({ inputData }) => inputData.flat())  // Output: [chunk1, chunk2, chunk3, chunk4]

--- a/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
@@ -43,7 +43,7 @@ workflow.map(async ({ inputData }) => `${inputData.value} - map`
 
 Use `inputData` to access the full output of the previous step.
 
-```typescript {3} filename="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3} filename="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map(({ inputData }) => {
     console.log(inputData);
@@ -54,7 +54,7 @@ Use `inputData` to access the full output of the previous step.
 
 Use `getStepResult()` to access the full output of a specific step by referencing the step's instance.
 
-```typescript {3} filename="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3} filename="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map(async ({ getStepResult }) => {
     console.log(getStepResult(step1));
@@ -65,7 +65,7 @@ Use `getStepResult()` to access the full output of a specific step by referencin
 
 Use `getInitData()` to access the initial input data provided to the workflow.
 
-```typescript {3} filename="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3} filename="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map(async ({ getInitData }) => {
       console.log(getInitData());
@@ -77,7 +77,7 @@ Use `getInitData()` to access the initial input data provided to the workflow.
 The object form of `.map()` provides an alternative declarative syntax for mapping fields. Instead of writing a function, you define an object where each key is a new field name and each value uses `mapVariable()` to extract data from previous steps or workflow input.
 Import `mapVariable()` from the workflows module:
 
-```typescript filename="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript filename="src/mastra/workflows/test-workflow.ts" copy
 import { mapVariable } from "@mastra/core/workflows";
 ```
 
@@ -86,7 +86,7 @@ import { mapVariable } from "@mastra/core/workflows";
 Use `mapVariable()` with `step` to extract a specific field from a step's output and map it to a new field name. The `path` parameter specifies which field to extract.
 In this example, the `value` field from `step1`'s output is extracted and mapped to a new field called `details`:
 
-```typescript {3-6} filename="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {3-6} filename="src/mastra/workflows/test-workflow.ts" copy
   .then(step1)
   .map({
     details: mapVariable({
@@ -101,7 +101,7 @@ In this example, the `value` field from `step1`'s output is extracted and mapped
 Use `mapVariable()` with `initData` to extract a specific field from the workflow's initial input data. This is useful when you need to pass the original workflow input to a later step.
 In this example, the `value` field from the workflow's input is extracted and mapped to a field called `details`:
 
-```typescript {6-9} filename="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript {6-9} filename="src/mastra/workflows/test-workflow.ts" copy
 export const testWorkflow = createWorkflow({...});
 
 testWorkflow

--- a/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
@@ -9,7 +9,7 @@ The `.map()` method maps output data from a previous step to the input of a subs
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.map(async ({ inputData }) => `${inputData.value} - map`
 ```
 
@@ -43,7 +43,7 @@ workflow.map(async ({ inputData }) => `${inputData.value} - map`
 
 Use `inputData` to access the full output of the previous step.
 
-```typescript {3} filename="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3} filename="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map(({ inputData }) => {
     console.log(inputData);
@@ -54,7 +54,7 @@ Use `inputData` to access the full output of the previous step.
 
 Use `getStepResult()` to access the full output of a specific step by referencing the step's instance.
 
-```typescript {3} filename="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3} filename="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map(async ({ getStepResult }) => {
     console.log(getStepResult(step1));
@@ -65,7 +65,7 @@ Use `getStepResult()` to access the full output of a specific step by referencin
 
 Use `getInitData()` to access the initial input data provided to the workflow.
 
-```typescript {3} filename="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3} filename="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map(async ({ getInitData }) => {
       console.log(getInitData());
@@ -77,7 +77,7 @@ Use `getInitData()` to access the initial input data provided to the workflow.
 The object form of `.map()` provides an alternative declarative syntax for mapping fields. Instead of writing a function, you define an object where each key is a new field name and each value uses `mapVariable()` to extract data from previous steps or workflow input.
 Import `mapVariable()` from the workflows module:
 
-```typescript filename="src/mastra/workflows/test-workflow.ts" copy
+```typescript filename="src/mastra/workflows/test-workflow.ts"
 import { mapVariable } from "@mastra/core/workflows";
 ```
 
@@ -86,7 +86,7 @@ import { mapVariable } from "@mastra/core/workflows";
 Use `mapVariable()` with `step` to extract a specific field from a step's output and map it to a new field name. The `path` parameter specifies which field to extract.
 In this example, the `value` field from `step1`'s output is extracted and mapped to a new field called `details`:
 
-```typescript {3-6} filename="src/mastra/workflows/test-workflow.ts" copy
+```typescript {3-6} filename="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map({
     details: mapVariable({
@@ -101,7 +101,7 @@ In this example, the `value` field from `step1`'s output is extracted and mapped
 Use `mapVariable()` with `initData` to extract a specific field from the workflow's initial input data. This is useful when you need to pass the original workflow input to a later step.
 In this example, the `value` field from the workflow's input is extracted and mapped to a field called `details`:
 
-```typescript {6-9} filename="src/mastra/workflows/test-workflow.ts" copy
+```typescript {6-9} filename="src/mastra/workflows/test-workflow.ts"
 export const testWorkflow = createWorkflow({...});
 
 testWorkflow

--- a/docs/src/content/en/reference/workflows/workflow-methods/parallel.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/parallel.mdx
@@ -9,7 +9,7 @@ The `.parallel()` method executes multiple steps in parallel.
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.parallel([step1, step2]);
 ```
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/sendEvent.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sendEvent.mdx
@@ -9,7 +9,7 @@ The `.sendEvent()` resumes execution when an event is sent.
 
 ## Usage example
 
-```typescript copy
+```typescript
 run.sendEvent("event-name", { value: "data" });
 ```
 
@@ -46,7 +46,7 @@ run.sendEvent("event-name", { value: "data" });
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 import { mastra } from "./mastra";
 
 const run = await mastra.getWorkflow("testWorkflow").createRun();

--- a/docs/src/content/en/reference/workflows/workflow-methods/sendEvent.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sendEvent.mdx
@@ -46,7 +46,7 @@ run.sendEvent("event-name", { value: "data" });
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { mastra } from "./mastra";
 
 const run = await mastra.getWorkflow("testWorkflow").createRun();

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
@@ -41,7 +41,7 @@ workflow.sleep(5000);
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({...});

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
@@ -9,7 +9,7 @@ The `.sleep()` method pauses execution for a specified number of milliseconds. I
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.sleep(5000);
 ```
 
@@ -41,7 +41,7 @@ workflow.sleep(5000);
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({...});

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
@@ -41,7 +41,7 @@ workflow.sleepUntil(new Date(Date.now() + 5000));
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({...});

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
@@ -9,7 +9,7 @@ The `.sleepUntil()` method pauses execution until a specified date.
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.sleepUntil(new Date(Date.now() + 5000));
 ```
 
@@ -41,7 +41,7 @@ workflow.sleepUntil(new Date(Date.now() + 5000));
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({...});

--- a/docs/src/content/en/reference/workflows/workflow-methods/then.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/then.mdx
@@ -9,7 +9,7 @@ The `.then()` method creates a sequential dependency between workflow steps, ens
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.then(step1).then(step2);
 ```
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/waitForEvent.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/waitForEvent.mdx
@@ -46,7 +46,7 @@ workflow.waitForEvent("event-name", step1);
 
 ## Extended usage example
 
-```typescript showLineNumbers copy
+```typescript copy
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({...});

--- a/docs/src/content/en/reference/workflows/workflow-methods/waitForEvent.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/waitForEvent.mdx
@@ -9,7 +9,7 @@ The `.waitForEvent()` method pauses execution until an event is received.
 
 ## Usage example
 
-```typescript copy
+```typescript
 workflow.waitForEvent("event-name", step1);
 ```
 
@@ -46,7 +46,7 @@ workflow.waitForEvent("event-name", step1);
 
 ## Extended usage example
 
-```typescript copy
+```typescript
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 
 const step1 = createStep({...});

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -9,7 +9,7 @@ The `Workflow` class enables you to create state machines for complex sequences 
 
 ## Usage example
 
-```typescript title="src/mastra/workflows/test-workflow.ts" showLineNumbers copy
+```typescript title="src/mastra/workflows/test-workflow.ts" copy
 import { createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -92,7 +92,7 @@ export const workflow = createWorkflow({
 
 When starting a workflow run, you can pass `initialState` to set the starting values for the workflow's state:
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 
 const result = await run.start({
@@ -143,7 +143,7 @@ A workflow's `status` indicates its current execution state. The possible values
 
 When a workflow contains an agent step that triggers a tripwire, the workflow returns with `status: 'tripwire'` and includes tripwire details:
 
-```typescript showLineNumbers copy
+```typescript copy
 const run = await workflow.createRun();
 const result = await run.start({ inputData: { message: "Hello" } });
 

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -9,7 +9,7 @@ The `Workflow` class enables you to create state machines for complex sequences 
 
 ## Usage example
 
-```typescript title="src/mastra/workflows/test-workflow.ts" copy
+```typescript title="src/mastra/workflows/test-workflow.ts"
 import { createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -92,7 +92,7 @@ export const workflow = createWorkflow({
 
 When starting a workflow run, you can pass `initialState` to set the starting values for the workflow's state:
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 
 const result = await run.start({
@@ -143,7 +143,7 @@ A workflow's `status` indicates its current execution state. The possible values
 
 When a workflow contains an agent step that triggers a tripwire, the workflow returns with `status: 'tripwire'` and includes tripwire details:
 
-```typescript copy
+```typescript
 const run = await workflow.createRun();
 const result = await run.start({ inputData: { message: "Hello" } });
 

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -582,7 +582,7 @@ Mastra reads the relevant environment variable (e.g. \`ANTHROPIC_API_KEY\`) and 
 
 <Tabs>
   <TabItem value="OpenAI" label="OpenAI">
-    \`\`\`typescript copy showLineNumbers
+    \`\`\`typescript
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -594,7 +594,7 @@ Mastra reads the relevant environment variable (e.g. \`ANTHROPIC_API_KEY\`) and 
     \`\`\`
   </TabItem>
   <TabItem value="Anthropic" label="Anthropic">
-    \`\`\`typescript copy showLineNumbers
+    \`\`\`typescript
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -606,7 +606,7 @@ Mastra reads the relevant environment variable (e.g. \`ANTHROPIC_API_KEY\`) and 
     \`\`\`
   </TabItem>
   <TabItem value="Google Gemini" label="Google Gemini">
-    \`\`\`typescript copy showLineNumbers
+    \`\`\`typescript
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -618,7 +618,7 @@ Mastra reads the relevant environment variable (e.g. \`ANTHROPIC_API_KEY\`) and 
     \`\`\`
   </TabItem>
   <TabItem value="xAI" label="xAI">
-    \`\`\`typescript copy showLineNumbers
+    \`\`\`typescript
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -630,7 +630,7 @@ Mastra reads the relevant environment variable (e.g. \`ANTHROPIC_API_KEY\`) and 
     \`\`\`
   </TabItem>
   <TabItem value="OpenRouter" label="OpenRouter">
-    \`\`\`typescript copy showLineNumbers
+    \`\`\`typescript
     import { Agent } from "@mastra/core/agent";
 
     const agent = new Agent({
@@ -728,7 +728,7 @@ In development, we auto-refresh your local model list every hour, ensuring your 
 
 Some models are faster but less capable, while others offer larger context windows or stronger reasoning skills. Use different models from the same provider, or mix and match across providers to fit each task.
 
-\`\`\`typescript showLineNumbers
+\`\`\`typescript
 import { Agent } from "@mastra/core/agent";
 
 // Use a cost-effective model for document processing
@@ -751,7 +751,7 @@ const reasoningAgent = new Agent({
 
 Since models are just strings, you can select them dynamically based on [request context](/docs/v1/server/request-context), variables, or any other logic.
 
-\`\`\`typescript showLineNumbers
+\`\`\`typescript
 const agent = new Agent({
   id: "dynamic-assistant",
   name: "Dynamic Assistant",
@@ -773,7 +773,7 @@ This enables powerful patterns:
 
 Different model providers expose their own configuration options. With OpenAI, you might adjust the \`reasoningEffort\`. With Anthropic, you might tune \`cacheControl\`. Mastra lets you set these specific \`providerOptions\` either at the agent level or per message.
 
-\`\`\`typescript showLineNumbers
+\`\`\`typescript
 // Agent level (apply to all future messages)
 const planner = new Agent({
   id: "planner",
@@ -808,7 +808,7 @@ const highEffort = await planner.generate([
 If you need to specify custom headers, such as an organization ID or other provider-specific fields, use this syntax.
 
 
-\`\`\`typescript showLineNumbers
+\`\`\`typescript
 const agent = new Agent({
   id: "custom-agent",
   name: "Custom Agent",
@@ -833,7 +833,7 @@ Configuration differs by provider. See the provider pages in the left navigation
 Relying on a single model creates a single point of failure for your application. Model fallbacks provide automatic failover between models and providers. If the primary model becomes unavailable, requests are retried against the next configured fallback until one succeeds.
 
 
-\`\`\`typescript showLineNumbers
+\`\`\`typescript
 import { Agent } from '@mastra/core/agent';
 
 const agent = new Agent({
@@ -865,7 +865,7 @@ Your users never experience the disruption - the response comes back with the sa
 Mastra supports AI SDK provider modules, should you need to use them directly.
 
 
-\`\`\`typescript showLineNumbers
+\`\`\`typescript
 import { groq } from '@ai-sdk/groq';
 import { Agent } from "@mastra/core/agent";
 


### PR DESCRIPTION
## Description

- Remove `copy` from codeblocks since the copy button shows by default
- Remove `showLineNumbers` from codeblocks since we don't want to show them in so many cases. They can be added back on a case-by-case basis if needed. They take up precious horizontal space and add visual noise.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
