### PR TITLE
fix(workflows): ensure writer.custom() bubbles up from nested workflo…

### DIFF
--- a/.changeset/wicked-animals-spend.md
+++ b/.changeset/wicked-animals-spend.md
@@ -1,0 +1,46 @@
+---
+'@mastra/core': patch
+---
+
+fix(workflows): ensure writer.custom() bubbles up from nested workflows and loops
+
+Previously, when using `writer.custom()` in steps within nested sub-workflows or loops (like `dountil`), the custom data events would not properly bubble up to the top-level workflow stream. This fix ensures that custom events are now correctly propagated through the nested workflow hierarchy without modification, allowing them to be consumed at the top level.
+
+This brings workflows in line with the existing behavior for agents, where custom data chunks properly bubble up through sub-agent execution.
+
+**What changed:**
+- Modified the `nestedWatchCb` function in workflow event handling to detect and preserve `data-*` custom events
+- Custom events now bubble up directly without being wrapped or modified
+- Regular workflow events continue to work as before with proper step ID prefixing
+
+**Example:**
+```typescript
+const subStep = createStep({
+  id: 'subStep',
+  execute: async ({ writer }) => {
+    await writer.custom({
+      type: 'custom-progress',
+      data: { status: 'processing' }
+    });
+    return { result: 'done' };
+  },
+});
+
+const subWorkflow = createWorkflow({ id: 'sub' })
+  .then(subStep)
+  .commit();
+
+const topWorkflow = createWorkflow({ id: 'top' })
+  .then(subWorkflow)
+  .commit();
+
+const run = await topWorkflow.createRun();
+const stream = run.stream({ inputData: {} });
+
+// Custom events from subStep now properly appear in the top-level stream
+for await (const event of stream) {
+  if (event.type === 'custom-progress') {
+    console.log(event.data); // { status: 'processing' }
+  }
+}
+```

--- a/packages/core/src/workflows/__tests__/writer-custom-bubbling.test.ts
+++ b/packages/core/src/workflows/__tests__/writer-custom-bubbling.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { Mastra } from '../../mastra';
+import { MockStore } from '../../storage/mock';
+import { createStep, createWorkflow } from '../workflow';
+
+const testStorage = new MockStore();
+
+describe('writer.custom() bubbling', () => {
+  const normalStep = createStep({
+    id: 'normalStep',
+    description: 'Normal step',
+    inputSchema: z.object({
+      context: z.string(),
+    }),
+    outputSchema: z.object({
+      context: z.string(),
+    }),
+    execute: async ({ inputData, writer }) => {
+      await writer?.write({
+        type: 'custom-status',
+        data: { customMessage: 'NORMAL_STEP_WRITE' },
+      });
+      await writer?.custom({
+        type: 'custom-status',
+        data: { customMessage: 'NORMAL_STEP_CUSTOM' },
+      });
+      return { context: `${inputData.context}-step` };
+    },
+  });
+
+  const subStep = createStep({
+    id: 'subStep',
+    description: 'Sub step',
+    inputSchema: z.object({
+      context: z.string(),
+    }),
+    outputSchema: z.object({
+      context: z.string(),
+    }),
+    execute: async ({ inputData, writer }) => {
+      await writer?.write({
+        type: 'custom-status',
+        data: { customMessage: 'SUB_STEP_WRITE' },
+      });
+      await writer?.custom({
+        type: 'custom-status',
+        data: { customMessage: 'SUB_STEP_CUSTOM' },
+      });
+      return { context: `${inputData.context}-step` };
+    },
+  });
+
+  const subWorkflow = createWorkflow({
+    id: 'subWorkflow',
+    description: 'Sub workflow',
+    inputSchema: z.object({
+      context: z.string(),
+    }),
+    outputSchema: z.object({
+      context: z.string(),
+    }),
+  })
+    .then(subStep)
+    .commit();
+
+  const loopStep = createStep({
+    id: 'loopStep',
+    description: 'Loop step',
+    inputSchema: z.object({
+      context: z.string(),
+    }),
+    outputSchema: z.object({
+      context: z.string(),
+    }),
+    execute: async ({ inputData, writer }) => {
+      await writer?.write({
+        type: 'custom-status',
+        data: { customMessage: 'LOOP_STEP_WRITE' },
+      });
+      await writer?.custom({
+        type: 'custom-status',
+        data: { customMessage: 'LOOP_STEP_CUSTOM' },
+      });
+      return { context: `${inputData.context}-step` };
+    },
+  });
+
+  const loopWorkflow = createWorkflow({
+    id: 'loopWorkflow',
+    description: 'Loop workflow',
+    inputSchema: z.object({
+      context: z.string(),
+    }),
+    outputSchema: z.object({
+      context: z.string(),
+    }),
+  })
+    .then(loopStep)
+    .commit();
+
+  const topWorkflow = createWorkflow({
+    id: 'topWorkflow',
+    description: 'Top workflow',
+    inputSchema: z.object({
+      context: z.string(),
+    }),
+    outputSchema: z.object({
+      context: z.string(),
+    }),
+  })
+    .then(normalStep)
+    .then(subWorkflow)
+    .dountil(loopWorkflow, async ({ inputData }) => inputData.context.length > 15)
+    .commit();
+
+  it('should write custom status with data from all steps including sub-workflows and loops', async () => {
+    new Mastra({
+      logger: false,
+      storage: testStorage,
+      workflows: { topWorkflow, subWorkflow, loopWorkflow },
+    });
+
+    const run = await topWorkflow.createRun();
+    const stream = run.stream({
+      inputData: {
+        context: 'start',
+      },
+    });
+
+    const events: any[] = [];
+
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    // Check for normalStep custom event
+    const normalStepCustom = events.find(
+      event => event.type === 'custom-status' && event.data?.customMessage === 'NORMAL_STEP_CUSTOM',
+    );
+    expect(normalStepCustom).toBeDefined();
+
+    // Check for subStep custom event (from nested sub-workflow)
+    const subStepCustom = events.find(
+      event => event.type === 'custom-status' && event.data?.customMessage === 'SUB_STEP_CUSTOM',
+    );
+    expect(subStepCustom).toBeDefined();
+
+    // Check for loopStep custom event (from loop)
+    const loopStepCustom = events.find(
+      event => event.type === 'custom-status' && event.data?.customMessage === 'LOOP_STEP_CUSTOM',
+    );
+    expect(loopStepCustom).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

…ws and loops

Previously, when using writer.custom() in steps within nested sub-workflows or loops (like dountil), the custom data events would not properly bubble up to the top-level workflow stream. This fix ensures that custom events (those with type starting with 'data-' and containing a 'data' property) are now correctly propagated through the nested workflow hierarchy without modification.

This brings workflows in line with the existing behavior for agents, where custom data chunks properly bubble up through sub-agent execution.

Changes:
- Modified nestedWatchCb in workflow.ts to detect and preserve data-* custom events
- Custom events now bubble up directly without being wrapped or modified
- Added comprehensive test covering normal steps, sub-workflows, and loops

## Related Issue(s)

Fixes #11415

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom events from nested workflows and loops now properly propagate through the top-level workflow event stream without modification.

* **Tests**
  * Added comprehensive tests validating custom event bubbling across nested and looped workflow execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->