### PR TITLE
fix(@mastra/core): support model-level and runtime headers for LLM calls

### DIFF
--- a/.changeset/busy-pets-start.md
+++ b/.changeset/busy-pets-start.md
@@ -1,0 +1,32 @@
+---
+'@mastra/core': patch
+---
+
+Fix model-level and runtime header support for LLM calls
+
+This fixes a bug where custom headers configured on models (like `anthropic-beta`) were not being passed through to the underlying AI SDK calls. The fix properly handles headers from multiple sources with correct priority:
+
+**Header Priority (low to high):**
+1. Model config headers - Headers set in model configuration
+2. ModelSettings headers - Runtime headers that override model config
+3. Provider-level headers - Headers baked into AI SDK providers (not overridden)
+
+**Examples that now work:**
+```typescript
+// Model config headers
+new Agent({
+  model: {
+    id: 'anthropic/claude-4-5-sonnet',
+    headers: { 'anthropic-beta': 'context-1m-2025-08-07' }
+  }
+})
+
+// Runtime headers override config
+agent.generate('...', {
+  modelSettings: { headers: { 'x-custom': 'runtime-value' } }
+})
+
+// Provider-level headers preserved
+const openai = createOpenAI({ headers: { 'openai-organization': 'org-123' } });
+new Agent({ model: openai('gpt-4o-mini') })
+```

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -20,6 +20,7 @@ import { resolveModelConfig } from '../llm';
 import { MastraLLMV1 } from '../llm/model';
 import type { GenerateObjectResult, GenerateTextResult, StreamTextResult } from '../llm/model/base.types';
 import { MastraLLMVNext } from '../llm/model/model.loop';
+import { ModelRouterLanguageModel } from '../llm/model/router';
 import type {
   MastraLanguageModel,
   MastraLanguageModelV2,
@@ -2528,12 +2529,19 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
         throw mastraError;
       }
 
+      // Extract headers from ModelRouterLanguageModel if available
+      let headers: Record<string, string> | undefined;
+      if (resolvedModel instanceof ModelRouterLanguageModel) {
+        headers = (resolvedModel as any).config?.headers;
+      }
+
       return [
         {
           id: 'main',
           model: resolvedModel,
           maxRetries: this.maxRetries ?? 0,
           enabled: true,
+          headers,
         },
       ];
     }
@@ -2573,11 +2581,18 @@ export class Agent<TAgentId extends string = string, TTools extends ToolsInput =
           throw mastraError;
         }
 
