### PR TITLE
fix(core): emit text events when routing agent handles requests without delegation

### DIFF
--- a/.changeset/lovely-chicken-return.md
+++ b/.changeset/lovely-chicken-return.md
@@ -1,0 +1,16 @@
+---
+'@mastra/ai-sdk': patch
+'@mastra/react': patch
+'@mastra/core': patch
+---
+
+Fixed agent network not returning text response when routing agent handles requests without delegation.
+
+**What changed:**
+- Agent networks now correctly stream text responses when the routing agent decides to handle a request itself instead of delegating to sub-agents, workflows, or tools
+- Added fallback in transformers to ensure text is always returned even if core events are missing
+
+**Why this matters:**
+Previously, when using `toAISdkV5Stream` or `networkRoute()` outside of the Mastra Studio UI, no text content was returned when the routing agent handled requests directly. This fix ensures consistent behavior across all API routes.
+
+Fixes #11219

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -846,7 +846,7 @@ export function transformNetwork(
         },
       } as const;
 
-      // Fallback: if no text events were emitted and there's result text, emit text events
+      // Fallback: emit text events from result if core didn't send routing-agent-text-* events
       if (!current.hasEmittedText && resultText && typeof resultText === 'string' && resultText.length > 0) {
         current.hasEmittedText = true;
         return [

--- a/client-sdks/react/src/lib/ai-sdk/transformers/AISdkNetworkTransformer.ts
+++ b/client-sdks/react/src/lib/ai-sdk/transformers/AISdkNetworkTransformer.ts
@@ -24,6 +24,7 @@ export class AISdkNetworkTransformer implements Transformer<NetworkChunkType> {
       return this.handleToolConversation(chunk, newConversation, metadata);
     }
 
+    // Fallback: extract text from result if core didn't send routing-agent-text-* events
     if (chunk.type === 'network-execution-event-step-finish') {
       const lastMessage = newConversation[newConversation.length - 1];
       if (!lastMessage || lastMessage.role !== 'assistant') return newConversation;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
- Fixed agent network not streaming text responses when routing agent handles requests directly without delegating to sub-agents, workflows, or tools
- Added fallback in `@mastra/ai-sdk` and `@mastra/react` transformers to ensure text is always returned

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->
Fixes #11219

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent networks now properly stream text responses when the routing agent handles requests directly.
  * Added fallback mechanism to ensure text content is always returned, even when core events are missing.
  * Fixed text output for streaming API responses in external integrations.

* **Tests**
  * Added comprehensive test coverage for text streaming in agent networks.
  * Added validation tests for fallback text emission scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->