### PR TITLE
Feat/workflow callback context

### DIFF
--- a/.changeset/expose-workflow-context-callbacks.md
+++ b/.changeset/expose-workflow-context-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Expose `getInitData`, `mastra`, and `requestContext` in `onFinish` and `onError` workflow lifecycle callbacks.

--- a/.changeset/expose-workflow-context-callbacks.md
+++ b/.changeset/expose-workflow-context-callbacks.md
@@ -2,4 +2,32 @@
 "@mastra/core": patch
 ---
 
-Expose `getInitData`, `mastra`, and `requestContext` in `onFinish` and `onError` workflow lifecycle callbacks.
+Workflow lifecycle callbacks (`onFinish` and `onError`) now receive additional context for improved debugging and observability.
+
+**What's new:**
+- `getInitData()`: Function that returns the initial workflow input data
+- `mastra`: Reference to the Mastra instance
+- `requestContext`: The current request context
+
+**Example usage:**
+
+```typescript
+const workflow = new Workflow({
+  onFinish: async (result) => {
+    // Access initial input for logging
+    const initData = result.getInitData?.();
+    console.log('Workflow completed', {
+      status: result.status,
+      initialInput: initData,
+    });
+    
+    // Use mastra instance to trigger other workflows
+    await result.mastra?.getWorkflow('notify').execute({ ... });
+  },
+  onError: async (error) => {
+    // Access request context for error tracking
+    const userId = error.requestContext?.get('userId');
+    console.error('Workflow failed for user:', userId, error.error);
+  },
+});
+```

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -259,18 +259,18 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     },
   ): Promise<
     | {
-      ok: true;
-      result: T;
-    }
+        ok: true;
+        result: T;
+      }
     | {
-      ok: false;
-      error: {
-        status: 'failed';
-        error: Error;
-        endedAt: number;
-        tripwire?: StepTripwireInfo;
-      };
-    }
+        ok: false;
+        error: {
+          status: 'failed';
+          error: Error;
+          endedAt: number;
+          tripwire?: StepTripwireInfo;
+        };
+      }
   > {
     for (let i = 0; i < params.retries + 1; i++) {
       if (i > 0 && params.delay) {
@@ -316,11 +316,11 @@ export class DefaultExecutionEngine extends ExecutionEngine {
               tripwire:
                 e instanceof TripWire
                   ? {
-                    reason: e.message,
-                    retry: e.options?.retry,
-                    metadata: e.options?.metadata,
-                    processorId: e.processorId,
-                  }
+                      reason: e.message,
+                      retry: e.options?.retry,
+                      metadata: e.options?.metadata,
+                      processorId: e.processorId,
+                    }
                   : undefined,
             },
           };

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -259,18 +259,18 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     },
   ): Promise<
     | {
-        ok: true;
-        result: T;
-      }
+      ok: true;
+      result: T;
+    }
     | {
-        ok: false;
-        error: {
-          status: 'failed';
-          error: Error;
-          endedAt: number;
-          tripwire?: StepTripwireInfo;
-        };
-      }
+      ok: false;
+      error: {
+        status: 'failed';
+        error: Error;
+        endedAt: number;
+        tripwire?: StepTripwireInfo;
+      };
+    }
   > {
     for (let i = 0; i < params.retries + 1; i++) {
       if (i > 0 && params.delay) {
@@ -316,11 +316,11 @@ export class DefaultExecutionEngine extends ExecutionEngine {
               tripwire:
                 e instanceof TripWire
                   ? {
-                      reason: e.message,
-                      retry: e.options?.retry,
-                      metadata: e.options?.metadata,
-                      processorId: e.processorId,
-                    }
+                    reason: e.message,
+                    retry: e.options?.retry,
+                    metadata: e.options?.metadata,
+                    processorId: e.processorId,
+                  }
                   : undefined,
             },
           };
@@ -632,7 +632,12 @@ export class DefaultExecutionEngine extends ExecutionEngine {
 
         if (lastOutput.result.status !== 'paused') {
           // Invoke lifecycle callbacks before returning
-          await this.invokeLifecycleCallbacks(result);
+          await this.invokeLifecycleCallbacks({
+            ...result,
+            getInitData: () => stepResults.input,
+            mastra: this.mastra,
+            requestContext: currentRequestContext,
+          });
         }
 
         if (lastOutput.result.status === 'paused') {
@@ -705,7 +710,12 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       },
     });
 