+        // Extract headers from ModelRouterLanguageModel if available
+        let headers: Record<string, string> | undefined;
+        if (model instanceof ModelRouterLanguageModel) {
+          headers = (model as any).config?.headers;
+        }
+
         return {
           id: modelId,
           model: model,
           maxRetries: modelConfig.maxRetries ?? 0,
           enabled: modelConfig.enabled ?? true,
+          headers,
         };
       }),
     );

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -1517,7 +1517,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
       });
 
       describe('options.headers', () => {
-        it('should pass headers to model', async () => {
+        it('should pass headers from modelSettings to model', async () => {
           const result = loopFn({
             methodType: 'stream',
             agentId: 'agent-id',
@@ -1554,7 +1554,6 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
             structuredOutput: { schema: z.object({ content: z.string() }) },
             messageList: createMessageListWithUserMessage(),
             modelSettings: { headers: { 'custom-request-header': 'request-header-value' } },
-            headers: { 'custom-request-header': 'request-header-value' },
           });
 
           // mastra
@@ -1563,6 +1562,215 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
           // aisdk
           expect(await convertAsyncIterableToArray(result.aisdk.v5.objectStream)).toStrictEqual([
             { content: 'headers test' },
+          ]);
+        });
+
+        it('should pass headers from model config to model', async () => {
+          const result = loopFn({
+            methodType: 'stream',
+            agentId: 'agent-id',
+            models: [
+              {
+                id: 'test-model',
+                maxRetries: 0,
+                headers: { 'x-model-header': 'from-config' },
+                model: new MockLanguageModelV2({
+                  doStream: async ({ headers }) => {
+                    expect(headers).toStrictEqual({
+                      'x-model-header': 'from-config',
+                    });
+
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: '1',
+                          delta: `{ "content": "config headers test" }`,
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  },
+                }),
+              },
+            ],
+            structuredOutput: { schema: z.object({ content: z.string() }) },
+            messageList: createMessageListWithUserMessage(),
+          });
+
+          expect(await convertAsyncIterableToArray(result.objectStream)).toStrictEqual([
+            { content: 'config headers test' },
+          ]);
+        });
+
+        it('should merge headers with modelSettings overriding model config', async () => {
+          const result = loopFn({
+            methodType: 'stream',
+            agentId: 'agent-id',
+            models: [
+              {
+                id: 'test-model',
+                maxRetries: 0,
+                headers: {
+                  'x-model-header': 'from-config',
+                  'x-shared-header': 'from-config',
+                },
+                model: new MockLanguageModelV2({
+                  doStream: async ({ headers }) => {
+                    expect(headers).toStrictEqual({
+                      'x-model-header': 'from-config',
+                      'x-shared-header': 'from-runtime', // modelSettings overrides config
+                      'x-runtime-header': 'from-runtime',
+                    });
+
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: '1',
+                          delta: `{ "content": "merged headers test" }`,
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  },
+                }),
+              },
+            ],
+            structuredOutput: { schema: z.object({ content: z.string() }) },
+            messageList: createMessageListWithUserMessage(),
+            modelSettings: {
+              headers: {
+                'x-shared-header': 'from-runtime',
+                'x-runtime-header': 'from-runtime',
+              },
+            },
+          });
+
+          expect(await convertAsyncIterableToArray(result.objectStream)).toStrictEqual([
+            { content: 'merged headers test' },
+          ]);
+        });
+
+        it('should use correct headers for each fallback model', async () => {
+          let attemptCount = 0;
+
+          const result = loopFn({
+            methodType: 'stream',
+            agentId: 'agent-id',
+            models: [
+              {
+                id: 'model-1',
+                maxRetries: 0,
+                headers: { 'x-model': 'model-1', 'x-provider': 'provider-a' },
+                model: new MockLanguageModelV2({
+                  doStream: async ({ headers }) => {
+                    attemptCount++;
+                    expect(headers).toStrictEqual({
+                      'x-model': 'model-1',
+                      'x-provider': 'provider-a',
+                    });
+
+                    // First model fails
+                    throw new Error('Model 1 failed');
+                  },
+                }),
+              },
+              {
+                id: 'model-2',
+                maxRetries: 0,
+                headers: { 'x-model': 'model-2', 'x-provider': 'provider-b' },
+                model: new MockLanguageModelV2({
+                  doStream: async ({ headers }) => {
+                    attemptCount++;
+                    expect(headers).toStrictEqual({
+                      'x-model': 'model-2',
+                      'x-provider': 'provider-b',
+                    });
+
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: '1',
+                          delta: `{ "content": "fallback success" }`,
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  },
+                }),
+              },
+            ],
+            structuredOutput: { schema: z.object({ content: z.string() }) },
+            messageList: createMessageListWithUserMessage(),
+            modelSettings: { maxRetries: 0 }, // Disable retries at the loop level
+          });
+
+          expect(await convertAsyncIterableToArray(result.objectStream)).toStrictEqual([
+            { content: 'fallback success' },
+          ]);
+          expect(attemptCount).toBe(2); // Both models should have been tried
+        });
+
+        it('should handle undefined headers gracefully', async () => {
+          const result = loopFn({
+            methodType: 'stream',
+            agentId: 'agent-id',
+            models: [
+              {
+                id: 'test-model',
+                maxRetries: 0,
+                // No headers field
+                model: new MockLanguageModelV2({
+                  doStream: async ({ headers }) => {
+                    expect(headers).toBeUndefined();
+
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: '1',
+                          delta: `{ "content": "no headers test" }`,
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  },
+                }),
+              },
+            ],
+            structuredOutput: { schema: z.object({ content: z.string() }) },
+            messageList: createMessageListWithUserMessage(),
+            // No modelSettings.headers
+          });
+
+          expect(await convertAsyncIterableToArray(result.objectStream)).toStrictEqual([
+            { content: 'no headers test' },
           ]);
         });
       });

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -84,7 +84,6 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT extends OutputSc
   messageList: MessageList;
   includeRawChunks?: boolean;
   modelSettings?: Omit<CallSettings, 'abortSignal'>;
-  headers?: Record<string, string>;
   toolChoice?: ToolChoice<TOOLS>;
   activeTools?: Array<keyof TOOLS>;
   options?: LoopConfig<OUTPUT>;

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -668,13 +668,14 @@ export type ToolResultChunk = BaseChunkType & { type: 'tool-result'; payload: To
 export type ReasoningChunk = BaseChunkType & { type: 'reasoning'; payload: ReasoningDeltaPayload };
 
 export type ExecuteStreamModelManager<T> = (
-  callback: (model: MastraLanguageModel, isLastModel: boolean) => Promise<T>,
+  callback: (modelConfig: ModelManagerModelConfig, isLastModel: boolean) => Promise<T>,
 ) => Promise<T>;
 
 export type ModelManagerModelConfig = {
   model: MastraLanguageModel;
   maxRetries: number;
   id: string;
+  headers?: Record<string, string>;
 };
 
 /**


### PR DESCRIPTION
## Description

Fixes a bug where custom headers configured on models (like anthropic-beta) were not being passed through to the underlying AI SDK calls. This fix properly handles headers from multiple sources with correct priority merging.

Header Priority (low to high):
1. Model config headers - Headers set in model configuration
2. ModelSettings headers - Runtime headers that override model config
3. Provider-level headers - Headers baked into AI SDK providers (not overridden)
4. 
## Related Issue(s)

slack

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed header propagation in LLM calls. Headers configured at model, runtime, and provider levels are now correctly passed through to underlying AI SDK calls with proper priority handling: model config headers < modelSettings headers < provider-level headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->