### PR TITLE
fix(deployer): use exact version match for @mastra/server dependency

### DIFF
--- a/.changeset/fix-deployer-server-version-resolution.md
+++ b/.changeset/fix-deployer-server-version-resolution.md
@@ -1,0 +1,8 @@
+---
+"@mastra/deployer": patch
+---
+
+Fix npm resolving wrong @mastra/server version
+
+Changed `@mastra/server` dependency from `workspace:^` to `workspace:*` to prevent npm from resolving to incompatible stable versions (e.g., 1.0.3) instead of the required beta versions.
+

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@babel/core": "^7.28.5",
     "@babel/preset-typescript": "^7.27.1",
-    "@mastra/server": "workspace:^",
+    "@mastra/server": "workspace:*",
     "@optimize-lodash/rollup-plugin": "^5.0.2",
     "@rollup/plugin-alias": "6.0.0",
     "@rollup/plugin-commonjs": "29.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2199,7 +2199,7 @@ importers:
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.28.5)
       '@mastra/server':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../server
       '@optimize-lodash/rollup-plugin':
         specifier: ^5.0.2


### PR DESCRIPTION

## Problem

`create-mastra` projects fail to build with npm:

Package subpath './server-adapter' is not defined by "exports" in @mastra/server/package.json


## Cause

`@mastra/deployer` declared `"@mastra/server": "workspace:^"` which publishes as `^1.0.0-beta.18`.

npm resolves this to `1.0.3` (stable) because it satisfies the range — but that version doesn't have the `./server-adapter` export.

pnpm works because workspace linking bypasses registry resolution.

## Fix

Changed to `workspace:*` which publishes as an exact version, matching what `@mastra/hono` and `@mastra/express` already do.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated @mastra/server dependency resolution in the deployer package to support a broader range of compatible versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->