### PR TITLE
fix: use MastraClient to recall messages in streaming memory test

### DIFF
--- a/packages/memory/integration-tests/src/shared/useChat.ts
+++ b/packages/memory/integration-tests/src/shared/useChat.ts
@@ -501,7 +501,12 @@ export function setupUseChatV5Plus({ useChatFunc, version }: { useChatFunc: any;
         responseContains: [state.clipboard],
       });
 
-      const messagesResult = await agentMemory.recall({ threadId: localThreadId, resourceId });
+      // Use MastraClient to recall messages from the server's memory (not the test's local memory)
+      // This is necessary because the server and test run in different processes with different databases
+      const mastraClient = new MastraClient({ baseUrl: `http://localhost:${port}` });
+      const messagesResult = await mastraClient
+        .getMemoryThread({ threadId: localThreadId, agentId: 'test' })
+        .listMessages({ resourceId });
 
       const clipboardToolInvocation = messagesResult.messages.filter(
         m =>


### PR DESCRIPTION
The v5+ streaming memory test was failing because it was recalling messages from the local `agentMemory` instance instead of the server's memory. Since the test server runs in a separate process with its own database, the clipboard tool invocations weren't being found.

The fix uses `MastraClient` to query the server's memory:

```ts
// Before
const messagesResult = await agentMemory.recall({ threadId: localThreadId, resourceId });

// After  
const mastraClient = new MastraClient({ baseUrl: `http://localhost:${port}` });
const messagesResult = await mastraClient.getMemoryThread({ threadId: localThreadId, agentId: 'test' }).listMessages({ resourceId });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated memory recall integration testing to verify server-side memory retrieval instead of local process memory. Memory functionality now validated through server-based verification, ensuring consistency with production memory operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->