### PR TITLE
fix(playground-ui): add missing loading states to TanStack Query hooks

### DIFF
--- a/.changeset/add-loading-states-tanstack-query-hooks.md
+++ b/.changeset/add-loading-states-tanstack-query-hooks.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Add missing loading state handlers to TanStack Query hooks. Components now properly show skeleton/loading UI instead of returning null or rendering incomplete states while data is being fetched.

--- a/packages/playground-ui/src/components/assistant-ui/tools/badges/agent-badge-wrapper.tsx
+++ b/packages/playground-ui/src/components/assistant-ui/tools/badges/agent-badge-wrapper.tsx
@@ -3,6 +3,7 @@ import { toAISdkV5Messages } from '@mastra/ai-sdk/ui';
 import { AgentBadge, AgentMessage } from './agent-badge';
 import { useAgentMessages } from '@/hooks/use-agent-messages';
 import { ToolApprovalButtonsProps } from './tool-approval-buttons';
+import { LoadingBadge } from './loading-badge';
 
 interface AgentBadgeWrapperProps extends Omit<ToolApprovalButtonsProps, 'toolCalled'> {
   agentId: string;
@@ -17,11 +18,16 @@ export const AgentBadgeWrapper = ({
   toolCallId,
   toolApprovalMetadata,
 }: AgentBadgeWrapperProps) => {
-  const { data } = useAgentMessages({
+  const { data, isLoading } = useAgentMessages({
     threadId: result?.subAgentThreadId,
     agentId,
     memory: true,
   });
+
+  if (isLoading) {
+    return <LoadingBadge />;
+  }
+
   const convertedMessages = data?.messages ? (toAISdkV5Messages(data.messages) as MastraUIMessage[]) : [];
   const childMessages = result?.childMessages ?? resolveToChildMessages(convertedMessages);
 

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-information.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-information.tsx
@@ -15,8 +15,8 @@ export interface AgentInformationProps {
 }
 
 export function AgentInformation({ agentId, threadId }: AgentInformationProps) {
-  const { data: memory } = useMemory(agentId);
-  const hasMemory = Boolean(memory?.result);
+  const { data: memory, isLoading: isMemoryLoading } = useMemory(agentId);
+  const hasMemory = !isMemoryLoading && Boolean(memory?.result);
 
   return (
     <AgentInformationLayout agentId={agentId}>

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-memory.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-memory.tsx
@@ -8,6 +8,7 @@ import { useThreadInput } from '@/domains/conversation';
 import { useMemoryConfig, useMemorySearch, useCloneThread } from '@/domains/memory/hooks';
 import { MemorySearch } from '@/components/assistant-ui/memory-search';
 import { Button } from '@/ds/components/Button/Button';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface AgentMemoryProps {
   agentId: string;
@@ -20,7 +21,7 @@ export function AgentMemory({ agentId, threadId }: AgentMemoryProps) {
   const { paths, navigate } = useLinkComponent();
 
   // Get memory config to check if semantic recall is enabled
-  const { data } = useMemoryConfig(agentId);
+  const { data, isLoading: isConfigLoading } = useMemoryConfig(agentId);
 
   // Check if semantic recall is enabled
   const config = data?.config;
@@ -70,6 +71,16 @@ export function AgentMemory({ agentId, threadId }: AgentMemoryProps) {
   );
 
   const searchScope = searchMemoryData?.searchScope;
+
+  if (isConfigLoading) {
+    return (
+      <div className="flex flex-col h-full p-4 gap-4">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col h-full">

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-working-memory.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-working-memory.tsx
@@ -21,10 +21,14 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
     useWorkingMemory();
 
   // Get memory config to check if working memory is enabled
-  const { data } = useMemoryConfig(agentId);
+  const { data, isLoading: isConfigLoading } = useMemoryConfig(agentId);
   const config = data?.config;
   // Check if working memory is enabled
   const isWorkingMemoryEnabled = Boolean(config?.workingMemory?.enabled);
+
+  if (isLoading || isConfigLoading) {
+    return <Skeleton className="h-32 w-full" />;
+  }
 
   const { isCopied, handleCopy } = useCopyToClipboard({
     text: workingMemoryData ?? '',
@@ -36,10 +40,6 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
   React.useEffect(() => {
     setEditValue(workingMemoryData ?? '');
   }, [workingMemoryData]);
-
-  if (isLoading) {
-    return <Skeleton className="h-32 w-full" />;
-  }
 
   return (
     <div className="flex flex-col gap-4 p-4">

--- a/packages/playground-ui/src/domains/configuration/context/studio-config-context.tsx
+++ b/packages/playground-ui/src/domains/configuration/context/studio-config-context.tsx
@@ -26,7 +26,7 @@ export interface StudioConfigProviderProps {
 const LOCAL_STORAGE_KEY = 'mastra-studio-config';
 
 export const StudioConfigProvider = ({ children, endpoint = 'http://localhost:4111' }: StudioConfigProviderProps) => {
-  const { data: instanceStatus } = useMastraInstanceStatus(endpoint);
+  const { data: instanceStatus, isLoading: isStatusLoading, error } = useMastraInstanceStatus(endpoint);
   const [config, setConfig] = useState<StudioConfig & { isLoading: boolean }>({
     baseUrl: '',
     headers: {},
@@ -34,6 +34,11 @@ export const StudioConfigProvider = ({ children, endpoint = 'http://localhost:41
   });
 
   useLayoutEffect(() => {
+    // Handle error case - stop loading but don't configure
+    if (error && !isStatusLoading) {
+      return setConfig({ baseUrl: '', headers: {}, isLoading: false });
+    }
+
     // Don't run the effect during the fetch request
     if (!instanceStatus?.status) return;
 
@@ -51,7 +56,7 @@ export const StudioConfigProvider = ({ children, endpoint = 'http://localhost:41
     }
 
     return setConfig({ baseUrl: '', headers: {}, isLoading: false });
-  }, [instanceStatus, endpoint]);
+  }, [instanceStatus, endpoint, isStatusLoading, error]);
 
   const doSetConfig = (partialNewConfig: Partial<StudioConfig>) => {
     setConfig(prev => {

--- a/packages/playground-ui/src/domains/mcps/components/MCPToolPanel.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/MCPToolPanel.tsx
@@ -3,6 +3,7 @@ import type { JsonSchema } from '@mastra/schema-compat/json-to-zod';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { z } from 'zod';
 import { Txt } from '@/ds/components/Txt';
+import { Skeleton } from '@/components/ui/skeleton';
 import ToolExecutor from '@/domains/tools/components/ToolExecutor';
 import { useExecuteMCPTool, useMCPServerTool } from '@/domains/mcps/hooks/use-mcp-server-tool';
 import { toast } from '@/lib/toast';
@@ -30,7 +31,16 @@ export const MCPToolPanel = ({ toolId, serverId }: MCPToolPanelProps) => {
     return await executeTool(data);
   };
 
-  if (isLoading || error) return null;
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error) return null;
 
   if (!tool)
     return (

--- a/packages/playground-ui/src/domains/templates/template-form.tsx
+++ b/packages/playground-ui/src/domains/templates/template-form.tsx
@@ -18,6 +18,7 @@ type TemplateFormProps = {
   handleInstallTemplate: () => void;
   handleVariableChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isLoadingEnvVars?: boolean;
+  isInstalling?: boolean;
   defaultModelProvider?: string;
   defaultModelId?: string;
   onModelUpdate?: (params: { provider: string; modelId: string }) => Promise<{ message: string }>;
@@ -32,6 +33,7 @@ export function TemplateForm({
   handleInstallTemplate,
   handleVariableChange,
   isLoadingEnvVars,
+  isInstalling,
   defaultModelProvider,
   defaultModelId,
   onModelUpdate,
@@ -123,9 +125,19 @@ export function TemplateForm({
               '[&>svg]:w-[1.1em] [&_svg]:h-[1.1em] [&_svg]:text-icon5',
             )}
             onClick={handleInstallTemplate}
-            disabled={!selectedProvider || !defaultModelProvider || !defaultModelId || errors.length > 0}
+            disabled={
+              !selectedProvider || !defaultModelProvider || !defaultModelId || errors.length > 0 || isInstalling
+            }
           >
-            Install <ArrowRightIcon />
+            {isInstalling ? (
+              <>
+                <Spinner className="w-4 h-4" /> Installing...
+              </>
+            ) : (
+              <>
+                Install <ArrowRightIcon />
+              </>
+            )}
           </Button>
         )}
       </div>

--- a/packages/playground-ui/src/domains/tools/components/ToolPanel.tsx
+++ b/packages/playground-ui/src/domains/tools/components/ToolPanel.tsx
@@ -6,6 +6,7 @@ import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { parse } from 'superjson';
 import { z } from 'zod';
 import { Txt } from '@/ds/components/Txt';
+import { Skeleton } from '@/components/ui/skeleton';
 import ToolExecutor from './ToolExecutor';
 import { useAgents } from '@/domains/agents/hooks/use-agents';
 import { useMemo, useEffect } from 'react';
@@ -60,7 +61,16 @@ export const ToolPanel = ({ toolId }: ToolPanelProps) => {
     ? resolveSerializedZodOutput(jsonSchemaToZod(parse(tool?.inputSchema)))
     : z.object({});
 
-  if (isLoading || error) return null;
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error) return null;
 
   if (!tool)
     return (

--- a/packages/playground/src/pages/templates/template/index.tsx
+++ b/packages/playground/src/pages/templates/template/index.tsx
@@ -57,9 +57,9 @@ export default function Template() {
   });
 
   // Fetch agent builder workflow info for step pre-population
-  const { data: workflowInfo } = useAgentBuilderWorkflow();
-  const { mutateAsync: createTemplateInstallRun } = useCreateTemplateInstallRun();
-  const { mutateAsync: getTemplateInstallRun } = useGetTemplateInstallRun();
+  const { data: workflowInfo, isLoading: isLoadingWorkflow } = useAgentBuilderWorkflow();
+  const { mutateAsync: createTemplateInstallRun, isPending: isCreatingRun } = useCreateTemplateInstallRun();
+  const { mutateAsync: getTemplateInstallRun, isPending: isGettingRun } = useGetTemplateInstallRun();
   const { streamInstall, streamResult, isStreaming } = useStreamTemplateInstall(workflowInfo);
   const {
     observeInstall,
@@ -393,7 +393,8 @@ export default function Template() {
                   setErrors={setErrors}
                   handleInstallTemplate={handleInstallTemplate}
                   handleVariableChange={handleVariableChange}
-                  isLoadingEnvVars={isLoadingEnvVars}
+                  isLoadingEnvVars={isLoadingEnvVars || isLoadingWorkflow}
+                  isInstalling={isCreatingRun}
                   defaultModelProvider={selectedModelProvider}
                   defaultModelId={selectedModelId}
                   onModelUpdate={handleModelUpdate}


### PR DESCRIPTION
Several components using TanStack Query hooks were missing proper loading state handling - they either returned `null` silently or rendered incomplete UI while data was being fetched.

Before:
```tsx
const { data: tool, isLoading } = useTool(toolId);
if (isLoading || error) return null; // User sees nothing
```

After:
```tsx
const { data: tool, isLoading } = useTool(toolId);
if (isLoading) {
  return (
    <div className="p-6">
      <Skeleton className="h-8 w-48 mb-4" />
      <Skeleton className="h-32 w-full" />
    </div>
  );
}
```

Files updated:
- `ToolPanel.tsx`, `MCPToolPanel.tsx` - Show skeleton instead of null
- `agent-badge-wrapper.tsx` - Show LoadingBadge while fetching messages
- `agent-memory.tsx`, `agent-working-memory.tsx` - Add skeleton for config loading
- `agent-information.tsx` - Prevent premature hasMemory calculation
- `studio-config-context.tsx` - Handle error case to prevent infinite loading
- `template-form.tsx` - Add isInstalling prop for button loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added loading state indicators throughout the application, displaying skeleton placeholders while data is being fetched
  * Agent information, memory, and tool panels now show visual feedback during data retrieval instead of rendering incomplete states
  * Template installation now displays a spinner and "Installing..." status during the installation process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->