### PR TITLE
docs: add workflows as tools section to agent docs

### DIFF
--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -91,6 +91,61 @@ export const weatherAgent = new Agent({
 });
 ```
 
+## Using workflows as tools
+
+Workflows can be added to agents through the `workflows` configuration. When you add a workflow, Mastra automatically converts it to a tool that the agent can call. The generated tool is named `workflow-<workflowName>` and uses the workflow's `inputSchema` and `outputSchema`.
+
+```typescript {14-16} title="src/mastra/agents/research-agent.ts"
+import { Agent } from "@mastra/core/agent";
+import { researchWorkflow } from "../workflows/research-workflow";
+
+export const researchAgent = new Agent({
+  id: "research-agent",
+  name: "Research Agent",
+  instructions: `
+      You are a research assistant.
+      Use the research workflow to gather and compile information on topics.`,
+  model: "openai/gpt-5.1",
+  tools: {
+    weatherTool,
+  },
+  workflows: {
+    researchWorkflow,
+  },
+});
+```
+
+The workflow should include a `description` to help the agent understand when to use it:
+
+```typescript title="src/mastra/workflows/research-workflow.ts"
+import { createWorkflow } from "@mastra/core/workflows";
+import { z } from "zod";
+
+export const researchWorkflow = createWorkflow({
+  id: "research-workflow",
+  description: "Gathers information on a topic and compiles a summary report.",
+  inputSchema: z.object({
+    topic: z.string(),
+  }),
+  outputSchema: z.object({
+    summary: z.string(),
+    sources: z.array(z.string()),
+  }),
+})
+  .then(gatherSourcesStep)
+  .then(compileReportStep)
+  .commit();
+```
+
+When the agent calls the workflow tool, it receives a response containing the workflow result and a `runId` that can be used to track the execution:
+
+```typescript
+{
+  result: { summary: "...", sources: ["..."] },
+  runId: "abc-123"
+}
+```
+
 ## Related
 
 - [MCP Overview](/docs/v1/mcp/overview)


### PR DESCRIPTION
Addresses #11578

The using-tools docs didn't mention that workflows can be passed to agents and are automatically converted to tools. Added a section showing how this works:

```typescript
export const researchAgent = new Agent({
  id: "research-agent",
  model: "openai/gpt-5.1",
  tools: { weatherTool },
  workflows: {
    researchWorkflow,  // becomes tool 'workflow-researchWorkflow'
  },
});
```

Also shows how to define a workflow with a good description so the agent knows when to use it, and what the response format looks like.

Fixes #11578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on using workflows as agent tools, including how workflows are automatically converted to named tools, with configuration examples, input/output schemas, and sample execution responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->