### PR TITLE
make initialState optional in studio

### DIFF
--- a/.changeset/orange-bags-retire.md
+++ b/.changeset/orange-bags-retire.md
@@ -1,0 +1,8 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/core': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Make initialState optional in studio

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2468,20 +2468,20 @@ export class Run<
   protected async _validateInitialState(initialState: z.input<TState>) {
     let initialStateToUse = initialState;
     if (this.validateInputs) {
-      let inputSchema: z.ZodType<any> | undefined = this.stateSchema;
+      let stateSchema: z.ZodType<any> | undefined = this.stateSchema;
 
-      if (inputSchema) {
-        const validatedInputData = await inputSchema.safeParseAsync(initialState);
+      if (stateSchema) {
+        const validatedInitialState = await stateSchema.safeParseAsync(initialState);
 
-        if (!validatedInputData.success) {
-          const errors = getZodErrors(validatedInputData.error);
+        if (!validatedInitialState.success) {
+          const errors = getZodErrors(validatedInitialState.error);
           throw new Error(
             'Invalid initial state: \n' +
               errors.map((e: z.ZodIssue) => `- ${e.path?.join('.')}: ${e.message}`).join('\n'),
           );
         }
 
-        initialStateToUse = validatedInputData.data;
+        initialStateToUse = validatedInitialState.data;
       }
     }
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2476,7 +2476,8 @@ export class Run<
         if (!validatedInputData.success) {
           const errors = getZodErrors(validatedInputData.error);
           throw new Error(
-            'Invalid input data: \n' + errors.map((e: z.ZodIssue) => `- ${e.path?.join('.')}: ${e.message}`).join('\n'),
+            'Invalid initial state: \n' +
+              errors.map((e: z.ZodIssue) => `- ${e.path?.join('.')}: ${e.message}`).join('\n'),
           );
         }
 

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -203,7 +203,7 @@ export function WorkflowTrigger({
   const zodSchemaToUse = zodStateSchema
     ? z.object({
         inputData: zodInputSchema,
-        initialState: zodStateSchema,
+        initialState: zodStateSchema.optional(),
       })
     : zodInputSchema;
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Follow up on #11560
Made `initialState` optional in studio. If the workflow run throws an error relating to initialState validation (for cases where `validateInputs` is not set to `false`), the error will be toasted on studio.


Uploading initial state studio.mp4…



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initial state is now optional in workflow triggers when a state schema is defined.

* **Bug Fixes**
  * Improved error messaging for initial state validation failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->