### PR TITLE
Improved CWD for dev command

### DIFF
--- a/.changeset/social-files-follow.md
+++ b/.changeset/social-files-follow.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'mastra': patch
+---
+
+Set public dir as cwd when running dev. Improver persisting of files.

--- a/.changeset/social-files-follow.md
+++ b/.changeset/social-files-follow.md
@@ -3,4 +3,7 @@
 'mastra': patch
 ---
 
-Set public dir as cwd when running dev. Improver persisting of files.
+@mastra/deployer: patch
+mastra: patch
+
+Improved file persistence in dev mode. Files created by `mastra dev` are now saved in the public directory, so you can commit them to version control or ignore them via `.gitignore`.

--- a/.changeset/social-files-follow.md
+++ b/.changeset/social-files-follow.md
@@ -3,7 +3,4 @@
 'mastra': patch
 ---
 
-@mastra/deployer: patch
-mastra: patch
-
 Improved file persistence in dev mode. Files created by `mastra dev` are now saved in the public directory, so you can commit them to version control or ignore them via `.gitignore`.

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -79,8 +79,6 @@ export class DevBundler extends Bundler {
 
     await this.writePackageJson(outputDir, new Map(), {});
 
-    const copyPublic = this.copyPublic.bind(this);
-
     const watcher = await createWatcher(
       {
         ...inputOptions,
@@ -103,15 +101,6 @@ export class DevBundler extends Bundler {
               for (const envFile of envFiles) {
                 this.addWatchFile(envFile);
               }
-            },
-          },
-          {
-            name: 'public-dir-watcher',
-            buildStart() {
-              this.addWatchFile(join(dirname(entryFile), 'public'));
-            },
-            buildEnd() {
-              return copyPublic(dirname(entryFile), outputDirectory);
             },
           },
           {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -95,6 +95,7 @@ const startServer = async (
 
     // Write mastra packages to a file and pass the file path via env var
     const packagesFilePath = join(dotMastraPath, '..', 'mastra-packages.json');
+    await mkdir(dotMastraPath, { recursive: true });
     if (startOptions.mastraPackages) {
       await writeFile(packagesFilePath, JSON.stringify(startOptions.mastraPackages), 'utf-8');
     }

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import process from 'node:process';
 import devcert from '@expo/devcert';
@@ -96,9 +96,10 @@ const startServer = async (
     // Write mastra packages to a file and pass the file path via env var
     const packagesFilePath = join(dotMastraPath, '..', 'mastra-packages.json');
     if (startOptions.mastraPackages) {
-      writeFileSync(packagesFilePath, JSON.stringify(startOptions.mastraPackages), 'utf-8');
+      await writeFile(packagesFilePath, JSON.stringify(startOptions.mastraPackages), 'utf-8');
     }
 
+    await mkdir(publicDir, { recursive: true });
     currentServerProcess = execa(process.execPath, commands, {
       cwd: publicDir,
       env: {

--- a/packages/cli/src/commands/start/start.ts
+++ b/packages/cli/src/commands/start/start.ts
@@ -28,7 +28,7 @@ export async function start(options: StartOptions = {}) {
     commands.push('index.mjs');
 
     // Start the server using node
-    const server = spawn('node', commands, {
+    const server = spawn(process.execPath, commands, {
       cwd: outputPath,
       stdio: ['inherit', 'inherit', 'pipe'],
       env: {

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -69,6 +69,12 @@ export async function createHonoServer(
   const a2aTaskStore = new InMemoryTaskStore();
   const routes = server?.apiRoutes;
 
+  let __dirname: string = '.';
+  if (import.meta.url) {
+    const __filename = fileURLToPath(import.meta.url);
+    __dirname = dirname(__filename);
+  }
+
   // Store custom route auth configurations
   const customRouteAuthConfig = new Map<string, boolean>();
 

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import * as https from 'node:https';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { swaggerUI } from '@hono/swagger-ui';
@@ -23,8 +24,10 @@ import { restartAllActiveWorkflowRunsHandler } from './handlers/restart-active-r
 import type { ServerBundleOptions } from './types';
 import { html } from './welcome';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 // Get studio path from env or default to ./playground relative to cwd
-const getStudioPath = () => process.env.MASTRA_STUDIO_PATH || './playground';
+const getStudioPath = () => process.env.MASTRA_STUDIO_PATH || join(__dirname, './playground');
 
 // Use adapter type definitions
 type Bindings = HonoBindings;
@@ -258,6 +261,7 @@ export async function createHonoServer(
         });
       },
     );
+
     // Playground routes - these should come after API routes
     // Serve static assets from playground directory
     // Note: Vite builds with base: './' so all asset URLs are relative

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -24,10 +24,21 @@ import { restartAllActiveWorkflowRunsHandler } from './handlers/restart-active-r
 import type { ServerBundleOptions } from './types';
 import { html } from './welcome';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 // Get studio path from env or default to ./playground relative to cwd
-const getStudioPath = () => process.env.MASTRA_STUDIO_PATH || join(__dirname, './playground');
+const getStudioPath = () => {
+  if (process.env.MASTRA_STUDIO_PATH) {
+    return process.env.MASTRA_STUDIO_PATH;
+  }
+
+  let __dirname: string = '.';
+  if (import.meta.url) {
+    const __filename = fileURLToPath(import.meta.url);
+    __dirname = dirname(__filename);
+  }
+
+  const studioPath = process.env.MASTRA_STUDIO_PATH || join(__dirname, 'playground');
+  return studioPath;
+};
 
 // Use adapter type definitions
 type Bindings = HonoBindings;
@@ -68,12 +79,6 @@ export async function createHonoServer(
   const server = mastra.getServer();
   const a2aTaskStore = new InMemoryTaskStore();
   const routes = server?.apiRoutes;
-
-  let __dirname: string = '.';
-  if (import.meta.url) {
-    const __filename = fileURLToPath(import.meta.url);
-    __dirname = dirname(__filename);
-  }
 
   // Store custom route auth configurations
   const customRouteAuthConfig = new Map<string, boolean>();

--- a/packages/memory/integration-tests/src/shared/useChat.ts
+++ b/packages/memory/integration-tests/src/shared/useChat.ts
@@ -280,7 +280,7 @@ export function setupUseChatV5Plus({ useChatFunc, version }: { useChatFunc: any;
 
       const mastraDir = path.resolve(import.meta.dirname, `..`, version, `mastra`);
       mastraServer = spawn(
-        'node',
+        process.execPath,
         [
           path.resolve(import.meta.dirname, `..`, `..`, `..`, `..`, `cli`, `dist`, `index.js`),
           'dev',

--- a/packages/memory/integration-tests/src/shared/useChat.ts
+++ b/packages/memory/integration-tests/src/shared/useChat.ts
@@ -70,7 +70,7 @@ export function setupUseChatV4() {
             PORT: port.toString(),
           },
         },
-      });
+      );
 
       // Wait for server to be ready
       await new Promise<void>((resolve, reject) => {

--- a/packages/memory/integration-tests/src/shared/useChat.ts
+++ b/packages/memory/integration-tests/src/shared/useChat.ts
@@ -55,7 +55,7 @@ export function setupUseChatV4() {
 
       const mastraDir = path.resolve(import.meta.dirname, `..`, `v4`, `mastra`);
       mastraServer = spawn(
-        'node',
+        process.execPath,
         [
           path.resolve(import.meta.dirname, `..`, `..`, `..`, `..`, `cli`, `dist`, `index.js`),
           'dev',
@@ -70,7 +70,7 @@ export function setupUseChatV4() {
             PORT: port.toString(),
           },
         },
-      );
+      });
 
       // Wait for server to be ready
       await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

CWD of mastra dev is now the public dir. Means that all relative files are saved from public folder instead of `.mastra/output`. Files will now be persisted and the user can ignore them using gitignore or commit them.

Will store it inside public folder
```ts
new LibSQLStore({
    id: "mastra-storage",
    // stores observability, scores, ... into memory storage, if it needs to persist, change to file:../mastra.db
    url: "file:./mastra.db",
  }),
```
## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/11081

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playground assets and HTML now load reliably via stable module-relative path resolution.

* **Changes**
  * Dev workflow writes generated files into the project's public directory and uses that directory as the dev server working directory.
  * Public directory contents are no longer automatically copied into build output during watch/build.
  * Server start now uses the running Node binary for consistent behavior.

* **Tests**
  * Integration tests run servers with the current Node runtime for more reliable test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->