### PR TITLE
fix(memory): fix flaky working memory network tests

### DIFF
--- a/.changeset/fix-network-validation-history.md
+++ b/.changeset/fix-network-validation-history.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+Fix network validation not seeing previous iteration results in multi-step tasks
+
+The validation LLM was unable to determine task completion for multi-step tasks because it couldn't see what primitives had already executed. Now includes a compact list of completed primitives in the validation prompt.

--- a/packages/core/src/loop/network/validation.ts
+++ b/packages/core/src/loop/network/validation.ts
@@ -383,9 +383,35 @@ export async function runDefaultCompletionCheck(
 ): Promise<ScorerResult> {
   const start = Date.now();
 
+  // Build compact list of completed primitives from network messages
+  const completedPrimitives = context.messages
+    .map(m => {
+      try {
+        if (typeof m.content === 'string') return null;
+
+        const text = m.content.parts?.[0]?.type === 'text' ? m.content.parts?.[0]?.text : null;
+
+        if (text?.includes('"isNetwork":true')) {
+          const parsed = JSON.parse(text);
+          if (parsed.isNetwork) {
+            return `${parsed.primitiveType} "${parsed.primitiveId}"`;
+          }
+        }
+      } catch {
+        // Ignore parse errors
+      }
+      return null;
+    })
+    .filter(Boolean);
+
+  const completedSection =
+    completedPrimitives.length > 0 ? `\n\nPrimitives already executed: ${completedPrimitives.join(', ')}` : '';
+
   const completionPrompt = `
     The ${context.selectedPrimitive.type} ${context.selectedPrimitive.id} has contributed to the task.
     This is the result: ${JSON.stringify(context.primitiveResult)}
+    
+    ${completedSection}
 
     You need to evaluate if the task is complete. Pay very close attention to the SYSTEM INSTRUCTIONS for when the task is considered complete. 
     Only return true if the task is complete according to the system instructions.

--- a/packages/memory/integration-tests/src/shared/working-memory.ts
+++ b/packages/memory/integration-tests/src/shared/working-memory.ts
@@ -1684,7 +1684,7 @@ function runWorkingMemoryNetworkTests(getMemory: () => Memory, model: MastraMode
     return textChunks
       .map(c => {
         if (c.type === 'agent-execution-event-text-delta') {
-          return c.payload?.payload?.textDelta || '';
+          return c.payload?.payload?.textDelta || c.payload?.payload?.text || '';
         }
         if (c.type === 'routing-agent-text-delta') {
           return c.payload?.text || '';


### PR DESCRIPTION
The `should query agent first, then call memory tool` test was flaky because the LLM would sometimes omit the actual numeric result from its response text.

Before:
```
'Calculate 15 times 4, then remember the result'
```

After:
```
'Calculate 15 times 4, then remember the result. Always include the actual numeric result in your response when doing calculations.'
```

Same fix applied to the similar test checking for `126`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completion prompts now include a compact summary of previously executed primitives so the model sees prior outcomes when deciding next steps.

* **Bug Fixes / Behavior**
  * Memory concatenation now falls back to existing text when a delta is absent, which may include additional content in combined outputs.

* **Tests**
  * Integration tests updated to ensure numeric results are explicitly included, improving agent output consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->