-    await this.invokeLifecycleCallbacks(result);
+    await this.invokeLifecycleCallbacks({
+      ...result,
+      getInitData: () => stepResults.input,
+      mastra: this.mastra,
+      requestContext: currentRequestContext,
+    });
 
     if (params.outputOptions?.includeState) {
       return { ...result, state: lastState };

--- a/packages/core/src/workflows/evented/execution-engine.ts
+++ b/packages/core/src/workflows/evented/execution-engine.ts
@@ -185,7 +185,12 @@ export class EventedExecutionEngine extends ExecutionEngine {
 
     if (callbackArg.status !== 'paused') {
       // Invoke lifecycle callbacks before returning
-      await this.invokeLifecycleCallbacks(callbackArg);
+      await this.invokeLifecycleCallbacks({
+        ...callbackArg,
+        getInitData: () => resultData.stepResults.input,
+        mastra: this.mastra,
+        requestContext: params.requestContext,
+      });
     }
 
     // Build the final result with any additional fields needed for the return type

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -76,6 +76,9 @@ export abstract class ExecutionEngine extends MastraBase {
     error?: any;
     steps: Record<string, StepResult<any, any, any, any>>;
     tripwire?: any;
+    getInitData?: () => any;
+    mastra?: Mastra;
+    requestContext?: RequestContext;
   }): Promise<void> {
     const { onFinish, onError } = this.options;
 
@@ -89,6 +92,9 @@ export abstract class ExecutionEngine extends MastraBase {
             error: result.error,
             steps: result.steps,
             tripwire: result.tripwire,
+            getInitData: result.getInitData,
+            mastra: result.mastra,
+            requestContext: result.requestContext,
           }),
         );
       } catch (err) {
@@ -105,6 +111,9 @@ export abstract class ExecutionEngine extends MastraBase {
             error: result.error,
             steps: result.steps,
             tripwire: result.tripwire,
+            getInitData: result.getInitData,
+            mastra: result.mastra,
+            requestContext: result.requestContext,
           }),
         );
       } catch (err) {

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -184,18 +184,18 @@ export type DynamicMapping<TPrevSchema extends z.ZodTypeAny, TSchemaOut extends 
 
 export type PathsToStringProps<T> =
   T extends z.ZodObject<infer V>
-  ? PathsToStringProps<V>
-  : T extends object
-  ? {
-    [K in keyof T]: T[K] extends object
-    ? K extends string
-    ? K | `${K}.${PathsToStringProps<T[K]>}`
-    : never
-    : K extends string
-    ? K
-    : never;
-  }[keyof T]
-  : never;
+    ? PathsToStringProps<V>
+    : T extends object
+      ? {
+          [K in keyof T]: T[K] extends object
+            ? K extends string
+              ? K | `${K}.${PathsToStringProps<T[K]>}`
+              : never
+            : K extends string
+              ? K
+              : never;
+        }[keyof T]
+      : never;
 
 export type ExtractSchemaType<T extends z.ZodType<any>> = T extends z.ZodObject<infer V> ? V : never;
 
@@ -207,34 +207,34 @@ export type ExtractSchemaFromStep<
 export type VariableReference<
   TStep extends Step<string, any, any> = Step<string, any, any>,
   TVarPath extends PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>> | '' | '.' =
-  | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
-  | ''
-  | '.',
+    | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
+    | ''
+    | '.',
 > =
   | {
-    step: TStep;
-    path: TVarPath;
-  }
+      step: TStep;
+      path: TVarPath;
+    }
   | { value: any; schema: z.ZodTypeAny };
 
 export type StreamEvent =
   // old events
   | TextStreamPart<any>
   | {
-    type: 'step-suspended';
-    payload: any;
-    id: string;
-  }
+      type: 'step-suspended';
+      payload: any;
+      id: string;
+    }
   | {
-    type: 'step-waiting';
-    payload: any;
-    id: string;
-  }
+      type: 'step-waiting';
+      payload: any;
+      id: string;
+    }
   | {
-    type: 'step-result';
-    payload: any;
-    id: string;
-  }
+      type: 'step-result';
+      payload: any;
+      id: string;
+    }
   // vnext events
   | WorkflowStreamEvent;
 
@@ -253,16 +253,16 @@ export type WorkflowRunStatus =
 // Type to get the inferred type at a specific path in a Zod schema
 export type ZodPathType<T extends z.ZodTypeAny, P extends string> =
   T extends z.ZodObject<infer Shape>
-  ? P extends `${infer Key}.${infer Rest}`
-  ? Key extends keyof Shape
-  ? Shape[Key] extends z.ZodTypeAny
-  ? ZodPathType<Shape[Key], Rest>
-  : never
-  : never
-  : P extends keyof Shape
-  ? Shape[P]
-  : never
-  : never;
+    ? P extends `${infer Key}.${infer Rest}`
+      ? Key extends keyof Shape
+        ? Shape[Key] extends z.ZodTypeAny
+          ? ZodPathType<Shape[Key], Rest>
+          : never
+        : never
+      : P extends keyof Shape
+        ? Shape[P]
+        : never
+    : never;
 
 export interface WorkflowState {
   status: WorkflowRunStatus;
@@ -384,29 +384,29 @@ export type StepFlowEntry<TEngineType = DefaultEngineType> =
   | { type: 'sleep'; id: string; duration?: number; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | { type: 'sleepUntil'; id: string; date?: Date; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | {
-    type: 'parallel';
-    steps: { type: 'step'; step: Step }[];
-  }
+      type: 'parallel';
+      steps: { type: 'step'; step: Step }[];
+    }
   | {
-    type: 'conditional';
-    steps: { type: 'step'; step: Step }[];
-    conditions: ConditionFunction<any, any, any, any, TEngineType>[];
-    serializedConditions: { id: string; fn: string }[];
-  }
+      type: 'conditional';
+      steps: { type: 'step'; step: Step }[];
+      conditions: ConditionFunction<any, any, any, any, TEngineType>[];
+      serializedConditions: { id: string; fn: string }[];
+    }
   | {
-    type: 'loop';
-    step: Step;
-    condition: LoopConditionFunction<any, any, any, any, TEngineType>;
-    serializedCondition: { id: string; fn: string };
-    loopType: 'dowhile' | 'dountil';
-  }
+      type: 'loop';
+      step: Step;
+      condition: LoopConditionFunction<any, any, any, any, TEngineType>;
+      serializedCondition: { id: string; fn: string };
+      loopType: 'dowhile' | 'dountil';
+    }
   | {
-    type: 'foreach';
-    step: Step;
-    opts: {
-      concurrency: number;
+      type: 'foreach';
+      step: Step;
+      opts: {
+        concurrency: number;
+      };
     };
-  };
 
 export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
   Step<any, any, any, any, any, any, TEngineType>,
