### PR TITLE
Update ssri

### DIFF
--- a/e2e-tests/commonjs/package.json
+++ b/e2e-tests/commonjs/package.json
@@ -8,7 +8,6 @@
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
     "rollup": "^4.41.1",
-    "ssri": "^6.0.2",
     "verdaccio": "^6.2.0",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.8"
@@ -17,7 +16,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "form-data": "^2.5.4",
-    "ssri": "^6.0.2"
+    "form-data": "^2.5.4"
+  },
+  "resolutions": {
+    "ssri": ">=6.0.2"
   }
 }

--- a/e2e-tests/commonjs/package.json
+++ b/e2e-tests/commonjs/package.json
@@ -8,6 +8,7 @@
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
     "rollup": "^4.41.1",
+    "ssri": "^6.0.2",
     "verdaccio": "^6.2.0",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.8"
@@ -16,6 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "form-data": "^2.5.4"
+    "form-data": "^2.5.4",
+    "ssri": "^6.0.2"
   }
 }

--- a/e2e-tests/commonjs/pnpm-lock.yaml
+++ b/e2e-tests/commonjs/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       form-data:
         specifier: ^2.5.4
         version: 2.5.5
+      ssri:
+        specifier: ^6.0.2
+        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.0
@@ -924,6 +927,10 @@ packages:
       picomatch:
         optional: true
 
+  figgy-pudding@3.5.2:
+    resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -1770,6 +1777,9 @@ packages:
 
   ssri@5.3.0:
     resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
+
+  ssri@6.0.2:
+    resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2968,6 +2978,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  figgy-pudding@3.5.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -3878,6 +3890,10 @@ snapshots:
   ssri@5.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  ssri@6.0.2:
+    dependencies:
+      figgy-pudding: 3.5.2
 
   stackback@0.0.2: {}
 

--- a/e2e-tests/commonjs/pnpm-lock.yaml
+++ b/e2e-tests/commonjs/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ssri: '>=6.0.2'
+
 importers:
 
   .:
@@ -11,9 +14,6 @@ importers:
       form-data:
         specifier: ^2.5.4
         version: 2.5.5
-      ssri:
-        specifier: ^6.0.2
-        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.0
@@ -1775,9 +1775,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  ssri@5.3.0:
-    resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
-
   ssri@6.0.2:
     resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
@@ -3460,7 +3457,7 @@ snapshots:
       safe-buffer: 5.2.1
       semver: 5.7.2
       slide: 1.1.6
-      ssri: 5.3.0
+      ssri: 6.0.2
     optionalDependencies:
       npmlog: 4.1.2
 
@@ -3886,10 +3883,6 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-
-  ssri@5.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   ssri@6.0.2:
     dependencies:

--- a/e2e-tests/create-mastra/package.json
+++ b/e2e-tests/create-mastra/package.json
@@ -12,13 +12,14 @@
     "get-port": "^7.1.0",
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
-    "ssri": "^6.0.2",
     "verdaccio": "^6.2.0",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.8"
   },
   "dependencies": {
-    "form-data": "^2.5.5",
-    "ssri": "^6.0.2"
+    "form-data": "^2.5.5"
+  },
+  "resolutions": {
+    "ssri": ">=6.0.2"
   }
 }

--- a/e2e-tests/create-mastra/package.json
+++ b/e2e-tests/create-mastra/package.json
@@ -12,11 +12,13 @@
     "get-port": "^7.1.0",
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
+    "ssri": "^6.0.2",
     "verdaccio": "^6.2.0",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.8"
   },
   "dependencies": {
-    "form-data": "^2.5.5"
+    "form-data": "^2.5.5",
+    "ssri": "^6.0.2"
   }
 }

--- a/e2e-tests/create-mastra/pnpm-lock.yaml
+++ b/e2e-tests/create-mastra/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ssri: '>=6.0.2'
+
 importers:
 
   .:
@@ -11,9 +14,6 @@ importers:
       form-data:
         specifier: ^2.5.5
         version: 2.5.5
-      ssri:
-        specifier: ^6.0.2
-        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.0
@@ -1772,9 +1772,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  ssri@5.3.0:
-    resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
-
   ssri@6.0.2:
     resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
@@ -3457,7 +3454,7 @@ snapshots:
       safe-buffer: 5.2.1
       semver: 5.7.2
       slide: 1.1.6
-      ssri: 5.3.0
+      ssri: 6.0.2
     optionalDependencies:
       npmlog: 4.1.2
 
