### PR TITLE
add docs for serializationOptions

### DIFF
--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -633,6 +633,67 @@ Processors are executed in the order they're defined, allowing you to chain mult
 - Sampling high-volume traces
 - Enriching spans with business context
 
+## Serialization Options
+
+Serialization options control how span data (input, output, and attributes) is truncated before export. This is useful when working with large payloads, deeply nested objects, or when you need to optimize trace storage.
+
+### Configuration
+
+Add `serializationOptions` to your observability configuration:
+
+```ts title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: "my-service",
+        serializationOptions: {
+          maxStringLength: 2048,   // Maximum length for string values (default: 1024)
+          maxDepth: 10,            // Maximum depth for nested objects (default: 6)
+          maxArrayLength: 100,     // Maximum number of items in arrays (default: 50)
+          maxObjectKeys: 75,       // Maximum number of keys in objects (default: 50)
+        },
+        exporters: [new DefaultExporter()],
+      },
+    },
+  }),
+});
+```
+
+### Available Options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `maxStringLength` | 1024 | Maximum length for string values. Longer strings are truncated. |
+| `maxDepth` | 6 | Maximum depth for nested objects. Deeper levels are omitted. |
+| `maxArrayLength` | 50 | Maximum number of items in arrays. Additional items are omitted. |
+| `maxObjectKeys` | 50 | Maximum number of keys in objects. Additional keys are omitted. |
+
+### Use Cases
+
+**Increasing limits for debugging**: If your agents or tools work with large documents, API responses, or data structures, increase these limits to capture more context in your traces:
+
+```ts
+serializationOptions: {
+  maxStringLength: 8192,  // Capture longer text content
+  maxDepth: 12,           // Handle deeply nested JSON responses
+  maxArrayLength: 200,    // Keep more items from large lists
+}
+```
+
+**Reducing trace size for production**: Lower these values to reduce storage costs and improve performance when you don't need full payload visibility:
+
+```ts
+serializationOptions: {
+  maxStringLength: 256,   // Truncate strings aggressively
+  maxDepth: 3,            // Shallow object representation
+  maxArrayLength: 10,     // Keep only first few items
+  maxObjectKeys: 20,      // Limit object keys
+}
+```
+
+All options are optional — if not specified, they fall back to the defaults shown above.
+
 ## Retrieving Trace IDs
 
 When you execute agents or workflows with tracing enabled, the response includes a `traceId` that you can use to look up the full trace in your observability platform. This is useful for debugging, customer support, or correlating traces with other events in your system.

--- a/docs/src/content/en/reference/observability/tracing/configuration.mdx
+++ b/docs/src/content/en/reference/observability/tracing/configuration.mdx
@@ -51,6 +51,7 @@ interface ObservabilityInstanceConfig {
   spanOutputProcessors?: SpanOutputProcessor[];
   includeInternalSpans?: boolean;
   requestContextKeys?: string[];
+  serializationOptions?: SerializationOptions;
 }
 ```
 
@@ -96,6 +97,54 @@ interface ObservabilityInstanceConfig {
       name: "requestContextKeys",
       type: "string[]",
       description: "RequestContext keys to extract as metadata (supports dot notation)",
+      required: false,
+    },
+    {
+      name: "serializationOptions",
+      type: "SerializationOptions",
+      description: "Options for controlling serialization of span data (input/output/attributes)",
+      required: false,
+    },
+  ]}
+/>
+
+## SerializationOptions
+
+Options for controlling how span data is serialized before export. Use these to customize truncation limits for large payloads.
+
+```typescript
+interface SerializationOptions {
+  maxStringLength?: number;
+  maxDepth?: number;
+  maxArrayLength?: number;
+  maxObjectKeys?: number;
+}
+```
+
+<PropertiesTable
+  props={[
+    {
+      name: "maxStringLength",
+      type: "number",
+      description: "Maximum length for string values (default: 1024)",
+      required: false,
+    },
+    {
+      name: "maxDepth",
+      type: "number",
+      description: "Maximum depth for nested objects (default: 6)",
+      required: false,
+    },
+    {
+      name: "maxArrayLength",
+      type: "number",
+      description: "Maximum number of items in arrays (default: 50)",
+      required: false,
+    },
+    {
+      name: "maxObjectKeys",
+      type: "number",
+      description: "Maximum number of keys in objects (default: 50)",
       required: false,
     },
   ]}


### PR DESCRIPTION
## Description

Adds documentation for the `serializationOptions` configuration option introduced in PR #11484. This feature allows users to configure how span data (input, output, and attributes) is serialized/truncated before export in Mastra Observability.

**Changes:**
- Added `serializationOptions` to the `ObservabilityInstanceConfig` interface in the reference docs
- Added a new `SerializationOptions` interface section with a PropertiesTable listing all options (`maxStringLength`, `maxDepth`, `maxArrayLength`, `maxObjectKeys`)
- Added a "Serialization Options" section to the tracing overview guide with:
  - Configuration examples
  - Options table with defaults
  - Use case examples for debugging (increasing limits) and production (reducing limits)

## Related Issue(s)

#11484

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Serialization Options documentation section detailing span data truncation during export, including configuration parameters and usage examples
  * Introduced new serializationOptions configuration with four optional parameters (maxStringLength, maxDepth, maxArrayLength, maxObjectKeys) for controlling span data serialization behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->