### PR TITLE
fix: update migration guides for processors and memory configuration

### DIFF
--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
@@ -261,9 +261,11 @@ To migrate, move processor configuration from Memory to Agent.
     embedder,
 -   processors: [/* ... */],
   });
-  
+
   const agent = new Agent({
     memory,
 +   processors: [/* ... */],
   });
 ```
+
+Additionally, the `@mastra/memory/processors` import path has been removed. Import processors from `@mastra/core/processors` instead. See the [processors migration guide](/guides/v1/migrations/upgrade-to-v1/processors#memory-processor-exports-moved-to-core) for details.

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
@@ -252,9 +252,11 @@ To migrate, use `MastraDBMessage` for storage or AI SDK v5 message formats direc
 
 The `processors` config option in the Memory constructor has been deprecated and now throws an error. Processors should be configured at the Agent level instead. This change provides clearer configuration boundaries and better encapsulation.
 
-To migrate, move processor configuration from Memory to Agent.
+To migrate, move processor configuration from Memory to Agent using `inputProcessors` and/or `outputProcessors`.
 
 ```diff
++ import { TokenLimiter } from '@mastra/core/processors';
++
   const memory = new Memory({
     storage,
     vector,
@@ -264,8 +266,12 @@ To migrate, move processor configuration from Memory to Agent.
 
   const agent = new Agent({
     memory,
-+   processors: [/* ... */],
++   inputProcessors: [
++     new TokenLimiter({ limit: 4000 }), // Limits historical messages to fit context window
++   ],
   });
 ```
 
 Additionally, the `@mastra/memory/processors` import path has been removed. Import processors from `@mastra/core/processors` instead. See the [processors migration guide](/guides/v1/migrations/upgrade-to-v1/processors#memory-processor-exports-moved-to-core) for details.
+
+For more information on using processors with agents, see the [Processors docs](/docs/v1/agents/processors). For a complete example with memory, see the [TokenLimiter reference](/reference/v1/processors/token-limiter-processor#extended-usage-example).

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/processors.mdx
@@ -60,3 +60,14 @@ If you have used `InputProcessor`, replace it with `Processor` which implements 
 - import { InputProcessor, ModerationProcessor } from '@mastra/core/agent/input-processors/processors';
 + import { Processor, ModerationProcessor } from '@mastra/core/processors';
 ```
+
+### Memory processor exports moved to core
+
+The `@mastra/memory/processors` export has been removed. All processors are now exported from `@mastra/core/processors`. This change consolidates all processor exports in a single location.
+
+To migrate, update your import paths from `@mastra/memory/processors` to `@mastra/core/processors`.
+
+```diff
+- import { TokenLimiter, ToolCallFilter } from '@mastra/memory/processors';
++ import { TokenLimiter, ToolCallFilter } from '@mastra/core/processors';
+```

--- a/docs/src/content/en/reference/processors/token-limiter-processor.mdx
+++ b/docs/src/content/en/reference/processors/token-limiter-processor.mdx
@@ -1,11 +1,14 @@
 ---
 title: "Reference: Token Limiter Processor | Processors"
-description: "Documentation for the TokenLimiterProcessor in Mastra, which limits the number of tokens in AI responses."
+description: "Documentation for the TokenLimiterProcessor in Mastra, which limits the number of tokens in messages."
 ---
 
 # TokenLimiterProcessor
 
-The `TokenLimiterProcessor` is an **output processor** that limits the number of tokens in AI responses. This processor helps control response length by implementing token counting with configurable strategies for handling exceeded limits, including truncation and abortion options for both streaming and non-streaming scenarios.
+The `TokenLimiterProcessor` limits the number of tokens in messages. It can be used as both an input and output processor:
+
+- **Input processor**: Filters historical messages to fit within the context window, prioritizing recent messages
+- **Output processor**: Limits generated response tokens via streaming or non-streaming with configurable strategies for handling exceeded limits
 
 ## Usage example
 
@@ -83,6 +86,12 @@ const processor = new TokenLimiterProcessor({
       isOptional: true,
     },
     {
+      name: "processInput",
+      type: "(args: { messages: MastraDBMessage[]; abort: (reason?: string) => never }) => Promise<MastraDBMessage[]>",
+      description: "Filters input messages to fit within token limit, prioritizing recent messages while preserving system messages",
+      isOptional: false,
+    },
+    {
       name: "processOutputStream",
       type: "(args: { part: ChunkType; streamParts: ChunkType[]; state: Record<string, any>; abort: (reason?: string) => never }) => Promise<ChunkType | null>",
       description: "Processes streaming output parts to limit token count during streaming",
@@ -90,20 +99,8 @@ const processor = new TokenLimiterProcessor({
     },
     {
       name: "processOutputResult",
-      type: "(args: { messages: MastraMessageV2[]; abort: (reason?: string) => never }) => Promise<MastraMessageV2[]>",
+      type: "(args: { messages: MastraDBMessage[]; abort: (reason?: string) => never }) => Promise<MastraDBMessage[]>",
       description: "Processes final output results to limit token count in non-streaming scenarios",
-      isOptional: false,
-    },
-    {
-      name: "reset",
-      type: "() => void",
-      description: "Reset the token counter (useful for testing or reusing the processor)",
-      isOptional: false,
-    },
-    {
-      name: "getCurrentTokens",
-      type: "() => number",
-      description: "Get the current token count",
       isOptional: false,
     },
     {
@@ -117,14 +114,38 @@ const processor = new TokenLimiterProcessor({
 
 ## Extended usage example
 
-```typescript title="src/mastra/agents/limited-agent.ts"
+### As an input processor (limit context window)
+
+Use `inputProcessors` to limit historical messages sent to the model, which helps stay within context window limits:
+
+```typescript title="src/mastra/agents/context-limited-agent.ts"
+import { Agent } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+import { TokenLimiterProcessor } from "@mastra/core/processors";
+
+export const agent = new Agent({
+  name: "context-limited-agent",
+  instructions: "You are a helpful assistant",
+  model: "openai/gpt-4o",
+  memory: new Memory({ /* ... */ }),
+  inputProcessors: [
+    new TokenLimiterProcessor({ limit: 4000 }) // Limits historical messages to ~4000 tokens
+  ]
+});
+```
+
+### As an output processor (limit response length)
+
+Use `outputProcessors` to limit the length of generated responses:
+
+```typescript title="src/mastra/agents/response-limited-agent.ts"
 import { Agent } from "@mastra/core/agent";
 import { TokenLimiterProcessor } from "@mastra/core/processors";
 
 export const agent = new Agent({
-  name: "limited-agent",
+  name: "response-limited-agent",
   instructions: "You are a helpful assistant",
-  model: "openai/gpt-5.1",
+  model: "openai/gpt-4o",
   outputProcessors: [
     new TokenLimiterProcessor({
       limit: 1000,

--- a/packages/core/src/processors/processors/token-limiter.ts
+++ b/packages/core/src/processors/processors/token-limiter.ts
@@ -30,8 +30,11 @@ export interface TokenLimiterOptions {
 }
 
 /**
- * Output processor that limits the number of tokens in generated responses.
- * Implements both processOutputStream for streaming and processOutputResult for non-streaming.
+ * Processor that limits the number of tokens in messages.
+ *
+ * Can be used as:
+ * - Input processor: Filters historical messages to fit within context window, prioritizing recent messages
+ * - Output processor: Limits generated response tokens via streaming (processOutputStream) or non-streaming (processOutputResult)
  */
 export class TokenLimiterProcessor implements Processor<'token-limiter'> {
   public readonly id = 'token-limiter';


### PR DESCRIPTION
## Summary

- Adds migration guide section for `@mastra/memory/processors` → `@mastra/core/processors` import path change
- Updates memory migration guide with concrete example using `inputProcessors` on Agent
- Fixes TokenLimiterProcessor documentation to accurately describe both input and output processor use cases
- Adds extended usage examples showing input processor (context window limiting) and output processor (response length limiting)

## Related Issue(s)

Related #11282

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works