### PR TITLE
fix(core): Use transform-safe JSON Schema conversion for Zod v4 in structuredOutput

### DIFF
--- a/.changeset/fix-zod-v4-transform-json-schema.md
+++ b/.changeset/fix-zod-v4-transform-json-schema.md
@@ -1,0 +1,10 @@
+---
+"@mastra/core": patch
+---
+
+Fixed "Transforms cannot be represented in JSON Schema" error when using Zod v4 with structuredOutput
+
+When using schemas with `.optional()`, `.nullable()`, `.default()`, or `.nullish().default("")` patterns with `structuredOutput` and Zod v4, users would encounter an error because OpenAI schema compatibility layer adds transforms that Zod v4's native `toJSONSchema()` cannot handle.
+
+The fix uses Mastra's transform-safe `zodToJsonSchema` function which gracefully handles transforms by using the `unrepresentable: 'any'` option.
+

--- a/.changeset/fix-zod-v4-transform-json-schema.md
+++ b/.changeset/fix-zod-v4-transform-json-schema.md
@@ -1,5 +1,6 @@
 ---
 "@mastra/core": patch
+"@mastra/schema-compat": patch
 ---
 
 Fixed "Transforms cannot be represented in JSON Schema" error when using Zod v4 with structuredOutput
@@ -7,4 +8,6 @@ Fixed "Transforms cannot be represented in JSON Schema" error when using Zod v4 
 When using schemas with `.optional()`, `.nullable()`, `.default()`, or `.nullish().default("")` patterns with `structuredOutput` and Zod v4, users would encounter an error because OpenAI schema compatibility layer adds transforms that Zod v4's native `toJSONSchema()` cannot handle.
 
 The fix uses Mastra's transform-safe `zodToJsonSchema` function which gracefully handles transforms by using the `unrepresentable: 'any'` option.
+
+Also exported `isZodType` utility from `@mastra/schema-compat` and updated it to detect both Zod v3 (`_def`) and Zod v4 (`_zod`) schemas.
 

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -1,6 +1,7 @@
 import { TransformStream } from 'node:stream/web';
 import { isDeepEqualData, jsonSchema, parsePartialJson } from '@internal/ai-sdk-v5';
 import type { JSONSchema7, Schema } from '@internal/ai-sdk-v5';
+import { isZodType } from '@mastra/schema-compat';
 import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import type z3 from 'zod/v3';
 import z4 from 'zod/v4';
