### PR TITLE
fix: support gs:// and s3:// cloud storage URLs in attachmentsToParts

### DIFF
--- a/.changeset/fix-gs-protocol-attachments.md
+++ b/.changeset/fix-gs-protocol-attachments.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+fix: support gs:// and s3:// cloud storage URLs in attachmentsToParts

--- a/packages/core/src/agent/message-list/prompt/attachments-to-parts.test.ts
+++ b/packages/core/src/agent/message-list/prompt/attachments-to-parts.test.ts
@@ -266,6 +266,83 @@ describe('attachmentsToParts', () => {
     expect(imagePart.image).toBe('https://example.com/images/my%20image%20(1).png');
   });
 
+  // Issue #11384: Support Google Cloud Storage gs:// URLs
+  it('should handle Google Cloud Storage gs:// URLs for images', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 'gs://my-bucket/path/to/image.png',
+        contentType: 'image/png',
+        name: 'image.png',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const imagePart = parts[0] as ImagePart;
+    expect(imagePart).toMatchObject({
+      type: 'image',
+      image: 'gs://my-bucket/path/to/image.png',
+      mimeType: 'image/png',
+    });
+  });
+
+  it('should handle Google Cloud Storage gs:// URLs for non-image files', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 'gs://my-bucket/path/to/document.pdf',
+        contentType: 'application/pdf',
+        name: 'document.pdf',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const filePart = parts[0] as unknown as FilePart;
+    expect(filePart).toMatchObject({
+      type: 'file',
+      data: 'gs://my-bucket/path/to/document.pdf',
+      mimeType: 'application/pdf',
+    });
+  });
+
+  it('should handle AWS S3 s3:// URLs for images', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 's3://my-bucket/path/to/image.jpg',
+        contentType: 'image/jpeg',
+        name: 'image.jpg',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const imagePart = parts[0] as ImagePart;
+    expect(imagePart).toMatchObject({
+      type: 'image',
+      image: 's3://my-bucket/path/to/image.jpg',
+      mimeType: 'image/jpeg',
+    });
+  });
+
+  it('should handle AWS S3 s3:// URLs for non-image files', () => {
+    const attachments: Attachment[] = [
+      {
+        url: 's3://my-bucket/path/to/document.pdf',
+        contentType: 'application/pdf',
+        name: 'document.pdf',
+      },
+    ];
+
+    const parts = attachmentsToParts(attachments);
+    expect(parts).toHaveLength(1);
+    const filePart = parts[0] as unknown as FilePart;
+    expect(filePart).toMatchObject({
+      type: 'file',
+      data: 's3://my-bucket/path/to/document.pdf',
+      mimeType: 'application/pdf',
+    });
+  });
+
   it('should not convert URLs to data URIs', () => {
     // URLs should remain as URLs, not be converted to data URIs
     const attachments: Attachment[] = [

--- a/packages/core/src/agent/message-list/prompt/attachments-to-parts.ts
+++ b/packages/core/src/agent/message-list/prompt/attachments-to-parts.ts
@@ -31,7 +31,10 @@ export function attachmentsToParts(attachments: Attachment[]): ContentPart[] {
 
     switch (url.protocol) {
       case 'http:':
-      case 'https:': {
+      case 'https:':
+      // Cloud storage protocols supported by AI providers (e.g., Vertex AI for gs://, Bedrock for s3://)
+      case 'gs:':
+      case 's3:': {
         if (attachment.contentType?.startsWith('image/')) {
           parts.push({ type: 'image', image: url.toString(), mimeType: attachment.contentType });
         } else {


### PR DESCRIPTION
Fixes #11384

When using Vertex AI with Google Cloud Storage URLs (`gs://...`), the agent works fine but throws an error when saving memory because `attachmentsToParts` only handles `http:`, `https:`, and `data:` protocols.

Before:
```
Error: Unsupported URL protocol: gs:
    at attachmentsToParts (...)
```

After, cloud storage URLs are passed through to the AI SDK which handles them natively:

```typescript
const response = await agent.generate([
  {
    role: 'user',
    content: [
      { type: 'text', text: 'check the image' },
      { type: 'file', data: 'gs://my-bucket/image.png', mimeType: 'image/png' },
    ],
  },
]);
// Works without error
```

Added support for `gs://` (Google Cloud Storage) and `s3://` (AWS S3) protocols.