### PR TITLE
feat(mcp-docs-server): add --log-level CLI argument

### DIFF
--- a/.changeset/add-mcp-docs-server-log-level.md
+++ b/.changeset/add-mcp-docs-server-log-level.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/mcp-docs-server': minor
+'@mastra/mcp-docs-server': patch
 ---
 
 Add --log-level CLI argument to control log verbosity

--- a/.changeset/add-mcp-docs-server-log-level.md
+++ b/.changeset/add-mcp-docs-server-log-level.md
@@ -1,0 +1,6 @@
+---
+'@mastra/mcp-docs-server': minor
+---
+
+Add --log-level CLI argument to control log verbosity
+

--- a/packages/mcp-docs-server/src/stdio.ts
+++ b/packages/mcp-docs-server/src/stdio.ts
@@ -1,6 +1,27 @@
 #!/usr/bin/env node
-import { writeErrorLog } from './logger';
+import { writeErrorLog, setLogLevel, type LogLevel } from './logger';
 import { runServer } from './index';
+
+// Parse --log-level argument
+function parseLogLevel(): LogLevel | undefined {
+  const args = process.argv.slice(2);
+  const logLevelIndex = args.indexOf('--log-level');
+  if (logLevelIndex === -1 || logLevelIndex === args.length - 1) {
+    return undefined;
+  }
+  const level = args[logLevelIndex + 1];
+  const validLevels: LogLevel[] = ['debug', 'info', 'warn', 'error', 'none'];
+  if (validLevels.includes(level as LogLevel)) {
+    return level as LogLevel;
+  }
+  console.error(`Invalid log level: ${level}. Valid levels: ${validLevels.join(', ')}`);
+  return undefined;
+}
+
+const logLevel = parseLogLevel();
+if (logLevel) {
+  setLogLevel(logLevel);
+}
 
 runServer().catch(error => {
   const errorMessage = 'Fatal error running server';

--- a/packages/mcp-docs-server/src/stdio.ts
+++ b/packages/mcp-docs-server/src/stdio.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { writeErrorLog, setLogLevel, type LogLevel } from './logger';
+import { writeErrorLog, setLogLevel } from './logger';
+import type { LogLevel } from './logger';
 import { runServer } from './index';
 
 // Parse --log-level argument


### PR DESCRIPTION
Adds a `--log-level` CLI argument to control log verbosity. Useful for suppressing noisy logs (like ENOENT errors) when running the MCP server.

```js
{
  command: 'npx',
  args: ['-y', '@mastra/mcp-docs-server@beta', '--log-level', 'none'],
}
```

Levels: `debug`, `info`, `warn`, `error`, `none` (matching the MCP client log levels).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable logging system with five verbosity levels (debug, info, warn, error, none) and a command-line option to set level at server start.
  * Added runtime controls to get/set the current log level so emission can be adjusted programmatically.
  * Logging now respects the selected level and suppresses lower-priority messages to reduce noise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->