### PR TITLE
feat(pg): add exportSchemas function for DDL generation

### DIFF
--- a/.changeset/add-pg-export-schemas.md
+++ b/.changeset/add-pg-export-schemas.md
@@ -1,0 +1,27 @@
+---
+"@mastra/pg": patch
+---
+
+Added `exportSchemas()` function to generate Mastra database schema as SQL DDL without a database connection.
+
+**What's New**
+
+You can now export your Mastra database schema as SQL DDL statements without connecting to a database. This is useful for:
+
+- Generating migration scripts
+- Reviewing the schema before deployment
+- Creating database schemas in environments where the application doesn't have CREATE privileges
+
+**Example**
+
+```typescript
+import { exportSchemas } from '@mastra/pg';
+
+// Export schema for default 'public' schema
+const ddl = exportSchemas();
+console.log(ddl);
+
+// Export schema for a custom schema
+const customDdl = exportSchemas('my_schema');
+// Creates: CREATE SCHEMA IF NOT EXISTS "my_schema"; and all tables within it
+```

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -24,6 +24,8 @@ const DEFAULT_MAX_CONNECTIONS = 20;
 /** Default idle timeout in milliseconds */
 const DEFAULT_IDLE_TIMEOUT_MS = 30000;
 
+export { exportSchemas } from './db';
+// Export domain classes for direct use with MastraStorage composition
 export { AgentsPG, MemoryPG, ObservabilityPG, ScoresPG, WorkflowsPG };
 export { PoolAdapter } from './client';
 export type { DbClient, TxClient, QueryValues, Pool, PoolClient, QueryResult } from './client';


### PR DESCRIPTION
## Description

Add `exportSchemas()` function that exports Mastra database schema as SQL DDL statements without requiring a database connection. This is useful for:
- Generating migration scripts
- Reviewing the schema before deployment
- Creating database schemas in environments where the application doesn't have CREATE privileges

Also refactored internal code to eliminate duplication:
- Extracted `generateTableSQL()` function from `createTable()` method
- Consolidated SQL type mapping into a single `mapToSqlType()` function

## Related Issue(s)

<!-- None - this is a new feature -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export database schemas as SQL DDL without a DB connection; optional schema name for targeted exports (emits CREATE SCHEMA if needed).
  * Centralized SQL type handling for consistent DDL (including timezone-aware timestamp columns).
  * Schema export function exposed in the public storage API with usage examples.

* **Tests**
  * Added tests validating exported SQL for default and custom schemas, constraint names, timestamps, and invalid/allowed schema names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->