### PR TITLE
fix(deployer): Fix bundling for packages without exports field

### DIFF
--- a/.changeset/fix-node-modules-extension-resolver.md
+++ b/.changeset/fix-node-modules-extension-resolver.md
@@ -1,0 +1,9 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed bundling issues for packages without an `exports` field in their package.json.
+
+Previously, the deployer could produce incorrect import paths for older npm packages that don't use the modern exports map (like lodash). This caused runtime errors when deploying to production environments.
+
+The fix ensures these packages now resolve correctly, while packages with proper exports maps continue to work as expected.

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -122,13 +122,15 @@ export async function getInputOptions(
       optimizeLodashImports({
         include: '**/*.{js,ts,mjs,cjs}',
       }),
-      commonjs({
-        extensions: ['.js', '.ts'],
-        transformMixedEsModules: true,
-        esmExternals(id) {
-          return externals.includes(id);
-        },
-      }),
+      externalsPreset
+        ? null
+        : commonjs({
+            extensions: ['.js', '.ts'],
+            transformMixedEsModules: true,
+            esmExternals(id) {
+              return externals.includes(id);
+            },
+          }),
       enableEsmShim ? esmShim() : undefined,
       externalsPreset ? nodeModulesExtensionResolver() : nodeResolvePlugin,
       // for debugging

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Plugin, PluginContext } from 'rollup';
 import { getPackageInfo } from 'local-pkg';
 import { readFile } from 'node:fs/promises';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 
