### PR TITLE
fix/11693  dynamo score metadata

### DIFF
--- a/.changeset/curvy-tigers-wash.md
+++ b/.changeset/curvy-tigers-wash.md
@@ -1,0 +1,7 @@
+---
+'@mastra/dynamodb': patch
+---
+
+Fix eval scores not being saved when using DynamoDB storage
+Scores from built-in scorers (like hallucination-scorer) were silently failing to save to DynamoDB. Scores now persist correctly with all their metadata.
+Fixes #11693. Add metadata field coverage to score storage tests

--- a/stores/_test-utils/src/domains/scores/data.ts
+++ b/stores/_test-utils/src/domains/scores/data.ts
@@ -58,5 +58,9 @@ export function createSampleScore({
       name: 'Sample entity',
     },
     requestContext: {},
+    metadata: {
+      scorerVersion: '1.0.0',
+      customField: 'test-value',
+    },
   };
 }

--- a/stores/dynamodb/src/entities/score.ts
+++ b/stores/dynamodb/src/entities/score.ts
@@ -221,6 +221,28 @@ export const scoreEntity = new Entity({
         return value;
       },
     },
+    metadata: {
+      type: 'string',
+      required: false,
+      set: (value?: Record<string, unknown> | string) => {
+        if (value && typeof value !== 'string') {
+          return JSON.stringify(value);
+        }
+        return value;
+      },
+      get: (value?: string) => {
+        if (value && typeof value === 'string') {
+          try {
+            if (value.startsWith('{') || value.startsWith('[')) {
+              return JSON.parse(value);
+            }
+          } catch {
+            return value;
+          }
+        }
+        return value;
+      },
+    },
     requestContext: {
       type: 'string',
       required: false,

--- a/stores/dynamodb/src/storage/domains/scores/index.ts
+++ b/stores/dynamodb/src/storage/domains/scores/index.ts
@@ -124,6 +124,18 @@ export class ScoresStorageDynamoDB extends ScoresStorage {
         : JSON.stringify(validatedScore.requestContext);
     const entity =
       typeof validatedScore.entity === 'string' ? validatedScore.entity : JSON.stringify(validatedScore.entity);
+    const metadata =
+      typeof validatedScore.metadata === 'string'
+        ? validatedScore.metadata
+        : validatedScore.metadata
+          ? JSON.stringify(validatedScore.metadata)
+          : undefined;
+    const additionalContext =
+      typeof validatedScore.additionalContext === 'string'
+        ? validatedScore.additionalContext
+        : validatedScore.additionalContext
+          ? JSON.stringify(validatedScore.additionalContext)
+          : undefined;
 
     const scoreData = Object.fromEntries(
       Object.entries({
@@ -136,6 +148,8 @@ export class ScoresStorageDynamoDB extends ScoresStorage {
         input,
         output,
         requestContext,
+        metadata,
+        additionalContext,
         entityData: entity,
         traceId: validatedScore.traceId || '',
         resourceId: validatedScore.resourceId || '',


### PR DESCRIPTION
## Description

Fix eval scores not being saved when using DynamoDB storage. Scores from built-in scorers (like hallucination-scorer) were failing with the following ElectroDB error:

```
Invalid value type at entity path: "metadata". Received value of type "object", expected value of type "string"
```

The DynamoDB score entity was missing the `metadata` attribute definition, and the `saveScore` method wasn't serializing `metadata` before passing it to ElectroDB. Added the missing attribute and proper JSON serialization to match how other storage adapters handle the field.

## Related Issue(s)

Fixes #11693

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works