### PR TITLE
Add externals: true by default on mastra build and cloud

### DIFF
--- a/.changeset/pink-cobras-melt.md
+++ b/.changeset/pink-cobras-melt.md
@@ -6,4 +6,6 @@
 'mastra': patch
 ---
 
-Set externals: true as default for mastra build and cloud-deployer
+Set `externals: true` as the default for `mastra build` and cloud-deployer to reduce bundle issues with native dependencies.
+
+**Note:** If you previously relied on the default bundling behavior (all dependencies bundled), you can explicitly set `externals: false` in your bundler configuration.

--- a/.changeset/pink-cobras-melt.md
+++ b/.changeset/pink-cobras-melt.md
@@ -1,0 +1,9 @@
+---
+'@mastra/deployer': minor
+'@mastra/deployer-cloudflare': minor
+'@mastra/deployer-cloud': minor
+'@mastra/core': patch
+'mastra': patch
+---
+
+Set externals: true as default for mastra build and cloud-deployer

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -1,6 +1,8 @@
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Config } from '@mastra/core/mastra';
 import { Deployer } from '@mastra/deployer';
+import { IS_DEFAULT } from '@mastra/deployer/bundler';
 import { readJSON } from 'fs-extra/esm';
 
 import { getAuthEntrypoint } from './utils/auth.js';
@@ -12,6 +14,22 @@ import { successEntrypoint } from './utils/report.js';
 export class CloudDeployer extends Deployer {
   constructor() {
     super({ name: 'cloud' });
+  }
+
+  protected async getUserBundlerOptions(
+    mastraEntryFile: string,
+    outputDirectory: string,
+  ): Promise<NonNullable<Config['bundler']>> {
+    const bundlerOptions = await super.getUserBundlerOptions(mastraEntryFile, outputDirectory);
+
+    if (!bundlerOptions?.[IS_DEFAULT]) {
+      return bundlerOptions;
+    }
+
+    return {
+      ...bundlerOptions,
+      externals: true,
+    };
   }
 
   async deploy(_outputDirectory: string): Promise<void> {}

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -2,6 +2,7 @@ import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Deployer } from '@mastra/deployer';
 import type { analyzeBundle } from '@mastra/deployer/analyze';
+import type { BundlerOptions } from '@mastra/deployer/bundler';
 import virtual from '@rollup/plugin-virtual';
 import { mastraInstanceWrapper } from './plugins/mastra-instance-wrapper';
 import { postgresStoreInstanceChecker } from './plugins/postgres-store-instance-checker';
@@ -120,15 +121,15 @@ export class CloudflareDeployer extends Deployer {
     await this.writeFiles(outputDirectory);
   }
 
-  async getBundlerOptions(
+  protected async getBundlerOptions(
     serverFile: string,
     mastraEntryFile: string,
     analyzedBundleInfo: Awaited<ReturnType<typeof analyzeBundle>>,
     toolsPaths: (string | string[])[],
-    { enableSourcemap = false }: { enableSourcemap?: boolean } = {},
+    bundlerOptions: BundlerOptions,
   ) {
     const inputOptions = await super.getBundlerOptions(serverFile, mastraEntryFile, analyzedBundleInfo, toolsPaths, {
-      enableSourcemap,
+      ...bundlerOptions,
       enableEsmShim: false,
     });
 

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -1,11 +1,28 @@
 import { FileService } from '@mastra/deployer/build';
-import { Bundler } from '@mastra/deployer/bundler';
+import { Bundler, IS_DEFAULT } from '@mastra/deployer/bundler';
+import type { Config } from '@mastra/core/mastra';
 
 import { shouldSkipDotenvLoading } from '../utils.js';
 
 export class BuildBundler extends Bundler {
   constructor() {
     super('Build');
+  }
+
+  protected async getUserBundlerOptions(
+    mastraEntryFile: string,
+    outputDirectory: string,
+  ): Promise<NonNullable<Config['bundler']>> {
+    const bundlerOptions = await super.getUserBundlerOptions(mastraEntryFile, outputDirectory);
+
+    if (!bundlerOptions?.[IS_DEFAULT]) {
+      return bundlerOptions;
+    }
+
+    return {
+      ...bundlerOptions,
+      externals: true,
+    };
   }
 
   getEnvFiles(): Promise<string[]> {

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { FileService } from '@mastra/deployer';
-import { createWatcher, getWatcherInputOptions, getBundlerOptions } from '@mastra/deployer/build';
+import { createWatcher, getWatcherInputOptions } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
 import * as fsExtra from 'fs-extra';
 import type { InputPluginOption, RollupWatcherEvent } from 'rollup';
@@ -62,14 +62,8 @@ export class DevBundler extends Bundler {
     const __dirname = dirname(__filename);
 
     const envFiles = await this.getEnvFiles();
-
-    let sourcemapEnabled = false;
-    try {
-      const bundlerOptions = await getBundlerOptions(entryFile, outputDirectory);
-      sourcemapEnabled = !!bundlerOptions?.sourcemap;
-    } catch (error) {
-      this.logger.debug('Failed to get bundler options, sourcemap will be disabled', { error });
-    }
+    const bundlerOptions = await this.getUserBundlerOptions(entryFile, outputDirectory);
+    const sourcemapEnabled = !!bundlerOptions?.sourcemap;
 
     const inputOptions = await getWatcherInputOptions(
       entryFile,

--- a/packages/core/src/bundler/types.ts
+++ b/packages/core/src/bundler/types.ts
@@ -15,4 +15,6 @@ export type BundlerConfig = {
    * Automatically includes workspace packages.
    */
   transpilePackages?: string[];
+
+  [key: symbol]: boolean | undefined;
 };

--- a/packages/deployer/src/build/types.ts
+++ b/packages/deployer/src/build/types.ts
@@ -15,3 +15,9 @@ export interface DependencyMetadata {
    */
   isWorkspace: boolean;
 }
+
+export interface BundlerOptions {
+  enableSourcemap: boolean;
+  enableEsmShim: boolean;
+  externals: boolean | string[];
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
By default enable externals true for non cloud builds, lowering bundle issues

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package versions across deployer, core, and framework packages
  * Set externals: true as the default for build and cloud deploy flows

* **New Features**
  * Added a unified bundler options surface and a marker for default bundlers
  * CLI build/dev now respect the unified bundler options and default externals behavior

* **Refactor**
  * Consolidated bundler configuration and streamlined externals/sourcemap handling across deployers and analysis tooling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->