### PR TITLE
fix(core): handle TripWire from processInputStep properly

### DIFF
--- a/.changeset/brave-apples-trade.md
+++ b/.changeset/brave-apples-trade.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': patch
+---
+
+When calling `abort()` inside a `processInputStep` processor, the TripWire was being caught by the model retry logic instead of emitting a tripwire chunk to the stream.
+
+Before this fix, processors using `processInputStep` with abort would see errors like:
+
+```
+Error executing model gpt-4o-mini, attempt 1==== TripWire [Error]: Potentially harmful content detected
+```
+
+Now the TripWire is properly handled - it emits a tripwire chunk and signals the abort correctly,

--- a/packages/core/src/agent/agent-processor.test.ts
+++ b/packages/core/src/agent/agent-processor.test.ts
@@ -3193,4 +3193,206 @@ describe('Workflow as Processor', () => {
       expect(result.text).toContain('[SUFFIX]');
     });
   });
+
+  describe('TripWire in processInputStep', () => {
+    it('should emit tripwire chunk when processor aborts in processInputStep', async () => {
+      const mockModel = new MockLanguageModelV2({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'test response' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        }),
+      });
+
+      const processInputStepProcessor = {
+        id: 'input-step-tripwire-processor',
+        processInputStep: async ({ abort }: { abort: (reason?: string, options?: any) => never }) => {
+          abort('Blocked by processInputStep', {
+            metadata: { toxicityScore: 0.9, category: 'harmful' },
+          });
+          return {};
+        },
+      } satisfies Processor;
+
+      const agent = new Agent({
+        id: 'process-input-step-tripwire-test-agent',
+        name: 'ProcessInputStep Tripwire Test Agent',
+        instructions: 'You are a helpful assistant.',
+        model: mockModel,
+        inputProcessors: [processInputStepProcessor],
+      });
+
+      const stream = await agent.stream('Hello');
+      const chunks: any[] = [];
+
+      for await (const chunk of stream.fullStream) {
+        chunks.push(chunk);
+      }
+
+      const tripwireChunk = chunks.find(c => c.type === 'tripwire');
+      expect(tripwireChunk).toBeDefined();
+      expect(tripwireChunk.payload.reason).toBe('Blocked by processInputStep');
+      expect(tripwireChunk.payload.metadata).toEqual({ toxicityScore: 0.9, category: 'harmful' });
+      expect(tripwireChunk.payload.processorId).toBe('input-step-tripwire-processor');
+    });
+
+    it('should emit tripwire chunk with retry option when processor aborts in processInputStep', async () => {
+      const mockModel = new MockLanguageModelV2({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'test response' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        }),
+      });
+
+      const processInputStepProcessor = {
+        id: 'input-step-retry-processor',
+        processInputStep: async ({ abort }: { abort: (reason?: string, options?: any) => never }) => {
+          abort('Please try again', { retry: true });
+          return {};
+        },
+      } satisfies Processor;
+
+      const agent = new Agent({
+        id: 'process-input-step-retry-tripwire-test-agent',
+        name: 'ProcessInputStep Retry Tripwire Test Agent',
+        instructions: 'You are a helpful assistant.',
+        model: mockModel,
+        inputProcessors: [processInputStepProcessor],
+      });
+
+      const stream = await agent.stream('Hello');
+      const chunks: any[] = [];
+
+      for await (const chunk of stream.fullStream) {
+        chunks.push(chunk);
+      }
+
+      const tripwireChunk = chunks.find(c => c.type === 'tripwire');
+      expect(tripwireChunk).toBeDefined();
+      expect(tripwireChunk.payload.reason).toBe('Please try again');
+      expect(tripwireChunk.payload.retry).toBe(true);
+    });
+  });
+
+  describe('TripWire in processOutputStep', () => {
+    it('should emit tripwire chunk when processor aborts in processOutputStep', async () => {
+      const mockModel = new MockLanguageModelV2({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'test response' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        }),
+      });
+
+      const processOutputStepProcessor = {
+        id: 'output-step-tripwire-processor',
+        processOutputStep: async ({ abort }: { abort: (reason?: string, options?: any) => never }) => {
+          abort('Blocked by processOutputStep', {
+            metadata: { toxicityScore: 0.8, category: 'inappropriate' },
+          });
+          return [];
+        },
+      } satisfies Processor;
+
+      const agent = new Agent({
+        id: 'process-output-step-tripwire-test-agent',
+        name: 'ProcessOutputStep Tripwire Test Agent',
+        instructions: 'You are a helpful assistant.',
+        model: mockModel,
+        outputProcessors: [processOutputStepProcessor],
+      });
+
+      const stream = await agent.stream('Hello');
+      const chunks: any[] = [];
+
+      for await (const chunk of stream.fullStream) {
+        chunks.push(chunk);
+      }
+
+      // processOutputStep tripwire is reported via step-finish with tripwire data
+      const stepFinishChunk = chunks.find(c => c.type === 'step-finish');
+      expect(stepFinishChunk).toBeDefined();
+      expect(stepFinishChunk.payload.stepResult.reason).toBe('tripwire');
+    });
+
+    it('should emit tripwire chunk with metadata when processor aborts in processOutputStep', async () => {
+      const mockModel = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          content: [{ type: 'text', text: 'harmful content' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        }),
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'harmful content' },
+            { type: 'text-end', id: '1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        }),
+      });
+
+      const processOutputStepProcessor = {
+        id: 'output-step-metadata-processor',
+        processOutputStep: async ({
+          text,
+          abort,
+        }: {
+          text?: string;
+          abort: (reason?: string, options?: any) => never;
+        }) => {
+          if (text?.includes('harmful')) {
+            abort('Content policy violation', {
+              metadata: { category: 'harmful_content', confidence: 0.95 },
+            });
+          }
+          return [];
+        },
+      } satisfies Processor;
+
+      const agent = new Agent({
+        id: 'process-output-step-metadata-tripwire-test-agent',
+        name: 'ProcessOutputStep Metadata Tripwire Test Agent',
+        instructions: 'You are a helpful assistant.',
+        model: mockModel,
+        outputProcessors: [processOutputStepProcessor],
+      });
+
+      const result = await agent.generate('Hello');
+
+      // The tripwire should be set on the result
+      expect(result.tripwire).toBeDefined();
+      expect(result.tripwire?.reason).toBe('Content policy violation');
+      expect(result.tripwire?.metadata).toEqual({ category: 'harmful_content', confidence: 0.95 });
+      expect(result.tripwire?.processorId).toBe('output-step-metadata-processor');
+    });
+  });
 });


### PR DESCRIPTION
When calling `abort()` inside a `processInputStep` processor, the TripWire was being caught by the model retry logic instead of emitting a tripwire chunk to the stream.

Before this fix, processors using `processInputStep` with abort would see errors like:
```
Error executing model gpt-4o-mini, attempt 1==== TripWire [Error]: Potentially harmful content detected
```

Now the TripWire is properly handled - it emits a tripwire chunk and signals the abort correctly, matching the behavior of `processInput`.

The fix adds a TripWire check in `executeStreamWithFallbackModels` to re-throw instead of retrying, and handles the TripWire in the `processInputStep` catch block to emit the proper chunk.

Added tests for both `processInputStep` and `processOutputStep` tripwire handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected abort handling so TripWire events are emitted immediately and aborts are not swallowed by retry logic.

* **Tests**
  * Added comprehensive tests covering TripWire behavior across input, output, prepare steps, streaming and workflow scenarios, including metadata, processor attribution, and retry variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->