### PR TITLE
fix: throw error when function passed as tool instead of tool object

### DIFF
--- a/.changeset/fix-malformed-tool-function-validation.md
+++ b/.changeset/fix-malformed-tool-function-validation.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+---
+
+Add validation to detect when a function is passed as a tool instead of a tool object. Previously, passing a tool factory function (e.g., `tools: { myTool }` instead of `tools: { myTool: myTool() }`) would silently fail - the LLM would request tool calls but nothing would execute. Now throws a clear error with guidance on how to fix it.
+

--- a/packages/core/src/tools/__tests__/malformed-tool.test.ts
+++ b/packages/core/src/tools/__tests__/malformed-tool.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { createTool } from '../tool';
+import { ensureToolProperties } from '../../utils';
+
+/**
+ * Test for GitHub Issue #11244
+ * https://github.com/mastra-ai/mastra/issues/11244
+ *
+ * When a user passes a function that returns a tool (instead of the tool itself),
+ * the agent silently fails - the LLM makes a tool call but the tool never executes.
+ * This should throw a descriptive error instead.
+ */
+describe('Malformed tool validation - Issue #11244', () => {
+  it('should throw an error when a function is passed as a tool instead of a tool object', () => {
+    // This is the malformed pattern from the issue:
+    // The user defined a function that returns a tool, but passed the function itself
+    const scanFolderFactory = (rootFolder: string) =>
+      createTool({
+        id: 'scan-folder',
+        description: 'Scans the content of a folder',
+        inputSchema: z.object({
+          path: z.string().optional(),
+        }),
+        execute: async () => {
+          return `Scanned ${rootFolder}`;
+        },
+      });
+
+    // User mistakenly passes the factory function instead of calling it
+    const malformedTools = {
+      scanFolder: scanFolderFactory, // BUG: Should be scanFolderFactory('/some/path')
+    };
+
+    // This should throw an error, not silently accept a function
+    expect(() => {
+      ensureToolProperties(malformedTools as any);
+    }).toThrow(/not a valid tool format/i);
+  });
+
+  it('should provide a helpful error message that mentions the tool key', () => {
+    const badToolFactory = () =>
+      createTool({
+        id: 'bad-tool',
+        description: 'A tool factory',
+        execute: async () => ({}),
+      });
+
+    const malformedTools = {
+      myBadTool: badToolFactory,
+    };
+
+    expect(() => {
+      ensureToolProperties(malformedTools as any);
+    }).toThrow(/myBadTool/);
+  });
+});

--- a/packages/core/src/tools/__tests__/malformed-tool.test.ts
+++ b/packages/core/src/tools/__tests__/malformed-tool.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import { createTool } from '../tool';
 import { ensureToolProperties } from '../../utils';
+import { createTool } from '../tool';
 
 /**
  * Test for GitHub Issue #11244


### PR DESCRIPTION
Fixes #11244

When you accidentally pass a tool factory function instead of calling it, the agent would silently fail - the LLM requests a tool call but nothing executes. Now you get a clear error message.

**Before:**
```js
const scanFolder = (path) => createTool({...})

// Silent failure - LLM calls tool but nothing happens
tools: { scanFolder }
```

**After:**
```
Error: Tool "scanFolder" is a function, not a tool.
Did you forget to call the function? For example, use "myTool()" instead of "myTool".
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects misconfigured tools (e.g., passing a factory function instead of a tool instance) and shows a clear, actionable error to guide correction.

* **Tests**
  * Added tests covering malformed tool configurations to ensure descriptive errors are thrown.

* **Chore**
  * Added a changelog entry documenting the new validation and guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->