### PR TITLE
fix(observability): preserve Date objects in SensitiveDataFilter

### DIFF
--- a/.changeset/fix-sensitive-data-filter-date-preservation.md
+++ b/.changeset/fix-sensitive-data-filter-date-preservation.md
@@ -1,0 +1,10 @@
+---
+'@mastra/observability': patch
+---
+
+Fix SensitiveDataFilter destroying Date objects
+
+The `deepFilter` method now correctly preserves `Date` objects instead of converting them to empty objects `{}`. This fixes issues with downstream exporters like `BraintrustExporter` that rely on `Date` methods like `getTime()`.
+
+Previously, `Object.keys(new Date())` returned `[]`, causing Date objects to be incorrectly converted to `{}`. The fix adds an explicit check for `Date` instances before generic object processing.
+

--- a/observability/mastra/src/span_processors/sensitive-data-filter.ts
+++ b/observability/mastra/src/span_processors/sensitive-data-filter.ts
@@ -113,6 +113,12 @@ export class SensitiveDataFilter implements SpanOutputProcessor {
     }
     seen.add(obj);
 
+    // Preserve Date objects - they have no enumerable keys
+    // and Object.keys() returns [], which would incorrectly convert them to {}
+    if (obj instanceof Date) {
+      return obj;
+    }
+
     if (Array.isArray(obj)) {
       return obj.map(item => this.deepFilter(item, seen));
     }


### PR DESCRIPTION
## Summary
`SensitiveDataFilter` was converting `Date` objects to empty objects `{}`, causing downstream errors in exporters like `BraintrustExporter`.

## Problem
The `deepFilter` method didn't handle `Date` objects properly. Since `Object.keys(new Date())` returns `[]`, Date objects were incorrectly converted to `{}`.

This caused:
```
TypeError: modelAttr.completionStartTime.getTime is not a function
    at BraintrustExporter.buildSpanPayload
```

## Solution
Added an explicit check for `Date` instances before generic object processing:

```typescript
if (obj instanceof Date) {
  return obj;
}
```

## Testing
- Added test case for Date object preservation
- All 10 existing tests pass

## Affected Packages
- `@mastra/observability`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sensitive data filter to properly preserve Date objects instead of converting them to empty objects, which was causing downstream exporters to fail when invoking Date methods.

* **Tests**
  * Added test coverage verifying that Date objects are correctly preserved with their original timestamps during the filtering process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->