### PR TITLE
fix(@mastra/core): support model-level and runtime headers for LLM calls

### DIFF
--- a/.changeset/busy-pets-start.md
+++ b/.changeset/busy-pets-start.md
@@ -1,0 +1,32 @@
+---
+'@mastra/core': patch
+---
+
+Fix model-level and runtime header support for LLM calls
+
+This fixes a bug where custom headers configured on models (like `anthropic-beta`) were not being passed through to the underlying AI SDK calls. The fix properly handles headers from multiple sources with correct priority:
+
+**Header Priority (low to high):**
+1. Model config headers - Headers set in model configuration
+2. ModelSettings headers - Runtime headers that override model config
+3. Provider-level headers - Headers baked into AI SDK providers (not overridden)
+
+**Examples that now work:**
+```typescript
+// Model config headers
+new Agent({
+  model: {
+    id: 'anthropic/claude-4-5-sonnet',
+    headers: { 'anthropic-beta': 'context-1m-2025-08-07' }
+  }
+})
+
+// Runtime headers override config
+agent.generate('...', {
+  modelSettings: { headers: { 'x-custom': 'runtime-value' } }
+})
+
+// Provider-level headers preserved
+const openai = createOpenAI({ headers: { 'openai-organization': 'org-123' } });
+new Agent({ model: openai('gpt-4o-mini') })
+```

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -33,6 +33,7 @@ import type {
 } from '../llm/model/base.types';
 import { isV2Model } from '../llm/model/is-v2-model';
 import { MastraLLMVNext } from '../llm/model/model.loop';
+import { ModelRouterLanguageModel } from '../llm/model/router';
 import type {
   TripwireProperties,
   MastraLanguageModel,
@@ -3409,6 +3410,12 @@ export class Agent<
         throw mastraError;
       }
 
+      // Extract headers from ModelRouterLanguageModel if available
+      let headers: Record<string, string> | undefined;
+      if (resolvedModel instanceof ModelRouterLanguageModel) {
+        headers = (resolvedModel as any).config?.headers;
+      }
+
       return [
         {
           id: 'main',
@@ -3416,6 +3423,7 @@ export class Agent<
           model: resolvedModel as MastraLanguageModelV2,
           maxRetries: this.maxRetries ?? 0,
           enabled: true,
+          headers,
         },
       ];
     }
@@ -3455,11 +3463,18 @@ export class Agent<
           throw mastraError;
         }
 
+        // Extract headers from ModelRouterLanguageModel if available
+        let headers: Record<string, string> | undefined;
+        if (model instanceof ModelRouterLanguageModel) {
+          headers = (model as any).config?.headers;
+        }
+
         return {
           id: modelId,
           model: model,
           maxRetries: modelConfig.maxRetries ?? 0,
           enabled: modelConfig.enabled ?? true,
+          headers,
         };
       }),
     );

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -1770,6 +1770,10 @@ exports[`Loop Tests > AISDK v5 > telemetry > should record telemetry data when e
       "stream.response.text": "Hello, world!",
       "stream.response.toolCalls": "[]",
       "stream.settings.frequencyPenalty": 0.3,
+      "stream.settings.headers": {
+        "header1": "value1",
+        "header2": "value2",
+      },
       "stream.settings.maxRetries": 2,
       "stream.settings.presencePenalty": 0.4,
       "stream.settings.stopSequences": [
@@ -1808,6 +1812,10 @@ exports[`Loop Tests > AISDK v5 > telemetry > should record telemetry data when e
       "stream.response.text": "Hello, world!",
       "stream.response.timestamp": "1970-01-01T00:00:00.000Z",
       "stream.settings.frequencyPenalty": 0.3,
+      "stream.settings.headers": {
+        "header1": "value1",
+        "header2": "value2",
+      },
       "stream.settings.maxRetries": 2,
       "stream.settings.presencePenalty": 0.4,
       "stream.settings.stopSequences": [

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -74,7 +74,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
       provider: firstModel.model.provider,
     },
     modelSettings,
-    headers: modelSettings?.headers ?? rest.headers,
+    headers: modelSettings?.headers,
     telemetry_settings,
   });
 
@@ -93,7 +93,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSchem
       provider: firstModel.model.provider,
     },
     modelSettings,
-    headers: modelSettings?.headers ?? rest.headers,
+    headers: modelSettings?.headers,
     telemetry_settings,
   });
 

--- a/packages/core/src/loop/test-utils/telemetry.ts
+++ b/packages/core/src/loop/test-utils/telemetry.ts
@@ -49,10 +49,10 @@ export function telemetryTests({ loopFn, runId }: { loopFn: typeof loop; runId: 
           temperature: 0.5,
           stopSequences: ['stop'],
           maxRetries: 2,
-        },
-        headers: {
-          header1: 'value1',
-          header2: 'value2',
+          headers: {
+            header1: 'value1',
+            header2: 'value2',
+          },
         },
         telemetry_settings: {
           isEnabled: true,

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -632,13 +632,14 @@ export type ToolResultChunk = BaseChunkType & { type: 'tool-result'; payload: To
 export type ReasoningChunk = BaseChunkType & { type: 'reasoning'; payload: ReasoningDeltaPayload };
 
 export type ExecuteStreamModelManager<T> = (
-  callback: (model: MastraLanguageModelV2, isLastModel: boolean) => Promise<T>,
+  callback: (modelConfig: ModelManagerModelConfig, isLastModel: boolean) => Promise<T>,
 ) => Promise<T>;
 
 export type ModelManagerModelConfig = {
   model: MastraLanguageModelV2;
   maxRetries: number;
   id: string;
+  headers?: Record<string, string>;
 };
 
 export interface LanguageModelUsage {


### PR DESCRIPTION
## Description

Backport of #11275

Fixes a bug where custom headers configured on models (like anthropic-beta) were not being passed through to the underlying AI SDK calls. This fix properly handles headers from multiple sources with correct priority merging.

## Related Issue(s)

slack

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
