### PR TITLE
Fix: telemetry decorators ignoring `enabled: false` configuration

### DIFF
--- a/.changeset/telemetry-enabled-fix.md
+++ b/.changeset/telemetry-enabled-fix.md
@@ -1,0 +1,24 @@
+---
+"@mastra/core": patch
+---
+
+Fix telemetry disabled configuration being ignored by decorators
+
+The `hasActiveTelemetry()` function now properly checks the `enabled` configuration flag before creating spans. Previously, it only checked if a tracer existed (which always returns true in OpenTelemetry), causing decorators to create spans even when `telemetry: { enabled: false }` was set.
+
+**What changed:**
+- Added short-circuit evaluation in `hasActiveTelemetry()` to check `globalThis.__TELEMETRY__?.isEnabled()` before checking for tracer existence
+- This prevents unnecessary span creation overhead when telemetry is disabled
+
+**How to use:**
+```typescript
+// Telemetry disabled at initialization
+const mastra = new Mastra({
+  telemetry: { enabled: false }
+});
+
+// Or disable at runtime
+Telemetry.setEnabled(false);
+```
+
+**Breaking changes:** None - this is a bug fix that makes the existing API work as documented.

--- a/packages/core/src/ai-tracing/integration-tests.test.ts
+++ b/packages/core/src/ai-tracing/integration-tests.test.ts
@@ -2084,3 +2084,53 @@ describe('AI Tracing Integration Tests', () => {
     testExporter.finalExpectations();
   });
 });
