### PR TITLE
Fixes  tracing model_step span start time appearing later than expected.

### DIFF
--- a/.changeset/fix-model-step-span-starttime.md
+++ b/.changeset/fix-model-step-span-starttime.md
@@ -1,0 +1,12 @@
+---
+"@mastra/core": patch
+"@mastra/observability": patch
+---
+
+fix(observability): start MODEL_STEP span at beginning of LLM execution
+
+The MODEL_STEP span was being created when the step-start chunk arrived (after the model API call completed), causing the span's startTime to be close to its endTime instead of accurately reflecting when the step began.
+
+This fix ensures MODEL_STEP spans capture the full duration of each LLM execution step, including the API call latency, by starting the span at the beginning of the step execution rather than when the response starts streaming.
+
+Fixes #11271

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -2073,12 +2073,8 @@ describe('Tracing Integration Tests', () => {
   });
 
   it('should have MODEL_STEP span startTime close to MODEL_GENERATION startTime, not endTime (issue #11271)', async () => {
-    // This test reproduces the bug where MODEL_STEP spans have incorrect startTime
-    // because the span is created when the step-start chunk arrives (late in the stream)
-    // rather than when the model API call actually started.
-    //
-    // Expected: MODEL_STEP startTime should be close to MODEL_GENERATION startTime
-    // Bug: MODEL_STEP startTime is close to MODEL_GENERATION endTime
+    // This test verifies that MODEL_STEP spans have correct startTime.
+    // The span should start when the model API call begins, not when the response starts streaming.
 
     const SIMULATED_MODEL_DELAY_MS = 100; // Simulate model processing time before first token
 
@@ -2158,24 +2154,10 @@ describe('Tracing Integration Tests', () => {
       startOffset: `${stepStartOffset}ms from generation start`,
     });
 
-    // BUG ASSERTION: The MODEL_STEP span startTime should be close to the MODEL_GENERATION startTime.
-    // Currently, due to the bug, the MODEL_STEP span starts late (close to when the first chunk arrives).
-    //
-    // This test is expected to FAIL until the bug is fixed.
-    // When the bug is fixed:
-    // - stepStartOffset should be small (close to 0ms)
-    // - stepStart should NOT be close to generationEnd
-    //
-    // With the bug:
-    // - stepStartOffset is close to SIMULATED_MODEL_DELAY_MS
-    // - stepStart is close to generationEnd
-
     // The step should start close to when the generation started (within 50ms tolerance)
-    // This assertion will FAIL with the current bug
     expect(stepStartOffset).toBeLessThan(50);
 
     // The step should NOT start close to when the generation ended
-    // This is a secondary check that should also fail with the bug
     const stepStartToGenerationEnd = generationEnd - stepStart;
     expect(stepStartToGenerationEnd).toBeGreaterThan(50);
 

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -2142,7 +2142,6 @@ describe('Tracing Integration Tests', () => {
     const generationStart = generationSpan.startTime.getTime();
     const generationEnd = generationSpan.endTime!.getTime();
     const stepStart = stepSpan.startTime.getTime();
-    const _stepEnd = stepSpan.endTime!.getTime();
 
     const generationDuration = generationEnd - generationStart;
     const stepStartOffset = stepStart - generationStart;

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -2071,4 +2071,115 @@ describe('Tracing Integration Tests', () => {
 
     testExporter.finalExpectations();
   });
+
+  it('should have MODEL_STEP span startTime close to MODEL_GENERATION startTime, not endTime (issue #11271)', async () => {
+    // This test reproduces the bug where MODEL_STEP spans have incorrect startTime
+    // because the span is created when the step-start chunk arrives (late in the stream)
+    // rather than when the model API call actually started.
+    //
+    // Expected: MODEL_STEP startTime should be close to MODEL_GENERATION startTime
+    // Bug: MODEL_STEP startTime is close to MODEL_GENERATION endTime
+
+    const SIMULATED_MODEL_DELAY_MS = 100; // Simulate model processing time before first token
+
+    const delayedMockModel = new MockLanguageModelV2({
+      doStream: async () => {
+        // Simulate model processing delay before first token
+        await new Promise(resolve => setTimeout(resolve, SIMULATED_MODEL_DELAY_MS));
+
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'response-metadata', id: 'resp-1' },
+            { type: 'text-delta', id: '1', delta: 'Hello ' },
+            { type: 'text-delta', id: '2', delta: 'world' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const delayedAgent = new Agent({
+      id: 'delayed-agent',
+      name: 'Delayed Agent',
+      instructions: 'You are a test agent',
+      model: delayedMockModel,
+    });
+
+    const mastra = new Mastra({
+      ...getBaseMastraConfig(testExporter),
+      agents: { delayedAgent },
+    });
+
+    const agent = mastra.getAgent('delayedAgent');
+    const result = await agent.stream('Hello');
+
+    // Consume the stream to trigger span lifecycle
+    let fullText = '';
+    for await (const chunk of result.textStream) {
+      fullText += chunk;
+    }
+    expect(fullText).toBe('Hello world');
+
+    const llmGenerationSpans = testExporter.getSpansByType(SpanType.MODEL_GENERATION);
+    const llmStepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+
+    expect(llmGenerationSpans.length).toBe(1);
+    expect(llmStepSpans.length).toBe(1);
+
+    const generationSpan = llmGenerationSpans[0]!;
+    const stepSpan = llmStepSpans[0]!;
+
+    // Both spans should have defined times
+    expect(generationSpan.startTime).toBeDefined();
+    expect(generationSpan.endTime).toBeDefined();
+    expect(stepSpan.startTime).toBeDefined();
+    expect(stepSpan.endTime).toBeDefined();
+
+    const generationStart = generationSpan.startTime.getTime();
+    const generationEnd = generationSpan.endTime!.getTime();
+    const stepStart = stepSpan.startTime.getTime();
+    const stepEnd = stepSpan.endTime!.getTime();
+
+    const generationDuration = generationEnd - generationStart;
+    const stepStartOffset = stepStart - generationStart;
+
+    // Log values for debugging (only visible in verbose mode or on failure)
+    console.log('MODEL_GENERATION span:', {
+      start: generationSpan.startTime.toISOString(),
+      end: generationSpan.endTime!.toISOString(),
+      duration: `${generationDuration}ms`,
+    });
+    console.log('MODEL_STEP span:', {
+      start: stepSpan.startTime.toISOString(),
+      end: stepSpan.endTime!.toISOString(),
+      startOffset: `${stepStartOffset}ms from generation start`,
+    });
+
+    // BUG ASSERTION: The MODEL_STEP span startTime should be close to the MODEL_GENERATION startTime.
+    // Currently, due to the bug, the MODEL_STEP span starts late (close to when the first chunk arrives).
+    //
+    // This test is expected to FAIL until the bug is fixed.
+    // When the bug is fixed:
+    // - stepStartOffset should be small (close to 0ms)
+    // - stepStart should NOT be close to generationEnd
+    //
+    // With the bug:
+    // - stepStartOffset is close to SIMULATED_MODEL_DELAY_MS
+    // - stepStart is close to generationEnd
+
+    // The step should start close to when the generation started (within 50ms tolerance)
+    // This assertion will FAIL with the current bug
+    expect(stepStartOffset).toBeLessThan(50);
+
+    // The step should NOT start close to when the generation ended
+    // This is a secondary check that should also fail with the bug
+    const stepStartToGenerationEnd = generationEnd - stepStart;
+    expect(stepStartToGenerationEnd).toBeGreaterThan(50);
+
+    testExporter.finalExpectations();
+  });
 });

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -2142,7 +2142,7 @@ describe('Tracing Integration Tests', () => {
     const generationStart = generationSpan.startTime.getTime();
     const generationEnd = generationSpan.endTime!.getTime();
     const stepStart = stepSpan.startTime.getTime();
-    const stepEnd = stepSpan.endTime!.getTime();
+    const _stepEnd = stepSpan.endTime!.getTime();
 
     const generationDuration = generationEnd - generationStart;
     const stepStartOffset = stepStart - generationStart;

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -106,9 +106,16 @@ export class ModelSpanTracker {
   }
 
   /**
-   * Start a new Model execution step
+   * Start a new Model execution step.
+   * This should be called at the beginning of LLM execution to capture accurate startTime.
+   * The step-start chunk payload can be passed later via updateStep() if needed.
    */
-  #startStepSpan(payload?: StepStartPayload) {
+  startStep(payload?: StepStartPayload): void {
+    // Don't create duplicate step spans
+    if (this.#currentStepSpan) {
+      return;
+    }
+
     this.#currentStepSpan = this.#modelSpan?.createChildSpan({
       name: `step: ${this.#stepIndex}`,
       type: SpanType.MODEL_STEP,
@@ -121,6 +128,25 @@ export class ModelSpanTracker {
     });
     // Reset chunk sequence for new step
     this.#chunkSequence = 0;
+  }
+
+  /**
+   * Update the current step span with additional payload data.
+   * Called when step-start chunk arrives with request/warnings info.
+   */
+  updateStep(payload?: StepStartPayload): void {
+    if (!this.#currentStepSpan || !payload) {
+      return;
+    }
+
+    // Update span with request/warnings from the step-start chunk
+    this.#currentStepSpan.update({
+      input: payload.request,
+      attributes: {
+        ...(payload.messageId ? { messageId: payload.messageId } : {}),
+        ...(payload.warnings?.length ? { warnings: payload.warnings } : {}),
+      },
+    });
   }
 
   /**
@@ -166,7 +192,7 @@ export class ModelSpanTracker {
   #startChunkSpan(chunkType: string, initialData?: Record<string, any>) {
     // Auto-create step if we see a chunk before step-start
     if (!this.#currentStepSpan) {
-      this.#startStepSpan();
+      this.startStep();
     }
 
     this.#currentChunkSpan = this.#currentStepSpan?.createChildSpan({
@@ -212,7 +238,7 @@ export class ModelSpanTracker {
   #createEventSpan(chunkType: string, output: any) {
     // Auto-create step if we see a chunk before step-start
     if (!this.#currentStepSpan) {
-      this.#startStepSpan();
+      this.startStep();
     }
 
     const span = this.#currentStepSpan?.createEventSpan({
@@ -360,7 +386,7 @@ export class ModelSpanTracker {
     if (!acc) {
       // Auto-create step if we see a chunk before step-start
       if (!this.#currentStepSpan) {
-        this.#startStepSpan();
+        this.startStep();
       }
 
       acc = {
@@ -500,7 +526,13 @@ export class ModelSpanTracker {
               break;
 
             case 'step-start':
-              this.#startStepSpan(chunk.payload);
+              // If step already started (via startStep()), just update with payload data
+              // Otherwise start a new step (for backwards compatibility)
+              if (this.#currentStepSpan) {
+                this.updateStep(chunk.payload);
+              } else {
+                this.startStep(chunk.payload);
+              }
               break;
 
             case 'step-finish':

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -490,6 +490,12 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT e
     inputSchema: llmIterationOutputSchema,
     outputSchema: llmIterationOutputSchema,
     execute: async ({ inputData, bail, tracingContext }) => {
+      // Start the MODEL_STEP span at the beginning of LLM execution
+      // This ensures the span's startTime accurately reflects when the step began,
+      // not when the model response started streaming (which could be delayed).
+      // The step-start chunk will update the span with request/warnings data later.
+      modelSpanTracker?.startStep();
+
       let modelResult;
       let warnings: any;
       let request: any;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -491,9 +491,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT e
     outputSchema: llmIterationOutputSchema,
     execute: async ({ inputData, bail, tracingContext }) => {
       // Start the MODEL_STEP span at the beginning of LLM execution
-      // This ensures the span's startTime accurately reflects when the step began,
-      // not when the model response started streaming (which could be delayed).
-      // The step-start chunk will update the span with request/warnings data later.
       modelSpanTracker?.startStep();
 
       let modelResult;

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -5,7 +5,7 @@ import type { MastraError } from '../../error';
 import type { IMastraLogger } from '../../logger';
 import type { Mastra } from '../../mastra';
 import type { RequestContext } from '../../request-context';
-import type { LanguageModelUsage, ProviderMetadata } from '../../stream/types';
+import type { LanguageModelUsage, ProviderMetadata, StepStartPayload } from '../../stream/types';
 import type { WorkflowRunStatus, WorkflowStepStatus } from '../../workflows';
 
 // ============================================================================
@@ -578,6 +578,12 @@ export interface IModelSpanTracker {
   reportGenerationError(options: ErrorSpanOptions<SpanType.MODEL_GENERATION>): void;
   endGeneration(options?: EndGenerationOptions): void;
   wrapStream<T extends { pipeThrough: Function }>(stream: T): T;
+  /**
+   * Start a new Model execution step.
+   * This should be called at the beginning of LLM execution to capture accurate startTime.
+   * The step-start chunk payload can be passed later via updateStep() if needed.
+   */
+  startStep(payload?: StepStartPayload): void;
 }
 
 /**

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -578,11 +578,6 @@ export interface IModelSpanTracker {
   reportGenerationError(options: ErrorSpanOptions<SpanType.MODEL_GENERATION>): void;
   endGeneration(options?: EndGenerationOptions): void;
   wrapStream<T extends { pipeThrough: Function }>(stream: T): T;
-  /**
-   * Start a new Model execution step.
-   * This should be called at the beginning of LLM execution to capture accurate startTime.
-   * The step-start chunk payload can be passed later via updateStep() if needed.
-   */
   startStep(payload?: StepStartPayload): void;
 }
 


### PR DESCRIPTION
## Description

The MODEL_STEP span was being created when the step-start chunk arrived (after the model API call completed), causing the span's startTime to be close to its endTime instead of accurately reflecting when the step began.

This fix ensures MODEL_STEP spans capture the full duration of each LLM execution step, including the API call latency, by starting the span at the beginning of the step execution rather than when the response starts streaming.

## Related Issue(s)

Fixes #11271

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MODEL_STEP tracing span now starts at the beginning of LLM execution steps, ensuring spans capture full execution duration (including API latency).

* **Improvements**
  * Tracing now captures step metadata earlier for more accurate timing and diagnostics.
  * Public tracing interface extended with new step start/update methods to support early capture and updates.

* **Tests**
  * Added integration test validating MODEL_STEP timing relative to MODEL_GENERATION during streaming.

* **Chores**
  * Published a patch bump for observability and core packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->