@@ -3883,10 +3880,6 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-
-  ssri@5.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   ssri@6.0.2:
     dependencies:

--- a/e2e-tests/create-mastra/pnpm-lock.yaml
+++ b/e2e-tests/create-mastra/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       form-data:
         specifier: ^2.5.5
         version: 2.5.5
+      ssri:
+        specifier: ^6.0.2
+        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.0
@@ -921,6 +924,10 @@ packages:
       picomatch:
         optional: true
 
+  figgy-pudding@3.5.2:
+    resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -1767,6 +1774,9 @@ packages:
 
   ssri@5.3.0:
     resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
+
+  ssri@6.0.2:
+    resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2965,6 +2975,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  figgy-pudding@3.5.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -3875,6 +3887,10 @@ snapshots:
   ssri@5.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  ssri@6.0.2:
+    dependencies:
+      figgy-pudding: 3.5.2
 
   stackback@0.0.2: {}
 

--- a/e2e-tests/deployers/package.json
+++ b/e2e-tests/deployers/package.json
@@ -8,6 +8,7 @@
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
     "rollup": "^4.53.5",
+    "ssri": "^6.0.2",
     "verdaccio": "^6.2.4",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.16"
@@ -21,6 +22,7 @@
     ]
   },
   "dependencies": {
-    "form-data": "^2.5.5"
+    "form-data": "^2.5.5",
+    "ssri": "^6.0.2"
   }
 }

--- a/e2e-tests/deployers/package.json
+++ b/e2e-tests/deployers/package.json
@@ -8,7 +8,6 @@
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
     "rollup": "^4.53.5",
-    "ssri": "^6.0.2",
     "verdaccio": "^6.2.4",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.16"
@@ -22,7 +21,9 @@
     ]
   },
   "dependencies": {
-    "form-data": "^2.5.5",
-    "ssri": "^6.0.2"
+    "form-data": "^2.5.5"
+  },
+  "resolutions": {
+    "ssri": ">=6.0.2"
   }
 }

--- a/e2e-tests/deployers/pnpm-lock.yaml
+++ b/e2e-tests/deployers/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ssri: '>=6.0.2'
+
 importers:
 
   .:
@@ -11,9 +14,6 @@ importers:
       form-data:
         specifier: ^2.5.5
         version: 2.5.5
-      ssri:
-        specifier: ^6.0.2
-        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.1
@@ -1775,9 +1775,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  ssri@5.3.0:
-    resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
-
   ssri@6.0.2:
     resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
@@ -3460,7 +3457,7 @@ snapshots:
       safe-buffer: 5.2.1
       semver: 5.7.2
       slide: 1.1.6
-      ssri: 5.3.0
+      ssri: 6.0.2
     optionalDependencies:
       npmlog: 4.1.2
 
@@ -3886,10 +3883,6 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-
-  ssri@5.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   ssri@6.0.2:
     dependencies:

--- a/e2e-tests/deployers/pnpm-lock.yaml
+++ b/e2e-tests/deployers/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       form-data:
         specifier: ^2.5.5
         version: 2.5.5
+      ssri:
+        specifier: ^6.0.2
+        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.1
@@ -924,6 +927,10 @@ packages:
       picomatch:
         optional: true
 
+  figgy-pudding@3.5.2:
+    resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -1770,6 +1777,9 @@ packages:
 
   ssri@5.3.0:
     resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
+
+  ssri@6.0.2:
+    resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2968,6 +2978,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  figgy-pudding@3.5.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -3878,6 +3890,10 @@ snapshots:
   ssri@5.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  ssri@6.0.2:
+    dependencies:
+      figgy-pudding: 3.5.2
 
   stackback@0.0.2: {}
 

--- a/e2e-tests/monorepo/package.json
+++ b/e2e-tests/monorepo/package.json
@@ -22,7 +22,6 @@
     ]
   },
   "dependencies": {
-    "form-data": "^2.5.5",
-    "ssri": "^6.0.2"
+    "form-data": "^2.5.5"
   }
 }

--- a/e2e-tests/monorepo/package.json
+++ b/e2e-tests/monorepo/package.json
@@ -8,6 +8,7 @@
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
     "rollup": "^4.41.1",
+    "ssri": "^6.0.2",
     "verdaccio": "^6.2.0",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.8"
@@ -21,6 +22,7 @@
     ]
   },
   "dependencies": {
-    "form-data": "^2.5.5"
+    "form-data": "^2.5.5",
+    "ssri": "^6.0.2"
   }
 }

