### PR TITLE
Feature:network-structure-output-added

### DIFF
--- a/.changeset/network-structured-output-support.md
+++ b/.changeset/network-structured-output-support.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+'@mastra/ai-sdk': minor
+---
+
+Add structured output support for agent network executions
+
+Introduces a centralized accumulator-based approach to collect streaming network events and produce a single, type-safe structured result. This feature simplifies consuming network results by eliminating the need to manually parse and correlate multiple event types, while preserving existing streaming behavior.
+
+Key additions:
+- `NetworkOutputAccumulator` class for collecting and processing network events
+- Structured output configuration via `structuredOutput` option in network execution
+- Type-safe result extraction with Zod schema support
+- Maintains full backward compatibility with existing streaming APIs
+
+Related to #11337

--- a/client-sdks/ai-sdk/src/index.ts
+++ b/client-sdks/ai-sdk/src/index.ts
@@ -3,8 +3,14 @@ export type { chatRouteOptions, ChatStreamHandlerParams, ChatStreamHandlerOption
 export { workflowRoute, handleWorkflowStream } from './workflow-route';
 export type { WorkflowRouteOptions, WorkflowStreamHandlerParams, WorkflowStreamHandlerOptions } from './workflow-route';
 export type { WorkflowDataPart } from './transformers';
-export { networkRoute, handleNetworkStream } from './network-route';
-export type { NetworkRouteOptions, NetworkStreamHandlerParams, NetworkStreamHandlerOptions } from './network-route';
+export { networkRoute, handleNetworkStream, handleNetworkStructuredOutput } from './network-route';
+export type {
+  NetworkRouteOptions,
+  NetworkStreamHandlerParams,
+  NetworkStreamHandlerOptions,
+  NetworkStructuredHandlerParams,
+  NetworkStructuredHandlerOptions,
+} from './network-route';
 export type { NetworkDataPart } from './transformers';
 export type { AgentDataPart } from './transformers';
 

--- a/client-sdks/ai-sdk/src/network-route.ts
+++ b/client-sdks/ai-sdk/src/network-route.ts
@@ -4,7 +4,11 @@ import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { registerApiRoute } from '@mastra/core/server';
 import type { OutputSchema } from '@mastra/core/stream';
-import { NetworkOutputAccumulator, type NetworkStructuredOutput, type StructuredNetworkOutputOptions } from '@mastra/core/network';
+import {
+  NetworkOutputAccumulator,
+  type NetworkStructuredOutput,
+  type StructuredNetworkOutputOptions,
+} from '@mastra/core/network';
 import { createUIMessageStream, createUIMessageStreamResponse } from 'ai';
 import type { InferUIMessageChunk, UIMessage } from 'ai';
 import { toAISdkV5Stream } from './convert-streams';
@@ -20,9 +24,10 @@ export type NetworkStreamHandlerOptions<OUTPUT extends OutputSchema = undefined>
   defaultOptions?: AgentExecutionOptions<OUTPUT>;
 };
 