-const mockNodeResolveHandler = vi.fn();
 const mockNodeResolveHandler = vi.fn();
 
 vi.mock('node:fs/promises', () => ({

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
@@ -1,16 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Plugin, PluginContext } from 'rollup';
+import { getPackageInfo } from 'local-pkg';
+import { readFile } from 'node:fs/promises';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const mockResolveFrom = vi.fn();
 const mockReadFileSync = vi.fn();
 const mockNodeResolveHandler = vi.fn();
 
-vi.mock('resolve-from', () => ({
-  default: (importer: string, id: string) => mockResolveFrom(importer, id),
+vi.mock('node:fs/promises', () => ({
+  exists: vi.fn(),
+  readFile: vi.fn(),
 }));
 
-vi.mock('node:fs', () => ({
-  readFileSync: (path: string, encoding: string) => mockReadFileSync(path, encoding),
+vi.mock('local-pkg', () => ({
+  getPackageInfo: vi.fn(),
 }));
 
 vi.mock('@rollup/plugin-node-resolve', () => ({
@@ -48,7 +52,7 @@ describe('nodeModulesExtensionResolver', () => {
       expect(result).toBeNull();
     });
 
-    it('imports without importer', async () => {
+    it('imports without an importer path', async () => {
       const result = await resolveId('lodash', undefined);
       expect(result).toBeNull();
     });
@@ -72,70 +76,89 @@ describe('nodeModulesExtensionResolver', () => {
       const result = await resolveId('@mastra/core', '/project/src/index.ts');
       expect(result).toBeNull();
     });
-  });
 
-  describe('imports with JS extension', () => {
-    it('strips extension for package with exports field', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/hono/dist/index.js');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'hono', exports: { '.': './dist/index.js' } }));
+    it('imports with an extension that have exports mapping', async () => {
+      const pkgJson = { name: 'hono', exports: { 'hono/utils/mime.js': './dist/utils/mime.js' } };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'hono', rootPath: '/project/node_modules/hono' });
+      // @ts-ignore  type should be correct
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
       const result = await resolveId('hono/utils/mime.js', '/project/src/index.ts');
 
-      expect(result).toEqual({ id: 'hono/utils/mime', external: true });
+      expect(result).toBeNull();
     });
+  });
 
-    it('keeps extension for package without exports field', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/lodash/index.js');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'lodash' }));
+  describe('imports with JS extension', () => {
+    it('It will resolve the import to the correct path if no exports present', async () => {
+      const pkgJson = { name: 'lodash' };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      // @ts-ignore  type should be correct
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
+
+      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.js' });
 
       const result = await resolveId('lodash/fp/get.js', '/project/src/index.ts');
 
-      expect(result).toEqual({ id: 'lodash/fp/get.js', external: true });
+      expect(result).toMatchObject({
+        external: true,
+        id: 'lodash/fp/get.js',
+      });
     });
 
     it('handles .mjs extension', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/pkg/index.mjs');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg' }));
+      const pkgJson = { name: 'lodash' };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      // @ts-ignore  type should be correct
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
-      const result = await resolveId('pkg/utils.mjs', '/project/src/index.ts');
+      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.mjs' });
 
-      expect(result).toEqual({ id: 'pkg/utils.mjs', external: true });
+      const result = await resolveId('lodash/fp/get.mjs', '/project/src/index.ts');
+
+      expect(result).toMatchObject({
+        external: true,
+        id: 'lodash/fp/get.mjs',
+      });
     });
 
     it('handles .cjs extension', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/pkg/index.cjs');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg' }));
+      const pkgJson = { name: 'lodash' };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      // @ts-ignore  type should be correct
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
-      const result = await resolveId('pkg/utils.cjs', '/project/src/index.ts');
+      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.cjs' });
 
-      expect(result).toEqual({ id: 'pkg/utils.cjs', external: true });
+      const result = await resolveId('lodash/fp/get.cjs', '/project/src/index.ts');
+
+      expect(result).toMatchObject({
+        external: true,
+        id: 'lodash/fp/get.cjs',
+      });
     });
   });
 
   describe('imports without extension', () => {
-    it('marks as external when package has exports', async () => {
-      // Package with exports field - Node.js resolves via exports map
-      mockResolveFrom.mockReturnValue('/project/node_modules/date-fns/dist/format.js');
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({ name: 'date-fns', exports: { './format': './dist/format.js' } }),
-      );
-      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/date-fns/dist/format.js' });
+    it('resolves the import to the correct path if no exports present', async () => {
+      const pkgJson = { name: 'lodash' };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
+      // @ts-ignore  type should be correct
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
-      const result = await resolveId('date-fns/format', '/project/src/index.ts');
-
-      expect(result).toEqual({ id: 'date-fns/format', external: true });
-    });
-
-    it('adds extension when node-resolve finds file but direct resolve fails', async () => {
-      // Simulate: node-resolve finds file, but direct safeResolve fails, then succeeds with .js
-      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.js' });
-      mockResolveFrom
-        .mockReturnValueOnce(null) // safeResolve(id) fails
-        .mockReturnValueOnce('/project/node_modules/lodash/fp/get.js'); // safeResolve(id + '.js') succeeds
+      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.cjs' });
 
       const result = await resolveId('lodash/fp/get', '/project/src/index.ts');
 
-      expect(result).toEqual({ id: 'lodash/fp/get.js', external: true });
+      expect(result).toMatchObject({
+        external: true,
+        id: 'lodash/fp/get.cjs',
+      });
     });
 
     it('returns null when resolution fails completely', async () => {
@@ -145,72 +168,52 @@ describe('nodeModulesExtensionResolver', () => {
 
       expect(result).toBeNull();
     });
-
-    it('keeps import as-is for package with exports field', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/hono/dist/utils/mime.js');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'hono', exports: { './*': './dist/*.js' } }));
-      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/hono/dist/utils/mime.js' });
-
-      const result = await resolveId('hono/utils/mime', '/project/src/index.ts');
-
-      expect(result).toEqual({ id: 'hono/utils/mime', external: true });
-    });
-
-    it('adds extension for subpath matching resolved file', async () => {
-      // lodash/fp/get resolves to /node_modules/lodash/fp/get.js
-      mockResolveFrom.mockReturnValue('/project/node_modules/lodash/fp/get.js');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'lodash' })); // no exports
-      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.js' });
-
-      const result = await resolveId('lodash/fp/get', '/project/src/index.ts');
-
-      expect(result).toEqual({ id: 'lodash/fp/get.js', external: true });
-    });
   });
 
   describe('scoped packages', () => {
     it('handles scoped package subpath imports with exports', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/@org/pkg/dist/utils.js');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@org/pkg', exports: { './*': './dist/*.js' } }));
-      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/@org/pkg/dist/utils.js' });
+      const pkgJson = { name: '@my/lodash', exports: {} };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
+      // @ts-ignore  type should be correct
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
-      const result = await resolveId('@org/pkg/utils', '/project/src/index.ts');
+      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/@my/lodash/fp/get.cjs' });
 
-      expect(result).toEqual({ id: '@org/pkg/utils', external: true });
+      const result = await resolveId('@my/lodash/fp/get', '/project/src/index.ts');
+
+      expect(result).toBeNull();
     });
 
     it('adds extension for scoped package without exports', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/@org/pkg/utils.js');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@org/pkg' })); // no exports
-      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/@org/pkg/utils.js' });
+      const pkgJson = { name: '@my/lodash' };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
+      // @ts-ignore  type should be correct
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
+      // @ts-ignore Partial input is fine
+      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/@my/lodash/utils.cjs' });
 
-      const result = await resolveId('@org/pkg/utils', '/project/src/index.ts');
+      const result = await resolveId('@my/lodash/utils', '/project/src/index.ts');
 
-      expect(result).toEqual({ id: '@org/pkg/utils.js', external: true });
+      expect(result).toEqual({ id: '@my/lodash/utils.cjs', external: true });
     });
   });
 
   describe('edge cases', () => {
     it('handles package.json read failure gracefully', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/broken/index.js');
-      mockReadFileSync.mockImplementation(() => {
+      const pkgJson = { name: '@my/lodash' };
+      // @ts-ignore parital is fine
+      vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
+
+      vi.mocked(readFile).mockImplementation(() => {
         throw new Error('ENOENT');
       });
 
-      const result = await resolveId('broken/utils.js', '/project/src/index.ts');
+      const result = await resolveId('broken/utils', '/project/src/index.ts');
 
       // Falls through to non-exports path
-      expect(result).toEqual({ id: 'broken/utils.js', external: true });
-    });
-
-    it('handles resolved path without JS extension', async () => {
-      mockResolveFrom.mockReturnValue('/project/node_modules/pkg/data.json');
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg' }));
-      mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/pkg/data.json' });
-
-      const result = await resolveId('pkg/data', '/project/src/index.ts');
-
-      expect(result).toEqual({ id: 'pkg/data', external: true });
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
@@ -4,8 +4,7 @@ import { getPackageInfo } from 'local-pkg';
 import { readFile } from 'node:fs/promises';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 
-const mockResolveFrom = vi.fn();
-const mockReadFileSync = vi.fn();
+const mockNodeResolveHandler = vi.fn();
 const mockNodeResolveHandler = vi.fn();
 
 vi.mock('node:fs/promises', () => ({

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
@@ -66,7 +66,14 @@ export function nodeModulesExtensionResolver(): Plugin {
           return null;
         }
 
-        const resolvedImportPath = nodeResolved.id.replace(packageRoot, pkgName);
+        let filePath = nodeResolved.id;
+        console.log({ nodeResolved });
+        if (nodeResolved.resolvedBy === 'commonjs--resolver') {
+          filePath = filePath.substring(1).split('?')[0];
+          console.log({ filePath });
+        }
+
+        const resolvedImportPath = filePath.replace(packageRoot, pkgName);
 
         return {
           id: resolvedImportPath,

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
@@ -1,57 +1,23 @@
-import { dirname, extname } from 'node:path';
-import { readFileSync } from 'node:fs';
-import resolveFrom from 'resolve-from';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
 import type { Plugin } from 'rollup';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import { getPackageName, isBuiltinModule } from '../utils';
-
-const JS_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
-
-const packageExportsCache = new Map<string, boolean>();
-const resolveCache = new Map<string, string | null>();
-
-function safeResolve(id: string, importer: string): string | null {
-  const cacheKey = `${id}\0${importer}`;
-  const cached = resolveCache.get(cacheKey);
-  if (cached !== undefined) {
-    return cached;
-  }
-  let result: string | null;
-  try {
-    result = resolveFrom(importer, id);
-  } catch {
-    result = null;
-  }
-  resolveCache.set(cacheKey, result);
-  return result;
-}
+import { getPackageRootPath } from '../package-info';
+import type { PackageJson } from 'type-fest';
 
 /**
  * Check if a package has an exports field in its package.json.
  * Results are cached to avoid repeated filesystem reads.
  */
-function packageHasExports(pkgName: string, importer: string): boolean {
-  const pkgMainPath = safeResolve(pkgName, importer);
-  if (!pkgMainPath) return false;
-  // Find package.json and cache by its directory
-  let dir = pkgMainPath;
-  for (let i = 0; i < 10; i++) {
-    dir = dirname(dir);
-    const cached = packageExportsCache.get(dir);
-    if (cached !== undefined) return cached;
-
-    try {
-      const pkgJson = JSON.parse(readFileSync(`${dir}/package.json`, 'utf-8'));
-      if (pkgJson.name === pkgName) {
-        const result = !!pkgJson.exports;
-        packageExportsCache.set(dir, result);
-        return result;
-      }
-    } catch {
-      // continue up
-    }
+async function getPackageJSON(pkgName: string, importer: string): Promise<PackageJson> {
+  const pkgRoot = await getPackageRootPath(pkgName, importer);
+  if (!pkgRoot) {
+    throw new Error(`Package ${pkgName} not found`);
   }
-  return false;
+
+  const pkgJSON = JSON.parse(await readFile(join(pkgRoot, 'package.json'), 'utf-8')) as PackageJson;
+  return pkgJSON;
 }
 
 /**
@@ -80,73 +46,36 @@ export function nodeModulesExtensionResolver(): Plugin {
         return null;
       }
 
-      const foundExt = extname(id);
       const pkgName = getPackageName(id);
-
-      // Handle imports that already have a JS extension
-      if (foundExt && JS_EXTENSIONS.has(foundExt)) {
-        // If package has exports, strip the extension to avoid double-extension issues
-        // (e.g., hono/utils/mime.js -> hono/dist/utils/mime.js.js)
-        if (pkgName && packageHasExports(pkgName, importer)) {
-          return {
-            id: id.slice(0, -foundExt.length),
-            external: true,
-          };
-        }
-        // For packages without exports, keep the extension as-is
-        return { id, external: true };
+      if (!pkgName) {
+        return null;
       }
 
-      // Try import.meta.resolve first - if it works, the import is valid as-is
-      // This respects ESM exports maps correctly
       try {
-        const resolved = import.meta.resolve(id);
-        if (resolved && extname(resolved)) {
-          return { id, external: true };
+        const packageJSON = await getPackageJSON(pkgName, importer);
+        // if it has exports, node should be able to rsolve it, if not the exports map is wrong.
+        if (!!packageJSON.exports) {
+          return null;
         }
-      } catch {
-        // import.meta.resolve failed, continue with fallback logic
-      }
 
-      // Fallback: For imports without extension, check if we need to add one
-      // @ts-expect-error - resolveId.handler exists but isn't typed
-      const nodeResolved = await nodeResolvePlugin.resolveId?.handler?.call(this, id, importer, options);
+        const packageRoot = await getPackageRootPath(pkgName, importer);
+        // @ts-expect-error - handle is part of resolveId signature
+        const nodeResolved = await nodeResolvePlugin.resolveId?.handler?.call(this, id, importer, options);
+        // if we cannot resolve it, it's not a valid import so we let node handle it
+        if (!nodeResolved?.id) {
+          return null;
+        }
 
-      if (!nodeResolved?.id) {
+        const resolvedImportPath = nodeResolved.id.replace(packageRoot, pkgName);
+
+        return {
+          id: resolvedImportPath,
+          external: true,
+        };
+      } catch (err) {
+        console.error(err);
         return null;
       }
-
-      const resolved = safeResolve(id, importer);
-      if (!resolved) {
-        // Try adding extensions manually
-        for (const ext of JS_EXTENSIONS) {
-          if (safeResolve(id + ext, importer)) {
-            return { id: id + ext, external: true };
-          }
-        }
-        return null;
-      }
-
-      const resolvedExt = extname(resolved);
-
-      // No JS extension in resolved path - keep as-is
-      if (!resolvedExt || !JS_EXTENSIONS.has(resolvedExt)) {
-        return { id, external: true };
-      }
-
-      // Package has exports - let Node.js resolve via exports map
-      if (pkgName && packageHasExports(pkgName, importer)) {
-        return { id, external: true };
-      }
-
-      // Check if this is a direct file reference that needs the extension
-      // e.g., lodash/fp/get resolves to .../lodash/fp/get.js
-      const subpath = pkgName ? id.slice(pkgName.length + 1) : '';
-      if (subpath && resolved.endsWith(`/${subpath}${resolvedExt}`)) {
-        return { id: id + resolvedExt, external: true };
-      }
-
-      return { id, external: true };
     },
   };
 }


### PR DESCRIPTION
## Summary

Fixed bundling issues for packages without an `exports` field in their package.json.

## Problem

Previously, the deployer could produce incorrect import paths for older npm packages that don't use the modern exports map (like lodash). This caused runtime errors when deploying to production environments.

## Solution

The fix ensures these packages now resolve correctly, while packages with proper exports maps continue to work as expected.

## Changes

- Simplified the node modules extension resolver to properly detect packages without exports fields
- Skip the commonjs plugin when externalsPreset is enabled to prevent double transformation
- Let Node.js handle resolution for packages that have proper exports maps

## Changeset

```
@mastra/deployer: patch
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes bundling/runtime errors for older npm packages that lack an exports field (e.g., lodash), ensuring correct import resolution in production while preserving behavior for packages with proper exports.

* **Tests**
  * Updated and expanded tests to cover packages with and without exports, scoped packages, multiple module variants, and error/fallback scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->