### PR TITLE
fix(react): fix TypeScript errors during build declaration generation

### DIFF
--- a/.changeset/fix-react-build-type-errors.md
+++ b/.changeset/fix-react-build-type-errors.md
@@ -1,0 +1,10 @@
+---
+'@mastra/react': patch
+---
+
+Fix TypeScript errors during build declaration generation
+
+Updated test file `toUIMessage.test.ts` to match current `@mastra/core` types:
+- Changed `error` property from string to `Error` object (per `StepFailure` type)
+- Added missing `resumeSchema` property to `tool-call-approval` payloads (per `ToolCallApprovalPayload` type)
+- Added `zod` as peer/dev dependency for test type support

--- a/client-sdks/react/package.json
+++ b/client-sdks/react/package.json
@@ -53,7 +53,8 @@
   },
   "peerDependencies": {
     "react": ">=19.0.0",
-    "react-dom": ">=19.0.0"
+    "react-dom": ">=19.0.0",
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {
     "@ai-sdk/react": "^2.0.57",
@@ -76,7 +77,8 @@
     "typescript": "catalog:",
     "vite": "^7.1.9",
     "vite-plugin-dts": "^4.5.4",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "^3.25.0"
   },
   "eslintConfig": {
     "extends": [

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import { toUIMessage, mapWorkflowStreamChunkToWatchResult } from './toUIMessage';
 import { MastraUIMessage, MastraUIMessageMetadata } from '../types';
 import { ChunkType, ChunkFrom } from '@mastra/core/stream';
@@ -154,7 +155,7 @@ describe('toUIMessage', () => {
           },
           step2: {
             status: 'failed',
-            error: 'error-message',
+            error: new Error('error-message'),
             payload: {},
             startedAt: Date.now(),
             endedAt: Date.now(),
@@ -184,13 +185,13 @@ describe('toUIMessage', () => {
           },
           step2: {
             status: 'failed',
-            error: 'error-message',
+            error: expect.any(Error),
             payload: {},
             startedAt: expect.any(Number),
             endedAt: expect.any(Number),
           },
         },
-        error: 'error-message',
+        error: expect.any(Error),
       });
     });
 
@@ -1602,6 +1603,7 @@ describe('toUIMessage', () => {
           toolCallId: 'call-1',
           toolName: 'dangerous-tool',
           args: { action: 'delete', target: 'database' },
+          resumeSchema: z.any(),
         },
         runId: 'run-123',
         from: ChunkFrom.AGENT,
@@ -1636,6 +1638,7 @@ describe('toUIMessage', () => {
           toolCallId: 'call-2',
           toolName: 'another-tool',
           args: { param: 'value' },
+          resumeSchema: z.any(),
         },
         runId: 'run-123',
         from: ChunkFrom.AGENT,
@@ -1673,6 +1676,7 @@ describe('toUIMessage', () => {
           toolCallId: 'call-1',
           toolName: 'tool',
           args: {},
+          resumeSchema: z.any(),
         },
         runId: 'run-123',
         from: ChunkFrom.AGENT,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,7 +452,7 @@ importers:
     devDependencies:
       '@ai-sdk/react':
         specifier: ^2.0.57
-        version: 2.0.76(react@19.2.3)(zod@4.1.13)
+        version: 2.0.76(react@19.2.3)(zod@3.25.76)
       '@assistant-ui/react':
         specifier: ^0.11.47
         version: 0.11.47(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -513,6 +513,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.13.17)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.4(@types/node@22.13.17)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
 
   deployers/cloud:
     dependencies:
@@ -18311,12 +18314,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.18(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/gateway@2.0.0(zod@4.1.13)':
+  '@ai-sdk/gateway@2.0.0(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.13)
+      '@ai-sdk/provider-utils': 3.0.12(zod@3.25.76)
       '@vercel/oidc': 3.0.3
-      zod: 4.1.13
+      zod: 3.25.76
 
   '@ai-sdk/gateway@2.0.12(zod@3.25.76)':
     dependencies:
@@ -18472,13 +18475,6 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.12(zod@4.1.13)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.1.13
-
   '@ai-sdk/provider-utils@3.0.17(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -18556,15 +18552,15 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  '@ai-sdk/react@2.0.76(react@19.2.3)(zod@4.1.13)':
+  '@ai-sdk/react@2.0.76(react@19.2.3)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.13)
-      ai: 5.0.76(zod@4.1.13)
+      '@ai-sdk/provider-utils': 3.0.12(zod@3.25.76)
+      ai: 5.0.76(zod@3.25.76)
       react: 19.2.3
       swr: 2.3.6(react@19.2.3)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 4.1.13
+      zod: 3.25.76
 
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
     dependencies:
@@ -26021,13 +26017,13 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ai@5.0.76(zod@4.1.13):
+  ai@5.0.76(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 2.0.0(zod@4.1.13)
+      '@ai-sdk/gateway': 2.0.0(zod@3.25.76)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.13)
+      '@ai-sdk/provider-utils': 3.0.12(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      zod: 4.1.13
+      zod: 3.25.76
 
   ai@5.0.97(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
The `@mastra/react` build was showing TypeScript errors during declaration generation from `vite-plugin-dts`. These were caused by outdated test data in `toUIMessage.test.ts` that didn't match current `@mastra/core` types.

Fixed by updating the test file:

```typescript
// Before
error: 'error-message',
payload: { toolCallId: '...', toolName: '...', args: {} },

// After  
error: new Error('error-message'),
payload: { toolCallId: '...', toolName: '...', args: {}, resumeSchema: z.any() },
```

Also added `zod` as a peer/dev dependency for test type support.

Build now completes cleanly and all 271 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript declaration generation to restore correct type compatibility.

* **Chores**
  * Added zod to peer and dev dependencies to support type checks.

* **Tests**
  * Updated tests to align with adjusted runtime types (error objects and additional payload fields).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->