### PR TITLE
Fix memory leak in telemetry decorators when processing large payload

### DIFF
--- a/.changeset/green-panda-kitchen.md
+++ b/.changeset/green-panda-kitchen.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix memory leak in telemetry decorators when processing large payloads. The `@withSpan` decorator now uses bounded serialization utilities to prevent unbounded memory growth when tracing agents with large inputs like base64 images.

--- a/packages/core/src/ai-tracing/index.ts
+++ b/packages/core/src/ai-tracing/index.ts
@@ -12,3 +12,4 @@ export * from './context';
 export * from './exporters';
 export * from './span_processors';
 export * from './model-tracing';
+export * from './serialization';

--- a/packages/core/src/ai-tracing/memory-leak.test.ts
+++ b/packages/core/src/ai-tracing/memory-leak.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Memory leak test for AI tracing with large payloads.
+ *
+ * This test simulates the scenario where agents process large payloads
+ * (e.g., 1MB+ base64-encoded images) repeatedly. Without bounded serialization,
+ * these large payloads would be stored in span attributes and cause OOM.
+ *
+ * The test runs 20 iterations and verifies heap stays under 1000MB.
+ */
+
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { MockLanguageModelV2, convertArrayToReadableStream } from 'ai-v5/test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Agent } from '../agent';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+
+import { clearAITracingRegistry, shutdownAITracingRegistry } from './registry';
+import type { AITracingExporter, AITracingEvent } from './types';
+
+/**
+ * Minimal test exporter that captures events without storing large data.
+ */
+class MinimalTestExporter implements AITracingExporter {
+  name = 'minimal-test-exporter';
+  eventCount = 0;
+
+  async exportEvent(_event: AITracingEvent) {
+    this.eventCount++;
+  }
+
+  async shutdown() {}
+
+  reset() {
+    this.eventCount = 0;
+  }
+}
+
+/**
+ * Generate a large base64-like string to simulate image data.
+ * Creates approximately 1MB of data.
+ */
+function generateLargePayload(sizeInBytes: number = 1024 * 1024): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  let result = 'data:image/png;base64,';
+  for (let i = 0; i < sizeInBytes; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+/**
+ * Get current heap usage in MB.
+ */
+function getHeapUsageMB(): number {
+  if (typeof global.gc === 'function') {
+    global.gc();
+  }
+  const usage = process.memoryUsage();
+  return Math.round(usage.heapUsed / 1024 / 1024);
+}
+
+describe('AI Tracing Memory Leak Tests', () => {
+  let testExporter: MinimalTestExporter;
+  let otelProvider: NodeTracerProvider;
+  let otelExporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    clearAITracingRegistry();
+    testExporter = new MinimalTestExporter();
+
+    // Set up OpenTelemetry tracer provider to activate @withSpan decorators
+    otelExporter = new InMemorySpanExporter();
+    otelProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(otelExporter)],
+    });
+    otelProvider.register();
+
+    // Mark telemetry as loaded to suppress warning
+    (globalThis as any).___MASTRA_TELEMETRY___ = true;
+  });
+
+  afterEach(async () => {
+    await shutdownAITracingRegistry();
+
+    // Clean up OpenTelemetry
+    await otelProvider.shutdown();
+    otelExporter.reset();
+
+    // Reset global telemetry flag
+    (globalThis as any).___MASTRA_TELEMETRY___ = false;
+  });
+
+  it('should not leak memory when processing large payloads repeatedly', async () => {
+    const ITERATIONS = 20;
+    const MAX_HEAP_MB = 1000;
+    const PAYLOAD_SIZE = 1024 * 1024; // 1MB payload per iteration
+
+    // Create a mock model that returns large payloads (simulating image responses)
+    const largePayload = generateLargePayload(PAYLOAD_SIZE);
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: `Response with data: ${largePayload.slice(0, 100)}...` }],
+        finishReason: 'stop',
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'response-metadata', id: '1', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-delta', id: '1', delta: `Response with data: ${largePayload.slice(0, 100)}...` },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 } },
+        ]),
+      }),
+    });
+
+    const testAgent = new Agent({
+      name: 'Memory Test Agent',
+      instructions: 'You are a test agent for memory leak testing',
+      model: mockModel,
+    });
+
+    const mastra = new Mastra({
+      telemetry: { enabled: true }, // Enable telemetry to test @withSpan decorator serialization
+      storage: new MockStore(),
+      observability: {
+        configs: {
+          test: {
+            serviceName: 'memory-leak-tests',
+            exporters: [testExporter],
+          },
+        },
+      },
+      agents: { testAgent },
+    });
+
+    const agent = mastra.getAgent('testAgent');
+
+    const initialHeap = getHeapUsageMB();
+
+    // Run iterations with large payloads
+    for (let i = 0; i < ITERATIONS; i++) {
+      // Create a prompt with the large payload (simulating sending an image)
+      const prompt = `Process this image data: ${largePayload}`;
+
+      const result = await agent.generate(prompt);
+      expect(result.text).toBeDefined();
+      expect(result.traceId).toBeDefined();
+
+      // Allow garbage collection between iterations
+      if (typeof global.gc === 'function') {
+        global.gc();
+      }
+
+      // Check memory during iterations to fail fast on leaks
+      const currentHeap = getHeapUsageMB();
+      expect(
+        currentHeap,
+        `Memory leak detected at iteration ${i + 1}: heap ${currentHeap}MB exceeds ${MAX_HEAP_MB}MB`,
+      ).toBeLessThan(MAX_HEAP_MB);
+    }
+
+    const finalHeap = getHeapUsageMB();
+
+    // Log results for debugging (will only show if test fails or in verbose mode)
+    console.log(`Memory test completed: ${ITERATIONS} iterations`);
+    console.log(`Initial heap: ${initialHeap}MB, Final heap: ${finalHeap}MB`);
+    console.log(`Events captured: ${testExporter.eventCount}`);
+
+    // Verify traces were actually created
+    expect(testExporter.eventCount).toBeGreaterThan(0);
+  }, 300000); // 5 minute timeout
+
+  it('should not leak memory when streaming large payloads repeatedly', async () => {
+    const ITERATIONS = 20;
+    const MAX_HEAP_MB = 1000;
+    const PAYLOAD_SIZE = 1024 * 1024; // 1MB payload per iteration
+
+    const largePayload = generateLargePayload(PAYLOAD_SIZE);
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: `Response: ${largePayload.slice(0, 100)}...` }],
+        finishReason: 'stop',
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'response-metadata', id: '1', modelId: 'mock-model-id', timestamp: new Date(0) },
+          // Simulate streaming a large response in chunks
+          { type: 'text-delta', id: '1', delta: largePayload.slice(0, 10000) },
+          { type: 'text-delta', id: '2', delta: largePayload.slice(10000, 20000) },
+          { type: 'text-delta', id: '3', delta: '...' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 } },
+        ]),
+      }),
+    });
+
+    const testAgent = new Agent({
+      name: 'Memory Test Agent Stream',
+      instructions: 'You are a test agent for memory leak testing',
+      model: mockModel,
+    });
+
+    const mastra = new Mastra({
+      telemetry: { enabled: true }, // Enable telemetry to test @withSpan decorator serialization
+      storage: new MockStore(),
+      observability: {
+        configs: {
+          test: {
+            serviceName: 'memory-leak-tests-stream',
+            exporters: [testExporter],
+          },
+        },
+      },
+      agents: { testAgent },
+    });
+
+    const agent = mastra.getAgent('testAgent');
+
+    const initialHeap = getHeapUsageMB();
+
+    // Run streaming iterations with large payloads
+    for (let i = 0; i < ITERATIONS; i++) {
+      const prompt = `Process this image data: ${largePayload}`;
+
+      const result = await agent.stream(prompt);
+      let fullText = '';
+      for await (const chunk of result.textStream) {
+        fullText += chunk;
+      }
+
+      expect(fullText).toBeDefined();
+      expect(result.traceId).toBeDefined();
+
+      // Allow garbage collection between iterations
+      if (typeof global.gc === 'function') {
+        global.gc();
+      }
+
+      // Check memory during iterations to fail fast on leaks
+      const currentHeap = getHeapUsageMB();
+      expect(
+        currentHeap,
+        `Memory leak detected at iteration ${i + 1}: heap ${currentHeap}MB exceeds ${MAX_HEAP_MB}MB`,
+      ).toBeLessThan(MAX_HEAP_MB);
+    }
+
+    const finalHeap = getHeapUsageMB();
+
+    console.log(`Stream memory test completed: ${ITERATIONS} iterations`);
+    console.log(`Initial heap: ${initialHeap}MB, Final heap: ${finalHeap}MB`);
+    console.log(`Events captured: ${testExporter.eventCount}`);
+
+    // Verify traces were actually created
+    expect(testExporter.eventCount).toBeGreaterThan(0);
+  }, 300000); // 5 minute timeout
+});

