### PR TITLE
fix(schema-compat): handle .default() fields in OpenAI structured output

### DIFF
--- a/.changeset/lucky-humans-film.md
+++ b/.changeset/lucky-humans-film.md
@@ -1,0 +1,9 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fix OpenAI structured output compatibility for fields with `.default()` values
+
+When using Zod schemas with `.default()` fields (e.g., `z.number().default(1)`), OpenAI's structured output API was failing with errors like `Missing '<field>' in required`. This happened because `zod-to-json-schema` doesn't include fields with defaults in the `required` array, but OpenAI requires all properties to be required.
+
+This fix converts `.default()` fields to `.nullable()` with a transform that returns the default value when `null` is received, ensuring compatibility with OpenAI's strict mode while preserving the original default value semantics.

--- a/packages/schema-compat/src/provider-compats/openai.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.test.ts
@@ -471,6 +471,145 @@ describe('OpenAISchemaCompatLayer - JSON Serialization', () => {
   });
 });
 
+describe('OpenAISchemaCompatLayer - Default Values', () => {
+  const modelInfo: ModelInformation = {
+    provider: 'openai',
+    modelId: 'gpt-4o',
+    supportsStructuredOutputs: false,
+  };
+
+  it('should convert default to nullable with transform that returns default value', () => {
+    const schema = z.object({
+      name: z.string(),
+      confidence: z.number().default(1),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    // When null is passed, should get the default value
+    const result = processed.parse({ name: 'John', confidence: null });
+    expect(result).toEqual({ name: 'John', confidence: 1 });
+  });
+
+  it('should preserve provided values for default fields', () => {
+    const schema = z.object({
+      name: z.string(),
+      confidence: z.number().default(1),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    // When actual value is passed, should keep it
+    const result = processed.parse({ name: 'John', confidence: 0.5 });
+    expect(result).toEqual({ name: 'John', confidence: 0.5 });
+  });
+
+  it('should handle string defaults', () => {
+    const schema = z.object({
+      name: z.string(),
+      explanation: z.string().default(''),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    const result = processed.parse({ name: 'John', explanation: null });
+    expect(result).toEqual({ name: 'John', explanation: '' });
+  });
+
+  it('should handle default with function', () => {
+    const schema = z.object({
+      name: z.string(),
+      createdAt: z.string().default(() => 'default-timestamp'),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    const result = processed.parse({ name: 'John', createdAt: null });
+    expect(result).toEqual({ name: 'John', createdAt: 'default-timestamp' });
+  });
+
+  it('should handle multiple default fields', () => {
+    const schema = z.object({
+      nonEnglish: z.boolean(),
+      translated: z.boolean(),
+      confidence: z.number().min(0).max(1).default(1),
+      explanation: z.string().default(''),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    const result = processed.parse({
+      nonEnglish: true,
+      translated: true,
+      confidence: null,
+      explanation: null,
+    });
+
+    expect(result).toEqual({
+      nonEnglish: true,
+      translated: true,
+      confidence: 1,
+      explanation: '',
+    });
+  });
+
+  it('should handle mix of optional and default fields', () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number().optional(),
+      score: z.number().default(0),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    const result = processed.parse({
+      name: 'John',
+      age: null,
+      score: null,
+    });
+
+    expect(result).toEqual({
+      name: 'John',
+      age: undefined,
+      score: 0,
+    });
+  });
+
+  it('should handle default with nested objects', () => {
+    const schema = z.object({
+      user: z.object({
+        name: z.string(),
+        settings: z.object({
+          theme: z.string().default('light'),
+        }),
+      }),
+    });
+
+    const layer = new OpenAISchemaCompatLayer(modelInfo);
+    const processed = layer.processZodType(schema);
+
+    const result = processed.parse({
+      user: {
+        name: 'John',
+        settings: { theme: null },
+      },
+    });
+
+    expect(result).toEqual({
+      user: {
+        name: 'John',
+        settings: { theme: 'light' },
+      },
+    });
+  });
+});
+
 describe('OpenAISchemaCompatLayer - shouldApply', () => {
   it('should apply for OpenAI models without structured outputs', () => {
     const modelInfo: ModelInformation = {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
- Fix OpenAI structured output compatibility for Zod schemas with .default() fields
- Convert .default() fields to .nullable() with transform to preserve default value semantics

When using Zod schemas with .default() fields (e.g., z.number().default(1)), OpenAI's structured output API was failing with errors like Missing 'field' in required. This happened because zod-to-json-schema doesn't include fields with defaults in the required array, but OpenAI requires all properties to be required.

The OpenAI schema compat layer now handles ZodDefault types by:
- Unwrapping the inner type
- Making it nullable (so it appears in required)
- Adding a transform that returns the default value when null is received

This ensures compatibility with OpenAI's strict mode while preserving the original default value semantics.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAI structured output compatibility with Zod default fields by implementing nullable-based solution with default value transforms.

* **Tests**
  * Added comprehensive test coverage for default value handling across diverse scenarios including null handling, multiple defaults, nested objects, and mixed field configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->