### PR TITLE
tests: clarify models-dev URL normalization test description

### DIFF
--- a/.changeset/test-models-dev-description-fix.md
+++ b/.changeset/test-models-dev-description-fix.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Improved test description in ModelsDevGateway to clearly reflect the behavior being tested

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -213,7 +213,7 @@ describe('ModelsDevGateway', () => {
       expect(providers.unknown_provider).toBeUndefined();
     });
 
-    it('should ensure URLs end with ', async () => {
+    it('should ensure URLs do not end with /chat/completions', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => mockApiResponse,


### PR DESCRIPTION
## Description

While working on a Groq model–related PR, I noticed this test had an incomplete and informal description.  
This change updates the test name to clearly reflect the behavior being asserted.  

No logic or behavior is changed.

## Related Issue(s)

N/A

## Type of Change

- [x] Test update

## Checklist

- [x] No documentation changes required
- [x] No new tests required (description-only update)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Clarified a test name to more accurately state that certain provider URLs do not end with /chat/completions.

* **Chores**
  * Added a changeset describing the test description fix and a patch bump for the core package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->