### PR TITLE
feat(core): Add embedderOptions support to Memory for AI SDK 5+ provider options

### DIFF
--- a/.changeset/odd-files-divide.md
+++ b/.changeset/odd-files-divide.md
@@ -1,0 +1,38 @@
+---
+'@mastra/core': minor
+---
+
+Add embedderOptions support to Memory for AI SDK 5+ provider-specific embedding options
+
+With AI SDK 5+, embedding models no longer accept options in their constructor. Options like `outputDimensionality` for Google embedding models must now be passed when calling `embed()` or `embedMany()`. This change adds `embedderOptions` to Memory configuration to enable passing these provider-specific options.
+
+You can now configure embedder options when creating Memory:
+
+```typescript
+import { Memory } from '@mastra/core';
+import { google } from '@ai-sdk/google';
+
+// Before: No way to specify providerOptions
+const memory = new Memory({
+  embedder: google.textEmbeddingModel('text-embedding-004'),
+});
+
+// After: Pass embedderOptions with providerOptions
+const memory = new Memory({
+  embedder: google.textEmbeddingModel('text-embedding-004'),
+  embedderOptions: {
+    providerOptions: {
+      google: {
+        outputDimensionality: 768,
+        taskType: 'RETRIEVAL_DOCUMENT',
+      },
+    },
+  },
+});
+```
+
+This is especially important for:
+- Google `text-embedding-004`: Control output dimensions (default 768)
+- Google `gemini-embedding-001`: Reduce from default 3072 dimensions to avoid pgvector's 2000 dimension limit for HNSW indexes
+
+Fixes #8248

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -165,6 +165,11 @@ https://mastra.ai/en/docs/memory/semantic-recall`,
       } else {
         this.embedder = config.embedder;
       }
+
+      // Set embedder options (e.g., providerOptions for Google models)
+      if (config.embedderOptions) {
+        this.embedderOptions = config.embedderOptions;
+      }
     }
   }
 
@@ -201,11 +206,17 @@ https://mastra.ai/en/docs/memory/overview`,
     this.vector = vector;
   }
 
-  public setEmbedder(embedder: EmbeddingModelId | MastraEmbeddingModel<string>) {
+  public setEmbedder(
+    embedder: EmbeddingModelId | MastraEmbeddingModel<string>,
+    embedderOptions?: MastraEmbeddingOptions,
+  ) {
     if (typeof embedder === 'string') {
       this.embedder = new ModelRouterEmbeddingModel(embedder);
     } else {
       this.embedder = embedder;
+    }
+    if (embedderOptions) {
+      this.embedderOptions = embedderOptions;
     }
   }
 
@@ -617,6 +628,7 @@ https://mastra.ai/en/docs/memory/overview`,
             storage: memoryStore,
             vector: this.vector,
             embedder: this.embedder,
+            embedderOptions: this.embedderOptions,
             indexName,
             ...semanticConfig,
           }),
@@ -692,6 +704,7 @@ https://mastra.ai/en/docs/memory/overview`,
             storage: memoryStore,
             vector: this.vector,
             embedder: this.embedder,
+            embedderOptions: this.embedderOptions,
             indexName,
             ...semanticRecallConfig,
           }),

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -8,7 +8,7 @@ import type { MastraLanguageModel, MastraModelConfig } from '../llm/model/shared
 import type { RequestContext } from '../request-context';
 import type { MastraStorage } from '../storage';
 import type { DynamicArgument } from '../types';
-import type { MastraEmbeddingModel, MastraVector } from '../vector';
+import type { MastraEmbeddingModel, MastraEmbeddingOptions, MastraVector } from '../vector';
 import type { MemoryProcessor } from '.';
 
 export type { Message as AiMessageType } from '@internal/ai-sdk-v4';
