### PR TITLE
refactor(pg): remove pg-promise dependency and use pg.Pool directly

### DIFF
--- a/.changeset/refactor-pg-remove-pg-promise.md
+++ b/.changeset/refactor-pg-remove-pg-promise.md
@@ -1,0 +1,36 @@
+---
+'@mastra/pg': minor
+---
+
+Remove pg-promise dependency and use pg.Pool directly
+
+**BREAKING CHANGE**: This release replaces pg-promise with vanilla node-postgres (`pg`).
+
+### Breaking Changes
+
+- **Removed `store.pgp`**: The pg-promise library instance is no longer exposed
+- **Config change**: `{ client: pgPromiseDb }` is no longer supported. Use `{ pool: pgPool }` instead
+- **Cloud SQL config**: `max` and `idleTimeoutMillis` must now be passed via `pgPoolOptions`
+
+### New Features
+
+- **`store.pool`**: Exposes the underlying `pg.Pool` for direct database access or ORM integration (e.g., Drizzle)
+- **`store.db`**: Provides a `DbClient` interface with methods like `one()`, `any()`, `tx()`, etc.
+- **`store.db.connect()`**: Acquire a client for session-level operations
+
+### Migration
+
+```typescript
+// Before (pg-promise)
+import pgPromise from 'pg-promise';
+const pgp = pgPromise();
+const client = pgp(connectionString);
+const store = new PostgresStore({ id: 'my-store', client });
+
+// After (pg.Pool)
+import { Pool } from 'pg';
+const pool = new Pool({ connectionString });
+const store = new PostgresStore({ id: 'my-store', pool });
+
+// Use store.pool with any library that accepts a pg.Pool
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4229,9 +4229,6 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.16.3
-      pg-promise:
-        specifier: ^11.15.0
-        version: 11.15.0(pg-query-stream@4.10.3(pg@8.16.3))
       xxhash-wasm:
         specifier: ^1.1.0
         version: 1.1.0
@@ -12361,10 +12358,6 @@ packages:
     resolution: {integrity: sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==}
     engines: {node: '>=12.0.0'}
 
-  assert-options@0.8.3:
-    resolution: {integrity: sha512-s6v4HnA+vYSGO4eZX+F+I3gvF74wPk+m6Z1Q3w1Dsg4Pnv/R24vhKAasoMVZGvDpOOfTg1Qz4ptZnEbuy95XsQ==}
-    engines: {node: '>=14.0.0'}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -16334,37 +16327,17 @@ packages:
   pg-connection-string@2.9.1:
     resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
 
-  pg-cursor@2.15.3:
-    resolution: {integrity: sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==}
-    peerDependencies:
-      pg: ^8
-
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
-
-  pg-minify@1.8.0:
-    resolution: {integrity: sha512-jO/oJOununpx8DzKgvSsWm61P8JjwXlaxSlbbfTBo1nvSWoo/+I6qZYaSN96jm/KDwa5d+JMQwPGgcP6HXDRow==}
-    engines: {node: '>=16.0.0'}
 
   pg-pool@3.10.1:
     resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
     peerDependencies:
       pg: '>=8.0'
 
-  pg-promise@11.15.0:
-    resolution: {integrity: sha512-EUXpXn90yPVPKxQH4qqUAEVcApd2tp/JdR3wG6LzBUgaXTUYqwmuXG4vFhhZTCctzhfzRA20EbORb9H4aAgUHA==}
-    engines: {node: '>=16.0'}
-    peerDependencies:
-      pg-query-stream: 4.10.3
-
   pg-protocol@1.10.3:
     resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
-
-  pg-query-stream@4.10.3:
-    resolution: {integrity: sha512-h2utrzpOIzeT9JfaqfvBbVuvCfBjH86jNfVrGGTbyepKAIOyTfDew0lAt8bbJjs9n/I5bGDl7S2sx6h5hPyJxw==}
-    peerDependencies:
-      pg: ^8
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -17411,10 +17384,6 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
-
-  spex@3.4.1:
-    resolution: {integrity: sha512-Br0Mu3S+c70kr4keXF+6K4B8ohR+aJjI9s7SbdsI3hliE1Riz4z+FQk7FQL+r7X1t90KPkpuKwQyITpCIQN9mg==}
-    engines: {node: '>=14.0.0'}
 
   spinnies@0.5.1:
     resolution: {integrity: sha512-WpjSXv9NQz0nU3yCT9TFEOfpFrXADY9C5fG6eAJqixLhvTX1jP3w92Y8IE5oafIe42nlF9otjhllnXN/QCaB3A==}
@@ -27265,8 +27234,6 @@ snapshots:
       pvutils: 1.1.3
       tslib: 2.8.1
 
-  assert-options@0.8.3: {}
-
   assertion-error@2.0.1: {}
 
   assistant-cloud@0.1.9:
@@ -32052,34 +32019,13 @@ snapshots:
 
   pg-connection-string@2.9.1: {}
 
-  pg-cursor@2.15.3(pg@8.16.3):
-    dependencies:
-      pg: 8.16.3
-
   pg-int8@1.0.1: {}
-
-  pg-minify@1.8.0: {}
 
   pg-pool@3.10.1(pg@8.16.3):
     dependencies:
       pg: 8.16.3
 
-  pg-promise@11.15.0(pg-query-stream@4.10.3(pg@8.16.3)):
-    dependencies:
-      assert-options: 0.8.3
-      pg: 8.16.3
-      pg-minify: 1.8.0
-      pg-query-stream: 4.10.3(pg@8.16.3)
-      spex: 3.4.1
-    transitivePeerDependencies:
-      - pg-native
-
   pg-protocol@1.10.3: {}
-
-  pg-query-stream@4.10.3(pg@8.16.3):
-    dependencies:
-      pg: 8.16.3
-      pg-cursor: 2.15.3(pg@8.16.3)
 
   pg-types@2.2.0:
     dependencies:
@@ -33431,8 +33377,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  spex@3.4.1: {}
 
   spinnies@0.5.1:
     dependencies:

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "pg": "^8.16.3",
-    "pg-promise": "^11.15.0",
     "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {

--- a/stores/pg/src/index.ts
+++ b/stores/pg/src/index.ts
@@ -1,4 +1,11 @@
 export * from './vector';
 export * from './storage';
-export type { PostgresConfig, PostgresStoreConfig, PgVectorConfig } from './shared/config';
+export type {
+  PostgresBaseConfig,
+  PostgresStoreConfig,
+  PgVectorConfig,
+  ConnectionStringConfig,
+  HostConfig,
+  PoolInstanceConfig,
+} from './shared/config';
 export { PGVECTOR_PROMPT } from './vector/prompt';

--- a/stores/pg/src/shared/config.ts
+++ b/stores/pg/src/shared/config.ts
@@ -1,19 +1,13 @@
 import type { ConnectionOptions } from 'node:tls';
 import type { CreateIndexOptions } from '@mastra/core/storage';
-import type { ClientConfig } from 'pg';
-import type * as pg from 'pg';
-import type pgPromise from 'pg-promise';
-import type { ISSLConfig } from 'pg-promise/typescript/pg-subset';
+import type { ClientConfig, Pool, PoolConfig } from 'pg';
 
 /**
- * Generic PostgreSQL configuration type.
- * @template SSLType - The SSL configuration type (ISSLConfig for pg-promise, ConnectionOptions for pg)
+ * Base configuration options shared across PostgreSQL configs.
  */
-export type PostgresConfig<SSLType = ISSLConfig | ConnectionOptions> = {
+export interface PostgresBaseConfig {
   id: string;
   schemaName?: string;
-  max?: number;
-  idleTimeoutMillis?: number;
   /**
    * When true, automatic initialization (table creation/migrations) is disabled.
    * This is useful for CI/CD pipelines where you want to:
@@ -63,122 +57,118 @@ export type PostgresConfig<SSLType = ISSLConfig | ConnectionOptions> = {
    * ```
    */
   indexes?: CreateIndexOptions[];
