### PR TITLE
Add more info to workflow lifecycle callbacks

### DIFF
--- a/.changeset/better-melons-bathe.md
+++ b/.changeset/better-melons-bathe.md
@@ -1,0 +1,42 @@
+---
+'@mastra/inngest': patch
+'@mastra/core': patch
+---
+
+Add additional context to workflow `onFinish` and `onError` callbacks
+
+The `onFinish` and `onError` lifecycle callbacks now receive additional properties:
+
+- `runId` - The unique identifier for the workflow run
+- `workflowId` - The workflow's identifier
+- `resourceId` - Optional resource identifier (if provided when creating the run)
+- `getInitData()` - Function that returns the initial input data passed to the workflow
+- `mastra` - The Mastra instance (if workflow is registered with Mastra)
+- `requestContext` - Request-scoped context data
+- `logger` - The workflow's logger instance
+- `state` - The workflow's current state object
+
+```typescript
+const workflow = createWorkflow({
+  id: 'order-processing',
+  inputSchema: z.object({ orderId: z.string() }),
+  outputSchema: z.object({ status: z.string() }),
+  options: {
+    onFinish: async ({ runId, workflowId, getInitData, logger, state, mastra }) => {
+      const inputData = getInitData();
+      logger.info(`Workflow ${workflowId} run ${runId} completed`, {
+        orderId: inputData.orderId,
+        finalState: state,
+      });
+
+      // Access other Mastra components if needed
+      const agent = mastra?.getAgent('notification-agent');
+    },
+    onError: async ({ runId, workflowId, error, logger, requestContext }) => {
+      logger.error(`Workflow ${workflowId} run ${runId} failed: ${error?.message}`);
+      // Access request context for additional debugging
+      const userId = requestContext.get('userId');
+    },
+  },
+});
+```

--- a/docs/src/content/en/docs/workflows/error-handling.mdx
+++ b/docs/src/content/en/docs/workflows/error-handling.mdx
@@ -96,6 +96,14 @@ The `onFinish` callback receives:
 - `error` - Error details (on failure)
 - `steps` - Individual step results
 - `tripwire` - Tripwire info (if status is `'tripwire'`)
+- `runId` - The unique identifier for this workflow run
+- `workflowId` - The workflow's identifier
+- `resourceId` - Optional resource identifier (if provided when creating the run)
+- `getInitData()` - Function that returns the initial input data
+- `mastra` - The Mastra instance (if workflow is registered with Mastra)
+- `requestContext` - Request-scoped context data
+- `logger` - The workflow's logger instance
+- `state` - The workflow's current state object
 
 ### onError
 
@@ -127,6 +135,14 @@ The `onError` callback receives:
 - `error` - Error details
 - `steps` - Individual step results
 - `tripwire` - Tripwire info (if status is `'tripwire'`)
+- `runId` - The unique identifier for this workflow run
+- `workflowId` - The workflow's identifier
+- `resourceId` - Optional resource identifier (if provided when creating the run)
+- `getInitData()` - Function that returns the initial input data
+- `mastra` - The Mastra instance (if workflow is registered with Mastra)
+- `requestContext` - Request-scoped context data
+- `logger` - The workflow's logger instance
+- `state` - The workflow's current state object
 
 ### Using both callbacks
 

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -104,6 +104,158 @@ export const workflow = createWorkflow({
   ]}
 />
 
