### PR TITLE
Deprecate `default: { enabled: true }` observability configuration

### DIFF
--- a/.changeset/deprecate-default-observability-config.md
+++ b/.changeset/deprecate-default-observability-config.md
@@ -1,0 +1,50 @@
+---
+'@mastra/core': minor
+'@mastra/observability': minor
+---
+
+Deprecate `default: { enabled: true }` observability configuration
+
+The shorthand `default: { enabled: true }` configuration is now deprecated and will be removed in a future version. Users should migrate to explicit configuration with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`.
+
+**Before (deprecated):**
+```typescript
+import { Observability } from '@mastra/observability';
+
+const mastra = new Mastra({
+  observability: new Observability({
+    default: { enabled: true },
+  }),
+});
+```
+
+**After (recommended):**
+```typescript
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from '@mastra/observability';
+
+const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(),
+          new CloudExporter(),
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(),
+        ],
+      },
+    },
+  }),
+});
+```
+
+The explicit configuration makes it clear exactly what exporters and processors are being used, improving code readability and maintainability.
+
+A deprecation warning will be logged when using the old configuration pattern.

--- a/docs/src/content/en/docs/observability/overview.mdx
+++ b/docs/src/content/en/docs/observability/overview.mdx
@@ -30,8 +30,13 @@ Configure Observability in your Mastra instance:
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { PinoLogger } from "@mastra/loggers";
-import { LibSqlStorage } from "@mastra/libsql";
-import { Observability } from "@mastra/observability";
+import { LibSQLStore } from "@mastra/libsql";
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from "@mastra/observability";
 
 export const mastra = new Mastra({
   logger: new PinoLogger(),
@@ -39,8 +44,19 @@ export const mastra = new Mastra({
     id: 'mastra-storage',
     url: "file:./mastra.db", // Storage is required for tracing
   }),
-  observability: new Observability({ // Enables Tracing
-    default: { enabled: true },
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: "mastra",
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
+    },
   }),
 });
 ```

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -42,17 +42,33 @@ export const mastra = new Mastra({
 });
 ```
 
-### Automatic Configuration
+### Recommended Configuration
 
-When using the default observability configuration, CloudExporter is automatically included if the access token is set:
+Include CloudExporter in your observability configuration:
 
 ```typescript
 import { Mastra } from "@mastra/core";
-import { Observability } from "@mastra/observability";
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from "@mastra/observability";
 
 export const mastra = new Mastra({
   observability: new Observability({
-    default: { enabled: true }, // Automatically includes CloudExporter if token exists
+    configs: {
+      default: {
+        serviceName: "mastra",
+        exporters: [
+          new DefaultExporter(),
+          new CloudExporter(), // Sends traces to Mastra Cloud (requires MASTRA_CLOUD_ACCESS_TOKEN)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(),
+        ],
+      },
+    },
   }),
 });
 ```

--- a/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
@@ -41,21 +41,38 @@ export const mastra = new Mastra({
 });
 ```
 
-### Automatic Configuration
+### Recommended Configuration
 
-When using the default observability configuration, DefaultExporter is automatically included:
+Include DefaultExporter in your observability configuration:
 
 ```typescript
 import { Mastra } from "@mastra/core";
-import { Observability } from "@mastra/observability";
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from "@mastra/observability";
 import { LibSQLStore } from "@mastra/libsql";
+
 export const mastra = new Mastra({
   storage: new LibSQLStore({
     id: 'mastra-storage',
     url: "file:./mastra.db",
   }),
   observability: new Observability({
-    default: { enabled: true }, // Automatically includes DefaultExporter
+    configs: {
+      default: {
+        serviceName: "mastra",
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(),
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(),
+        ],
+      },
+    },
   }),
 });
 ```

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -65,27 +65,6 @@ This configuration includes:
   - `CloudExporter` - Sends traces to Mastra Cloud (requires `MASTRA_CLOUD_ACCESS_TOKEN`)
 - **Span Output Processors**: `SensitiveDataFilter` - Automatically redacts sensitive fields
 