@@ -420,49 +420,49 @@ export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
 
 export type SerializedStepFlowEntry =
   | {
-    type: 'step';
-    step: SerializedStep;
-  }
-  | {
-    type: 'sleep';
-    id: string;
-    duration?: number;
-    fn?: string;
-  }
-  | {
-    type: 'sleepUntil';
-    id: string;
-    date?: Date;
-    fn?: string;
-  }
-  | {
-    type: 'parallel';
-    steps: {
       type: 'step';
       step: SerializedStep;
-    }[];
-  }
+    }
   | {
-    type: 'conditional';
-    steps: {
-      type: 'step';
+      type: 'sleep';
+      id: string;
+      duration?: number;
+      fn?: string;
+    }
+  | {
+      type: 'sleepUntil';
+      id: string;
+      date?: Date;
+      fn?: string;
+    }
+  | {
+      type: 'parallel';
+      steps: {
+        type: 'step';
+        step: SerializedStep;
+      }[];
+    }
+  | {
+      type: 'conditional';
+      steps: {
+        type: 'step';
+        step: SerializedStep;
+      }[];
+      serializedConditions: { id: string; fn: string }[];
+    }
+  | {
+      type: 'loop';
       step: SerializedStep;
-    }[];
-    serializedConditions: { id: string; fn: string }[];
-  }
+      serializedCondition: { id: string; fn: string };
+      loopType: 'dowhile' | 'dountil';
+    }
   | {
-    type: 'loop';
-    step: SerializedStep;
-    serializedCondition: { id: string; fn: string };
-    loopType: 'dowhile' | 'dountil';
-  }
-  | {
-    type: 'foreach';
-    step: SerializedStep;
-    opts: {
-      concurrency: number;
+      type: 'foreach';
+      step: SerializedStep;
+      opts: {
+        concurrency: number;
+      };
     };
-  };
 
 export type StepWithComponent = Step<string, any, any, any, any, any> & {
   component?: string;
@@ -515,91 +515,91 @@ export type WorkflowResult<
   TSteps extends Step<string, any, any>[],
 > =
   | ({
-    status: 'success';
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    result: z.infer<TOutput>;
-    input: z.infer<TInput>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-  } & TracingProperties)
+      status: 'success';
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      result: z.infer<TOutput>;
+      input: z.infer<TInput>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+    } & TracingProperties)
   | ({
-    status: 'failed';
-    input: z.infer<TInput>;
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-    error: Error;
-  } & TracingProperties)
+      status: 'failed';
+      input: z.infer<TInput>;
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+      error: Error;
+    } & TracingProperties)
   | ({
-    status: 'tripwire';
-    input: z.infer<TInput>;
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-    /** Tripwire data including reason, retry flag, metadata, and processor ID */
-    tripwire: StepTripwireInfo;
-  } & TracingProperties)
+      status: 'tripwire';
+      input: z.infer<TInput>;
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+      /** Tripwire data including reason, retry flag, metadata, and processor ID */
+      tripwire: StepTripwireInfo;
+    } & TracingProperties)
   | ({
-    status: 'suspended';
-    input: z.infer<TInput>;
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-    suspendPayload: any;
-    suspended: [string[], ...string[][]];
-  } & TracingProperties)
+      status: 'suspended';
+      input: z.infer<TInput>;
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+      suspendPayload: any;
+      suspended: [string[], ...string[][]];
+    } & TracingProperties)
   | ({
-    status: 'paused';
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    input: z.infer<TInput>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-  } & TracingProperties);
+      status: 'paused';
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      input: z.infer<TInput>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+    } & TracingProperties);
 
 export type WorkflowStreamResult<
   TState extends z.ZodObject<any>,
@@ -609,19 +609,19 @@ export type WorkflowStreamResult<
 > =
   | WorkflowResult<TState, TInput, TOutput, TSteps>
   | {
-    status: 'running' | 'waiting' | 'pending' | 'canceled';
-    input: z.infer<TInput>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
+      status: 'running' | 'waiting' | 'pending' | 'canceled';
+      input: z.infer<TInput>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
     };
-  };
 
 export type WorkflowConfig<
   TWorkflowId extends string = string,
@@ -653,16 +653,16 @@ export type WorkflowConfig<
  */
 export type SubsetOf<TStepState extends z.ZodObject<any>, TState extends z.ZodObject<any>> =
   TStepState extends z.ZodObject<infer TStepShape>
