### PR TITLE
fix: provider-executed tools not working with AI SDK v6 models

### DIFF
--- a/.changeset/fix-provider-tools-ai-sdk-v6.md
+++ b/.changeset/fix-provider-tools-ai-sdk-v6.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix provider-executed tools (like `openai.tools.webSearch()`) not working correctly with AI SDK v6 models. The agent's `generate()` method was ending prematurely with `finishReason: 'tool-calls'` instead of completing with a text response after tool execution.
+
+The issue was that V6 provider tools have `type: 'provider'` while V5 uses `type: 'provider-defined'`. The tool preparation code now detects the model version and uses the correct type.

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { prepareToolsAndToolChoice } from './prepare-tools';
 import { z } from 'zod';
 import { createTool } from '../../../../tools/tool';
+import { prepareToolsAndToolChoice } from './prepare-tools';
 
 describe('prepareToolsAndToolChoice', () => {
   describe('isProviderTool detection', () => {

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import { prepareToolsAndToolChoice } from './prepare-tools';
+import { z } from 'zod';
+import { createTool } from '../../../../tools/tool';
+
+describe('prepareToolsAndToolChoice', () => {
+  describe('isProviderTool detection', () => {
+    it('should detect provider tools by id format (provider.tool_name)', () => {
+      // Mock a provider tool like openai.tools.webSearch() returns
+      const providerTool = {
+        id: 'openai.web_search',
+        type: 'function',
+        args: { search_context_size: 'medium' },
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v3',
+      });
+
+      expect(result.tools).toBeDefined();
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools![0]).toMatchObject({
+        type: 'provider',
+        name: 'web_search',
+        id: 'openai.web_search',
+        args: { search_context_size: 'medium' },
+      });
+    });
+
+    it('should use provider-defined type for v2 target version', () => {
+      const providerTool = {
+        id: 'openai.web_search',
+        type: 'function',
+        args: {},
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v2',
+      });
+
+      expect(result.tools).toBeDefined();
+      expect(result.tools![0]).toMatchObject({
+        type: 'provider-defined',
+        name: 'web_search',
+        id: 'openai.web_search',
+      });
+    });
+
+    it('should handle nested provider tool names correctly', () => {
+      // Tool with nested name like 'provider.category.tool_name'
+      const providerTool = {
+        id: 'anthropic.tools.web_search_20250305',
+        type: 'function',
+        args: {},
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v3',
+      });
+
+      expect(result.tools![0]).toMatchObject({
+        type: 'provider',
+        name: 'tools.web_search_20250305',
+        id: 'anthropic.tools.web_search_20250305',
+      });
+    });
+  });
+
+  describe('regular function tools', () => {
+    it('should convert Mastra tools to function tools', () => {
+      const mastraTool = createTool({
+        id: 'test-tool',
+        description: 'A test tool',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+        }),
+        execute: async ({ query }) => `Result for: ${query}`,
+      });
+
+      const result = prepareToolsAndToolChoice({
+        tools: { testTool: mastraTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v3',
+      });
+
+      expect(result.tools).toBeDefined();
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools![0]).toMatchObject({
+        type: 'function',
+        name: 'testTool',
+        description: 'A test tool',
+      });
+    });
+
+    it('should not treat regular tools with no id as provider tools', () => {
+      const regularTool = createTool({
+        id: 'regular-tool',
+        description: 'A regular tool',
+        inputSchema: z.object({
+          input: z.string(),
+        }),
+        execute: async ({ input }) => input,
+      });
+
+      const result = prepareToolsAndToolChoice({
+        tools: { regular: regularTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v3',
+      });
+
+      expect(result.tools![0]).toMatchObject({
+        type: 'function',
+        name: 'regular',
+      });
+    });
+  });
+
+  describe('activeTools filtering', () => {
+    it('should filter tools based on activeTools array', () => {
+      const tool1 = {
+        id: 'openai.tool1',
+        type: 'function',
+        args: {},
+      };
+      const tool2 = {
+        id: 'openai.tool2',
+        type: 'function',
+        args: {},
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { tool1: tool1 as any, tool2: tool2 as any },
+        toolChoice: undefined,
+        activeTools: ['tool1'],
+        targetVersion: 'v3',
+      });
+
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools![0]).toMatchObject({
+        name: 'tool1',
+      });
+    });
+  });
+
+  describe('toolChoice handling', () => {
+    it('should default to auto when toolChoice is undefined but tools exist', () => {
+      const providerTool = { id: 'openai.web_search', args: {} };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+      });
+
+      expect(result.toolChoice).toEqual({ type: 'auto' });
+    });
+
+    it('should handle string toolChoice values', () => {
+      const providerTool = { id: 'openai.web_search', args: {} };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: 'required',
+        activeTools: undefined,
+      });
+
+      expect(result.toolChoice).toEqual({ type: 'required' });
+    });
+
+    it('should handle specific tool choice', () => {
+      const providerTool = { id: 'openai.web_search', args: {} };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: { toolName: 'search' } as any,
+        activeTools: undefined,
+      });
+
+      expect(result.toolChoice).toEqual({ type: 'tool', toolName: 'search' });
+    });
+  });
+
+  describe('empty tools', () => {
+    it('should return undefined for empty tools object', () => {
+      const result = prepareToolsAndToolChoice({
+        tools: {},
+        toolChoice: undefined,
+        activeTools: undefined,
+      });
+
+      expect(result.tools).toBeUndefined();
+      expect(result.toolChoice).toBeUndefined();
+    });
+
+    it('should return undefined for undefined tools', () => {
+      const result = prepareToolsAndToolChoice({
+        tools: undefined,
+        toolChoice: undefined,
+        activeTools: undefined,
+      });
+
+      expect(result.tools).toBeUndefined();
+      expect(result.toolChoice).toBeUndefined();
+    });
+  });
+
+  describe('default targetVersion', () => {
+    it('should default to v2 when targetVersion is not specified', () => {
+      const providerTool = {
+        id: 'openai.web_search',
+        type: 'function',
+        args: {},
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        // No targetVersion specified - should default to 'v2'
+      });
+
+      expect(result.tools![0]).toMatchObject({
+        type: 'provider-defined', // v2 uses 'provider-defined'
+      });
+    });
+  });
+});

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -3,20 +3,60 @@ import type {
   LanguageModelV2ProviderDefinedTool,
   LanguageModelV2ToolChoice,
 } from '@ai-sdk/provider-v5';