--- a/packages/core/src/ai-tracing/serialization.ts
+++ b/packages/core/src/ai-tracing/serialization.ts
@@ -1,0 +1,351 @@
+/**
+ * Bounded serialization utilities for AI tracing.
+ *
+ * These utilities prevent memory issues by enforcing strict limits on
+ * string lengths, array sizes, object depths, and total output size.
+ * They are designed to be used across all tracing/telemetry systems.
+ */
+
+/**
+ * Configuration limits for serialization.
+ * These defaults are intentionally conservative to prevent OOM issues.
+ */
+export interface SerializationLimits {
+  /** Maximum characters for any single attribute string (default: 1024) */
+  maxAttrChars: number;
+  /** Maximum characters for preview strings (default: 256) */
+  maxPreviewChars: number;
+  /** Maximum array items to show in preview (default: 10) */
+  maxArrayPreviewItems: number;
+  /** Maximum depth for recursive serialization (default: 6) */
+  maxDepth: number;
+  /** Maximum object keys to serialize (default: 50) */
+  maxKeys: number;
+  /** Maximum array elements to serialize (default: 50) */
+  maxArrayItems: number;
+  /** Maximum total output characters (default: 8192) */
+  maxTotalChars: number;
+}
+
+export const DEFAULT_SERIALIZATION_LIMITS: SerializationLimits = {
+  maxAttrChars: 1024,
+  maxPreviewChars: 256,
+  maxArrayPreviewItems: 10,
+  maxDepth: 6,
+  maxKeys: 50,
+  maxArrayItems: 50,
+  maxTotalChars: 8192,
+};
+
+/**
+ * Hard-cap any string to prevent unbounded growth.
+ */
+export function truncateString(s: string, maxChars: number): string {
+  if (s.length <= maxChars) return s;
+  return s.slice(0, maxChars) + '…[truncated]';
+}
+
+/**
+ * Small, non-recursive preview of unknown values.
+ * Never walks object graphs deeply - meant for span attributes (cheap + safe).
+ *
+ * @param value - The value to preview
+ * @param limits - Optional limits (uses defaults if not provided)
+ * @returns A string representation of the value
+ */
+export function previewValue(value: unknown, limits: Partial<SerializationLimits> = {}): string {
+  const { maxAttrChars, maxPreviewChars, maxArrayPreviewItems } = {
+    ...DEFAULT_SERIALIZATION_LIMITS,
+    ...limits,
+  };
+
+  if (value == null) return String(value);
+
+  switch (typeof value) {
+    case 'string': {
+      const s = value as string;
+      const preview = s.length > maxPreviewChars ? s.slice(0, maxPreviewChars) + '…' : s;
+      return truncateString(preview, maxAttrChars);
+    }
+
+    case 'number':
+    case 'boolean':
+      return String(value);
+
+    case 'bigint':
+      return `${value}n`;
+
+    case 'function':
+      return '[Function]';
+
+    case 'symbol': {
+      const sym = value as symbol;
+      return sym.description ? `[Symbol(${sym.description})]` : '[Symbol]';
+    }
+
+    default:
+      break;
+  }
+
+  // Handle special object types
+  if (value instanceof Error) {
+    return truncateString(`[Error ${value.name}: ${value.message}]`, maxAttrChars);
+  }
+
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+    return `[Buffer length=${value.length}]`;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    const ctor = (value as any).constructor?.name ?? 'TypedArray';
+    const byteLength = (value as any).byteLength ?? '?';
+    return `[${ctor} byteLength=${byteLength}]`;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return `[ArrayBuffer byteLength=${value.byteLength}]`;
+  }
+
+  if (Array.isArray(value)) {
+    const len = value.length;
+    const sample = value.slice(0, maxArrayPreviewItems).map(v => {
+      const pv = previewValue(v, limits);
+      return pv.length > 64 ? pv.slice(0, 64) + '…' : pv;
+    });
+    return truncateString(`[Array length=${len} sample=[${sample.join(', ')}]]`, maxAttrChars);
+  }
+
+  // Generic object handling
+  const ctor = (value as any)?.constructor?.name ?? 'Object';
+  let keys: string[] | undefined;
+  try {
+    keys = Object.keys(value as any).slice(0, 10);
+  } catch {
+    keys = undefined;
+  }
+  if (keys && keys.length) {
+    return truncateString(`[${ctor} keys=${keys.join(',')}${keys.length === 10 ? ',…' : ''}]`, maxAttrChars);
+  }
+  return truncateString(`[${ctor}]`, maxAttrChars);
+}
+
+/**
+ * Bounded safe stringify for when you need JSON output.
+ * Still capped and depth/size limited to prevent memory issues.
+ *
+ * @param value - The value to stringify
+ * @param limits - Optional limits (uses defaults if not provided)
+ * @returns A JSON string representation with enforced limits
+ */
+export function boundedStringify(value: unknown, limits: Partial<SerializationLimits> = {}): string {
+  const { maxAttrChars, maxDepth, maxKeys, maxArrayItems, maxTotalChars } = {
+    ...DEFAULT_SERIALIZATION_LIMITS,
+    ...limits,
+  };
+
+  const seen = new WeakSet<object>();
+
+  function helper(v: any, depth: number): any {
+    if (v == null) return v;
+
+    const t = typeof v;
+    if (t === 'string') {
+      return v.length > maxAttrChars ? v.slice(0, maxAttrChars) + '…[truncated]' : v;
+    }
+    if (t === 'number' || t === 'boolean') return v;
+    if (t === 'bigint') return `${v}n`;
+    if (t === 'function') return '[Function]';
+    if (t === 'symbol') return v.description ? `[Symbol(${v.description})]` : '[Symbol]';
+
+    if (v instanceof Error) {
+      return {
+        name: v.name,
+        message: v.message ? truncateString(v.message, maxAttrChars) : undefined,
+      };
+    }
+
+    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
+      return `[Buffer length=${v.length}]`;
+    }
+
+    if (ArrayBuffer.isView(v)) {
+      const ctor = v.constructor?.name ?? 'TypedArray';
+      const byteLength = (v as any).byteLength ?? '?';
+      return `[${ctor} byteLength=${byteLength}]`;
+    }
+
+    if (v instanceof ArrayBuffer) {
+      return `[ArrayBuffer byteLength=${v.byteLength}]`;
+    }
+
+    if (depth <= 0) {
+      const ctor = v?.constructor?.name ?? 'Object';
+      return `[${ctor} depthLimit]`;
+    }
+
+    if (typeof v === 'object') {
+      if (seen.has(v)) return '[Circular]';
+      seen.add(v);
+
+      if (Array.isArray(v)) {
+        const result = v.slice(0, maxArrayItems).map(x => helper(x, depth - 1));
+        if (v.length > maxArrayItems) {
+          result.push(`[…${v.length - maxArrayItems} more items]`);
+        }
+        return result;
+      }
+
+      const out: Record<string, any> = {};
+      const keys = Object.keys(v).slice(0, maxKeys);
+      for (const k of keys) {
+        try {
+          out[k] = helper(v[k], depth - 1);
+        } catch {
+          out[k] = '[Not Serializable]';
+        }
+      }
+      if (Object.keys(v).length > keys.length) {
+        out.__truncated = `${Object.keys(v).length - keys.length} more keys`;
+      }
+      return out;
+    }
+
+    return String(v);
+  }
+
+  try {
+    const json = JSON.stringify(helper(value, maxDepth));
+    if (json.length > maxTotalChars) {
+      return json.slice(0, maxTotalChars) + '…[truncated]';
+    }
+    return json;
+  } catch {
+    return '[Not Serializable]';
+  }
+}
+
+/**
+ * Default keys to strip from objects during deep cleaning.
+ * These are typically internal/sensitive fields that shouldn't be traced.
+ */
+export const DEFAULT_KEYS_TO_STRIP = new Set([
+  'logger',
+  'experimental_providerMetadata',
+  'providerMetadata',
+  'steps',
+  'tracingContext',
+]);
+
+export interface DeepCleanOptions {
+  keysToStrip?: Set<string>;
+  maxDepth?: number;
+  maxStringLength?: number;
+  maxArrayLength?: number;
+  maxObjectKeys?: number;
+}
+
+/**
+ * Recursively cleans a value by removing circular references, stripping problematic keys,
+ * and enforcing size limits on strings, arrays, and objects.
+ *
+ * This is used by AI tracing spans to sanitize input/output data before storing.
+ *
+ * @param value - The value to clean (object, array, primitive, etc.)
+ * @param options - Optional configuration for cleaning behavior
+ * @returns A cleaned version of the input with size limits enforced
+ */
+export function deepClean(
+  value: any,
+  options: DeepCleanOptions = {},
+  _seen: WeakSet<any> = new WeakSet(),
+  _depth: number = 0,
+): any {
+  const {
+    keysToStrip = DEFAULT_KEYS_TO_STRIP,
+    maxDepth = DEFAULT_SERIALIZATION_LIMITS.maxDepth,
+    maxStringLength = DEFAULT_SERIALIZATION_LIMITS.maxAttrChars,
+    maxArrayLength = DEFAULT_SERIALIZATION_LIMITS.maxArrayItems,
+    maxObjectKeys = DEFAULT_SERIALIZATION_LIMITS.maxKeys,
+  } = options;
+
+  if (_depth > maxDepth) {
+    return '[MaxDepth]';
+  }
+
+  // Handle primitives
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  // Handle strings - enforce length limit
+  if (typeof value === 'string') {
+    if (value.length > maxStringLength) {
+      return value.slice(0, maxStringLength) + `…[truncated, was ${value.length} chars]`;
+    }
+    return value;
+  }
+
+  // Handle other primitives
+  if (typeof value !== 'object') {
+    try {
+      JSON.stringify(value);
+      return value;
+    } catch (error) {
+      return `[${error instanceof Error ? error.message : String(error)}]`;
+    }
+  }
+
+  // Handle circular references
+  if (_seen.has(value)) {
+    return '[Circular]';
+  }
+
+  _seen.add(value);
+
+  // Handle arrays - enforce length limit
+  if (Array.isArray(value)) {
+    const limitedArray = value.slice(0, maxArrayLength);
+    const cleaned = limitedArray.map(item => deepClean(item, options, _seen, _depth + 1));
+    if (value.length > maxArrayLength) {
+      cleaned.push(`[…${value.length - maxArrayLength} more items]`);
+    }
+    return cleaned;
+  }
+
+  // Handle Buffer and typed arrays - don't serialize large binary data
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+    return `[Buffer length=${value.length}]`;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    const ctor = (value as any).constructor?.name ?? 'TypedArray';
+    const byteLength = (value as any).byteLength ?? '?';
+    return `[${ctor} byteLength=${byteLength}]`;
+  }
+
+  // Handle objects - enforce key limit
+  const cleaned: Record<string, any> = {};
+  const entries = Object.entries(value);
+  let keyCount = 0;
+
+  for (const [key, val] of entries) {
+    if (keysToStrip.has(key)) {
+      continue;
+    }
+
+    if (keyCount >= maxObjectKeys) {
+      cleaned['__truncated'] = `${entries.length - keyCount} more keys omitted`;
+      break;
+    }
+
+    try {
+      cleaned[key] = deepClean(val, options, _seen, _depth + 1);
+      keyCount++;
+    } catch (error) {
+      cleaned[key] = `[${error instanceof Error ? error.message : String(error)}]`;
+      keyCount++;
+    }
+  }
+
+  return cleaned;
+}

