### PR TITLE
fix(docs): chat sidebar resize handle does not affect layout

### DIFF
--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
@@ -98,10 +98,13 @@ export default function ChatbotSidebar() {
   }, [toggle, hiddenSidebar]);
 
   // Click wrapper: only toggle if the pointer interaction wasn't a drag
-  const handleToggleClick = useCallback((e: React.MouseEvent) => {
-    if (hasDraggedRef.current) return;
-    toggleSidebar();
-  }, [toggleSidebar]);
+  const handleToggleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (hasDraggedRef.current) return;
+      toggleSidebar();
+    },
+    [toggleSidebar],
+  );
 
   // Handle drag to resize sidebar
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -110,7 +113,10 @@ export default function ChatbotSidebar() {
     startXRef.current = e.clientX;
     setIsDragging(true);
     // disable transitions for main/sidebar while dragging
-    document.documentElement.style.setProperty("--chatbot-transition-duration", "0s");
+    document.documentElement.style.setProperty(
+      "--chatbot-transition-duration",
+      "0s",
+    );
     // set cursor globally
     document.body.style.cursor = "col-resize";
   }, []);
@@ -133,7 +139,7 @@ export default function ChatbotSidebar() {
         setSidebarWidth(newWidth);
         document.documentElement.style.setProperty(
           "--chatbot-sidebar-width",
-          `${newWidth}px`
+          `${newWidth}px`,
         );
       }
     };
@@ -142,7 +148,10 @@ export default function ChatbotSidebar() {
       setIsDragging(false);
       startXRef.current = null;
       // restore transitions and cursor
-      document.documentElement.style.setProperty("--chatbot-transition-duration", "0.3s");
+      document.documentElement.style.setProperty(
+        "--chatbot-transition-duration",
+        "0.3s",
+      );
       document.body.style.cursor = "";
     };
 
@@ -153,7 +162,10 @@ export default function ChatbotSidebar() {
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
       document.body.style.cursor = "";
-      document.documentElement.style.setProperty("--chatbot-transition-duration", "0.3s");
+      document.documentElement.style.setProperty(
+        "--chatbot-transition-duration",
+        "0.3s",
+      );
     };
   }, [isDragging, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH]);
 

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
@@ -30,6 +30,11 @@ import { useChatbotSidebar } from "./context";
 import styles from "./styles.module.css";
 import { TextShimmer } from "./text-shimmer";
 