-export type NetworkStructuredHandlerParams<OUTPUT extends OutputSchema = undefined> = NetworkStreamHandlerParams<OUTPUT> & {
-  structuredOutputOptions?: StructuredNetworkOutputOptions;
-};
+export type NetworkStructuredHandlerParams<OUTPUT extends OutputSchema = undefined> =
+  NetworkStreamHandlerParams<OUTPUT> & {
+    structuredOutputOptions?: StructuredNetworkOutputOptions;
+  };
 
 export type NetworkStructuredHandlerOptions<OUTPUT extends OutputSchema = undefined> = {
   mastra: Mastra;

--- a/packages/core/src/network/index.ts
+++ b/packages/core/src/network/index.ts
@@ -1,7 +1,4 @@
-export { Mastra, type Config } from './mastra';
-
-// Network exports
-export { NetworkOutputAccumulator } from './network';
+export { NetworkOutputAccumulator } from './output-accumulator';
 export type {
   NetworkStructuredOutput,
   NetworkExecutionStep,
@@ -9,4 +6,4 @@ export type {
   NetworkTokenUsage,
   ToolCallResult,
   StructuredNetworkOutputOptions,
-} from './network';
+} from './structured-output';

--- a/packages/core/src/network/output-accumulator.ts
+++ b/packages/core/src/network/output-accumulator.ts
@@ -1,0 +1,352 @@
+import type { ChunkType } from '../stream';
+import type {
+  NetworkStructuredOutput,
+  NetworkExecutionStep,
+  ToolCallResult,
+  StructuredNetworkOutputOptions,
+} from './structured-output';
+
+/**
+ * Accumulates network stream chunks into a structured output format.
+ * Transforms raw event stream into a organized, type-safe output structure.
+ */
+export class NetworkOutputAccumulator {
+  private steps = new Map<string, NetworkExecutionStep>();
+  private currentStep: NetworkExecutionStep | null = null;
+  private textContent = '';
+  private reasoning = '';
+  private sources: Array<{ type: string; content: string; metadata?: Record<string, unknown> }> = [];
+  private networkId = '';
+  private runId = '';
+  private startTime = new Date();
+  private endTime = new Date();
+  private status: 'success' | 'error' | 'incomplete' = 'incomplete';
+  private errorMessage = '';
+  private tokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    reasoningTokens: 0,
+    cachedInputTokens: 0,
+  };
+  private stepCounter = 0;
+  private options: StructuredNetworkOutputOptions;
+
+  constructor(options: StructuredNetworkOutputOptions = {}) {
+    this.options = {
+      includeToolCalls: true,
+      includeSteps: true,
+      includeReasoning: false,
+      includeSources: false,
+      ...options,
+    };
+  }
+
+  /**
+   * Process a single chunk from the network stream
+   */
+  processChunk(chunk: ChunkType): void {
+    if (!chunk) return;
+
+    const type = chunk.type as string;
+
+    switch (type) {
+      case 'routing-agent-start':
+        this.handleRoutingAgentStart(chunk);
+        break;
+
+      case 'routing-agent-end':
+        this.handleRoutingAgentEnd(chunk);
+        break;
+
+      case 'agent-execution-event-text-delta':
+      case 'text-delta':
+        this.handleTextDelta(chunk);
+        break;
+
+      case 'agent-execution-event-text-start':
+      case 'text-start':
+        this.handleTextStart(chunk);
+        break;
+
+      case 'agent-execution-event-tool-call':
+      case 'tool-call':
+        this.handleToolCall(chunk);
+        break;
+
+      case 'agent-execution-event-tool-result':
+      case 'tool-result':
+        this.handleToolResult(chunk);
+        break;
+
+      case 'reasoning-delta':
+        if (this.options.includeReasoning) {
+          this.handleReasoningDelta(chunk);
+        }
+        break;
+
+      case 'source':
+        if (this.options.includeSources) {
+          this.handleSource(chunk);
+        }
+        break;
+
+      case 'network-execution-event-step-finish':
+        this.handleNetworkStepFinish(chunk);
+        break;
+
+      case 'step-output':
+        this.handleStepOutput(chunk);
+        break;
+
+      case 'step-finish':
+        this.handleStepFinish(chunk);
+        break;
+
+      case 'step-start':
+        this.handleStepStart(chunk);
+        break;
+
+      default:
+        // Handle other chunk types silently
+        break;
+    }
+
+    // Update token usage if available
+    if ('payload' in chunk && chunk.payload && 'usage' in chunk.payload) {
+      this.updateTokenUsage(chunk.payload.usage);
+    }
+  }
+
+  private handleRoutingAgentStart(chunk: any): void {
+    const payload = chunk.payload || {};
+    this.networkId = payload.networkId || this.networkId;
+    this.runId = chunk.runId || payload.runId || this.runId;
+    this.startTime = new Date();
+  }
+
+  private handleRoutingAgentEnd(chunk: any): void {
+    const payload = chunk.payload || {};
+
+    if (this.options.includeSteps) {
+      const stepId = `step_${this.stepCounter++}`;
+      const step: NetworkExecutionStep = {
+        stepId,
+        primitiveId: payload.primitiveId || '',
+        primitiveType: payload.primitiveType || 'agent',
+        primitiveDescription: payload.description,
+        status: 'success',
+        input: payload.input,
+        output: payload.output,
+        duration: payload.duration || 0,
+        timestamp: new Date().toISOString(),
+      };
+      this.steps.set(stepId, step);
+    }
+
+    if (payload.usage) {
+      this.updateTokenUsage(payload.usage);
+    }
+  }
+
+  private handleTextDelta(chunk: any): void {
+    const payload = chunk.payload || {};
+    if (payload.text) {
+      this.textContent += payload.text;
+    }
+  }
+
+  private handleTextStart(chunk: any): void {
+    // Reset text content on new text start
+    this.textContent = '';
+  }
+
+  private handleToolCall(chunk: any): void {
+    const payload = chunk.payload || {};
+
+    if (!this.currentStep) {
+      const stepId = `step_${this.stepCounter++}`;
+      this.currentStep = {
+        stepId,
+        primitiveId: payload.toolName || 'unknown-tool',
+        primitiveType: 'tool',
+        status: 'executing',
+        input: payload.args || {},
+        duration: 0,
+        timestamp: new Date().toISOString(),
+        toolCalls: [],
+      };
+    }
+
+    if (this.options.includeToolCalls) {
+      const toolCall: ToolCallResult = {
+        toolCallId: payload.toolCallId || `${payload.toolName}_${Date.now()}`,
+        toolName: payload.toolName || 'unknown',
+        args: payload.args || {},
+      };
+      if (!this.currentStep.toolCalls) {
+        this.currentStep.toolCalls = [];
+      }
+      this.currentStep.toolCalls.push(toolCall);
+    }
+  }
+
+  private handleToolResult(chunk: any): void {
+    const payload = chunk.payload || {};
+
+    if (this.currentStep && this.options.includeToolCalls && this.currentStep.toolCalls?.length) {
+      const lastToolCall = this.currentStep.toolCalls[this.currentStep.toolCalls.length - 1];
+      if (lastToolCall) {
+        lastToolCall.result = payload.result || payload.output;
+        if (payload.error) {
+          lastToolCall.error = payload.error;
+        }
+      }
+    }
+  }
+
+  private handleReasoningDelta(chunk: any): void {
+    const payload = chunk.payload || {};
+    if (payload.text) {
+      this.reasoning += payload.text;
+    }
+  }
+
+  private handleSource(chunk: any): void {
+    const payload = chunk.payload || {};
+    this.sources.push({
+      type: payload.type || 'unknown',
+      content: payload.content || '',
+      metadata: payload.metadata,
+    });
+  }
+
+  private handleNetworkStepFinish(chunk: any): void {
+    const payload = chunk.payload || {};
+    this.endTime = new Date();
+    this.status = payload.status === 'error' ? 'error' : 'success';
+
+    if (payload.result) {
+      this.textContent = payload.result;
+    }
+
+    if (payload.error) {
+      this.errorMessage = payload.error;
+      this.status = 'error';
+    }
+
+    if (payload.usage) {
+      this.updateTokenUsage(payload.usage);
+    }
+  }
+
+  private handleStepOutput(chunk: any): void {
+    const payload = chunk.payload || {};
+    const output = payload.output || {};
+
+    // Handle nested output structure
+    if (output.type === 'finish') {
+      const finishPayload = output.payload || {};
+      if (finishPayload.usage) {
+        this.updateTokenUsage(finishPayload.usage);
+      }
+    }
+  }
+
+  private handleStepFinish(chunk: any): void {
+    const payload = chunk.payload || {};
+    if (payload.usage) {
+      this.updateTokenUsage(payload.usage);
+    }
+  }
+
+  private handleStepStart(chunk: any): void {
+    const payload = chunk.payload || {};
+    if (this.options.includeSteps && payload.id) {
+      this.currentStep = {
+        stepId: payload.id,
+        primitiveId: payload.primitiveId || payload.id,
+        primitiveType: payload.primitiveType || 'agent',
+        primitiveDescription: payload.description,
+        status: 'executing',
+        input: payload.input,
+        duration: 0,
+        timestamp: new Date().toISOString(),
+      };
+    }
+  }
+
+  private updateTokenUsage(usage: any): void {
+    if (!usage) return;
+
+    if (usage.inputTokens) {
+      this.tokenUsage.inputTokens += parseInt(String(usage.inputTokens), 10);
+    }
+    if (usage.outputTokens) {
+      this.tokenUsage.outputTokens += parseInt(String(usage.outputTokens), 10);
+    }
+    if (usage.totalTokens) {
+      this.tokenUsage.totalTokens += parseInt(String(usage.totalTokens), 10);
+    }
+    if (usage.reasoningTokens) {
+      this.tokenUsage.reasoningTokens += parseInt(String(usage.reasoningTokens), 10);
+    }
+    if (usage.cachedInputTokens) {
+      this.tokenUsage.cachedInputTokens += parseInt(String(usage.cachedInputTokens), 10);
+    }
+  }
+
+  /**
+   * Get the accumulated structured output
+   */
+  getStructuredOutput(): NetworkStructuredOutput {
+    return {
+      networkId: this.networkId,
+      runId: this.runId,
+      steps: this.options.includeSteps ? Array.from(this.steps.values()) : [],
+      finalResult: {
+        text: this.textContent,
+        reasoning: this.options.includeReasoning && this.reasoning ? this.reasoning : undefined,
+        sources: this.options.includeSources && this.sources.length > 0 ? this.sources : undefined,
+      },
+      totalIterations: this.steps.size,
+      tokenUsage: {
+        inputTokens: this.tokenUsage.inputTokens,
+        outputTokens: this.tokenUsage.outputTokens,
+        totalTokens: this.tokenUsage.totalTokens,
+        reasoningTokens: this.tokenUsage.reasoningTokens || undefined,
+        cachedInputTokens: this.tokenUsage.cachedInputTokens || undefined,
+      },
+      status: this.status,
+      error: this.errorMessage || undefined,
+      startTime: this.startTime.toISOString(),
+      endTime: this.endTime.toISOString(),
+      durationMs: this.endTime.getTime() - this.startTime.getTime(),
+    };
+  }
+
+  /**
+   * Reset the accumulator for a new stream
+   */
+  reset(): void {
+    this.steps.clear();
+    this.currentStep = null;
+    this.textContent = '';
+    this.reasoning = '';
+    this.sources = [];
+    this.networkId = '';
+    this.runId = '';
+    this.startTime = new Date();
+    this.endTime = new Date();
+    this.status = 'incomplete';
+    this.errorMessage = '';
+    this.stepCounter = 0;
+    this.tokenUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      reasoningTokens: 0,
+      cachedInputTokens: 0,
+    };
+  }
+}

