### PR TITLE
feat: add MASTRA_SERVER_URL env var for cloud deployments

### DIFF
--- a/.changeset/add-mastra-server-url-env.md
+++ b/.changeset/add-mastra-server-url-env.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/deployer': patch
-'@internal/playground': patch
 ---
 
 Add MASTRA_AUTO_DETECT_URL env var to auto-detect server URL from browser origin

--- a/.changeset/add-mastra-server-url-env.md
+++ b/.changeset/add-mastra-server-url-env.md
@@ -1,0 +1,14 @@
+---
+'@mastra/deployer': patch
+'@internal/playground': patch
+---
+
+Add MASTRA_SERVER_URL environment variable support for cloud deployments
+
+Allows setting the full server URL via environment variable when running the playground in containerized/cloud environments where the external URL differs from the internal host/port.
+
+```bash
+MASTRA_SERVER_URL=https://myapp.com node ./index.mjs
+```
+
+When set, this takes priority over the constructed `${protocol}://${host}:${port}` endpoint.

--- a/.changeset/add-mastra-server-url-env.md
+++ b/.changeset/add-mastra-server-url-env.md
@@ -2,12 +2,12 @@
 '@mastra/deployer': patch
 ---
 
-Add MASTRA_AUTO_DETECT_URL env var to auto-detect server URL from browser origin
+Add MASTRA_SERVER_URL_FROM_BROWSER env var to auto-detect server URL from browser origin
 
 When set to `true`, the playground uses `window.location.origin` as the server URL. This makes cloud deployments work without needing to know the URL ahead of time.
 
 ```bash
-MASTRA_AUTO_DETECT_URL=true node ./index.mjs
+MASTRA_SERVER_URL_FROM_BROWSER=true node ./index.mjs
 ```
 
 Users visiting `https://myapp.com/` will have the playground automatically connect to that URL.

--- a/.changeset/add-mastra-server-url-env.md
+++ b/.changeset/add-mastra-server-url-env.md
@@ -3,12 +3,12 @@
 '@internal/playground': patch
 ---
 
-Add MASTRA_SERVER_URL support and auto-detect from request origin
+Add MASTRA_AUTO_DETECT_URL env var to auto-detect server URL from browser origin
 
-The playground now automatically uses `window.location.origin` as the server URL, so cloud deployments work without any configuration. Users visiting `https://myapp.com/` will have the playground connect to that URL automatically.
-
-You can still override with `MASTRA_SERVER_URL` env var if needed:
+When set to `true`, the playground uses `window.location.origin` as the server URL. This makes cloud deployments work without needing to know the URL ahead of time.
 
 ```bash
-MASTRA_SERVER_URL=https://custom-api.com node ./index.mjs
+MASTRA_AUTO_DETECT_URL=true node ./index.mjs
 ```
+
+Users visiting `https://myapp.com/` will have the playground automatically connect to that URL.

--- a/.changeset/add-mastra-server-url-env.md
+++ b/.changeset/add-mastra-server-url-env.md
@@ -3,12 +3,12 @@
 '@internal/playground': patch
 ---
 
-Add MASTRA_SERVER_URL environment variable support for cloud deployments
+Add MASTRA_SERVER_URL support and auto-detect from request origin
 
-Allows setting the full server URL via environment variable when running the playground in containerized/cloud environments where the external URL differs from the internal host/port.
+The playground now automatically uses `window.location.origin` as the server URL, so cloud deployments work without any configuration. Users visiting `https://myapp.com/` will have the playground connect to that URL automatically.
+
+You can still override with `MASTRA_SERVER_URL` env var if needed:
 
 ```bash
-MASTRA_SERVER_URL=https://myapp.com node ./index.mjs
+MASTRA_SERVER_URL=https://custom-api.com node ./index.mjs
 ```
