### PR TITLE
fix(@mastra/ai-sdk): filter data chunks to only include type, data, a…

### DIFF
--- a/.changeset/brown-rules-rush.md
+++ b/.changeset/brown-rules-rush.md
@@ -1,0 +1,13 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fix data chunk property filtering to only include type, data, and id properties
+
+Previously, when `isDataChunkType` checks were performed, the entire chunk object was returned, potentially letting extra properties like `from`, `runId`, `metadata`, etc go through. This could cause issues with `useChat` and other UI components.
+
+Now, all locations that handle `DataChunkType` properly destructure and return only the allowed properties:
+- `type` (required): The chunk type identifier starting with "data-"
+- `data` (required): The actual data payload
+- `id` (optional): An optional identifier for the chunk
+

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -468,7 +468,8 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
             `UI Messages require a data property when using data- prefixed chunks \n ${JSON.stringify(part)}`,
           );
         }
-        return part.output;
+        const { type, data, id } = part.output;
+        return { type, data, ...(id !== undefined && { id }) } as InferUIMessageChunk<UI_MESSAGE>;
       }
       return;
     }
@@ -543,7 +544,8 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
             `UI Messages require a data property when using data- prefixed chunks \n ${JSON.stringify(part)}`,
           );
         }
-        return part;
+        const { type, data, id } = part;
+        return { type, data, ...(id !== undefined && { id }) } as InferUIMessageChunk<UI_MESSAGE>;
       }
 
       return;

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -527,7 +527,8 @@ export function transformWorkflow<TOutput extends ZodType<any>>(
             `UI Messages require a data property when using data- prefixed chunks \n ${JSON.stringify(output)}`,
           );
         }
-        return output;
+        const { type, data, id } = output;
+        return { type, data, ...(id !== undefined && { id }) };
       }
       return null;
     }
@@ -539,7 +540,13 @@ export function transformWorkflow<TOutput extends ZodType<any>>(
             `UI Messages require a data property when using data- prefixed chunks \n ${JSON.stringify(payload)}`,
           );
         }
-        return payload;
+        const { type, data, id } = payload;
+
+        return {
+          type,
+          data,
+          ...(id !== undefined && { id }),
+        };
       }
       return null;
     }
@@ -845,8 +852,8 @@ export function transformNetwork(
           );
         }
 
-        const { type, data } = payload.payload;
-        return { type, data };
+        const { type, data, id } = payload.payload;
+        return { type, data, ...(id !== undefined && { id }) };
       }
       if (isWorkflowExecutionDataChunkType(payload)) {
         if (!('data' in payload.payload)) {
@@ -854,8 +861,8 @@ export function transformNetwork(
             `UI Messages require a data property when using data- prefixed chunks \n ${JSON.stringify(payload)}`,
           );
         }
-        const { type, data } = payload.payload;
-        return { type, data };
+        const { type, data, id } = payload.payload;
+        return { type, data, ...(id !== undefined && { id }) };
       }
 
       if (payload.type.startsWith('agent-execution-event-')) {
@@ -926,8 +933,8 @@ export function transformNetwork(
           );
         }
 
-        const { type, data } = payload;
-        return { type, data };
+        const { type, data, id } = payload;
+        return { type, data, ...(id !== undefined && { id }) };
       }
       return null;
     }


### PR DESCRIPTION
## Description

…nd id

Fixes property leaking in DataChunkType chunks by properly destructuring and returning only the allowed properties (type, data, id).

## Related Issue(s)

https://discord.com/channels/1309558646228779139/1453367882993106955/1455148732151631977

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed data chunk property filtering across all code paths to ensure consistent handling and prevent unintended properties from appearing in the user interface. This resolves compatibility issues that occurred in data chunk streaming and workflow processing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->