-  ? TState extends z.ZodObject<infer TStateShape>
-  ? keyof TStepShape extends keyof TStateShape
-  ? {
-    [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
-  } extends TStepShape
-  ? TStepState
-  : never
-  : never
-  : never
-  : never;
+    ? TState extends z.ZodObject<infer TStateShape>
+      ? keyof TStepShape extends keyof TStateShape
+        ? {
+            [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
+          } extends TStepShape
+          ? TStepState
+          : never
+        : never
+      : never
+    : never;
 
 /**
  * Execution context passed through workflow execution

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -184,18 +184,18 @@ export type DynamicMapping<TPrevSchema extends z.ZodTypeAny, TSchemaOut extends 
 
 export type PathsToStringProps<T> =
   T extends z.ZodObject<infer V>
-  ? PathsToStringProps<V>
-  : T extends object
-  ? {
-    [K in keyof T]: T[K] extends object
-    ? K extends string
-    ? K | `${K}.${PathsToStringProps<T[K]>}`
-    : never
-    : K extends string
-    ? K
-    : never;
-  }[keyof T]
-  : never;
+    ? PathsToStringProps<V>
+    : T extends object
+      ? {
+          [K in keyof T]: T[K] extends object
+            ? K extends string
+              ? K | `${K}.${PathsToStringProps<T[K]>}`
+              : never
+            : K extends string
+              ? K
+              : never;
+        }[keyof T]
+      : never;
 
 export type ExtractSchemaType<T extends z.ZodType<any>> = T extends z.ZodObject<infer V> ? V : never;
 
@@ -207,34 +207,34 @@ export type ExtractSchemaFromStep<
 export type VariableReference<
   TStep extends Step<string, any, any> = Step<string, any, any>,
   TVarPath extends PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>> | '' | '.' =
-  | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
-  | ''
-  | '.',
+    | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
+    | ''
+    | '.',
 > =
   | {
-    step: TStep;
-    path: TVarPath;
-  }
+      step: TStep;
+      path: TVarPath;
+    }
   | { value: any; schema: z.ZodTypeAny };
 
 export type StreamEvent =
   // old events
   | TextStreamPart<any>
   | {
-    type: 'step-suspended';
-    payload: any;
-    id: string;
-  }
+      type: 'step-suspended';
+      payload: any;
+      id: string;
+    }
   | {
-    type: 'step-waiting';
-    payload: any;
-    id: string;
-  }
+      type: 'step-waiting';
+      payload: any;
+      id: string;
+    }
   | {
-    type: 'step-result';
-    payload: any;
-    id: string;
-  }
+      type: 'step-result';
+      payload: any;
+      id: string;
+    }
   // vnext events
   | WorkflowStreamEvent;
 
@@ -253,16 +253,16 @@ export type WorkflowRunStatus =
 // Type to get the inferred type at a specific path in a Zod schema
 export type ZodPathType<T extends z.ZodTypeAny, P extends string> =
   T extends z.ZodObject<infer Shape>
-  ? P extends `${infer Key}.${infer Rest}`
-  ? Key extends keyof Shape
-  ? Shape[Key] extends z.ZodTypeAny
-  ? ZodPathType<Shape[Key], Rest>
-  : never
-  : never
-  : P extends keyof Shape
-  ? Shape[P]
-  : never
-  : never;
+    ? P extends `${infer Key}.${infer Rest}`
+      ? Key extends keyof Shape
+        ? Shape[Key] extends z.ZodTypeAny
+          ? ZodPathType<Shape[Key], Rest>
+          : never
+        : never
+      : P extends keyof Shape
+        ? Shape[P]
+        : never
+    : never;
 
 export interface WorkflowState {
   status: WorkflowRunStatus;
@@ -390,29 +390,29 @@ export type StepFlowEntry<TEngineType = DefaultEngineType> =
   | { type: 'sleep'; id: string; duration?: number; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | { type: 'sleepUntil'; id: string; date?: Date; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | {
-    type: 'parallel';
-    steps: { type: 'step'; step: Step }[];
-  }
+      type: 'parallel';
+      steps: { type: 'step'; step: Step }[];
+    }
   | {
-    type: 'conditional';
-    steps: { type: 'step'; step: Step }[];
-    conditions: ConditionFunction<any, any, any, any, TEngineType>[];
-    serializedConditions: { id: string; fn: string }[];
-  }
+      type: 'conditional';
+      steps: { type: 'step'; step: Step }[];
+      conditions: ConditionFunction<any, any, any, any, TEngineType>[];
+      serializedConditions: { id: string; fn: string }[];
+    }
   | {
-    type: 'loop';
-    step: Step;
-    condition: LoopConditionFunction<any, any, any, any, TEngineType>;
-    serializedCondition: { id: string; fn: string };
-    loopType: 'dowhile' | 'dountil';
-  }
+      type: 'loop';
+      step: Step;
+      condition: LoopConditionFunction<any, any, any, any, TEngineType>;
+      serializedCondition: { id: string; fn: string };
+      loopType: 'dowhile' | 'dountil';
+    }
   | {
-    type: 'foreach';
-    step: Step;
-    opts: {
-      concurrency: number;
+      type: 'foreach';
+      step: Step;
+      opts: {
+        concurrency: number;
+      };
     };
-  };
 
 export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
   Step<any, any, any, any, any, any, TEngineType>,
@@ -426,49 +426,49 @@ export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
 
 export type SerializedStepFlowEntry =
   | {
-    type: 'step';
-    step: SerializedStep;
-  }
-  | {
-    type: 'sleep';
-    id: string;
-    duration?: number;
-    fn?: string;
-  }
-  | {
-    type: 'sleepUntil';
-    id: string;
-    date?: Date;
-    fn?: string;
-  }
-  | {
-    type: 'parallel';
-    steps: {
       type: 'step';
       step: SerializedStep;
-    }[];
-  }
+    }
   | {
-    type: 'conditional';
-    steps: {
-      type: 'step';
+      type: 'sleep';
+      id: string;
+      duration?: number;
+      fn?: string;
+    }
+  | {
+      type: 'sleepUntil';
+      id: string;
+      date?: Date;
+      fn?: string;
+    }
+  | {
+      type: 'parallel';
+      steps: {
+        type: 'step';
+        step: SerializedStep;
+      }[];
+    }
+  | {
+      type: 'conditional';
+      steps: {
+        type: 'step';
+        step: SerializedStep;
+      }[];
+      serializedConditions: { id: string; fn: string }[];
+    }
+  | {
+      type: 'loop';
       step: SerializedStep;
-    }[];
-    serializedConditions: { id: string; fn: string }[];
-  }
+      serializedCondition: { id: string; fn: string };
+      loopType: 'dowhile' | 'dountil';
+    }
   | {
-    type: 'loop';
-    step: SerializedStep;
-    serializedCondition: { id: string; fn: string };
-    loopType: 'dowhile' | 'dountil';
-  }
-  | {
-    type: 'foreach';
-    step: SerializedStep;
-    opts: {
-      concurrency: number;
+      type: 'foreach';
+      step: SerializedStep;
+      opts: {
+        concurrency: number;
+      };
     };
-  };
 
 export type StepWithComponent = Step<string, any, any, any, any, any> & {
   component?: string;
@@ -521,91 +521,91 @@ export type WorkflowResult<
   TSteps extends Step<string, any, any>[],
 > =
   | ({
-    status: 'success';
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    result: z.infer<TOutput>;
-    input: z.infer<TInput>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-  } & TracingProperties)
+      status: 'success';
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      result: z.infer<TOutput>;
+      input: z.infer<TInput>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+    } & TracingProperties)
   | ({
-    status: 'failed';
-    input: z.infer<TInput>;
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-    error: Error;
-  } & TracingProperties)
+      status: 'failed';
+      input: z.infer<TInput>;
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+      error: Error;
+    } & TracingProperties)
   | ({
-    status: 'tripwire';
-    input: z.infer<TInput>;
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-    /** Tripwire data including reason, retry flag, metadata, and processor ID */
-    tripwire: StepTripwireInfo;
-  } & TracingProperties)
+      status: 'tripwire';
+      input: z.infer<TInput>;
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+      /** Tripwire data including reason, retry flag, metadata, and processor ID */
+      tripwire: StepTripwireInfo;
+    } & TracingProperties)
   | ({
-    status: 'suspended';
-    input: z.infer<TInput>;
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-    suspendPayload: any;
-    suspended: [string[], ...string[][]];
-  } & TracingProperties)
+      status: 'suspended';
+      input: z.infer<TInput>;
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+      suspendPayload: any;
+      suspended: [string[], ...string[][]];
+    } & TracingProperties)
   | ({
-    status: 'paused';
-    state?: z.infer<TState>;
-    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-    input: z.infer<TInput>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
-    };
-  } & TracingProperties);
+      status: 'paused';
+      state?: z.infer<TState>;
+      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+      input: z.infer<TInput>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
+    } & TracingProperties);
 
 export type WorkflowStreamResult<
   TState extends z.ZodObject<any>,