@@ -147,13 +148,7 @@ abstract class BaseFormatHandler<OUTPUT extends OutputSchema = undefined> {
    * Checks if the original schema is a Zod schema with safeParse method.
    */
   protected isZodSchema(schema: unknown): schema is z3.ZodType<any, z3.ZodTypeDef, any> | z4.ZodType<any, any> {
-    return (
-      schema !== undefined &&
-      schema !== null &&
-      typeof schema === 'object' &&
-      'safeParse' in schema &&
-      typeof schema.safeParse === 'function'
-    );
+    return isZodType(schema);
   }
 
   /**

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -1,6 +1,7 @@
 import { TransformStream } from 'node:stream/web';
-import { asSchema, isDeepEqualData, jsonSchema, parsePartialJson } from '@internal/ai-sdk-v5';
+import { isDeepEqualData, jsonSchema, parsePartialJson } from '@internal/ai-sdk-v5';
 import type { JSONSchema7, Schema } from '@internal/ai-sdk-v5';
+import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import type z3 from 'zod/v3';
 import z4 from 'zod/v4';
 import type { StructuredOutputOptions } from '../../agent/types';
@@ -454,8 +455,9 @@ class EnumFormatHandler<OUTPUT extends OutputSchema = undefined> extends BaseFor
     let enumValues: unknown[] | undefined;
 
     if (this.isZodSchema(this.schema)) {
-      const wrappedSchema = asSchema(this.schema);
-      enumValues = wrappedSchema.jsonSchema?.enum;
+      // Use transform-safe zodToJsonSchema to avoid "Transforms cannot be represented in JSON Schema" error
+      const convertedSchema = zodToJsonSchema(this.schema as z3.ZodType<any> | z4.ZodType<any, any>);
+      enumValues = (convertedSchema as JSONSchema7)?.enum;
     } else if (typeof this.schema === 'object' && !(this.schema as Schema<any>).jsonSchema) {
       // Plain JSONSchema7
       const wrappedSchema = jsonSchema(this.schema as JSONSchema7);

--- a/packages/core/src/stream/base/schema.test.ts
+++ b/packages/core/src/stream/base/schema.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Test for Zod v4 JSON Schema compatibility issue
+ *
+ * This test reproduces the bug where:
+ * 1. OpenAISchemaCompatLayer.processZodType() adds .transform() to handle .optional(), .nullable(), .default()
+ * 2. When the processed schema is converted to JSON Schema via asJsonSchema()
+ * 3. It throws "Transforms cannot be represented in JSON Schema"
+ *
+ * Bug Report Pattern:
+ * ```typescript
+ * const schema = z.object({
+ *   rate: z.string().nullish().default(""),
+ * });
+ * const result = await agent.generate(prompt, { structuredOutput: { schema } });
+ * // Error: Transforms cannot be represented in JSON Schema
+ * ```
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { asJsonSchema } from './schema';
+
+// Mock zod to use zod/v4
+vi.mock('zod', async () => {
+  const zodV4 = await import('zod/v4');
+  return {
+    z: zodV4.z,
+  };
+});
+
+describe('asJsonSchema - Zod v4 transform compatibility', () => {
+  describe('should handle schemas with transforms', () => {
+    it('should convert schema with .transform() to JSON Schema without error', () => {
+      // This simulates what OpenAISchemaCompatLayer does:
+      // It converts .optional() to .nullable().transform(v => v === null ? undefined : v)
+      const schemaWithTransform = z.object({
+        name: z.string(),
+        // This is what OpenAISchemaCompatLayer produces for .optional() fields
+        age: z
+          .number()
+          .nullable()
+          .transform(v => (v === null ? undefined : v)),
+      });
+
+      // This should NOT throw "Transforms cannot be represented in JSON Schema"
+      // Currently it DOES throw, which is the bug we're fixing
+      expect(() => {
+        asJsonSchema(schemaWithTransform);
+      }).not.toThrow();
+
+      const result = asJsonSchema(schemaWithTransform);
+      expect(result).toBeDefined();
+      expect(result?.type).toBe('object');
+    });
+
+    it('should convert schema with default transform to JSON Schema without error', () => {
+      // This simulates what OpenAISchemaCompatLayer does for .default() fields:
+      // It converts .default(value) to .nullable().transform(v => v === null ? defaultValue : v)
+      const schemaWithDefaultTransform = z.object({
+        name: z.string(),
+        score: z
+          .number()
+          .nullable()
+          .transform(v => (v === null ? 100 : v)),
+      });
+
+      expect(() => {
+        asJsonSchema(schemaWithDefaultTransform);
+      }).not.toThrow();
+
+      const result = asJsonSchema(schemaWithDefaultTransform);
+      expect(result).toBeDefined();
+    });
+
+    it('should convert complex nested schema with transforms to JSON Schema', () => {
+      // Mimics the user's EpidemiologySchema pattern
+      const schemaWithNestedTransforms = z.object({
+        prevalence: z.object({
+          global: z
+            .object({
+              rate: z
+                .string()
+                .nullable()
+                .transform(v => (v === null ? '' : v)),
+              context: z
+                .string()
+                .nullable()
+                .transform(v => (v === null ? '' : v)),
+            })
+            .nullable(),
+          regional: z
+            .array(
+              z.object({
+                region: z
+                  .string()
+                  .nullable()
+                  .transform(v => (v === null ? '' : v)),
+                rate: z
+                  .string()
+                  .nullable()
+                  .transform(v => (v === null ? '' : v)),
+              }),
+            )
+            .nullable()
+            .transform(v => (v === null ? [] : v)),
+        }),
+        totalPatients: z.object({
+          estimated: z
+            .string()
+            .nullable()
+            .transform(v => (v === null ? '' : v)),
+          year: z.number().nullable(),
+        }),
+      });
+
+      // This currently fails with "Transforms cannot be represented in JSON Schema"
+      expect(() => {
+        asJsonSchema(schemaWithNestedTransforms);
+      }).not.toThrow();
+
+      const result = asJsonSchema(schemaWithNestedTransforms);
+      expect(result).toBeDefined();
+      expect(result?.type).toBe('object');
+    });
+  });
+
+  describe('schemas without transforms should still work', () => {
+    it('should convert simple schema to JSON Schema', () => {
+      const simpleSchema = z.object({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      expect(() => {
+        asJsonSchema(simpleSchema);
+      }).not.toThrow();
+
+      const result = asJsonSchema(simpleSchema);
+      expect(result).toBeDefined();
+      expect(result?.type).toBe('object');
+    });
+
+    it('should convert schema with nullable (no transform) to JSON Schema', () => {
+      const nullableSchema = z.object({
+        name: z.string(),
+        deletedAt: z.string().nullable(),
+      });
+
+      expect(() => {
+        asJsonSchema(nullableSchema);
+      }).not.toThrow();
+
+      const result = asJsonSchema(nullableSchema);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('validation should work after JSON Schema conversion', () => {
+    it('should parse correctly with transform after getting JSON Schema', () => {
+      const schemaWithTransform = z.object({
+        name: z.string(),
+        age: z
+          .number()
+          .nullable()
+          .transform(v => (v === null ? undefined : v)),
+      });
+
+      // First, should be able to get JSON Schema without error
+      expect(() => {
+        asJsonSchema(schemaWithTransform);
+      }).not.toThrow();
+
+      // Then, the schema should still parse and transform correctly
+      const result = schemaWithTransform.parse({ name: 'John', age: null });
+      expect(result).toEqual({ name: 'John', age: undefined });
+    });
+  });
+});

--- a/packages/core/src/stream/base/schema.ts
+++ b/packages/core/src/stream/base/schema.ts
@@ -1,7 +1,21 @@
 import { asSchema } from '@internal/ai-sdk-v5';
 import type { JSONSchema7, Schema } from '@internal/ai-sdk-v5';
+import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import type z3 from 'zod/v3';
 import type z4 from 'zod/v4';
+
+/**
+ * Check if a value is a Zod schema (v3 or v4)
+ */
+function isZodSchema(value: unknown): value is z3.ZodType<any> | z4.ZodType<any, any> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'safeParse' in value &&
+    typeof (value as any).safeParse === 'function' &&
+    ('_def' in value || '_zod' in value) // _def for v3, _zod for v4
+  );
+}
 
 export type PartialSchemaOutput<OUTPUT extends OutputSchema = undefined> = OUTPUT extends undefined
   ? undefined