-} & (
-  | {
-      host: string;
-      port: number;
-      database: string;
-      user: string;
-      password: string;
-      ssl?: boolean | SSLType;
-    }
-  | {
-      connectionString: string;
-      ssl?: boolean | SSLType;
-    }
-  // Support Cloud SQL Connector & pg ClientConfig
-  | ClientConfig
-);
+}
 
 /**
- * PostgreSQL configuration for PostgresStore (uses pg-promise with ISSLConfig)
- *
- * Accepts either:
- * - A pre-configured pg-promise client: `{ id, client, schemaName? }`
- * - Connection string: `{ id, connectionString, ... }`
- * - Host/port config: `{ id, host, port, database, user, password, ... }`
- * - Cloud SQL connector config: `{ id, stream, ... }`
+ * Connection string configuration.
  */
-export type PostgresStoreConfig =
-  | PostgresConfig<ISSLConfig>
-  | {
-      id: string;
-      /**
-       * Pre-configured pg-promise database client.
-       * Use this when you need to configure the client before initialization,
-       * e.g., to add pool listeners or set connection-level settings.
-       *
-       * @example
-       * ```typescript
-       * import pgPromise from 'pg-promise';
-       *
-       * const pgp = pgPromise();
-       * const client = pgp({ connectionString: '...' });
-       *
-       * // Custom setup before using
-       * client.$pool.on('connect', async (poolClient) => {
-       *   await poolClient.query('SET ROLE my_role;');
-       * });
-       *
-       * const store = new PostgresStore({ id: 'my-store', client });
-       * ```
-       */
-      client: pgPromise.IDatabase<{}>;
-      schemaName?: string;
-      disableInit?: boolean;
-      skipDefaultIndexes?: boolean;
-      indexes?: CreateIndexOptions[];
-    };
+export interface ConnectionStringConfig extends PostgresBaseConfig {
+  connectionString: string;
+  ssl?: boolean | ConnectionOptions;
+  max?: number;
+  idleTimeoutMillis?: number;
+}
 
 /**
- * PostgreSQL configuration for PgVector (uses pg with ConnectionOptions)
+ * Host-based configuration.
  */