+import type {
+  LanguageModelV3FunctionTool,
+  LanguageModelV3ProviderTool,
+  LanguageModelV3ToolChoice,
+} from '@ai-sdk/provider-v6';
 import { asSchema, tool as toolFn } from '@internal/ai-sdk-v5';
 import type { Tool, ToolChoice } from '@internal/ai-sdk-v5';
+
+/** Model specification version for tool type conversion */
+export type ModelSpecVersion = 'v2' | 'v3';
+
+/** Combined tool types for both V2 and V3 */
+type PreparedTool =
+  | LanguageModelV2FunctionTool
+  | LanguageModelV2ProviderDefinedTool
+  | LanguageModelV3FunctionTool
+  | LanguageModelV3ProviderTool;
+
+type PreparedToolChoice = LanguageModelV2ToolChoice | LanguageModelV3ToolChoice;
+
+/**
+ * Checks if a tool is a provider tool by examining its id property.
+ * Provider tools have an id in the format '<provider>.<tool_name>' (e.g., 'openai.web_search').
+ * This works for both V5 and V6 provider tools.
+ */
+function isProviderTool(tool: unknown): tool is { id: string; args?: Record<string, unknown> } {
+  if (typeof tool !== 'object' || tool === null) return false;
+  const t = tool as Record<string, unknown>;
+  // Check for id property with provider prefix format
+  return typeof t.id === 'string' && t.id.includes('.');
+}
+
+/**
+ * Extracts the tool name from a provider tool id.
+ * e.g., 'openai.web_search' -> 'web_search'
+ */
+function getProviderToolName(providerId: string): string {
+  return providerId.split('.').slice(1).join('.');
+}
 
 export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
   tools,
   toolChoice,
   activeTools,