-### Shorthand Config
-
-For convenience, a shorthand configuration is also available that expands to the same config as above:
-
-```ts title="src/mastra/index.ts"
-import { Mastra } from "@mastra/core";
-import { Observability } from "@mastra/observability";
-
-export const mastra = new Mastra({
-  observability: new Observability({
-    default: { enabled: true },
-  }),
-  storage: new LibSQLStore({
-    id: 'mastra-storage',
-    url: "file:./mastra.db", // Storage is required for tracing
-  }),
-});
-```
-
-The explicit configuration is recommended as it makes clear exactly what exporters and processors are being used.
-
 ## Exporters
 
 Exporters determine where your trace data is sent and how it's stored. Choosing the right exporters allows you to integrate with your existing observability stack, comply with data residency requirements, and optimize for cost and performance. You can use multiple exporters simultaneously to send the same trace data to different destinations — for example, storing detailed traces locally for debugging while sending sampled data to a cloud provider for production monitoring.

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -27,37 +27,10 @@ Traces are created by:
 
 ```ts title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
-import { Observability } from "@mastra/observability";
-
-export const mastra = new Mastra({
-  observability: new Observability({
-    default: { enabled: true }, // Enables DefaultExporter and CloudExporter
-  }),
-  storage: new LibSQLStore({
-    id: 'mastra-storage',
-    url: "file:./mastra.db", // Storage is required for tracing
-  }),
-});
-```
-
-When enabled, the default configuration automatically includes:
-
-- **Service Name**: `"mastra"`
-- **Sampling**: `"always"`- Sample (100% of traces)
-- **Exporters**:
-  - `DefaultExporter` - Persists traces to your configured storage
-  - `CloudExporter` - Sends traces to Mastra Cloud (requires `MASTRA_CLOUD_ACCESS_TOKEN`)
-- **Span Output Processors**: `SensitiveDataFilter` - Automatically redacts sensitive fields
-
-### Expanded Basic Config
-
-This default configuration is a minimal helper that equates to this more verbose configuration:
-
-```ts title="src/mastra/index.ts"
 import {
   Observability,
-  CloudExporter,
   DefaultExporter,
+  CloudExporter,
   SensitiveDataFilter,
 } from "@mastra/observability";
 
@@ -66,9 +39,13 @@ export const mastra = new Mastra({
     configs: {
       default: {
         serviceName: "mastra",
-        sampling: { type: "always" },
-        spanOutputProcessors: [new SensitiveDataFilter()],
-        exporters: [new CloudExporter(), new DefaultExporter()],
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
       },
     },
   }),
@@ -78,6 +55,36 @@ export const mastra = new Mastra({
   }),
 });
 ```