-export type PgVectorConfig = PostgresConfig<ConnectionOptions> & {
-  pgPoolOptions?: Omit<pg.PoolConfig, 'connectionString'>;
-};
-
-export const isConnectionStringConfig = <SSLType>(
-  cfg: PostgresConfig<SSLType>,
-): cfg is PostgresConfig<SSLType> & { connectionString: string; ssl?: boolean | SSLType } => {
-  return 'connectionString' in cfg;
-};
-
-export const isHostConfig = <SSLType>(
-  cfg: PostgresConfig<SSLType>,
-): cfg is PostgresConfig<SSLType> & {
+export interface HostConfig extends PostgresBaseConfig {
   host: string;
   port: number;
   database: string;
   user: string;
   password: string;
-  ssl?: boolean | SSLType;
-} => {
+  ssl?: boolean | ConnectionOptions;
+  max?: number;
+  idleTimeoutMillis?: number;
+}
+
+/**
+ * Pre-configured pg.Pool configuration.
+ */
+export interface PoolInstanceConfig extends PostgresBaseConfig {
+  /**
+   * Pre-configured pg.Pool instance.
+   * Use this for direct control over the connection pool, or for
+   * integration with libraries that expect a pg.Pool.
+   *
+   * @example
+   * ```typescript
+   * import { Pool } from 'pg';
+   *
+   * const pool = new Pool({ connectionString: '...' });
+   * const store = new PostgresStore({ id: 'my-store', pool });
+   *
+   * // Use store.pool for other libraries that need a pg.Pool
+   * ```
+   */
+  pool: Pool;
+}
+
+/**
+ * PostgreSQL configuration for PostgresStore.
+ *
+ * Accepts either:
+ * - A pre-configured pg.Pool: `{ id, pool, schemaName? }`
+ * - Connection string: `{ id, connectionString, ... }`
+ * - Host/port config: `{ id, host, port, database, user, password, ... }`
+ * - Cloud SQL connector config: `{ id, stream, ... }` (via pg.ClientConfig)
+ */
+export type PostgresStoreConfig =
+  | PoolInstanceConfig
+  | ConnectionStringConfig
+  | HostConfig
+  | (PostgresBaseConfig & ClientConfig);
+
+/**
+ * PostgreSQL configuration for PgVector (uses pg with ConnectionOptions)
+ */
+export type PgVectorConfig = (ConnectionStringConfig | HostConfig | (PostgresBaseConfig & ClientConfig)) & {
+  pgPoolOptions?: Omit<PoolConfig, 'connectionString'>;
+};
+
+/**
+ * Type guard for pre-configured pg.Pool config
+ */
+export const isPoolConfig = (cfg: PostgresStoreConfig): cfg is PoolInstanceConfig => {
+  return 'pool' in cfg;
+};
+
+/**
+ * Type guard for connection string config
+ */
+export const isConnectionStringConfig = (cfg: PostgresStoreConfig): cfg is ConnectionStringConfig => {
+  return 'connectionString' in cfg && typeof cfg.connectionString === 'string';
+};
+
+/**
+ * Type guard for host-based config
+ */
+export const isHostConfig = (cfg: PostgresStoreConfig): cfg is HostConfig => {
   return 'host' in cfg && 'database' in cfg && 'user' in cfg && 'password' in cfg;
 };
 
-export const isCloudSqlConfig = <SSLType>(
-  cfg: PostgresConfig<SSLType>,
-): cfg is PostgresConfig<SSLType> & ClientConfig => {
+/**
+ * Type guard for Cloud SQL connector config
+ */
+export const isCloudSqlConfig = (cfg: PostgresStoreConfig): cfg is PostgresBaseConfig & ClientConfig => {
   return 'stream' in cfg || ('password' in cfg && typeof cfg.password === 'function');
 };
 
 /**
- * Type guard for pre-configured client config (PostgresStore only)
+ * Validate PostgresStore configuration.
  */
-export const isClientConfig = (
-  cfg: PostgresStoreConfig,
-): cfg is {
-  id: string;
-  client: pgPromise.IDatabase<{}>;
-  schemaName?: string;
-  disableInit?: boolean;
-  skipDefaultIndexes?: boolean;
-  indexes?: CreateIndexOptions[];
-} => {
-  return 'client' in cfg;
-};
-
 export const validateConfig = (name: string, config: PostgresStoreConfig) => {
   if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
     throw new Error(`${name}: id must be provided and cannot be empty.`);
   }
 
-  // Client config: user provides pre-configured pg-promise client
-  if (isClientConfig(config)) {
-    if (!config.client) {
-      throw new Error(`${name}: client must be provided when using client config.`);
+  // Pool config: user provides pre-configured pg.Pool
+  if (isPoolConfig(config)) {
+    if (!config.pool) {
+      throw new Error(`${name}: pool must be provided when using pool config.`);
     }
-    return; // Valid client config
+    return; // Valid pool config
   }
 
   if (isConnectionStringConfig(config)) {
@@ -204,7 +194,7 @@ export const validateConfig = (name: string, config: PostgresStoreConfig) => {
     }
   } else {
     throw new Error(
-      `${name}: invalid config. Provide either {client}, {connectionString}, {host,port,database,user,password}, or a pg ClientConfig (e.g., Cloud SQL connector with \`stream\`).`,
+      `${name}: invalid config. Provide either {pool}, {connectionString}, {host,port,database,user,password}, or a pg ClientConfig (e.g., Cloud SQL connector with \`stream\`).`,
     );
   }
 };

--- a/stores/pg/src/storage/client.ts
+++ b/stores/pg/src/storage/client.ts
@@ -1,0 +1,238 @@
+import type { Pool, PoolClient, QueryResult } from 'pg';
+
+// Re-export pg types for consumers
+export type { Pool, PoolClient, QueryResult } from 'pg';
+
+/**
+ * Values array for parameterized queries.
+ */
+export type QueryValues = unknown[];
+
+/**
+ * Common interface for database clients.
+ * PoolAdapter implements this interface by wrapping a pg.Pool.
+ */
+export interface DbClient {
+  /**
+   * The underlying connection pool.
+   */
+  readonly $pool: Pool;
+
+  /**
+   * Acquire a client from the pool for manual query execution.
+   * Remember to call client.release() when done.
+   */
+  connect(): Promise<PoolClient>;
+
+  /**
+   * Execute a query that returns no data.
+   * Use for INSERT, UPDATE, DELETE without RETURNING.
+   */
+  none(query: string, values?: QueryValues): Promise<null>;
+
+  /**
+   * Execute a query that returns exactly one row.
+   * @throws Error if zero or more than one row is returned
+   */
+  one<T = any>(query: string, values?: QueryValues): Promise<T>;
+
+  /**
+   * Execute a query that returns zero or one row.
+   * @returns The row, or null if no rows returned
+   * @throws Error if more than one row is returned
+   */
+  oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null>;
+
+  /**
+   * Execute a query that returns any number of rows (including zero).
+   * Alias for manyOrNone.
+   */
+  any<T = any>(query: string, values?: QueryValues): Promise<T[]>;
+
+  /**
+   * Execute a query that returns zero or more rows.
+   */
+  manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]>;
+
+  /**
+   * Execute a query that returns at least one row.
+   * @throws Error if no rows are returned
+   */
+  many<T = any>(query: string, values?: QueryValues): Promise<T[]>;
+
+  /**
+   * Execute a raw query, returning the full result object.
+   */
+  query(query: string, values?: QueryValues): Promise<QueryResult>;
+
+  /**
+   * Execute a function within a transaction.
+   * Automatically handles BEGIN, COMMIT, and ROLLBACK.
+   */
+  tx<T>(callback: (t: TxClient) => Promise<T>): Promise<T>;
+}
+
+/**
+ * Transaction client interface for executing queries within a transaction.
+ */
+export interface TxClient {
+  none(query: string, values?: QueryValues): Promise<null>;
+  one<T = any>(query: string, values?: QueryValues): Promise<T>;
+  oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null>;
+  any<T = any>(query: string, values?: QueryValues): Promise<T[]>;
+  manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]>;
+  many<T = any>(query: string, values?: QueryValues): Promise<T[]>;
+  query(query: string, values?: QueryValues): Promise<QueryResult>;
+  /** Execute multiple promises in parallel */
+  batch<T>(promises: Promise<T>[]): Promise<T[]>;
+}
+
+/**
+ * Truncate a query string for error messages.
+ */
+function truncateQuery(query: string, maxLength = 100): string {
+  const normalized = query.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return normalized.slice(0, maxLength) + '...';
+}
+
+/**
+ * Adapter that wraps a pg.Pool to implement DbClient.
+ */
+export class PoolAdapter implements DbClient {
+  constructor(public readonly $pool: Pool) {}
+
+  connect(): Promise<PoolClient> {
+    return this.$pool.connect();
+  }
+
+  async none(query: string, values?: QueryValues): Promise<null> {
+    await this.$pool.query(query, values);
+    return null;
+  }
+
+  async one<T = any>(query: string, values?: QueryValues): Promise<T> {
+    const result = await this.$pool.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+    }
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
+    }
+    return result.rows[0] as T;
+  }
+
+  async oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null> {
+    const result = await this.$pool.query(query, values);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
+    }
+    return result.rows[0] as T;
+  }
+
+  async any<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.$pool.query(query, values);
+    return result.rows as T[];
+  }
+
+  async manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.any<T>(query, values);
+  }
+
+  async many<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.$pool.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+    }
+    return result.rows as T[];
+  }
+
+  async query(query: string, values?: QueryValues): Promise<QueryResult> {
+    return this.$pool.query(query, values);
+  }
+
+  async tx<T>(callback: (t: TxClient) => Promise<T>): Promise<T> {
+    const client = await this.$pool.connect();
+    try {
+      await client.query('BEGIN');
+      const txClient = new TransactionClient(client);
+      const result = await callback(txClient);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackError) {
+        // Log rollback failure but throw original error
+        console.error('Transaction rollback failed:', rollbackError);
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+/**
+ * Transaction client that wraps a PoolClient for executing queries within a transaction.
+ */
+class TransactionClient implements TxClient {
+  constructor(private readonly client: PoolClient) {}
+
+  async none(query: string, values?: QueryValues): Promise<null> {
+    await this.client.query(query, values);
+    return null;
+  }
+
+  async one<T = any>(query: string, values?: QueryValues): Promise<T> {
+    const result = await this.client.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+    }
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
+    }
+    return result.rows[0] as T;
+  }
+
+  async oneOrNone<T = any>(query: string, values?: QueryValues): Promise<T | null> {
+    const result = await this.client.query(query, values);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    if (result.rows.length > 1) {
+      throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
+    }
+    return result.rows[0] as T;
+  }
+
+  async any<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.client.query(query, values);
+    return result.rows as T[];
+  }
+
+  async manyOrNone<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.any<T>(query, values);
+  }
+
+  async many<T = any>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.client.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+    }
+    return result.rows as T[];
+  }
+
+  async query(query: string, values?: QueryValues): Promise<QueryResult> {
+    return this.client.query(query, values);
+  }
+
+  async batch<T>(promises: Promise<T>[]): Promise<T[]> {
+    return Promise.all(promises);
+  }
+}

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -1,3 +1,4 @@
+import type { ConnectionOptions } from 'node:tls';
 import { MastraBase } from '@mastra/core/base';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