+// Sidebar width bounds and default. Keep in sync with CSS `:root` defaults.
+const SIDEBAR_MIN_WIDTH = 250;
+const SIDEBAR_MAX_WIDTH = 600;
+const SIDEBAR_DEFAULT_WIDTH = 400;
+
 function LeftClickableBorder({
   onClick,
   hiddenChatbotSidebar,
@@ -61,11 +66,6 @@ export default function ChatbotSidebar() {
   const { isHidden: hiddenChatbotSidebar, toggle } = useChatbotSidebar();
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-
-  // Width constants (kept in sync with CSS defaults)
-  const SIDEBAR_MIN_WIDTH = 250;
-  const SIDEBAR_MAX_WIDTH = 600;
-  const SIDEBAR_DEFAULT_WIDTH = 400;
 
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -167,7 +167,7 @@ export default function ChatbotSidebar() {
         "0.3s",
       );
     };
-  }, [isDragging, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH]);
+  }, [isDragging]);
 
   const {
     conversation,

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
@@ -36,11 +36,6 @@ interface LeftClickableBorderProps {
   onMouseDown: (e: React.MouseEvent) => void;
 }
 
-// Sidebar width bounds and default. Keep in sync with CSS `:root` defaults.
-const SIDEBAR_MIN_WIDTH = 250;
-const SIDEBAR_MAX_WIDTH = 600;
-const SIDEBAR_DEFAULT_WIDTH = 400;
-
 function LeftClickableBorder({
   onClick,
   hiddenChatbotSidebar,
@@ -69,11 +64,24 @@ export default function ChatbotSidebar() {
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
 
-  const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
+  const [sidebarWidth, setSidebarWidth] = useState(400);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const hasDraggedRef = useRef(false);
   const startXRef = useRef<number | null>(null);
+
+  const minWidthRef = useRef(250);
+  const maxWidthRef = useRef(600);
+
+  useEffect(() => {
+    const rootStyles = getComputedStyle(document.documentElement);
+    minWidthRef.current =
+      parseInt(rootStyles.getPropertyValue("--chatbot-sidebar-min-width")) ||
+      250;
+    maxWidthRef.current =
+      parseInt(rootStyles.getPropertyValue("--chatbot-sidebar-max-width")) ||
+      600;
+  }, []);
 
   useEffect(() => {
     if (!hiddenChatbotSidebar) {
@@ -129,7 +137,7 @@ export default function ChatbotSidebar() {
     const handleMouseMove = (e: MouseEvent) => {
       if (!sidebarRef.current) return;
 
-      const startX = startXRef.current ?? e.clientX;
+      const startX = startXRef.current!;
       const moved = Math.abs(e.clientX - startX);
       if (moved > 0) {
         hasDraggedRef.current = true;
@@ -137,7 +145,7 @@ export default function ChatbotSidebar() {
 
       const newWidth = window.innerWidth - e.clientX;
 
-      if (newWidth >= SIDEBAR_MIN_WIDTH && newWidth <= SIDEBAR_MAX_WIDTH) {
+      if (newWidth >= minWidthRef.current && newWidth <= maxWidthRef.current) {
         setSidebarWidth(newWidth);
         document.documentElement.style.setProperty(
           "--chatbot-sidebar-width",

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
@@ -31,7 +31,7 @@ import styles from "./styles.module.css";
 import { TextShimmer } from "./text-shimmer";
 
 interface LeftClickableBorderProps {
-  onClick: (e: React.MouseEvent) => void;
+  onClick: (e: React.MouseEvent | React.KeyboardEvent) => void;
   hiddenChatbotSidebar: boolean;
   onMouseDown: (e: React.MouseEvent) => void;
 }
@@ -55,7 +55,7 @@ function LeftClickableBorder({
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
-          onClick(e as unknown as React.MouseEvent);
+          onClick(e);
         }
       }}
       title={hiddenChatbotSidebar ? "Expand chatbot" : "Collapse chatbot"}
@@ -101,7 +101,7 @@ export default function ChatbotSidebar() {
 
   // Click wrapper: only toggle if the pointer interaction wasn't a drag
   const handleToggleClick = useCallback(
-    (e: React.MouseEvent) => {
+    (e: React.MouseEvent | React.KeyboardEvent) => {
       if (hasDraggedRef.current) return;
       toggleSidebar();
     },

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
@@ -36,6 +36,10 @@ interface LeftClickableBorderProps {
   onMouseDown: (e: React.MouseEvent) => void;
 }
 
+const SIDEBAR_DEFAULT_WIDTH = 400;
+const SIDEBAR_MIN_WIDTH = 250;
+const SIDEBAR_MAX_WIDTH = 600;
+
 function LeftClickableBorder({
   onClick,
   hiddenChatbotSidebar,
@@ -64,23 +68,29 @@ export default function ChatbotSidebar() {
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
 
-  const [sidebarWidth, setSidebarWidth] = useState(400);
+  const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const hasDraggedRef = useRef(false);
   const startXRef = useRef<number | null>(null);
 
-  const minWidthRef = useRef(250);
-  const maxWidthRef = useRef(600);
+  const minWidthRef = useRef(SIDEBAR_MIN_WIDTH);
+  const maxWidthRef = useRef(SIDEBAR_MAX_WIDTH);
+  const originalTransitionDurationRef = useRef("0.3s");
 
   useEffect(() => {
     const rootStyles = getComputedStyle(document.documentElement);
+    const defaultWidth =
+      parseInt(
+        rootStyles.getPropertyValue("--chatbot-sidebar-default-width"),
+      ) || SIDEBAR_DEFAULT_WIDTH;
+    setSidebarWidth(defaultWidth);
     minWidthRef.current =
       parseInt(rootStyles.getPropertyValue("--chatbot-sidebar-min-width")) ||
-      250;
+      SIDEBAR_MIN_WIDTH;
     maxWidthRef.current =
       parseInt(rootStyles.getPropertyValue("--chatbot-sidebar-max-width")) ||
-      600;
+      SIDEBAR_MAX_WIDTH;
   }, []);
 
   useEffect(() => {
@@ -122,6 +132,13 @@ export default function ChatbotSidebar() {
     hasDraggedRef.current = false;
     startXRef.current = e.clientX;
     setIsDragging(true);
+
+    // Save original transition duration
+    originalTransitionDurationRef.current =
+      getComputedStyle(document.documentElement).getPropertyValue(
+        "--chatbot-transition-duration",
+      ) || "0.3s";
+
     // disable transitions for main/sidebar while dragging
     document.documentElement.style.setProperty(
       "--chatbot-transition-duration",
@@ -160,7 +177,7 @@ export default function ChatbotSidebar() {
       // restore transitions and cursor
       document.documentElement.style.setProperty(
         "--chatbot-transition-duration",
-        "0.3s",
+        originalTransitionDurationRef.current,
       );
       document.body.style.cursor = "";
     };
@@ -174,7 +191,7 @@ export default function ChatbotSidebar() {
       document.body.style.cursor = "";
       document.documentElement.style.setProperty(
         "--chatbot-transition-duration",
-        "0.3s",
+        originalTransitionDurationRef.current,
       );
     };
   }, [isDragging]);

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/index.tsx
@@ -30,6 +30,12 @@ import { useChatbotSidebar } from "./context";
 import styles from "./styles.module.css";
 import { TextShimmer } from "./text-shimmer";
 
+interface LeftClickableBorderProps {
+  onClick: (e: React.MouseEvent) => void;
+  hiddenChatbotSidebar: boolean;
+  onMouseDown: (e: React.MouseEvent) => void;
+}
+
 // Sidebar width bounds and default. Keep in sync with CSS `:root` defaults.
 const SIDEBAR_MIN_WIDTH = 250;
 const SIDEBAR_MAX_WIDTH = 600;
@@ -39,11 +45,7 @@ function LeftClickableBorder({
   onClick,
   hiddenChatbotSidebar,
   onMouseDown,
-}: {
-  onClick: (e: React.MouseEvent) => void;
-  hiddenChatbotSidebar: boolean;
-  onMouseDown: (e: React.MouseEvent) => void;
-}) {
+}: LeftClickableBorderProps) {
   return (
     <div
       className="absolute top-0 bottom-0 -left-2 w-4 h-full cursor-col-resize z-100"

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/styles.module.css
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/styles.module.css
@@ -1,6 +1,7 @@
 :root {
   --chatbot-sidebar-width: 400px;
   --chatbot-sidebar-hidden-width: 40px;
+  --chatbot-transition-duration: 0.3s;
 }
 
 .chatbotSidebarContainer {
@@ -19,7 +20,7 @@
     position: fixed;
     bottom: 0;
     right: 0;
-    transition: width 0.3s ease-in-out;
+    transition: width var(--chatbot-transition-duration, 0.3s) ease-in-out;
   }
 
   .chatbotSidebarContainerHidden {

--- a/docs/src/theme/DocRoot/Layout/ChatbotSidebar/styles.module.css
+++ b/docs/src/theme/DocRoot/Layout/ChatbotSidebar/styles.module.css
@@ -19,6 +19,7 @@
     position: fixed;
     bottom: 0;
     right: 0;
+    transition: width 0.3s ease-in-out;
   }
 
   .chatbotSidebarContainerHidden {

--- a/docs/src/theme/DocRoot/Layout/Main/styles.module.css
+++ b/docs/src/theme/DocRoot/Layout/Main/styles.module.css
@@ -5,6 +5,7 @@
   flex-basis: 0%;
   justify-content: center;
   min-width: 0;
+  transition: max-width 0.3s ease-in-out;
 }
 
 @media (min-width: 997px) {
@@ -41,14 +42,14 @@
 
   .docItemWrapperChatbotHidden {
     max-width: calc(
-      var(--ifm-container-width) + var(--chatbot-sidebar-width)
+      var(--ifm-container-width) + var(--chatbot-sidebar-hidden-width)
     ) !important;
   }
 
   .docItemWrapperEnhanced.docItemWrapperChatbotHidden {
     max-width: calc(
       var(--ifm-container-width) + var(--doc-sidebar-width) +
-        var(--chatbot-sidebar-width)
+        var(--chatbot-sidebar-hidden-width)
     ) !important;
   }
 }

--- a/docs/src/theme/DocRoot/Layout/Main/styles.module.css
+++ b/docs/src/theme/DocRoot/Layout/Main/styles.module.css
@@ -5,7 +5,7 @@
   flex-basis: 0%;
   justify-content: center;
   min-width: 0;
-  transition: max-width 0.3s ease-in-out;
+  transition: max-width var(--chatbot-transition-duration, 0.3s) ease-in-out;
 }
 
 @media (min-width: 997px) {


### PR DESCRIPTION
## Description

Fixes an issue in the docs layout where the chat sidebar resize/expand handle had no visible effect.
The layout width calculation was incorrectly using the hidden sidebar width even when the chat panel was visible, causing resizing to appear broken.

This change corrects the CSS variable used for width calculation so the main content area responds properly when the chat sidebar is shown or resized.

## Related Issue(s)
Closes #11706

## Before
https://github.com/user-attachments/assets/fa8926bf-52a1-40a6-b327-b939d7adf09f

## After
https://github.com/user-attachments/assets/ec5d4a11-5638-4380-bb24-5c6de1a332dc

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chatbot sidebar can be resized by dragging its left border; dragging is distinguished from clicks to avoid accidental toggles.
  * Sidebar enforces sensible min/max/default widths and preserves sizing behavior.

* **Accessibility**
  * Keyboard toggle and focus behaviors are preserved; the interactive border supports Enter/Space activation.

* **Style**
  * Smooth, configurable width transition and adjusted main-content sizing when the sidebar is hidden.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->