@@ -615,19 +615,19 @@ export type WorkflowStreamResult<
 > =
   | WorkflowResult<TState, TInput, TOutput, TSteps>
   | {
-    status: 'running' | 'waiting' | 'pending' | 'canceled';
-    input: z.infer<TInput>;
-    steps: {
-      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-      ? StepResult<unknown, unknown, unknown, unknown>
-      : StepResult<
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-      >;
+      status: 'running' | 'waiting' | 'pending' | 'canceled';
+      input: z.infer<TInput>;
+      steps: {
+        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+          ? StepResult<unknown, unknown, unknown, unknown>
+          : StepResult<
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+            >;
+      };
     };
-  };
 
 export type WorkflowConfig<
   TWorkflowId extends string = string,
@@ -659,16 +659,16 @@ export type WorkflowConfig<
  */
 export type SubsetOf<TStepState extends z.ZodObject<any>, TState extends z.ZodObject<any>> =
   TStepState extends z.ZodObject<infer TStepShape>
-  ? TState extends z.ZodObject<infer TStateShape>
-  ? keyof TStepShape extends keyof TStateShape
-  ? {
-    [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
-  } extends TStepShape
-  ? TStepState
-  : never
-  : never
-  : never
-  : never;
+    ? TState extends z.ZodObject<infer TStateShape>
+      ? keyof TStepShape extends keyof TStateShape
+        ? {
+            [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
+          } extends TStepShape
+          ? TStepState
+          : never
+        : never
+      : never
+    : never;
 
 /**
  * Execution context passed through workflow execution

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -184,18 +184,18 @@ export type DynamicMapping<TPrevSchema extends z.ZodTypeAny, TSchemaOut extends 
 
 export type PathsToStringProps<T> =
   T extends z.ZodObject<infer V>
-    ? PathsToStringProps<V>
-    : T extends object
-      ? {
-          [K in keyof T]: T[K] extends object
-            ? K extends string
-              ? K | `${K}.${PathsToStringProps<T[K]>}`
-              : never
-            : K extends string
-              ? K
-              : never;
-        }[keyof T]
-      : never;
+  ? PathsToStringProps<V>
+  : T extends object
+  ? {
+    [K in keyof T]: T[K] extends object
+    ? K extends string
+    ? K | `${K}.${PathsToStringProps<T[K]>}`
+    : never
+    : K extends string
+    ? K
+    : never;
+  }[keyof T]
+  : never;
 
 export type ExtractSchemaType<T extends z.ZodType<any>> = T extends z.ZodObject<infer V> ? V : never;
 
@@ -207,34 +207,34 @@ export type ExtractSchemaFromStep<
 export type VariableReference<
   TStep extends Step<string, any, any> = Step<string, any, any>,
   TVarPath extends PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>> | '' | '.' =
-    | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
-    | ''
-    | '.',
+  | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
+  | ''
+  | '.',
 > =
   | {
-      step: TStep;
-      path: TVarPath;
-    }
+    step: TStep;
+    path: TVarPath;
+  }
   | { value: any; schema: z.ZodTypeAny };
 
 export type StreamEvent =
   // old events
   | TextStreamPart<any>
   | {
-      type: 'step-suspended';
-      payload: any;
-      id: string;
-    }
+    type: 'step-suspended';
+    payload: any;
+    id: string;
+  }
   | {
-      type: 'step-waiting';
-      payload: any;
-      id: string;
-    }
+    type: 'step-waiting';
+    payload: any;
+    id: string;
+  }
   | {
-      type: 'step-result';
-      payload: any;
-      id: string;
-    }
+    type: 'step-result';
+    payload: any;
+    id: string;
+  }
   // vnext events
   | WorkflowStreamEvent;
 
@@ -253,16 +253,16 @@ export type WorkflowRunStatus =
 // Type to get the inferred type at a specific path in a Zod schema
 export type ZodPathType<T extends z.ZodTypeAny, P extends string> =
   T extends z.ZodObject<infer Shape>
-    ? P extends `${infer Key}.${infer Rest}`
-      ? Key extends keyof Shape
-        ? Shape[Key] extends z.ZodTypeAny
-          ? ZodPathType<Shape[Key], Rest>
-          : never
-        : never
-      : P extends keyof Shape
-        ? Shape[P]
-        : never
-    : never;
+  ? P extends `${infer Key}.${infer Rest}`
+  ? Key extends keyof Shape
+  ? Shape[Key] extends z.ZodTypeAny
+  ? ZodPathType<Shape[Key], Rest>
+  : never
+  : never
+  : P extends keyof Shape
+  ? Shape[P]
+  : never
+  : never;
 
 export interface WorkflowState {
   status: WorkflowRunStatus;
@@ -322,6 +322,9 @@ export interface WorkflowFinishCallbackResult {
   error?: SerializedError;
   steps: Record<string, StepResult<any, any, any, any>>;
   tripwire?: StepTripwireInfo;
+  getInitData?: () => any;
+  mastra?: Mastra;
+  requestContext?: RequestContext;
 }
 
 /**
@@ -332,6 +335,9 @@ export interface WorkflowErrorCallbackInfo {
   error?: SerializedError;
   steps: Record<string, StepResult<any, any, any, any>>;
   tripwire?: StepTripwireInfo;
+  getInitData?: () => any;
+  mastra?: Mastra;
+  requestContext?: RequestContext;
 }
 
 export interface WorkflowOptions {
@@ -378,29 +384,29 @@ export type StepFlowEntry<TEngineType = DefaultEngineType> =
   | { type: 'sleep'; id: string; duration?: number; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | { type: 'sleepUntil'; id: string; date?: Date; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | {
-      type: 'parallel';
-      steps: { type: 'step'; step: Step }[];
-    }
+    type: 'parallel';
+    steps: { type: 'step'; step: Step }[];
+  }
   | {
-      type: 'conditional';
-      steps: { type: 'step'; step: Step }[];
-      conditions: ConditionFunction<any, any, any, any, TEngineType>[];
-      serializedConditions: { id: string; fn: string }[];
-    }
+    type: 'conditional';
+    steps: { type: 'step'; step: Step }[];
+    conditions: ConditionFunction<any, any, any, any, TEngineType>[];
+    serializedConditions: { id: string; fn: string }[];
+  }
   | {
-      type: 'loop';
-      step: Step;
-      condition: LoopConditionFunction<any, any, any, any, TEngineType>;
-      serializedCondition: { id: string; fn: string };
-      loopType: 'dowhile' | 'dountil';
-    }
+    type: 'loop';
+    step: Step;
+    condition: LoopConditionFunction<any, any, any, any, TEngineType>;
+    serializedCondition: { id: string; fn: string };
+    loopType: 'dowhile' | 'dountil';
+  }
   | {
-      type: 'foreach';
-      step: Step;
-      opts: {
-        concurrency: number;
-      };
+    type: 'foreach';
+    step: Step;
+    opts: {
+      concurrency: number;
     };
+  };
 
 export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
   Step<any, any, any, any, any, any, TEngineType>,
@@ -414,49 +420,49 @@ export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
 
 export type SerializedStepFlowEntry =
   | {
+    type: 'step';
+    step: SerializedStep;
+  }
+  | {
+    type: 'sleep';
+    id: string;
+    duration?: number;
+    fn?: string;
+  }
+  | {
+    type: 'sleepUntil';
+    id: string;
+    date?: Date;
+    fn?: string;
+  }
+  | {
+    type: 'parallel';
+    steps: {
       type: 'step';
       step: SerializedStep;
-    }
+    }[];
+  }
   | {
-      type: 'sleep';
-      id: string;
-      duration?: number;
-      fn?: string;
-    }
-  | {
-      type: 'sleepUntil';
-      id: string;
-      date?: Date;
-      fn?: string;
-    }
-  | {
-      type: 'parallel';
-      steps: {
-        type: 'step';
-        step: SerializedStep;
-      }[];
-    }
-  | {
-      type: 'conditional';
-      steps: {
-        type: 'step';
-        step: SerializedStep;
-      }[];
-      serializedConditions: { id: string; fn: string }[];
-    }
-  | {
-      type: 'loop';
+    type: 'conditional';
+    steps: {
+      type: 'step';
       step: SerializedStep;
-      serializedCondition: { id: string; fn: string };
-      loopType: 'dowhile' | 'dountil';
-    }
+    }[];
+    serializedConditions: { id: string; fn: string }[];
+  }
   | {
-      type: 'foreach';
-      step: SerializedStep;
-      opts: {
-        concurrency: number;
-      };
+    type: 'loop';
+    step: SerializedStep;
+    serializedCondition: { id: string; fn: string };
+    loopType: 'dowhile' | 'dountil';
+  }
+  | {
+    type: 'foreach';
+    step: SerializedStep;
+    opts: {
+      concurrency: number;
     };
+  };
 
 export type StepWithComponent = Step<string, any, any, any, any, any> & {
   component?: string;
@@ -509,91 +515,91 @@ export type WorkflowResult<
   TSteps extends Step<string, any, any>[],
 > =
   | ({
-      status: 'success';
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      result: z.infer<TOutput>;
-      input: z.infer<TInput>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-    } & TracingProperties)
+    status: 'success';
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    result: z.infer<TOutput>;
+    input: z.infer<TInput>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+  } & TracingProperties)
   | ({
-      status: 'failed';
-      input: z.infer<TInput>;
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-      error: Error;
-    } & TracingProperties)
+    status: 'failed';
+    input: z.infer<TInput>;
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+    error: Error;
+  } & TracingProperties)
   | ({
-      status: 'tripwire';
-      input: z.infer<TInput>;
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-      /** Tripwire data including reason, retry flag, metadata, and processor ID */
-      tripwire: StepTripwireInfo;
-    } & TracingProperties)
+    status: 'tripwire';
+    input: z.infer<TInput>;
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+    /** Tripwire data including reason, retry flag, metadata, and processor ID */
+    tripwire: StepTripwireInfo;
+  } & TracingProperties)
   | ({
-      status: 'suspended';
-      input: z.infer<TInput>;
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-      suspendPayload: any;
-      suspended: [string[], ...string[][]];
-    } & TracingProperties)
+    status: 'suspended';
+    input: z.infer<TInput>;
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+    suspendPayload: any;
+    suspended: [string[], ...string[][]];
+  } & TracingProperties)
   | ({
-      status: 'paused';
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      input: z.infer<TInput>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-    } & TracingProperties);
+    status: 'paused';
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    input: z.infer<TInput>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+  } & TracingProperties);
 
 export type WorkflowStreamResult<
   TState extends z.ZodObject<any>,