--- a/e2e-tests/monorepo/package.json
+++ b/e2e-tests/monorepo/package.json
@@ -8,7 +8,6 @@
     "globby": "^14.1.0",
     "npm-cli-login": "^1.0.0",
     "rollup": "^4.41.1",
-    "ssri": "^6.0.2",
     "verdaccio": "^6.2.0",
     "verdaccio-auth-memory": "^10.3.1",
     "vitest": "^4.0.8"
@@ -23,5 +22,8 @@
   },
   "dependencies": {
     "form-data": "^2.5.5"
+  },
+  "resolutions": {
+    "ssri": ">=6.0.2"
   }
 }

--- a/e2e-tests/monorepo/pnpm-lock.yaml
+++ b/e2e-tests/monorepo/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ssri: '>=6.0.2'
+
 importers:
 
   .:
@@ -27,9 +30,6 @@ importers:
       rollup:
         specifier: ^4.41.1
         version: 4.53.5
-      ssri:
-        specifier: ^6.0.2
-        version: 6.0.2
       verdaccio:
         specifier: ^6.2.0
         version: 6.2.4(typanion@3.14.0)
@@ -1775,9 +1775,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  ssri@5.3.0:
-    resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
-
   ssri@6.0.2:
     resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
@@ -3460,7 +3457,7 @@ snapshots:
       safe-buffer: 5.2.1
       semver: 5.7.2
       slide: 1.1.6
-      ssri: 5.3.0
+      ssri: 6.0.2
     optionalDependencies:
       npmlog: 4.1.2
 
@@ -3886,10 +3883,6 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-
-  ssri@5.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   ssri@6.0.2:
     dependencies:

--- a/e2e-tests/monorepo/pnpm-lock.yaml
+++ b/e2e-tests/monorepo/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       form-data:
         specifier: ^2.5.5
         version: 2.5.5
+      ssri:
+        specifier: ^6.0.2
+        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.0
@@ -924,6 +927,10 @@ packages:
       picomatch:
         optional: true
 
+  figgy-pudding@3.5.2:
+    resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -1770,6 +1777,9 @@ packages:
 
   ssri@5.3.0:
     resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
+
+  ssri@6.0.2:
+    resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2968,6 +2978,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  figgy-pudding@3.5.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -3878,6 +3890,10 @@ snapshots:
   ssri@5.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  ssri@6.0.2:
+    dependencies:
+      figgy-pudding: 3.5.2
 
   stackback@0.0.2: {}
 

--- a/e2e-tests/monorepo/pnpm-lock.yaml
+++ b/e2e-tests/monorepo/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       form-data:
         specifier: ^2.5.5
         version: 2.5.5
-      ssri:
-        specifier: ^6.0.2
-        version: 6.0.2
     devDependencies:
       execa:
         specifier: ^9.6.0
@@ -30,6 +27,9 @@ importers:
       rollup:
         specifier: ^4.41.1
         version: 4.53.5
+      ssri:
+        specifier: ^6.0.2
+        version: 6.0.2
       verdaccio:
         specifier: ^6.2.0
         version: 6.2.4(typanion@3.14.0)

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "@types/node": "22.13.17",
     "cookie": ">=0.7.2",
     "tmp": ">=0.2.5",
-    "jsondiffpatch": ">=0.7.3"
+    "jsondiffpatch": ">=0.7.3",
+    "ssri": ">=6.0.2"
   },
   "license": "Apache-2.0",
   "packageManager": "pnpm@10.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   cookie: '>=0.7.2'
   tmp: '>=0.2.5'
   jsondiffpatch: '>=0.7.3'
+  ssri: '>=6.0.2'
 
 patchedDependencies:
   '@changesets/get-dependents-graph':


### PR DESCRIPTION
## Description

Updates ssri to 6.0.2 or higher

## Related Issue(s)

https://github.com/mastra-ai/mastra/security/dependabot/92
https://github.com/mastra-ai/mastra/security/dependabot/123
https://github.com/mastra-ai/mastra/security/dependabot/126
https://github.com/mastra-ai/mastra/security/dependabot/386

## Type of Change

- [X ] Vuln patch

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a top-level resolution enforcing ssri >= 6.0.2 across end-to-end test setups.
  * No changes to declared dependencies or runtime behavior; this only constrains transitive dependency resolution.
  * No functional or API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->