+### WorkflowFinishCallbackResult
+
+The result object passed to `onFinish` callbacks.
+
+<PropertiesTable
+  content={[
+    {
+      name: "status",
+      type: "WorkflowRunStatus",
+      description: "The workflow status: 'success', 'failed', 'suspended', or 'tripwire'",
+    },
+    {
+      name: "result",
+      type: "any",
+      description: "The workflow output (when status is 'success')",
+      isOptional: true,
+    },
+    {
+      name: "error",
+      type: "SerializedError",
+      description: "Error details (when status is 'failed')",
+      isOptional: true,
+    },
+    {
+      name: "steps",
+      type: "Record<string, StepResult>",
+      description: "Individual step results with their status and output",
+    },
+    {
+      name: "tripwire",
+      type: "StepTripwireInfo",
+      description: "Tripwire information (when status is 'tripwire')",
+      isOptional: true,
+    },
+    {
+      name: "runId",
+      type: "string",
+      description: "The unique identifier for this workflow run",
+    },
+    {
+      name: "workflowId",
+      type: "string",
+      description: "The workflow's identifier",
+    },
+    {
+      name: "resourceId",
+      type: "string",
+      description: "Optional resource identifier (if provided when creating the run)",
+      isOptional: true,
+    },
+    {
+      name: "getInitData",
+      type: "() => any",
+      description: "Function that returns the initial input data passed to the workflow",
+    },
+    {
+      name: "mastra",
+      type: "Mastra",
+      description: "The Mastra instance (if workflow is registered with Mastra)",
+      isOptional: true,
+    },
+    {
+      name: "requestContext",
+      type: "RequestContext",
+      description: "Request-scoped context data",
+    },
+    {
+      name: "logger",
+      type: "IMastraLogger",
+      description: "The workflow's logger instance",
+    },
+    {
+      name: "state",
+      type: "Record<string, any>",
+      description: "The workflow's current state object",
+    },
+  ]}
+/>
+
+### WorkflowErrorCallbackInfo
+
+The error info object passed to `onError` callbacks.
+
+<PropertiesTable
+  content={[
+    {
+      name: "status",
+      type: "'failed' | 'tripwire'",
+      description: "The workflow status (either 'failed' or 'tripwire')",
+    },
+    {
+      name: "error",
+      type: "SerializedError",
+      description: "Error details",
+      isOptional: true,
+    },
+    {
+      name: "steps",
+      type: "Record<string, StepResult>",
+      description: "Individual step results with their status and output",
+    },
+    {
+      name: "tripwire",
+      type: "StepTripwireInfo",
+      description: "Tripwire information (when status is 'tripwire')",
+      isOptional: true,
+    },
+    {
+      name: "runId",
+      type: "string",
+      description: "The unique identifier for this workflow run",
+    },
+    {
+      name: "workflowId",
+      type: "string",
+      description: "The workflow's identifier",
+    },
+    {
+      name: "resourceId",
+      type: "string",
+      description: "Optional resource identifier (if provided when creating the run)",
+      isOptional: true,
+    },
+    {
+      name: "getInitData",
+      type: "() => any",
+      description: "Function that returns the initial input data passed to the workflow",
+    },
+    {
+      name: "mastra",
+      type: "Mastra",
+      description: "The Mastra instance (if workflow is registered with Mastra)",
+      isOptional: true,
+    },
+    {
+      name: "requestContext",
+      type: "RequestContext",
+      description: "Request-scoped context data",
+    },
+    {
+      name: "logger",
+      type: "IMastraLogger",
+      description: "The workflow's logger instance",
+    },
+    {
+      name: "state",
+      type: "Record<string, any>",
+      description: "The workflow's current state object",
+    },
+  ]}
+/>
+
 ## Running with initial state
 
 When starting a workflow run, you can pass `initialState` to set the starting values for the workflow's state:

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -632,7 +632,15 @@ export class DefaultExecutionEngine extends ExecutionEngine {
 
         if (lastOutput.result.status !== 'paused') {
           // Invoke lifecycle callbacks before returning
-          await this.invokeLifecycleCallbacks(result);
+          await this.invokeLifecycleCallbacks({
+            ...result,
+            runId,
+            workflowId,
+            resourceId,
+            input,
+            requestContext: currentRequestContext,
+            state: lastState,
+          });
         }
 
         if (lastOutput.result.status === 'paused') {
@@ -705,7 +713,15 @@ export class DefaultExecutionEngine extends ExecutionEngine {
       },
     });
 
