### PR TITLE
fix(core): preserve Date objects in tool input validation

### DIFF
--- a/.changeset/fix-date-objects-tool-validation.md
+++ b/.changeset/fix-date-objects-tool-validation.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool input validation destroying non-plain objects
+
+The `convertUndefinedToNull` function in tool input validation was treating all objects as plain objects and recursively processing them. For objects like `Date`, `Map`, `URL`, and class instances, this resulted in empty objects `{}` because they have no enumerable own properties.
+
+This fix changes the approach to only recurse into plain objects (objects with `Object.prototype` or `null` prototype). All other objects (Date, Map, Set, URL, RegExp, Error, custom class instances, etc.) are now preserved as-is.
+
+Fixes #11502


### PR DESCRIPTION
Fixes #11502

## Problem

The `convertUndefinedToNull` function in tool input validation was treating `Date` objects as plain objects and recursively processing them. Since `Date` objects have no enumerable properties, this resulted in empty objects `{}`, which broke `z.coerce.date()` validation.

This caused tools using `z.coerce.date()` schemas to fail with "Invalid date" errors when receiving date inputs from LLMs, even though the inputs were valid `Date` objects or ISO strings.

## Solution

Added checks to preserve built-in object types (Date, RegExp, Error) before recursive processing in `convertUndefinedToNull`. This ensures that:
- `Date` objects are passed through unchanged to Zod validation
- `z.coerce.date()` can properly validate and coerce both Date objects and ISO strings
- Other built-in types are also preserved correctly

## Changes

- Modified `convertUndefinedToNull` in `packages/core/src/tools/validation.ts` to check for and preserve built-in object types
- Added 8 comprehensive tests in `packages/core/src/tools/validation.test.ts` covering:
  - Date object preservation with `z.coerce.date()`
  - ISO string to Date coercion
  - Nested structures with dates
  - Optional date fields
  - RegExp and Error object preservation
  - Date objects in arrays
  - Mixed Date objects and ISO strings
- Added changeset for release notes

## Testing

All new tests pass:
```
✓ should preserve Date objects when validating z.coerce.date() schemas
✓ should handle ISO string dates with z.coerce.date()
✓ should preserve Date objects in nested structures
✓ should preserve Date objects with optional fields
✓ should preserve RegExp objects
✓ should preserve Error objects
✓ should handle Date objects in arrays
✓ should handle mixed Date objects and ISO strings
```

Tested end-to-end with real tools using `z.coerce.date()` parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool input validation now preserves non-plain objects (e.g., Date, RegExp, Error, Map, Set, URL, class instances), preventing them from becoming empty objects and allowing Date objects and ISO date strings to validate correctly.

* **Tests**
  * Added comprehensive tests covering preservation of built-in and custom object types across nested structures, arrays, optional/nullable fields, and mixed inputs.

* **Chores**
  * Added changelog entry and bumped patch version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->