### PR TITLE
fix(core): use findParent for input step processor span parenting

### DIFF
--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -856,9 +856,10 @@ export class ProcessorRunner {
         requestContext,
       };
 
-      // Use the current span (the step span) as the parent for processor spans
+      // Find the AGENT_RUN span by walking up the parent chain
       const currentSpan = tracingContext?.currentSpan;
-      const processorSpan = currentSpan?.createChildSpan({
+      const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
+      const processorSpan = parentSpan?.createChildSpan({
         type: SpanType.PROCESSOR_RUN,
         name: `input step processor: ${processor.id}`,
         entityType: EntityType.INPUT_PROCESSOR,


### PR DESCRIPTION


## Description

Input step processor spans were incorrectly parented to MODEL_GENERATION spans instead of AGENT_RUN spans, causing orphaned spans in Langfuse.

- Add findParent(SpanType.AGENT_RUN) in runInputStepProcessors
- Add unit tests for span parent resolution behavior

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating span parent resolution and fallback behavior when creating processor spans for input steps.

* **Improvements**
  * Processor spans for input-step processing now link to the nearest agent-run ancestor in traces (falling back to the step parent or current span), changing the resulting span hierarchy and tracing context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->