### PR TITLE
fix(tracing): reuse model_step span to preserve correct start time

### DIFF
--- a/.changeset/fix-model-step-span-start-time.md
+++ b/.changeset/fix-model-step-span-start-time.md
@@ -2,8 +2,10 @@
 "@mastra/observability": patch
 ---
 
-fix(tracing): reuse model_step span to preserve correct start time
+fix(tracing): correct span timing when step-start events arrive late
 
-Ensures that when a `model_step` span already exists, the existing span is reused and updated with metadata from the `step-start` payload instead of creating a new span. This preserves the original `startTime` so the span correctly reflects the full duration of the step.
+**The problem:** When step-start events arrived after other tracing events (like token generation), a new step span was incorrectly created, duplicating the span and corrupting the parent-child relationships. This made trace timings inaccurate.
+
+**The fix:** Step spans are now reused and updated when late-arriving step-start events occur, preserving the correct start time and maintaining proper span hierarchy. Traces now show accurate durations and relationships for model steps, even when events arrive out of order.
 
 Fixes #11271

--- a/.changeset/fix-model-step-span-start-time.md
+++ b/.changeset/fix-model-step-span-start-time.md
@@ -1,0 +1,9 @@
+---
+"@mastra/observability": patch
+---
+
+fix(tracing): reuse model_step span to preserve correct start time
+
+Ensures that when a `model_step` span already exists, the existing span is reused and updated with metadata from the `step-start` payload instead of creating a new span. This preserves the original `startTime` so the span correctly reflects the full duration of the step.
+
+Fixes #11271

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -536,7 +536,7 @@ describe('ModelSpanTracker', () => {
           type: 'text-end',
           payload: {},
         },
-        // tep finish
+        // Step finish
         {
           type: 'step-finish',
           payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} },

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -109,6 +109,18 @@ export class ModelSpanTracker {
    * Start a new Model execution step
    */
   #startStepSpan(payload?: StepStartPayload) {
+    if (this.#currentStepSpan) {
+      this.#currentStepSpan.update({
+        attributes: {
+          stepIndex: this.#stepIndex,
+          ...(payload?.messageId ? { messageId: payload.messageId } : {}),
+          ...(payload?.warnings?.length ? { warnings: payload.warnings } : {}),
+        },
+        input: payload?.request,
+      });
+      return;
+    }
+
     this.#currentStepSpan = this.#modelSpan?.createChildSpan({
       name: `step: ${this.#stepIndex}`,
       type: SpanType.MODEL_STEP,


### PR DESCRIPTION
## Description

The fix ensures that if a `model_step` span already exists, it is reused and updated with metadata from the `step-start` payload instead of creating a new span. This preserves the original `startTime` and correctly reflects the full duration of the step.

A regression test has been added to verify that late `step-start` events do not overwrite existing step spans and that chunk spans remain correctly parented.

## Related Issue(s)

- #11271

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active model step spans are now reused and updated when step-start events arrive late, preserving original start times and maintaining correct parent‑child trace relationships to improve trace accuracy for long-running steps.

* **Tests**
  * Added a test that validates step‑span reuse and updates, and ensures text‑chunk spans correctly link to the updated step span when step‑start events are delayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->