### PR TITLE
fix: preserve optionality in OpenAI schema compat layer for MCP tools

### DIFF
--- a/.changeset/twenty-zebras-jump.md
+++ b/.changeset/twenty-zebras-jump.md
@@ -1,0 +1,28 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixes #11016
+
+When MCP tools with optional fields were used with OpenAI models, validation failed with "Required" errors when OpenAI omitted those fields.
+
+The issue was in `OpenAISchemaCompatLayer.processZodType()` - it converted `.optional()` to just `.nullable().transform()`, which made fields required (but nullable) instead of truly optional.
+
+Before:
+
+```ts
+// .optional() -> .nullable().transform()
+return processedInner.nullable().transform(val => (val === null ? undefined : val));
+```
+
+After:
+
+```ts
+// .optional() -> .nullable().optional().transform()
+return processedInner
+  .nullable()
+  .optional()
+  .transform(val => (val === null ? undefined : val));
+```
+
+The order matters here - `nullable().optional().transform()` keeps the field in the JSON Schema's `required` array (because transform is outermost), but validation now accepts both `null` and `undefined`.

--- a/packages/schema-compat/src/provider-compats/openai.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.test.ts
@@ -505,3 +505,188 @@ describe('OpenAISchemaCompatLayer - shouldApply', () => {
     expect(layer.shouldApply()).toBe(false);
   });
 });
+
+describe('OpenAISchemaCompatLayer - MCP Tool Optional Fields (Issue #11016)', () => {
+  /**
+   * This test reproduces the bug reported in GitHub issue #11016:
+   * https://github.com/mastra-ai/mastra/issues/11016
+   *
+   * When MCP tools with optional fields are used with OpenAI models:
+   * 1. The JSON Schema from MCP has fields NOT in the "required" array (meaning they're optional)
+   * 2. When converted to Zod, these fields become .optional()
+   * 3. OpenAI's schema compat layer converts .optional() to .nullable() for strict mode
+   * 4. BUT when OpenAI doesn't provide a value for these fields (omits them entirely),
+   *    the validation fails with "Required" errors
+   *
+   * The issue is that the .optional() wrapper is being stripped during processing,
+   * making the fields required (but nullable) instead of truly optional.
+   */
+  const modelInfo: ModelInformation = {
+    provider: 'openai',
+    modelId: 'gpt-4.1',
+    supportsStructuredOutputs: false,
+  };
+
+  it('should accept omitted optional fields (reproduces issue #11016)', () => {
+    // This schema mimics the Perplexity MCP tool from the issue:
+    // - systemContent and userContent are required
+    // - All other fields are optional (not in required array)
+    const schema = z.object({
+      frequency_penalty: z.number().gt(0).optional(),
+      presence_penalty: z.number().min(-2).max(2).optional(),
+      stream: z.boolean().optional(),
+      systemContent: z.string(),
+      userContent: z.string(),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    // When OpenAI calls the tool, it might only provide the required fields
+    // and OMIT the optional ones entirely (not pass null, just not include them)
+    const result = processed.safeParse({
+      systemContent: 'You are a helpful assistant.',
+      userContent: 'What is the weather?',
+      // frequency_penalty: NOT PROVIDED
+      // presence_penalty: NOT PROVIDED
+      // stream: NOT PROVIDED
+    });
+
+    // This should succeed because these fields are optional
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        systemContent: 'You are a helpful assistant.',
+        userContent: 'What is the weather?',
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+        stream: undefined,
+      });
+    }
+  });
+
+  it('should accept null for optional fields and transform to undefined', () => {
+    const schema = z.object({
+      frequency_penalty: z.number().gt(0).optional(),
+      presence_penalty: z.number().min(-2).max(2).optional(),
+      stream: z.boolean().optional(),
+      systemContent: z.string(),
+      userContent: z.string(),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    // When OpenAI passes null for optional fields (as per strict mode)
+    const result = processed.safeParse({
+      frequency_penalty: null,
+      presence_penalty: null,
+      stream: null,
+      systemContent: 'You are a helpful assistant.',
+      userContent: 'What is the weather?',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        systemContent: 'You are a helpful assistant.',
+        userContent: 'What is the weather?',
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+        stream: undefined,
+      });
+    }
+  });
+
+  it('should accept valid values for optional fields', () => {
+    const schema = z.object({
+      frequency_penalty: z.number().gt(0).optional(),
+      presence_penalty: z.number().min(-2).max(2).optional(),
+      stream: z.boolean().optional(),
+      systemContent: z.string(),
+      userContent: z.string(),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    // When OpenAI provides values for optional fields
+    const result = processed.safeParse({
+      frequency_penalty: 0.5,
+      presence_penalty: 1.0,
+      stream: true,
+      systemContent: 'You are a helpful assistant.',
+      userContent: 'What is the weather?',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        frequency_penalty: 0.5,
+        presence_penalty: 1.0,
+        stream: true,
+        systemContent: 'You are a helpful assistant.',
+        userContent: 'What is the weather?',
+      });
+    }
+  });
+
+  it('should handle Google Calendar MCP schema with optional fields', () => {
+    // This schema mimics the events_list tool from Google Calendar MCP
+    // where maxAttendees and maxResults are optional integer fields
+    const schema = z.object({
+      calendarId: z.string(),
+      maxAttendees: z.number().int().optional(),
+      maxResults: z.number().int().optional(),
+      orderBy: z.enum(['startTime', 'updated']).optional(),
+      timeMin: z.string().optional(),
+      timeMax: z.string().optional(),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    // OpenAI omits optional fields
+    const result = processed.safeParse({
+      calendarId: 'primary',
+      // All optional fields omitted
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.calendarId).toBe('primary');
+      expect(result.data.maxAttendees).toBeUndefined();
+      expect(result.data.maxResults).toBeUndefined();
+    }
+  });
+
+  it('should handle mix of omitted and null optional fields', () => {
+    const schema = z.object({
+      required_field: z.string(),
+      optional_string: z.string().optional(),
+      optional_number: z.number().optional(),
+      optional_boolean: z.boolean().optional(),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    // Mix of omitted and null
+    const result = processed.safeParse({
+      required_field: 'test',
+      optional_string: null, // Explicitly null
+      // optional_number: omitted
+      optional_boolean: null, // Explicitly null
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        required_field: 'test',
+        optional_string: undefined,
+        optional_number: undefined,
+        optional_boolean: undefined,
+      });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #11016

When MCP tools with optional fields were used with OpenAI models, validation failed with "Required" errors when OpenAI omitted those fields.

The issue was in `OpenAISchemaCompatLayer.processZodType()` - it converted `.optional()` to just `.nullable().transform()`, which made fields required (but nullable) instead of truly optional.

Before:
```ts
// .optional() -> .nullable().transform()
return processedInner.nullable().transform((val) => val === null ? undefined : val);
```

After:
```ts
// .optional() -> .nullable().optional().transform()
return processedInner.nullable().optional().transform((val) => val === null ? undefined : val);
```

The order matters here - `nullable().optional().transform()` keeps the field in the JSON Schema's `required` array (because transform is outermost), but validation now accepts both `null` and `undefined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation of optional fields in OpenAI/MCP compatibility layer. Optional fields can now be properly omitted or set to null without causing validation failures, improving compatibility with MCP tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->