@@ -37,7 +51,7 @@ export function asJsonSchema(schema: OutputSchema): JSONSchema7 | undefined {
   if (!schema) {
     return undefined;
   }
-  // Handle JSONSchema7 directly
+  // Handle JSONSchema7 directly (plain object without safeParse or jsonSchema property)
   if (
     schema &&
     typeof schema === 'object' &&
@@ -46,7 +60,20 @@ export function asJsonSchema(schema: OutputSchema): JSONSchema7 | undefined {
   ) {
     return schema as JSONSchema7;
   }
-  // Handle Zod schemas and AI SDK Schema types
+
+  // Handle Zod schemas using our transform-safe converter
+  // This uses `unrepresentable: 'any'` which gracefully handles transforms
+  // that would otherwise throw "Transforms cannot be represented in JSON Schema"
+  if (isZodSchema(schema)) {
+    return zodToJsonSchema(schema as z3.ZodType<any> | z4.ZodType<any, any>) as JSONSchema7;
+  }
+
+  // Handle AI SDK Schema types (objects with jsonSchema property)
+  if ((schema as Schema<any>).jsonSchema) {
+    return (schema as Schema<any>).jsonSchema;
+  }
+
+  // Fallback to AI SDK's asSchema for any other cases
   return asSchema(schema as z3.ZodType<any> | z4.ZodType<any, any> | Schema<any>).jsonSchema;
 }
 

--- a/packages/core/src/stream/base/schema.ts
+++ b/packages/core/src/stream/base/schema.ts
@@ -1,21 +1,9 @@
 import { asSchema } from '@internal/ai-sdk-v5';
 import type { JSONSchema7, Schema } from '@internal/ai-sdk-v5';
+import { isZodType } from '@mastra/schema-compat';
 import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import type z3 from 'zod/v3';
 import type z4 from 'zod/v4';
-
-/**
- * Check if a value is a Zod schema (v3 or v4)
- */
-function isZodSchema(value: unknown): value is z3.ZodType<any> | z4.ZodType<any, any> {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'safeParse' in value &&
-    typeof (value as any).safeParse === 'function' &&
-    ('_def' in value || '_zod' in value) // _def for v3, _zod for v4
-  );
-}
 
 export type PartialSchemaOutput<OUTPUT extends OutputSchema = undefined> = OUTPUT extends undefined
   ? undefined
