### PR TITLE
[FIX] Exclude deprecated Groq models during template creation

### DIFF
--- a/.changeset/fix-deprecated-groq-models.md
+++ b/.changeset/fix-deprecated-groq-models.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+---
+
+Fixed an issue where deprecated Groq models were shown during template creation. The model selection now filters out models marked as deprecated, displaying only active and supported models.
+

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -155,6 +155,30 @@ describe('ModelsDevGateway', () => {
       expect(providers.groq.models).not.toContain('deepseek-r1-distill-llama-70b');
     });
 
+    it('should return empty models array when all models are deprecated', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          groq: {
+            id: 'groq',
+            name: 'Groq',
+            models: {
+              'model-1': { name: 'Model 1', status: 'deprecated' },
+              'model-2': { name: 'Model 2', status: 'deprecated' },
+            },
+            env: ['GROQ_API_KEY'],
+            api: 'https://api.groq.com/openai/v1',
+            npm: '@ai-sdk/openai-compatible',
+          },
+        }),
+      });
+
+      const providers = await gateway.fetchProviders();
+      
+      expect(providers.groq).toBeDefined();
+      expect(providers.groq.models).toEqual([]);
+    });
+
     it('should extract model IDs from each provider', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -127,6 +127,34 @@ describe('ModelsDevGateway', () => {
       expect(providers['fireworks-ai'].apiKeyEnvVar).toBe('FIREWORKS_API_KEY');
     });
 
+    it('should filter out deprecated models', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          groq: {
+            id: 'groq',
+            name: 'Groq',
+            models: {
+              'llama-3.1-8b': { name: 'Llama 3.1 8B' },
+              'deepseek-r1-distill-llama-70b': {
+                name: 'DeepSeek R1 Distill LLaMA 70B',
+                status: 'deprecated',
+              },
+            },
+            env: ['GROQ_API_KEY'],
+            api: 'https://api.groq.com/openai/v1',
+            npm: '@ai-sdk/openai-compatible',
+          },
+        }),
+      });
+
+      const providers = await gateway.fetchProviders();
+
+      expect(providers.groq).toBeDefined();
+      expect(providers.groq.models).toEqual(['llama-3.1-8b']);
+      expect(providers.groq.models).not.toContain('deepseek-r1-distill-llama-70b');
+    });
+    
     it('should extract model IDs from each provider', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -154,7 +154,7 @@ describe('ModelsDevGateway', () => {
       expect(providers.groq.models).toEqual(['llama-3.1-8b']);
       expect(providers.groq.models).not.toContain('deepseek-r1-distill-llama-70b');
     });
-    
+
     it('should extract model IDs from each provider', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -174,7 +174,7 @@ describe('ModelsDevGateway', () => {
       });
 
       const providers = await gateway.fetchProviders();
-      
+
       expect(providers.groq).toBeDefined();
       expect(providers.groq.models).toEqual([]);
     });

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -99,8 +99,11 @@ export class ModelsDevGateway extends MastraModelGateway {
 
       if (isOpenAICompatible || hasInstalledPackage || hasApiAndEnv) {
         // Get model IDs from the models object
-        const modelIds = Object.keys(providerInfo.models).sort();
-
+        const modelIds = Object.entries(providerInfo.models)
+          .filter(([, modelInfo]) => modelInfo?.status !== 'deprecated')
+          .map(([modelId]) => modelId)
+          .sort();
+          
         // Get the API URL from the provider info or overrides
         const url = providerInfo.api || OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.url;
 

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -103,7 +103,7 @@ export class ModelsDevGateway extends MastraModelGateway {
           .filter(([, modelInfo]) => modelInfo?.status !== 'deprecated')
           .map(([modelId]) => modelId)
           .sort();
-          
+
         // Get the API URL from the provider info or overrides
         const url = providerInfo.api || OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.url;
 

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -99,6 +99,7 @@ export class ModelsDevGateway extends MastraModelGateway {
 
       if (isOpenAICompatible || hasInstalledPackage || hasApiAndEnv) {
         // Get model IDs from the models object
+        // Filter out deprecated models before collecting model IDs
         const modelIds = Object.entries(providerInfo.models)
           .filter(([, modelInfo]) => modelInfo?.status !== 'deprecated')
           .map(([modelId]) => modelId)


### PR DESCRIPTION
## Description

When creating a new template in Mastra and selecting Groq as the model provider, the model selection list currently includes some deprecated models. These models are no longer supported or usable, which forces users to rely on trial-and-error to determine which models work.

This change updates the template creation logic to **filter out models marked as `deprecated`**, ensuring that only active and supported models are displayed. This improves usability and prevents confusion for developers, especially for those new to the platform.

Reference: [Groq model deprecations](https://console.groq.com/docs/deprecations)

## Related Issue(s)

#11430

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Documentation update  
- [ ] Code refactoring  
- [ ] Performance improvement  
- [ ] Test update  

## Checklist

- [x] I have updated the code to filter out deprecated models  
- [x] I have added or updated tests to verify the change works as intended  
- [ ] I have updated documentation if necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecated models are now filtered out and excluded from the available model list so users see only supported models.

* **Tests**
  * Added tests verifying deprecated models are excluded and that an all-deprecated response yields no available models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->