### PR TITLE
fix: handle empty overrideScorers in agent scoring

### DIFF
--- a/.changeset/fix-empty-override-scorers.md
+++ b/.changeset/fix-empty-override-scorers.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+---
+
+Fix empty overrideScorers causing error instead of skipping scoring
+
+When `overrideScorers` was passed as an empty object `{}`, the agent would throw a "No scorers found" error. Now an empty object explicitly skips scoring, while `undefined` continues to use default scorers.
+

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2412,11 +2412,6 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
     resourceId?: string;
     tracingContext: TracingContext;
   }) {
-    // If overrideScorers is explicitly empty, skip scoring
-    if (overrideScorers && Object.keys(overrideScorers).length === 0) {
-      return;
-    }
-
     let scorers: Record<string, { scorer: MastraScorer; sampling?: ScoringSamplingConfig }> = {};
     try {
       scorers = overrideScorers
@@ -2491,7 +2486,8 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
       }
     }
 
-    if (Object.keys(result).length === 0) {
+    // Only throw if scorers were provided but none could be resolved
+    if (Object.keys(result).length === 0 && Object.keys(overrideScorers).length > 0) {
       throw new MastraError({
         id: 'AGENT_GENEREATE_SCORER_NOT_FOUND',
         domain: ErrorDomain.AGENT,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2412,6 +2412,11 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
     resourceId?: string;
     tracingContext: TracingContext;
   }) {
+    // If overrideScorers is explicitly empty, skip scoring
+    if (overrideScorers && Object.keys(overrideScorers).length === 0) {
+      return;
+    }
+
     let scorers: Record<string, { scorer: MastraScorer; sampling?: ScoringSamplingConfig }> = {};
     try {
       scorers = overrideScorers


### PR DESCRIPTION
When `overrideScorers` was passed as an empty object `{}`, the agent would throw a "No scorers found" error because `{}` is truthy but has no entries.

Now:
- `overrideScorers: undefined` → uses default scorers via `listScorers()`
- `overrideScorers: {}` → early return, skips scoring entirely  
- `overrideScorers: { ... }` → resolves and uses the provided scorers

```typescript
// Before: throws error
await agent.generate({ overrideScorers: {} })

// After: skips scoring gracefully
await agent.generate({ overrideScorers: {} })
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scorer override handling to gracefully skip scoring when provided with an empty override configuration.
  * Enhanced error handling for cases where specified override scorers cannot be resolved, with improved error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->