@@ -487,6 +487,25 @@ export type SharedMemoryConfig = {
    * ```
    */
   embedder?: EmbeddingModelId | MastraEmbeddingModel<string>;
+
+  /**
+   * Options to pass to the embedder when generating embeddings.
+   * Use this to pass provider-specific options like outputDimensionality for Google models.
+   *
+   * @example
+   * ```typescript
+   * // Control embedding dimensions for Google models
+   * embedderOptions: {
+   *   providerOptions: {
+   *     google: {
+   *       outputDimensionality: 768,
+   *       taskType: 'RETRIEVAL_DOCUMENT'
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  embedderOptions?: MastraEmbeddingOptions;
 
   /**
    * @deprecated This option is deprecated and will throw an error if used.

--- a/packages/core/src/processors/memory/semantic-recall.test.ts
+++ b/packages/core/src/processors/memory/semantic-recall.test.ts
@@ -1924,5 +1924,213 @@ describe('SemanticRecall', () => {
         },
       });
     });
+
+    it('should work without embedderOptions (backwards compatibility)', async () => {
+      // Create processor without embedderOptions
+      const processor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: mockEmbedder,
+        topK: 3,
+        // No embedderOptions
+      });
+
+      const inputMessages: MastraDBMessage[] = [
+        {
+          id: 'msg-new',
+          role: 'user',
+          content: { format: 2, content: 'Test query', parts: [] },
+          createdAt: new Date(),
+        },
+      ];
+
+      vi.mocked(mockEmbedder.doEmbed).mockResolvedValue({
+        embeddings: [[0.1, 0.2, 0.3]],
+        warnings: [],
+      });
+
+      vi.mocked(mockVector.listIndexes).mockResolvedValue(['mastra_memory_text_embedding_3_small']);
+      vi.mocked(mockVector.query).mockResolvedValue([]);
+
+      const messageList = new MessageList();
+      messageList.add(inputMessages, 'input');
+
+      await processor.processInput({
+        messages: inputMessages,
+        messageList,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      // Verify embedder was called with only values (no extra options)
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledWith({
+        values: ['Test query'],
+      });
+    });
+
+    it('should pass non-providerOptions embedderOptions (like maxRetries)', async () => {
+      const embedderOptions = {
+        maxRetries: 5,
+        maxParallelCalls: 2,
+      };
+
+      const processor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: mockEmbedder,
+        topK: 3,
+        embedderOptions,
+      });
+
+      const inputMessages: MastraDBMessage[] = [
+        {
+          id: 'msg-new',
+          role: 'user',
+          content: { format: 2, content: 'Test query', parts: [] },
+          createdAt: new Date(),
+        },
+      ];
+
+      vi.mocked(mockEmbedder.doEmbed).mockResolvedValue({
+        embeddings: [[0.1, 0.2, 0.3]],
+        warnings: [],
+      });
+
+      vi.mocked(mockVector.listIndexes).mockResolvedValue(['mastra_memory_text_embedding_3_small']);
+      vi.mocked(mockVector.query).mockResolvedValue([]);
+
+      const messageList = new MessageList();
+      messageList.add(inputMessages, 'input');
+
+      await processor.processInput({
+        messages: inputMessages,
+        messageList,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      // Verify embedder was called with maxRetries and maxParallelCalls
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledWith({
+        values: ['Test query'],
+        maxRetries: 5,
+        maxParallelCalls: 2,
+      });
+    });
+
+    it('should handle empty embedderOptions object', async () => {
+      const processor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: mockEmbedder,
+        topK: 3,
+        embedderOptions: {}, // Empty object
+      });
+
+      const inputMessages: MastraDBMessage[] = [
+        {
+          id: 'msg-new',
+          role: 'user',
+          content: { format: 2, content: 'Test query', parts: [] },
+          createdAt: new Date(),
+        },
+      ];
+
+      vi.mocked(mockEmbedder.doEmbed).mockResolvedValue({
+        embeddings: [[0.1, 0.2, 0.3]],
+        warnings: [],
+      });
+
+      vi.mocked(mockVector.listIndexes).mockResolvedValue(['mastra_memory_text_embedding_3_small']);
+      vi.mocked(mockVector.query).mockResolvedValue([]);
+
+      const messageList = new MessageList();
+      messageList.add(inputMessages, 'input');
+
+      await processor.processInput({
+        messages: inputMessages,
+        messageList,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      // Verify embedder was called (empty object spread is fine)
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledWith({
+        values: ['Test query'],
+      });
+    });
+
+    it('should handle embedding errors gracefully when embedderOptions are configured', async () => {
+      const localMockStorage = {
+        listMessages: vi.fn(),
+        saveMessages: vi.fn(),
+      };
+
+      const localMockEmbedder = {
+        modelId: 'gemini-embedding-001',
+        doEmbed: vi.fn().mockRejectedValue(new Error('Invalid outputDimensionality value')),
+      };
+
+      const localMockVector = {
+        upsert: vi.fn(),
+        query: vi.fn(),
+        createIndex: vi.fn().mockResolvedValue(undefined),
+        listIndexes: vi.fn().mockResolvedValue(['mastra_memory_gemini_embedding_001']),
+      };
+
+      const processor = new SemanticRecall({
+        storage: localMockStorage as any,
+        embedder: localMockEmbedder as any,
+        vector: localMockVector as any,
+        embedderOptions: {
+          providerOptions: {
+            google: {
+              outputDimensionality: -1, // Invalid value that would cause an error
+            },
+          },
+        },
+      });
+
+      const userMessage: MastraDBMessage = {
+        id: 'msg-user-1',
+        role: 'user',
+        content: {
+          format: 2,
+          content: 'Hello',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+        createdAt: new Date('2024-01-01T10:00:00Z'),
+      };
+
+      const localRequestContext = new RequestContext();
+      localRequestContext.set('MastraMemory', {
+        thread: { id: 'thread-123' },
+        resourceId: 'user-456',
+      });
+
+      const messageList = new MessageList();
+      messageList.add([userMessage], 'input');
+
+      // Should not throw, should handle error gracefully
+      const result = await processor.processOutputResult({
+        messages: [userMessage],
+        messageList,
+        abort: vi.fn() as any,
+        requestContext: localRequestContext,
+      });
+
+      // Should return messageList (no transformation, just side effect embedding)
+      expect(result).toBe(messageList);
+      // Embedder should have been called with the providerOptions
+      expect(localMockEmbedder.doEmbed).toHaveBeenCalledWith({
+        values: ['Hello'],
+        providerOptions: {
+          google: {
+            outputDimensionality: -1,
+          },
+        },
+      });
+      // Vector upsert should not be called since embedding failed
+      expect(localMockVector.upsert).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/processors/memory/semantic-recall.test.ts
+++ b/packages/core/src/processors/memory/semantic-recall.test.ts
@@ -1811,7 +1811,7 @@ describe('SemanticRecall', () => {
         vector: mockVector,
         embedder: mockEmbedder,
         topK: 3,
-        embedderOptions, // This option doesn't exist yet - this is what we're testing
+        embedderOptions,
       });
 
       const inputMessages: MastraDBMessage[] = [
@@ -1840,8 +1840,7 @@ describe('SemanticRecall', () => {
         requestContext,
       });
 
-      // Verify embedder was called WITH providerOptions
-      // Currently this will fail because providerOptions is not passed through
+      // Verify embedder was called with providerOptions
       expect(mockEmbedder.doEmbed).toHaveBeenCalledWith({
         values: ['Test query'],
         providerOptions: {
@@ -1885,7 +1884,7 @@ describe('SemanticRecall', () => {
         storage: localMockStorage as any,
         embedder: localMockEmbedder as any,
         vector: localMockVector as any,
-        embedderOptions, // This option doesn't exist yet
+        embedderOptions,
       });
 
       const userMessage: MastraDBMessage = {
@@ -1915,7 +1914,7 @@ describe('SemanticRecall', () => {
         requestContext: localRequestContext,
       });
 
-      // Verify embedder was called WITH providerOptions
+      // Verify embedder was called with providerOptions
       expect(localMockEmbedder.doEmbed).toHaveBeenCalledWith({
         values: ['Hello'],
         providerOptions: {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Add `embedderOptions` to Memory configuration to enable passing provider-specific options to embedding models. With AI SDK 5+, embedding models no longer accept options in their constructor—options like `outputDimensionality` for Google models must be passed when calling `embed()` or `embedMany()`. This change wires `embedderOptions` through `MastraMemory` to the `SemanticRecall` processor.

```typescript
const memory = new Memory({
  embedder: google.textEmbeddingModel('text-embedding-004'),
  embedderOptions: {
    providerOptions: {
      google: {
        outputDimensionality: 768,
        taskType: 'RETRIEVAL_DOCUMENT',
      },
    },
  },
});
```
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
#8248

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory now accepts provider-specific embedding options in its configuration, allowing embed-time customization (e.g., output dimensionality or task type) for finer control of embeddings.
* **Tests**
  * Added test coverage validating embedder options across input/output embedding paths, compatibility scenarios, caching, and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->