### PR TITLE
fix(memory): move readOnly to memory.options 

### DIFF
--- a/.changeset/cute-heads-trade.md
+++ b/.changeset/cute-heads-trade.md
@@ -1,0 +1,39 @@
+---
+'@mastra/codemod': patch
+'@mastra/core': patch
+---
+
+**Breaking Change:** `memory.readOnly` has been moved to `memory.options.readOnly`
+
+The `readOnly` option now lives inside `memory.options` alongside other memory configuration like `lastMessages` and `semanticRecall`.
+
+**Before:**
+```typescript
+agent.stream('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+    readOnly: true,
+  },
+});
+```
+
+**After:**
+```typescript
+agent.stream('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+    options: {
+      readOnly: true,
+    },
+  },
+});
+```
+
+**Migration:** Run the codemod to update your code automatically:
+```shell
+npx @mastra/codemod@beta v1/memory-readonly-to-options .
+```
+
+This also fixes issue #11519 where `readOnly: true` was being ignored and messages were saved to memory anyway.

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/memory.mdx
@@ -97,6 +97,35 @@ To migrate, if you were relying on the previous defaults, explicitly set these v
   });
 ```
 
+### `memory.readOnly` moved to `memory.options.readOnly`
+
+The `readOnly` property has been moved from the top-level of the memory option to inside `options`. This change aligns `readOnly` with other memory configuration options like `lastMessages` and `semanticRecall`.
+
+To migrate, move `readOnly` from the top level to inside `options`.
+
+```diff
+  agent.stream('Hello', {
+    memory: {
+      thread: threadId,
+      resource: resourceId,
+-     readOnly: true,
++     options: {
++       readOnly: true,
++     },
+    },
+  });
+```
+
+:::tip[Codemod]
+
+You can use Mastra's codemod CLI to update your code automatically:
+
+```shell
+npx @mastra/codemod@beta v1/memory-readonly-to-options .
+```
+
+:::
+
 ### `Memory.query()` renamed to `Memory.recall()`
 
 The `Memory.query()` method has been renamed to `Memory.recall()`. The new method returns a simpler format with just `{ messages: MastraDBMessage[] }` instead of multiple format variations. This change better describes the action of retrieving messages from memory and simplifies the API.

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -333,7 +333,7 @@ const limitedResult = await agent.generate("Write a short poem about coding", {
               type: "MemoryConfig",
               isOptional: true,
               description:
-                "Additional memory configuration options for conversation management.",
+                "Additional memory configuration options including lastMessages, readOnly, semanticRecall, and workingMemory.",
             },
           ],
         },

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -88,6 +88,14 @@ export const agent = new Agent({
       defaultValue: "10",
     },
     {
+      name: "readOnly",
+      type: "boolean",
+      description:
+        "When true, prevents memory from saving new messages. Useful for read-only operations like previews or internal routing agents.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
       name: "semanticRecall",
       type: "boolean | { topK: number; messageRange: number | { before: number; after: number }; scope?: 'thread' | 'resource' }",
       description:

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -324,7 +324,7 @@ const stream = await agent.stream("message for agent");
               type: "MemoryConfig",
               isOptional: true,
               description:
-                "Configuration for memory behavior, like message history and semantic recall.",
+                "Configuration for memory behavior including lastMessages, readOnly, semanticRecall, and workingMemory.",
             },
           ],
         },

--- a/packages/codemod/src/codemods/v1/memory-readonly-to-options.ts
+++ b/packages/codemod/src/codemods/v1/memory-readonly-to-options.ts
@@ -1,0 +1,94 @@
+import { createTransformer } from '../lib/create-transformer';
+
+/**
+ * Moves memory.readOnly to memory.options.readOnly in agent.stream() and agent.generate() calls.
+ * The top-level readOnly property has been removed in favor of options.readOnly.
+ *
+ * Before:
+ * agent.stream('Hello', {
+ *   memory: {
+ *     thread: threadId,
+ *     resource: resourceId,
+ *     readOnly: true,
+ *   },
+ * });
+ *
+ * After:
+ * agent.stream('Hello', {
+ *   memory: {
+ *     thread: threadId,
+ *     resource: resourceId,
+ *     options: {
+ *       readOnly: true,
+ *     },
+ *   },
+ * });
+ */
+export default createTransformer((_fileInfo, _api, _options, context) => {
+  const { j, root } = context;
+
+  // Find all object expressions that have a 'memory' property
+  root.find(j.ObjectExpression).forEach(path => {
+    const memoryProp = path.value.properties.find(
+      (prop: any) =>
+        (prop.type === 'Property' || prop.type === 'ObjectProperty') &&
+        prop.key &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'memory',
+    ) as any;
+
+    if (!memoryProp || !memoryProp.value || memoryProp.value.type !== 'ObjectExpression') {
+      return;
+    }
+
+    const memoryObj = memoryProp.value;
+    const properties = memoryObj.properties;
+
+    // Find readOnly property
+    const readOnlyPropIndex = properties.findIndex(
+      (prop: any) =>
+        (prop.type === 'Property' || prop.type === 'ObjectProperty') &&
+        prop.key &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'readOnly',
+    );
+
+    if (readOnlyPropIndex === -1) {
+      return;
+    }
+
+    const readOnlyProp = properties[readOnlyPropIndex] as any;
+    const readOnlyValue = readOnlyProp.value;
+
+    // Remove readOnly from top level
+    properties.splice(readOnlyPropIndex, 1);
+
+    // Find or create options property
+    let optionsProp = properties.find(
+      (prop: any) =>
+        (prop.type === 'Property' || prop.type === 'ObjectProperty') &&
+        prop.key &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'options',
+    ) as any;
+
+    if (optionsProp && optionsProp.value && optionsProp.value.type === 'ObjectExpression') {
+      // Add readOnly to existing options
+      optionsProp.value.properties.push(j.property('init', j.identifier('readOnly'), readOnlyValue));
+    } else {
+      // Create new options object with readOnly
+      const newOptionsProp = j.property(
+        'init',
+        j.identifier('options'),
+        j.objectExpression([j.property('init', j.identifier('readOnly'), readOnlyValue)]),
+      );
+      properties.push(newOptionsProp);
+    }
+
+    context.hasChanges = true;
+  });
+
+  if (context.hasChanges) {
+    context.messages.push('Moved memory.readOnly to memory.options.readOnly');
+  }
+});

--- a/packages/codemod/src/lib/bundle.ts
+++ b/packages/codemod/src/lib/bundle.ts
@@ -30,6 +30,7 @@ export const BUNDLE = [
   'v1/memory-query-to-recall',
   'v1/memory-vector-search-param',
   'v1/memory-message-v2-type',
+  'v1/memory-readonly-to-options',
   'v1/storage-get-threads-by-resource',
   'v1/storage-list-messages-by-id',
   'v1/storage-postgres-schema-name',

--- a/packages/codemod/src/test/__fixtures__/memory-readonly-to-options.input.ts
+++ b/packages/codemod/src/test/__fixtures__/memory-readonly-to-options.input.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+// Test: basic readOnly migration
+agent.stream('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+    readOnly: true,
+  },
+});
+
+// Test: readOnly with existing options
+agent.generate('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+    readOnly: true,
+    options: {
+      lastMessages: 10,
+    },
+  },
+});
+
+// Test: readOnly false
+agent.stream('Hello', {
+  memory: {
+    thread: 'thread-1',
+    resource: 'user-1',
+    readOnly: false,
+  },
+});
+
+// Test: no readOnly (should not change)
+agent.stream('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+  },
+});

--- a/packages/codemod/src/test/__fixtures__/memory-readonly-to-options.output.ts
+++ b/packages/codemod/src/test/__fixtures__/memory-readonly-to-options.output.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+// Test: basic readOnly migration
+agent.stream('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+
+    options: {
+      readOnly: true
+    }
+  },
+});
+
+// Test: readOnly with existing options
+agent.generate('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+
+    options: {
+      lastMessages: 10,
+      readOnly: true
+    }
+  },
+});
+
+// Test: readOnly false
+agent.stream('Hello', {
+  memory: {
+    thread: 'thread-1',
+    resource: 'user-1',
+
+    options: {
+      readOnly: false
+    }
+  },
+});
+
+// Test: no readOnly (should not change)
+agent.stream('Hello', {
+  memory: {
+    thread: threadId,
+    resource: resourceId,
+  },
+});

--- a/packages/codemod/src/test/memory-readonly-to-options.test.ts
+++ b/packages/codemod/src/test/memory-readonly-to-options.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v1/memory-readonly-to-options';
+import { testTransform } from './test-utils';
+
+describe('memory-readonly-to-options', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'memory-readonly-to-options');
+  });
+});

--- a/packages/core/src/agent/__tests__/memory-readonly.test.ts
+++ b/packages/core/src/agent/__tests__/memory-readonly.test.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { MockMemory } from '../../memory/mock';
+import { Agent } from '../agent';
+import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model';
+
+/**
+ * Creates a simple mock model for testing.
+ */
+function createSimpleMockModel() {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [
+        {
+          type: 'text',
+          text: 'Hello! How can I help you?',
+        },
+      ],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        {
+          type: 'stream-start',
+          warnings: [],
+        },
+        {
+          type: 'response-metadata',
+          id: 'response-1',
+          modelId: 'mock-model',
+          timestamp: new Date(0),
+        },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello! How can I help you?' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        },
+      ]),
+    }),
+  });
+}
+
+describe('Memory readOnly option', () => {
+  /**
+   * This test verifies that when `memory.options.readOnly: true` is passed to `.stream()`,
+   * no messages are saved to memory.
+   */
+  it('should NOT save messages when memory.options.readOnly is true in stream()', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'user-readonly-test';
+
+    const mockMemory = new MockMemory();
+    const saveMessagesSpy = vi.spyOn(mockMemory, 'saveMessages');
+
+    const agent = new Agent({
+      id: 'readonly-test-agent',
+      name: 'ReadOnly Test Agent',
+      instructions: 'You are a helpful assistant.',
+      model: createSimpleMockModel(),
+      memory: mockMemory,
+    });
+
+    // Create the thread first
+    await mockMemory.createThread({
+      threadId,
+      resourceId,
+    });
+
+    // Call stream with options.readOnly: true
+    const response = await agent.stream('Hello!', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+        options: {
+          readOnly: true, // This should prevent any writes to memory
+        },
+      },
+    });
+
+    await response.consumeStream();
+
+    // Verify that saveMessages was NOT called
+    expect(saveMessagesSpy).not.toHaveBeenCalled();
+
+    // Verify no messages were saved
+    const result = await mockMemory.recall({ threadId, resourceId });
+    expect(result.messages.length).toBe(0);
+  });
+
+  /**
+   * Same test but for generate() method
+   */
+  it('should NOT save messages when memory.options.readOnly is true in generate()', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'user-readonly-test-generate';
+
+    const mockMemory = new MockMemory();
+    const saveMessagesSpy = vi.spyOn(mockMemory, 'saveMessages');
+
+    const agent = new Agent({
+      id: 'readonly-test-agent-generate',
+      name: 'ReadOnly Test Agent',
+      instructions: 'You are a helpful assistant.',
+      model: createSimpleMockModel(),
+      memory: mockMemory,
+    });
+
+    // Create the thread first
+    await mockMemory.createThread({
+      threadId,
+      resourceId,
+    });
+
+    // Call generate with options.readOnly: true
+    await agent.generate('Hello!', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+        options: {
+          readOnly: true, // This should prevent any writes to memory
+        },
+      },
+    });
+
+    // Verify that saveMessages was NOT called
+    expect(saveMessagesSpy).not.toHaveBeenCalled();
+
+    // Verify no messages were saved
+    const result = await mockMemory.recall({ threadId, resourceId });
+    expect(result.messages.length).toBe(0);
+  });
+
+  /**
+   * Verify that without readOnly, messages ARE saved (control test)
+   */
+  it('should save messages when memory.options.readOnly is NOT set', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'user-save-test';
+
+    const mockMemory = new MockMemory();
+
+    const agent = new Agent({
+      id: 'save-test-agent',
+      name: 'Save Test Agent',
+      instructions: 'You are a helpful assistant.',
+      model: createSimpleMockModel(),
+      memory: mockMemory,
+    });
+
+    // Call stream WITHOUT readOnly (should save)
+    const response = await agent.stream('Hello!', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+        // No readOnly flag - messages should be saved
+      },
+    });
+
+    await response.consumeStream();
+
+    // Verify messages were saved (MessageHistory processor saves via storage directly)
+    const result = await mockMemory.recall({ threadId, resourceId });
+    expect(result.messages.length).toBeGreaterThan(0);
+
+    // Verify we have both user and assistant messages
+    const userMessages = result.messages.filter(m => m.role === 'user');
+    const assistantMessages = result.messages.filter(m => m.role === 'assistant');
+    expect(userMessages.length).toBeGreaterThan(0);
+    expect(assistantMessages.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Verify that readOnly: true still allows reading from memory
+   */
+  it('should still read from memory when options.readOnly is true', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'user-readonly-read-test';
+
+    const mockMemory = new MockMemory();
+
+    const agent = new Agent({
+      id: 'readonly-read-test-agent',
+      name: 'ReadOnly Read Test Agent',
+      instructions: 'You are a helpful assistant.',
+      model: createSimpleMockModel(),
+      memory: mockMemory,
+    });
+
+    // First, save some messages to memory (without readOnly)
+    const response1 = await agent.stream('Hello, my name is Alice!', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+      },
+    });
+    await response1.consumeStream();
+
+    // Verify first message was saved
+    const result1 = await mockMemory.recall({ threadId, resourceId });
+    expect(result1.messages.length).toBeGreaterThan(0);
+
+    const messageCountBefore = result1.messages.length;
+
+    // Now make a second request with options.readOnly: true
+    // It should be able to READ the previous messages but NOT save new ones
+    const saveMessagesSpy = vi.spyOn(mockMemory, 'saveMessages');
+
+    const response2 = await agent.stream('What is my name?', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+        options: {
+          readOnly: true,
+          lastMessages: 10, // Should retrieve previous messages
+        },
+      },
+    });
+    await response2.consumeStream();
+
+    // Verify that saveMessages was NOT called for the second request
+    expect(saveMessagesSpy).not.toHaveBeenCalled();
+
+    // Verify the message count didn't change
+    const result2 = await mockMemory.recall({ threadId, resourceId });
+    expect(result2.messages.length).toBe(messageCountBefore);
+  });
+
+  /**
+   * Verify that savePerStep also respects readOnly flag
+   */
+  it('should NOT save messages with savePerStep when memory.options.readOnly is true', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'user-readonly-savePerStep';
+
+    const mockMemory = new MockMemory();
+    const saveMessagesSpy = vi.spyOn(mockMemory, 'saveMessages');
+
+    const agent = new Agent({
+      id: 'readonly-savePerStep-agent',
+      name: 'ReadOnly SavePerStep Agent',
+      instructions: 'You are a helpful assistant.',
+      model: createSimpleMockModel(),
+      memory: mockMemory,
+    });
+
+    // Create the thread first
+    await mockMemory.createThread({
+      threadId,
+      resourceId,
+    });
+
+    // Call stream with options.readOnly: true AND savePerStep: true
+    const response = await agent.stream('Hello!', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+        options: {
+          readOnly: true,
+        },
+      },
+      savePerStep: true, // Even with savePerStep, readOnly should be respected
+    });
+
+    await response.consumeStream();
+
+    // Verify that saveMessages was NOT called
+    expect(saveMessagesSpy).not.toHaveBeenCalled();
+
+    // Verify no messages were saved
+    const result = await mockMemory.recall({ threadId, resourceId });
+    expect(result.messages.length).toBe(0);
+  });
+});

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -221,7 +221,6 @@ export type AgentMemoryOption = {
   thread: string | (Partial<StorageThreadType> & { id: string });
   resource: string;
   options?: MemoryConfig;
-  readOnly?: boolean;
 };
 
 /**

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -66,7 +66,7 @@ export function createMapResultsStep<OUTPUT extends OutputSchema | undefined = u
       requestContext,
       messageList: memoryData.messageList,
       onStepFinish: async (props: any) => {
-        if (options.savePerStep) {
+        if (options.savePerStep && !memoryConfig?.readOnly) {
           if (!memoryData.threadExists && memory && memoryData.thread) {
             await memory.createThread({
               threadId: memoryData.thread?.id,
@@ -191,7 +191,7 @@ export function createMapResultsStep<OUTPUT extends OutputSchema | undefined = u
               outputText,
               thread: result.thread,
               threadId: result.threadId,
-              readOnlyMemory: options.memory?.readOnly,
+              readOnlyMemory: memoryConfig?.readOnly,
               resourceId,
               memoryConfig,
               requestContext,


### PR DESCRIPTION
## Description

BREAKING CHANGE: `memory.readOnly` moved to `memory.options.readOnly`
- Remove top-level `readOnly` from `AgentMemoryOption` type
- Fix savePerStep to respect readOnly flag
- Add codemod: `v1/memory-readonly-to-options`
- Add migration docs and tests

## Related Issue(s)

fix #11519

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The memory config moved: `readOnly` is now nested under `memory.options.readOnly`. Migration guidance provided.

* **Bug Fixes**
  * Respects `readOnly` so messages are no longer saved unintentionally.

* **Documentation**
  * Migration guide and updated memory/agent docs showing the new `memory.options` shape and examples.

* **Chores**
  * Added a codemod to automate the migration.

* **Tests**
  * New unit and codemod tests covering readOnly behaviors and transformations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->