### PR TITLE
feat(@mastra/core): automate score saving in runEvals for improved ob…

### DIFF
--- a/.changeset/wild-berries-watch.md
+++ b/.changeset/wild-berries-watch.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': patch
+---
+
+Fix `runEvals()` to automatically save scores to storage, making them visible in Studio observability.
+
+Previously, `runEvals()` would calculate scores but not persist them to storage, requiring users to manually implement score saving via the `onItemComplete` callback. Scores now automatically save when the target (Agent/Workflow) has an associated Mastra instance with storage configured.
+
+**What changed:**
+- Scores are now automatically saved to storage after each evaluation run
+- Fixed compatibility with both Agent (`getMastraInstance()`) and Workflow (`.mastra` getter)
+- Saved scores include complete context: `groundTruth` (in `additionalContext`), `requestContext`, `traceId`, and `spanId`
+- Scores are marked with `source: 'TEST'` to distinguish them from live scoring
+
+**Migration:**
+No action required. The `onItemComplete` workaround for saving scores can be removed if desired, but will continue to work for custom logic.
+
+**Example:**
+```typescript
+const result = await runEvals({
+  target: mastra.getWorkflow("myWorkflow"),
+  data: [{ input: {...}, groundTruth: {...} }],
+  scorers: [myScorer],
+});
+// Scores are now automatically saved and visible in Studio!
+```

--- a/packages/core/src/evals/run/index.test.ts
+++ b/packages/core/src/evals/run/index.test.ts
@@ -530,4 +530,155 @@ describe('runEvals', () => {
       expect(selectedInstance).toHaveBeenCalled();
     });
   });
+
+  describe('Score persistence', () => {
+    it.skip('should save scores to storage when runEvals is called', async () => {
+      // Create agent
+      const dummyModel = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          content: [{ type: 'text', text: 'Response from agent' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        }),
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Response' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+          ]),
+        }),
+      });
+
+      const agent = new Agent({
+        id: 'testAgent',
+        name: 'Test Agent',
+        instructions: 'Test agent',
+        model: dummyModel,
+      });
+
+      // Create mock scores storage
+      const saveScoreSpy = vi.fn().mockResolvedValue({ score: {} });
+      const mockScoresStore = {
+        saveScore: saveScoreSpy,
+      };
+
+      const mockStorage = {
+        init: vi.fn().mockResolvedValue(undefined),
+        getStore: vi.fn().mockResolvedValue(mockScoresStore),
+        __setLogger: vi.fn(),
+      };
+
+      const mastra = new Mastra({
+        agents: {
+          testAgent: agent,
+        },
+        logger: false,
+      });
+
+      mastra.setStorage(mockStorage as any);
+
+      const scorer = createScorer({
+        id: 'testScorer',
+        description: 'Test scorer',
+        name: 'testScorer',
+      }).generateScore(() => 0.85);
+
+      // Run evals
+      await runEvals({
+        data: [
+          { input: 'test input 1', groundTruth: 'expected output 1' },
+          { input: 'test input 2', groundTruth: 'expected output 2' },
+        ],
+        scorers: [scorer],
+        target: mastra.getAgent('testAgent'),
+      });
+
+      // Verify scores were saved to storage
+      expect(saveScoreSpy).toHaveBeenCalledTimes(2);
+
+      // Verify the saved score structure
+      expect(saveScoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scorerId: 'testScorer',
+          entityId: 'testAgent',
+          entityType: 'AGENT',
+          score: 0.85,
+          source: 'TEST',
+          runId: expect.any(String),
+        }),
+      );
+    });
+
+    it.skip('should save workflow scores to storage', async () => {
+      const mockStep = createStep({
+        id: 'test-step',
+        inputSchema: z.object({ input: z.string() }),
+        outputSchema: z.object({ output: z.string() }),
+        execute: async ({ inputData }) => {
+          return { output: `Processed: ${inputData.input}` };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-workflow',
+        inputSchema: z.object({ input: z.string() }),
+        outputSchema: z.object({ output: z.string() }),
+        options: { validateInputs: false },
+      })
+        .then(mockStep)
+        .commit();
+
+      // Create mock scores storage
+      const saveScoreSpy = vi.fn().mockResolvedValue({ score: {} });
+      const mockScoresStore = {
+        saveScore: saveScoreSpy,
+      };
+
+      const mockStorage = {
+        init: vi.fn().mockResolvedValue(undefined),
+        getStore: vi.fn().mockResolvedValue(mockScoresStore),
+        __setLogger: vi.fn(),
+      };
+
+      const mastra = new Mastra({
+        workflows: {
+          testWorkflow: workflow,
+        },
+        logger: false,
+      });
+
+      mastra.setStorage(mockStorage as any);
+
+      const scorer = createScorer({
+        id: 'workflowScorer',
+        description: 'Workflow scorer',
+        name: 'workflowScorer',
+      }).generateScore(() => 0.75);
+
+      // Run evals with workflow
+      await runEvals({
+        data: [{ input: { input: 'Test input' }, groundTruth: 'Expected' }],
+        scorers: [scorer],
+        target: mastra.getWorkflow('testWorkflow'),
+      });
+
+      // Verify scores were saved
+      expect(saveScoreSpy).toHaveBeenCalledTimes(1);
+      expect(saveScoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scorerId: 'workflowScorer',
+          entityId: 'test-workflow',
+          entityType: 'WORKFLOW',
+          score: 0.75,
+          source: 'TEST',
+        }),
+      );
+    });
+  });
 });

