### PR TITLE
feat: add instructions field to MCPServer

### DIFF
--- a/.changeset/light-flies-lick.md
+++ b/.changeset/light-flies-lick.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': patch
+'@mastra/mcp': patch
+---
+
+Add support for `instructions` field in MCPServer
+
+Implements the official MCP specification's `instructions` field, which allows MCP servers to provide system-wide prompts that are automatically sent to clients during initialization. This eliminates the need for per-project configuration files (like AGENTS.md) by centralizing the system prompt in the server definition.
+
+**What's New:**
+- Added `instructions` optional field to `MCPServerConfig` type
+- Instructions are passed to the underlying MCP SDK Server during initialization
+- Instructions are sent to clients in the `InitializeResult` response
+- Fully compatible with all MCP clients (Cursor, Windsurf, Claude Desktop, etc.)
+
+**Example Usage:**
+```typescript
+const server = new MCPServer({
+  name: "GitHub MCP Server",
+  version: "1.0.0",
+  instructions: "Use the available tools to help users manage GitHub repositories, issues, and pull requests. Always search before creating to avoid duplicates.",
+  tools: { searchIssues, createIssue, listPRs }
+});
+```

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -41,6 +41,8 @@ const server = new MCPServer({
   id: "my-custom-server",
   name: "My Custom Server",
   version: "1.0.0",
+  description: "A server that provides weather data and agent capabilities",
+  instructions: "Use the available tools to help users with weather information and data processing tasks.",
   tools: { weatherTool },
   agents: { myAgent }, // this agent will become tool "ask_myAgent"
   workflows: {
@@ -101,6 +103,13 @@ The constructor accepts an `MCPServerConfig` object with the following propertie
       type: "string",
       isOptional: true,
       description: "Optional description of what the MCP server does.",
+    },
+    {
+      name: "instructions",
+      type: "string",
+      isOptional: true,
+      description:
+        "Optional instructions describing how to use the server and its features.",
     },
     {
       name: "repository",

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -36,6 +36,8 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
   private _id: TId;
   /** A description of what the MCP server does. */
   public readonly description?: string;
+  /** Optional instructions describing how to use the server and its features. */
+  public readonly instructions?: string;
   /** Repository information for the server's source code. */
   public readonly repository?: Repository;
   /** The release date of this server version (ISO 8601 string). */
@@ -181,6 +183,7 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
     }
 
     this.description = config.description;
+    this.instructions = config.instructions;
     this.repository = config.repository;
     this.releaseDate = config.releaseDate || new Date().toISOString();
     this.isLatest = config.isLatest === undefined ? true : config.isLatest;

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -216,6 +216,8 @@ export interface MCPServerConfig<TId extends string = string> {
   id?: TId;
   /** Optional description of the MCP server. */
   description?: string;
+  /** Optional instructions describing how to use the server and its features. */
+  instructions?: string;
   /** Optional repository information for the server's source code. */
   repository?: Repository;
   /**

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -187,6 +187,7 @@ describe('MCPServer', () => {
       expect(server.name).toBe('TestServer');
       expect(server.version).toBe('1.0.0');
       expect(server.description).toBeUndefined();
+      expect(server.instructions).toBeUndefined();
       expect(server.repository).toBeUndefined();
       // MCPServerBase stores releaseDate as string, compare directly or re-parse
       expect(server.releaseDate).toBe(mockDateISO);
@@ -222,6 +223,33 @@ describe('MCPServer', () => {
       expect(server.packageCanonical).toBe('npm');
       expect(server.packages).toEqual(packages);
       expect(server.remotes).toEqual(remotes);
+    });
+
+    it('should initialize with instructions when provided', () => {
+      const instructions = 'You are a helpful assistant. Use the available tools to help users.';
+      const customConfig: MCPServerConfig = {
+        ...minimalConfig,
+        instructions,
+      };
+      const server = new MCPServer(customConfig);
+
+      expect(server.instructions).toBe(instructions);
+    });
+
+    it('should pass instructions to underlying SDK Server', () => {
+      const instructions = 'You are a weather assistant with access to real-time weather data.';
+      const customConfig: MCPServerConfig = {
+        ...minimalConfig,
+        instructions,
+      };
+      const server = new MCPServer(customConfig);
+
+      // Access the underlying SDK Server
+      const sdkServer = server.getServer();
+
+      // Check that the SDK Server was initialized with instructions
+      // @ts-ignore - accessing private property for testing
+      expect(sdkServer._instructions).toBe(instructions);
     });
   });
 

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -253,7 +253,16 @@ export class MCPServer extends MCPServerBase {
       capabilities.prompts = { listChanged: true };
     }
 
-    this.server = new Server({ name: this.name, version: this.version }, { capabilities });
+    this.server = new Server(
+      {
+        name: this.name,
+        version: this.version,
+      },
+      {
+        capabilities,
+        ...(this.instructions ? { instructions: this.instructions } : {}),
+      },
+    );
 
     this.logger.info(
       `Initialized MCPServer '${this.name}' v${this.version} (ID: ${this.id}) with tools: ${Object.keys(this.convertedTools).join(', ')} and resources. Capabilities: ${JSON.stringify(capabilities)}`,
@@ -378,7 +387,16 @@ export class MCPServer extends MCPServerBase {
       capabilities.prompts = { listChanged: true };
     }
 
-    const serverInstance = new Server({ name: this.name, version: this.version }, { capabilities });
+    const serverInstance = new Server(
+      {
+        name: this.name,
+        version: this.version,
+      },
+      {
+        capabilities,
+        ...(this.instructions ? { instructions: this.instructions } : {}),
+      },
+    );
 
     // Register all handlers on the new server instance
     this.registerHandlersOnServer(serverInstance);


### PR DESCRIPTION
## Description

Implements the official MCP specification's instructions field, which allows MCP servers to provide system-wide prompts automatically sent to clients during initialization. This eliminates the need for per-project configuration files.

- Add instructions field to MCPServerConfig type
- Store instructions in MCPServerBase class
- Pass instructions to MCP SDK Server in ServerOptions
- Add comprehensive test coverage (81 tests passing)
- Update documentation with usage examples

The instructions field is optional and fully compatible with all MCP clients (Cursor, Windsurf, Claude Desktop, etc.)

## Related Issue(s)

slack request

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional instructions field to MCP Server configuration. These instructions are forwarded to the underlying MCP SDK and included in server initialization responses sent to clients.

* **Documentation**
  * Updated reference documentation with examples showing how to supply instructions when configuring an MCP Server.

* **Tests**
  * Added test coverage for instructions field initialization and propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->