### PR TITLE
feat(otel-exporter): add flush() method to force export span

### DIFF
--- a/.changeset/add-flush-to-exporters.md
+++ b/.changeset/add-flush-to-exporters.md
@@ -4,4 +4,24 @@
 "@mastra/otel-exporter": minor
 ---
 
-Add flush method to observability exporters to allow manual flushing of spans (e.g. for serverless environments)
+Added flush method to observability exporters for manual span flushing
+
+Observability exporters now support a `flush()` method that forces immediate export of buffered spans without shutting down the exporter. This is particularly useful in serverless environments where you need to ensure spans are exported before an instance is frozen or reused.
+
+**Usage:**
+
+```typescript
+// Force flush spans before returning from a serverless handler
+await mastra.observability.flush();
+
+// Or call flush directly on an exporter
+const exporter = new OtelExporter(config);
+await exporter.flush();
+
+// Unlike shutdown(), the exporter remains operational after flush
+await exporter.exportTracingEvent(event); // Still works
+```
+
+**Note:** `BaseExporter` provides a default no-op implementation, while `OtelExporter` calls the OpenTelemetry processor's `forceFlush()` to ensure all queued spans are exported immediately.
+
+Closes #11372

--- a/.changeset/add-flush-to-exporters.md
+++ b/.changeset/add-flush-to-exporters.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": minor
+"@mastra/observability": minor
+"@mastra/otel-exporter": minor
+---
+
+Add flush method to observability exporters to allow manual flushing of spans (e.g. for serverless environments)

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -152,6 +152,15 @@ export abstract class BaseExporter implements ObservabilityExporter {
   }): Promise<void>;
 
   /**
+   * Flush any buffered data to the exporter
+   *
+   * Default implementation does nothing. Override to add custom flush logic.
+   */
+  async flush(): Promise<void> {
+    // No-op by default
+  }
+
+  /**
    * Shutdown the exporter and clean up resources
    *
    * Default implementation just logs. Override to add custom cleanup.

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -156,7 +156,7 @@ export abstract class BaseExporter implements ObservabilityExporter {
    *
    * Default implementation does nothing. Override to add custom flush logic.
    */
-  async flush(): Promise<void> {
+  protected async flush(): Promise<void> {
     // No-op by default
   }
 

--- a/observability/mastra/src/exporters/cloud.ts
+++ b/observability/mastra/src/exporters/cloud.ts
@@ -129,7 +129,7 @@ export class CloudExporter extends BaseExporter {
     return spanRecord;
   }
 
-  private shouldFlush(): boolean {
+  protected shouldFlush(): boolean {
     // Size-based flush
     if (this.buffer.totalSize >= this.config.maxBatchSize) {
       return true;
@@ -166,7 +166,7 @@ export class CloudExporter extends BaseExporter {
     }, this.config.maxBatchWaitMs);
   }
 
-  private async flush(): Promise<void> {
+  protected async flush(): Promise<void> {
     // Clear timer since we're flushing
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);

--- a/observability/mastra/src/exporters/default.ts
+++ b/observability/mastra/src/exporters/default.ts
@@ -333,7 +333,7 @@ export class DefaultExporter extends BaseExporter {
   /**
    * Schedules a flush using setTimeout
    */
-  private scheduleFlush(): void {
+  protected scheduleFlush(): void {
     if (this.#flushTimer) {
       clearTimeout(this.#flushTimer);
     }
@@ -541,7 +541,7 @@ export class DefaultExporter extends BaseExporter {
   /**
    * Flushes the current buffer to storage with retry logic
    */
-  private async flush(): Promise<void> {
+  protected async flush(): Promise<void> {
     if (!this.#observability) {
       this.logger.debug('Cannot flush traces. Observability storage is not initialized');
       return;

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -112,7 +112,7 @@ export class OtelExporter extends BaseExporter {
         } catch (grpcError) {
           this.logger.error(
             `[OtelExporter] Failed to load gRPC metadata. Install required packages:\n` +
-              `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js\n`,
+            `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js\n`,
             grpcError,
           );
           this.isDisabled = true;
@@ -210,6 +210,12 @@ export class OtelExporter extends BaseExporter {
       );
     } catch (error) {
       this.logger.error(`[OtelExporter] Failed to export span ${span.id}:`, error);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.processor) {
+      await this.processor.forceFlush();
     }
   }
 

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -112,7 +112,7 @@ export class OtelExporter extends BaseExporter {
         } catch (grpcError) {
           this.logger.error(
             `[OtelExporter] Failed to load gRPC metadata. Install required packages:\n` +
-              `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js\n`,
+            `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js\n`,
             grpcError,
           );
           this.isDisabled = true;
@@ -215,7 +215,11 @@ export class OtelExporter extends BaseExporter {
 
   async flush(): Promise<void> {
     if (this.processor) {
-      await this.processor.forceFlush();
+      try {
+        await this.processor.forceFlush();
+      } catch (error) {
+        this.logger.error(`[OtelExporter] Failed to flush spans:`, error);
+      }
     }
   }
 

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -217,7 +217,7 @@ export class OtelExporter extends BaseExporter {
    * Flush any pending spans to the exporter without shutting down.
    * Useful in serverless environments to export spans before instance termination.
    */
-  async flush(): Promise<void> {
+  protected async flush(): Promise<void> {
     if (this.isDisabled) {
       return;
     }

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -213,7 +213,14 @@ export class OtelExporter extends BaseExporter {
     }
   }
 
+  /**
+   * Flush any pending spans to the exporter without shutting down.
+   * Useful in serverless environments to export spans before instance termination.
+   */
   async flush(): Promise<void> {
+    if (this.isDisabled) {
+      return;
+    }
     if (this.processor) {
       try {
         await this.processor.forceFlush();

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -112,7 +112,7 @@ export class OtelExporter extends BaseExporter {
         } catch (grpcError) {
           this.logger.error(
             `[OtelExporter] Failed to load gRPC metadata. Install required packages:\n` +
-            `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js\n`,
+              `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js\n`,
             grpcError,
           );
           this.isDisabled = true;

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -74,7 +74,7 @@ export enum EntityType {
 /**
  * Base attributes that all spans can have
  */
-export interface AIBaseAttributes { }
+export interface AIBaseAttributes {}
 
 /**
  * Agent Run attributes

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -74,7 +74,7 @@ export enum EntityType {
 /**
  * Base attributes that all spans can have
  */
-export interface AIBaseAttributes {}
+export interface AIBaseAttributes { }
 
 /**
  * Agent Run attributes


### PR DESCRIPTION
## Description

This PR adds a `flush()` method to the Mastra AI observability exporters, allowing manual flushing of spans without shutting down the exporter. This is critical for serverless environments (like Vercel) where instances may be reused for multiple requests.

Changes include:  
- Updated the `ObservabilityExporter` interface to include an optional `flush(): Promise<void>` method.  
- Added a default no-op `flush()` method in `BaseExporter` for backward compatibility.  
- Implemented `flush()` in `OtelExporter` to call `this.processor.forceFlush()`, ensuring all spans are exported immediately.  
- Created a changeset documenting the minor version bump for affected packages.

## Related Issue(s)

- Closes #11372

## Type of Change

- [x] New feature (non-breaking change that adds functionality)  

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)  
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability exporters now support an explicit flush operation to manually flush queued spans; default exporters are no-ops unless implemented, and the OTEL exporter performs an immediate flush when invoked.

* **Chores**
  * Bumped observability and exporter packages to minor versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->