### PR TITLE
feat(@mastra/server): Add execution metadata to A2A message/send resp…

### DIFF
--- a/.changeset/quiet-showers-join.md
+++ b/.changeset/quiet-showers-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Add execution metadata to A2A message/send responses. The A2A protocol now returns detailed execution information including tool calls, tool results, token usage, and finish reason in the task metadata. This allows clients to inspect which tools were invoked during agent execution and access execution statistics without additional queries.

--- a/packages/server/src/server/handlers/a2a.ts
+++ b/packages/server/src/server/handlers/a2a.ts
@@ -148,7 +148,7 @@ export async function handleMessageSend({
   });
 
   try {
-    const { text } = await agent.generate([convertToCoreMessage(message)], {
+    const result = await agent.generate([convertToCoreMessage(message)], {
       runId: taskId,
       runtimeContext,
     });
@@ -161,12 +161,23 @@ export async function handleMessageSend({
         parts: [
           {
             kind: 'text',
-            text: text,
+            text: result.text,
           },
         ],
         kind: 'message',
       },
     });
+
+    // Store execution details in task metadata
+    currentData.metadata = {
+      ...currentData.metadata,
+      execution: {
+        toolCalls: result.toolCalls,
+        toolResults: result.toolResults,
+        usage: result.usage,
+        finishReason: result.finishReason,
+      },
+    };
 
     await taskStore.save({ agentId, data: currentData });
     context.task = currentData;


### PR DESCRIPTION
## Description

…onses

Backport of PR #11241 to 0.x branch.

This update enhances the A2A protocol by including detailed execution information in the task metadata. Clients can now access tool calls, tool results, token usage, and finish reasons without additional queries.

Changes:
- Modified handleMessageSend to capture full result from agent.generate()
- Store execution details (toolCalls, toolResults, usage, finishReason) in task metadata
- Updated tests to validate execution metadata storage and preservation
- Added test for preserving existing metadata when adding execution details

The A2A protocol now returns detailed execution information including:
- Tool calls made during agent execution
- Tool results from executed tools
- Token usage statistics
- Finish reason for completion

This allows clients to inspect which tools were invoked during agent execution and access execution statistics without additional queries.

## Related Issue(s)

Slack

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