+
+This configuration includes:
+
+- **Service Name**: `"mastra"` - identifies your service in traces
+- **Sampling**: `"always"` by default (100% of traces)
+- **Exporters**:
+  - `DefaultExporter` - Persists traces to your configured storage for Mastra Studio
+  - `CloudExporter` - Sends traces to Mastra Cloud (requires `MASTRA_CLOUD_ACCESS_TOKEN`)
+- **Span Output Processors**: `SensitiveDataFilter` - Automatically redacts sensitive fields
+
+### Shorthand Config
+
+For convenience, a shorthand configuration is also available that expands to the same config as above:
+
+```ts title="src/mastra/index.ts"
+import { Mastra } from "@mastra/core";
+import { Observability } from "@mastra/observability";
+
+export const mastra = new Mastra({
+  observability: new Observability({
+    default: { enabled: true },
+  }),
+  storage: new LibSQLStore({
+    id: 'mastra-storage',
+    url: "file:./mastra.db", // Storage is required for tracing
+  }),
+});
+```
+
+The explicit configuration is recommended as it makes clear exactly what exporters and processors are being used.
 
 ## Exporters
 

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -277,46 +277,34 @@ export const mastra = new Mastra({
 
 ### Common Configuration Patterns & Troubleshooting
 
-#### Default & Custom Configs
-
-Having both the default config enabled and adding custom configs is an invalid configuration of Observability. Use either the default or custom config, but not both.
-
-```ts title="src/mastra/index.ts"
-export const mastra = new Mastra({
-  observability: new Observability({
-    default: { enabled: true }, // This will always be used!
-    configs: {
-      langfuse: {
-        serviceName: "my-service",
-        exporters: [langfuseExporter], // This won't be reached
-      },
-    },
-  }),
-});
-```
-
 #### Maintaining Studio and Cloud Access
 
-When creating a custom config with external exporters, you might lose access to Studio and Cloud. To maintain access while adding external exporters, include the default exporters in your custom config:
+When adding external exporters, include `DefaultExporter` and `CloudExporter` to maintain access to Studio and Mastra Cloud:
 
 ```ts title="src/mastra/index.ts"
-import { DefaultExporter, CloudExporter } from "@mastra/observability";
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from "@mastra/observability";
 import { ArizeExporter } from "@mastra/arize";
 
 export const mastra = new Mastra({
   observability: new Observability({
-    default: { enabled: false }, // Disable default to use custom
     configs: {
       production: {
         serviceName: "my-service",
         exporters: [
           new ArizeExporter({
-            // External exporter
             endpoint: process.env.PHOENIX_ENDPOINT,
             apiKey: process.env.PHOENIX_API_KEY,
           }),
           new DefaultExporter(), // Keep Studio access
           new CloudExporter(), // Keep Cloud access
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(),
         ],
       },
     },

--- a/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
@@ -11,12 +11,30 @@ The Sensitive Data Filter is a span processor that automatically redacts sensiti
 
 ## Default Configuration
 
-By default, the Sensitive Data Filter is automatically enabled when you use the standard Mastra configuration:
+The Sensitive Data Filter is included in the recommended observability configuration:
 
 ```ts title="src/mastra/index.ts"
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from "@mastra/observability";
+
 export const mastra = new Mastra({
   observability: new Observability({
-    default: { enabled: true }, // Automatically includes SensitiveDataFilter
+    configs: {
+      default: {
+        serviceName: "mastra",
+        exporters: [
+          new DefaultExporter(),
+          new CloudExporter(),
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Automatically redacts sensitive fields
+        ],
+      },
+    },
   }),
   storage: new LibSQLStore({
     id: 'mastra-storage',

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
@@ -33,20 +33,36 @@ export const mastra = new Mastra({
 });
 ```
 
-**After (v1 with observability - quick start):**
+**After (v1 with observability):**
 
 ```typescript
 import { Mastra } from '@mastra/core';
-import { Observability } from '@mastra/observability';
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from '@mastra/observability';
 
 export const mastra = new Mastra({
   observability: new Observability({
-    default: { enabled: true },
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
+    },
   }),
 });
 ```
 
-This minimal configuration automatically includes the `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter` processor. See the [observability tracing documentation](/docs/v1/observability/tracing/overview) for full configuration options.
+This configuration includes `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter` processor. See the [observability tracing documentation](/docs/v1/observability/tracing/overview) for full configuration options.
 
 **After (v1 with custom configuration):**
 
@@ -86,14 +102,14 @@ export const mastra = new Mastra({
 Key changes:
 1. Install `@mastra/observability` package
 2. Replace `telemetry:` with `observability: new Observability()`
-3. Use `default: { enabled: true }` for quick setup, or `configs:` for custom configuration
+3. Use explicit `configs:` with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`
 4. Export types change from string literals (`'otlp'`) to exporter class instances (`new OtelExporter()`)
 
 See the [exporters documentation](/docs/v1/observability/tracing/overview#exporters) for all available exporters.
 
 ### From AI Tracing
 
-If you already upgraded to AI tracing (the intermediate system), you only need to wrap your configuration and install the new package.
+If you already upgraded to AI tracing (the intermediate system), you need to install the new package and use the explicit configuration.
 
 **Before (AI tracing):**
 
@@ -111,19 +127,35 @@ export const mastra = new Mastra({
 
 ```typescript
 import { Mastra } from '@mastra/core';
-import { Observability } from '@mastra/observability';
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from '@mastra/observability';
 
 export const mastra = new Mastra({
   observability: new Observability({
-    default: { enabled: true },
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(),
+          new CloudExporter(),
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(),
+        ],
+      },
+    },
   }),
 });
 ```
 
 Key changes:
 1. Install `@mastra/observability` package
-2. Import `Observability` from `@mastra/observability`
-3. Wrap configuration with `new Observability()`
+2. Import `Observability`, exporters, and processors from `@mastra/observability`
+3. Use explicit `configs` with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`
 
 ## Changed
 
@@ -144,18 +176,30 @@ npm install @mastra/observability@beta
 
 ### Registry configuration
 
-The observability registry is now configured using an `Observability` class instance instead of a plain object.
+The observability registry is now configured using an `Observability` class instance with explicit configs instead of a plain object.
 
-To migrate, wrap your configuration object with `new Observability()`.
+To migrate, use `new Observability()` with explicit exporters and processors.
 
 ```diff
-+ import { Observability } from '@mastra/observability';
++ import {
++   Observability,
++   DefaultExporter,
++   CloudExporter,
++   SensitiveDataFilter,
++ } from '@mastra/observability';
 
   export const mastra = new Mastra({
 -   observability: {
-+   observability: new Observability({
-      default: { enabled: true },
+-     default: { enabled: true },
 -   },
++   observability: new Observability({
++     configs: {
++       default: {
++         serviceName: 'mastra',
++         exporters: [new DefaultExporter(), new CloudExporter()],
++         spanOutputProcessors: [new SensitiveDataFilter()],
++       },
++     },
 +   }),
   });
 ```
@@ -236,11 +280,22 @@ Simply remove the `instrumentation.mjs` file and configure observability in your
 
 ```typescript
 // src/mastra/index.ts
-import { Observability } from '@mastra/observability';
+import {
+  Observability,
+  DefaultExporter,
+  CloudExporter,
+  SensitiveDataFilter,
+} from '@mastra/observability';
 
 export const mastra = new Mastra({
   observability: new Observability({
-    default: { enabled: true },
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [new DefaultExporter(), new CloudExporter()],
+        spanOutputProcessors: [new SensitiveDataFilter()],
+      },
+    },
   }),
 });
 ```

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -1,7 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 
 import { agentThatHarassesYou, chefAgent, chefAgentResponses, dynamicAgent, evalAgent } from './agents/index';
 import { myMcpServer, myMcpServerTwo } from './mcp/server';
@@ -98,7 +98,18 @@ const config = {
     testScorer,
   },
   observability: new Observability({
-    default: { enabled: true },
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
+    },
   }),
 };
 

--- a/observability/mastra/src/config.ts
+++ b/observability/mastra/src/config.ts
@@ -86,7 +86,11 @@ export interface ObservabilityInstanceConfig {
  * Complete Observability registry configuration
  */
 export interface ObservabilityRegistryConfig {
-  /** Enables default exporters, with sampling: always, and sensitive data filtering */
+  /**
+   * Enables default exporters, with sampling: always, and sensitive data filtering
+   * @deprecated Use explicit `configs` with DefaultExporter, CloudExporter, and SensitiveDataFilter instead.
+   * This option will be removed in a future version.
+   */
   default?: {
     enabled?: boolean;
   };

--- a/observability/mastra/src/default.ts
+++ b/observability/mastra/src/default.ts
@@ -79,8 +79,14 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
       }
     }
 
-    // Setup default config if enabled
+    // Setup default config if enabled (deprecated)
     if (config.default?.enabled) {
+      console.warn(
+        '[Mastra Observability] The "default: { enabled: true }" configuration is deprecated and will be removed in a future version. ' +
+          'Please use explicit configs with DefaultExporter, CloudExporter, and SensitiveDataFilter instead. ' +
+          'See https://mastra.ai/docs/observability/tracing/overview for the recommended configuration.',
+      );
+
       const defaultInstance = new DefaultObservabilityInstance({
         serviceName: 'mastra',
         name: 'default',

--- a/observability/mastra/src/exporters/cloud.ts
+++ b/observability/mastra/src/exporters/cloud.ts
@@ -52,10 +52,7 @@ export class CloudExporter extends BaseExporter {
 
     const accessToken = config.accessToken ?? process.env.MASTRA_CLOUD_ACCESS_TOKEN;
     if (!accessToken) {
-      this.setDisabled(
-        'MASTRA_CLOUD_ACCESS_TOKEN environment variable not set.\n' +
-          '🚀 Sign up at https://cloud.mastra.ai to see your AI traces online and obtain your access token.',
-      );
+      this.setDisabled('MASTRA_CLOUD_ACCESS_TOKEN environment variable not set.');
     }
 
     const endpoint =

--- a/observability/mastra/src/registry.test.ts
+++ b/observability/mastra/src/registry.test.ts
@@ -786,7 +786,6 @@ describe('Observability Registry', () => {
           'mastra-cloud-observability-exporter disabled: MASTRA_CLOUD_ACCESS_TOKEN environment variable not set',
         ),
       );
-      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Sign up at https://cloud.mastra.ai'));
 
       // Verify exporter is disabled but doesn't throw
       const event = {

--- a/templates/template-ad-copy-from-content/src/mastra/index.ts
+++ b/templates/template-ad-copy-from-content/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -31,8 +31,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-browsing-agent/src/mastra/index.ts
+++ b/templates/template-browsing-agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { PinoLogger } from '@mastra/loggers';
@@ -16,8 +16,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-coding-agent/src/mastra/index.ts
+++ b/templates/template-coding-agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { PinoLogger } from '@mastra/loggers';
@@ -12,8 +12,17 @@ export const mastra = new Mastra({
     level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-csv-to-questions/src/mastra/index.ts
+++ b/templates/template-csv-to-questions/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -24,8 +24,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-deep-research/src/mastra/index.ts
+++ b/templates/template-deep-research/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { researchWorkflow } from './workflows/researchWorkflow';
@@ -23,8 +23,17 @@ export const mastra = new Mastra({
   },
   workflows: { generateReportWorkflow, researchWorkflow },
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-docs-chatbot/apps/agent/src/mastra/index.ts
+++ b/templates/template-docs-chatbot/apps/agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { registerApiRoute } from '@mastra/core/server';
 import { PinoLogger } from '@mastra/loggers';
@@ -34,8 +34,17 @@ export const mastra = new Mastra({
     level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-flash-cards-from-pdf/src/mastra/index.ts
+++ b/templates/template-flash-cards-from-pdf/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -31,8 +31,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-google-sheets/src/mastra/index.ts
+++ b/templates/template-google-sheets/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { financialModelingAgent } from './agents/financial-modeling-agent';
@@ -87,8 +87,17 @@ export const mastra = new Mastra({
     ],
   },
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-meeting-scheduler/src/mastra/index.ts
+++ b/templates/template-meeting-scheduler/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -35,8 +35,17 @@ export const mastra = new Mastra({
     ],
   },
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-pdf-questions/src/mastra/index.ts
+++ b/templates/template-pdf-questions/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -24,8 +24,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-pdf-to-audio/src/mastra/index.ts
+++ b/templates/template-pdf-to-audio/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -23,8 +23,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/template-text-to-sql/src/mastra/index.ts
+++ b/templates/template-text-to-sql/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { PinoLogger } from '@mastra/loggers';
@@ -21,8 +21,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });

--- a/templates/weather-agent/src/mastra/index.ts
+++ b/templates/weather-agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability } from '@mastra/observability';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -20,8 +20,17 @@ export const mastra = new Mastra({
     level: 'info',
   }),
   observability: new Observability({
-    default: {
-      enabled: true,
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [
+          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+        ],
+        spanOutputProcessors: [
+          new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
+        ],
+      },
     },
   }),
 });


### PR DESCRIPTION
## Description

The shorthand `default: { enabled: true }` configuration is now deprecated and will be removed in a future version. Users should migrate to explicit configuration with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`.

**Before (deprecated):**
```typescript
import { Observability } from '@mastra/observability';

const mastra = new Mastra({
  observability: new Observability({
    default: { enabled: true },
  }),
});
```
 
**After (recommended):**
```typescript
import {
  Observability,
  DefaultExporter,
  CloudExporter,
  SensitiveDataFilter,
} from '@mastra/observability';
 
const mastra = new Mastra({
  observability: new Observability({
    configs: {
      default: {
        serviceName: 'mastra',
        exporters: [
          new DefaultExporter(),
          new CloudExporter(),
        ],
        spanOutputProcessors: [
          new SensitiveDataFilter(),
        ],
      },
    },
  }),
});

```

The explicit configuration makes it clear exactly what exporters and processors are being used, improving code readability and maintainability.

A deprecation warning will be logged when using the old configuration pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Default observability configuration pattern deprecated; users must migrate to explicit configuration with exporters and processors.

* **New Features**
  * Observability now supports explicit exporter configuration and includes automatic sensitive data filtering for trace spans.

* **Documentation**
  * Updated observability configuration guidance, exporter setup instructions, and migration guidance for v1 across all docs and examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->