-
-When set, this takes priority over the constructed `${protocol}://${host}:${port}` endpoint.

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -341,7 +341,7 @@ export async function createHonoServer(
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PORT%%'`, `'${port}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_HIDE_CLOUD_CTA%%'`, `'${hideCloudCta}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PROTOCOL%%'`, `'${protocol}'`);
-      indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_URL%%'`, `'${process.env.MASTRA_SERVER_URL || ''}'`);
+      indexHtml = indexHtml.replace(`'%%MASTRA_AUTO_DETECT_URL%%'`, `'${process.env.MASTRA_AUTO_DETECT_URL || ''}'`);
       // Inject the base path for frontend routing
       // The <base href> tag uses this to resolve all relative URLs correctly
       indexHtml = indexHtml.replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', studioBasePath);

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -341,6 +341,7 @@ export async function createHonoServer(
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PORT%%'`, `'${port}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_HIDE_CLOUD_CTA%%'`, `'${hideCloudCta}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PROTOCOL%%'`, `'${protocol}'`);
+      indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_URL%%'`, `'${process.env.MASTRA_SERVER_URL || ''}'`);
       // Inject the base path for frontend routing
       // The <base href> tag uses this to resolve all relative URLs correctly
       indexHtml = indexHtml.replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', studioBasePath);

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -341,7 +341,10 @@ export async function createHonoServer(
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PORT%%'`, `'${port}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_HIDE_CLOUD_CTA%%'`, `'${hideCloudCta}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PROTOCOL%%'`, `'${protocol}'`);
-      indexHtml = indexHtml.replace(`'%%MASTRA_AUTO_DETECT_URL%%'`, `'${process.env.MASTRA_AUTO_DETECT_URL || ''}'`);
+      indexHtml = indexHtml.replace(
+        `'%%MASTRA_SERVER_URL_FROM_BROWSER%%'`,
+        `'${process.env.MASTRA_SERVER_URL_FROM_BROWSER || ''}'`,
+      );
       // Inject the base path for frontend routing
       // The <base href> tag uses this to resolve all relative URLs correctly
       indexHtml = indexHtml.replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', studioBasePath);

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -13,7 +13,7 @@
       window.MASTRA_HIDE_CLOUD_CTA = '%%MASTRA_HIDE_CLOUD_CTA%%';
       window.MASTRA_STUDIO_BASE_PATH = '%%MASTRA_STUDIO_BASE_PATH%%';
       window.MASTRA_SERVER_PROTOCOL = '%%MASTRA_SERVER_PROTOCOL%%';
-      window.MASTRA_SERVER_URL = '%%MASTRA_SERVER_URL%%' || window.location.origin;
+      window.MASTRA_SERVER_URL = '%%MASTRA_AUTO_DETECT_URL%%' === 'true' ? window.location.origin : '';
 
       function connectSSE() {
         const basePath = window.MASTRA_STUDIO_BASE_PATH || '';

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -13,6 +13,7 @@
       window.MASTRA_HIDE_CLOUD_CTA = '%%MASTRA_HIDE_CLOUD_CTA%%';
       window.MASTRA_STUDIO_BASE_PATH = '%%MASTRA_STUDIO_BASE_PATH%%';
       window.MASTRA_SERVER_PROTOCOL = '%%MASTRA_SERVER_PROTOCOL%%';
+      window.MASTRA_SERVER_URL = '%%MASTRA_SERVER_URL%%';
 
       function connectSSE() {
         const basePath = window.MASTRA_STUDIO_BASE_PATH || '';

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -13,7 +13,7 @@
       window.MASTRA_HIDE_CLOUD_CTA = '%%MASTRA_HIDE_CLOUD_CTA%%';
       window.MASTRA_STUDIO_BASE_PATH = '%%MASTRA_STUDIO_BASE_PATH%%';
       window.MASTRA_SERVER_PROTOCOL = '%%MASTRA_SERVER_PROTOCOL%%';
-      window.MASTRA_SERVER_URL = '%%MASTRA_AUTO_DETECT_URL%%' === 'true' ? window.location.origin : '';
+      window.MASTRA_SERVER_URL = '%%MASTRA_SERVER_URL_FROM_BROWSER%%' === 'true' ? window.location.origin : '';
 
       function connectSSE() {
         const basePath = window.MASTRA_STUDIO_BASE_PATH || '';

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -13,7 +13,7 @@
       window.MASTRA_HIDE_CLOUD_CTA = '%%MASTRA_HIDE_CLOUD_CTA%%';
       window.MASTRA_STUDIO_BASE_PATH = '%%MASTRA_STUDIO_BASE_PATH%%';
       window.MASTRA_SERVER_PROTOCOL = '%%MASTRA_SERVER_PROTOCOL%%';
-      window.MASTRA_SERVER_URL = '%%MASTRA_SERVER_URL%%';
+      window.MASTRA_SERVER_URL = '%%MASTRA_SERVER_URL%%' || window.location.origin;
 
       function connectSSE() {
         const basePath = window.MASTRA_STUDIO_BASE_PATH || '';

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -12,6 +12,7 @@ declare global {
     MASTRA_TELEMETRY_DISABLED?: string;
     MASTRA_HIDE_CLOUD_CTA: string;
     MASTRA_SERVER_PROTOCOL: string;
+    MASTRA_SERVER_URL?: string;
   }
 }
 
@@ -196,10 +197,11 @@ function App() {
 }
 
 export default function AppWrapper() {
+  const serverUrl = window.MASTRA_SERVER_URL;
   const protocol = window.MASTRA_SERVER_PROTOCOL || 'http';
   const host = window.MASTRA_SERVER_HOST || 'localhost';
   const port = window.MASTRA_SERVER_PORT || 4111;
-  const endpoint = `${protocol}://${host}:${port}`;
+  const endpoint = serverUrl || `${protocol}://${host}:${port}`;
 
   return (
     <PlaygroundQueryClient>


### PR DESCRIPTION

Add MASTRA_SERVER_URL_FROM_BROWSER env var to auto-detect server URL from browser origin

When set to `true`, the playground uses `window.location.origin` as the server URL. This makes cloud deployments work without needing to know the URL ahead of time.

```bash
MASTRA_SERVER_URL_FROM_BROWSER=true node ./index.mjs
```

Users visiting `https://myapp.com/` will have the playground automatically connect to that URL.