-    await this.invokeLifecycleCallbacks(result);
+    await this.invokeLifecycleCallbacks({
+      ...result,
+      runId,
+      workflowId,
+      resourceId,
+      input,
+      requestContext: currentRequestContext,
+      state: lastState,
+    });
 
     if (params.outputOptions?.includeState) {
       return { ...result, state: lastState };

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -633,7 +633,11 @@ export class DefaultExecutionEngine extends ExecutionEngine {
         if (lastOutput.result.status !== 'paused') {
           // Invoke lifecycle callbacks before returning
           await this.invokeLifecycleCallbacks({
-            ...result,
+            status: result.status,
+            result: result.result,
+            error: result.error,
+            steps: result.steps,
+            tripwire: result.tripwire,
             runId,
             workflowId,
             resourceId,
@@ -714,7 +718,11 @@ export class DefaultExecutionEngine extends ExecutionEngine {
     });
 
     await this.invokeLifecycleCallbacks({
-      ...result,
+      status: result.status,
+      result: result.result,
+      error: result.error,
+      steps: result.steps,
+      tripwire: result.tripwire,
       runId,
       workflowId,
       resourceId,

--- a/packages/core/src/workflows/evented/execution-engine.ts
+++ b/packages/core/src/workflows/evented/execution-engine.ts
@@ -186,7 +186,11 @@ export class EventedExecutionEngine extends ExecutionEngine {
     if (callbackArg.status !== 'paused') {
       // Invoke lifecycle callbacks before returning
       await this.invokeLifecycleCallbacks({
-        ...callbackArg,
+        status: callbackArg.status,
+        result: callbackArg.result,
+        error: callbackArg.error,
+        steps: callbackArg.steps,
+        tripwire: undefined,
         runId: params.runId,
         workflowId: params.workflowId,
         resourceId: undefined,

--- a/packages/core/src/workflows/evented/execution-engine.ts
+++ b/packages/core/src/workflows/evented/execution-engine.ts
@@ -185,7 +185,15 @@ export class EventedExecutionEngine extends ExecutionEngine {
 
     if (callbackArg.status !== 'paused') {
       // Invoke lifecycle callbacks before returning
-      await this.invokeLifecycleCallbacks(callbackArg);
+      await this.invokeLifecycleCallbacks({
+        ...callbackArg,
+        runId: params.runId,
+        workflowId: params.workflowId,
+        resourceId: undefined,
+        input: params.input,
+        requestContext: params.requestContext,
+        state: {},
+      });
     }
 
     // Build the final result with any additional fields needed for the return type

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -4,6 +4,7 @@ import type { z } from 'zod';
 import type { SerializedError } from '../error';
 import type { MastraScorers } from '../evals';
 import type { PubSub } from '../events/pubsub';
+import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { AnySpan, TracingContext, TracingPolicy, TracingProperties } from '../observability';
 import type { RequestContext } from '../request-context';
@@ -349,21 +350,62 @@ export interface WorkflowRunState {
  * Result object passed to the onFinish callback when a workflow completes.
  */
 export interface WorkflowFinishCallbackResult {
+  /** The final status of the workflow */
   status: WorkflowRunStatus;
+  /** The workflow result (only for successful workflows) */
   result?: any;
+  /** Error details (only for failed workflows) */
   error?: SerializedError;
+  /** All step results */
   steps: Record<string, StepResult<any, any, any, any>>;
+  /** Tripwire info (only if failure was due to tripwire) */
   tripwire?: StepTripwireInfo;
+  /** The unique workflow run ID */
+  runId: string;
+  /** The workflow identifier */
+  workflowId: string;
+  /** Resource/user identifier for multi-tenant scenarios (optional) */
+  resourceId?: string;
+  /** Function to get the initial workflow input data */
+  getInitData: () => any;
+  /** The Mastra instance (if registered) */
+  mastra?: Mastra;
+  /** The request context */
+  requestContext: RequestContext;
+  /** The Mastra logger for structured logging */
+  logger: IMastraLogger;
+  /** The final workflow state */
+  state: Record<string, any>;
 }
 
 /**
  * Error info object passed to the onError callback when a workflow fails.
  */
 export interface WorkflowErrorCallbackInfo {
+  /** The failure status (either 'failed' or 'tripwire') */
   status: 'failed' | 'tripwire';
+  /** Error details */
   error?: SerializedError;
+  /** All step results */
   steps: Record<string, StepResult<any, any, any, any>>;
+  /** Tripwire info (only if status is 'tripwire') */
   tripwire?: StepTripwireInfo;
+  /** The unique workflow run ID */
+  runId: string;
+  /** The workflow identifier */
+  workflowId: string;
+  /** Resource/user identifier for multi-tenant scenarios (optional) */
+  resourceId?: string;
+  /** Function to get the initial workflow input data */
+  getInitData: () => any;
+  /** The Mastra instance (if registered) */
+  mastra?: Mastra;
+  /** The request context */
+  requestContext: RequestContext;
+  /** The Mastra logger for structured logging */
+  logger: IMastraLogger;
+  /** The final workflow state */
+  state: Record<string, any>;
 }
 
 export interface WorkflowOptions {

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -21030,5 +21030,544 @@ describe('Workflow', () => {
         }),
       );
     });
+
+    it('should provide getInitData function in onFinish callback', async () => {
+      let receivedInitData: any = null;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: vi.fn().mockResolvedValue({ result: 'success' }),
+        inputSchema: z.object({ userId: z.string() }),
+        outputSchema: z.object({ result: z.string() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-getInitData-onFinish-workflow',
+        inputSchema: z.object({ userId: z.string() }),
+        outputSchema: z.object({ result: z.string() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedInitData = result.getInitData();
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: { userId: 'user-123' } });
+
+      expect(receivedInitData).toEqual({ userId: 'user-123' });
+    });
+
+    it('should provide getInitData function in onError callback', async () => {
+      let receivedInitData: any = null;
+      const error = new Error('Step execution failed');
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(error),
+        inputSchema: z.object({ userId: z.string() }),
+        outputSchema: z.object({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-getInitData-onError-workflow',
+        inputSchema: z.object({ userId: z.string() }),
+        outputSchema: z.object({}),
+        steps: [failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedInitData = errorInfo.getInitData();
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: { userId: 'user-456' } });
+
+      expect(receivedInitData).toEqual({ userId: 'user-456' });
+    });
+
+    it('should provide mastra instance in onFinish callback', async () => {
+      let receivedMastra: Mastra | undefined = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: vi.fn().mockResolvedValue({ result: 'success' }),
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-mastra-onFinish-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedMastra = result.mastra;
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'test-mastra-onFinish-workflow': workflow },
+        storage: testStorage,
+      });
+
+      const run = await mastra.getWorkflow('test-mastra-onFinish-workflow').createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedMastra).toBe(mastra);
+    });
+
+    it('should provide mastra instance in onError callback', async () => {
+      let receivedMastra: Mastra | undefined = undefined;
+      const error = new Error('Step execution failed');
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(error),
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-mastra-onError-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        steps: [failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedMastra = errorInfo.mastra;
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'test-mastra-onError-workflow': workflow },
+        storage: testStorage,
+      });
+
+      const run = await mastra.getWorkflow('test-mastra-onError-workflow').createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedMastra).toBe(mastra);
+    });
+
+    it('should provide requestContext in onFinish callback', async () => {
+      let receivedRequestContext: RequestContext | undefined = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: vi.fn().mockResolvedValue({ result: 'success' }),
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-requestContext-onFinish-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedRequestContext = result.requestContext;
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'test-requestContext-onFinish-workflow': workflow },
+        storage: testStorage,
+      });
+
+      const requestContext = new RequestContext([['customKey', 'customValue']]);
+
+      const run = await mastra.getWorkflow('test-requestContext-onFinish-workflow').createRun();
+      await run.start({ inputData: {}, requestContext });
+
+      expect(receivedRequestContext).toBeDefined();
+      expect(receivedRequestContext?.get('customKey')).toBe('customValue');
+    });
+
+    it('should provide requestContext in onError callback', async () => {
+      let receivedRequestContext: RequestContext | undefined = undefined;
+      const error = new Error('Step execution failed');
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(error),
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-requestContext-onError-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        steps: [failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedRequestContext = errorInfo.requestContext;
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'test-requestContext-onError-workflow': workflow },
+        storage: testStorage,
+      });
+
+      const requestContext = new RequestContext([['errorKey', 'errorValue']]);
+
+      const run = await mastra.getWorkflow('test-requestContext-onError-workflow').createRun();
+      await run.start({ inputData: {}, requestContext });
+
+      expect(receivedRequestContext).toBeDefined();
+      expect(receivedRequestContext?.get('errorKey')).toBe('errorValue');
+    });
+
+    it('should provide runId in onFinish callback', async () => {
+      let receivedRunId: string | undefined = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: vi.fn().mockResolvedValue({ result: 'success' }),
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-runId-onFinish-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedRunId = result.runId;
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedRunId).toBeDefined();
+      expect(typeof receivedRunId).toBe('string');
+      expect(receivedRunId).toBe(run.runId);
+    });
+
+    it('should provide workflowId in onFinish callback', async () => {
+      let receivedWorkflowId: string | undefined = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: vi.fn().mockResolvedValue({ result: 'success' }),
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-workflowId-onFinish-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedWorkflowId = result.workflowId;
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedWorkflowId).toBe('test-workflowId-onFinish-workflow');
+    });
+
+    it('should provide resourceId in onFinish callback when provided', async () => {
+      let receivedResourceId: string | undefined = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: vi.fn().mockResolvedValue({ result: 'success' }),
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-resourceId-onFinish-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedResourceId = result.resourceId;
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'test-resourceId-onFinish-workflow': workflow },
+        storage: testStorage,
+      });
+
+      const run = await mastra.getWorkflow('test-resourceId-onFinish-workflow').createRun({
+        resourceId: 'user-resource-123',
+      });
+      await run.start({ inputData: {} });
+
+      expect(receivedResourceId).toBe('user-resource-123');
+    });
+
+    it('should provide logger in onFinish callback', async () => {
+      let receivedLogger: any = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: vi.fn().mockResolvedValue({ result: 'success' }),
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-logger-onFinish-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedLogger = result.logger;
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedLogger).toBeDefined();
+      expect(typeof receivedLogger.info).toBe('function');
+      expect(typeof receivedLogger.error).toBe('function');
+    });
+
+    it('should provide state in onFinish callback', async () => {
+      let receivedState: Record<string, any> | undefined = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: async ({ setState }) => {
+          await setState({ counter: 42 });
+          return { result: 'success' };
+        },
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        stateSchema: z.object({ counter: z.number().optional() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-state-onFinish-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        stateSchema: z.object({ counter: z.number().optional() }),
+        steps: [step1],
+        options: {
+          onFinish: result => {
+            receivedState = result.state;
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedState).toBeDefined();
+      expect(receivedState?.counter).toBe(42);
+    });
+
+    it('should provide runId in onError callback', async () => {
+      let receivedRunId: string | undefined = undefined;
+      const error = new Error('Step execution failed');
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(error),
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-runId-onError-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        steps: [failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedRunId = errorInfo.runId;
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedRunId).toBeDefined();
+      expect(typeof receivedRunId).toBe('string');
+      expect(receivedRunId).toBe(run.runId);
+    });
+
+    it('should provide workflowId in onError callback', async () => {
+      let receivedWorkflowId: string | undefined = undefined;
+      const error = new Error('Step execution failed');
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(error),
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-workflowId-onError-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        steps: [failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedWorkflowId = errorInfo.workflowId;
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedWorkflowId).toBe('test-workflowId-onError-workflow');
+    });
+
+    it('should provide logger in onError callback', async () => {
+      let receivedLogger: any = undefined;
+      const error = new Error('Step execution failed');
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(error),
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-logger-onError-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        steps: [failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedLogger = errorInfo.logger;
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedLogger).toBeDefined();
+      expect(typeof receivedLogger.info).toBe('function');
+      expect(typeof receivedLogger.error).toBe('function');
+    });
+
+    it('should provide resourceId in onError callback when provided', async () => {
+      let receivedResourceId: string | undefined = undefined;
+      const error = new Error('Step execution failed');
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(error),
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-resourceId-onError-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        steps: [failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedResourceId = errorInfo.resourceId;
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'test-resourceId-onError-workflow': workflow },
+        storage: testStorage,
+      });
+
+      const run = await mastra.getWorkflow('test-resourceId-onError-workflow').createRun({
+        resourceId: 'error-resource-456',
+      });
+      await run.start({ inputData: {} });
+
+      expect(receivedResourceId).toBe('error-resource-456');
+    });
+
+    it('should provide state in onError callback', async () => {
+      let receivedState: Record<string, any> | undefined = undefined;
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: async ({ setState }) => {
+          await setState({ counter: 10 });
+          return { result: 'success' };
+        },
+        inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
+        stateSchema: z.object({ counter: z.number().optional() }),
+      });
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: vi.fn().mockRejectedValue(new Error('Step execution failed')),
+        inputSchema: z.object({ result: z.string() }),
+        outputSchema: z.object({}),
+        stateSchema: z.object({ counter: z.number().optional() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-state-onError-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        stateSchema: z.object({ counter: z.number().optional() }),
+        steps: [step1, failingStep],
+        options: {
+          onError: errorInfo => {
+            receivedState = errorInfo.state;
+          },
+        },
+      });
+      workflow.then(step1).then(failingStep).commit();
+
+      const run = await workflow.createRun();
+      await run.start({ inputData: {} });
+
+      expect(receivedState).toBeDefined();
+      expect(receivedState?.counter).toBe(10);
+    });
   });
 });

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import type { RequestContext } from '@mastra/core/di';
 import { getErrorFromUnknown } from '@mastra/core/error';
 import type { SerializedError } from '@mastra/core/error';
 import type { PubSub } from '@mastra/core/events';