@@ -64,7 +52,7 @@ export function asJsonSchema(schema: OutputSchema): JSONSchema7 | undefined {
   // Handle Zod schemas using our transform-safe converter
   // This uses `unrepresentable: 'any'` which gracefully handles transforms
   // that would otherwise throw "Transforms cannot be represented in JSON Schema"
-  if (isZodSchema(schema)) {
+  if (isZodType(schema)) {
     return zodToJsonSchema(schema as z3.ZodType<any> | z4.ZodType<any, any>) as JSONSchema7;
   }
 

--- a/packages/schema-compat/src/index.ts
+++ b/packages/schema-compat/src/index.ts
@@ -29,7 +29,7 @@ export { SchemaCompatLayer as SchemaCompatLayerV4 } from './schema-compatibility
 export { SchemaCompatLayer } from './schema-compatibility';
 
 // Utility functions
-export { convertZodSchemaToAISDKSchema, applyCompatLayer, convertSchemaToZod } from './utils';
+export { convertZodSchemaToAISDKSchema, applyCompatLayer, convertSchemaToZod, isZodType } from './utils';
 
 // Provider compatibility implementations
 export { AnthropicSchemaCompatLayer } from './provider-compats/anthropic';

--- a/packages/schema-compat/src/utils.ts
+++ b/packages/schema-compat/src/utils.ts
@@ -56,10 +56,11 @@ export function convertZodSchemaToAISDKSchema(zodSchema: ZodSchema, target: Targ
  */
 export function isZodType(value: unknown): value is ZodType {
   // Check if it's a Zod schema by looking for common Zod properties and methods
+  // _def is used in Zod v3, _zod is used in Zod v4
   return (
     typeof value === 'object' &&
     value !== null &&
-    '_def' in value &&
+    ('_def' in value || '_zod' in value) &&
     'parse' in value &&
     typeof (value as any).parse === 'function' &&
     'safeParse' in value &&


### PR DESCRIPTION
## Description

**Root Cause**: 
1. `OpenAISchemaCompatLayer.processZodType()` adds `.transform()` to schemas for OpenAI strict mode compatibility
2. The processed schema is passed to `asJsonSchema()` which calls AI SDK's `asSchema()`
3. AI SDK's `asSchema()` uses Zod v4's native `toJSONSchema()` which throws on transforms

## Solution

Use Mastra's `zodToJsonSchema` function (from `@mastra/schema-compat`) which passes `unrepresentable: 'any'` to Zod v4's `toJSONSchema()`. This gracefully handles transforms by converting them to `any` type in the JSON Schema instead of throwing.

## Changes

- `packages/core/src/stream/base/schema.ts`: Use `zodToJsonSchema` for Zod schemas instead of AI SDK's `asSchema`
- `packages/core/src/stream/base/output-format-handlers.ts`: Same fix for enum value extraction
- `packages/core/src/stream/base/schema.test.ts`: Added 6 tests for transform compatibility

## Testing

All existing tests pass plus 6 new tests:
- Schemas with `.transform()` now convert to JSON Schema without error
- Schemas without transforms continue to work
- End-to-end agent structured output tests pass
<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)
Fixes #11353
<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed errors when using Zod v4 transforms with structuredOutput; improved JSON Schema generation and OpenAI compatibility for transform-heavy Zod schemas.
  * Better handling of optional, nullable, default, and nullish patterns to avoid unrepresentable-transform errors.

* **New Features**
  * Exported Zod detection utility for broader Zod v3/v4 support.
  * Added a JSON string escaping helper.

* **Tests**
  * Added tests covering Zod v4 transform compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->