### PR TITLE
fix(evals): add main entry point to package exports

### DIFF
--- a/.changeset/social-hotels-attack.md
+++ b/.changeset/social-hotels-attack.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Add main entry point to @mastra/evals package. Packages with exports field should define a "." entry point. The package now exports commonly used utilities and prebuilt scorers from the main entry, allowing users to import directly from '@mastra/evals' in addition to the existing subpath exports.

--- a/packages/evals/src/index.ts
+++ b/packages/evals/src/index.ts
@@ -1,18 +1,12 @@
 /**
  * @mastra/evals - Evaluation framework for AI agents
  *
- * This package provides scorers for evaluating AI agent performance.
- * Import specific scorers from subpaths:
+ * This package uses subpath exports. Import from specific paths:
  *
  * @example
  * ```ts
  * import { createToolCallAccuracyScorerCode } from '@mastra/evals/scorers/prebuilt';
  * import { getUserMessageFromRunInput } from '@mastra/evals/scorers/utils';
- * ```
- */
+ * */
 
-// Re-export commonly used utilities
-export * from './scorers/utils';
-
-// Re-export prebuilt scorers for convenience
-export * from './scorers/prebuilt';
+// This package uses subpath exports - see package.json for available paths

--- a/packages/evals/src/index.ts
+++ b/packages/evals/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @mastra/evals - Evaluation framework for AI agents
+ * 
+ * This package provides scorers for evaluating AI agent performance.
+ * Import specific scorers from subpaths:
+ * 
+ * @example
+ * ```ts
+ * import { createToolCallAccuracyScorerCode } from '@mastra/evals/scorers/prebuilt';
+ * import { getUserMessageFromRunInput } from '@mastra/evals/scorers/utils';
+ * ```
+ */
+
+// Re-export commonly used utilities
+export * from './scorers/utils';
+
+// Re-export prebuilt scorers for convenience
+export * from './scorers/prebuilt';

--- a/packages/evals/src/index.ts
+++ b/packages/evals/src/index.ts
@@ -1,9 +1,9 @@
 /**
  * @mastra/evals - Evaluation framework for AI agents
- * 
+ *
  * This package provides scorers for evaluating AI agent performance.
  * Import specific scorers from subpaths:
- * 
+ *
  * @example
  * ```ts
  * import { createToolCallAccuracyScorerCode } from '@mastra/evals/scorers/prebuilt';

--- a/packages/evals/tsup.config.ts
+++ b/packages/evals/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: {
+    index: 'src/index.ts',
     'scorers/prebuilt/index': 'src/scorers/prebuilt/index.ts',
     'scorers/utils': 'src/scorers/utils.ts',
   },


### PR DESCRIPTION
## Description

Fixes a package structure issue in `@mastra/evals` where the package defined subpath exports (`./scorers/utils`, `./scorers/prebuilt`) but was missing a main entry point (`"."`). 

According to Node.js package.json spec, packages with an `exports` field should define a main entry point. This PR adds the missing entry point.

## Changes

- **Added** `src/index.ts` that re-exports commonly used utilities and prebuilt scorers
- **Updated** `tsup.config.ts` to build the index entry point
- **Package now builds** `dist/index.js` and `dist/index.cjs` for the main entry

## Impact
- **Fixes bundler compatibility**: Resolves issues with module resolution in deployment scenarios

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package now exposes a main entry point, allowing direct imports of common utilities and prebuilt scorers for simpler usage.

* **Build**
  * Added an additional build target producing an extra bundle so the new main entry point is distributable.

* **Documentation**
  * Added package-level documentation with examples showing how to import from the main entry point and available subpath exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->