### PR TITLE
fix(langfuse): handle out-of-order span arrival with lazy trace creation

### DIFF
--- a/.changeset/fix-langfuse-out-of-order-spans.md
+++ b/.changeset/fix-langfuse-out-of-order-spans.md
@@ -1,0 +1,6 @@
+---
+'@mastra/langfuse': patch
+---
+
+Fix "No trace data found for span" warning when child spans arrive before root spans due to async event processing.
+


### PR DESCRIPTION
Fixes #11060

When spans are emitted asynchronously via `.catch()` (fire-and-forget), child spans like `MODEL_STEP` can arrive at the Langfuse exporter before their root span. This was causing warnings and dropping spans:

```
WARN Langfuse exporter: No trace data found for span
    spanType: "model_step"
    spanName: "step: 0"
```

Now we create a "lazy trace" when child spans arrive first, which gets upgraded with full metadata when the root span arrives.

**Before:** Child span arrives first → warning logged, span dropped
**After:** Child span arrives first → lazy trace created, span tracked, root span upgrades trace later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved "No trace data found for span" warning that occurred when child spans arrived before root spans due to asynchronous event processing. The system now handles out-of-order span arrival gracefully by creating placeholder traces that are automatically updated when root spans arrive later.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->