--- a/packages/core/src/ai-tracing/spans/default.ts
+++ b/packages/core/src/ai-tracing/spans/default.ts
@@ -1,4 +1,5 @@
 import { MastraError } from '../../error';
+import { deepClean } from '../serialization';
 import type {
   AISpanType,
   AITracing,
@@ -7,7 +8,7 @@ import type {
   UpdateSpanOptions,
   CreateSpanOptions,
 } from '../types';
-import { BaseAISpan, deepClean } from './base';
+import { BaseAISpan } from './base';
 
 export class DefaultAISpan<TType extends AISpanType> extends BaseAISpan<TType> {
   public id: string;


### PR DESCRIPTION
## Description

- The @withSpan decorator was using unbounded JSON.stringify for span attributes, causing full 1MB+ base64 payloads to be stored in OpenTelemetry spans
- Created shared ai-tracing/serialization.ts with bounded utilities (previewValue, boundedStringify, deepClean) that enforce configurable limits on string length, array size, and object depth
- Updated telemetry.decorators.ts to use bounded serialization, preventing memory growth when tracing agents with large inputs/outputs
- Added memory leak regression test that verifies heap stays under 1000MB across 20 iterations with 1MB payloads

Included test fails in `0.x` in 5 iterations. After this change I can run 2000 iterations without issue. 

Also, everything seems to run faster.

## Related Issue(s)

- #6322
- #8046
- #11169
- #11172

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved memory leak in the @withSpan decorator when processing large payloads in tracing

* **New Features**
  * Introduced bounded serialization utilities for improved safety when handling large data in AI applications

* **Tests**
  * Added comprehensive memory-leak test suite validating large payload processing and streaming scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->