### PR TITLE
fix(deployer): support spread operator in Mastra config

### DIFF
--- a/.changeset/fix-spread-operator-mastra-config.md
+++ b/.changeset/fix-spread-operator-mastra-config.md
@@ -1,0 +1,5 @@
+---
+"@mastra/deployer": patch
+---
+
+Fix spread operator support in Mastra config. Previously, using `new Mastra({ ...config })` would cause a `BABEL_TRANSFORM_ERROR` during build because the Babel plugins didn't handle `SpreadElement` nodes in the config object.

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -45,7 +45,8 @@ const testScorer = createScorer({
   return 1;
 });
 
-export const mastra = new Mastra({
+// Test spread operator support (fixes #11130)
+const baseConfig = {
   agents: {
     chefAgent,
     chefAgentResponses,
@@ -86,6 +87,9 @@ export const mastra = new Mastra({
     advancedModerationWorkflow,
     findUserWorkflow,
   },
+} as const;
+
+const serverConfig = {
   bundler: {
     sourcemap: true,
   },
@@ -94,10 +98,27 @@ export const mastra = new Mastra({
       swaggerUI: true,
     },
   },
-  scorers: {
-    testScorer,
-  },
+};
+
+const observabilityConfig = {
   observability: new Observability({
     default: { enabled: true },
   }),
+};
+
+const scorersConfig = {
+  scorers: {
+    testScorer,
+  },
+};
+
+const mastraConfig = {
+  ...baseConfig,
+  ...serverConfig,
+  ...scorersConfig,
+  ...observabilityConfig,
+};
+
+export const mastra = new Mastra({
+  ...mastraConfig,
 });

--- a/packages/deployer/src/build/babel/check-config-export.test.ts
+++ b/packages/deployer/src/build/babel/check-config-export.test.ts
@@ -69,4 +69,14 @@ describe('checkConfigExport Babel plugin', () => {
     const code = 'type A = any; const foo: A = 123; export const mastra = new Mastra()';
     expect(runPlugin(code)).toBe(true);
   });
+
+  it('matches export const mastra = new Mastra({ ...config })', () => {
+    const code = 'const config = { agents: {} }; export const mastra = new Mastra({ ...config })';
+    expect(runPlugin(code)).toBe(true);
+  });
+
+  it('matches new Mastra with spread and explicit properties', () => {
+    const code = 'const config = { agents: {} }; export const mastra = new Mastra({ ...config, server: {} })';
+    expect(runPlugin(code)).toBe(true);
+  });
 });

--- a/packages/deployer/src/build/babel/get-deployer.ts
+++ b/packages/deployer/src/build/babel/get-deployer.ts
@@ -1,4 +1,5 @@
 import babel from '@babel/core';
+import { findPropertyByKeyName } from './utils';
 
 export function removeAllExceptDeployer() {
   const t = babel.types;
@@ -26,14 +27,11 @@ export function removeAllExceptDeployer() {
           return;
         }
 
-        // @ts-ignore
-        const deployer = path.node.arguments[0]?.properties?.find(
-          // @ts-ignore
-          prop => prop.key.name === 'deployer',
-        );
+        const args = path.node.arguments[0];
+        const deployer = t.isObjectExpression(args) ? findPropertyByKeyName(args.properties, 'deployer') : undefined;
 
         const programPath = path.scope.getProgramParent().path;
-        if (!deployer || !programPath) {
+        if (!deployer || !programPath || !t.isExpression(deployer.value)) {
           return;
         }
 

--- a/packages/deployer/src/build/babel/remove-all-options-except.ts
+++ b/packages/deployer/src/build/babel/remove-all-options-except.ts
@@ -2,6 +2,7 @@ import babel from '@babel/core';
 import type { NodePath, types } from '@babel/core';
 import type { Config as MastraConfig } from '@mastra/core/mastra';
 import type { IMastraLogger } from '@mastra/core/logger';
+import { findPropertyByKeyName } from './utils';
 
 export function removeAllOptionsFromMastraExcept(
   result: { hasCustomConfig: boolean },
@@ -38,10 +39,7 @@ export function removeAllOptionsFromMastraExcept(
           mastraArgs = path.node.arguments[0];
         }
 
-        let configProperty = mastraArgs.properties.find(
-          // @ts-ignore
-          prop => prop.key.name === option,
-        );
+        const configProperty = findPropertyByKeyName(mastraArgs.properties, option);
         let configValue: types.Expression = t.objectExpression([]);
 
         const programPath = path.scope.getProgramParent().path as NodePath<types.Program> | undefined;

--- a/packages/deployer/src/build/babel/remove-deployer.ts
+++ b/packages/deployer/src/build/babel/remove-deployer.ts
@@ -1,4 +1,5 @@
 import babel from '@babel/core';
+import { findPropertyByKeyName } from './utils';
 
 export function removeDeployer() {
   const t = babel.types;
@@ -22,10 +23,8 @@ export function removeDeployer() {
         if (!state.hasReplaced) {
           state.hasReplaced = true;
           const newMastraObj = t.cloneNode(path.node);
-          if (t.isObjectExpression(newMastraObj.arguments[0]) && newMastraObj.arguments[0].properties?.[0]) {
-            const deployer = newMastraObj.arguments[0].properties.find(
-              prop => t.isObjectProperty(prop) && t.isIdentifier(prop.key) && prop.key.name === 'deployer',
-            );
+          if (t.isObjectExpression(newMastraObj.arguments[0])) {
+            const deployer = findPropertyByKeyName(newMastraObj.arguments[0].properties, 'deployer');
 
             if (!deployer) {
               return;
@@ -36,7 +35,7 @@ export function removeDeployer() {
             );
 
             // try to find the binding of the deployer which should be the reference to the deployer
-            if (t.isObjectProperty(deployer) && t.isIdentifier(deployer.value)) {
+            if (t.isIdentifier(deployer.value)) {
               const deployerBinding = state.file.scope.getBinding(deployer.value.name);
 
               if (deployerBinding) {

--- a/packages/deployer/src/build/babel/utils.test.ts
+++ b/packages/deployer/src/build/babel/utils.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { transformSync } from '@babel/core';
+import type { types, PluginObj } from '@babel/core';
+import babel from '@babel/core';
+import { findPropertyByKeyName, hasSpreadElement } from './utils';
+
+const t = babel.types;
+
+describe('findPropertyByKeyName', () => {
+  // Helper to extract the ObjectExpression from code like `const x = { ... }`
+  function getObjectExpression(code: string): types.ObjectExpression | null {
+    let result: types.ObjectExpression | null = null;
+
+    const plugin: PluginObj = {
+      visitor: {
+        ObjectExpression(path) {
+          result = path.node;
+          path.stop();
+        },
+      },
+    };
+
+    transformSync(code, {
+      filename: 'test.ts',
+      presets: ['@babel/preset-typescript'],
+      plugins: [plugin],
+      configFile: false,
+      babelrc: false,
+    });
+
+    return result;
+  }
+
+  it('finds a property with identifier key', () => {
+    const objExpr = getObjectExpression('const x = { server: 123, agents: {} }');
+    expect(objExpr).not.toBeNull();
+    const prop = findPropertyByKeyName(objExpr!.properties, 'server');
+    expect(prop).toBeDefined();
+    expect(t.isObjectProperty(prop)).toBe(true);
+    expect(t.isIdentifier(prop!.key)).toBe(true);
+    expect((prop!.key as types.Identifier).name).toBe('server');
+  });
+
+  it('finds a property with string literal key', () => {
+    const objExpr = getObjectExpression('const x = { "server": 123 }');
+    expect(objExpr).not.toBeNull();
+    const prop = findPropertyByKeyName(objExpr!.properties, 'server');
+    expect(prop).toBeDefined();
+    expect(t.isObjectProperty(prop)).toBe(true);
+  });
+
+  it('returns undefined when property is not found', () => {
+    const objExpr = getObjectExpression('const x = { agents: {} }');
+    expect(objExpr).not.toBeNull();
+    const prop = findPropertyByKeyName(objExpr!.properties, 'server');
+    expect(prop).toBeUndefined();
+  });
+
+  it('returns undefined for empty object', () => {
+    const objExpr = getObjectExpression('const x = {}');
+    expect(objExpr).not.toBeNull();
+    const prop = findPropertyByKeyName(objExpr!.properties, 'server');
+    expect(prop).toBeUndefined();
+  });
+
+  it('handles spread elements without throwing', () => {
+    // We need to get the second object expression (the one with spread)
+    let spreadObj: types.ObjectExpression | null = null;
+    const plugin: PluginObj = {
+      visitor: {
+        ObjectExpression(path) {
+          if (path.node.properties.some(p => t.isSpreadElement(p))) {
+            spreadObj = path.node;
+            path.stop();
+          }
+        },
+      },
+    };
+
+    transformSync('const config = { a: 1 }; const x = { ...config, server: 123 }', {
+      filename: 'test.ts',
+      presets: ['@babel/preset-typescript'],
+      plugins: [plugin],
+      configFile: false,
+      babelrc: false,
+    });
+
+    expect(spreadObj).not.toBeNull();
+    // Should not throw and should find the explicit property
+    const prop = findPropertyByKeyName(spreadObj!.properties, 'server');
+    expect(prop).toBeDefined();
+    expect(t.isIdentifier(prop!.key)).toBe(true);
+    expect((prop!.key as types.Identifier).name).toBe('server');
+  });
+
+  it('handles object with only spread elements', () => {
+    let spreadObj: types.ObjectExpression | null = null;
+    const plugin: PluginObj = {
+      visitor: {
+        ObjectExpression(path) {
+          if (path.node.properties.some(p => t.isSpreadElement(p))) {
+            spreadObj = path.node;
+            path.stop();
+          }
+        },
+      },
+    };
+
+    transformSync('const config = { server: 123 }; const x = { ...config }', {
+      filename: 'test.ts',
+      presets: ['@babel/preset-typescript'],
+      plugins: [plugin],
+      configFile: false,
+      babelrc: false,
+    });
+
+    expect(spreadObj).not.toBeNull();
+    // Should not throw but will not find the property (it's inside the spread)
+    const prop = findPropertyByKeyName(spreadObj!.properties, 'server');
+    expect(prop).toBeUndefined();
+  });
+
+  it('handles spread before explicit property', () => {
+    let spreadObj: types.ObjectExpression | null = null;
+    const plugin: PluginObj = {
+      visitor: {
+        ObjectExpression(path) {
+          if (path.node.properties.some(p => t.isSpreadElement(p))) {
+            spreadObj = path.node;
+            path.stop();
+          }
+        },
+      },
+    };
+
+    transformSync('const base = { a: 1 }; const x = { ...base, deployer: myDeployer }', {
+      filename: 'test.ts',
+      presets: ['@babel/preset-typescript'],
+      plugins: [plugin],
+      configFile: false,
+      babelrc: false,
+    });
+
+    expect(spreadObj).not.toBeNull();
+    const prop = findPropertyByKeyName(spreadObj!.properties, 'deployer');
+    expect(prop).toBeDefined();
+  });
+
+  it('handles multiple spread elements', () => {
+    let spreadObj: types.ObjectExpression | null = null;
+    const plugin: PluginObj = {
+      visitor: {
+        ObjectExpression(path) {
+          const spreadCount = path.node.properties.filter(p => t.isSpreadElement(p)).length;
+          if (spreadCount >= 2) {
+            spreadObj = path.node;
+            path.stop();
+          }
+        },
+      },
+    };
+
+    transformSync('const a = { x: 1 }; const b = { y: 2 }; const x = { ...a, ...b, server: 3 }', {
+      filename: 'test.ts',
+      presets: ['@babel/preset-typescript'],
+      plugins: [plugin],
+      configFile: false,
+      babelrc: false,
+    });
+
+    expect(spreadObj).not.toBeNull();
+    const prop = findPropertyByKeyName(spreadObj!.properties, 'server');
+    expect(prop).toBeDefined();
+  });
+});
+
+describe('hasSpreadElement', () => {
+  function getObjectExpression(code: string): types.ObjectExpression | null {
+    let result: types.ObjectExpression | null = null;
+
+    const plugin: PluginObj = {
+      visitor: {
+        ObjectExpression(path) {
+          result = path.node;
+          path.stop();
+        },
+      },
+    };
+
+    transformSync(code, {
+      filename: 'test.ts',
+      presets: ['@babel/preset-typescript'],
+      plugins: [plugin],
+      configFile: false,
+      babelrc: false,
+    });
+
+    return result;
+  }
+
+  it('returns false for object without spread', () => {
+    const objExpr = getObjectExpression('const x = { a: 1, b: 2 }');
+    expect(objExpr).not.toBeNull();
+    expect(hasSpreadElement(objExpr!)).toBe(false);
+  });
+
+  it('returns true for object with spread', () => {
+    let spreadObj: types.ObjectExpression | null = null;
+    const plugin: PluginObj = {
+      visitor: {
+        ObjectExpression(path) {
+          if (path.node.properties.some(p => t.isSpreadElement(p))) {
+            spreadObj = path.node;
+            path.stop();
+          }
+        },
+      },
+    };
+
+    transformSync('const base = {}; const x = { ...base }', {
+      filename: 'test.ts',
+      presets: ['@babel/preset-typescript'],
+      plugins: [plugin],
+      configFile: false,
+      babelrc: false,
+    });
+
+    expect(spreadObj).not.toBeNull();
+    expect(hasSpreadElement(spreadObj!)).toBe(true);
+  });
+
+  it('returns false for empty object', () => {
+    const objExpr = getObjectExpression('const x = {}');
+    expect(objExpr).not.toBeNull();
+    expect(hasSpreadElement(objExpr!)).toBe(false);
+  });
+});

--- a/packages/deployer/src/build/babel/utils.ts
+++ b/packages/deployer/src/build/babel/utils.ts
@@ -1,0 +1,46 @@
+import babel from '@babel/core';
+import type { types } from '@babel/core';
+
+const t = babel.types;
+
+/**
+ * Finds an ObjectProperty in an array of properties by its key name.
+ * This function safely handles SpreadElement nodes which don't have a `key` property.
+ *
+ * @param properties - The array of object properties (may include SpreadElement nodes)
+ * @param keyName - The key name to search for
+ * @returns The matching ObjectProperty or undefined if not found
+ */
+export function findPropertyByKeyName(
+  properties: types.ObjectExpression['properties'],
+  keyName: string,
+): types.ObjectProperty | undefined {
+  for (const prop of properties) {
+    // Skip SpreadElement nodes - they don't have a key property
+    if (!t.isObjectProperty(prop)) {
+      continue;
+    }
+
+    // Handle both Identifier keys (e.g., { server: ... }) and StringLiteral keys (e.g., { "server": ... })
+    if (t.isIdentifier(prop.key) && prop.key.name === keyName) {
+      return prop;
+    }
+
+    if (t.isStringLiteral(prop.key) && prop.key.value === keyName) {
+      return prop;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Checks if an ObjectExpression contains a SpreadElement.
+ * This is useful for warning users that spread elements cannot be statically analyzed.
+ *
+ * @param objectExpr - The ObjectExpression to check
+ * @returns true if the object contains at least one SpreadElement
+ */
+export function hasSpreadElement(objectExpr: types.ObjectExpression): boolean {
+  return objectExpr.properties.some(prop => t.isSpreadElement(prop));
+}

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-spread.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-spread.js
@@ -1,0 +1,23 @@
+import { Mastra } from '@mastra/core/mastra';
+import { createLogger } from '@mastra/core/logger';
+import { weatherAgent } from '@/agents';
+import { TestDeployer } from '@mastra/deployer/test';
+
+const config = {
+  agents: { weatherAgent },
+  logger: createLogger({
+    name: 'Mastra',
+    level: 'info',
+  }),
+};
+
+export const mastra = new Mastra({
+  ...config,
+  server: {
+    port: 3000,
+  },
+  bundler: {
+    external: ['nodemailer'],
+  },
+  deployer: new TestDeployer(),
+});

--- a/packages/deployer/src/build/plugins/__snapshots__/remove-deployer.test.ts.snap
+++ b/packages/deployer/src/build/plugins/__snapshots__/remove-deployer.test.ts.snap
@@ -150,3 +150,31 @@ const mastra = new Mastra({
 export { mastra };
 "
 `;
+
+exports[`Remove deployer > should remove the deployer from ./__fixtures__/basic-with-spread.js 1`] = `
+"import { Mastra } from '@mastra/core/mastra';
+import { createLogger } from '@mastra/core/logger';
+import { weatherAgent } from '@/agents';
+
+const config = {
+  agents: {
+    weatherAgent
+  },
+  logger: createLogger({
+    name: "Mastra",
+    level: "info"
+  })
+};
+const mastra = new Mastra({
+  ...config,
+  server: {
+    port: 3e3
+  },
+  bundler: {
+    external: ["nodemailer"]
+  }
+});
+
+export { mastra };
+"
+`;

--- a/packages/deployer/src/build/plugins/remove-deployer.test.ts
+++ b/packages/deployer/src/build/plugins/remove-deployer.test.ts
@@ -13,6 +13,7 @@ describe('Remove deployer', () => {
     ['./__fixtures__/basic-with-const.js'],
     ['./__fixtures__/basic-with-import.js'],
     ['./__fixtures__/basic-with-function.js'],
+    ['./__fixtures__/basic-with-spread.js'],
   ])('should remove the deployer from %s', async ([fileName]) => {
     const file = join(_dirname, fileName);
 


### PR DESCRIPTION
## Summary
- Fix `BABEL_TRANSFORM_ERROR` when using spread operator in Mastra config (e.g., `new Mastra({ ...config })`)
- Add shared `findPropertyByKeyName()` utility that safely handles `SpreadElement` nodes in AST parsing

Fixes #11130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configurations using spread syntax (e.g., new Mastra({ ...config })) no longer cause build errors.

* **Tests**
  * Added coverage to ensure spread-based configs and utility helpers are handled correctly.

* **Refactor**
  * Improved dependency resolution to preserve npm alias entries when installing project dependencies.

* **Chores**
  * Added a changeset entry documenting the patch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->