### PR TITLE
feat(@mastra/server): Add execution metadata to A2A message/send resp…

### DIFF
--- a/.changeset/four-peaches-own.md
+++ b/.changeset/four-peaches-own.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Add execution metadata to A2A message/send responses. The A2A protocol now returns detailed execution information including tool calls, tool results, token usage, and finish reason in the task metadata. This allows clients to inspect which tools were invoked during agent execution and access execution statistics without additional queries.

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -61,6 +61,7 @@ describe('A2A Handler', () => {
 
     beforeEach(() => {
       const mockAgent = new MockAgent({
+        id: 'test-agent',
         name: 'test-agent',
         instructions: 'test instructions',
         model: openai('gpt-4o'),
@@ -147,6 +148,7 @@ describe('A2A Handler', () => {
     beforeEach(() => {
       vi.useFakeTimers();
       const mockAgent = new MockAgent({
+        id: 'test-agent',
         name: 'test-agent',
         instructions: 'test instructions',
         model: openai('gpt-4o'),
@@ -196,7 +198,15 @@ describe('A2A Handler', () => {
           artifacts: [],
           id: expect.any(String),
           contextId: expect.any(String),
-          metadata: undefined,
+          metadata: {
+            execution: {
+              steps: undefined,
+              toolCalls: undefined,
+              toolResults: undefined,
+              usage: undefined,
+              finishReason: undefined,
+            },
+          },
           status: {
             message: {
               messageId: expect.any(String),
@@ -679,7 +689,15 @@ describe('A2A Handler', () => {
               role: 'user',
             },
           ],
-          metadata: undefined,
+          metadata: {
+            execution: {
+              steps: undefined,
+              toolCalls: undefined,
+              toolResults: undefined,
+              usage: undefined,
+              finishReason: undefined,
+            },
+          },
           status: {
             message: {
               messageId: expect.any(String),
@@ -699,6 +717,161 @@ describe('A2A Handler', () => {
         },
       });
     });
+
+    it('should store execution details (steps, toolCalls, toolResults, usage) in task metadata', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const userMessage = 'Create a chart';
+      const agentResponseText = 'Here is your chart';
+
+      const mockExecutionData = {
+        text: agentResponseText,
+        steps: [
+          {
+            stepType: 'initial',
+            toolCalls: [
+              {
+                toolCallId: 'call_123',
+                toolName: 'createChart',
+                args: { data: 'sales data' },
+              },
+            ],
+            toolResults: [
+              {
+                toolCallId: 'call_123',
+                toolName: 'createChart',
+                result: { chartUrl: 'https://example.com/chart.png' },
+              },
+            ],
+          },
+        ],
+        toolCalls: [
+          {
+            toolCallId: 'call_123',
+            toolName: 'createChart',
+            args: { data: 'sales data' },
+          },
+        ],
+        toolResults: [
+          {
+            toolCallId: 'call_123',
+            toolName: 'createChart',
+            result: { chartUrl: 'https://example.com/chart.png' },
+          },
+        ],
+        usage: {
+          promptTokens: 150,
+          completionTokens: 200,
+          totalTokens: 350,
+        },
+        finishReason: 'stop',
+      };
+
+      const params: MessageSendParams = {
+        message: { messageId, kind: 'message', role: 'user', parts: [{ kind: 'text', text: userMessage }] },
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue(mockExecutionData);
+
+      vi.setSystemTime(new Date('2025-05-08T11:47:38.458Z'));
+      const requestContext = new RequestContext();
+      const result = await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify the execution metadata is stored
+      expect(result.result?.metadata).toEqual({
+        execution: {
+          steps: mockExecutionData.steps,
+          toolCalls: mockExecutionData.toolCalls,
+          toolResults: mockExecutionData.toolResults,
+          usage: mockExecutionData.usage,
+          finishReason: mockExecutionData.finishReason,
+        },
+      });
+
+      // Verify the task was saved with the metadata
+      const taskId = result.result?.id;
+      if (!taskId) {
+        throw new Error('Task ID is required');
+      }
+      const savedTask = await mockTaskStore.load({ agentId, taskId });
+      expect(savedTask?.metadata).toEqual({
+        execution: {
+          steps: mockExecutionData.steps,
+          toolCalls: mockExecutionData.toolCalls,
+          toolResults: mockExecutionData.toolResults,
+          usage: mockExecutionData.usage,
+          finishReason: mockExecutionData.finishReason,
+        },
+      });
+    });
+
+    it('should preserve existing metadata when adding execution details', async () => {
+      const requestId = 'test-request-id';
+      const messageId = 'test-message-id';
+      const agentId = 'test-agent';
+      const userMessage = 'Hello';
+      const agentResponseText = 'Hi there';
+
+      const existingMetadata = {
+        customField: 'custom value',
+        anotherField: 123,
+      };
+
+      const mockExecutionData = {
+        text: agentResponseText,
+        steps: [],
+        toolCalls: [],
+        toolResults: [],
+        usage: {
+          promptTokens: 10,
+          completionTokens: 20,
+          totalTokens: 30,
+        },
+        finishReason: 'stop',
+      };
+
+      const params: MessageSendParams = {
+        message: { messageId, kind: 'message', role: 'user', parts: [{ kind: 'text', text: userMessage }] },
+        metadata: existingMetadata,
+      };
+
+      const mockAgent = mockMastra.getAgentById(agentId);
+      // @ts-expect-error - mockResolvedValue is not available on the Agent class
+      mockAgent.generate.mockResolvedValue(mockExecutionData);
+
+      vi.setSystemTime(new Date('2025-05-08T11:47:38.458Z'));
+      const requestContext = new RequestContext();
+      const result = await handleMessageSend({
+        requestId,
+        params,
+        taskStore: mockTaskStore,
+        agent: mockAgent,
+        agentId,
+        requestContext,
+      });
+
+      // Verify both existing metadata and execution metadata are present
+      expect(result.result?.metadata).toEqual({
+        ...existingMetadata,
+        execution: {
+          steps: mockExecutionData.steps,
+          toolCalls: mockExecutionData.toolCalls,
+          toolResults: mockExecutionData.toolResults,
+          usage: mockExecutionData.usage,
+          finishReason: mockExecutionData.finishReason,
+        },
+      });
+    });
   });
 
   describe('handleMessageStream', () => {
@@ -707,6 +880,7 @@ describe('A2A Handler', () => {
 
     beforeEach(() => {
       const mockAgent = new MockAgent({
+        id: 'test-agent',
         name: 'test-agent',
         instructions: 'test instructions',
         model: openai('gpt-4o'),
@@ -769,7 +943,15 @@ describe('A2A Handler', () => {
           artifacts: [],
           id: expect.any(String),
           contextId: expect.any(String),
-          metadata: undefined,
+          metadata: {
+            execution: {
+              steps: undefined,
+              toolCalls: undefined,
+              toolResults: undefined,
+              usage: undefined,
+              finishReason: undefined,
+            },
+          },
           status: {
             message: {
               messageId: expect.any(String),

--- a/packages/server/src/server/handlers/a2a.test.ts
+++ b/packages/server/src/server/handlers/a2a.test.ts
@@ -200,7 +200,6 @@ describe('A2A Handler', () => {
           contextId: expect.any(String),
           metadata: {
             execution: {
-              steps: undefined,
               toolCalls: undefined,
               toolResults: undefined,
               usage: undefined,
@@ -691,7 +690,6 @@ describe('A2A Handler', () => {
           ],
           metadata: {
             execution: {
-              steps: undefined,
               toolCalls: undefined,
               toolResults: undefined,
               usage: undefined,
@@ -718,7 +716,7 @@ describe('A2A Handler', () => {
       });
     });
 
-    it('should store execution details (steps, toolCalls, toolResults, usage) in task metadata', async () => {
+    it('should store execution details (toolCalls, toolResults, usage) in task metadata', async () => {
       const requestId = 'test-request-id';
       const messageId = 'test-message-id';
       const agentId = 'test-agent';
@@ -727,25 +725,6 @@ describe('A2A Handler', () => {
 
       const mockExecutionData = {
         text: agentResponseText,
-        steps: [
-          {
-            stepType: 'initial',
-            toolCalls: [
-              {
-                toolCallId: 'call_123',
-                toolName: 'createChart',
-                args: { data: 'sales data' },
-              },
-            ],
-            toolResults: [
-              {
-                toolCallId: 'call_123',
-                toolName: 'createChart',
-                result: { chartUrl: 'https://example.com/chart.png' },
-              },
-            ],
-          },
-        ],
         toolCalls: [
           {
             toolCallId: 'call_123',
@@ -790,7 +769,6 @@ describe('A2A Handler', () => {
       // Verify the execution metadata is stored
       expect(result.result?.metadata).toEqual({
         execution: {
-          steps: mockExecutionData.steps,
           toolCalls: mockExecutionData.toolCalls,
           toolResults: mockExecutionData.toolResults,
           usage: mockExecutionData.usage,
@@ -806,7 +784,6 @@ describe('A2A Handler', () => {
       const savedTask = await mockTaskStore.load({ agentId, taskId });
       expect(savedTask?.metadata).toEqual({
         execution: {
-          steps: mockExecutionData.steps,
           toolCalls: mockExecutionData.toolCalls,
           toolResults: mockExecutionData.toolResults,
           usage: mockExecutionData.usage,
@@ -829,7 +806,6 @@ describe('A2A Handler', () => {
 
       const mockExecutionData = {
         text: agentResponseText,
-        steps: [],
         toolCalls: [],
         toolResults: [],
         usage: {
@@ -864,7 +840,6 @@ describe('A2A Handler', () => {
       expect(result.result?.metadata).toEqual({
         ...existingMetadata,
         execution: {
-          steps: mockExecutionData.steps,
           toolCalls: mockExecutionData.toolCalls,
           toolResults: mockExecutionData.toolResults,
           usage: mockExecutionData.usage,
@@ -945,7 +920,6 @@ describe('A2A Handler', () => {
           contextId: expect.any(String),
           metadata: {
             execution: {
-              steps: undefined,
               toolCalls: undefined,
               toolResults: undefined,
               usage: undefined,


### PR DESCRIPTION
## Description

…onses

This update enhances the A2A protocol by including detailed execution information in the task metadata. Clients can now access tool calls, tool results, token usage, and finish reasons without additional queries. The changes also include updates to the test suite to verify the correct storage of execution details and the preservation of existing metadata.

- New feature: Execution metadata added to A2A responses
- Updated tests to validate execution details storage and metadata preservation

## Related Issue(s)

Slack

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution metadata is now included in A2A message/send responses. Responses include detailed execution info: tool calls, tool results, token usage, and finish reason, so clients can inspect invoked tools and execution stats without extra queries.

* **Tests**
  * Updated and expanded tests to validate presence, shape, merging, and persistence of execution metadata.

* **Chores**
  * Added changelog entry and patch version bump.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->