### PR TITLE
Rename VERCEL_API_KEY to AI_GATEWAY_API_KEY

### DIFF
--- a/docs/src/content/en/models/gateways/vercel.mdx
+++ b/docs/src/content/en/models/gateways/vercel.mdx
@@ -36,7 +36,7 @@ Mastra uses the OpenAI-compatible `/chat/completions` endpoint. Some provider-sp
 
 ```bash
 # Use gateway API key
-VERCEL_API_KEY=your-gateway-key
+AI_GATEWAY_API_KEY=your-gateway-key
 
 # Or use provider API keys directly
 OPENAI_API_KEY=sk-...


### PR DESCRIPTION
## Description

According to the error message, this shoud be AI_GATEWAY_API_KEY now.

```
ERROR [2026-01-07 00:04:13.078 +0800] (Mastra): Error in agent stream
    runId: "c30a0aa0-1ea4-41a1-a575-c07afbd2819d"
    error: {
      "message": "Could not find API key process.env.AI_GATEWAY_API_KEY for model id vercel/google/gemini-2.5-flash",
      "name": "Error",
      "stack":
          Error: Could not find API key process.env.AI_GATEWAY_API_KEY for model id vercel/google/gemini-2.5-flash
```

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated gateway configuration example to reflect the current environment variable naming convention for API key setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->