@@ -16,7 +17,6 @@ import type {
   StorageIndexStats,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
-import type { ConnectionOptions } from 'node:tls';
 import { Pool } from 'pg';
 import type { DbClient } from '../client';
 import { PoolAdapter } from '../client';

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -16,24 +16,28 @@ import type {
   StorageIndexStats,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
-import pgPromise from 'pg-promise';
-import type { IDatabase } from 'pg-promise';
-import type { ISSLConfig } from 'pg-promise/typescript/pg-subset';
+import type { ConnectionOptions } from 'node:tls';
+import { Pool } from 'pg';
+import type { DbClient } from '../client';
+import { PoolAdapter } from '../client';
+
+// Re-export DbClient for external use
+export type { DbClient } from '../client';
 
 /**
  * Configuration for standalone domain usage.
  * Accepts either:
- * 1. An existing pg-promise database instance
- * 2. Config to create a new client internally
+ * 1. An existing database client (Pool or PoolAdapter)
+ * 2. Config to create a new pool internally
  */
-export type PgDomainConfig = PgDomainClientConfig | PgDomainRestConfig;
+export type PgDomainConfig = PgDomainClientConfig | PgDomainPoolConfig | PgDomainRestConfig;
 
 /**
- * Pass an existing pg-promise database instance
+ * Pass an existing database client (DbClient)
  */
 export interface PgDomainClientConfig {
-  /** The pg-promise database instance */
-  client: IDatabase<{}>;
+  /** The database client */
+  client: DbClient;
   /** Optional schema name (defaults to 'public') */
   schemaName?: string;
   /** When true, default indexes will not be created during initialization */
@@ -43,7 +47,21 @@ export interface PgDomainClientConfig {
 }
 
 /**
- * Pass config to create a new pg-promise client internally
+ * Pass an existing pg.Pool
+ */
+export interface PgDomainPoolConfig {
+  /** Pre-configured pg.Pool */
+  pool: Pool;
+  /** Optional schema name (defaults to 'public') */
+  schemaName?: string;
+  /** When true, default indexes will not be created during initialization */
+  skipDefaultIndexes?: boolean;
+  /** Custom indexes to create for this domain's tables */
+  indexes?: CreateIndexOptions[];
+}
+
+/**
+ * Pass config to create a new pg.Pool internally
  */
 export type PgDomainRestConfig = {
   /** Optional schema name (defaults to 'public') */
@@ -59,20 +77,20 @@ export type PgDomainRestConfig = {
       database: string;
       user: string;
       password: string;
-      ssl?: boolean | ISSLConfig;
+      ssl?: boolean | ConnectionOptions;
     }
   | {
       connectionString: string;
-      ssl?: boolean | ISSLConfig;
+      ssl?: boolean | ConnectionOptions;
     }
 );
 
 /**
- * Resolves PgDomainConfig to a pg-promise database instance and schema.
- * Handles creating a new client if config is provided.
+ * Resolves PgDomainConfig to a database client and schema.
+ * Handles creating a new pool if config is provided.
  */
 export function resolvePgConfig(config: PgDomainConfig): {
-  client: IDatabase<{}>;
+  client: DbClient;
   schemaName?: string;
   skipDefaultIndexes?: boolean;
   indexes?: CreateIndexOptions[];
@@ -87,11 +105,36 @@ export function resolvePgConfig(config: PgDomainConfig): {
     };
   }
 
-  // Config to create new client
-  const pgp = pgPromise();
-  const client = pgp(config as any);
+  // Existing pool
+  if ('pool' in config) {
+    return {
+      client: new PoolAdapter(config.pool),
+      schemaName: config.schemaName,
+      skipDefaultIndexes: config.skipDefaultIndexes,
+      indexes: config.indexes,
+    };
+  }
+
+  // Config to create new pool
+  let pool: Pool;
+  if ('connectionString' in config) {
+    pool = new Pool({
+      connectionString: config.connectionString,
+      ssl: config.ssl,
+    });
+  } else {
+    pool = new Pool({
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.user,
+      password: config.password,
+      ssl: config.ssl,
+    });
+  }
+
   return {
-    client,
+    client: new PoolAdapter(pool),
     schemaName: config.schemaName,
     skipDefaultIndexes: config.skipDefaultIndexes,
     indexes: config.indexes,
@@ -113,7 +156,7 @@ function getTableName({ indexName, schemaName }: { indexName: string; schemaName
  * Internal config for PgDB - accepts already-resolved client
  */
 export interface PgDBInternalConfig {
-  client: IDatabase<{}>;
+  client: DbClient;
   schemaName?: string;
   skipDefaultIndexes?: boolean;
 }
@@ -124,7 +167,7 @@ export interface PgDBInternalConfig {
 const schemaSetupRegistry = new Map<string, { promise: Promise<void> | null; complete: boolean }>();
 
 export class PgDB extends MastraBase {
-  public client: IDatabase<{}>;
+  public client: DbClient;
   public schemaName?: string;
   public skipDefaultIndexes?: boolean;
 
@@ -934,9 +977,9 @@ export class PgDB extends MastraBase {
         size: result.size || '0',
         definition: result.definition || '',
         method: result.method || 'btree',
-        scans: parseInt(result.scans) || 0,
-        tuples_read: parseInt(result.tuples_read) || 0,
-        tuples_fetched: parseInt(result.tuples_fetched) || 0,
+        scans: parseInt(String(result.scans)) || 0,
+        tuples_read: parseInt(String(result.tuples_read)) || 0,
+        tuples_fetched: parseInt(String(result.tuples_fetched)) || 0,
       };
     } catch (error) {
       throw new MastraError(

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@internal/storage-test-utils';
 import { TABLE_THREADS } from '@mastra/core/storage';
 import { Pool } from 'pg';
-import { describe, it, expect, vi, afterAll } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { MemoryPG } from './domains/memory';
 import { ScoresPG } from './domains/scores';

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,128 +1,95 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
-import pgPromise from 'pg-promise';
+import { Pool } from 'pg';
 import {
   validateConfig,
   isCloudSqlConfig,
   isConnectionStringConfig,
   isHostConfig,
-  isClientConfig,
+  isPoolConfig,
 } from '../shared/config';
 import type { PostgresStoreConfig } from '../shared/config';
-import type { PgDomainConfig } from './db';
+import { PoolAdapter } from './client';
+import type { DbClient } from './client';
+import type { PgDomainClientConfig } from './db';
 import { AgentsPG } from './domains/agents';
 import { MemoryPG } from './domains/memory';
 import { ObservabilityPG } from './domains/observability';
 import { ScoresPG } from './domains/scores';
 import { WorkflowsPG } from './domains/workflows';
 
-// Export domain classes for direct use with MastraStorage composition
+/** Default maximum number of connections in the pool */
+const DEFAULT_MAX_CONNECTIONS = 20;
+/** Default idle timeout in milliseconds */
+const DEFAULT_IDLE_TIMEOUT_MS = 30000;
+
 export { AgentsPG, MemoryPG, ObservabilityPG, ScoresPG, WorkflowsPG };
-export type { PgDomainConfig } from './db';
+export { PoolAdapter } from './client';
+export type { DbClient, TxClient, QueryValues, Pool, PoolClient, QueryResult } from './client';
+export type { PgDomainConfig, PgDomainClientConfig, PgDomainPoolConfig, PgDomainRestConfig } from './db';
 
 /**
  * PostgreSQL storage adapter for Mastra.
  *
- * Access domain-specific storage via `getStore()`:
- *
  * @example
  * ```typescript
- * const storage = new PostgresStore({ connectionString: '...' });
+ * // Option 1: Connection string
+ * const store = new PostgresStore({
+ *   id: 'my-store',
+ *   connectionString: 'postgresql://...',
+ * });
  *
- * // Access memory domain
- * const memory = await storage.getStore('memory');
+ * // Option 2: Pre-configured pool
+ * const pool = new Pool({ connectionString: 'postgresql://...' });
+ * const store = new PostgresStore({ id: 'my-store', pool });
+ *
+ * // Access domain storage
+ * const memory = await store.getStore('memory');
  * await memory?.saveThread({ thread });
  *
- * // Access workflows domain
- * const workflows = await storage.getStore('workflows');
- * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
+ * // Execute custom queries
+ * const rows = await store.db.any('SELECT * FROM my_table');
  * ```
  */
 export class PostgresStore extends MastraStorage {
-  #db: pgPromise.IDatabase<{}>;
-  #pgp: pgPromise.IMain;
+  #pool: Pool;
+  #db: DbClient;
+  #ownsPool: boolean;
   private schema: string;
   private isInitialized: boolean = false;
 
   stores: StorageDomains;
 
   constructor(config: PostgresStoreConfig) {
-    // Validation: connectionString or host/database/user/password must not be empty
     try {
       validateConfig('PostgresStore', config);
       super({ id: config.id, name: 'PostgresStore', disableInit: config.disableInit });
       this.schema = config.schemaName || 'public';
 
-      // Initialize pg-promise
-      this.#pgp = pgPromise();
-
-      // Handle pre-configured client vs creating new connection
-      if (isClientConfig(config)) {
-        // User provided a pre-configured pg-promise client
-        this.#db = config.client;
+      if (isPoolConfig(config)) {
+        this.#pool = config.pool;
+        this.#ownsPool = false;
       } else {
-        // Create connection from config
-        let pgConfig: PostgresStoreConfig;
-        if (isConnectionStringConfig(config)) {
-          pgConfig = {
-            id: config.id,
-            connectionString: config.connectionString,
-            max: config.max,
-            idleTimeoutMillis: config.idleTimeoutMillis,
-            ssl: config.ssl,
-          };
-        } else if (isCloudSqlConfig(config)) {
-          // Cloud SQL connector config
-          pgConfig = {
-            ...config,
-            id: config.id,
-            max: config.max,
-            idleTimeoutMillis: config.idleTimeoutMillis,
-          };
-        } else if (isHostConfig(config)) {
-          pgConfig = {
-            id: config.id,
-            host: config.host,
-            port: config.port,
-            database: config.database,
-            user: config.user,
-            password: config.password,
-            ssl: config.ssl,
-            max: config.max,
-            idleTimeoutMillis: config.idleTimeoutMillis,
-          };
-        } else {
-          // This should never happen due to validation above, but included for completeness
-          throw new Error(
-            'PostgresStore: invalid config. Provide either {client}, {connectionString}, {host,port,database,user,password}, or a pg ClientConfig (e.g., Cloud SQL connector with `stream`).',
-          );
-        }
-
-        // Note: pg-promise creates connections lazily when queries are executed,
-        // so this is safe to do in the constructor
-        this.#db = this.#pgp(pgConfig as any);
+        this.#pool = this.createPool(config);
+        this.#ownsPool = true;
       }
 
-      // Create all domain instances synchronously in the constructor
-      // This is required for Memory to work correctly, as it checks for
-      // stores.memory during getInputProcessors() before init() is called
-      const skipDefaultIndexes = config.skipDefaultIndexes;
-      const indexes = config.indexes;
-      const domainConfig: PgDomainConfig = { client: this.#db, schemaName: this.schema, skipDefaultIndexes, indexes };
+      this.#db = new PoolAdapter(this.#pool);
 
-      const scores = new ScoresPG(domainConfig);
-      const workflows = new WorkflowsPG(domainConfig);
-      const memory = new MemoryPG(domainConfig);
-      const observability = new ObservabilityPG(domainConfig);
-      const agents = new AgentsPG(domainConfig);
+      const domainConfig: PgDomainClientConfig = {
+        client: this.#db,
+        schemaName: this.schema,
+        skipDefaultIndexes: config.skipDefaultIndexes,
+        indexes: config.indexes,
+      };
 
       this.stores = {
-        scores,
-        workflows,
-        memory,
-        observability,
-        agents,
+        scores: new ScoresPG(domainConfig),
+        workflows: new WorkflowsPG(domainConfig),
+        memory: new MemoryPG(domainConfig),
+        observability: new ObservabilityPG(domainConfig),
+        agents: new AgentsPG(domainConfig),
       };
     } catch (e) {
       throw new MastraError(
@@ -136,6 +103,36 @@ export class PostgresStore extends MastraStorage {
     }
   }
 
+  private createPool(config: PostgresStoreConfig): Pool {
+    if (isConnectionStringConfig(config)) {
+      return new Pool({
+        connectionString: config.connectionString,
+        ssl: config.ssl,
+        max: config.max ?? DEFAULT_MAX_CONNECTIONS,
+        idleTimeoutMillis: config.idleTimeoutMillis ?? DEFAULT_IDLE_TIMEOUT_MS,
+      });
+    }
+
+    if (isHostConfig(config)) {
+      return new Pool({
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        user: config.user,
+        password: config.password,
+        ssl: config.ssl,
+        max: config.max ?? DEFAULT_MAX_CONNECTIONS,
+        idleTimeoutMillis: config.idleTimeoutMillis ?? DEFAULT_IDLE_TIMEOUT_MS,
+      });
+    }
+
+    if (isCloudSqlConfig(config)) {
+      return new Pool(config as any);
+    }
+
+    throw new Error('PostgresStore: invalid config');
+  }
+
   async init(): Promise<void> {
     if (this.isInitialized) {
       return;
@@ -143,8 +140,6 @@ export class PostgresStore extends MastraStorage {
 
     try {
       this.isInitialized = true;
-
-      // Each domain creates its own indexes during init()
       await super.init();
     } catch (error) {
       this.isInitialized = false;
@@ -159,20 +154,33 @@ export class PostgresStore extends MastraStorage {
     }
   }
 
-  public get db() {
+  /**
+   * Database client for executing queries.
+   *
+   * @example
+   * ```typescript
+   * const rows = await store.db.any('SELECT * FROM users WHERE active = $1', [true]);
+   * const user = await store.db.one('SELECT * FROM users WHERE id = $1', [userId]);
+   * ```
+   */
+  public get db(): DbClient {
     return this.#db;
   }
 
-  public get pgp() {
-    return this.#pgp;
+  /**
+   * The underlying pg.Pool for direct database access or ORM integration.
+   */
+  public get pool(): Pool {
+    return this.#pool;
   }
 
   /**
-   * Closes the pg-promise connection pool.
-   *
-   * This will close ALL connections in the pool, including pre-configured clients.
+   * Closes the connection pool if it was created by this store.
+   * If a pool was passed in via config, it will not be closed.
    */
   async close(): Promise<void> {
-    this.pgp.end();
+    if (this.#ownsPool) {
+      await this.#pool.end();
+    }
   }
 }

--- a/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
+++ b/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
@@ -3,16 +3,18 @@ import { MemoryPG } from '../domains/memory';
 import { ObservabilityPG } from '../domains/observability';
 import { ScoresPG } from '../domains/scores';
 
-// Mock pg-promise
+// Mock DbClient
 const mockClient = {
+  $pool: {},
   none: vi.fn(),
   one: vi.fn(),
   manyOrNone: vi.fn(),
   oneOrNone: vi.fn(),
+  many: vi.fn(),
+  any: vi.fn(),
   query: vi.fn(),
+  tx: vi.fn(),
 };
-
-vi.mock('pg-promise', () => ({ default: vi.fn(() => vi.fn(() => mockClient)) }));
 
 describe('PostgresStore Domain Performance Indexes', () => {
   beforeEach(() => {

--- a/stores/pg/src/storage/test-utils.ts
+++ b/stores/pg/src/storage/test-utils.ts
@@ -610,7 +610,7 @@ export function pgTests() {
 
     // PG-specific: pool field exposure with pre-configured pool
     describe('Pre-configured Pool Field Exposure', () => {
-      it('should expose client and pool fields with pre-configured pool', () => {
+      it('should expose client and pool fields with pre-configured pool', async () => {
         const pool = new Pool({ connectionString });
 
         const poolStore = new PostgresStore({

--- a/stores/pg/src/storage/test-utils.ts
+++ b/stores/pg/src/storage/test-utils.ts
@@ -1,6 +1,6 @@
 import { createSampleThread } from '@internal/storage-test-utils';
 import type { MemoryStorage, StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
-import pgPromise from 'pg-promise';
+import { Pool } from 'pg';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { PostgresStoreConfig } from '../shared/config';
 import { PgDB } from './db';
@@ -26,7 +26,7 @@ export function pgTests() {
     beforeAll(async () => {
       store = new PostgresStore(TEST_CONFIG);
       await store.init();
-      // Create PgDB instance for low-level operations (not exposed on main store)
+      // Create PgDB instance for low-level operations
       dbOps = new PgDB({ client: store.db });
     });
     afterAll(async () => {
@@ -36,36 +36,27 @@ export function pgTests() {
     });
 
     describe('Public Fields Access', () => {
-      it('should expose db field as public', () => {
+      it('should expose client field as public', () => {
         expect(store.db).toBeDefined();
         expect(typeof store.db).toBe('object');
         expect(store.db.query).toBeDefined();
         expect(typeof store.db.query).toBe('function');
       });
 
-      it('should expose pgp field as public', () => {
-        expect(store.pgp).toBeDefined();
-        expect(typeof store.pgp).toBe('function');
-        expect(store.pgp.end).toBeDefined();
-        expect(typeof store.pgp.end).toBe('function');
+      it('should expose pool field as public', () => {
+        expect(store.pool).toBeDefined();
+        expect(store.pool).toBeInstanceOf(Pool);
       });
 
-      it('should allow direct database queries via public db field', async () => {
-        const result = await store.db.one('SELECT 1 as test');
+      it('should allow direct database queries via public client field', async () => {
+        const result = await store.db.one<{ test: number }>('SELECT 1 as test');
         expect(result.test).toBe(1);
       });
 
-      it('should allow access to pgp utilities via public pgp field', () => {
-        const helpers = store.pgp.helpers;
-        expect(helpers).toBeDefined();
-        expect(helpers.insert).toBeDefined();
-        expect(helpers.update).toBeDefined();
-      });
-
-      it('should maintain connection state through public db field', async () => {
+      it('should maintain connection state through public client field', async () => {
         // Test multiple queries to ensure connection state
-        const result1 = await store.db.one('SELECT NOW() as timestamp1');
-        const result2 = await store.db.one('SELECT NOW() as timestamp2');
+        const result1 = await store.db.one<{ timestamp1: Date }>('SELECT NOW() as timestamp1');
+        const result2 = await store.db.one<{ timestamp2: Date }>('SELECT NOW() as timestamp2');
 
         expect(result1.timestamp1).toBeDefined();
         expect(result2.timestamp2).toBeDefined();
@@ -161,24 +152,21 @@ export function pgTests() {
       const schemaRestrictedUser = 'mastra_schema_restricted_storage';
       const restrictedPassword = 'test123';
       const testSchema = 'testSchema';
-      let adminDb: pgPromise.IDatabase<{}>;
-      let pgpAdmin: pgPromise.IMain;
+      let adminPool: Pool;
 
       beforeAll(async () => {
         // Re-initialize the main store for subsequent tests
-
         await store.init();
 
-        // Create a separate pg-promise instance for admin operations
-        pgpAdmin = pgPromise();
-        adminDb = pgpAdmin(connectionString);
+        // Create a separate pool for admin operations
+        adminPool = new Pool({ connectionString });
+        const client = await adminPool.connect();
         try {
-          await adminDb.tx(async t => {
-            // Drop the test schema if it exists from previous runs
-            await t.none(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
+          // Drop the test schema if it exists from previous runs
+          await client.query(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
 
-            // Create schema restricted user with minimal permissions
-            await t.none(`
+          // Create schema restricted user with minimal permissions
+          await client.query(`
                 DO $$
                 BEGIN
                   IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${schemaRestrictedUser}') THEN
@@ -187,71 +175,55 @@ export function pgTests() {
                 END
                 $$;`);
 
-            // Grant only connect and usage to schema restricted user
-            await t.none(`
+          // Grant only connect and usage to schema restricted user
+          await client.query(`
                   REVOKE ALL ON DATABASE ${(TEST_CONFIG as any).database} FROM ${schemaRestrictedUser};
                   GRANT CONNECT ON DATABASE ${(TEST_CONFIG as any).database} TO ${schemaRestrictedUser};
                   REVOKE ALL ON SCHEMA public FROM ${schemaRestrictedUser};
                   GRANT USAGE ON SCHEMA public TO ${schemaRestrictedUser};
                 `);
-          });
-        } catch (error) {
-          // Clean up the database connection on error
-          pgpAdmin.end();
-          throw error;
+        } finally {
+          client.release();
         }
       });
 
       afterAll(async () => {
+        const client = await adminPool.connect();
         try {
-          // Then clean up test user in admin connection
-          await adminDb.tx(async t => {
-            await t.none(`
+          await client.query(`
                   REASSIGN OWNED BY ${schemaRestrictedUser} TO postgres;
                   DROP OWNED BY ${schemaRestrictedUser};
                   DROP USER IF EXISTS ${schemaRestrictedUser};
                 `);
-          });
-
-          // Finally clean up admin connection
-          if (pgpAdmin) {
-            pgpAdmin.end();
-          }
-        } catch (error) {
-          console.error('Error cleaning up test user:', error);
-          if (pgpAdmin) pgpAdmin.end();
+        } finally {
+          client.release();
+          await adminPool.end();
         }
       });
 
       describe('Schema Creation', () => {
         beforeEach(async () => {
-          // Create a fresh connection for each test
-          const tempPgp = pgPromise();
-          const tempDb = tempPgp(connectionString);
-
+          const client = await adminPool.connect();
           try {
             // Ensure schema doesn't exist before each test
-            await tempDb.none(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
+            await client.query(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
 
             // Ensure no active connections from restricted user
-            await tempDb.none(`
+            await client.query(`
                   SELECT pg_terminate_backend(pid)
                   FROM pg_stat_activity
                   WHERE usename = '${schemaRestrictedUser}'
                 `);
           } finally {
-            tempPgp.end(); // Always clean up the connection
+            client.release();
           }
         });
 
         afterEach(async () => {
-          // Create a fresh connection for cleanup
-          const tempPgp = pgPromise();
-          const tempDb = tempPgp(connectionString);
-
+          const client = await adminPool.connect();
           try {
             // Clean up any connections from the restricted user and drop schema
-            await tempDb.none(`
+            await client.query(`
                   DO $$
                   BEGIN
                     -- Terminate connections
@@ -263,10 +235,8 @@ export function pgTests() {
                     DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
                   END $$;
                 `);
-          } catch (error) {
-            console.error('Error in afterEach cleanup:', error);
           } finally {
-            tempPgp.end(); // Always clean up the connection
+            client.release();
           }
         });
 
@@ -279,10 +249,6 @@ export function pgTests() {
             schemaName: testSchema,
           });
 
-          // Create a fresh connection for verification
-          const tempPgp = pgPromise();
-          const tempDb = tempPgp(connectionString);
-
           try {
             // Test schema creation by initializing the store
             await expect(async () => {
@@ -292,14 +258,13 @@ export function pgTests() {
             );
 
             // Verify schema was not created
-            const exists = await tempDb.oneOrNone(
+            const result = await adminPool.query(
               `SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)`,
               [testSchema],
             );
-            expect(exists?.exists).toBe(false);
+            expect(result.rows[0]?.exists).toBe(false);
           } finally {
             await restrictedDB.close();
-            tempPgp.end(); // Clean up the verification connection
           }
         });
 
@@ -312,10 +277,6 @@ export function pgTests() {
             schemaName: testSchema,
           });
 
-          // Create a fresh connection for verification
-          const tempPgp = pgPromise();
-          const tempDb = tempPgp(connectionString);
-
           try {
             await expect(async () => {
               await restrictedDB.init();
@@ -327,14 +288,13 @@ export function pgTests() {
             );
 
             // Verify schema was not created
-            const exists = await tempDb.oneOrNone(
+            const result = await adminPool.query(
               `SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)`,
               [testSchema],
             );
-            expect(exists?.exists).toBe(false);
+            expect(result.rows[0]?.exists).toBe(false);
           } finally {
             await restrictedDB.close();
-            tempPgp.end(); // Clean up the verification connection
           }
         });
       });
@@ -343,19 +303,20 @@ export function pgTests() {
     describe('Function Namespace in Schema', () => {
       const testSchema = 'schema_fn_test';
       let testStore: PostgresStore;
+      let adminPool: Pool;
 
       beforeAll(async () => {
-        // Use a temp connection to set up schema
-        const tempPgp = pgPromise();
-        const tempDb = tempPgp(connectionString);
+        // Use a temp pool to set up schema
+        adminPool = new Pool({ connectionString });
+        const client = await adminPool.connect();
 
         try {
-          await tempDb.none(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
-          await tempDb.none(`CREATE SCHEMA ${testSchema}`);
+          await client.query(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
+          await client.query(`CREATE SCHEMA ${testSchema}`);
           // Drop the function from public schema if it exists from other tests
-          await tempDb.none(`DROP FUNCTION IF EXISTS public.trigger_set_timestamps() CASCADE`);
+          await client.query(`DROP FUNCTION IF EXISTS public.trigger_set_timestamps() CASCADE`);
         } finally {
-          tempPgp.end();
+          client.release();
         }
 
         testStore = new PostgresStore({
@@ -369,14 +330,12 @@ export function pgTests() {
       afterAll(async () => {
         await testStore?.close();
 
-        // Use a temp connection to clean up
-        const tempPgp = pgPromise();
-        const tempDb = tempPgp(connectionString);
-
+        const client = await adminPool.connect();
         try {
-          await tempDb.none(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
+          await client.query(`DROP SCHEMA IF EXISTS ${testSchema} CASCADE`);
         } finally {
-          tempPgp.end();
+          client.release();
+          await adminPool.end();
         }
       });
 
@@ -396,7 +355,7 @@ export function pgTests() {
         });
 
         // Verify trigger function exists in the correct schema
-        const functionInfo = await testStore.db.oneOrNone(
+        const functionInfo = await testStore.db.oneOrNone<{ proname: string; nspname: string }>(
           `SELECT p.proname, n.nspname
            FROM pg_proc p
            JOIN pg_namespace n ON p.pronamespace = n.oid
@@ -649,39 +608,37 @@ export function pgTests() {
       });
     });
 
-    // PG-specific: db and pgp field exposure with pre-configured client
-    describe('Pre-configured Client Field Exposure', () => {
-      it('should expose db and pgp fields with pre-configured client', () => {
-        const pgp = pgPromise();
-        const client = pgp(connectionString);
+    // PG-specific: pool field exposure with pre-configured pool
+    describe('Pre-configured Pool Field Exposure', () => {
+      it('should expose client and pool fields with pre-configured pool', () => {
+        const pool = new Pool({ connectionString });
 
-        const clientStore = new PostgresStore({
-          id: 'pre-configured-client-fields-store',
-          client,
+        const poolStore = new PostgresStore({
+          id: 'pre-configured-pool-fields-store',
+          pool,
         });
 
-        // db should be the same client we passed in
-        expect(clientStore.db).toBe(client);
-        // pgp should be defined (may be a new instance or the one used internally)
-        expect(clientStore.pgp).toBeDefined();
+        // pool should be the same pool we passed in
+        expect(poolStore.pool).toBe(pool);
+        // db should be defined
+        expect(poolStore.db).toBeDefined();
 
         // Clean up
-        pgp.end();
+        pool.end();
       });
     });
 
-    // PG-specific: Domain schemaName verification with pre-configured client
-    describe('Domain schemaName with Pre-configured Client', () => {
-      it('should allow domains to use custom schemaName with pre-configured client', async () => {
-        const pgp = pgPromise();
-        const client = pgp(connectionString);
+    // PG-specific: Domain schemaName verification with pre-configured pool
+    describe('Domain schemaName with Pre-configured Pool', () => {
+      it('should allow domains to use custom schemaName with pre-configured pool', async () => {
+        const pool = new Pool({ connectionString });
 
         // Create schema for test
-        await client.none('CREATE SCHEMA IF NOT EXISTS domain_test_schema');
+        await pool.query('CREATE SCHEMA IF NOT EXISTS domain_test_schema');
 
         try {
           const memoryDomain = new MemoryPG({
-            client,
+            pool,
             schemaName: 'domain_test_schema',
           });
 
@@ -689,18 +646,18 @@ export function pgTests() {
           await memoryDomain.init();
 
           // Verify tables were created in the custom schema
-          const tableExists = await client.oneOrNone(
+          const result = await pool.query(
             `SELECT EXISTS (
               SELECT 1 FROM information_schema.tables
               WHERE table_schema = 'domain_test_schema'
               AND table_name = 'mastra_threads'
             )`,
           );
-          expect(tableExists?.exists).toBe(true);
+          expect(result.rows[0]?.exists).toBe(true);
         } finally {
           // Clean up
-          await client.none('DROP SCHEMA IF EXISTS domain_test_schema CASCADE');
-          pgp.end();
+          await pool.query('DROP SCHEMA IF EXISTS domain_test_schema CASCADE');
+          await pool.end();
         }
       });
     });

--- a/stores/pg/src/storage/test-utils.ts
+++ b/stores/pg/src/storage/test-utils.ts
@@ -624,7 +624,7 @@ export function pgTests() {
         expect(poolStore.db).toBeDefined();
 
         // Clean up
-        pool.end();
+        await pool.end();
       });
     });
 

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -111,8 +111,8 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       } else if (isCloudSqlConfig(config)) {
         poolConfig = {
           ...config,
-          max: config.max ?? 20,
-          idleTimeoutMillis: config.idleTimeoutMillis ?? 30000,
+          max: config.pgPoolOptions?.max ?? 20,
+          idleTimeoutMillis: config.pgPoolOptions?.idleTimeoutMillis ?? 30000,
           connectionTimeoutMillis: 2000,
           ...config.pgPoolOptions,
         } as pg.PoolConfig;


### PR DESCRIPTION
## Description

Remove the `pg-promise` dependency from `@mastra/pg` and replace it with vanilla `node-postgres` (`pg`). This enables direct integration with ORMs (e.g., Drizzle) without creating duplicate connection pools.

### Key Changes

- Replace `pg-promise` dependency with direct `pg.Pool` usage
- Expose the underlying `pg.Pool` for direct access or ORM integration
- Provide a `DbClient` abstraction for making queries.
- Refactor config types

## Related Issue(s)

<!-- Link any related issues here -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * pg-promise removed — legacy client configs and pg-promise exposure no longer supported
  * Config shape changed — pool- and Cloud SQL options must be provided via pool-oriented config (pgPoolOptions/pool)

* **New Features**
  * Added store.pool to access the underlying PostgreSQL connection pool
  * Added store.db — a typed pool-backed DB interface with query and transaction helpers
  * New pool-first configuration types and guards exposed for clearer connection handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->