### PR TITLE
fix: add AI SDK v6 embedding model support

### DIFF
--- a/.changeset/fastembed-ai-sdk-v5.md
+++ b/.changeset/fastembed-ai-sdk-v5.md
@@ -2,4 +2,4 @@
 '@mastra/fastembed': major
 ---
 
-Added AI SDK v6 (specification version v3) support. Default exports now use v3 specification. V2 exports available via `fastembed.smallV2` and `fastembed.baseV2`. Legacy v1 exports available via `fastembed.smallLegacy` and `fastembed.baseLegacy`.
+Upgraded to AI SDK v5 (specification version v2) for compatibility with @mastra/core. Default exports now use v2 specification. Legacy v1 exports available for backwards compatibility via `fastembed.smallLegacy` and `fastembed.baseLegacy`.

--- a/.changeset/fastembed-ai-sdk-v5.md
+++ b/.changeset/fastembed-ai-sdk-v5.md
@@ -2,4 +2,4 @@
 '@mastra/fastembed': major
 ---
 
-Upgraded to AI SDK v5 (specification version v2) for compatibility with @mastra/core. Default exports now use v2 specification. Legacy v1 exports available for backwards compatibility via `fastembed.smallLegacy` and `fastembed.baseLegacy`.
+Added AI SDK v6 (specification version v3) support. Default exports now use v3 specification. V2 exports available via `fastembed.smallV2` and `fastembed.baseV2`. Legacy v1 exports available via `fastembed.smallLegacy` and `fastembed.baseLegacy`.

--- a/.changeset/fix-embedding-model-v3-support.md
+++ b/.changeset/fix-embedding-model-v3-support.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+'@mastra/memory': patch
+'@mastra/fastembed': patch
+---
+
+Added support for AI SDK v6 embedding models (specification version v3) in memory and vector modules. Fixed TypeScript error where `ModelRouterEmbeddingModel` was trying to implement a union type instead of `EmbeddingModelV2` directly.
+

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -1,7 +1,7 @@
 import { createGoogleGenerativeAI } from '@ai-sdk/google-v5';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
 import { createOpenAI } from '@ai-sdk/openai-v5';
-import type { EmbeddingModelV2 } from '@ai-sdk/provider-v5';
+import type { EmbeddingModelV2 } from '@internal/ai-sdk-v5';
 
 import { GatewayRegistry } from './provider-registry.js';
 import type { OpenAICompatibleConfig } from './shared.types.js';

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -1,9 +1,9 @@
-import type { EmbeddingModelV2 } from '@ai-sdk/provider-v5';
-import type { EmbeddingModel, AssistantContent, UserContent, CoreMessage } from '@internal/ai-sdk-v4';
+import type { AssistantContent, UserContent, CoreMessage } from '@internal/ai-sdk-v4';
 import type { MastraDBMessage } from '../agent/message-list';
 import { MastraBase } from '../base';
 import { ErrorDomain, MastraError } from '../error';
