### PR TITLE
feat(core): add support for AI SDK needsApproval in tools

### DIFF
--- a/.changeset/chubby-planes-shop.md
+++ b/.changeset/chubby-planes-shop.md
@@ -2,4 +2,54 @@
 '@mastra/core': patch
 ---
 
-Add support for AI SDK's `needsApproval` in tools. Tools created with AI SDK's `tool()` function can now use `needsApproval` (boolean or function) which will be mapped to Mastra's internal `requireApproval` system. This enables tool execution approval for both Mastra tools (`createTool` with `requireApproval`) and AI SDK tools (`tool` with `needsApproval`). Also fixes `isVercelTool()` to recognize AI SDK v6 tools that use `inputSchema` instead of `parameters`.
+Add support for AI SDK's `needsApproval` in tools.
+
+**AI SDK tools with static approval:**
+
+```typescript
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const weatherTool = tool({
+  description: 'Get weather information',
+  parameters: z.object({ city: z.string() }),
+  needsApproval: true,
+  execute: async ({ city }) => {
+    return { weather: 'sunny', temp: 72 };
+  },
+});
+```
+
+**AI SDK tools with dynamic approval:**
+
+```typescript
+const paymentTool = tool({
+  description: 'Process payment',
+  parameters: z.object({ amount: z.number() }),
+  needsApproval: async ({ amount }) => amount > 1000,
+  execute: async ({ amount }) => {
+    return { success: true, amount };
+  },
+});
+```
+
+**Mastra tools continue to work with `requireApproval`:**
+
+```typescript
+import { createTool } from '@mastra/core';
+
+const deleteTool = createTool({
+  id: 'delete-file',
+  description: 'Delete a file',
+  inputSchema: z.object({ path: z.string() }),
+  requireApproval: true,
+  execute: async ({ path }) => {
+    return { deleted: true };
+  },
+});
+```
+
+**What changed:**
+- AI SDK's `needsApproval` (boolean or function) now maps to Mastra's `requireApproval`
+- Function-based approval is evaluated dynamically at tool execution time
+- Fixed `isVercelTool()` to recognize AI SDK v6 tools using `inputSchema` instead of `parameters`

--- a/.changeset/chubby-planes-shop.md
+++ b/.changeset/chubby-planes-shop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add support for AI SDK's `needsApproval` in tools. Tools created with AI SDK's `tool()` function can now use `needsApproval` (boolean or function) which will be mapped to Mastra's internal `requireApproval` system. This enables tool execution approval for both Mastra tools (`createTool` with `requireApproval`) and AI SDK tools (`tool` with `needsApproval`). Also fixes `isVercelTool()` to recognize AI SDK v6 tools that use `inputSchema` instead of `parameters`.

