### PR TITLE
feat(cloudflare): add assets configuration to wrangler.json

### DIFF
--- a/.changeset/add-cloudflare-assets-configuration.md
+++ b/.changeset/add-cloudflare-assets-configuration.md
@@ -2,4 +2,25 @@
 "@mastra/deployer-cloudflare": minor
 ---
 
-Add support for configuring Cloudflare Workers assets via CloudflareDeployer. Introduces a new `CFAssets` interface with typed configuration options (directory, binding, run_worker_first, html_handling, not_found_handling) that aligns with the official Wrangler schema. The assets configuration is now forwarded to the generated wrangler.json, enabling users to serve static assets such as SPA builds using Cloudflare Workers Assets.
+**Added support for serving static assets with Cloudflare Workers.** You can now configure assets (such as SPA builds) directly via CloudflareDeployer, and the configuration will be forwarded to wrangler.json.
+
+**Usage example:**
+
+```typescript
+const deployer = new CloudflareDeployer({
+    assets: {
+        directory: './dist',
+        binding: 'ASSETS',
+        html_handling: 'auto-trailing-slash',
+        not_found_handling: 'single-page-application',
+    },
+});
+```
+**What you can configure:**
+- `directory`: Path to your assets directory
+- `binding` (optional): Variable binding name
+- `run_worker_first` (optional): Control execution order
+- `html_handling` (optional): Trailing slash handling
+- `not_found_handling` (optional): 404 and SPA behavior
+
+See [#11463](https://github.com/mastra-ai/mastra/issues/11463) for more context.

--- a/.changeset/add-cloudflare-assets-configuration.md
+++ b/.changeset/add-cloudflare-assets-configuration.md
@@ -1,0 +1,5 @@
+---
+"@mastra/deployer-cloudflare": minor
+---
+
+Add support for configuring Cloudflare Workers assets via CloudflareDeployer. Introduces a new `CFAssets` interface with typed configuration options (directory, binding, run_worker_first, html_handling, not_found_handling) that aligns with the official Wrangler schema. The assets configuration is now forwarded to the generated wrangler.json, enabling users to serve static assets such as SPA builds using Cloudflare Workers Assets.

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -13,6 +13,14 @@ interface CFRoute {
   custom_domain?: boolean;
 }
 
+interface CFAssets {
+  directory: string;
+  binding?: string;
+  run_worker_first?: boolean | string[];
+  html_handling?: 'auto-trailing-slash' | 'force-trailing-slash' | 'drop-trailing-slash' | 'none';
+  not_found_handling?: 'none' | '404-page' | 'single-page-application';
+}
+
 interface D1DatabaseBinding {
   binding: string;
   database_name: string;
@@ -32,6 +40,7 @@ export class CloudflareDeployer extends Deployer {
   projectName?: string;
   d1Databases?: D1DatabaseBinding[];
   kvNamespaces?: KVNamespaceBinding[];
+  assets?: CFAssets;
 
   constructor({
     env,
@@ -40,6 +49,7 @@ export class CloudflareDeployer extends Deployer {
     workerNamespace,
     d1Databases,
     kvNamespaces,
+    assets,
   }: {
     env?: Record<string, any>;
     projectName?: string;
@@ -47,6 +57,7 @@ export class CloudflareDeployer extends Deployer {
     workerNamespace?: string;
     d1Databases?: D1DatabaseBinding[];
     kvNamespaces?: KVNamespaceBinding[];
+    assets?: CFAssets;
   }) {
     super({ name: 'CLOUDFLARE' });
 
@@ -60,6 +71,7 @@ export class CloudflareDeployer extends Deployer {
 
     if (d1Databases) this.d1Databases = d1Databases;
     if (kvNamespaces) this.kvNamespaces = kvNamespaces;
+    if (assets) this.assets = assets;
   }
 
   async writeFiles(outputDirectory: string): Promise<void> {
@@ -90,6 +102,9 @@ export class CloudflareDeployer extends Deployer {
     }
     if (this.kvNamespaces?.length) {
       wranglerConfig.kv_namespaces = this.kvNamespaces;
+    }
+    if (this.assets) {
+      wranglerConfig.assets = this.assets;
     }
     await writeFile(join(outputDirectory, this.outputDir, 'wrangler.json'), JSON.stringify(wranglerConfig));
   }

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -13,7 +13,7 @@ interface CFRoute {
   custom_domain?: boolean;
 }
 
-interface CFAssets {
+export interface CFAssets {
   directory: string;
   binding?: string;
   run_worker_first?: boolean | string[];


### PR DESCRIPTION
## Description

This PR adds support for configuring Cloudflare Workers **assets** via `CloudflareDeployer` and forwards the supported configuration to the generated `wrangler.json`.

Previously, `deployer-cloudflare` only exposed a limited subset of Wrangler configuration, which made it impossible to serve static assets (e.g. SPA builds) using Cloudflare Workers Assets.  
This change introduces a typed `assets` option aligned with the official Wrangler schema, enabling users to specify an assets directory and related behavior while preserving existing defaults.

Reference: https://developers.cloudflare.com/workers/wrangler/configuration/#assests

## Related Issue(s)

- #11463

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring static assets for Cloudflare deployments (directory, binding, execution order).
  * New options control HTML trailing‑slash behavior and 404 handling (none / 404 page / single‑page app).
  * Asset configuration can be provided in deployment settings and is included in the generated Cloudflare deployment config.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->