### PR TITLE
test: clean up malformed tool regression test JSDoc

### DIFF
--- a/.changeset/clean-up-malformed-tool-test-jsdoc.md
+++ b/.changeset/clean-up-malformed-tool-test-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Updated JSDoc in malformed tool regression test to clarify the current behavior after the fix for #11244. The documentation now reflects that the issue has been resolved and the validation properly throws descriptive errors.

--- a/packages/core/src/tools/__tests__/malformed-tool.test.ts
+++ b/packages/core/src/tools/__tests__/malformed-tool.test.ts
@@ -5,12 +5,11 @@ import { ensureToolProperties } from '../../utils';
 import { createTool } from '../tool';
 
 /**
- * Test for GitHub Issue #11244
- * https://github.com/mastra-ai/mastra/issues/11244
+ * Regression test for malformed tool validation
  *
  * When a user passes a function that returns a tool (instead of the tool itself),
  * the agent silently fails - the LLM makes a tool call but the tool never executes.
- * This should throw a descriptive error instead.
+ * Now throws a descriptive error instead.
  */
 describe('Malformed tool validation - Issue #11244', () => {
   it('should throw an error when a function is passed as a tool instead of a tool object', () => {


### PR DESCRIPTION
## Description

Clarifies the intent of the malformed tool regression test by updating the JSDoc to reflect the current behavior after the fix for #11244. This improves test readability and avoids confusion about whether the issue is still unresolved.

## Related Issue(s)

Related to #11244

## Type of Change

- [x] Documentation update
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated regression test documentation to reflect that malformed tool validation now produces descriptive errors.
* **Chores**
  * Added a changeset entry recording a patch release bump and describing the corrected validation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->