### PR TITLE
fix(pg): add missing timezone columns during spans table migration (#…

### DIFF
--- a/.changeset/brown-frogs-hope.md
+++ b/.changeset/brown-frogs-hope.md
@@ -1,0 +1,7 @@
+---
+'@mastra/pg': patch
+---
+
+Fix missing timezone columns during PostgreSQL spans table migration
+
+Fixes issue #11410 where users upgrading to observability beta.7 encountered errors about missing `startedAtZ`, `endedAtZ`, `createdAtZ`, and `updatedAtZ` columns. The migration now properly adds timezone-aware columns for all timestamp fields when upgrading existing databases, ensuring compatibility with the new observability implementation that requires these columns for batch operations.


### PR DESCRIPTION
## Description

…11410)

Users upgrading to observability beta.7 encountered errors about missing startedAtZ, endedAtZ, createdAtZ, and updatedAtZ columns. The issue occurred because new databases got these timezone columns via alterTable(), but existing databases only ran migrateSpansTable() which didn't create them.

This fix updates migrateSpansTable() to:
- Add timezone columns (*Z) when adding new timestamp columns
- Add timezone columns for existing timestamp columns that lack them

This ensures both new and existing databases have the required timezone columns for observability batch operations.

Test added: migration.test.ts now includes a test that reproduces the issue and verifies the fix by creating an old schema table, running migration, and confirming all 4 timezone columns are created.

## Related Issue(s)

Fixes #11410 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a migration issue where database upgrades to the latest observability version failed due to missing timezone-aware timestamp columns. The migration now automatically creates these columns for existing databases, enabling full compatibility with the new observability implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->