### PR TITLE
revert(elasticsearch): downgrade docker image from v9 to v8.17.0

### DIFF
--- a/stores/elasticsearch/docker-compose.yaml
+++ b/stores/elasticsearch/docker-compose.yaml
@@ -2,7 +2,9 @@ version: '3.8'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.3
+    # TODO: ES 9.x breaks updateVector - client.get() no longer returns dense_vector fields
+    # See: https://github.com/mastra-ai/mastra/issues/11628
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
     platform: linux/amd64
     ports:
       - '9200:9200'


### PR DESCRIPTION
## Description

The v9 upgrade broke updateVector when only updating metadata because client.get() no longer returns dense_vector fields in ES 9.x. Downgrading to v8.17.0 until a proper fix can be implemented alongside the upgrade.

## Related Issue(s)

broken CI

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Elasticsearch service version for the application's search infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->