### PR TITLE
fix(core): support LanguageModelV3 in MastraModelGateway.resolveLanguageModel

### DIFF
--- a/.changeset/giant-maps-kiss.md
+++ b/.changeset/giant-maps-kiss.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+fix(core): support LanguageModelV3 in MastraModelGateway.resolveLanguageModel

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -148,7 +148,7 @@ export type LLMStreamObjectOptions<Z extends ZodSchema | JSONSchema7 | undefined
 } & LLMInnerStreamOptions<Z> &
   DefaultLLMStreamObjectOptions;
 
-export type { ProviderConfig } from './model/gateways/base';
+export type { ProviderConfig, GatewayLanguageModel } from './model/gateways/base';
 export { MastraModelGateway, NetlifyGateway, ModelsDevGateway, AzureOpenAIGateway } from './model/gateways';
 export type { AzureOpenAIGatewayConfig } from './model/gateways';
 

--- a/packages/core/src/llm/model/gateways/base.ts
+++ b/packages/core/src/llm/model/gateways/base.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
 
 export interface ProviderConfig {
   url?: string;
@@ -14,6 +15,12 @@ export interface ProviderConfig {
   docUrl?: string; // Optional documentation URL
   gateway: string;
 }
+
+/**
+ * Union type for language models that can be returned by gateways.
+ * Supports both AI SDK v5 (LanguageModelV2) and v6 (LanguageModelV3).
+ */
+export type GatewayLanguageModel = LanguageModelV2 | LanguageModelV3;
 
 export abstract class MastraModelGateway {
   /**
@@ -51,10 +58,14 @@ export abstract class MastraModelGateway {
 
   abstract getApiKey(modelId: string): Promise<string>;
 
+  /**
+   * Resolve a language model from the gateway.
+   * Supports returning either LanguageModelV2 (AI SDK v5) or LanguageModelV3 (AI SDK v6).
+   */
   abstract resolveLanguageModel(args: {
     modelId: string;
     providerId: string;
     apiKey: string;
     headers?: Record<string, string>;
-  }): Promise<LanguageModelV2> | LanguageModelV2;
+  }): Promise<GatewayLanguageModel> | GatewayLanguageModel;
 }

--- a/packages/core/src/llm/model/gateways/index.ts
+++ b/packages/core/src/llm/model/gateways/index.ts
@@ -1,6 +1,6 @@
 import { MastraError } from '../../../error/index.js';
 import type { MastraModelGateway } from './base.js';
-export { MastraModelGateway, type ProviderConfig } from './base.js';
+export { MastraModelGateway, type ProviderConfig, type GatewayLanguageModel } from './base.js';
 export { AzureOpenAIGateway, type AzureOpenAIGatewayConfig } from './azure.js';
 export { ModelsDevGateway } from './models-dev.js';
 export { NetlifyGateway } from './netlify.js';


### PR DESCRIPTION
## Summary

This PR enables custom gateways to return either `LanguageModelV2` (AI SDK v5) or `LanguageModelV3` (AI SDK v6) from the `resolveLanguageModel` method.

## Changes

- **`packages/core/src/llm/model/gateways/base.ts`**
  - Added `GatewayLanguageModel` union type (`LanguageModelV2 | LanguageModelV3`)
  - Updated `MastraModelGateway.resolveLanguageModel` abstract method to return `GatewayLanguageModel`

- **`packages/core/src/llm/model/router.ts`**
  - Added `isLanguageModelV3` type guard function
  - Updated `doGenerate` and `doStream` methods to detect V3 models and wrap them with `AISDKV6LanguageModel`
  - Updated internal `resolveLanguageModel` return type and `modelInstances` Map to use `GatewayLanguageModel`

- **`packages/core/src/llm/model/gateways/index.ts`** & **`packages/core/src/llm/index.ts`**
  - Exported `GatewayLanguageModel` type for external use

## Example Usage

```typescript
import { MastraModelGateway, type GatewayLanguageModel } from '@mastra/core/llm';
import { createOpenAICompatible } from '@ai-sdk/openai-compatible'; // v6

class CustomGateway extends MastraModelGateway {
  async resolveLanguageModel({ modelId, providerId, apiKey }): Promise<GatewayLanguageModel> {
    // Now works with both V2 and V3!
    return createOpenAICompatible({
      name: providerId,
      apiKey,
      baseURL: 'https://...',
    }).chatModel(modelId);
  }
}
```

## Testing

- All 115 gateway and router tests pass ✅
- Type check passes ✅

Fixes #11443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AI SDK v6 language models in the core runtime.
  * Routing and model resolution updated to handle mixed v5/v6 models while preserving full backward compatibility with existing v5 workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->