### PR TITLE
feat(observability): add AgentRunFormatter span processor

### DIFF
--- a/.changeset/add-agent-run-formatter.md
+++ b/.changeset/add-agent-run-formatter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': minor
+---
+
+Add AgentRunFormatter span processor that simplifies AGENT_RUN span input/output for cleaner trace displays. Extracts content from single user message inputs and unwraps single non-empty output properties.

--- a/observability/mastra/src/span_processors/agent-run-formatter.test.ts
+++ b/observability/mastra/src/span_processors/agent-run-formatter.test.ts
@@ -1,0 +1,259 @@
+import { SpanType } from '@mastra/core/observability';
+import { describe, expect, it } from 'vitest';
+import { AgentRunFormatter } from './agent-run-formatter';
+
+// Helper to create a mock span
+function createMockSpan(overrides: { type?: SpanType; input?: unknown; output?: unknown }) {
+  return {
+    id: 'test-span-1',
+    name: 'test-span',
+    type: overrides.type ?? SpanType.AGENT_RUN,
+    startTime: new Date(),
+    traceId: 'trace-123',
+    attributes: {},
+    input: overrides.input,
+    output: overrides.output,
+    observabilityInstance: {} as any,
+    end: () => {},
+    error: () => {},
+    update: () => {},
+    createChildSpan: () => ({}) as any,
+  } as any;
+}
+
+describe('AgentRunFormatter', () => {
+  describe('process', () => {
+    it('should return undefined for undefined span', () => {
+      const processor = new AgentRunFormatter();
+      expect(processor.process(undefined)).toBeUndefined();
+    });
+
+    it('should return non-AGENT_RUN spans unchanged', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        type: SpanType.MODEL_GENERATION,
+        output: { text: 'Hello', object: undefined, files: [] },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.output).toEqual({ text: 'Hello', object: undefined, files: [] });
+    });
+
+    it('should extract single non-empty property from output', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: { text: 'Hello world', object: undefined, files: [] },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.output).toBe('Hello world');
+    });
+
+    it('should extract content from single user message input', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        input: { messages: [{ role: 'user', content: 'Hello there' }] },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.input).toBe('Hello there');
+    });
+
+    it('should not transform input with multiple messages', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        input: {
+          messages: [
+            { role: 'user', content: 'Hi' },
+            { role: 'assistant', content: 'Hello' },
+          ],
+        },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.input).toEqual({
+        messages: [
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Hello' },
+        ],
+      });
+    });
+
+    it('should not transform input with single non-user message', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        input: { messages: [{ role: 'system', content: 'You are helpful' }] },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.input).toEqual({ messages: [{ role: 'system', content: 'You are helpful' }] });
+    });
+
+    it('should not transform input without messages property', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        input: { data: 'some data' },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.input).toEqual({ data: 'some data' });
+    });
+
+    it('should not transform when multiple non-empty properties exist', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: { text: 'Hello', object: { foo: 1 }, files: [] },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.output).toEqual({ text: 'Hello', object: { foo: 1 }, files: [] });
+    });
+
+    it('should not transform when all properties are empty', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: { text: undefined, object: null, files: [] },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.output).toEqual({ text: undefined, object: null, files: [] });
+    });
+
+    it('should not transform output arrays', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: [{ id: 1 }, { id: 2 }],
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.output).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('should not transform array input (not object with messages)', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        input: [{ role: 'user', content: 'Hi' }],
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.input).toEqual([{ role: 'user', content: 'Hi' }]);
+    });
+
+    it('should not transform primitive values', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        input: 'just a string',
+        output: 42,
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.input).toBe('just a string');
+      expect(result?.output).toBe(42);
+    });
+
+    it('should not transform null or undefined', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        input: null,
+        output: undefined,
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.input).toBeNull();
+      expect(result?.output).toBeUndefined();
+    });
+
+    it('should treat empty string as empty value', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: { text: '', object: { foo: 1 }, files: [] },
+      });
+
+      const result = processor.process(span);
+
+      // Only object is non-empty, so extract it
+      expect(result?.output).toEqual({ foo: 1 });
+    });
+
+    it('should treat empty array as empty value', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: { text: 'Hello', files: [] },
+      });
+
+      const result = processor.process(span);
+
+      // Only text is non-empty, so extract it
+      expect(result?.output).toBe('Hello');
+    });
+
+    it('should treat non-empty array as non-empty value', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: { text: undefined, files: [{ name: 'doc.pdf' }] },
+      });
+
+      const result = processor.process(span);
+
+      // Only files is non-empty, so extract it
+      expect(result?.output).toEqual([{ name: 'doc.pdf' }]);
+    });
+
+    it('should handle nested objects as single value', () => {
+      const processor = new AgentRunFormatter();
+
+      const span = createMockSpan({
+        output: {
+          text: undefined,
+          object: { nested: { deep: 'value' } },
+          files: [],
+        },
+      });
+
+      const result = processor.process(span);
+
+      expect(result?.output).toEqual({ nested: { deep: 'value' } });
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should resolve without error', async () => {
+      const processor = new AgentRunFormatter();
+      await expect(processor.shutdown()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('name', () => {
+    it('should have correct name', () => {
+      const processor = new AgentRunFormatter();
+      expect(processor.name).toBe('agent-run-formatter');
+    });
+  });
+});

--- a/observability/mastra/src/span_processors/agent-run-formatter.ts
+++ b/observability/mastra/src/span_processors/agent-run-formatter.ts
@@ -1,0 +1,106 @@
+import type { AnySpan, SpanOutputProcessor } from '@mastra/core/observability';
+import { SpanType } from '@mastra/core/observability';
+
+/**
+ * AgentRunFormatter
+ *
+ * A SpanOutputProcessor that simplifies AGENT_RUN span input/output.
+ *
+ * Input rules:
+ * - If single user message → extract content text
+ * - Otherwise → no transformation
+ *
+ * Output rules:
+ * - If object has exactly ONE non-empty property → return that value directly
+ * - Otherwise → no transformation (return as-is)
+ *
+ * @example
+ * // Input: { messages: [{ role: 'user', content: 'Hello' }] }
+ * // After: 'Hello'
+ *
+ * // Output: { text: "Hello world", object: undefined, files: [] }
+ * // After: "Hello world"
+ */
+export class AgentRunFormatter implements SpanOutputProcessor {
+  name = 'agent-run-formatter';
+
+  /**
+   * Process a span by simplifying AGENT_RUN input/output.
+   * Non-AGENT_RUN spans are returned unchanged.
+   */
+  process(span?: AnySpan): AnySpan | undefined {
+    if (!span || span.type !== SpanType.AGENT_RUN) {
+      return span;
+    }
+
+    span.input = this.simplifyInput(span.input);
+    span.output = this.simplifyOutput(span.output);
+    return span;
+  }
+
+  /**
+   * Simplify input by extracting content from single user message.
+   * Input format: { messages: [{ role: 'user', content: 'text' }] }
+   * If single user message, return the content text.
+   */
+  private simplifyInput(value: unknown): unknown {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return value;
+    }
+
+    const obj = value as Record<string, unknown>;
+    if (!('messages' in obj) || !Array.isArray(obj.messages) || obj.messages.length !== 1) {
+      return value;
+    }
+
+    const message = obj.messages[0];
+    if (
+      message &&
+      typeof message === 'object' &&
+      'role' in message &&
+      message.role === 'user' &&
+      'content' in message
+    ) {
+      return message.content;
+    }
+
+    return value;
+  }
+
+  /**
+   * Simplify output by extracting single non-empty property.
+   * Returns original value if not an object, or if multiple/zero non-empty properties.
+   */
+  private simplifyOutput(value: unknown): unknown {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return value;
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>);
+    const nonEmpty = entries.filter(([_, v]) => this.hasValue(v));
+
+    if (nonEmpty.length === 1) {
+      return nonEmpty[0]?.[1];
+    }
+
+    return value;
+  }
+
+  /**
+   * Check if a value is considered "non-empty".
+   * Empty values: undefined, null, empty string, empty array.
+   */
+  private hasValue(v: unknown): boolean {
+    if (v === undefined || v === null || v === '') {
+      return false;
+    }
+    if (Array.isArray(v) && v.length === 0) {
+      return false;
+    }
+    return true;
+  }
+
+  async shutdown(): Promise<void> {
+    // No cleanup needed
+  }
+}

--- a/observability/mastra/src/span_processors/index.ts
+++ b/observability/mastra/src/span_processors/index.ts
@@ -2,4 +2,5 @@
  * Mastra Span Processors
  */
 
+export * from './agent-run-formatter';
 export * from './sensitive-data-filter';


### PR DESCRIPTION
Adds `AgentRunFormatter` - an opt-in span processor that simplifies AGENT_RUN span displays.

issue: https://github.com/mastra-ai/mastra/issues/9822

**Input**: extracts content from single user message
```ts
// before: { messages: [{ role: 'user', content: 'Hello' }] }
// after: 'Hello'
```

**Output**: unwraps single non-empty property
```ts
// before: { text: 'Hello world', object: undefined, files: [] }
// after: 'Hello world'
```

Usage:
```ts
import { AgentRunFormatter } from '@mastra/observability';

new Observability({
  configs: {
    myConfig: {
      serviceName: 'my-service',
      spanOutputProcessors: [new AgentRunFormatter()],
    },
  },
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AgentRunFormatter span processor to the observability library that automatically simplifies AGENT_RUN span input/output for improved trace readability, extracting key content from inputs and unwrapping output properties for cleaner traces in observability dashboards and monitoring tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->