### PR TITLE
chore(@mastra/core): Reorganize and expand stream type exports from @…

### DIFF
--- a/.changeset/nice-lies-smoke.md
+++ b/.changeset/nice-lies-smoke.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Reorganize and expand stream type exports from @mastra/core/stream
+
+- Consolidated all type exports into a single organized export statement
+- Added missing chunk types: ToolCallChunk, ToolResultChunk, SourceChunk, FileChunk, ReasoningChunk
+- Added missing payload types: ToolCallPayload, ToolResultPayload, TextDeltaPayload, ReasoningDeltaPayload, FilePayload, SourcePayload
+- Added JSON utility types: JSONValue, JSONObject, JSONArray and their readonly variants
+- Improved code organization with clear categorization of core types, chunk types, payload types, and JSON types

--- a/.changeset/nice-lies-smoke.md
+++ b/.changeset/nice-lies-smoke.md
@@ -2,10 +2,11 @@
 '@mastra/core': patch
 ---
 
-Reorganize and expand stream type exports from @mastra/core/stream
+Added missing stream types to @mastra/core/stream for better TypeScript support
 
-- Consolidated all type exports into a single organized export statement
-- Added missing chunk types: ToolCallChunk, ToolResultChunk, SourceChunk, FileChunk, ReasoningChunk
-- Added missing payload types: ToolCallPayload, ToolResultPayload, TextDeltaPayload, ReasoningDeltaPayload, FilePayload, SourcePayload
-- Added JSON utility types: JSONValue, JSONObject, JSONArray and their readonly variants
-- Improved code organization with clear categorization of core types, chunk types, payload types, and JSON types
+**New types available:**
+- Chunk types: `ToolCallChunk`, `ToolResultChunk`, `SourceChunk`, `FileChunk`, `ReasoningChunk`
+- Payload types: `ToolCallPayload`, `ToolResultPayload`, `TextDeltaPayload`, `ReasoningDeltaPayload`, `FilePayload`, `SourcePayload`
+- JSON utilities: `JSONValue`, `JSONObject`, `JSONArray` and readonly variants
+
+These types are now properly exported, enabling full TypeScript IntelliSense when working with streaming data.

--- a/packages/core/src/stream/index.ts
+++ b/packages/core/src/stream/index.ts
@@ -1,21 +1,58 @@
+// ============================================================================
+// Types
+// ============================================================================
 export type {
+  // Core Types
   ChunkType,
-  DataChunkType,
-  LanguageModelUsage,
-  NetworkChunkType,
-  ReadonlyJSONObject,
-  AgentChunkType,
-  StepFinishPayload,
-  StepStartPayload,
+  TypedChunkType,
   MastraFinishReason,
   ProviderMetadata,
+  LanguageModelUsage,
+
+  // Chunk Types
+  AgentChunkType,
+  DataChunkType,
+  NetworkChunkType,
+  WorkflowStreamEvent,
+  FileChunk,
+  ReasoningChunk,
+  SourceChunk,
+  ToolCallChunk,
+  ToolResultChunk,
+
+  // Payload Types
+  StepFinishPayload,
+  StepStartPayload,
+  DynamicToolCallPayload,
+  DynamicToolResultPayload,
+  ToolCallPayload,
+  ToolResultPayload,
+  ReasoningDeltaPayload,
+  ReasoningStartPayload,
+  TextDeltaPayload,
+  TextStartPayload,
+  FilePayload,
+  SourcePayload,
+
+  // JSON & Data Types
+  JSONArray,
+  JSONObject,
+  JSONValue,
+  ReadonlyJSONArray,
+  ReadonlyJSONObject,
+  ReadonlyJSONValue,
 } from './types';
+
+export type { OutputSchema, PartialSchemaOutput } from './base/schema';
+
+// ============================================================================
+// Enums & Classes
+// ============================================================================
 export { ChunkFrom } from './types';
+export { MastraAgentNetworkStream } from './MastraAgentNetworkStream';
 export { MastraModelOutput } from './base/output';
+export { WorkflowRunOutput } from './RunOutput';
 export { AISDKV5OutputStream } from './aisdk/v5/output';
 export { DefaultGeneratedFile, DefaultGeneratedFileWithType } from './aisdk/v5/file';
-export { convertMastraChunkToAISDKv5, convertFullStreamChunkToMastra } from './aisdk/v5/transform';
+export { convertFullStreamChunkToMastra, convertMastraChunkToAISDKv5 } from './aisdk/v5/transform';
 export { convertFullStreamChunkToUIMessageStream } from './aisdk/v5/compat';
-export type { OutputSchema, PartialSchemaOutput } from './base/schema';
-export { MastraAgentNetworkStream } from './MastraAgentNetworkStream';
-export { WorkflowRunOutput } from './RunOutput';


### PR DESCRIPTION
## Description

…mastra/core/stream

- Consolidated all type exports into a single organized statement.
- Added missing chunk types: ToolCallChunk, ToolResultChunk, SourceChunk, FileChunk, ReasoningChunk.
- Added missing payload types: ToolCallPayload, ToolResultPayload, TextDeltaPayload, ReasoningDeltaPayload, FilePayload, SourcePayload.
- Introduced JSON utility types: JSONValue, JSONObject, JSONArray and their readonly variants.
- Improved code organization with clear categorization of core types, chunk types, payload types, and JSON types.

## Related Issue(s)

slack

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded stream type exports with additional chunk and payload types for fuller TypeScript streaming support
  * Added JSON utility types (JSONValue, JSONObject, JSONArray and readonly variants)
  * Exposed new exports: MastraAgentNetworkStream, WorkflowRunOutput, and schema output types

* **Chores**
  * Reorganized and consolidated public type exports for clearer API surface and improved developer experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->