### PR TITLE
docs: add missing CLI flags to reference docs

### DIFF
--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -92,6 +92,12 @@ If you're deploying to a [serverless platform](/guides/v1/deployment) you need t
 
 It accepts [common flags][common-flags].
 
+### Flags
+
+#### `--studio`
+
+Bundle the Studio UI with the build.
+
 ### Configs
 
 You can set certain environment variables to modify the behavior of `mastra build`.
@@ -137,6 +143,18 @@ The command accepts [common flags][common-flags] and the following additional fl
 #### `--port`
 
 The port to run Studio on. Defaults to `3000`.
+
+#### `--server-host`
+
+The host of the Mastra API server to connect to. Defaults to `localhost`.
+
+#### `--server-port`
+
+The port of the Mastra API server to connect to. Defaults to `4111`.
+
+#### `--server-protocol`
+
+The protocol of the Mastra API server to connect to. Defaults to `http`.
 
 ## `mastra lint`
 


### PR DESCRIPTION
The CLI reference docs were missing a few flags:

**`mastra build`**
- `--studio` - bundle Studio UI with the build

**`mastra studio`**
- `--server-host` - host of the Mastra API server (default: localhost)
- `--server-port` - port of the Mastra API server (default: 4111)
- `--server-protocol` - protocol of the Mastra API server (default: http)

These are now documented alongside the existing flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference with new flags for bundling Studio UI with builds and configuring API server connection settings in the Studio command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->