+
+describe('Telemetry disabled integration tests', () => {
+  beforeEach(() => {
+    // Clear global telemetry instance before each test
+    globalThis.__TELEMETRY__ = undefined;
+  });
+
+  it('should respect enabled: false configuration via hasActiveTelemetry', async () => {
+    const { hasActiveTelemetry } = await import('../telemetry/utility');
+    const { Telemetry } = await import('../telemetry/telemetry');
+
+    // Initialize telemetry with enabled: false
+    Telemetry.init({ enabled: false });
+
+    // Verify hasActiveTelemetry returns false due to short-circuit on isEnabled check
+    expect(hasActiveTelemetry()).toBe(false);
+    expect(Telemetry.isEnabled()).toBe(false);
+  });
+
+  it('should respect enabled: true configuration via hasActiveTelemetry', async () => {
+    const { hasActiveTelemetry } = await import('../telemetry/utility');
+    const { Telemetry } = await import('../telemetry/telemetry');
+
+    // Initialize telemetry with enabled: true
+    Telemetry.init({ enabled: true });
+
+    // Verify hasActiveTelemetry returns true (tracer always exists from OpenTelemetry)
+    expect(hasActiveTelemetry()).toBe(true);
+    expect(Telemetry.isEnabled()).toBe(true);
+  });
+
+  it('should allow runtime control of telemetry', async () => {
+    const { hasActiveTelemetry } = await import('../telemetry/utility');
+    const { Telemetry } = await import('../telemetry/telemetry');
+
+    // Initialize with enabled: true
+    Telemetry.init({ enabled: true });
+    expect(hasActiveTelemetry()).toBe(true);
+
+    // Disable at runtime - should short-circuit and return false
+    Telemetry.setEnabled(false);
+    expect(hasActiveTelemetry()).toBe(false);
+    expect(Telemetry.isEnabled()).toBe(false);
+
+    // Re-enable at runtime
+    Telemetry.setEnabled(true);
+    expect(hasActiveTelemetry()).toBe(true);
+    expect(Telemetry.isEnabled()).toBe(true);
+  });
+});

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -9,7 +9,6 @@ import { getBaggageValues, hasActiveTelemetry } from './utility';
 // Add type declaration for global namespace
 declare global {
   var __TELEMETRY__: Telemetry | undefined;
-  var __TELEMETRY_ENABLED__: boolean | undefined;
 }
 
 export class Telemetry {
@@ -22,9 +21,6 @@ export class Telemetry {
     this.enabled = config.enabled !== false;
 
     this.tracer = trace.getTracer(this.name);
-
-    // Store enabled state globally for hasActiveTelemetry to check
-    globalThis.__TELEMETRY_ENABLED__ = this.enabled;
   }
 
   /**
@@ -84,7 +80,8 @@ export class Telemetry {
    * Check if telemetry is enabled
    */
   static isEnabled(): boolean {
-    return globalThis.__TELEMETRY_ENABLED__ === true;
+    // If telemetry not initialized, default to true for backward compatibility
+    return globalThis.__TELEMETRY__?.isEnabled() ?? true;
   }
 
   /**
@@ -92,9 +89,8 @@ export class Telemetry {
    * This allows runtime control of span creation
    */
   static setEnabled(enabled: boolean): void {
-    globalThis.__TELEMETRY_ENABLED__ = enabled;
     if (globalThis.__TELEMETRY__) {
-      globalThis.__TELEMETRY__.enabled = enabled;
+      globalThis.__TELEMETRY__.setEnabled(enabled);
     }
   }
 
@@ -110,7 +106,6 @@ export class Telemetry {
    */
   public setEnabled(enabled: boolean): void {
     this.enabled = enabled;
-    globalThis.__TELEMETRY_ENABLED__ = enabled;
   }
 
   /**

--- a/packages/core/src/telemetry/utility.ts
+++ b/packages/core/src/telemetry/utility.ts
@@ -1,22 +1,17 @@
 import { propagation, trace } from '@opentelemetry/api';
 import type { Context } from '@opentelemetry/api';
 
-declare global {
-  var __TELEMETRY_ENABLED__: boolean | undefined;
-}
-
 /**
  * Check if telemetry is active and enabled.
- * This function checks both if a tracer exists AND if telemetry is enabled in the configuration.
+ * This function checks both if telemetry is enabled in the configuration AND if a tracer exists.
  *
  * @param tracerName - Optional tracer name to check (currently unused, kept for backwards compatibility)
  * @returns true if telemetry is both initialized and enabled, false otherwise
  */
 export function hasActiveTelemetry(tracerName: string = 'default-tracer'): boolean {
   try {
-    // Check if telemetry is explicitly enabled via the global flag
-    // This flag is set by Telemetry.init() based on the enabled config option
-    return globalThis.__TELEMETRY_ENABLED__ === true && !!trace.getTracer(tracerName);
+    const isEnabled = globalThis.__TELEMETRY__?.isEnabled() ?? true;
+    return isEnabled && !!trace.getTracer(tracerName);
   } catch {
     return false;
   }

--- a/packages/core/src/telemetry/utility.ts
+++ b/packages/core/src/telemetry/utility.ts
@@ -1,10 +1,22 @@
-import { propagation, trace } from '@opentelemetry/api';
+import { propagation } from '@opentelemetry/api';
 import type { Context } from '@opentelemetry/api';
 
-// Helper function to check if telemetry is active
-export function hasActiveTelemetry(tracerName: string = 'default-tracer'): boolean {
+declare global {
+  var __TELEMETRY_ENABLED__: boolean | undefined;
+}
+
+/**
+ * Check if telemetry is active and enabled.
+ * This function checks both if a tracer exists AND if telemetry is enabled in the configuration.
+ *
+ * @param _tracerName - Optional tracer name to check (currently unused, kept for backwards compatibility)
+ * @returns true if telemetry is both initialized and enabled, false otherwise
+ */
+export function hasActiveTelemetry(_tracerName: string = 'default-tracer'): boolean {
   try {
-    return !!trace.getTracer(tracerName);
+    // Check if telemetry is explicitly enabled via the global flag
+    // This flag is set by Telemetry.init() based on the enabled config option
+    return globalThis.__TELEMETRY_ENABLED__ === true;
   } catch {
     return false;
   }

--- a/packages/core/src/telemetry/utility.ts
+++ b/packages/core/src/telemetry/utility.ts
@@ -1,4 +1,4 @@
-import { propagation } from '@opentelemetry/api';
+import { propagation, trace } from '@opentelemetry/api';
 import type { Context } from '@opentelemetry/api';
 
 declare global {
@@ -9,14 +9,14 @@ declare global {
  * Check if telemetry is active and enabled.
  * This function checks both if a tracer exists AND if telemetry is enabled in the configuration.
  *
- * @param _tracerName - Optional tracer name to check (currently unused, kept for backwards compatibility)
+ * @param tracerName - Optional tracer name to check (currently unused, kept for backwards compatibility)
  * @returns true if telemetry is both initialized and enabled, false otherwise
  */
-export function hasActiveTelemetry(_tracerName: string = 'default-tracer'): boolean {
+export function hasActiveTelemetry(tracerName: string = 'default-tracer'): boolean {
   try {
     // Check if telemetry is explicitly enabled via the global flag
     // This flag is set by Telemetry.init() based on the enabled config option
-    return globalThis.__TELEMETRY_ENABLED__ === true;
+    return globalThis.__TELEMETRY_ENABLED__ === true && !!trace.getTracer(tracerName);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Problem

When users configured `telemetry: { enabled: false }` in their Mastra initialization, telemetry decorators would still execute and create spans despite the explicit opt-out. This occurred because the `hasActiveTelemetry()` utility function only checked for the existence of a tracer, not whether telemetry was actually enabled.

This was observed at [Omnia](useomnia.com) when we saw excess heap allocation due to the creation of spans, when we had telemetry disabled in mastra. 

### Root Cause

The previous implementation of `hasActiveTelemetry()` in [utility.ts](packages/core/src/telemetry/utility.ts) used:

```typescript
export function hasActiveTelemetry(tracerName: string = 'default-tracer'): boolean {
  try {
    return !!trace.getTracer(tracerName);
  } catch {
    return false;
  }
}
```

The OpenTelemetry `trace.getTracer()` API [**always returns a tracer object**](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts#L64-L84) Therefore, `!!trace.getTracer('default-tracer')` always evaluated to `true`.

The new implementation combines both checks:

```typescript
export function hasActiveTelemetry(tracerName: string = 'default-tracer'): boolean {
  try {
    const isEnabled = globalThis.__TELEMETRY__?.isEnabled() ?? true;
    return isEnabled && !!trace.getTracer(tracerName);
  } catch {
    return false;
  }
}
```

This ensures telemetry is only disabled when explicitly configured. The logic:
- If `__TELEMETRY__` is not initialized → `isEnabled` is `true` (backward compatible)
- If `__TELEMETRY__` exists → calls `isEnabled()` method (respects configuration)

The short-circuit evaluation provides an early exit for better performance when telemetry is disabled. 

### Impact

All telemetry decorators (`@withSpan`, `@InstrumentClass`) and runtime instrumentation methods (`traceClass()`, `traceMethod()`) invoked throughout the codebase would:

1. Execute instrumentation logic even when `enabled: false` was set
2. Create spans and serialize arguments/results (performance overhead)
3. Process these spans through the no-op tracer (wasted CPU cycles)
4. Ignore the user's explicit configuration to disable telemetry

This was particularly problematic for:
- Performance-sensitive applications where users explicitly disabled telemetry
- Development environments where telemetry was unnecessary overhead
- Privacy-focused deployments where span data should never be collected

## Solution

Uses the existing `globalThis.__TELEMETRY__` instance to check the enabled state directly instead of introducing a new global flag

## Usage Examples

### Disable at Initialization

```typescript
import { Mastra } from '@mastra/core';

const mastra = new Mastra({
  telemetry: {
    enabled: false  // Completely disables telemetry
  },
  agents: { myAgent }
});

// hasActiveTelemetry() → false
// No spans created, zero overhead
```

### Runtime Control

```typescript
import { Telemetry } from '@mastra/core';

// Disable telemetry dynamically
Telemetry.setEnabled(false);

// Do work without telemetry
await agent.generate('test');

// Re-enable telemetry
Telemetry.setEnabled(true);

// Spans are created again
await agent.generate('test 2');
```

### Environment-Based Configuration

```typescript
import { Mastra } from '@mastra/core';

const mastra = new Mastra({
  telemetry: {
    enabled: process.env.NODE_ENV === 'production',
    serviceName: 'my-service'
  }
});
```

## Testing

### Before Fix

```typescript
const mastra = new Mastra({
  telemetry: { enabled: false },
  agents: { myAgent }
});

// hasActiveTelemetry() → true ❌ (wrong!)
// Spans were created and processed by no-op tracer
// Performance overhead from serialization
```

### After Fix

```typescript
const mastra = new Mastra({
  telemetry: { enabled: false },
  agents: { myAgent }
});

// hasActiveTelemetry() → false ✅ (correct!)
// No spans created, zero overhead
// Decorators are complete no-ops
```