@@ -178,6 +179,12 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
     error?: any;
     steps: Record<string, any>;
     tripwire?: any;
+    runId: string;
+    workflowId: string;
+    resourceId?: string;
+    input?: any;
+    requestContext: RequestContext;
+    state: Record<string, any>;
   }): Promise<void> {
     // No-op: Inngest handles callbacks in workflow.ts finalize step
   }
@@ -191,6 +198,12 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
     error?: any;
     steps: Record<string, any>;
     tripwire?: any;
+    runId: string;
+    workflowId: string;
+    resourceId?: string;
+    input?: any;
+    requestContext: RequestContext;
+    state: Record<string, any>;
   }): Promise<void> {
     return super.invokeLifecycleCallbacks(result);
   }

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -14699,5 +14699,187 @@ describe('MastraInngestWorkflow', () => {
 
       srv.close();
     });
+
+    it('should provide all expected properties in onFinish callback', async ctx => {
+      const inngest = new Inngest({
+        id: 'mastra',
+        baseUrl: `http://localhost:${(ctx as any).inngestPort}`,
+      });
+
+      const { createWorkflow, createStep } = init(inngest);
+
+      const onFinishResults: any[] = [];
+
+      const step1 = createStep({
+        id: 'step1',
+        execute: async () => {
+          return { value: 42 };
+        },
+        inputSchema: z.object({ inputValue: z.string() }),
+        outputSchema: z.object({ value: z.number() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-onFinish-properties-workflow',
+        inputSchema: z.object({ inputValue: z.string() }),
+        outputSchema: z.object({ value: z.number() }),
+        steps: [step1],
+        retryConfig: { attempts: 0 },
+        options: {
+          onFinish: result => {
+            onFinishResults.push(result);
+          },
+        },
+      });
+      workflow.then(step1).commit();
+
+      const mastra = new Mastra({
+        storage: new DefaultStorage({
+          id: 'test-storage',
+          url: ':memory:',
+        }),
+        workflows: {
+          'test-onFinish-properties-workflow': workflow,
+        },
+        server: {
+          apiRoutes: [
+            {
+              path: '/inngest/api',
+              method: 'ALL',
+              createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
+            },
+          ],
+        },
+      });
+
+      const app = await createHonoServer(mastra);
+
+      const srv = (globServer = serve({
+        fetch: app.fetch,
+        port: (ctx as any).handlerPort,
+      }));
+
+      await resetInngest();
+
+      const run = await workflow.createRun();
+      const result = await run.start({ inputData: { inputValue: 'test-input' } });
+
+      expect(result.status).toBe('success');
+      expect(onFinishResults.length).toBe(1);
+
+      const callbackResult = onFinishResults[0];
+
+      // Verify new properties are present
+      expect(callbackResult.runId).toBeDefined();
+      expect(typeof callbackResult.runId).toBe('string');
+
+      expect(callbackResult.workflowId).toBe('test-onFinish-properties-workflow');
+
+      expect(callbackResult.getInitData).toBeDefined();
+      expect(typeof callbackResult.getInitData).toBe('function');
+      expect(callbackResult.getInitData()).toEqual({ inputValue: 'test-input' });
+
+      expect(callbackResult.mastra).toBeDefined();
+
+      expect(callbackResult.requestContext).toBeDefined();
+
+      expect(callbackResult.logger).toBeDefined();
+
+      expect(callbackResult.state).toBeDefined();
+      expect(typeof callbackResult.state).toBe('object');
+
+      srv.close();
+    });
+
+    it('should provide all expected properties in onError callback', async ctx => {
+      const inngest = new Inngest({
+        id: 'mastra',
+        baseUrl: `http://localhost:${(ctx as any).inngestPort}`,
+      });
+
+      const { createWorkflow, createStep } = init(inngest);
+
+      const onErrorResults: any[] = [];
+
+      const failingStep = createStep({
+        id: 'failing-step',
+        execute: async () => {
+          throw new Error('Intentional failure for property test');
+        },
+        inputSchema: z.object({ inputValue: z.string() }),
+        outputSchema: z.object({ value: z.number() }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'test-onError-properties-workflow',
+        inputSchema: z.object({ inputValue: z.string() }),
+        outputSchema: z.object({ value: z.number() }),
+        steps: [failingStep],
+        retryConfig: { attempts: 0 },
+        options: {
+          onError: errorInfo => {
+            onErrorResults.push(errorInfo);
+          },
+        },
+      });
+      workflow.then(failingStep).commit();
+
+      const mastra = new Mastra({
+        storage: new DefaultStorage({
+          id: 'test-storage',
+          url: ':memory:',
+        }),
+        workflows: {
+          'test-onError-properties-workflow': workflow,
+        },
+        server: {
+          apiRoutes: [
+            {
+              path: '/inngest/api',
+              method: 'ALL',
+              createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
+            },
+          ],
+        },
+      });
+
+      const app = await createHonoServer(mastra);
+
+      const srv = (globServer = serve({
+        fetch: app.fetch,
+        port: (ctx as any).handlerPort,
+      }));
+
+      await resetInngest();
+
+      const run = await workflow.createRun();
+      const result = await run.start({ inputData: { inputValue: 'test-input' } });
+
+      expect(result.status).toBe('failed');
+      expect(onErrorResults.length).toBe(1);
+
+      const callbackResult = onErrorResults[0];
+
+      // Verify new properties are present
+      expect(callbackResult.runId).toBeDefined();
+      expect(typeof callbackResult.runId).toBe('string');
+
+      expect(callbackResult.workflowId).toBe('test-onError-properties-workflow');
+
+      expect(callbackResult.getInitData).toBeDefined();
+      expect(typeof callbackResult.getInitData).toBe('function');
+      expect(callbackResult.getInitData()).toEqual({ inputValue: 'test-input' });
+
+      expect(callbackResult.mastra).toBeDefined();
+
+      expect(callbackResult.requestContext).toBeDefined();
+
+      expect(callbackResult.logger).toBeDefined();
+
+      expect(callbackResult.state).toBeDefined();
+      expect(typeof callbackResult.state).toBe('object');
+
+      srv.close();
+    });
   });
 }, 80e3);

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -278,13 +278,17 @@ export class InngestWorkflow<
             // Use invokeLifecycleCallbacksInternal to call the real implementation
             // (invokeLifecycleCallbacks is overridden to no-op to prevent double calling)
             await engine.invokeLifecycleCallbacksInternal({
-              ...(result as any),
+              status: result.status,
+              result: 'result' in result ? result.result : undefined,
+              error: 'error' in result ? result.error : undefined,
+              steps: result.steps,
+              tripwire: 'tripwire' in result ? result.tripwire : undefined,
               runId,
               workflowId: this.id,
               resourceId,
               input: inputData,
               requestContext,
-              state: (result as any).state ?? initialState ?? {},
+              state: result.state ?? initialState ?? {},
             });
           }
 

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -232,7 +232,9 @@ export class InngestWorkflow<
         const pubsub = new InngestPubSub(this.inngest, this.id, publish);
 
         // Create requestContext before execute so we can reuse it in finalize
