### PR TITLE
fix(ci): export schema-compat-changed output in core tests workflow

### DIFF
--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       core-changed: ${{ steps.changes.outputs.core }}
+      schema-compat-changed: ${{ steps.changes.outputs.schema-compat }}
     permissions:
       contents: read
       statuses: write


### PR DESCRIPTION
## Summary
- Adds missing `schema-compat-changed` output to the `check-changes` job in the core tests workflow

## Context
The workflow defines a `schema-compat` filter to detect changes in `packages/schema-compat/**`, and downstream jobs reference `needs.check-changes.outputs.schema-compat-changed` in their conditionals.

However, the `check-changes` job only exported `core-changed` and never exported `schema-compat-changed`, causing the output to be undefined when referenced by other jobs.

## Changes
```yaml
outputs:
  core-changed: ${{ steps.changes.outputs.core }}
+ schema-compat-changed: ${{ steps.changes.outputs.schema-compat }}
```

## Impact
- ✅ Fixes the skip-tests job condition (line 51)
- ✅ Fixes the test job condition (line 69)  
- ✅ Ensures workflow correctly handles schema-compat package changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to improve change detection and test execution capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->