### PR TITLE
fix: preprocess entityType=workflow to workflow_run before validation

### DIFF
--- a/.changeset/gentle-masks-hope.md
+++ b/.changeset/gentle-masks-hope.md
@@ -1,0 +1,19 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/server': patch
+---
+
+Fix workflow observability view broken by invalid entityType parameter
+
+The UI workflow observability view was failing with a Zod validation error when trying to filter traces by workflow. The UI was sending `entityType=workflow`, but the backend's `EntityType` enum only accepts `workflow_run`.
+
+**Root Cause**: The legacy value transformation was happening in the handler (after validation), but Zod validation occurred earlier in the request pipeline, rejecting the request before it could be transformed.
+
+**Solution**: 
+- Added `z.preprocess()` to the query schema to transform `workflow` → `workflow_run` before validation
+- Kept handler transformation for defense in depth
+- Updated UI to use `EntityType.WORKFLOW_RUN` enum value for type safety
+
+This maintains backward compatibility with legacy clients while fixing the validation error.
+
+Fixes #11412

--- a/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
@@ -2,8 +2,14 @@ import { SelectField, DateTimePicker } from '@/components/ui/elements';
 import { Button } from '@/components/ui/elements/buttons';
 import { cn } from '@/lib/utils';
 import { XIcon } from 'lucide-react';
+import { EntityType } from '@mastra/core/observability';
 
-export type EntityOptions = { value: string; label: string; type: 'agent' | 'workflow' | 'all' };
+// UI-specific entity options that map to API EntityType values
+// Using the enum values (lowercase strings) for the type field
+export type EntityOptions =
+  | { value: string; label: string; type: EntityType.AGENT }
+  | { value: string; label: string; type: EntityType.WORKFLOW_RUN }
+  | { value: string; label: string; type: 'all' };
 
 type TracesToolsProps = {
   selectedEntity?: EntityOptions;

--- a/packages/playground/src/pages/observability/index.tsx
+++ b/packages/playground/src/pages/observability/index.tsx
@@ -21,6 +21,7 @@ import {
   useWorkflows,
   useScorers,
 } from '@mastra/playground-ui';
+import { EntityType } from '@mastra/core/observability';
 import { useEffect, useState } from 'react';
 import { EyeIcon } from 'lucide-react';
 import { useTraces } from '@/domains/observability/hooks/use-traces';
@@ -86,13 +87,13 @@ export default function Observability() {
   const agentOptions: EntityOptions[] = (Object.entries(agents) || []).map(([_, value]) => ({
     value: value.id,
     label: value.name,
-    type: 'agent' as const,
+    type: EntityType.AGENT,
   }));
 
   const workflowOptions: EntityOptions[] = (Object.entries(workflows || {}) || []).map(([, value]) => ({
     value: value.name,
     label: value.name,
-    type: 'workflow' as const,
+    type: EntityType.WORKFLOW_RUN,
   }));
 
   const entityOptions: EntityOptions[] = [

--- a/packages/server/src/server/handlers/observability.ts
+++ b/packages/server/src/server/handlers/observability.ts
@@ -32,6 +32,8 @@ const legacyQueryParamsSchema = z.object({
   dateRange: dateRangeSchema.optional(),
   // Old: name matched span names like "agent run: 'myAgent'"
   name: z.string().optional(),
+  // entityType needs preprocessing to handle legacy 'workflow' value
+  entityType: z.preprocess(val => (val === 'workflow' ? 'workflow_run' : val), z.string().optional()),
 });
 
 /**
@@ -44,7 +46,7 @@ const legacyQueryParamsSchema = z.object({
 function transformLegacyParams(params: Record<string, unknown>): Record<string, unknown> {
   const result = { ...params };
 
-  // Transform old entityType='workflow' -> 'workflow_run' (before Zod validation)
+  // Transform old entityType='workflow' -> 'workflow_run' (the Zod validation would have already transformed this)
   if (result.entityType === 'workflow') {
     result.entityType = 'workflow_run';
   }


### PR DESCRIPTION
## Description

Fixes issue where UI Workflow Observability view was broken due to entityType=workflow being rejected by Zod validation.

- Add z.preprocess() to transform 'workflow' -> 'workflow_run' before validation
- Keep handler transformation for defense in depth
- Update UI to use EntityType.WORKFLOW_RUN enum value
- Update EntityOptions type to use proper enum values

This ensures backward compatibility with legacy clients while fixing the validation error that prevented the UI from filtering traces by workflow.

## Related Issue(s)

Fixes #11412

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the workflow observability UI where filtering by workflow type was not functioning correctly. Backward compatibility with existing integrations is maintained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->