+  targetVersion = 'v2',
 }: {
   tools: TOOLS | undefined;
   toolChoice: ToolChoice<TOOLS> | undefined;
   activeTools: Array<keyof TOOLS> | undefined;
+  /** Target model version: 'v2' for AI SDK v5, 'v3' for AI SDK v6. Defaults to 'v2'. */
+  targetVersion?: ModelSpecVersion;
 }): {
-  tools: Array<LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool> | undefined;
-  toolChoice: LanguageModelV2ToolChoice | undefined;
+  tools: PreparedTool[] | undefined;
+  toolChoice: PreparedToolChoice | undefined;
 } {
   if (Object.keys(tools || {}).length === 0) {
     return {
@@ -31,10 +71,27 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
       ? Object.entries(tools || {}).filter(([name]) => activeTools.includes(name as keyof TOOLS))
       : Object.entries(tools || {});
 
+  // Provider tool type differs between versions:
+  // - V2 (AI SDK v5): 'provider-defined'
+  // - V3 (AI SDK v6): 'provider'
+  const providerToolType = targetVersion === 'v3' ? 'provider' : 'provider-defined';
+
   return {
     tools: filteredTools
       .map(([name, tool]) => {
         try {
+          // Check if this is a provider tool BEFORE calling toolFn
+          // V6 provider tools (like openaiV6.tools.webSearch()) have type='function' but
+          // contain an 'id' property with format '<provider>.<tool_name>'
+          if (isProviderTool(tool)) {
+            return {
+              type: providerToolType,
+              name: getProviderToolName(tool.id),
+              id: tool.id,
+              args: tool.args ?? {},
+            } as PreparedTool;
+          }
+
           let inputSchema;
           if ('inputSchema' in tool) {
             inputSchema = tool.inputSchema;
@@ -63,26 +120,14 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
                 providerOptions: sdkTool.providerOptions,
               };
             case 'provider-defined': {
-              // For provider-defined tools, extract the name from the ID to match doStream behavior
-              // ID format is typically "provider.toolName" (e.g. "openai.web_search")
-              // doStream returns just "toolName" part, so we use that as name for consistency
+              // Fallback for tools that pass through toolFn and still get recognized as provider-defined
               const providerId = (sdkTool as any).id;
-
-              let providerToolName = name;
-
-              if (providerId && providerId.includes('.')) {
-                providerToolName = providerId.split('.').slice(1).join('.');
-              } else if (providerId) {
-                providerToolName = providerId;
-              }
-
               return {
-                type: 'provider-defined' as const,
-                name: providerToolName,
-                // TODO: as any seems wrong here. are there cases where we don't have an id?
+                type: providerToolType,
+                name: providerId ? getProviderToolName(providerId) : name,
                 id: providerId,
                 args: (sdkTool as any).args,
-              };
+              } as PreparedTool;
             }
             default: {
               const exhaustiveCheck: never = toolType;
@@ -94,7 +139,7 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
           return null;
         }
       })
-      .filter(tool => tool !== null) as (LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool)[],
+      .filter((tool): tool is PreparedTool => tool !== null),
     toolChoice:
       toolChoice == null
         ? { type: 'auto' }

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -9,7 +9,8 @@ import type { LoopOptions } from '../../../loop/types';
 import { getResponseFormat } from '../../base/schema';
 import type { OutputSchema } from '../../base/schema';
 import type { LanguageModelV2StreamResult, OnResult } from '../../types';
-import { prepareToolsAndToolChoice, type ModelSpecVersion } from './compat';
+import { prepareToolsAndToolChoice } from './compat';
+import type { ModelSpecVersion } from './compat';
 import { AISDKV5InputStream } from './input';
 
 function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -9,7 +9,7 @@ import type { LoopOptions } from '../../../loop/types';
 import { getResponseFormat } from '../../base/schema';
 import type { OutputSchema } from '../../base/schema';
 import type { LanguageModelV2StreamResult, OnResult } from '../../types';
-import { prepareToolsAndToolChoice } from './compat';
+import { prepareToolsAndToolChoice, type ModelSpecVersion } from './compat';
 import { AISDKV5InputStream } from './input';
 
 function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {
@@ -69,10 +69,15 @@ export function execute<OUTPUT extends OutputSchema = undefined>({
     generateId,
   });
 
+  // Determine target version based on model's specificationVersion
+  // V3 models (AI SDK v6) need 'provider' type, V2 models need 'provider-defined'
+  const targetVersion: ModelSpecVersion = model.specificationVersion === 'v3' ? 'v3' : 'v2';
+
   const toolsAndToolChoice = prepareToolsAndToolChoice({
     tools,
     toolChoice,
     activeTools,
+    targetVersion,
   });
 
   const structuredOutputMode = structuredOutput?.schema

--- a/packages/core/src/tools/provider-tools.test.ts
+++ b/packages/core/src/tools/provider-tools.test.ts
@@ -2,6 +2,7 @@ import { anthropic } from '@ai-sdk/anthropic-v5';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic-v5';
 import { google } from '@ai-sdk/google-v5';
 import { openai } from '@ai-sdk/openai-v5';
+import { openai as openaiV6 } from '@ai-sdk/openai-v6';
 import { describe, expect, it } from 'vitest';
 import { Agent } from '../agent';
 
@@ -294,5 +295,88 @@ describe('provider-defined tools', () => {
     expect(toolResult).toBeDefined();
     expect(toolResult?.payload.providerExecuted).toBe(true);
     expect((toolResult?.payload.result as any).type).toBe('code_execution_result');
+  });
+});
+
+// NOTE: AI SDK v6 (@ai-sdk/openai@3) webSearch tests were previously skipped because of
+// what was thought to be an upstream bug. The issue was actually that Mastra's tool preparation
+// was using V2 tool types ('provider-defined') when V3 models expect ('provider').
+// This has been fixed in prepare-tools.ts by using the correct tool type based on model version.
+describe('provider-defined tools with AI SDK v6 (@ai-sdk/openai@3)', () => {
+  it('stream - should handle openai web search tool with v6 provider', { timeout: 60000 }, async () => {
+    const tool = openaiV6.tools.webSearch({});
+
+    const agent = new Agent({
+      id: 'test-openai-v6-web-search-agent',
+      name: 'test-openai-v6-web-search-agent',
+      instructions: 'You are a search assistant. When asked to search for something, always use the search tool.',
+      model: openaiV6('gpt-4o-mini'),
+      tools: { search: tool },
+    });
+
+    const result = await agent.stream('What is the capital of France? Use the search tool to find the answer.', {});
+
+    await result.consumeStream();
+
+    expect(result).toBeDefined();
+
+    const text = await result.text;
+    const finishReason = await result.finishReason;
+    const toolCalls = await result.toolCalls;
+    const toolResults = await result.toolResults;
+
+    // Verify web search tool was called
+    const webSearchToolCall = toolCalls.find(tc => tc.payload.toolName === 'web_search');
+    expect(webSearchToolCall).toBeDefined();
+    expect(webSearchToolCall?.payload.providerExecuted).toBe(true);
+
+    // Verify web search tool result was processed
+    const webSearchToolResult = toolResults.find(tr => tr.payload.toolName === 'web_search');
+    expect(webSearchToolResult).toBeDefined();
+    // Note: providerExecuted flag on tool results is optional - the key check is that the result exists
+
+    // The agent should generate a text response after processing the web search results
+    expect(text).toBeDefined();
+    expect(text.length).toBeGreaterThan(0);
+    // The response should mention Paris (the capital of France)
+    expect(text.toLowerCase()).toContain('paris');
+
+    // Verify finish reason is 'stop' (not 'tool-calls')
+    expect(finishReason).toBe('stop');
+  });
+
+  it('generate - should handle openai web search tool with v6 provider', { timeout: 60000 }, async () => {
+    const tool = openaiV6.tools.webSearch({});
+
+    const agent = new Agent({
+      id: 'test-openai-v6-web-search-agent-generate',
+      name: 'test-openai-v6-web-search-agent-generate',
+      instructions: 'You are a search assistant. When asked to search for something, always use the search tool.',
+      model: openaiV6('gpt-4o-mini'),
+      tools: { search: tool },
+    });
+
+    const result = await agent.generate('What is the capital of France? Use the search tool to find the answer.', {});
+
+    expect(result).toBeDefined();
+
+    // The agent should generate a text response after processing the web search results
+    expect(result.text).toBeDefined();
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.text.toLowerCase()).toContain('paris');
+
+    // Verify web search tool was called
+    const webSearchToolCall = result.toolCalls.find(tc => tc.payload.toolName === 'web_search');
+    expect(webSearchToolCall).toBeDefined();
+    expect(webSearchToolCall?.payload.providerExecuted).toBe(true);
+
+    // Verify web search tool result was processed
+    const webSearchToolResult = result.toolResults.find(tr => tr.payload.toolName === 'web_search');
+    expect(webSearchToolResult).toBeDefined();
+    // Note: For provider-executed tools, the result may not have providerExecuted flag
+    // since it's implied by the presence of the tool result from a provider tool
+
+    // Verify finish reason is 'stop' (not 'tool-calls')
+    expect(result.finishReason).toBe('stop');
   });
 });


### PR DESCRIPTION
When using provider-executed tools like `openai.tools.webSearch()` with AI SDK v6 (`@ai-sdk/openai@3`), the agent's `generate()` method was ending prematurely with `finishReason: 'tool-calls'` instead of completing with a text response.

The issue was that V6 provider tools expect `type: 'provider'` while V5 uses `type: 'provider-defined'`. The tool preparation wasn't detecting the model version correctly.

Before (broken with v6):
```ts
const agent = new Agent({
  model: openaiV6('gpt-4o-mini'),
  tools: { search: openaiV6.tools.webSearch({}) },
});

const result = await agent.generate('Search for TypeScript');
// result.finishReason was 'tool-calls', result.text was empty
```

After (works correctly):
```ts
const result = await agent.generate('Search for TypeScript');
// result.finishReason is 'stop', result.text contains the response
```

Added unit tests for the helper functions and enabled the v6 integration tests.

fixes https://github.com/mastra-ai/mastra/issues/11553
fixes https://github.com/mastra-ai/mastra/issues/11573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider-executed tools (e.g., web search) now finish with a final text response when using AI SDK v6 models instead of stopping on a tool-call status.
  * Tool handling now supports both v2/v3 model tool formats for consistent behavior across model versions.

* **Tests**
  * Added comprehensive tests covering provider tool execution and cross-version tool-preparation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->