### PR TITLE
fix(elasticsearch): preserve embedding when updating only metadata

### DIFF
--- a/.changeset/fix-elasticsearch-update-vector-embedding.md
+++ b/.changeset/fix-elasticsearch-update-vector-embedding.md
@@ -1,0 +1,9 @@
+---
+'@mastra/elasticsearch': patch
+---
+
+Fix updateVector losing embedding data when only updating metadata.
+
+After the ElasticSearch upgrade from v8 to v9, `client.get()` no longer returns `dense_vector` fields in `_source`. This caused `updateVectorById` to write documents without embeddings when only metadata was being updated, effectively deleting vectors from the index.
+
+Switched to `client.search()` with an `ids` query, which properly returns `dense_vector` fields when explicitly requested in `_source`.

--- a/stores/elasticsearch/src/vector/index.test.ts
+++ b/stores/elasticsearch/src/vector/index.test.ts
@@ -377,11 +377,11 @@ describe('ElasticSearchVector', () => {
     });
 
     describe('updates', () => {
-      let testIndexName = 'test_vector_updates';
+      // Use vectors with distinct directions to ensure predictable query results with cosine similarity
       const testVectors = [
-        [1, 2, 3],
-        [4, 5, 6],
-        [7, 8, 9],
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
       ];
 
       beforeEach(async () => {


### PR DESCRIPTION
The recent ES upgrade to v9 broke `updateVector` when only updating metadata. The embedding was being lost because `client.get()` doesn't return `dense_vector` fields in ES 9.x.

Before (broken):
```ts
const result = await this.client.get({ index: indexName, id: id });
// result._source.embedding is undefined in ES 9.x
```

After (fixed):
```ts
const searchResult = await this.client.search({
  index: indexName,
  query: { ids: { values: [id] } },
  _source: ['id', 'metadata', 'embedding'],
});
// searchResult.hits.hits[0]._source.embedding is properly returned
```

Also updated test vectors in the updates test suite to use orthogonal vectors for more deterministic query results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where vector embeddings in Elasticsearch were lost when updating document metadata. Embeddings are now properly preserved during metadata-only updates.

* **Tests**
  * Updated test vector data to use basis vectors for more predictable and consistent test results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->