### PR TITLE
fix(client-js): fix listMemoryThreads orderBy serialization and type

### DIFF
--- a/.changeset/fix-listmemorythreads-orderby-serialization.md
+++ b/.changeset/fix-listmemorythreads-orderby-serialization.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fix listMemoryThreads orderBy parameter serialization and type definition. The `orderBy` parameter now correctly expects an object with `field` and `direction` properties matching the server schema, and is properly JSON-serialized in the query string instead of being converted to `[object Object]`.

--- a/.changeset/fix-listmemorythreads-orderby-serialization.md
+++ b/.changeset/fix-listmemorythreads-orderby-serialization.md
@@ -3,3 +3,27 @@
 ---
 
 Fix listMemoryThreads orderBy parameter serialization and type definition. The `orderBy` parameter now correctly expects an object with `field` and `direction` properties matching the server schema, and is properly JSON-serialized in the query string instead of being converted to `[object Object]`.
+
+**Breaking change**: The `orderBy` parameter structure has changed.
+
+**Before:**
+```typescript
+client.listMemoryThreads({
+  resourceId: 'resource-123',
+  agentId: 'agent-456',
+  orderBy: 'createdAt',
+  sortDirection: 'DESC'
+});
+```
+
+**After:**
+```typescript
+client.listMemoryThreads({
+  resourceId: 'resource-123',
+  agentId: 'agent-456',
+  orderBy: {
+    field: 'createdAt',
+    direction: 'DESC'
+  }
+});
+```

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -109,8 +109,7 @@ export class MastraClient extends BaseResource {
       agentId: params.agentId,
       ...(params.page !== undefined && { page: params.page.toString() }),
       ...(params.perPage !== undefined && { perPage: params.perPage.toString() }),
-      ...(params.orderBy && { orderBy: params.orderBy }),
-      ...(params.sortDirection && { sortDirection: params.sortDirection }),
+      ...(params.orderBy && { orderBy: JSON.stringify(params.orderBy) }),
     });
 
     const response: ListMemoryThreadsResponse | ListMemoryThreadsResponse['threads'] = await this.request(

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -284,8 +284,10 @@ export interface ListMemoryThreadsParams {
   agentId: string;
   page?: number;
   perPage?: number;
-  orderBy?: 'createdAt' | 'updatedAt';
-  sortDirection?: 'ASC' | 'DESC';
+  orderBy?: {
+    field?: 'createdAt' | 'updatedAt';
+    direction?: 'ASC' | 'DESC';
+  };
   requestContext?: RequestContext | Record<string, any>;
 }
 


### PR DESCRIPTION
## Summary

Fixes the `listMemoryThreads` method in `@mastra/client-js` where the `orderBy` parameter was not working correctly.

## Problem

1. **Type mismatch**: The client type defined `orderBy` as a string (`'createdAt' | 'updatedAt'`) with a separate `sortDirection` field, but the server expects an object: `{ field: 'createdAt' | 'updatedAt', direction: 'ASC' | 'DESC' }`

2. **Serialization bug**: When passing an object to `orderBy`, it was being converted to `[object Object]` in the query string because `URLSearchParams` calls `.toString()` on values

## Changes

- Updated `ListMemoryThreadsParams.orderBy` type to match server schema:
  ```typescript
  orderBy?: {
    field?: 'createdAt' | 'updatedAt';
    direction?: 'ASC' | 'DESC';
  };
  ```
- Removed unused `sortDirection` field
- Added `JSON.stringify()` for proper serialization of `orderBy` in query params

## Usage

```typescript
const result = await client.listMemoryThreads({
  resourceId,
  agentId,
  page: 1,
  perPage: 20,
  orderBy: { field: "createdAt", direction: "DESC" },
});
```

## Testing

- All existing client SDK tests pass (`pnpm test:clients`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serialization of ordering parameters so ordering is transmitted correctly to the API.
* **Breaking Changes**
  * The ordering parameter shape has changed: it now uses a nested object with `field` and `direction` (previous separate fields removed).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->