### PR TITLE
fix(templates): add missing @mastra/libsql and @mastra/loggers dependencies

### DIFF
--- a/templates/template-docs-chatbot/apps/mcp-server/package.json
+++ b/templates/template-docs-chatbot/apps/mcp-server/package.json
@@ -23,6 +23,8 @@
   },
   "dependencies": {
     "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
     "@mastra/mcp": "latest",
     "zod": "^3.25.76",
     "dotenv": "^17.0.1"

--- a/templates/weather-agent/package.json
+++ b/templates/weather-agent/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^2.0.87",
     "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
     "@mastra/loggers": "latest",
     "zod": "^3.25.76"
   },


### PR DESCRIPTION
Ensures all templates have the standard trio of mastra packages (`@mastra/core`, `@mastra/loggers`, `@mastra/libsql`).

Added the missing deps to:
- `weather-agent` - was missing `@mastra/libsql`
- `template-docs-chatbot/apps/mcp-server` - was missing `@mastra/loggers` and `@mastra/libsql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)