@@ -603,19 +609,19 @@ export type WorkflowStreamResult<
 > =
   | WorkflowResult<TState, TInput, TOutput, TSteps>
   | {
-      status: 'running' | 'waiting' | 'pending' | 'canceled';
-      input: z.infer<TInput>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
+    status: 'running' | 'waiting' | 'pending' | 'canceled';
+    input: z.infer<TInput>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
     };
+  };
 
 export type WorkflowConfig<
   TWorkflowId extends string = string,
@@ -647,16 +653,16 @@ export type WorkflowConfig<
  */
 export type SubsetOf<TStepState extends z.ZodObject<any>, TState extends z.ZodObject<any>> =
   TStepState extends z.ZodObject<infer TStepShape>
-    ? TState extends z.ZodObject<infer TStateShape>
-      ? keyof TStepShape extends keyof TStateShape
-        ? {
-            [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
-          } extends TStepShape
-          ? TStepState
-          : never
-        : never
-      : never
-    : never;
+  ? TState extends z.ZodObject<infer TStateShape>
+  ? keyof TStepShape extends keyof TStateShape
+  ? {
+    [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
+  } extends TStepShape
+  ? TStepState
+  : never
+  : never
+  : never
+  : never;
 
 /**
  * Execution context passed through workflow execution

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -184,18 +184,18 @@ export type DynamicMapping<TPrevSchema extends z.ZodTypeAny, TSchemaOut extends 
 
 export type PathsToStringProps<T> =
   T extends z.ZodObject<infer V>
-    ? PathsToStringProps<V>
-    : T extends object
-      ? {
-          [K in keyof T]: T[K] extends object
-            ? K extends string
-              ? K | `${K}.${PathsToStringProps<T[K]>}`
-              : never
-            : K extends string
-              ? K
-              : never;
-        }[keyof T]
-      : never;
+  ? PathsToStringProps<V>
+  : T extends object
+  ? {
+    [K in keyof T]: T[K] extends object
+    ? K extends string
+    ? K | `${K}.${PathsToStringProps<T[K]>}`
+    : never
+    : K extends string
+    ? K
+    : never;
+  }[keyof T]
+  : never;
 
 export type ExtractSchemaType<T extends z.ZodType<any>> = T extends z.ZodObject<infer V> ? V : never;
 
@@ -207,34 +207,34 @@ export type ExtractSchemaFromStep<
 export type VariableReference<
   TStep extends Step<string, any, any> = Step<string, any, any>,
   TVarPath extends PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>> | '' | '.' =
-    | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
-    | ''
-    | '.',
+  | PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>>
+  | ''
+  | '.',
 > =
   | {
-      step: TStep;
-      path: TVarPath;
-    }
+    step: TStep;
+    path: TVarPath;
+  }
   | { value: any; schema: z.ZodTypeAny };
 
 export type StreamEvent =
   // old events
   | TextStreamPart<any>
   | {
-      type: 'step-suspended';
-      payload: any;
-      id: string;
-    }
+    type: 'step-suspended';
+    payload: any;
+    id: string;
+  }
   | {
-      type: 'step-waiting';
-      payload: any;
-      id: string;
-    }
+    type: 'step-waiting';
+    payload: any;
+    id: string;
+  }
   | {
-      type: 'step-result';
-      payload: any;
-      id: string;
-    }
+    type: 'step-result';
+    payload: any;
+    id: string;
+  }
   // vnext events
   | WorkflowStreamEvent;
 
@@ -253,16 +253,16 @@ export type WorkflowRunStatus =
 // Type to get the inferred type at a specific path in a Zod schema
 export type ZodPathType<T extends z.ZodTypeAny, P extends string> =
   T extends z.ZodObject<infer Shape>
-    ? P extends `${infer Key}.${infer Rest}`
-      ? Key extends keyof Shape
-        ? Shape[Key] extends z.ZodTypeAny
-          ? ZodPathType<Shape[Key], Rest>
-          : never
-        : never
-      : P extends keyof Shape
-        ? Shape[P]
-        : never
-    : never;
+  ? P extends `${infer Key}.${infer Rest}`
+  ? Key extends keyof Shape
+  ? Shape[Key] extends z.ZodTypeAny
+  ? ZodPathType<Shape[Key], Rest>
+  : never
+  : never
+  : P extends keyof Shape
+  ? Shape[P]
+  : never
+  : never;
 
 export interface WorkflowState {
   status: WorkflowRunStatus;
@@ -322,8 +322,11 @@ export interface WorkflowFinishCallbackResult {
   error?: SerializedError;
   steps: Record<string, StepResult<any, any, any, any>>;
   tripwire?: StepTripwireInfo;
+  /** Function that returns the initial workflow input data for debugging and observability */
   getInitData?: () => any;
+  /** Reference to the Mastra instance, enabling access to other workflows and resources */
   mastra?: Mastra;
+  /** The request context containing request-scoped data */
   requestContext?: RequestContext;
 }
 
@@ -335,8 +338,11 @@ export interface WorkflowErrorCallbackInfo {
   error?: SerializedError;
   steps: Record<string, StepResult<any, any, any, any>>;
   tripwire?: StepTripwireInfo;
+  /** Function that returns the initial workflow input data for debugging and observability */
   getInitData?: () => any;
+  /** Reference to the Mastra instance, enabling access to other workflows and resources */
   mastra?: Mastra;
+  /** The request context containing request-scoped data */
   requestContext?: RequestContext;
 }
 
@@ -384,29 +390,29 @@ export type StepFlowEntry<TEngineType = DefaultEngineType> =
   | { type: 'sleep'; id: string; duration?: number; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | { type: 'sleepUntil'; id: string; date?: Date; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
   | {
-      type: 'parallel';
-      steps: { type: 'step'; step: Step }[];
-    }
+    type: 'parallel';
+    steps: { type: 'step'; step: Step }[];
+  }
   | {
-      type: 'conditional';
-      steps: { type: 'step'; step: Step }[];
-      conditions: ConditionFunction<any, any, any, any, TEngineType>[];
-      serializedConditions: { id: string; fn: string }[];
-    }
+    type: 'conditional';
+    steps: { type: 'step'; step: Step }[];
+    conditions: ConditionFunction<any, any, any, any, TEngineType>[];
+    serializedConditions: { id: string; fn: string }[];
+  }
   | {
-      type: 'loop';
-      step: Step;
-      condition: LoopConditionFunction<any, any, any, any, TEngineType>;
-      serializedCondition: { id: string; fn: string };
-      loopType: 'dowhile' | 'dountil';
-    }
+    type: 'loop';
+    step: Step;
+    condition: LoopConditionFunction<any, any, any, any, TEngineType>;
+    serializedCondition: { id: string; fn: string };
+    loopType: 'dowhile' | 'dountil';
+  }
   | {
-      type: 'foreach';
-      step: Step;
-      opts: {
-        concurrency: number;
-      };
+    type: 'foreach';
+    step: Step;
+    opts: {
+      concurrency: number;
     };
+  };
 
 export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
   Step<any, any, any, any, any, any, TEngineType>,
