### PR TITLE
run e2e tests on more folders

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -41,6 +41,9 @@ jobs:
             e2e:
               - '!(**/*.md)packages/**'
               - '!(**/*.md)e2e-tests/**'
+              - '!(**/*.md)stores/**'
+              - '!(**/*.md)client-sdks/**'
+              - '!(**/*.md)deployers/**'
               - '.github/workflows/secrets.e2e.yml'
 
   skip-tests:


### PR DESCRIPTION
Our e2e tests test storage providers, client side packages, and deployers but on changes those pieces of code we previously didn't run the e2e tests for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded end-to-end test configuration to trigger tests for additional code areas. Changes affecting stores, client-sdks, and deployers now automatically run end-to-end tests, increasing test coverage and ensuring comprehensive quality assurance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->