### PR TITLE
docs: improve MCP server authentication context documentation

### DIFF
--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1200,7 +1200,7 @@ Tools can access request metadata via `context.mcp.extra` when using HTTP-based 
 Whatever you set on `req.auth` in your HTTP middleware becomes available as `context.mcp.extra.authInfo` in your tools:
 
 ```
-req.auth = { ... }  →  context.mcp.extra.authInfo = { ... }
+req.auth = { ... }  →  context?.mcp?.extra?.authInfo.extra = { ... }
 ```
 
 ### Setting Up Authentication Middleware
@@ -1221,7 +1221,7 @@ app.use("/mcp", (req, res, next) => {
   // @ts-ignore - req.auth is read by the MCP SDK
   req.auth = {
     token,
-    userId: user.id,
+    userId: user.userId,
     email: user.email,
   };
   next();
@@ -1240,19 +1240,19 @@ The `req.auth` object is available as `context.mcp.extra.authInfo` in your tool'
 ```typescript
 execute: async (inputData, context) => {
   // Access the auth data you set in middleware
-  const authInfo = context.mcp?.extra?.authInfo;
+  const authInfo = context?.mcp?.extra?.authInfo;
 
-  if (!authInfo?.userId) {
+  if (!authInfo?.extra?.userId) {
     return { error: "Authentication required" };
   }
 
   // Use the auth data
-  console.log("User ID:", authInfo.userId);
-  console.log("Email:", authInfo.email);
+  console.log("User ID:", authInfo.extra.userId);
+  console.log("Email:", authInfo.extra.email);
 
   const response = await fetch("/api/data", {
     headers: { Authorization: `Bearer ${authInfo.token}` },
-    signal: context.mcp.extra.signal,
+    signal: context?.mcp?.extra?.signal,
   });
 
   return response.json();
@@ -1281,29 +1281,38 @@ import { MCPServer } from "@mastra/mcp";
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
+const verifyToken = (token: string) => {
+  // TODO: Implement token verification
+  return {
+    userId: "123",
+    email: "test@test.com",
+  };
+};
+
 // 1. Define your tool that uses auth context
 const getUserData = createTool({
   id: "get-user-data",
   description: "Fetches data for the authenticated user",
-  parameters: z.object({}),
+  inputSchema: z.object({}),
   execute: async (inputData, context) => {
-    const authInfo = context.mcp?.extra?.authInfo;
+    const authInfo = context?.mcp?.extra?.authInfo;
 
-    if (!authInfo?.userId) {
+    if (!authInfo?.extra?.userId) {
       return { error: "Authentication required" };
     }
 
     // Access the data you set in middleware
     return {
-      userId: authInfo.userId,
-      email: authInfo.email,
+      userId: authInfo.extra.userId,
+      email: authInfo.extra.email,
     };
   },
 });
 
 // 2. Create the MCP server with your tools
 const server = new MCPServer({
-  name: "my-server",
+  id: "my-server",
+  name: "My Server",
   version: "1.0.0",
   tools: { getUserData },
 });
@@ -1319,7 +1328,7 @@ app.use("/mcp", (req, res, next) => {
   // @ts-ignore - req.auth is read by the MCP SDK
   req.auth = {
     token,
-    userId: user.id,
+    userId: user.userId,
     email: user.email,
   };
   next();

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1193,17 +1193,65 @@ type ElicitResult = {
 
 ## Authentication Context
 
-Tools can access request metadata via `context.mcp.extra` when using HTTP-based transports:
+Tools can access request metadata via `context.mcp.extra` when using HTTP-based transports. This allows you to pass authentication info, user context, or any custom data from your HTTP middleware to your MCP tools.
+
+### How It Works
+
+Whatever you set on `req.auth` in your HTTP middleware becomes available as `context.mcp.extra.authInfo` in your tools:
+
+```
+req.auth = { ... }  →  context.mcp.extra.authInfo = { ... }
+```
+
+### Setting Up Authentication Middleware
+
+To pass data to your tools, populate `req.auth` on the Node.js request object in your HTTP server middleware before calling `server.startHTTP()`.
+
+```typescript
+import express from "express";
+
+const app = express();
+
+// Auth middleware - set req.auth before the MCP handler
+app.use("/mcp", (req, res, next) => {
+  const token = req.headers.authorization?.replace("Bearer ", "");
+  const user = verifyToken(token);
+
+  // This entire object becomes context.mcp.extra.authInfo
+  // @ts-ignore - req.auth is read by the MCP SDK
+  req.auth = {
+    token,
+    userId: user.id,
+    email: user.email,
+  };
+  next();
+});
+
+app.all("/mcp", async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  await server.startHTTP({ url, httpPath: "/mcp", req, res });
+});
+```
+
+### Accessing Auth Data in Tools
+
+The `req.auth` object is available as `context.mcp.extra.authInfo` in your tool's execute function:
 
 ```typescript
 execute: async (inputData, context) => {
-  if (!context.mcp?.extra?.authInfo?.token) {
-    return "Authentication required";
+  // Access the auth data you set in middleware
+  const authInfo = context.mcp?.extra?.authInfo;
+
+  if (!authInfo?.userId) {
+    return { error: "Authentication required" };
   }
 
-  // Use the auth token
+  // Use the auth data
+  console.log("User ID:", authInfo.userId);
+  console.log("Email:", authInfo.email);
+
   const response = await fetch("/api/data", {
-    headers: { Authorization: `Bearer ${context.mcp.extra.authInfo.token}` },
+    headers: { Authorization: `Bearer ${authInfo.token}` },
     signal: context.mcp.extra.signal,
   });
 
@@ -1211,24 +1259,79 @@ execute: async (inputData, context) => {
 };
 ```
 
-The `extra` object contains:
+### The `extra` Object
 
-- `authInfo`: Authentication info (when provided by server middleware)
-- `sessionId`: Session identifier
-- `signal`: AbortSignal for cancellation
-- `sendNotification`/`sendRequest`: MCP protocol functions
+The full `context.mcp.extra` object contains:
 
-> Note: To enable authentication, your HTTP server needs middleware that populates `req.auth` before calling `server.startHTTP()`. For example:
->
-> ```typescript
-> httpServer.createServer((req, res) => {
->   // Add auth middleware
->   req.auth = validateAuthToken(req.headers.authorization);
->
->   // Then pass to MCP server
->   await server.startHTTP({ url, httpPath, req, res });
-> });
-> ```
+| Property | Description |
+|----------|-------------|
+| `authInfo` | Whatever you set on `req.auth` in your middleware |
+| `sessionId` | Session identifier for the MCP connection |
+| `signal` | AbortSignal for request cancellation |
+| `sendNotification` | MCP protocol function for sending notifications |
+| `sendRequest` | MCP protocol function for sending requests |
+
+### Complete Example
+
+Here's a complete example showing the data flow from middleware to tool:
+
+```typescript
+import express from "express";
+import { MCPServer } from "@mastra/mcp";
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+// 1. Define your tool that uses auth context
+const getUserData = createTool({
+  id: "get-user-data",
+  description: "Fetches data for the authenticated user",
+  parameters: z.object({}),
+  execute: async (inputData, context) => {
+    const authInfo = context.mcp?.extra?.authInfo;
+
+    if (!authInfo?.userId) {
+      return { error: "Authentication required" };
+    }
+
+    // Access the data you set in middleware
+    return {
+      userId: authInfo.userId,
+      email: authInfo.email,
+    };
+  },
+});
+
+// 2. Create the MCP server with your tools
+const server = new MCPServer({
+  name: "my-server",
+  version: "1.0.0",
+  tools: { getUserData },
+});
+
+// 3. Set up Express with auth middleware
+const app = express();
+
+app.use("/mcp", (req, res, next) => {
+  const token = req.headers.authorization?.replace("Bearer ", "");
+  const user = verifyToken(token);
+
+  // This entire object becomes context.mcp.extra.authInfo
+  // @ts-ignore - req.auth is read by the MCP SDK
+  req.auth = {
+    token,
+    userId: user.id,
+    email: user.email,
+  };
+  next();
+});
+
+app.all("/mcp", async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  await server.startHTTP({ url, httpPath: "/mcp", req, res });
+});
+
+app.listen(3000);
+```
 
 ## Related Information
 


### PR DESCRIPTION
Improves the Authentication Context section of the MCP server docs based on user feedback. The previous docs were unclear about how to pass auth data to MCP tools.

**Before:** Docs mentioned `req.auth` but didn't explain the data flow or show practical examples.

**After:** Clear explanation showing:

```
req.auth = { ... }  →  context.mcp.extra.authInfo = { ... }
```

Added practical Express middleware example and consistent code showing how to set and access auth data in tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded MCPServer Authentication Context docs with a full "How It Works" guide, setup instructions for middleware, examples showing how auth data flows into tools, a complete end-to-end example, clearer descriptions of the `extra` object fields, and improved tool examples for handling and reporting auth-related errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->