### PR TITLE
Improves AI SDK message conversion for Braintrust Thread view

### DIFF
--- a/.changeset/improved-braintrust-message-conversion.md
+++ b/.changeset/improved-braintrust-message-conversion.md
@@ -1,0 +1,10 @@
+---
+'@mastra/braintrust': patch
+---
+
+Improves AI SDK message conversion for Braintrust Thread view:
+
+- Adds support for non-text content types (images, files, reasoning) with informative placeholders
+- Handles both AI SDK v4 `result` and v5 `output` fields for tool results
+- Gracefully handles empty content arrays and unknown content types
+- Adds comprehensive TypeScript type definitions for message conversion

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -1103,6 +1103,34 @@ describe('BraintrustExporter', () => {
         }),
       );
     });
+
+    it('should handle undefined tool results (missing output/result fields)', async () => {
+      const llmSpan = createMockSpan({
+        id: 'undefined-tool-result',
+        name: 'llm-call',
+        type: SpanType.MODEL_GENERATION,
+        isRoot: true,
+        input: [
+          {
+            role: 'tool',
+            content: [{ type: 'tool-result', toolCallId: 'call_456' }], // no output or result field
+          },
+        ],
+        output: { text: 'Done.' },
+        attributes: { model: 'gpt-4' },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: llmSpan,
+      });
+
+      expect(mockLogger.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [{ role: 'tool', content: '', tool_call_id: 'call_456' }],
+        }),
+      );
+    });
   });
 
   describe('Span Updates', () => {

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -494,9 +494,7 @@ export class BraintrustExporter extends BaseExporter {
 
       // For user/system messages, extract text and represent non-text content
       if (role === 'user' || role === 'system') {
-        const contentParts = content
-          .map((part: any) => this.convertContentPart(part))
-          .filter(Boolean);
+        const contentParts = content.map((part: any) => this.convertContentPart(part)).filter(Boolean);
 
         return {
           role,
@@ -553,9 +551,7 @@ export class BraintrustExporter extends BaseExporter {
 
       // For tool messages, convert to OpenAI tool message format
       if (role === 'tool') {
-        const toolResult = content.find(
-          (part): part is AISDKToolResultPart => part?.type === 'tool-result',
-        );
+        const toolResult = content.find((part): part is AISDKToolResultPart => part?.type === 'tool-result');
         if (toolResult) {
           // Support both v4 'result' and v5 'output' fields
           const resultData = toolResult.output ?? toolResult.result;

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -640,7 +640,11 @@ export class BraintrustExporter extends BaseExporter {
     if (resultData === undefined || resultData === null) {
       return '';
     }
-    return JSON.stringify(resultData);
+    try {
+      return JSON.stringify(resultData);
+    } catch {
+      return '[unserializable result]';
+    }
   }
 
   /**


### PR DESCRIPTION
- Add support for non-text content types (images, files, reasoning) with informative placeholders like [image], [file: filename], [reasoning: ...]
- Handle both AI SDK v4 'result' and v5 'output' fields for tool results
- Gracefully handle empty content arrays and unknown content types
- Add comprehensive TypeScript type definitions for message conversion:
  - AISDKMessage, AISDKContentPart (text, image, file, reasoning, tool-call, tool-result)
  - OpenAIMessage, OpenAIToolCall
- Rename convertAISDKV5Message to convertAISDKMessage to reflect v4/v5 support
- Add helper methods: convertContentPart, serializeToolResult
- Add tests for all new functionality

Builds on top of PR #11613 to address:
- Silent content loss for images, files, and reasoning parts
- v4 tool result compatibility
- Empty content edge cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended AI SDK message conversion to comprehensively support both v4 and v5 formats, including text, images, files, and reasoning placeholders.
  * Improved assembly of messages to match OpenAI-style expectations and handle tool call/results across versions.

* **Tests**
  * Added a broad test suite covering conversions, mixed formats, empty/unknown content, and tool-call/result scenarios.

* **Chores**
  * Added a changeset documenting the improved message conversion behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->