--- a/.changeset/chubby-planes-shop.md
+++ b/.changeset/chubby-planes-shop.md
@@ -12,7 +12,7 @@ import { z } from 'zod';
 
 const weatherTool = tool({
   description: 'Get weather information',
-  parameters: z.object({ city: z.string() }),
+  inputSchema: z.object({ city: z.string() }),
   needsApproval: true,
   execute: async ({ city }) => {
     return { weather: 'sunny', temp: 72 };
@@ -25,7 +25,7 @@ const weatherTool = tool({
 ```typescript
 const paymentTool = tool({
   description: 'Process payment',
-  parameters: z.object({ amount: z.number() }),
+  inputSchema: z.object({ amount: z.number() }),
   needsApproval: async ({ amount }) => amount > 1000,
   execute: async ({ amount }) => {
     return { success: true, amount };
@@ -41,15 +41,10 @@ import { createTool } from '@mastra/core';
 const deleteTool = createTool({
   id: 'delete-file',
   description: 'Delete a file',
-  inputSchema: z.object({ path: z.string() }),
   requireApproval: true,
+  inputSchema: z.object({ path: z.string() }),
   execute: async ({ path }) => {
     return { deleted: true };
   },
 });
 ```
-
-**What changed:**
-- AI SDK's `needsApproval` (boolean or function) now maps to Mastra's `requireApproval`
-- Function-based approval is evaluated dynamically at tool execution time
-- Fixed `isVercelTool()` to recognize AI SDK v6 tools using `inputSchema` instead of `parameters`

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -207,20 +207,6 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT ext
           createdAt: new Date(),
         };
 
-        console.log('[TOOL-APPROVAL-DEBUG] Adding tool result message to messageList:');
-        console.log('[TOOL-APPROVAL-DEBUG] Role:', toolResultMessage.role);
-        console.log(
-          '[TOOL-APPROVAL-DEBUG] Tool results:',
-          JSON.stringify(
-            inputData.map(tc => ({
-              toolName: tc.toolName,
-              result: tc.result,
-            })),
-            null,
-            2,
-          ),
-        );
-
         rest.messageList.add(toolResultMessage, 'response');
 
         // Check if any tool calls were declined (result indicates denial/not approved)
@@ -245,8 +231,6 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT ext
             `IMPORTANT: The following tool(s) were explicitly DENIED by the user: ${declinedTools}. You MUST NOT retry calling these tools. The user has declined these actions. Acknowledge this and provide alternative assistance without attempting to use these tools again.`,
             'tool-approval-declined',
           );
-
-          console.log('[TOOL-APPROVAL-DEBUG] Added system message for declined tools:', declinedTools);
         }
 
         return {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -209,30 +209,6 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT ext
 
         rest.messageList.add(toolResultMessage, 'response');
 
-        // Check if any tool calls were declined (result indicates denial/not approved)
-        const hasDeclinedApprovals = inputData.some(
-          toolCall =>
-            typeof toolCall.result === 'string' &&
-            (toolCall.result.includes('denied by the user') || toolCall.result.includes('not approved by the user')),
-        );
-
-        // Add system message to prevent the model from retrying declined tool calls
-        if (hasDeclinedApprovals) {
-          const declinedTools = inputData
-            .filter(
-              tc =>
-                typeof tc.result === 'string' &&
-                (tc.result.includes('denied by the user') || tc.result.includes('not approved by the user')),
-            )
-            .map(tc => tc.toolName)
-            .join(', ');
-
-          rest.messageList.addSystem(
-            `IMPORTANT: The following tool(s) were explicitly DENIED by the user: ${declinedTools}. You MUST NOT retry calling these tools. The user has declined these actions. Acknowledge this and provide alternative assistance without attempting to use these tools again.`,
-            'tool-approval-declined',
-          );
-        }
-
         return {
           ...initialResult,
           messages: {

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -220,12 +220,14 @@ export function createToolCallStep<
         // - undefined (no approval needed)
         // If needsApprovalFn exists, evaluate it with the tool args
         let toolRequiresApproval = requireToolApproval || (tool as any).requireApproval;
-        if (toolRequiresApproval && (tool as any).needsApprovalFn) {
+        if ((tool as any).needsApprovalFn) {
           // Evaluate the function with the parsed args
           try {
             const needsApprovalResult = await (tool as any).needsApprovalFn(args);
             toolRequiresApproval = needsApprovalResult;
-          } catch {
+          } catch (error) {
+            // Log error to help developers debug faulty needsApprovalFn implementations
+            console.error(`Error evaluating needsApprovalFn for tool ${inputData.toolName}:`, error);
             // On error, default to requiring approval to be safe
             toolRequiresApproval = true;
           }

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -214,7 +214,24 @@ export function createToolCallStep<
 
         const isResumeToolCall = !!resumeDataFromArgs;
 
-        if (requireToolApproval || (tool as any).requireApproval) {
+        // Check if approval is required
+        // requireApproval can be:
+        // - boolean (from Mastra createTool or mapped from AI SDK needsApproval: true)
+        // - undefined (no approval needed)
+        // If needsApprovalFn exists, evaluate it with the tool args
+        let toolRequiresApproval = requireToolApproval || (tool as any).requireApproval;
+        if (toolRequiresApproval && (tool as any).needsApprovalFn) {
+          // Evaluate the function with the parsed args
+          try {
+            const needsApprovalResult = await (tool as any).needsApprovalFn(args);
+            toolRequiresApproval = needsApprovalResult;
+          } catch {
+            // On error, default to requiring approval to be safe
+            toolRequiresApproval = true;
+          }
+        }
+
+        if (toolRequiresApproval) {
           if (!resumeData) {
             controller.enqueue({
               type: 'tool-call-approval',

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -599,10 +599,28 @@ export class CoreToolBuilder extends MastraBase {
       });
     }
 
+    // Map AI SDK's needsApproval to our requireApproval
+    // needsApproval can be boolean or a function that takes input and returns boolean
+    let requireApproval = this.options.requireApproval;
+    let needsApprovalFn: ((input: any) => boolean | Promise<boolean>) | undefined;
+
+    if (isVercelTool(this.originalTool) && 'needsApproval' in this.originalTool) {
+      const needsApproval = (this.originalTool as any).needsApproval;
+      if (typeof needsApproval === 'boolean') {
+        requireApproval = needsApproval;
+      } else if (typeof needsApproval === 'function') {
+        // Store the function to evaluate it per-call
+        needsApprovalFn = needsApproval;
+        // Set requireApproval to true so the tool-call-step knows to check the function
+        requireApproval = true;
+      }
+    }
+
     const definition = {
       type: 'function' as const,
       description: this.originalTool.description,
-      requireApproval: this.options.requireApproval,
+      requireApproval,
+      needsApprovalFn,
       hasSuspendSchema: !!this.getSuspendSchema(),
       execute: this.originalTool.execute
         ? this.createExecute(

--- a/packages/core/src/tools/toolchecks.ts
+++ b/packages/core/src/tools/toolchecks.ts
@@ -8,7 +8,15 @@ import type { VercelTool } from './types';
  * @returns True if the tool is a Vercel Tool, false otherwise
  */
 export function isVercelTool(tool?: ToolToConvert): tool is VercelTool {
-  // Checks if this tool is not an instance of Tool
-  // AI SDK v4 tools have 'parameters', v5/v6 tools have 'inputSchema'
-  return !!(tool && !(tool instanceof Tool) && ('parameters' in tool || 'inputSchema' in tool));
+  // Checks if this tool is not an instance of Mastra's Tool class
+  // AI SDK tools must have an execute function and either:
+  // - 'parameters' (v4) or 'inputSchema' (v5/v6)
+  // This prevents plain objects with inputSchema (like client tools) from being treated as VercelTools
+  return !!(
+    tool &&
+    !(tool instanceof Tool) &&
+    'execute' in tool &&
+    typeof tool.execute === 'function' &&
+    ('parameters' in tool || 'inputSchema' in tool)
+  );
 }

--- a/packages/core/src/tools/toolchecks.ts
+++ b/packages/core/src/tools/toolchecks.ts
@@ -15,8 +15,6 @@ export function isVercelTool(tool?: ToolToConvert): tool is VercelTool {
   return !!(
     tool &&
     !(tool instanceof Tool) &&
-    'execute' in tool &&
-    typeof tool.execute === 'function' &&
-    ('parameters' in tool || 'inputSchema' in tool)
+    ('parameters' in tool || ('execute' in tool && typeof tool.execute === 'function' && 'inputSchema' in tool))
   );
 }

--- a/packages/core/src/tools/toolchecks.ts
+++ b/packages/core/src/tools/toolchecks.ts
@@ -3,11 +3,12 @@ import type { ToolToConvert } from './tool-builder/builder';
 import type { VercelTool } from './types';
 
 /**
- * Checks if a tool is a Vercel Tool
+ * Checks if a tool is a Vercel Tool (AI SDK tool)
  * @param tool - The tool to check
  * @returns True if the tool is a Vercel Tool, false otherwise
  */
 export function isVercelTool(tool?: ToolToConvert): tool is VercelTool {
   // Checks if this tool is not an instance of Tool
-  return !!(tool && !(tool instanceof Tool) && 'parameters' in tool);
+  // AI SDK v4/v5 tools have 'parameters', v6 tools have 'inputSchema'
+  return !!(tool && !(tool instanceof Tool) && ('parameters' in tool || 'inputSchema' in tool));
 }

--- a/packages/core/src/tools/toolchecks.ts
+++ b/packages/core/src/tools/toolchecks.ts
@@ -9,6 +9,6 @@ import type { VercelTool } from './types';
  */
 export function isVercelTool(tool?: ToolToConvert): tool is VercelTool {
   // Checks if this tool is not an instance of Tool
-  // AI SDK v4/v5 tools have 'parameters', v6 tools have 'inputSchema'
+  // AI SDK v4 tools have 'parameters', v5/v6 tools have 'inputSchema'
   return !!(tool && !(tool instanceof Tool) && ('parameters' in tool || 'inputSchema' in tool));
 }


### PR DESCRIPTION
## Description

Adds support for AI SDK's `needsApproval` field in tools, enabling tool execution approval for both Mastra tools and AI SDK tools.

### Changes

1. **Map `needsApproval` to `requireApproval`**: When using AI SDK's `tool()` function with `needsApproval`, it now correctly maps to Mastra's internal `requireApproval` system
2. **Support boolean and function forms**: Handles both `needsApproval: true` and `needsApproval: ({ input }) => input.amount > 1000`
3. **Fix AI SDK v6 tool detection**: Updated `isVercelTool()` to recognize AI SDK v6 tools that use `inputSchema` instead of `parameters`
4. **Dynamic approval evaluation**: When `needsApproval` is a function, it's evaluated at tool execution time with the actual tool arguments

### Example Usage

```typescript
import { tool } from 'ai';

// Boolean approval
const weatherTool = tool({
  description: 'Get weather info',
  parameters: z.object({ city: z.string() }),
  needsApproval: true,
  execute: async ({ city }) => { /* ... */ },
});

// Dynamic approval based on input
const paymentTool = tool({
  description: 'Process payment',
  parameters: z.object({ amount: z.number() }),
  needsApproval: async ({ amount }) => amount > 1000,
  execute: async ({ amount }) => { /* ... */ },
});
```

### Before

- AI SDK tools with `needsApproval` were not recognized
- Tools would execute without requesting approval
- `isVercelTool()` only recognized v4/v5 tools with `parameters`

### After

- AI SDK tools with `needsApproval` correctly trigger approval flow
- Both static and dynamic approval conditions work
- AI SDK v6 tools are properly detected

## Related Issue(s)

Part of AI SDK v6 tool approval support work

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (fixes AI SDK v6 tool detection)

## Checklist

- [x] Code changes tested with both Mastra `createTool` and AI SDK `tool()`
- [x] Tested with both boolean and function forms of `needsApproval`
- [x] Verified approval flow works for declined and approved tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can now declare per-call approval with a new needsApproval option (boolean or async function) enabling dynamic, conditional approval flows.
  * Per-call evaluation supports async logic and safer defaulting to require approval on errors.

* **Bug Fixes / Compatibility**
  * Improved recognition and compatibility with newer AI SDK tool formats (input schema/execute patterns).
  * Existing requireApproval-based tools continue to operate as before.

* **Documentation**
  * Added changeset documenting needsApproval usage and examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->