@@ -420,49 +426,49 @@ export type SerializedStep<TEngineType = DefaultEngineType> = Pick<
 
 export type SerializedStepFlowEntry =
   | {
+    type: 'step';
+    step: SerializedStep;
+  }
+  | {
+    type: 'sleep';
+    id: string;
+    duration?: number;
+    fn?: string;
+  }
+  | {
+    type: 'sleepUntil';
+    id: string;
+    date?: Date;
+    fn?: string;
+  }
+  | {
+    type: 'parallel';
+    steps: {
       type: 'step';
       step: SerializedStep;
-    }
+    }[];
+  }
   | {
-      type: 'sleep';
-      id: string;
-      duration?: number;
-      fn?: string;
-    }
-  | {
-      type: 'sleepUntil';
-      id: string;
-      date?: Date;
-      fn?: string;
-    }
-  | {
-      type: 'parallel';
-      steps: {
-        type: 'step';
-        step: SerializedStep;
-      }[];
-    }
-  | {
-      type: 'conditional';
-      steps: {
-        type: 'step';
-        step: SerializedStep;
-      }[];
-      serializedConditions: { id: string; fn: string }[];
-    }
-  | {
-      type: 'loop';
+    type: 'conditional';
+    steps: {
+      type: 'step';
       step: SerializedStep;
-      serializedCondition: { id: string; fn: string };
-      loopType: 'dowhile' | 'dountil';
-    }
+    }[];
+    serializedConditions: { id: string; fn: string }[];
+  }
   | {
-      type: 'foreach';
-      step: SerializedStep;
-      opts: {
-        concurrency: number;
-      };
+    type: 'loop';
+    step: SerializedStep;
+    serializedCondition: { id: string; fn: string };
+    loopType: 'dowhile' | 'dountil';
+  }
+  | {
+    type: 'foreach';
+    step: SerializedStep;
+    opts: {
+      concurrency: number;
     };
+  };
 
 export type StepWithComponent = Step<string, any, any, any, any, any> & {
   component?: string;
@@ -515,91 +521,91 @@ export type WorkflowResult<
   TSteps extends Step<string, any, any>[],
 > =
   | ({
-      status: 'success';
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      result: z.infer<TOutput>;
-      input: z.infer<TInput>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-    } & TracingProperties)
+    status: 'success';
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    result: z.infer<TOutput>;
+    input: z.infer<TInput>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+  } & TracingProperties)
   | ({
-      status: 'failed';
-      input: z.infer<TInput>;
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-      error: Error;
-    } & TracingProperties)
+    status: 'failed';
+    input: z.infer<TInput>;
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+    error: Error;
+  } & TracingProperties)
   | ({
-      status: 'tripwire';
-      input: z.infer<TInput>;
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-      /** Tripwire data including reason, retry flag, metadata, and processor ID */
-      tripwire: StepTripwireInfo;
-    } & TracingProperties)
+    status: 'tripwire';
+    input: z.infer<TInput>;
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+    /** Tripwire data including reason, retry flag, metadata, and processor ID */
+    tripwire: StepTripwireInfo;
+  } & TracingProperties)
   | ({
-      status: 'suspended';
-      input: z.infer<TInput>;
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-      suspendPayload: any;
-      suspended: [string[], ...string[][]];
-    } & TracingProperties)
+    status: 'suspended';
+    input: z.infer<TInput>;
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+    suspendPayload: any;
+    suspended: [string[], ...string[][]];
+  } & TracingProperties)
   | ({
-      status: 'paused';
-      state?: z.infer<TState>;
-      resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
-      input: z.infer<TInput>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
-    } & TracingProperties);
+    status: 'paused';
+    state?: z.infer<TState>;
+    resumeLabels?: Record<string, { stepId: string; forEachIndex?: number }>;
+    input: z.infer<TInput>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
+    };
+  } & TracingProperties);
 
 export type WorkflowStreamResult<
   TState extends z.ZodObject<any>,