-import { ModelRouterEmbeddingModel } from '../llm/model/index.js';
+import { ModelRouterEmbeddingModel } from '../llm/model';
+import type { EmbeddingModelId } from '../llm/model';
 import type { Mastra } from '../mastra';
 import type {
   InputProcessor,
@@ -23,7 +23,7 @@ import type {
 import { augmentWithInit } from '../storage/storageWithInit';
 import type { ToolAction } from '../tools';
 import { deepMerge } from '../utils';
-import type { MastraVector } from '../vector';
+import type { MastraEmbeddingModel, MastraEmbeddingOptions, MastraVector } from '../vector';
 
 import type {
   SharedMemoryConfig,
@@ -96,7 +96,8 @@ export abstract class MastraMemory extends MastraBase {
 
   protected _storage?: MastraStorage;
   vector?: MastraVector;
-  embedder?: EmbeddingModel<string> | EmbeddingModelV2<string>;
+  embedder?: MastraEmbeddingModel<string>;
+  embedderOptions?: MastraEmbeddingOptions;
   protected threadConfig: MemoryConfig = { ...memoryDefaultOptions };
   #mastra?: Mastra;
 
@@ -200,8 +201,12 @@ https://mastra.ai/en/docs/memory/overview`,
     this.vector = vector;
   }
 
-  public setEmbedder(embedder: EmbeddingModel<string>) {
-    this.embedder = embedder;
+  public setEmbedder(embedder: EmbeddingModelId | MastraEmbeddingModel<string>) {
+    if (typeof embedder === 'string') {
+      this.embedder = new ModelRouterEmbeddingModel(embedder);
+    } else {
+      this.embedder = embedder;
+    }
   }
 
   /**

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1,5 +1,4 @@
-import type { EmbeddingModel, AssistantContent, CoreMessage, ToolContent, UserContent } from '@internal/ai-sdk-v4';
-import type { EmbeddingModel as EmbeddingModelV2 } from '@internal/ai-sdk-v5';
+import type { AssistantContent, CoreMessage, ToolContent, UserContent } from '@internal/ai-sdk-v4';
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodObject } from 'zod';
 
@@ -9,7 +8,7 @@ import type { MastraLanguageModel, MastraModelConfig } from '../llm/model/shared
 import type { RequestContext } from '../request-context';
 import type { MastraStorage } from '../storage';
 import type { DynamicArgument } from '../types';
-import type { MastraVector } from '../vector';
+import type { MastraEmbeddingModel, MastraVector } from '../vector';
 import type { MemoryProcessor } from '.';
 
 export type { Message as AiMessageType } from '@internal/ai-sdk-v4';
@@ -487,7 +486,7 @@ export type SharedMemoryConfig = {
    * embedder: openai.embedding("text-embedding-3-small")
    * ```
    */
-  embedder?: EmbeddingModelId | EmbeddingModel<string> | EmbeddingModelV2<string>;
+  embedder?: EmbeddingModelId | MastraEmbeddingModel<string>;
 
   /**
    * @deprecated This option is deprecated and will throw an error if used.

--- a/packages/core/src/vector/vector.ts
+++ b/packages/core/src/vector/vector.ts
@@ -1,6 +1,18 @@
-import type { EmbeddingModelV2 } from '@ai-sdk/provider-v5';
-import type { EmbeddingModelV3 } from '@ai-sdk/provider-v6';
-import type { EmbeddingModel as EmbeddingModelV1 } from '@internal/ai-sdk-v4';
+import type {
+  EmbeddingModel as EmbeddingModelV1,
+  ProviderOptions as ProviderOptionsV1,
+  TelemetrySettings as TelemetrySettingsV1,
+} from '@internal/ai-sdk-v4';
+import type {
+  EmbeddingModelV2,
+  TelemetrySettings as TelemetrySettingsV5,
+  ProviderOptions as ProviderOptionsV5,
+} from '@internal/ai-sdk-v5';
+import type {
+  EmbeddingModelV3,
+  TelemetrySettings as TelemetrySettingsV6,
+  ProviderOptions as ProviderOptionsV6,
+} from '@internal/ai-v6';
 import { MastraBase } from '../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { VectorFilter } from './filter';
@@ -25,6 +37,20 @@ export type MastraSupportedEmbeddingModel<T> = EmbeddingModelV2<T> | EmbeddingMo
 
 /** All supported embedding model types */
 export type MastraEmbeddingModel<T> = MastraLegacyEmbeddingModel<T> | MastraSupportedEmbeddingModel<T>;
+
+export type MastraEmbeddingOptions = {
+  maxRetries?: number;
+
+  headers?: Record<string, string>;
+  /**
+   * Optional telemetry configuration (experimental).
+   */
+  telemetry?: TelemetrySettingsV1 | TelemetrySettingsV5 | TelemetrySettingsV6;
+
+  providerOptions?: ProviderOptionsV1 | ProviderOptionsV5 | ProviderOptionsV6;
+
+  maxParallelCalls?: number;
+};
 
 /** Specification versions for supported (modern) embedding models */
 export const supportedEmbeddingModelSpecifications = ['v2', 'v3'] as const;

--- a/packages/fastembed/package.json
+++ b/packages/fastembed/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@internal/ai-sdk-v4": "workspace:*",
     "@internal/ai-sdk-v5": "workspace:*",
+    "@internal/ai-v6": "workspace:*",
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@types/node": "22.13.17",

--- a/packages/fastembed/src/index.ts
+++ b/packages/fastembed/src/index.ts
@@ -2,7 +2,7 @@ import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { customProvider as customProviderV2 } from '@internal/ai-sdk-v5';
-import { customProvider as customProvierLegacy } from '@internal/ai-sdk-v4';
+import { customProvider as customProviderLegacy } from '@internal/ai-sdk-v4';
 import type { EmbeddingModel as EmbeddingModelV3 } from '@internal/ai-v6';
 import { customProvider as customProviderV3 } from '@internal/ai-v6';
 import { FlagEmbedding, EmbeddingModel } from 'fastembed';
@@ -42,7 +42,7 @@ async function generateEmbeddings(values: string[], modelType: 'BGESmallENV15' |
 }
 
 // Legacy v1 provider for backwards compatibility
-const fastEmbedLegacyProvider = customProvierLegacy({
+const fastEmbedLegacyProvider = customProviderLegacy({
   textEmbeddingModels: {
     'bge-small-en-v1.5': {
       specificationVersion: 'v1',

--- a/packages/fastembed/src/index.ts
+++ b/packages/fastembed/src/index.ts
@@ -1,12 +1,15 @@
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { customProvider, type EmbeddingModel as EmbeddingModelV2 } from '@internal/ai-sdk-v5';
-import { experimental_customProvider } from '@internal/ai-sdk-v4';
+import { customProvider as customProviderV2 } from '@internal/ai-sdk-v5';
+import { customProvider as customProvierLegacy } from '@internal/ai-sdk-v4';
+import type { EmbeddingModel as EmbeddingModelV3 } from '@internal/ai-v6';
+import { customProvider as customProviderV3 } from '@internal/ai-v6';
 import { FlagEmbedding, EmbeddingModel } from 'fastembed';
 
 export type { EmbeddingModel as EmbeddingModelV1 } from '@internal/ai-sdk-v4';
 export type { EmbeddingModel as EmbeddingModelV2 } from '@internal/ai-sdk-v5';
+export type { EmbeddingModel as EmbeddingModelV3 } from '@internal/ai-v6';
 
 async function getModelCachePath() {
   const cachePath = path.join(os.homedir(), '.cache', 'mastra', 'fastembed-models');
@@ -39,7 +42,7 @@ async function generateEmbeddings(values: string[], modelType: 'BGESmallENV15' |
 }
 
 // Legacy v1 provider for backwards compatibility
-const fastEmbedLegacyProvider = experimental_customProvider({
+const fastEmbedLegacyProvider = customProvierLegacy({
   textEmbeddingModels: {
     'bge-small-en-v1.5': {
       specificationVersion: 'v1',
@@ -64,8 +67,8 @@ const fastEmbedLegacyProvider = experimental_customProvider({
   },
 });
 
-// // V2 provider for AI SDK v5 compatibility
-const fastEmbedProvider = customProvider({
+// V2 provider for AI SDK v5 compatibility
+const fastEmbedProviderV2 = customProviderV2({
   textEmbeddingModels: {
     'bge-small-en-v1.5': {
       specificationVersion: 'v2',
@@ -90,9 +93,39 @@ const fastEmbedProvider = customProvider({
   },
 });
 
-export const fastembed: EmbeddingModelV2 = Object.assign(fastEmbedProvider.textEmbeddingModel(`bge-small-en-v1.5`), {
-  small: fastEmbedProvider.textEmbeddingModel(`bge-small-en-v1.5`),
-  base: fastEmbedProvider.textEmbeddingModel(`bge-base-en-v1.5`),
+// V3 provider for AI SDK v6 compatibility
+const fastEmbedProviderV3 = customProviderV3({
+  embeddingModels: {
+    'bge-small-en-v1.5': {
+      specificationVersion: 'v3',
+      provider: 'fastembed',
+      modelId: 'bge-small-en-v1.5',
+      maxEmbeddingsPerCall: 256,
+      supportsParallelCalls: true,
+      async doEmbed({ values }) {
+        const result = await generateEmbeddings(values, 'BGESmallENV15');
+        return { ...result, warnings: [] };
+      },
+    },
+    'bge-base-en-v1.5': {
+      specificationVersion: 'v3',
+      provider: 'fastembed',
+      modelId: 'bge-base-en-v1.5',
+      maxEmbeddingsPerCall: 256,
+      supportsParallelCalls: true,
+      async doEmbed({ values }) {
+        const result = await generateEmbeddings(values, 'BGEBaseENV15');
+        return { ...result, warnings: [] };
+      },
+    },
+  },
+});
+
+export const fastembed: EmbeddingModelV3 = Object.assign(fastEmbedProviderV3.embeddingModel(`bge-small-en-v1.5`), {
+  small: fastEmbedProviderV3.embeddingModel(`bge-small-en-v1.5`),
+  base: fastEmbedProviderV3.embeddingModel(`bge-base-en-v1.5`),
+  smallV2: fastEmbedProviderV2.textEmbeddingModel(`bge-small-en-v1.5`),
+  baseV2: fastEmbedProviderV2.textEmbeddingModel(`bge-base-en-v1.5`),
   smallLegacy: fastEmbedLegacyProvider.textEmbeddingModel(`bge-small-en-v1.5`),
   baseLegacy: fastEmbedLegacyProvider.textEmbeddingModel(`bge-base-en-v1.5`),
 });

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@internal/ai-sdk-v4": "workspace:*",
     "@internal/ai-sdk-v5": "workspace:*",
+    "@internal/ai-v6": "workspace:*",
     "@ai-sdk/openai": "^1.3.24",
     "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.53",
     "@internal/lint": "workspace:*",

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -4,7 +4,7 @@ import { embedMany as embedManyV5 } from '@internal/ai-sdk-v5';
 import { embedMany as embedManyV6 } from '@internal/ai-v6';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+
 import { MastraMemory } from '@mastra/core/memory';
 import type {
   MastraMessageV1,
@@ -573,22 +573,18 @@ ${workingMemory}`;
     }
 
     let embedFn: typeof embedMany | typeof embedManyV5 | typeof embedManyV6;
+    const specVersion = this.embedder.specificationVersion;
 
-    if (this.embedder.specificationVersion === `v3`) {
-      embedFn = embedManyV6;
-    } else if (this.embedder.specificationVersion === `v2`) {
-      embedFn = embedManyV5;
-    } else {
-      embedFn = embedMany;
-    }
-
-    if (!embedFn) {
-      throw new MastraError({
-        id: 'EMBEDDER_INVALID_REQUEST',
-        domain: ErrorDomain.MASTRA_MEMORY,
-        category: ErrorCategory.USER,
-        text: `Tried to embed message content but this Memory instance doesn't have an attached embedder.`,
-      });
+    switch (specVersion) {
+      case 'v3':
+        embedFn = embedManyV6;
+        break;
+      case 'v2':
+        embedFn = embedManyV5;
+        break;
+      default:
+        embedFn = embedMany;
+        break;
     }
 
     const promise = embedFn({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2399,6 +2399,9 @@ importers:
       '@internal/ai-sdk-v5':
         specifier: workspace:*
         version: link:../_vendored/ai_v5
+      '@internal/ai-v6':
+        specifier: workspace:*
+        version: link:../_vendored/ai_v6
       '@internal/lint':
         specifier: workspace:*
         version: link:../_config
@@ -2710,6 +2713,9 @@ importers:
       '@internal/ai-sdk-v5':
         specifier: workspace:*
         version: link:../_vendored/ai_v5
+      '@internal/ai-v6':
+        specifier: workspace:*
+        version: link:../_vendored/ai_v6
       '@internal/lint':
         specifier: workspace:*
         version: link:../_config


### PR DESCRIPTION
## Summary
- Add AI SDK v6 embedding model support (`EmbeddingModelV3` / specification version v3) in memory and vector modules
- Fix TypeScript error where `ModelRouterEmbeddingModel` was implementing a union type instead of `EmbeddingModelV2` directly
## Changes
### `@mastra/core`
- Extended `MastraEmbeddingModel<T>` type to include `EmbeddingModelV3`
- Added `MastraEmbeddingOptions` type for embedding configuration passthrough
- Updated `Memory.setEmbedder()` to accept string model IDs (auto-wrapped in `ModelRouterEmbeddingModel`)
- Fixed `ModelRouterEmbeddingModel` to implement `EmbeddingModelV2` directly instead of the union type
### `@mastra/memory`
- Added v3 model detection to route to correct `embedMany` function (`embedManyV6` for v3, `embedManyV5` for v2, `embedMany` for v1)
- Added error handling for missing embedder
### `@mastra/fastembed`
- Updated default exports to use v3 models
- Added `.smallV2`/`.baseV2` for v2 models
- Added `.smallLegacy`/`.baseLegacy` for backwards compatibility
- Fixed `doEmbed` return type to include required `warnings` property
## Before/After
**fastembed V3 provider fix:**
```ts
// Before
async doEmbed({ values }) {
  return generateEmbeddings(values, 'BGESmallENV15');
}
// After
async doEmbed({ values }) {
  const result = await generateEmbeddings(values, 'BGESmallENV15');
  return { ...result, warnings: [] };
}
```

Fixes https://github.com/mastra-ai/mastra/issues/11344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript type compatibility issue with embedding models.

* **New Features**
  * Added support for AI SDK v6 embedding models.
  * Added support for multiple embedding model versions.
  * Enhanced memory configuration with new embedding options including retry limits, headers, and telemetry settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->