### PR TITLE
fix(core): use accumulated text instead of last step text in onFinish

### DIFF
--- a/.changeset/fix-braintrust-text-chunks.md
+++ b/.changeset/fix-braintrust-text-chunks.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+Fix agent runs with multiple steps only showing last text chunk in observability tools
+
+When an agent model executes multiple steps and generates multiple text chunks, the onFinish payload was only receiving the text from the last step instead of all accumulated text. This caused observability tools like Braintrust to only display the final text chunk. The fix now correctly concatenates all text chunks from all steps.

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -746,7 +746,7 @@ export class MastraModelOutput<OUTPUT extends OutputSchema = undefined> extends 
                 const onFinishPayload: MastraOnFinishCallbackArgs<OUTPUT> = {
                   // StepResult properties from baseFinishStep
                   providerMetadata: baseFinishStep.providerMetadata,
-                  text: baseFinishStep.text,
+                  text: self.#bufferedText.join(''),
                   warnings: baseFinishStep.warnings ?? [],
                   finishReason: chunk.payload.stepResult.reason,
                   content: messageList.get.response.aiV5.stepContent(),


### PR DESCRIPTION
When an agent model executes multiple steps, the onFinish payload was only receiving the text from the last step instead of all accumulated text. This caused observability tools like Braintrust to only display the final text chunk.

The fix changes `baseFinishStep.text` (last step only) to `self.#bufferedText.join('')` (all steps accumulated), matching the behavior already used in the suspended state handler.

Fixes #11659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where only the last text chunk was included in agent finish callbacks. The onFinish payload now concatenates all text chunks from multi-step agent runs so observability shows the complete output.

* **Tests**
  * Added an integration test that verifies text accumulation across multi-step agent workflows and validates final streamed output and spans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->