### PR TITLE
fix(playground): derive resourceId from RequestContext instead of age…

### DIFF
--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -361,7 +361,7 @@ export function MastraRuntimeProvider({
             seed,
             instructions,
             requestContext: requestContextInstance,
-            ...(memory ? { threadId, resourceId: agentId } : {}),
+            ...(memory ? { threadId, resourceId } : {}),
             providerOptions,
           });
           if (generateResponse.response && 'messages' in generateResponse.response) {
@@ -479,7 +479,7 @@ export function MastraRuntimeProvider({
             seed,
             instructions,
             requestContext: requestContextInstance,
-            ...(memory ? { threadId, resourceId: agentId } : {}),
+            ...(memory ? { threadId, resourceId } : {}),
             providerOptions,
           });
 


### PR DESCRIPTION
## Description

Removed the direct `resourceId` UI input from `AgentChat` and ensured `MastraRuntimeProvider` uses the programmatically derived `resourceId` from `RequestContext`.  
This aligns the Studio environment with production behavior, where `resourceId` is securely set by middleware, maintaining security and avoiding user manipulation of memory-scoped resources.

## Related Issue(s)
#11459 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)  
- [x] Code refactoring  

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)  
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected resourceId parameter assignment in memory-enabled runtime operations to use the appropriate identifier source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->