-        const requestContext = new RequestContext(Object.entries(event.data.requestContext ?? {}));
+        const requestContext = new RequestContext(
+          Object.entries(event.data.requestContext ?? {}) as [string, {} | undefined][],
+        );
 
         const engine = new InngestExecutionEngine(this.#mastra, step, attempt, this.options);
         const result = await engine.execute<

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -232,9 +232,7 @@ export class InngestWorkflow<
         const pubsub = new InngestPubSub(this.inngest, this.id, publish);
 
         // Create requestContext before execute so we can reuse it in finalize
-        const requestContext = new RequestContext(
-          Object.entries(event.data.requestContext ?? {}) as [string, {} | undefined][],
-        );
+        const requestContext = new RequestContext<Record<string, any>>(Object.entries(event.data.requestContext ?? {}));
 
         const engine = new InngestExecutionEngine(this.#mastra, step, attempt, this.options);
         const result = await engine.execute<


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/11514

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow callbacks (onFinish and onError) now receive expanded runtime context: runId, workflowId, optional resourceId, getInitData(), mastra, requestContext, logger, and state.

* **Documentation**
  * Updated reference and guides with callback parameter specs and usage examples.

* **Tests**
  * Added tests verifying the expanded callback context across success, failure, suspend/resume, nested workflows, and async scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->