--- a/packages/core/src/network/structured-output.ts
+++ b/packages/core/src/network/structured-output.ts
@@ -1,0 +1,106 @@
+import type { OutputSchema } from '../stream';
+
+/**
+ * Represents the result of a tool call made during agent execution
+ */
+export interface ToolCallResult {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+}
+
+/**
+ * Represents a single execution step in the network
+ */
+export interface NetworkExecutionStep {
+  stepId: string;
+  primitiveId: string;
+  primitiveType: 'agent' | 'workflow' | 'tool';
+  primitiveDescription?: string;
+  status: 'pending' | 'executing' | 'success' | 'error';
+  input: unknown;
+  output?: unknown;
+  error?: string;
+  toolCalls?: ToolCallResult[];
+  duration: number;
+  timestamp: string;
+}
+
+/**
+ * Represents the final message and its metadata
+ */
+export interface NetworkFinalResult {
+  text: string;
+  output?: unknown;
+  reasoning?: string;
+  sources?: Array<{
+    type: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+  }>;
+}
+
+/**
+ * Token usage information
+ */
+export interface NetworkTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+}
+
+/**
+ * Structured output for network execution
+ */
+export interface NetworkStructuredOutput<OUTPUT extends OutputSchema = undefined> {
+  networkId: string;
+  runId: string;
+  steps: NetworkExecutionStep[];
+  finalResult: NetworkFinalResult;
+  totalIterations: number;
+  tokenUsage: NetworkTokenUsage;
+  status: 'success' | 'error' | 'incomplete';
+  error?: string;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+}
+
+/**
+ * Options for configuring structured output behavior
+ */
+export interface StructuredNetworkOutputOptions {
+  /**
+   * Whether to include tool calls in the output
+   * @default true
+   */
+  includeToolCalls?: boolean;
+
+  /**
+   * Whether to include intermediate steps in the output
+   * @default true
+   */
+  includeSteps?: boolean;
+
+  /**
+   * Whether to include reasoning information
+   * @default false
+   */
+  includeReasoning?: boolean;
+
+  /**
+   * Whether to include sources information
+   * @default false
+   */
+  includeSources?: boolean;
+
+  /**
+   * Maximum number of steps to track
+   * @default unlimited
+   */
+  maxSteps?: number;
+}


### PR DESCRIPTION
## Description

This PR introduces **structured output support for agent network executions**.  
It adds a centralized accumulator-based approach to collect streaming network events and produce a single, type-safe structured result. This simplifies consuming network results by eliminating the need to manually parse and correlate multiple event types, while preserving existing streaming behavior.

## Related Issue(s)

#11337

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured output support for network executions: network results can now be returned as a single, consistent structured representation.
  * New processing endpoint/handler to produce consolidated structured network outputs from streaming events, with configurable options.
  * Type-safe schema and token/step metadata included for richer result inspection.
* **Documentation**
  * Examples and manifest entry added describing structured output usage and options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->