### PR TITLE
fix: check if chunk path is a file before reading in findExportLine

### DIFF
--- a/scripts/generate-package-docs.ts
+++ b/scripts/generate-package-docs.ts
@@ -322,6 +322,12 @@ function findExportLine(chunkPath: string, exportName: string): number | undefin
     return undefined;
   }
 
+  // Make sure it's a file, not a directory
+  const stat = fs.statSync(chunkPath);
+  if (!stat.isFile()) {
+    return undefined;
+  }
+
   const content = fs.readFileSync(chunkPath, 'utf-8');
   const lines = content.split('\n');
 


### PR DESCRIPTION
## Problem
Team members were encountering `EISDIR: illegal operation on a directory, read` errors when building packages with embedded docs generation.

The error occurred in `findExportLine` when a chunk path resolved to a directory instead of a file.

## Solution
Added a check using `fs.statSync` to verify the path is actually a file before attempting to read it.

## Root Cause
`fs.existsSync` returns `true` for both files and directories. When the chunk path happened to be a directory (possibly from stale build artifacts or unusual export patterns), `fs.readFileSync` would fail with EISDIR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the documentation generation script by adding validation to handle edge cases with invalid or missing paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->