### PR TITLE
fix(cli): Skip gitInit + better defaults

### DIFF
--- a/.changeset/pretty-tools-do.md
+++ b/.changeset/pretty-tools-do.md
@@ -1,0 +1,8 @@
+---
+'mastra': patch
+---
+
+Two smaller quality of life improvements:
+
+- The default `create-mastra` project no longer defines a LibSQLStore storage for the weather agent memory. It uses the root level `storage` option now (which is memory). This way no `mastra.db` files are created outside of the project
+- When running `mastra init` inside a project that already has git initialized, the prompt to initialize git is skipped

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -4,7 +4,7 @@ import { init } from '../init/init';
 import type { Editor } from '../init/mcp-docs-server-install';
 import { checkAndInstallCoreDeps, checkForPkgJson, interactivePrompt } from '../init/utils';
 import type { Component, LLMProvider } from '../init/utils';
-import { getVersionTag } from '../utils';
+import { getVersionTag, isGitInitialized } from '../utils';
 
 const origin = process.env.MASTRA_ANALYTICS_ORIGIN as CLI_ORIGIN;
 
@@ -27,11 +27,12 @@ export const initProject = async (args: InitArgs) => {
 
       // Detect the version tag (e.g., 'beta', 'latest') from the running CLI
       const versionTag = await getVersionTag();
+      const skipGitInit = await isGitInitialized({ cwd: process.cwd() });
 
       await checkAndInstallCoreDeps(Boolean(args?.example || args?.default), versionTag);
 
       if (!Object.keys(args).length) {
-        const result = await interactivePrompt();
+        const result = await interactivePrompt({ skip: { gitInit: skipGitInit } });
         await init({
           ...result,
           llmApiKey: result?.llmApiKey as string,

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -80,7 +80,6 @@ export async function writeAgentSample(
   const content = `
 import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
-import { LibSQLStore } from '@mastra/libsql';
 ${addExampleTool ? `import { weatherTool } from '../tools/weather-tool';` : ''}
 ${addScorers ? `import { scorers } from '../scorers/weather-scorer';` : ''}
 
@@ -117,12 +116,7 @@ export const weatherAgent = new Agent({
   },`
       : ''
   }
-  memory: new Memory({
-    storage: new LibSQLStore({
-      id: "memory-storage",
-      url: "file:../mastra.db", // path is relative to the .mastra/output directory
-    })
-  })
+  memory: new Memory()
 });
     `;
   const formattedContent = await prettier.format(content, {
@@ -516,7 +510,7 @@ export const mastra = new Mastra({
   observability: new Observability({
     // Enables DefaultExporter and CloudExporter for tracing
     default: { enabled: true },
-    }),
+  }),
 });
 `,
     );

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -654,6 +654,7 @@ interface InteractivePromptArgs {
   skip?: {
     llmProvider?: boolean;
     llmApiKey?: boolean;
+    gitInit?: boolean;
   };
 }
 
@@ -763,6 +764,8 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
         return editor;
       },
       initGit: async () => {
+        if (skip?.gitInit) return false;
+
         return p.confirm({
           message: 'Initialize a new git repository?',
           initialValue: true,

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -91,6 +91,18 @@ export async function getVersionTag(): Promise<string | undefined> {
 }
 
 /**
+ * Check if the current directory already has git initialized.
+ */
+export async function isGitInitialized({ cwd }: { cwd: string }): Promise<boolean> {
+  try {
+    await execa('git', ['rev-parse', '--is-inside-work-tree'], { cwd, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Initialize a git repository in the specified directory.
  */
 export async function gitInit({ cwd }: { cwd: string }) {


### PR DESCRIPTION
## Description

Two smaller quality of life improvements:

- The default `create-mastra` project no longer defines a LibSQLStore storage for the weather agent memory. It uses the root level `storage` option now (which is memory). This way no `mastra.db` files are created outside of the project
- When running `mastra init` inside a project that already has git initialized, the prompt to initialize git is skipped

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes & Improvements

* **Bug Fixes**
  * Default create-mastra projects now use in-memory storage, preventing unnecessary database files from being created outside the project directory.
  * Running `mastra init` in an existing Git repository now skips the Git initialization prompt.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->