### PR TITLE
docs: add commands section to playground CLAUDE.md files

### DIFF
--- a/packages/playground-ui/CLAUDE.md
+++ b/packages/playground-ui/CLAUDE.md
@@ -4,6 +4,24 @@ Standards and conventions for building components in `packages/playground-ui`.
 
 ---
 
+## Commands
+
+### Local Commands (run from `packages/playground-ui`)
+
+- `pnpm build`: TypeCheck and build the package with Vite
+- `pnpm dev`: Build in watch mode
+- `pnpm test`: Run tests with Vitest
+- `pnpm preview`: Preview the production build
+- `pnpm storybook`: Start Storybook dev server on port 6006
+- `pnpm build-storybook`: Build Storybook for production
+
+### Root Commands (run from monorepo root)
+
+- `pnpm dev:playground`: Start dev servers for playground, playground-ui, and react client SDK
+- `pnpm build:cli`: Build the CLI (includes playground and playground-ui as dependencies)
+
+---
+
 ## Package Architecture
 
 ### Scope

--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -6,6 +6,21 @@ Standards and conventions for building the local studio in `packages/playground`
 
 ---
 
+## Commands
+
+### Local Commands (run from `packages/playground`)
+
+- `pnpm dev`: Start Vite development server
+- `pnpm build`: Build the playground with Vite
+- `pnpm build:watch`: Build in watch mode
+- `pnpm preview`: Preview the production build
+- `pnpm lint`: Run ESLint
+
+### Root Commands (run from monorepo root)
+
+- `pnpm dev:playground`: Start dev servers for playground, playground-ui, and react client SDK
+- `pnpm build:cli`: Build the CLI (includes playground and playground-ui as dependencies)
+
 ## Package Architecture
 
 ### Scope


### PR DESCRIPTION
Added a Commands section to both `packages/playground/CLAUDE.md` and `packages/playground-ui/CLAUDE.md` documenting the available local and root commands for development.

This makes it easier to discover what commands are available when working on these packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added command reference documentation for local development and root-level operations across packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->