--- a/packages/core/src/evals/run/index.test.ts
+++ b/packages/core/src/evals/run/index.test.ts
@@ -532,7 +532,7 @@ describe('runEvals', () => {
   });
 
   describe('Score persistence', () => {
-    it.skip('should save scores to storage when runEvals is called', async () => {
+    it('should save scores to storage when runEvals is called', async () => {
       // Create agent
       const dummyModel = new MockLanguageModelV2({
         doGenerate: async () => ({
@@ -615,7 +615,7 @@ describe('runEvals', () => {
       );
     });
 
-    it.skip('should save workflow scores to storage', async () => {
+    it('should save workflow scores to storage', async () => {
       const mockStep = createStep({
         id: 'test-step',
         inputSchema: z.object({ input: z.string() }),

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -2,6 +2,7 @@ import type { CoreMessage } from '@internal/ai-sdk-v4';
 import type { Agent, AiMessageType, UIMessageWithMetadata } from '../../agent';
 import { isSupportedLanguageModel } from '../../agent';
 import { MastraError } from '../../error';
+import { validateAndSaveScore } from '../../mastra/hooks';
 import type { TracingContext } from '../../observability';
 import type { RequestContext } from '../../request-context';
 import { Workflow } from '../../workflows';
@@ -91,6 +92,11 @@ export async function runEvals(config: {
   let totalItems = 0;
   const scoreAccumulator = new ScoreAccumulator();
 
+  // Get storage from target's Mastra instance if available
+  // Agent uses getMastraInstance(), Workflow uses .mastra getter
+  const mastra = (target as any).getMastraInstance?.() || (target as any).mastra;
+  const storage = mastra?.getStorage();
+
   const pMap = (await import('p-map')).default;
   await pMap(
     data,
@@ -98,6 +104,17 @@ export async function runEvals(config: {
       const targetResult = await executeTarget(target, item);
       const scorerResults = await runScorers(scorers, targetResult, item);
       scoreAccumulator.addScores(scorerResults);
+
+      // Save scores to storage if available
+      if (storage) {
+        await saveScoresToStorage({
+          storage,
+          scorerResults,
+          target,
+          item,
+          mastra,
+        });
+      }
 
       if (onItemComplete) {
         await onItemComplete({
@@ -340,4 +357,165 @@ async function runScorers(
   }
 
   return scorerResults;
+}
+
+/**
+ * Saves scorer results to storage when running evaluations.
+ * This makes scores visible in Studio's observability section.
+ */
+async function saveScoresToStorage({
+  storage,
+  scorerResults,
+  target,
+  item,
+  mastra,
+}: {
+  storage: any;
+  scorerResults: Record<string, any>;
+  target: Agent | Workflow;
+  item: RunEvalsDataItem<any>;
+  mastra: any;
+}): Promise<void> {
+  const entityId = target.id;
+  const entityType = isWorkflow(target) ? 'WORKFLOW' : 'AGENT';
+
+  // Handle flat scorer results (for agents or workflow-level scorers)
+  if (Array.isArray(scorerResults) || !('workflow' in scorerResults && 'steps' in scorerResults)) {
+    for (const [scorerId, scoreResult] of Object.entries(scorerResults)) {
+      if (scoreResult && typeof scoreResult === 'object' && 'score' in scoreResult) {
+        await saveSingleScore({
+          storage,
+          scoreResult,
+          scorerId,
+          entityId,
+          entityType,
+          mastra,
+          target,
+          item,
+        });
+      }
+    }
+  } else {
+    // Handle workflow scorer config with workflow and step scorers
+    if (scorerResults.workflow) {
+      for (const [scorerId, scoreResult] of Object.entries(scorerResults.workflow)) {
+        if (scoreResult && typeof scoreResult === 'object' && 'score' in scoreResult) {
+          await saveSingleScore({
+            storage,
+            scoreResult,
+            scorerId,
+            entityId,
+            entityType: 'WORKFLOW',
+            mastra,
+            target,
+            item,
+          });
+        }
+      }
+    }
+
+    if (scorerResults.steps) {
+      for (const [stepId, stepScorers] of Object.entries(scorerResults.steps)) {
+        for (const [scorerId, scoreResult] of Object.entries(stepScorers as Record<string, any>)) {
+          if (scoreResult && typeof scoreResult === 'object' && 'score' in scoreResult) {
+            await saveSingleScore({
+              storage,
+              scoreResult,
+              scorerId,
+              entityId: stepId,
+              entityType: 'STEP',
+              mastra,
+              target,
+              item,
+            });
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Saves a single scorer result to storage
+ */
+async function saveSingleScore({
+  storage,
+  scoreResult,
+  scorerId,
+  entityId,
+  entityType,
+  mastra,
+  target,
+  item,
+}: {
+  storage: any;
+  scoreResult: any;
+  scorerId: string;
+  entityId: string;
+  entityType: string;
+  mastra: any;
+  target: Agent | Workflow;
+  item: RunEvalsDataItem<any>;
+}): Promise<void> {
+  try {
+    // Get scorer information
+    let scorer = mastra?.getScorerById?.(scorerId);
+
+    if (!scorer) {
+      // Try to get from target's scorers
+      const targetScorers = await (target as any).listScorers?.();
+      if (targetScorers) {
+        for (const [_, scorerEntry] of Object.entries(targetScorers)) {
+          if ((scorerEntry as any).scorer?.id === scorerId) {
+            scorer = (scorerEntry as any).scorer;
+            break;
+          }
+        }
+      }
+    }
+
+    // Extract tracing context if available
+    let traceId: string | undefined;
+    let spanId: string | undefined;
+    if (item.tracingContext?.currentSpan && item.tracingContext.currentSpan.isValid) {
+      spanId = item.tracingContext.currentSpan.id;
+      traceId = item.tracingContext.currentSpan.traceId;
+    }
+
+    // Build additional context with groundTruth if available
+    const additionalContext: Record<string, any> = {};
+    if (item.groundTruth !== undefined) {
+      additionalContext.groundTruth = item.groundTruth;
+    }
+
+    const payload = {
+      ...scoreResult,
+      scorerId,
+      entityId,
+      entityType,
+      source: 'TEST' as const,
+      scorer: {
+        id: scorer?.id || scorerId,
+        name: scorer?.name || scorerId,
+        description: scorer?.description || '',
+        type: scorer?.type || 'unknown',
+      },
+      entity: {
+        id: target.id,
+        name: (target as any).name || target.id,
+      },
+      // Include requestContext from item
+      requestContext: item.requestContext ? Object.fromEntries(item.requestContext.entries()) : undefined,
+      // Include additionalContext with groundTruth
+      additionalContext: Object.keys(additionalContext).length > 0 ? additionalContext : undefined,
+      // Include tracing information
+      traceId,
+      spanId,
+    };
+
+    await validateAndSaveScore(storage, payload);
+  } catch (error) {
+    // Log error but don't fail the evaluation
+    mastra?.getLogger?.()?.warn?.(`Failed to save score for scorer ${scorerId}:`, error);
+  }
 }

--- a/packages/core/src/evals/run/score-persistence.test.ts
+++ b/packages/core/src/evals/run/score-persistence.test.ts
@@ -1,5 +1,4 @@
-import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
-import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, it, expect, vi } from 'vitest';
 import { Agent } from '../../agent';
 import { Mastra } from '../../mastra';
@@ -42,7 +41,7 @@ describe('runEvals - Score Persistence', () => {
       id: 'testScorer',
       description: 'Test scorer for bug demonstration',
       name: 'testScorer',
-    }).generateScore(({ run }) => {
+    }).generateScore(({}) => {
       // Simple scorer that always returns 0.85
       return 0.85;
     });

--- a/packages/core/src/evals/run/score-persistence.test.ts
+++ b/packages/core/src/evals/run/score-persistence.test.ts
@@ -41,7 +41,7 @@ describe('runEvals - Score Persistence', () => {
       id: 'testScorer',
       description: 'Test scorer for bug demonstration',
       name: 'testScorer',
-    }).generateScore(({}) => {
+    }).generateScore(() => {
       // Simple scorer that always returns 0.85
       return 0.85;
     });

--- a/packages/core/src/evals/run/score-persistence.test.ts
+++ b/packages/core/src/evals/run/score-persistence.test.ts
@@ -1,0 +1,124 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, vi } from 'vitest';
+import { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
+import { createScorer } from '../base';
+import { runEvals } from '.';
+
+describe('runEvals - Score Persistence', () => {
+  it('automatically saves scores to storage when Mastra instance is available', async () => {
+    // Create a simple agent
+    const dummyModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'Test response' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Test' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+        ]),
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'testAgent',
+      name: 'Test Agent',
+      instructions: 'Test instructions',
+      model: dummyModel,
+    });
+
+    // Create a scorer
+    const scorer = createScorer({
+      id: 'testScorer',
+      description: 'Test scorer for bug demonstration',
+      name: 'testScorer',
+    }).generateScore(({ run }) => {
+      // Simple scorer that always returns 0.85
+      return 0.85;
+    });
+
+    // Track if saveScore is called
+    const saveScoreCalls: any[] = [];
+
+    // Mock storage that tracks saveScore calls
+    const mockStorage = {
+      init: vi.fn().mockResolvedValue(undefined),
+      getStore: vi.fn(async (storeName: string) => {
+        if (storeName === 'scores') {
+          return {
+            saveScore: vi.fn(async (payload: any) => {
+              saveScoreCalls.push(payload);
+              return { score: { id: 'mock-id', ...payload } };
+            }),
+          };
+        }
+        // Return minimal mocks for other stores
+        return null;
+      }),
+      __setLogger: vi.fn(),
+    };
+
+    const mastra = new Mastra({
+      agents: { testAgent: agent },
+      scorers: { testScorer: scorer },
+      logger: false,
+    });
+
+    mastra.setStorage(mockStorage as any);
+
+    // Run the evaluation
+    const result = await runEvals({
+      data: [
+        { input: 'Test input 1', groundTruth: 'Expected output 1' },
+        { input: 'Test input 2', groundTruth: 'Expected output 2' },
+      ],
+      scorers: [scorer],
+      target: agent,
+    });
+
+    // Verify the scores were calculated correctly
+    expect(result.scores.testScorer).toBe(0.85);
+    expect(result.summary.totalItems).toBe(2);
+
+    // Verify saveScore was called twice (once per data item)
+    console.log('Number of times saveScore was called:', saveScoreCalls.length);
+    console.log('Save score calls:', saveScoreCalls);
+
+    // Scores should be automatically saved to storage
+    expect(saveScoreCalls.length).toBe(2);
+
+    // Verify first score includes groundTruth in additionalContext
+    expect(saveScoreCalls[0]).toMatchObject({
+      scorerId: 'testScorer',
+      score: 0.85,
+      source: 'TEST',
+      entityId: 'testAgent',
+      entityType: 'AGENT',
+      additionalContext: {
+        groundTruth: 'Expected output 1',
+      },
+    });
+
+    // Verify second score includes its groundTruth
+    expect(saveScoreCalls[1]).toMatchObject({
+      scorerId: 'testScorer',
+      score: 0.85,
+      source: 'TEST',
+      entityId: 'testAgent',
+      entityType: 'AGENT',
+      additionalContext: {
+        groundTruth: 'Expected output 2',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Description

…servability

This update enhances the `runEvals()` function to automatically save evaluation scores to storage, eliminating the need for manual score saving via the `onItemComplete` callback. Scores are now saved after each evaluation run when a Mastra instance with storage is configured, ensuring they are visible in Studio's observability section.

Key changes include:
- Automatic score persistence for both Agents and Workflows.
- Inclusion of complete context in saved scores, such as `groundTruth`, `requestContext`, `traceId`, and `spanId`.
- Scores are marked with `source: 'TEST'` for differentiation from live scoring.

Migration is seamless; existing `onItemComplete` logic can be removed if desired. Comprehensive tests have been added to validate this functionality.

## Related Issue(s)

fixes https://github.com/mastra-ai/mastra/issues/11061

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation scores are now automatically persisted to configured storage after runs. Saved entries include full context (ground truth, request/trace info), are tagged source: "TEST", and become visible in Studio while remaining backward compatible.

* **Tests**
  * Added tests verifying automatic score persistence for agent and workflow targets, checking saved payload contents and expected save-call counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->