### PR TITLE
fix(core): prevent reasoning itemId from being used as assistant message id

### DIFF
--- a/.changeset/fix-reasoning-id-message.md
+++ b/.changeset/fix-reasoning-id-message.md
@@ -1,0 +1,12 @@
+---
+"@mastra/core": patch
+---
+
+fix(core): prevent reasoning itemId from being used as assistant message id
+
+Fixed an issue where OpenAI reasoning models would fail with "reasoning item without required following item" error on follow-up messages. The problem was that text parts were incorrectly inheriting the reasoning's `providerMetadata` (containing `openai.itemId: 'rs_...'`), which the OpenAI SDK then used as the assistant message's `id`. This caused OpenAI to reject the request because assistant messages must have `msg_` prefixed IDs.
+
+The fix introduces `textProviderMetadata` to capture text-specific metadata separately from reasoning metadata, ensuring text parts don't inherit the reasoning's `itemId`.
+
+Fixes #11103
+

--- a/packages/core/src/loop/workflows/run-state.ts
+++ b/packages/core/src/loop/workflows/run-state.ts
@@ -16,6 +16,9 @@ type State = {
   isReasoning: boolean;
   isStreaming: boolean;
   providerOptions: Record<string, any> | undefined;
+  // Separate text-specific providerMetadata to avoid inheriting reasoning's itemId
+  // See: https://github.com/mastra-ai/mastra/issues/11103
+  textProviderMetadata: Record<string, any> | undefined;
 };
 
 export class AgenticRunState {
@@ -38,6 +41,7 @@ export class AgenticRunState {
       isReasoning: false,
       isStreaming: false,
       providerOptions: undefined,
+      textProviderMetadata: undefined,
       hasToolCallStreaming: false,
       hasErrored: false,
       reasoningDeltas: [],


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)
Fixes #11103


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a metadata handling issue that caused follow-up messages to fail when using reasoning features. Messages now correctly process without triggering OpenAI validation errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->