### PR TITLE
remove extra logs

### DIFF
--- a/.changeset/fluffy-keys-clean.md
+++ b/.changeset/fluffy-keys-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Remove extra console log statements in node-modules-extension-resolver

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
@@ -67,10 +67,8 @@ export function nodeModulesExtensionResolver(): Plugin {
         }
 
         let filePath = nodeResolved.id;
-        console.log({ nodeResolved });
         if (nodeResolved.resolvedBy === 'commonjs--resolver') {
           filePath = filePath.substring(1).split('?')[0];
-          console.log({ filePath });
         }
 
         const resolvedImportPath = filePath.replace(packageRoot, pkgName);


### PR DESCRIPTION
## Description

Remove leftover debug `console.log` statements from the `node-modules-extension-resolver` Rollup plugin that were accidentally left in during a recent fix.

These debug logs were outputting verbose bundler information during `pnpm run dev`:
```javascript
{ nodeResolved: { attributes: {}, external: false, id: '...', resolvedBy: 'commonjs--resolver', ... } }
{ filePath: '/Users/username/path/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/memoize.js' }
```

## Related Issue(s)

#11456

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [] I have made corresponding changes to the documentation (if applicable)
- [] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statements for cleaner console output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->