### PR TITLE
fix timezones in threads

### DIFF
--- a/.changeset/lemon-turtles-sort.md
+++ b/.changeset/lemon-turtles-sort.md
@@ -1,0 +1,7 @@
+---
+'@mastra/pg': patch
+---
+
+Fix thread timestamps being returned in incorrect timezone from listThreadsByResourceId
+
+The method was not using the timezone-aware columns (createdAtZ/updatedAtZ), causing timestamps to be interpreted in local timezone instead of UTC. Now correctly uses TIMESTAMPTZ columns with fallback for legacy data.


### PR DESCRIPTION
## Description

Fix thread timestamps being returned in incorrect timezone from `listThreadsByResourceId`.

The `listThreadsByResourceId` method was not selecting or using the timezone-aware columns (`createdAtZ`/`updatedAtZ` which are `TIMESTAMPTZ` type). This caused timestamps to be read from the `TIMESTAMP WITHOUT TIME ZONE` columns and interpreted in local timezone instead of UTC.

The fix updates `listThreadsByResourceId` to:
1. Select the timezone-aware columns (`createdAtZ`, `updatedAtZ`)
2. Use them with fallback for legacy data (matching the pattern already used in `getThreadById`)

## Related Issue(s)

#11496

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patched @mastra/pg to fix thread timestamp handling by implementing timezone-aware timestamp columns with automatic fallback support for legacy data, ensuring consistent timestamp values across operations

* **Tests**
  * Added comprehensive test to verify timestamp consistency across thread retrieval operations, confirming that created and updated timestamps remain synchronized across different data access methods

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->