@@ -609,19 +615,19 @@ export type WorkflowStreamResult<
 > =
   | WorkflowResult<TState, TInput, TOutput, TSteps>
   | {
-      status: 'running' | 'waiting' | 'pending' | 'canceled';
-      input: z.infer<TInput>;
-      steps: {
-        [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
-          ? StepResult<unknown, unknown, unknown, unknown>
-          : StepResult<
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
-              z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
-            >;
-      };
+    status: 'running' | 'waiting' | 'pending' | 'canceled';
+    input: z.infer<TInput>;
+    steps: {
+      [K in keyof StepsRecord<TSteps>]: StepsRecord<TSteps>[K]['outputSchema'] extends undefined
+      ? StepResult<unknown, unknown, unknown, unknown>
+      : StepResult<
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['inputSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['resumeSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['suspendSchema']>>,
+        z.infer<NonNullable<StepsRecord<TSteps>[K]['outputSchema']>>
+      >;
     };
+  };
 
 export type WorkflowConfig<
   TWorkflowId extends string = string,
@@ -653,16 +659,16 @@ export type WorkflowConfig<
  */
 export type SubsetOf<TStepState extends z.ZodObject<any>, TState extends z.ZodObject<any>> =
   TStepState extends z.ZodObject<infer TStepShape>
-    ? TState extends z.ZodObject<infer TStateShape>
-      ? keyof TStepShape extends keyof TStateShape
-        ? {
-            [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
-          } extends TStepShape
-          ? TStepState
-          : never
-        : never
-      : never
-    : never;
+  ? TState extends z.ZodObject<infer TStateShape>
+  ? keyof TStepShape extends keyof TStateShape
+  ? {
+    [K in keyof TStepShape]: TStepShape[K] extends TStateShape[K] ? TStepShape[K] : never;
+  } extends TStepShape
+  ? TStepState
+  : never
+  : never
+  : never
+  : never;
 
 /**
  * Execution context passed through workflow execution


### PR DESCRIPTION
## Description

This PR enriches workflow lifecycle callbacks (`onFinish` and `onError`) by providing additional execution context.
It adds access to the initial workflow input, the Mastra runtime instance, and the request context when lifecycle callbacks are invoked.

This improves debuggability, observability, and overall developer experience without changing existing workflow behavior.

## Related Issue(s)

- #11514 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow lifecycle callbacks (onFinish and onError) now receive extra context: getInitData (access initial input), mastra (runtime instance), and requestContext (current request metadata).
  * Callbacks can use this info for richer post-run actions, enhanced error reporting, and custom cleanup.

* **Documentation**
  * Added a short changeset describing the new callback context and usage example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->