### PR TITLE
forward-port mem-leak fixes from 0.x to main

### DIFF
--- a/.changeset/fresh-bats-spend.md
+++ b/.changeset/fresh-bats-spend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Limits the size of large payloads in span data.

--- a/observability/_examples/otel-bridge/hono-multi/pnpm-lock.yaml
+++ b/observability/_examples/otel-bridge/hono-multi/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions':
-        specifier: ^1.37.0
+        specifier: 1.38.0
         version: 1.38.0
     devDependencies:
       '@types/node':
@@ -147,7 +147,7 @@ importers:
         specifier: ^0.208.0
         version: 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions':
-        specifier: ^1.38.0
+        specifier: 1.38.0
         version: 1.38.0
       dotenv:
         specifier: ^17.2.0

--- a/observability/_examples/otel-bridge/hono-multi/service-mastra/src/index.ts
+++ b/observability/_examples/otel-bridge/hono-multi/service-mastra/src/index.ts
@@ -30,9 +30,9 @@ app.use('*', httpInstrumentationMiddleware());
 app.use('*', cors());
 
 // Register Mastra routes via the HonoServerAdapter
-const honoServerAdapter = new MastraServer({ app, mastra });
-honoServerAdapter.registerContextMiddleware(app);
-await honoServerAdapter.registerRoutes(app, { openapiPath: '/openapi.json' });
+const honoServerAdapter = new MastraServer({ app, mastra, openapiPath: '/openapi.json' });
+honoServerAdapter.registerContextMiddleware();
+await honoServerAdapter.registerRoutes();
 
 // Custom routes
 app.get('/healthz', async c => {

--- a/observability/_examples/otel-bridge/hono-multi/service-mastra/src/instrumentation.ts
+++ b/observability/_examples/otel-bridge/hono-multi/service-mastra/src/instrumentation.ts
@@ -4,3 +4,5 @@ try {
 } catch (error) {
   console.error('[instrumentation] Failed to initialize telemetry:', error);
 }
+
+export {};

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -1,3 +1,4 @@
+import { MockLanguageModelV1, simulateReadableStream } from '@internal/ai-sdk-v4/test';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { Agent } from '@mastra/core/agent';
 import type { StructuredOutputOptions } from '@mastra/core/agent';
@@ -19,7 +20,6 @@ import type { OutputSchema } from '@mastra/core/stream';
 import type { ToolExecutionContext } from '@mastra/core/tools';
 import { createTool } from '@mastra/core/tools';
 import { createWorkflow, createStep } from '@mastra/core/workflows';
-import { MockLanguageModelV1, simulateReadableStream } from 'ai/test';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -3,7 +3,8 @@ import { SpanType, SamplingStrategyType, InternalSpans } from '@mastra/core/obse
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { DefaultObservabilityInstance } from '../instances';
-import { getExternalParentId, deepClean } from './base';
+import { getExternalParentId } from './base';
+import { deepClean } from './serialization';
 
 // Simple test exporter for capturing events
 class TestExporter implements ObservabilityExporter {

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -17,6 +17,7 @@ import type {
 
 import { SpanType, InternalSpans } from '@mastra/core/observability';
 import { ModelSpanTracker } from '../model-tracing';
+import { deepClean } from './serialization';
 
 /**
  * Determines if a span type should be considered internal based on flags.
@@ -271,80 +272,4 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
 
     return fn();
   }
-}
-
-const DEFAULT_KEYS_TO_STRIP = new Set([
-  'logger',
-  'experimental_providerMetadata',
-  'providerMetadata',
-  'steps',
-  'tracingContext',
-]);
-export interface DeepCleanOptions {
-  keysToStrip?: Set<string>;
-  maxDepth?: number;
-}
-
-/**
- * Recursively cleans a value by removing circular references and stripping problematic or sensitive keys.
- * Circular references are replaced with "[Circular]". Unserializable values are replaced with error messages.
- * Keys like "logger" and "tracingContext" are stripped by default.
- * A maximum recursion depth is enforced to avoid stack overflow or excessive memory usage.
- *
- * @param value - The value to clean (object, array, primitive, etc.)
- * @param options - Optional configuration:
- *   - keysToStrip: Set of keys to remove from objects (default: logger, tracingContext)
- *   - maxDepth: Maximum recursion depth before values are replaced with "[MaxDepth]" (default: 10)
- * @returns A cleaned version of the input with circular references, specified keys, and overly deep values handled
- */
-export function deepClean(
-  value: any,
-  options: DeepCleanOptions = {},
-  _seen: WeakSet<any> = new WeakSet(),
-  _depth: number = 0,
-): any {
-  const { keysToStrip = DEFAULT_KEYS_TO_STRIP, maxDepth = 10 } = options;
-
-  if (_depth > maxDepth) {
-    return '[MaxDepth]';
-  }
-
-  if (value === null || typeof value !== 'object') {
-    try {
-      JSON.stringify(value);
-      return value;
-    } catch (error) {
-      return `[${error instanceof Error ? error.message : String(error)}]`;
-    }
-  }
-
-  if (_seen.has(value)) {
-    return '[Circular]';
-  }
-
-  _seen.add(value);
-
-  // Handle Date objects - return as-is (they are JSON-serializable)
-  if (value instanceof Date) {
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    return value.map(item => deepClean(item, options, _seen, _depth + 1));
-  }
-
-  const cleaned: Record<string, any> = {};
-  for (const [key, val] of Object.entries(value)) {
-    if (keysToStrip.has(key)) {
-      continue;
-    }
-
-    try {
-      cleaned[key] = deepClean(val, options, _seen, _depth + 1);
-    } catch (error) {
-      cleaned[key] = `[${error instanceof Error ? error.message : String(error)}]`;
-    }
-  }
-
-  return cleaned;
 }

--- a/observability/mastra/src/spans/default.ts
+++ b/observability/mastra/src/spans/default.ts
@@ -7,7 +7,8 @@ import type {
   UpdateSpanOptions,
   CreateSpanOptions,
 } from '@mastra/core/observability';
-import { BaseSpan, deepClean } from './base';
+import { BaseSpan } from './base';
+import { deepClean } from './serialization';
 
 export class DefaultSpan<TType extends SpanType> extends BaseSpan<TType> {
   public id: string;

--- a/observability/mastra/src/spans/index.ts
+++ b/observability/mastra/src/spans/index.ts
@@ -5,3 +5,4 @@
 export * from './base';
 export * from './default';
 export * from './no-op';
+export * from './serialization';

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -1,0 +1,193 @@
+/**
+ * Bounded serialization utilities for AI tracing.
+ *
+ * These utilities prevent memory issues by enforcing strict limits on
+ * string lengths, array sizes, object depths, and total output size.
+ * They are designed to be used across all tracing/telemetry systems.
+ */
+
+/**
+ * Configuration limits for serialization.
+ * These defaults are intentionally conservative to prevent OOM issues.
+ */
+export interface SerializationLimits {
+  /** Maximum characters for any single attribute string (default: 1024) */
+  maxAttrChars: number;
+  /** Maximum depth for recursive serialization (default: 6) */
+  maxDepth: number;
+  /** Maximum object keys to serialize (default: 50) */
+  maxKeys: number;
+  /** Maximum array elements to serialize (default: 50) */
+  maxArrayItems: number;
+  /** Maximum total output characters (default: 8192) */
+  maxTotalChars: number;
+}
+
+export const DEFAULT_SERIALIZATION_LIMITS: SerializationLimits = {
+  maxAttrChars: 1024,
+  maxDepth: 6,
+  maxKeys: 50,
+  maxArrayItems: 50,
+  maxTotalChars: 8192,
+};
+
+/**
+ * Hard-cap any string to prevent unbounded growth.
+ */
+export function truncateString(s: string, maxChars: number): string {
+  if (s.length <= maxChars) return s;
+  return s.slice(0, maxChars) + '…[truncated]';
+}
+
+/**
+ * Default keys to strip from objects during deep cleaning.
+ * These are typically internal/sensitive fields that shouldn't be traced.
+ */
+export const DEFAULT_KEYS_TO_STRIP = new Set([
+  'logger',
+  'experimental_providerMetadata',
+  'providerMetadata',
+  'steps',
+  'tracingContext',
+]);
+
+export interface DeepCleanOptions {
+  keysToStrip?: Set<string>;
+  maxDepth?: number;
+  maxStringLength?: number;
+  maxArrayLength?: number;
+  maxObjectKeys?: number;
+}
+
+/**
+ * Recursively cleans a value by removing circular references, stripping problematic keys,
+ * and enforcing size limits on strings, arrays, and objects.
+ *
+ * This is used by AI tracing spans to sanitize input/output data before storing.
+ *
+ * @param value - The value to clean (object, array, primitive, etc.)
+ * @param options - Optional configuration for cleaning behavior
+ * @returns A cleaned version of the input with size limits enforced
+ */
+export function deepClean(value: any, options: DeepCleanOptions = {}): any {
+  const {
+    keysToStrip = DEFAULT_KEYS_TO_STRIP,
+    maxDepth = DEFAULT_SERIALIZATION_LIMITS.maxDepth,
+    maxStringLength = DEFAULT_SERIALIZATION_LIMITS.maxAttrChars,
+    maxArrayLength = DEFAULT_SERIALIZATION_LIMITS.maxArrayItems,
+    maxObjectKeys = DEFAULT_SERIALIZATION_LIMITS.maxKeys,
+  } = options;
+
+  const seen = new WeakSet<any>();
+
+  function helper(val: any, depth: number): any {
+    if (depth > maxDepth) {
+      return '[MaxDepth]';
+    }
+
+    // Handle primitives
+    if (val === null || val === undefined) {
+      return val;
+    }
+
+    // Handle strings - enforce length limit
+    if (typeof val === 'string') {
+      if (val.length > maxStringLength) {
+        return val.slice(0, maxStringLength) + '…[truncated]';
+      }
+      return val;
+    }
+
+    // Handle other non-object primitives explicitly
+    if (typeof val === 'number' || typeof val === 'boolean') {
+      return val;
+    }
+    if (typeof val === 'bigint') {
+      return `${val}n`;
+    }
+    if (typeof val === 'function') {
+      return '[Function]';
+    }
+    if (typeof val === 'symbol') {
+      return val.description ? `[Symbol(${val.description})]` : '[Symbol]';
+    }
+
+    // Handle Date objects - preserve as-is
+    if (val instanceof Date) {
+      return val;
+    }
+
+    // Handle Errors specially - preserve name and message
+    if (val instanceof Error) {
+      return {
+        name: val.name,
+        message: val.message
+          ? val.message.length > maxStringLength
+            ? val.message.slice(0, maxStringLength) + '…[truncated]'
+            : val.message
+          : undefined,
+      };
+    }
+
+    // Handle circular references
+    if (typeof val === 'object') {
+      if (seen.has(val)) {
+        return '[Circular]';
+      }
+      seen.add(val);
+    }
+
+    // Handle arrays - enforce length limit
+    if (Array.isArray(val)) {
+      const limitedArray = val.slice(0, maxArrayLength);
+      const cleaned = limitedArray.map(item => helper(item, depth + 1));
+      if (val.length > maxArrayLength) {
+        cleaned.push(`[…${val.length - maxArrayLength} more items]`);
+      }
+      return cleaned;
+    }
+
+    // Handle Buffer and typed arrays - don't serialize large binary data
+    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(val)) {
+      return `[Buffer length=${val.length}]`;
+    }
+
+    if (ArrayBuffer.isView(val)) {
+      const ctor = (val as any).constructor?.name ?? 'TypedArray';
+      const byteLength = (val as any).byteLength ?? '?';
+      return `[${ctor} byteLength=${byteLength}]`;
+    }
+
+    if (val instanceof ArrayBuffer) {
+      return `[ArrayBuffer byteLength=${val.byteLength}]`;
+    }
+
+    // Handle objects - enforce key limit
+    const cleaned: Record<string, any> = {};
+    const entries = Object.entries(val);
+    let keyCount = 0;
+
+    for (const [key, v] of entries) {
+      if (keysToStrip.has(key)) {
+        continue;
+      }
+
+      if (keyCount >= maxObjectKeys) {
+        cleaned['__truncated'] = `${entries.length - keyCount} more keys omitted`;
+        break;
+      }
+
+      try {
+        cleaned[key] = helper(v, depth + 1);
+        keyCount++;
+      } catch (error) {
+        cleaned[key] = `[${error instanceof Error ? error.message : String(error)}]`;
+        keyCount++;
+      }
+    }
+
+    return cleaned;
+  }
+
+  return helper(value, 0);
+}


### PR DESCRIPTION
## Description

This forward-ports a fix from the `0.x` branch to `main`. I didn't include the memory-leak test from #11231 here, since it wasn't failing on `main` without this change. However the test does run about 10x faster after this change, so I still think this is a good fix to bring forward.

I'll continue to investigate memory issues in `main` before & after this fix.

This PR also fixes some broken Observability tests due to recent API changes in the server adapters.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payload size limiting to the observability module for span data.
  * Introduced serialization limits configuration with constraints for data depth, string length, array items, and total character size.
  * Added deep cleaning utility for recursive sanitization with circular reference detection.

* **Refactor**
  * Reorganized deep cleaning utilities into dedicated serialization module.
  * Updated MastraServer constructor and method signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->