### PR TITLE
DRAFT: moved common code in most exporters to new TrackingExporter base class

### DIFF
--- a/observability/_test-utils/package.json
+++ b/observability/_test-utils/package.json
@@ -4,19 +4,22 @@
   "description": "Test utilities for observability exporters",
   "type": "module",
   "private": true,
-  "main": "./index.ts",
+  "main": "./src/index.ts",
   "files": [
-    "index.ts"
+    "src"
   ],
   "scripts": {
     "test": "vitest run"
   },
   "devDependencies": {
     "@mastra/core": "workspace:*",
+    "@mastra/observability": "workspace:*",
     "@vitest/coverage-v8": "catalog:",
-    "@vitest/ui": "catalog:"
+    "@vitest/ui": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=0.18.1-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/observability": ">=1.0.0-0 <2.0.0-0"
   }
 }

--- a/observability/_test-utils/src/index.ts
+++ b/observability/_test-utils/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Test utilities for observability exporters.
+ * Provides shared test scenarios, trace generators, and test exporter implementations.
+ */
+
+export * from './trace-generator';
+export * from './test-exporter';
+export * from './test-scenarios';

--- a/observability/_test-utils/src/test-exporter.ts
+++ b/observability/_test-utils/src/test-exporter.ts
@@ -1,0 +1,228 @@
+/**
+ * Test implementation of TrackingExporter for unit testing.
+ * Exposes internals and tracks method calls for verification.
+ */
+
+import type { AnyExportedSpan, SpanErrorInfo } from '@mastra/core/observability';
+import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
+import { TrackingExporter } from '@mastra/observability';
+
+export interface TestTrackingExporterConfig extends TrackingExporterConfig {
+  /** Simulate _buildSpan returning undefined for specific span IDs */
+  failBuildSpanFor?: string[];
+  /** Simulate _buildEvent returning undefined for specific span IDs */
+  failBuildEventFor?: string[];
+  /** Skip building root (like LangSmith) */
+  skipRoot?: boolean;
+}
+
+type TestRootData = { type: 'root'; spanId: string };
+type TestSpanData = { type: 'span'; spanId: string };
+type TestEventData = { type: 'event'; spanId: string };
+type TestMetadata = Record<string, unknown>;
+type TestTraceData = TraceData<TestRootData, TestSpanData, TestEventData, TestMetadata>;
+
+export interface MethodCall {
+  method: string;
+  spanId: string;
+  traceId: string;
+  timestamp: Date;
+  args?: Record<string, unknown>;
+}
+
+export class TestTrackingExporter extends TrackingExporter<
+  TestRootData,
+  TestSpanData,
+  TestEventData,
+  TestMetadata,
+  TestTrackingExporterConfig
+> {
+  name = 'test-exporter';
+
+  // Track all method calls for verification
+  public calls: MethodCall[] = [];
+
+  // Track built spans/events for verification
+  public builtRoots: Map<string, TestRootData> = new Map();
+  public builtSpans: Map<string, TestSpanData> = new Map();
+  public builtEvents: Map<string, TestEventData> = new Map();
+  public abortedSpans: Map<string, SpanErrorInfo> = new Map();
+
+  // Track root span ID for parent checking
+  private rootSpanId?: string;
+
+  private failBuildSpanFor: Set<string>;
+  private failBuildEventFor: Set<string>;
+
+  constructor(config: TestTrackingExporterConfig = {}) {
+    super(config);
+
+    this.failBuildSpanFor = new Set(config.failBuildSpanFor ?? []);
+    this.failBuildEventFor = new Set(config.failBuildEventFor ?? []);
+
+    if (config.skipRoot) {
+      this.skipBuildRootTask = true;
+    }
+  }
+
+  // Allow test access to protected method
+  public async exportTracingEvent(event: Parameters<typeof this._exportTracingEvent>[0]): Promise<void> {
+    return this._exportTracingEvent(event);
+  }
+
+  // Allow test access to trace data
+  public getTraceDataPublic(args: { traceId: string; method: string }): TestTraceData {
+    return this.getTraceData(args);
+  }
+
+  // Get trace map size for verification
+  public getTraceMapSize(): number {
+    return this.traceMapSize();
+  }
+
+  protected override async _buildRoot(args: {
+    span: AnyExportedSpan;
+    traceData: TestTraceData;
+  }): Promise<TestRootData | undefined> {
+    this.calls.push({
+      method: '_buildRoot',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+
+    const rootData: TestRootData = { type: 'root', spanId: args.span.id };
+    this.builtRoots.set(args.span.id, rootData);
+    this.rootSpanId = args.span.id;
+    return rootData;
+  }
+
+  protected override async _buildSpan(args: {
+    span: AnyExportedSpan;
+    traceData: TestTraceData;
+  }): Promise<TestSpanData | undefined> {
+    this.calls.push({
+      method: '_buildSpan',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+
+    // Simulate failure if configured
+    if (this.failBuildSpanFor.has(args.span.id)) {
+      return undefined;
+    }
+
+    // Check if parent exists (simulate real exporter behavior)
+    // For non-root spans, we need the actual parent to exist (not just root)
+    if (!args.span.isRootSpan) {
+      const parentId = args.span.parentSpanId;
+      if (parentId) {
+        // Check if specific parent exists in spans
+        const parent = args.traceData.getSpan({ spanId: parentId });
+        // If parent doesn't exist in spans, check if parent is root
+        if (!parent && parentId !== this.rootSpanId) {
+          return undefined;
+        }
+      } else {
+        // No parentId means direct child of root, check root exists
+        if (!args.traceData.hasRoot() && !args.traceData.isRootProcessed()) {
+          return undefined;
+        }
+      }
+    }
+
+    const spanData: TestSpanData = { type: 'span', spanId: args.span.id };
+    this.builtSpans.set(args.span.id, spanData);
+
+    // If this is a root span (skipRoot=true mode), track the root ID
+    if (args.span.isRootSpan) {
+      this.rootSpanId = args.span.id;
+    }
+
+    return spanData;
+  }
+
+  protected override async _buildEvent(args: {
+    span: AnyExportedSpan;
+    traceData: TestTraceData;
+  }): Promise<TestEventData | undefined> {
+    this.calls.push({
+      method: '_buildEvent',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+
+    // Simulate failure if configured
+    if (this.failBuildEventFor.has(args.span.id)) {
+      return undefined;
+    }
+
+    // Check if parent exists (simulate real exporter behavior)
+    const parent = args.traceData.getParentOrRoot({ span: args.span });
+    if (!parent) {
+      return undefined;
+    }
+
+    const eventData: TestEventData = { type: 'event', spanId: args.span.id };
+    this.builtEvents.set(args.span.id, eventData);
+    return eventData;
+  }
+
+  protected override async _updateSpan(args: { span: AnyExportedSpan; traceData: TestTraceData }): Promise<void> {
+    this.calls.push({
+      method: '_updateSpan',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+  }
+
+  protected override async _finishSpan(args: { span: AnyExportedSpan; traceData: TestTraceData }): Promise<void> {
+    this.calls.push({
+      method: '_finishSpan',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+  }
+
+  protected override async _abortSpan(args: {
+    span: TestSpanData;
+    traceData: TestTraceData;
+    reason: SpanErrorInfo;
+  }): Promise<void> {
+    this.calls.push({
+      method: '_abortSpan',
+      spanId: args.span.spanId,
+      traceId: 'unknown', // TraceData doesn't have traceId directly
+      timestamp: new Date(),
+      args: { reason: args.reason },
+    });
+
+    this.abortedSpans.set(args.span.spanId, args.reason);
+  }
+
+  // Helper methods for test assertions
+
+  public getCallsForMethod(method: string): MethodCall[] {
+    return this.calls.filter(c => c.method === method);
+  }
+
+  public getCallsForSpan(spanId: string): MethodCall[] {
+    return this.calls.filter(c => c.spanId === spanId);
+  }
+
+  public wasMethodCalledForSpan(method: string, spanId: string): boolean {
+    return this.calls.some(c => c.method === method && c.spanId === spanId);
+  }
+
+  public reset(): void {
+    this.calls = [];
+    this.builtRoots.clear();
+    this.builtSpans.clear();
+    this.builtEvents.clear();
+    this.abortedSpans.clear();
+  }
+}

--- a/observability/_test-utils/src/test-scenarios.ts
+++ b/observability/_test-utils/src/test-scenarios.ts
@@ -1,0 +1,420 @@
+/**
+ * Shared test scenarios for early/late data handling.
+ * These can be run against any TrackingExporter-based exporter.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { TracingEvent } from '@mastra/core/observability';
+import { generateTrace, reverseHierarchyOrder, sendWithDelays } from './trace-generator';
+
+/**
+ * Flush async processing (setImmediate callbacks) with fake timers.
+ * Uses advanceTimersToNextTimerAsync to run each scheduled timer one at a time.
+ */
+async function flushAsync(times: number = 1): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await vi.advanceTimersToNextTimerAsync();
+  }
+}
+
+export interface TestableExporter {
+  exportTracingEvent: (event: TracingEvent) => Promise<void>;
+  shutdown: () => Promise<void>;
+  getTraceMapSize?: () => number;
+}
+
+export type ExporterFactory = () => TestableExporter;
+
+/**
+ * Run all early data handling tests for an exporter.
+ */
+export function runAllEarlyDataTests(factory: ExporterFactory, exporterName: string): void {
+  runOutOfOrderSpanTests(factory, exporterName);
+  runRootArrivesLastTests(factory, exporterName);
+  runDeepHierarchyTests(factory, exporterName);
+}
+
+/**
+ * Test out-of-order span arrival.
+ */
+export function runOutOfOrderSpanTests(factory: ExporterFactory, exporterName: string): void {
+  describe(`${exporterName}: Out-of-order span arrival`, () => {
+    let exporter: TestableExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory();
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should process spans when children arrive before parents', async () => {
+      // Generate a trace and reverse order so children come first
+      const events = generateTrace({ depth: 3, breadth: 2, includeEvents: false });
+      const reversedEvents = reverseHierarchyOrder(events);
+
+      // Send events
+      await sendWithDelays(exporter, reversedEvents);
+
+      // Allow async processing
+      await flushAsync(10);
+
+      // Advance timers to allow cleanup scheduling
+      vi.advanceTimersByTime(1000);
+
+      // All spans should eventually be processed
+      // (verification depends on exporter implementation)
+    });
+
+    it('should handle interleaved start and end events', async () => {
+      const events = generateTrace({ depth: 2, breadth: 3, includeEvents: true });
+
+      // Interleave events: start1, start2, end1, start3, end2, end3...
+      const starts = events.filter(e => e.type === 'span_started');
+      const ends = events.filter(e => e.type === 'span_ended');
+
+      const interleaved: TracingEvent[] = [];
+      const maxLen = Math.max(starts.length, ends.length);
+      for (let i = 0; i < maxLen; i++) {
+        if (i < starts.length) interleaved.push(starts[i]);
+        if (i < ends.length) interleaved.push(ends[i]);
+      }
+
+      await sendWithDelays(exporter, interleaved);
+      await flushAsync(10);
+    });
+  });
+}
+
+/**
+ * Test root span arriving last.
+ */
+export function runRootArrivesLastTests(factory: ExporterFactory, exporterName: string): void {
+  describe(`${exporterName}: Root arrives last`, () => {
+    let exporter: TestableExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory();
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should queue children and process after root arrives', async () => {
+      const events = generateTrace({ depth: 2, breadth: 2, includeEvents: false });
+
+      // Find root and non-root events
+      const rootStart = events.find(e => e.type === 'span_started' && e.exportedSpan.isRootSpan)!;
+      const nonRootStarts = events.filter(e => e.type === 'span_started' && !e.exportedSpan.isRootSpan);
+      const ends = events.filter(e => e.type === 'span_ended');
+
+      // Send children first
+      await sendWithDelays(exporter, nonRootStarts);
+
+      // Children should be queued (can't process without root)
+      // Now send root
+      await exporter.exportTracingEvent(rootStart);
+
+      // Allow async processing
+      await flushAsync(10);
+
+      // Send end events
+      await sendWithDelays(exporter, ends);
+      await flushAsync(5);
+    });
+
+    it('should handle multiple children waiting for root', async () => {
+      // Generate a wide trace (many children at same level)
+      const events = generateTrace({ depth: 2, breadth: 5, includeEvents: false });
+
+      // Separate root from children
+      const rootEvents = events.filter(e => e.exportedSpan.isRootSpan);
+      const childEvents = events.filter(e => !e.exportedSpan.isRootSpan);
+
+      // Send all children first
+      await sendWithDelays(
+        exporter,
+        childEvents.filter(e => e.type === 'span_started'),
+      );
+
+      // Then send root
+      await sendWithDelays(
+        exporter,
+        rootEvents.filter(e => e.type === 'span_started'),
+      );
+
+      await flushAsync(15);
+
+      // Send end events
+      await sendWithDelays(
+        exporter,
+        events.filter(e => e.type === 'span_ended'),
+      );
+      await flushAsync(5);
+    });
+  });
+}
+
+/**
+ * Test deep hierarchy with out-of-order arrival.
+ */
+export function runDeepHierarchyTests(factory: ExporterFactory, exporterName: string): void {
+  describe(`${exporterName}: Deep hierarchy out of order`, () => {
+    let exporter: TestableExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory();
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should cascade processing through deep hierarchy', async () => {
+      // Generate a deep, narrow trace
+      const events = generateTrace({ depth: 5, breadth: 1, includeEvents: false });
+      const starts = events.filter(e => e.type === 'span_started');
+      const ends = events.filter(e => e.type === 'span_ended');
+
+      // Reverse the starts so deepest comes first
+      const reversedStarts = [...starts].reverse();
+
+      // Send in reverse order
+      await sendWithDelays(exporter, reversedStarts);
+
+      // Allow multiple rounds of async processing for cascade
+      await flushAsync(20);
+
+      // Send ends in normal order
+      await sendWithDelays(exporter, ends);
+      await flushAsync(5);
+    });
+
+    it('should handle D->B->C->A arrival order', async () => {
+      // Manually create 4 spans: A (root) -> B -> C -> D
+      const traceId = `test-trace-${Date.now()}`;
+      const now = new Date();
+
+      const spanA: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-A',
+          traceId,
+          name: 'span-A',
+          type: 'AGENT_RUN' as any,
+          isRootSpan: true,
+          isEvent: false,
+          startTime: now,
+        },
+      };
+
+      const spanB: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-B',
+          traceId,
+          parentSpanId: 'span-A',
+          name: 'span-B',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 100),
+        },
+      };
+
+      const spanC: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-C',
+          traceId,
+          parentSpanId: 'span-B',
+          name: 'span-C',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 200),
+        },
+      };
+
+      const spanD: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-D',
+          traceId,
+          parentSpanId: 'span-C',
+          name: 'span-D',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 300),
+        },
+      };
+
+      // Send in order: D, B, C, A (worst case for queue)
+      await exporter.exportTracingEvent(spanD);
+      await exporter.exportTracingEvent(spanB);
+      await exporter.exportTracingEvent(spanC);
+      await exporter.exportTracingEvent(spanA);
+
+      // Allow cascade processing: A enables B, B enables C, C enables D
+      await flushAsync(20);
+
+      // All should now be processed
+    });
+  });
+}
+
+/**
+ * Test late event handling (events arriving after spans end).
+ */
+export function runLateEventTests(factory: ExporterFactory, exporterName: string): void {
+  describe(`${exporterName}: Late event handling`, () => {
+    let exporter: TestableExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory();
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should process events during cleanup delay window', async () => {
+      const events = generateTrace({ depth: 2, breadth: 1, includeEvents: false });
+
+      // Send all events normally
+      await sendWithDelays(exporter, events);
+      await flushAsync(5);
+
+      // All spans have ended, cleanup is scheduled
+      // Send a late event before cleanup fires
+      const lateEvent: TracingEvent = {
+        type: 'span_ended',
+        exportedSpan: {
+          id: 'late-event',
+          traceId: events[0].exportedSpan.traceId,
+          parentSpanId: events[0].exportedSpan.id,
+          name: 'late-event',
+          type: 'EVENT' as any,
+          isRootSpan: false,
+          isEvent: true,
+          startTime: new Date(),
+          endTime: new Date(),
+        },
+      };
+
+      await exporter.exportTracingEvent(lateEvent);
+      await flushAsync(5);
+
+      // Event should have been processed
+    });
+
+    it('should handle data after cleanup completes', async () => {
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+
+      // Send all events
+      await sendWithDelays(exporter, events);
+      await flushAsync(5);
+
+      // Advance time past cleanup delay
+      vi.advanceTimersByTime(60000); // 60 seconds
+
+      // Try to send data for the (now cleaned up) trace
+      const veryLateEvent: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'very-late-span',
+          traceId: events[0].exportedSpan.traceId,
+          name: 'very-late-span',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(),
+        },
+      };
+
+      // Should not throw, should create new trace or handle gracefully
+      await exporter.exportTracingEvent(veryLateEvent);
+    });
+  });
+}
+
+/**
+ * Test orphaned span handling (parent never arrives).
+ */
+export function runOrphanedSpanTests(factory: ExporterFactory, exporterName: string): void {
+  describe(`${exporterName}: Orphaned span handling`, () => {
+    let exporter: TestableExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory();
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should drop spans after max attempts', async () => {
+      // Send a child without ever sending the parent
+      const orphanSpan: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'orphan-span',
+          traceId: `orphan-trace-${Date.now()}`,
+          parentSpanId: 'non-existent-parent',
+          name: 'orphan-span',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(),
+        },
+      };
+
+      await exporter.exportTracingEvent(orphanSpan);
+
+      // Trigger many processing attempts
+      for (let i = 0; i < 10; i++) {
+        await flushAsync(5);
+        vi.advanceTimersByTime(1000);
+      }
+
+      // Span should eventually be dropped (can't verify without access to logs)
+    });
+
+    it('should drop spans after TTL expiry', async () => {
+      const orphanSpan: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'ttl-orphan-span',
+          traceId: `ttl-orphan-trace-${Date.now()}`,
+          parentSpanId: 'non-existent-parent',
+          name: 'ttl-orphan-span',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(),
+        },
+      };
+
+      await exporter.exportTracingEvent(orphanSpan);
+
+      // Advance time past TTL (default 30 seconds)
+      vi.advanceTimersByTime(35000);
+      await flushAsync(5);
+
+      // Span should be dropped due to TTL
+    });
+  });
+}

--- a/observability/_test-utils/src/trace-generator.ts
+++ b/observability/_test-utils/src/trace-generator.ts
@@ -1,0 +1,293 @@
+/**
+ * Test trace generator for observability exporter testing.
+ * Generates realistic trace data with configurable depth and breadth.
+ */
+
+import type { TracingEvent, AnyExportedSpan } from '@mastra/core/observability';
+import { SpanType } from '@mastra/core/observability';
+
+export interface GenerateTraceOptions {
+  /** Number of levels deep (default: 3) */
+  depth?: number;
+  /** Number of children per span (default: 2) */
+  breadth?: number;
+  /** Include event spans (default: true) */
+  includeEvents?: boolean;
+  /** Custom trace ID (default: generated) */
+  traceId?: string;
+  /** Base timestamp (default: now) */
+  baseTime?: Date;
+  /** Time increment between spans in ms (default: 100) */
+  timeIncrementMs?: number;
+}
+
+interface SpanInfo {
+  id: string;
+  parentId?: string;
+  depth: number;
+  isRoot: boolean;
+  isEvent: boolean;
+}
+
+let spanCounter = 0;
+
+function generateSpanId(): string {
+  return `span-${++spanCounter}-${Date.now()}`;
+}
+
+function generateTraceId(): string {
+  return `trace-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Create an exported span with the given properties.
+ */
+function createExportedSpan(args: {
+  id: string;
+  traceId: string;
+  parentSpanId?: string;
+  name: string;
+  type: SpanType;
+  isRootSpan: boolean;
+  isEvent: boolean;
+  startTime: Date;
+  endTime?: Date;
+  input?: unknown;
+  output?: unknown;
+}): AnyExportedSpan {
+  return {
+    id: args.id,
+    traceId: args.traceId,
+    parentSpanId: args.parentSpanId,
+    name: args.name,
+    type: args.type,
+    isRootSpan: args.isRootSpan,
+    isEvent: args.isEvent,
+    startTime: args.startTime,
+    endTime: args.endTime,
+    input: args.input,
+    output: args.output,
+    tags: args.isRootSpan ? ['test-trace'] : undefined,
+  };
+}
+
+/**
+ * Create a tracing event for a span.
+ */
+function createTracingEvent(type: 'span_started' | 'span_updated' | 'span_ended', span: AnyExportedSpan): TracingEvent {
+  return {
+    type,
+    exportedSpan: span,
+  };
+}
+
+/**
+ * Generate a tree structure of span info.
+ */
+function generateSpanTree(opts: GenerateTraceOptions): SpanInfo[] {
+  const depth = opts.depth ?? 3;
+  const breadth = opts.breadth ?? 2;
+  const includeEvents = opts.includeEvents ?? true;
+
+  const spans: SpanInfo[] = [];
+
+  function addSpan(parentId: string | undefined, currentDepth: number, isEvent: boolean = false): string {
+    const id = generateSpanId();
+    spans.push({
+      id,
+      parentId,
+      depth: currentDepth,
+      isRoot: currentDepth === 0 && !isEvent,
+      isEvent,
+    });
+    return id;
+  }
+
+  function buildTree(parentId: string | undefined, currentDepth: number): void {
+    if (currentDepth >= depth) return;
+
+    // Create spans at this level
+    for (let i = 0; i < breadth; i++) {
+      const spanId = addSpan(parentId, currentDepth);
+
+      // Add events if enabled and not at root level
+      if (includeEvents && currentDepth > 0) {
+        addSpan(spanId, currentDepth, true);
+      }
+
+      // Recurse to create children
+      buildTree(spanId, currentDepth + 1);
+    }
+  }
+
+  // Create root span
+  const rootId = addSpan(undefined, 0);
+
+  // Build tree from root
+  buildTree(rootId, 1);
+
+  return spans;
+}
+
+/**
+ * Generate a complete trace with all events (start, update, end).
+ * Returns events in the natural order they would occur.
+ */
+export function generateTrace(opts: GenerateTraceOptions = {}): TracingEvent[] {
+  const traceId = opts.traceId ?? generateTraceId();
+  const baseTime = opts.baseTime ?? new Date();
+  const timeIncrement = opts.timeIncrementMs ?? 100;
+
+  const spanTree = generateSpanTree(opts);
+  const events: TracingEvent[] = [];
+  let currentTime = baseTime.getTime();
+
+  // Generate start events (in tree order - parents before children)
+  for (const spanInfo of spanTree) {
+    const startTime = new Date(currentTime);
+    currentTime += timeIncrement;
+
+    const span = createExportedSpan({
+      id: spanInfo.id,
+      traceId,
+      parentSpanId: spanInfo.parentId,
+      name: spanInfo.isEvent ? `event-${spanInfo.id}` : `span-${spanInfo.id}`,
+      type: spanInfo.isEvent ? SpanType.EVENT : spanInfo.isRoot ? SpanType.AGENT_RUN : SpanType.TOOL_CALL,
+      isRootSpan: spanInfo.isRoot,
+      isEvent: spanInfo.isEvent,
+      startTime,
+      input: { test: 'input' },
+    });
+
+    if (spanInfo.isEvent) {
+      // Events are single-shot
+      events.push(createTracingEvent('span_ended', { ...span, endTime: startTime }));
+    } else {
+      events.push(createTracingEvent('span_started', span));
+    }
+  }
+
+  // Generate end events (in reverse tree order - children before parents)
+  const nonEventSpans = spanTree.filter(s => !s.isEvent);
+  for (let i = nonEventSpans.length - 1; i >= 0; i--) {
+    const spanInfo = nonEventSpans[i];
+    const endTime = new Date(currentTime);
+    currentTime += timeIncrement;
+
+    const span = createExportedSpan({
+      id: spanInfo.id,
+      traceId,
+      parentSpanId: spanInfo.parentId,
+      name: `span-${spanInfo.id}`,
+      type: spanInfo.isRoot ? SpanType.AGENT_RUN : SpanType.TOOL_CALL,
+      isRootSpan: spanInfo.isRoot,
+      isEvent: false,
+      startTime: new Date(baseTime.getTime()), // Approximate
+      endTime,
+      output: { test: 'output' },
+    });
+
+    events.push(createTracingEvent('span_ended', span));
+  }
+
+  return events;
+}
+
+/**
+ * Shuffle events to simulate out-of-order arrival.
+ * Preserves that span_started comes before span_ended for same span.
+ */
+export function shuffleEvents(events: TracingEvent[]): TracingEvent[] {
+  // Separate start and end events
+  const startEvents = events.filter(e => e.type === 'span_started');
+  const endEvents = events.filter(e => e.type === 'span_ended' && !e.exportedSpan.isEvent);
+  const eventSpans = events.filter(e => e.exportedSpan.isEvent);
+
+  // Shuffle each group
+  const shuffled = (arr: TracingEvent[]) => {
+    const result = [...arr];
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  };
+
+  // Combine shuffled groups: some starts, some events, some ends, interleaved
+  const shuffledStarts = shuffled(startEvents);
+  const shuffledEnds = shuffled(endEvents);
+  const shuffledEvents = shuffled(eventSpans);
+
+  // Interleave in a way that still mostly makes sense
+  // (starts generally before ends, but not strictly)
+  const result: TracingEvent[] = [];
+  let startIdx = 0,
+    endIdx = 0,
+    eventIdx = 0;
+
+  while (startIdx < shuffledStarts.length || endIdx < shuffledEnds.length || eventIdx < shuffledEvents.length) {
+    const r = Math.random();
+    if (r < 0.5 && startIdx < shuffledStarts.length) {
+      result.push(shuffledStarts[startIdx++]);
+    } else if (r < 0.8 && eventIdx < shuffledEvents.length) {
+      result.push(shuffledEvents[eventIdx++]);
+    } else if (endIdx < shuffledEnds.length) {
+      result.push(shuffledEnds[endIdx++]);
+    } else if (startIdx < shuffledStarts.length) {
+      result.push(shuffledStarts[startIdx++]);
+    } else if (eventIdx < shuffledEvents.length) {
+      result.push(shuffledEvents[eventIdx++]);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Reorder events so children come before parents (worst case for early queue).
+ */
+export function reverseHierarchyOrder(events: TracingEvent[]): TracingEvent[] {
+  const startEvents = events.filter(e => e.type === 'span_started');
+  const endEvents = events.filter(e => e.type === 'span_ended' && !e.exportedSpan.isEvent);
+  const eventSpans = events.filter(e => e.exportedSpan.isEvent);
+
+  // Reverse start events so children come first
+  const reversedStarts = [...startEvents].reverse();
+  // Keep end events in original order (children end before parents)
+  // Reverse event spans too
+  const reversedEvents = [...eventSpans].reverse();
+
+  return [...reversedStarts, ...reversedEvents, ...endEvents];
+}
+
+/**
+ * Send events to an exporter with configurable delays.
+ */
+export async function sendWithDelays(
+  exporter: { exportTracingEvent: (event: TracingEvent) => Promise<void> },
+  events: TracingEvent[],
+  delayMs: number = 0,
+): Promise<void> {
+  for (const event of events) {
+    await exporter.exportTracingEvent(event);
+    if (delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
+/**
+ * Wait for setImmediate callbacks to complete.
+ */
+export function flushSetImmediate(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+/**
+ * Wait for multiple rounds of setImmediate (for cascading async processing).
+ */
+export async function flushSetImmediateMultiple(rounds: number = 5): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await flushSetImmediate();
+  }
+}

--- a/observability/braintrust/package.json
+++ b/observability/braintrust/package.json
@@ -41,6 +41,7 @@
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
+    "@observability/test-utils": "workspace:*",
     "@types/node": "22.13.17",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",

--- a/observability/braintrust/src/braintrust-nesting.test.ts
+++ b/observability/braintrust/src/braintrust-nesting.test.ts
@@ -17,9 +17,24 @@ import type { Logger, Span } from 'braintrust';
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { BraintrustExporter } from './tracing';
 
+class TestBraintrustExporter extends BraintrustExporter {
+  _getTraceData(traceId: string) {
+    return this.getTraceData({ traceId, method: 'test' });
+  }
+
+  get _traceMapSize(): number {
+    return this.traceMapSize();
+  }
+
+  get _isDisabled(): boolean {
+    return this.isDisabled;
+  }
+}
+
 // Helper to access internal Braintrust span properties
 // These become root_span_id and span_parents in the Braintrust API
-function getSpanInternals(span: Span) {
+function getSpanInternals(span: Span | undefined) {
+  expect(span).toBeDefined();
   return {
     spanId: (span as any)._spanId as string,
     rootSpanId: (span as any)._rootSpanId as string,
@@ -110,7 +125,7 @@ describe('Braintrust SDK - Direct startSpan() behavior', () => {
 
 describe('BraintrustExporter Integration - Non-External Case', () => {
   let logger: Logger<true>;
-  let exporter: BraintrustExporter;
+  let exporter: TestBraintrustExporter;
 
   beforeAll(async () => {
     logger = await initLogger({
@@ -120,7 +135,7 @@ describe('BraintrustExporter Integration - Non-External Case', () => {
   });
 
   beforeEach(() => {
-    exporter = new BraintrustExporter({
+    exporter = new TestBraintrustExporter({
       braintrustLogger: logger,
     });
   });
@@ -140,13 +155,12 @@ describe('BraintrustExporter Integration - Non-External Case', () => {
     });
 
     // Get the Braintrust span from the exporter's internal state
-    const spanData = (exporter as any).traceMap.get(mastraRoot.traceId);
-    expect(spanData).toBeDefined();
+    const traceData = exporter._getTraceData(mastraRoot.traceId);
 
-    const braintrustSpan = spanData.spans.get(mastraRoot.id);
+    const braintrustSpan = traceData.getSpan({ spanId: mastraRoot.id });
     expect(braintrustSpan).toBeDefined();
 
-    const internals = getSpanInternals(braintrustSpan);
+    const internals = getSpanInternals(braintrustSpan!);
 
     // Root span should have rootSpanId = its own spanId
     expect(internals.rootSpanId).toBe(internals.spanId);
@@ -197,10 +211,10 @@ describe('BraintrustExporter Integration - Non-External Case', () => {
     });
 
     // Get Braintrust spans from exporter
-    const spanData = (exporter as any).traceMap.get(mastraRoot.traceId);
-    const rootBt = spanData.spans.get('root-span');
-    const llmBt = spanData.spans.get('llm-span');
-    const toolBt = spanData.spans.get('tool-span');
+    const traceData = exporter._getTraceData(mastraRoot.traceId);
+    const rootBt = traceData.getSpan({ spanId: 'root-span' });
+    const llmBt = traceData.getSpan({ spanId: 'llm-span' });
+    const toolBt = traceData.getSpan({ spanId: 'tool-span' });
 
     const root = getSpanInternals(rootBt);
     const llm = getSpanInternals(llmBt);
@@ -255,11 +269,11 @@ describe('BraintrustExporter Integration - Non-External Case', () => {
       });
     }
 
-    const spanData = (exporter as any).traceMap.get(traceId);
-    const l1 = getSpanInternals(spanData.spans.get('l1'));
-    const l2 = getSpanInternals(spanData.spans.get('l2'));
-    const l3 = getSpanInternals(spanData.spans.get('l3'));
-    const l4 = getSpanInternals(spanData.spans.get('l4'));
+    const traceData = exporter._getTraceData(traceId);
+    const l1 = getSpanInternals(traceData.getSpan({ spanId: 'l1' }));
+    const l2 = getSpanInternals(traceData.getSpan({ spanId: 'l2' }));
+    const l3 = getSpanInternals(traceData.getSpan({ spanId: 'l3' }));
+    const l4 = getSpanInternals(traceData.getSpan({ spanId: 'l4' }));
 
     // All share rootSpanId
     expect(l1.rootSpanId).toBe(l1.spanId);
@@ -297,7 +311,7 @@ describe('BraintrustExporter Integration - External Case', () => {
     // Create exporter that will attach to the external span
     // We need to mock currentSpan() to return our external span
     // For this test, we'll use braintrustLogger with the external span directly
-    const exporter = new BraintrustExporter({
+    const exporter = new TestBraintrustExporter({
       braintrustLogger: externalSpan as any, // Treat external span as the "logger"
     });
 
@@ -329,9 +343,9 @@ describe('BraintrustExporter Integration - External Case', () => {
     });
 
     // Get Braintrust spans
-    const spanData = (exporter as any).traceMap.get(mastraRoot.traceId);
-    const rootBt = spanData.spans.get('mastra-root');
-    const childBt = spanData.spans.get('mastra-child');
+    const traceData = exporter._getTraceData(mastraRoot.traceId);
+    const rootBt = traceData.getSpan({ spanId: 'mastra-root' });
+    const childBt = traceData.getSpan({ spanId: 'mastra-child' });
 
     const root = getSpanInternals(rootBt);
     const child = getSpanInternals(childBt);
@@ -346,8 +360,8 @@ describe('BraintrustExporter Integration - External Case', () => {
     expect(child.spanParents).toEqual([root.spanId]);
 
     // Cleanup
-    childBt.end();
-    rootBt.end();
+    childBt!.end();
+    rootBt!.end();
     externalSpan.end();
   });
 });

--- a/observability/braintrust/src/tracing.early-data.test.ts
+++ b/observability/braintrust/src/tracing.early-data.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Early Data Handling Tests for Braintrust Exporter
+ *
+ * These tests verify that the Braintrust exporter correctly handles:
+ * - Out-of-order span arrival
+ * - Root spans arriving after children
+ * - Deep hierarchy cascading
+ * - Late events during cleanup delay
+ * - Orphaned span handling
+ *
+ * Braintrust uses skipBuildRootTask = false, meaning:
+ * - Root spans create a trace wrapper via _buildRoot
+ * - Child spans wait for root before processing
+ */
+
+import { describe, beforeEach, afterEach, vi, it, expect } from 'vitest';
+import {
+  runAllEarlyDataTests,
+  runLateEventTests,
+  runOrphanedSpanTests,
+  type ExporterFactory,
+} from '@observability/test-utils';
+import { BraintrustExporter } from './tracing';
+
+// Mock Braintrust to avoid real API calls
+vi.mock('braintrust', () => {
+  const mockSpan = {
+    id: 'mock-span',
+    startSpan: vi.fn(),
+    log: vi.fn(),
+    end: vi.fn(),
+  };
+  // Allow nested spans
+  mockSpan.startSpan.mockReturnValue(mockSpan);
+
+  const mockLogger = {
+    id: 'mock-logger',
+    startSpan: vi.fn().mockReturnValue(mockSpan),
+  };
+
+  return {
+    initLogger: vi.fn().mockResolvedValue(mockLogger),
+    currentSpan: vi.fn().mockReturnValue(mockSpan),
+  };
+});
+
+describe('BraintrustExporter Early Data Handling', () => {
+  const factory: ExporterFactory = () => {
+    return new BraintrustExporter({
+      apiKey: 'test-api-key',
+      // Use long cleanup delay to prevent cleanup during tests
+      traceCleanupDelayMs: 60 * 60 * 1000,
+    });
+  };
+
+  // Run shared early data test scenarios
+  runAllEarlyDataTests(factory, 'BraintrustExporter');
+  runLateEventTests(factory, 'BraintrustExporter');
+  runOrphanedSpanTests(factory, 'BraintrustExporter');
+
+  // Braintrust-specific tests
+  describe('Braintrust-specific behavior', () => {
+    let exporter: BraintrustExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory() as BraintrustExporter;
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should create trace wrapper for root span', async () => {
+      // Braintrust creates a wrapper via _buildRoot for the root span
+      // This test verifies the root span is properly identified
+      const { generateTrace, sendWithDelays } = await import('@observability/test-utils');
+
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+      const rootStart = events.find(e => e.type === 'span_started' && e.exportedSpan.isRootSpan);
+
+      expect(rootStart).toBeDefined();
+      expect(rootStart!.exportedSpan.isRootSpan).toBe(true);
+
+      await sendWithDelays(exporter, [rootStart!]);
+      // Use vi.advanceTimersToNextTimerAsync for fake timers
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersToNextTimerAsync();
+      }
+    });
+  });
+});

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -6,11 +6,11 @@
  * Events are handled as zero-duration spans with matching start/end times.
  */
 
-import type { TracingEvent, AnyExportedSpan, ModelGenerationAttributes } from '@mastra/core/observability';
+import type { AnyExportedSpan, ModelGenerationAttributes, SpanErrorInfo } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import { omitKeys } from '@mastra/core/utils';
-import { BaseExporter } from '@mastra/observability';
-import type { BaseExporterConfig } from '@mastra/observability';
+import { TrackingExporter } from '@mastra/observability';
+import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
 import { initLogger, currentSpan } from 'braintrust';
 import type { Span, Logger } from 'braintrust';
 import { formatUsageMetrics } from './metrics';
@@ -102,9 +102,7 @@ interface OpenAIMessage {
   [key: string]: unknown; // Allow additional properties
 }
 
-const MASTRA_TRACE_ID_METADATA_KEY = 'mastra-trace-id';
-
-export interface BraintrustExporterConfig extends BaseExporterConfig {
+export interface BraintrustExporterConfig extends TrackingExporterConfig {
   /**
    * Optional Braintrust logger instance.
    * When provided, enables integration with Braintrust contexts such as:
@@ -124,12 +122,11 @@ export interface BraintrustExporterConfig extends BaseExporterConfig {
   tuningParameters?: Record<string, any>;
 }
 
-type SpanData = {
-  logger: Logger<true> | Span; // Braintrust logger (for root spans) or external span
-  spans: Map<string, Span>; // Maps span.id to Braintrust span
-  activeIds: Set<string>; // Tracks started (non-event) spans not yet ended, including root
-  isExternal: boolean; // True if logger is an external span from logger.traced() or Eval()
-};
+type BraintrustRoot = Logger<true> | Span;
+type BraintrustSpan = Span;
+type BraintrustEvent = Span;
+type BraintrustMetadata = unknown;
+type BraintrustTraceData = TraceData<BraintrustRoot, BraintrustSpan, BraintrustEvent, BraintrustMetadata>;
 
 // Default span type for all spans
 const DEFAULT_SPAN_TYPE = 'task';
@@ -148,327 +145,169 @@ function mapSpanType(spanType: SpanType): 'llm' | 'score' | 'function' | 'eval' 
   return (SPAN_TYPE_EXCEPTIONS[spanType] as any) ?? DEFAULT_SPAN_TYPE;
 }
 
-export class BraintrustExporter extends BaseExporter {
+export class BraintrustExporter extends TrackingExporter<
+  BraintrustRoot,
+  BraintrustSpan,
+  BraintrustEvent,
+  BraintrustMetadata,
+  BraintrustExporterConfig
+> {
   name = 'braintrust';
-  private traceMap = new Map<string, SpanData>();
-  private config: BraintrustExporterConfig;
 
   // Flags and logger for context-aware mode
-  private useProvidedLogger: boolean;
-  private providedLogger?: Logger<true>;
+  #useProvidedLogger: boolean;
+  #providedLogger?: Logger<true>;
+  #localLogger?: Logger<true>;
 
   constructor(config: BraintrustExporterConfig = {}) {
-    super(config);
+    // Resolve env vars BEFORE calling super (config is readonly in base class)
+    const resolvedApiKey = config.apiKey ?? process.env.BRAINTRUST_API_KEY;
+    const resolvedEndpoint = config.endpoint ?? process.env.BRAINTRUST_ENDPOINT;
 
-    if (config.braintrustLogger) {
+    super({
+      ...config,
+      apiKey: resolvedApiKey,
+      endpoint: resolvedEndpoint,
+    });
+
+    this.#useProvidedLogger = !!config.braintrustLogger;
+
+    if (this.#useProvidedLogger) {
       // Use provided logger - enables Braintrust context integration
-      this.useProvidedLogger = true;
-      this.providedLogger = config.braintrustLogger;
-      this.config = config;
+      this.#providedLogger = config.braintrustLogger;
     } else {
-      // Read credentials from config or environment variables
-      const apiKey = config.apiKey ?? process.env.BRAINTRUST_API_KEY;
-      const endpoint = config.endpoint ?? process.env.BRAINTRUST_ENDPOINT;
-
       // Validate apiKey for creating loggers per trace
-      if (!apiKey) {
+      if (!this.config.apiKey) {
         this.setDisabled(
           `Missing required API key. Set BRAINTRUST_API_KEY environment variable or pass apiKey in config.`,
         );
-        this.config = null as any;
-        this.useProvidedLogger = false;
         return;
       }
-      this.useProvidedLogger = false;
-      this.config = {
-        ...config,
-        apiKey,
-        endpoint,
-      };
+      // lazy create logger on first rootSpan
+      this.#localLogger = undefined;
     }
   }
 
-  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
-    if (event.exportedSpan.isEvent) {
-      await this.handleEventSpan(event.exportedSpan);
-      return;
+  private async getLocalLogger(): Promise<Logger<true> | undefined> {
+    if (this.#localLogger) {
+      return this.#localLogger;
     }
-
-    switch (event.type) {
-      case 'span_started':
-        await this.handleSpanStarted(event.exportedSpan);
-        break;
-      case 'span_updated':
-        await this.handleSpanUpdateOrEnd(event.exportedSpan, false);
-        break;
-      case 'span_ended':
-        await this.handleSpanUpdateOrEnd(event.exportedSpan, true);
-        break;
-    }
-  }
-
-  private async handleSpanStarted(span: AnyExportedSpan): Promise<void> {
-    if (span.isRootSpan) {
-      if (this.useProvidedLogger) {
-        // Use provided logger, detect external Braintrust spans
-        await this.initLoggerOrUseContext(span);
-      } else {
-        // Create new logger per trace
-        await this.initLoggerPerTrace(span);
-      }
-    }
-
-    const method = 'handleSpanStarted';
-    const spanData = this.getSpanData({ span, method });
-    if (!spanData) {
-      return;
-    }
-
-    // Refcount: track active non-event spans (including root)
-    if (!span.isEvent) {
-      spanData.activeIds.add(span.id);
-    }
-
-    const braintrustParent = this.getBraintrustParent({ spanData, span, method });
-    if (!braintrustParent) {
-      return;
-    }
-
-    const payload = this.buildSpanPayload(span);
-
-    const braintrustSpan = braintrustParent.startSpan({
-      spanId: span.id,
-      name: span.name,
-      type: mapSpanType(span.type),
-      ...payload,
-    });
-
-    // Include the Mastra trace ID in the span metadata for correlation
-    // Also include tags if present (only for root spans)
-    braintrustSpan.log({
-      metadata: {
-        [MASTRA_TRACE_ID_METADATA_KEY]: span.traceId,
-      },
-      ...(span.isRootSpan && span.tags?.length ? { tags: span.tags } : {}),
-    });
-
-    spanData.spans.set(span.id, braintrustSpan);
-  }
-
-  private async handleSpanUpdateOrEnd(span: AnyExportedSpan, isEnd: boolean): Promise<void> {
-    const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
-
-    const spanData = this.getSpanData({ span, method });
-    if (!spanData) {
-      return;
-    }
-
-    const braintrustSpan = spanData.spans.get(span.id);
-    if (!braintrustSpan) {
-      this.logger.warn('Braintrust exporter: No Braintrust span found for span update/end', {
-        traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-        spanType: span.type,
-        isRootSpan: span.isRootSpan,
-        parentSpanId: span.parentSpanId,
-        method,
+    try {
+      return await initLogger({
+        projectName: this.config.projectName ?? 'mastra-tracing',
+        apiKey: this.config.apiKey,
+        appUrl: this.config.endpoint,
+        ...this.config.tuningParameters,
       });
-      return;
-    }
-
-    braintrustSpan.log(this.buildSpanPayload(span));
-
-    if (isEnd) {
-      // End the span with the correct endTime (convert milliseconds to seconds)
-      if (span.endTime) {
-        braintrustSpan.end({ endTime: span.endTime.getTime() / 1000 });
-      } else {
-        braintrustSpan.end();
-      }
-
-      // Refcount: mark this span as ended
-      if (!span.isEvent) {
-        spanData.activeIds.delete(span.id);
-      }
-
-      // If no more active spans remain for this trace, clean up the trace entry
-      // Don't clean up if using external spans (they're managed by Braintrust)
-      if (spanData.activeIds.size === 0 && !spanData.isExternal) {
-        this.traceMap.delete(span.traceId);
-      }
+    } catch (err) {
+      this.logger.error('Braintrust exporter: Failed to initialize logger', { error: err });
+      this.setDisabled('Failed to initialize Braintrust logger');
     }
   }
 
-  private async handleEventSpan(span: AnyExportedSpan): Promise<void> {
-    if (span.isRootSpan) {
-      this.logger.debug('Braintrust exporter: Creating logger for event', {
-        traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-        method: 'handleEventSpan',
-      });
-
-      if (this.useProvidedLogger) {
-        // Use provided logger, detect external Braintrust spans
-        await this.initLoggerOrUseContext(span);
-      } else {
-        // Create new logger per trace
-        await this.initLoggerPerTrace(span);
-      }
-    }
-
-    const method = 'handleEventSpan';
-    const spanData = this.getSpanData({ span, method });
-    if (!spanData) {
-      return;
-    }
-
-    const braintrustParent = this.getBraintrustParent({ spanData, span, method });
-    if (!braintrustParent) {
-      return;
-    }
-
+  private startSpan(args: { parent: Span | Logger<true>; span: AnyExportedSpan }): Span {
+    const { parent, span } = args;
     const payload = this.buildSpanPayload(span);
-
-    // Create zero-duration span for event (convert milliseconds to seconds)
-    const braintrustSpan = braintrustParent.startSpan({
+    return parent.startSpan({
       spanId: span.id,
       name: span.name,
       type: mapSpanType(span.type),
       startTime: span.startTime.getTime() / 1000,
       ...payload,
     });
-
-    braintrustSpan.end({ endTime: span.startTime.getTime() / 1000 });
   }
 
-  private initTraceMap(params: { traceId: string; isExternal: boolean; logger: Logger<true> | Span }): void {
-    const { traceId, isExternal, logger } = params;
-
-    // Check if trace already exists - reuse existing trace data
-    if (this.traceMap.has(traceId)) {
-      this.logger.debug('Braintrust exporter: Reusing existing trace from local map', { traceId });
-      return;
-    }
-
-    this.traceMap.set(traceId, {
-      logger,
-      spans: new Map(),
-      activeIds: new Set(),
-      isExternal,
-    });
-  }
-
-  /**
-   * Creates a new logger per trace using config credentials
-   */
-  private async initLoggerPerTrace(span: AnyExportedSpan): Promise<void> {
-    // Check if trace already exists - reuse existing trace data
-    if (this.traceMap.has(span.traceId)) {
-      this.logger.debug('Braintrust exporter: Reusing existing trace from local map', { traceId: span.traceId });
-      return;
-    }
-
-    // Guard against null config (when exporter is disabled)
-    if (!this.config) {
-      return;
-    }
-
-    try {
-      const loggerInstance = await initLogger({
-        projectName: this.config.projectName ?? 'mastra-tracing',
-        apiKey: this.config.apiKey,
-        appUrl: this.config.endpoint,
-        ...this.config.tuningParameters,
-      });
-
-      this.initTraceMap({ logger: loggerInstance, isExternal: false, traceId: span.traceId });
-    } catch (err) {
-      this.logger.error('Braintrust exporter: Failed to initialize logger', { error: err, traceId: span.traceId });
-      this.setDisabled('Failed to initialize Braintrust logger');
-    }
-  }
-
-  /**
-   * Uses provided logger and detects external Braintrust spans.
-   * If a Braintrust span is detected (from logger.traced() or Eval()), attaches to it.
-   * Otherwise, uses the provided logger instance.
-   */
-  private async initLoggerOrUseContext(span: AnyExportedSpan): Promise<void> {
-    // Check if trace already exists - reuse existing trace data
-    if (this.traceMap.has(span.traceId)) {
-      this.logger.debug('Braintrust exporter: Reusing existing trace from local map', { traceId: span.traceId });
-      return;
-    }
-
-    // Try to find a Braintrust span to attach to:
-    // 1. Auto-detect from Braintrust's current span (logger.traced(), Eval(), etc.)
-    // 2. Fall back to the configured logger
-    const braintrustSpan = currentSpan();
-
-    // Check if it's a valid span (not the NOOP_SPAN)
-    if (braintrustSpan && braintrustSpan.id) {
-      // External span detected - attach Mastra traces to it
-      this.initTraceMap({ logger: braintrustSpan, isExternal: true, traceId: span.traceId });
-    } else {
-      // No external span - use provided logger
-      this.initTraceMap({ logger: this.providedLogger!, isExternal: false, traceId: span.traceId });
-    }
-  }
-
-  private getSpanData(options: { span: AnyExportedSpan; method: string }): SpanData | undefined {
-    const { span, method } = options;
-    if (this.traceMap.has(span.traceId)) {
-      return this.traceMap.get(span.traceId);
-    }
-
-    this.logger.warn('Braintrust exporter: No span data found for span', {
-      traceId: span.traceId,
-      spanId: span.id,
-      spanName: span.name,
-      spanType: span.type,
-      isRootSpan: span.isRootSpan,
-      parentSpanId: span.parentSpanId,
-      method,
-    });
-  }
-
-  private getBraintrustParent(options: {
-    spanData: SpanData;
+  protected override async _buildRoot(_args: {
     span: AnyExportedSpan;
-    method: string;
-  }): Logger<true> | Span | undefined {
-    const { spanData, span, method } = options;
+    traceData: BraintrustTraceData;
+  }): Promise<BraintrustRoot | undefined> {
+    if (this.#useProvidedLogger) {
+      // Try to find a Braintrust span to attach to:
+      // 1. Auto-detect from Braintrust's current span (logger.traced(), Eval(), etc.)
+      // 2. Fall back to the configured logger
+      const externalSpan = currentSpan();
 
-    const parentId = span.parentSpanId;
-    if (!parentId) {
-      return spanData.logger;
+      // Check if it's a valid span (not the NOOP_SPAN)
+      if (externalSpan && externalSpan.id) {
+        // External span detected - attach Mastra traces to it
+        return externalSpan;
+      } else {
+        // No external span - use provided logger
+        return this.#providedLogger!;
+      }
+    } else {
+      // Use the local logger
+      return this.getLocalLogger();
+    }
+  }
+
+  protected override async _buildSpan(args: {
+    span: AnyExportedSpan;
+    traceData: BraintrustTraceData;
+  }): Promise<Span | undefined> {
+    const { span, traceData } = args;
+
+    if (span.isRootSpan) {
+      const root = traceData.getRoot();
+      if (root) {
+        return this.startSpan({ parent: root, span });
+      }
+    } else {
+      const parent = traceData.getParent(args);
+      if (parent) {
+        return this.startSpan({ parent, span });
+      }
+    }
+  }
+
+  protected override async _buildEvent(args: {
+    span: AnyExportedSpan;
+    traceData: BraintrustTraceData;
+  }): Promise<Span | undefined> {
+    const braintrustSpan = await this._buildSpan(args);
+
+    if (!braintrustSpan) {
+      // parent doesn't exist and not creating rootSpan, return early data
+      return;
     }
 
-    if (spanData.spans.has(parentId)) {
-      return spanData.spans.get(parentId);
-    }
+    braintrustSpan.end({ endTime: args.span.startTime.getTime() / 1000 });
+    return braintrustSpan;
+  }
 
-    // If the parent exists but is the root span (not represented as a Braintrust
-    // span because we use the logger as the root), attach to the logger so the
-    // span is not orphaned. We need to check if parentSpanId exists but the
-    // parent span is not in our spans map (indicating it's the root span).
-    if (parentId && !spanData.spans.has(parentId)) {
-      // This means the parent exists but isn't tracked as a Braintrust span,
-      // which happens when the parent is the root span (we use logger as root)
-      return spanData.logger;
-    }
+  protected override async _updateSpan(args: { span: AnyExportedSpan; traceData: BraintrustTraceData }): Promise<void> {
+    const { span, traceData } = args;
 
-    this.logger.warn('Braintrust exporter: No parent data found for span', {
-      traceId: span.traceId,
-      spanId: span.id,
-      spanName: span.name,
-      spanType: span.type,
-      isRootSpan: span.isRootSpan,
-      parentSpanId: span.parentSpanId,
-      method,
+    const braintrustSpan = traceData.getSpan({ spanId: span.id });
+    if (!braintrustSpan) {
+      return;
+    }
+    braintrustSpan.log(this.buildSpanPayload(span, false));
+  }
+
+  protected override async _finishSpan(args: { span: AnyExportedSpan; traceData: BraintrustTraceData }): Promise<void> {
+    const { span, traceData } = args;
+
+    const braintrustSpan = traceData.getSpan({ spanId: span.id });
+    if (!braintrustSpan) {
+      return;
+    }
+    braintrustSpan.log(this.buildSpanPayload(span, false));
+
+    if (span.endTime) {
+      braintrustSpan.end({ endTime: span.endTime.getTime() / 1000 });
+    } else {
+      braintrustSpan.end();
+    }
+  }
+
+  protected override async _abortSpan(args: { span: BraintrustSpan; reason: SpanErrorInfo }): Promise<void> {
+    const { span, reason } = args;
+    span.log({
+      error: reason.message,
+      metadata: { errorDetails: reason },
     });
+    span.end();
   }
 
   /**
@@ -695,7 +534,7 @@ export class BraintrustExporter extends BaseExporter {
     return output;
   }
 
-  private buildSpanPayload(span: AnyExportedSpan): Record<string, any> {
+  private buildSpanPayload(span: AnyExportedSpan, isCreate = true): Record<string, any> {
     const payload: Record<string, any> = {};
 
     if (span.input !== undefined) {
@@ -706,12 +545,20 @@ export class BraintrustExporter extends BaseExporter {
       payload.output = this.transformOutput(span.output, span.type);
     }
 
+    if (isCreate && span.isRootSpan && span.tags?.length) {
+      payload.tags = span.tags;
+    }
+
     // Initialize metrics and metadata objects
     payload.metrics = {};
     payload.metadata = {
       spanType: span.type,
       ...span.metadata,
     };
+
+    if (isCreate) {
+      payload.metadata['mastra-trace-id'] = span.traceId;
+    }
 
     const attributes = (span.attributes ?? {}) as Record<string, any>;
 
@@ -769,21 +616,5 @@ export class BraintrustExporter extends BaseExporter {
     }
 
     return payload;
-  }
-
-  async shutdown(): Promise<void> {
-    if (!this.config) {
-      return;
-    }
-
-    // End all active spans
-    for (const [_traceId, spanData] of this.traceMap) {
-      for (const [_spanId, span] of spanData.spans) {
-        span.end();
-      }
-      // Loggers don't have an explicit shutdown method
-    }
-    this.traceMap.clear();
-    await super.shutdown();
   }
 }

--- a/observability/langfuse/package.json
+++ b/observability/langfuse/package.json
@@ -38,6 +38,7 @@
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
+    "@observability/test-utils": "workspace:*",
     "@types/node": "22.13.17",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",

--- a/observability/langfuse/src/metrics.test.ts
+++ b/observability/langfuse/src/metrics.test.ts
@@ -1,6 +1,6 @@
 import type { UsageStats } from '@mastra/core/observability';
 import { describe, it, expect } from 'vitest';
-import { formatUsageMetrics } from './tracing';
+import { formatUsageMetrics } from './metrics';
 
 describe('formatUsageMetrics', () => {
   it('should extract basic tokens', () => {

--- a/observability/langfuse/src/metrics.ts
+++ b/observability/langfuse/src/metrics.ts
@@ -1,0 +1,52 @@
+import type { UsageStats } from '@mastra/core/observability';
+
+/**
+ * Token usage format compatible with Langfuse.
+ */
+export interface LangfuseUsageMetrics {
+  input?: number;
+  output?: number;
+  total?: number;
+  reasoning?: number;
+  cache_read_input_tokens?: number;
+  cache_write_input_tokens?: number;
+}
+
+/**
+ * Formats UsageStats to Langfuse's expected format.
+ */
+export function formatUsageMetrics(usage?: UsageStats): LangfuseUsageMetrics {
+  if (!usage) return {};
+
+  const metrics: LangfuseUsageMetrics = {};
+
+  if (usage.inputTokens !== undefined) {
+    metrics.input = usage.inputTokens;
+
+    if (usage.inputDetails?.cacheWrite !== undefined) {
+      metrics.cache_write_input_tokens = usage.inputDetails.cacheWrite;
+      metrics.input -= metrics.cache_write_input_tokens;
+    }
+  }
+
+  if (usage.inputDetails?.cacheRead !== undefined) {
+    metrics.cache_read_input_tokens = usage.inputDetails.cacheRead;
+  }
+
+  if (usage.outputTokens !== undefined) {
+    metrics.output = usage.outputTokens;
+  }
+
+  if (usage.outputDetails?.reasoning !== undefined) {
+    metrics.reasoning = usage.outputDetails.reasoning;
+  }
+
+  if (metrics.input && metrics.output) {
+    metrics.total = metrics.input + metrics.output;
+    if (metrics.cache_write_input_tokens) {
+      metrics.total += metrics.cache_write_input_tokens;
+    }
+  }
+
+  return metrics;
+}

--- a/observability/langfuse/src/tracing.early-data.test.ts
+++ b/observability/langfuse/src/tracing.early-data.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Early Data Handling Tests for Langfuse Exporter
+ *
+ * These tests verify that the Langfuse exporter correctly handles:
+ * - Out-of-order span arrival
+ * - Root spans arriving after children
+ * - Deep hierarchy cascading
+ * - Late events during cleanup delay
+ * - Orphaned span handling
+ *
+ * Langfuse uses skipBuildRootTask = false (default), meaning:
+ * - Root spans create a trace wrapper via _buildRoot
+ * - Child spans wait for root before processing
+ */
+
+import { describe, beforeEach, afterEach, vi, it, expect } from 'vitest';
+import {
+  runAllEarlyDataTests,
+  runLateEventTests,
+  runOrphanedSpanTests,
+  type ExporterFactory,
+} from '@observability/test-utils';
+import { LangfuseExporter } from './tracing';
+
+// Mock Langfuse to avoid real API calls
+vi.mock('langfuse', () => {
+  const createMockSpan = (): any => {
+    const mockSpan: any = {
+      id: `mock-span-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      span: vi.fn(),
+      generation: vi.fn(),
+      event: vi.fn(),
+      update: vi.fn(),
+      end: vi.fn(),
+    };
+    // Allow nested spans - create new instances for each call
+    mockSpan.span.mockImplementation(() => createMockSpan());
+    mockSpan.generation.mockImplementation(() => createMockSpan());
+    mockSpan.event.mockReturnValue({ id: 'mock-event' });
+    return mockSpan;
+  };
+
+  const createMockTrace = (): any => {
+    const mockSpan = createMockSpan();
+    return {
+      id: `mock-trace-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      span: vi.fn().mockImplementation(() => createMockSpan()),
+      generation: vi.fn().mockImplementation(() => createMockSpan()),
+      event: vi.fn().mockReturnValue({ id: 'mock-event' }),
+      update: vi.fn(),
+    };
+  };
+
+  // Use a class constructor for proper `new` support
+  class MockLangfuse {
+    trace = vi.fn().mockImplementation(() => createMockTrace());
+    score = vi.fn().mockResolvedValue(undefined);
+    flushAsync = vi.fn().mockResolvedValue(undefined);
+    shutdownAsync = vi.fn().mockResolvedValue(undefined);
+  }
+
+  return {
+    Langfuse: MockLangfuse,
+  };
+});
+
+describe('LangfuseExporter Early Data Handling', () => {
+  const factory: ExporterFactory = () => {
+    return new LangfuseExporter({
+      publicKey: 'test-public-key',
+      secretKey: 'test-secret-key',
+      // Use long cleanup delay to prevent cleanup during tests
+      traceCleanupDelayMs: 60 * 60 * 1000,
+    });
+  };
+
+  // Run shared early data test scenarios
+  runAllEarlyDataTests(factory, 'LangfuseExporter');
+  runLateEventTests(factory, 'LangfuseExporter');
+  runOrphanedSpanTests(factory, 'LangfuseExporter');
+
+  // Langfuse-specific tests
+  describe('Langfuse-specific behavior', () => {
+    let exporter: LangfuseExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory() as LangfuseExporter;
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should create trace wrapper for root span', async () => {
+      // Langfuse creates a wrapper via _buildRoot for the root span
+      // This test verifies the root span is properly identified
+      const { generateTrace, sendWithDelays } = await import('@observability/test-utils');
+
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+      const rootStart = events.find(e => e.type === 'span_started' && e.exportedSpan.isRootSpan);
+
+      expect(rootStart).toBeDefined();
+      expect(rootStart!.exportedSpan.isRootSpan).toBe(true);
+
+      await sendWithDelays(exporter, [rootStart!]);
+      // Use vi.advanceTimersToNextTimerAsync for fake timers
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersToNextTimerAsync();
+      }
+    });
+  });
+});

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -23,6 +23,16 @@ import type { LangfuseExporterConfig } from './tracing';
 // Mock Langfuse constructor (must be at the top level)
 vi.mock('langfuse');
 
+class TestLangfuseExporter extends LangfuseExporter {
+  _getTraceData(traceId: string) {
+    return this.getTraceData({ traceId, method: 'test' });
+  }
+
+  get _traceMapSize(): number {
+    return this.traceMapSize();
+  }
+}
+
 describe('LangfuseExporter', () => {
   // Mock objects
   let mockGeneration: any;
@@ -31,7 +41,7 @@ describe('LangfuseExporter', () => {
   let mockLangfuseClient: any;
   let LangfuseMock: any;
 
-  let exporter: LangfuseExporter;
+  let exporter: TestLangfuseExporter;
   let config: LangfuseExporterConfig;
 
   beforeEach(() => {
@@ -39,28 +49,41 @@ describe('LangfuseExporter', () => {
 
     // Set up mocks
     mockGeneration = {
-      update: vi.fn(),
+      kind: 'mockGeneration',
       event: vi.fn(),
+      generation: vi.fn(),
+      span: vi.fn(),
+      update: vi.fn(),
+      end: vi.fn(),
     };
 
+    // Set up circular reference
+    mockGeneration.generation.mockReturnValue(mockGeneration);
+
     mockSpan = {
+      kind: 'mockSpan',
       update: vi.fn(),
+      end: vi.fn(),
       generation: vi.fn().mockReturnValue(mockGeneration),
       span: vi.fn(),
       event: vi.fn(),
     };
 
+    // Set up circular reference
+    mockSpan.span.mockReturnValue(mockSpan);
+    mockGeneration.span.mockReturnValue(mockSpan);
+
     mockTrace = {
+      kind: 'mockTrace',
       generation: vi.fn().mockReturnValue(mockGeneration),
       span: vi.fn().mockReturnValue(mockSpan),
       update: vi.fn(),
+      end: vi.fn(),
       event: vi.fn(),
     };
 
-    // Set up circular reference
-    mockSpan.span.mockReturnValue(mockSpan);
-
     mockLangfuseClient = {
+      kind: 'mockLangfuseClient',
       trace: vi.fn().mockReturnValue(mockTrace),
       shutdownAsync: vi.fn().mockResolvedValue(undefined),
     };
@@ -80,9 +103,12 @@ describe('LangfuseExporter', () => {
         flushAt: 1,
         flushInterval: 1000,
       },
+      logLevel: 'debug',
+      // Short cleanup delay for faster tests
+      traceCleanupDelayMs: 10,
     };
 
-    exporter = new LangfuseExporter(config);
+    exporter = new TestLangfuseExporter(config);
   });
 
   describe('Initialization', () => {
@@ -100,63 +126,98 @@ describe('LangfuseExporter', () => {
     });
 
     it('should initialize without baseUrl (uses Langfuse default)', () => {
-      const configWithoutBaseUrl = {
-        publicKey: 'test-public-key',
-        secretKey: 'test-secret-key',
-      };
+      // Clear env var to ensure baseUrl comes from config only
+      const originalBaseUrl = process.env.LANGFUSE_BASE_URL;
+      delete process.env.LANGFUSE_BASE_URL;
 
-      const exporterWithoutBaseUrl = new LangfuseExporter(configWithoutBaseUrl);
+      try {
+        const configWithoutBaseUrl = {
+          publicKey: 'test-public-key',
+          secretKey: 'test-secret-key',
+        };
 
-      expect(exporterWithoutBaseUrl.name).toBe('langfuse');
-      expect(LangfuseMock).toHaveBeenCalledWith({
-        publicKey: 'test-public-key',
-        secretKey: 'test-secret-key',
-        baseUrl: undefined,
-      });
+        const exporterWithoutBaseUrl = new LangfuseExporter(configWithoutBaseUrl);
+
+        expect(exporterWithoutBaseUrl.name).toBe('langfuse');
+        expect(LangfuseMock).toHaveBeenCalledWith({
+          publicKey: 'test-public-key',
+          secretKey: 'test-secret-key',
+          baseUrl: undefined,
+        });
+      } finally {
+        if (originalBaseUrl) process.env.LANGFUSE_BASE_URL = originalBaseUrl;
+      }
     });
 
     it('should warn and disable exporter when publicKey is missing', () => {
-      const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // Clear env vars to ensure exporter is truly disabled
+      const originalPublicKey = process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_PUBLIC_KEY;
 
-      const exporterWithMissingKey = new LangfuseExporter({
-        secretKey: 'test-secret-key',
-        baseUrl: 'https://test-langfuse.com',
-      });
+      try {
+        const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      // Should create exporter but disable it
-      expect(exporterWithMissingKey.name).toBe('langfuse');
-      expect((exporterWithMissingKey as any).client).toBeNull();
+        const exporterWithMissingKey = new LangfuseExporter({
+          secretKey: 'test-secret-key',
+          baseUrl: 'https://test-langfuse.com',
+        });
 
-      mockConsoleWarn.mockRestore();
+        // Should create exporter but disable it
+        expect(exporterWithMissingKey.name).toBe('langfuse');
+        expect(exporterWithMissingKey.isDisabled).toBeTruthy();
+
+        mockConsoleWarn.mockRestore();
+      } finally {
+        if (originalPublicKey) process.env.LANGFUSE_PUBLIC_KEY = originalPublicKey;
+      }
     });
 
     it('should warn and disable exporter when secretKey is missing', () => {
-      const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // Clear env vars to ensure exporter is truly disabled
+      const originalSecretKey = process.env.LANGFUSE_SECRET_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
 
-      const exporterWithMissingKey = new LangfuseExporter({
-        publicKey: 'test-public-key',
-        baseUrl: 'https://test-langfuse.com',
-      });
+      try {
+        const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      // Should create exporter but disable it
-      expect(exporterWithMissingKey.name).toBe('langfuse');
-      expect((exporterWithMissingKey as any).client).toBeNull();
+        const exporterWithMissingKey = new LangfuseExporter({
+          publicKey: 'test-public-key',
+          baseUrl: 'https://test-langfuse.com',
+        });
 
-      mockConsoleWarn.mockRestore();
+        // Should create exporter but disable it
+        expect(exporterWithMissingKey.name).toBe('langfuse');
+        expect(exporterWithMissingKey.isDisabled).toBeTruthy();
+
+        mockConsoleWarn.mockRestore();
+      } finally {
+        if (originalSecretKey) process.env.LANGFUSE_SECRET_KEY = originalSecretKey;
+      }
     });
 
     it('should warn and disable exporter when both keys are missing', () => {
-      const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // Clear env vars to ensure exporter is truly disabled
+      const originalPublicKey = process.env.LANGFUSE_PUBLIC_KEY;
+      const originalSecretKey = process.env.LANGFUSE_SECRET_KEY;
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
 
-      const exporterWithMissingKeys = new LangfuseExporter({
-        baseUrl: 'https://test-langfuse.com',
-      });
+      try {
+        const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      // Should create exporter but disable it
-      expect(exporterWithMissingKeys.name).toBe('langfuse');
-      expect((exporterWithMissingKeys as any).client).toBeNull();
+        const exporterWithMissingKeys = new LangfuseExporter({
+          baseUrl: 'https://test-langfuse.com',
+        });
 
-      mockConsoleWarn.mockRestore();
+        // Should create exporter but disable it
+        expect(exporterWithMissingKeys.name).toBe('langfuse');
+        expect(exporterWithMissingKeys.isDisabled).toBeTruthy();
+
+        mockConsoleWarn.mockRestore();
+      } finally {
+        if (originalPublicKey) process.env.LANGFUSE_PUBLIC_KEY = originalPublicKey;
+        if (originalSecretKey) process.env.LANGFUSE_SECRET_KEY = originalSecretKey;
+      }
     });
   });
 
@@ -648,6 +709,7 @@ describe('LangfuseExporter', () => {
       // First, start a span
       const llmSpan = createMockSpan({
         id: 'llm-span',
+        traceId: 'llm-trace',
         name: 'gpt-4-call',
         type: SpanType.MODEL_GENERATION,
         isRoot: true,
@@ -718,6 +780,81 @@ describe('LangfuseExporter', () => {
         }),
         output: { result: 42 },
       });
+    });
+
+    it('should include input in update payload (MODEL_STEP pattern)', async () => {
+      // This test verifies the common pattern where MODEL_STEP spans:
+      // 1. Start empty (to capture start time early)
+      // 2. Get updated with input data later
+      // 3. End with the final data
+
+      // First create a root span (parent for the MODEL_STEP)
+      const rootSpan = createMockSpan({
+        id: 'root-span',
+        name: 'agent-run',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: rootSpan,
+      });
+
+      // Create MODEL_STEP span with no input (empty start to capture timing)
+      const modelStepSpan = createMockSpan({
+        id: 'model-step-span',
+        name: 'model-step',
+        type: SpanType.MODEL_STEP,
+        isRoot: false,
+        parentSpanId: 'root-span',
+        traceId: 'root-span',
+        attributes: {},
+        // Note: no input here - span starts empty
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: modelStepSpan,
+      });
+
+      // Verify span was created without input
+      expect(mockSpan.span).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'model-step-span',
+          name: 'model-step',
+        }),
+      );
+      expect(mockSpan.span).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          input: expect.anything(),
+        }),
+      );
+
+      // Clear mock to track update calls
+      mockSpan.update.mockClear();
+      // Get the nested span mock (what mockSpan.span returns)
+      const nestedSpan = mockSpan.span.mock.results[0]?.value;
+
+      // Update the span with input data (this is what happens in practice)
+      modelStepSpan.input = {
+        messages: [{ role: 'user', content: 'Hello, world!' }],
+      };
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_UPDATED,
+        exportedSpan: modelStepSpan,
+      });
+
+      // Verify update was called with the input
+      expect(nestedSpan.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: {
+            messages: [{ role: 'user', content: 'Hello, world!' }],
+          },
+        }),
+      );
     });
   });
 
@@ -797,6 +934,7 @@ describe('LangfuseExporter', () => {
         type: SpanType.AGENT_RUN,
         isRoot: true,
         attributes: {},
+        traceId: 'trace-id',
       });
 
       rootSpan.output = { result: 'success' };
@@ -807,10 +945,10 @@ describe('LangfuseExporter', () => {
         exportedSpan: rootSpan,
       });
 
+      const traceData = exporter._getTraceData(rootSpan.traceId);
+
       // Verify trace was created and span is tracked as active
-      expect((exporter as any).traceMap.has('root-span-id')).toBe(true);
-      const traceData = (exporter as any).traceMap.get('root-span-id');
-      expect(traceData.activeSpans.has('root-span-id')).toBe(true);
+      expect(traceData.isActiveSpan({ spanId: rootSpan.id })).toBe(true);
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_ENDED,
@@ -822,8 +960,14 @@ describe('LangfuseExporter', () => {
         output: { result: 'success' },
       });
 
+      // Wait for cleanup delay (config uses 10ms)
+      await new Promise(resolve => setTimeout(resolve, 20));
+
       // Trace should be cleaned up since this was the only active span
-      expect((exporter as any).traceMap.has('root-span-id')).toBe(false);
+      // (traceData is always created if it doesn't exist, but the old object
+      // should have been cleaned up.)
+      const newTraceData = exporter._getTraceData(rootSpan.traceId);
+      expect(traceData).not.toBe(newTraceData);
     });
   });
 
@@ -1011,6 +1155,8 @@ describe('LangfuseExporter', () => {
 
   describe('Out-of-order span handling with delayed ends', () => {
     it('should handle spans that end after parent trace is removed', async () => {
+      const traceId = 'out-of-order trace';
+
       // Create a root workflow span
       const workflowSpan = createMockSpan({
         id: 'workflow-1',
@@ -1018,6 +1164,7 @@ describe('LangfuseExporter', () => {
         type: SpanType.WORKFLOW_RUN,
         isRoot: true,
         attributes: { workflowId: 'wf-123' },
+        traceId,
       });
 
       // Create a child step span
@@ -1027,9 +1174,9 @@ describe('LangfuseExporter', () => {
         type: SpanType.WORKFLOW_STEP,
         isRoot: false,
         attributes: { stepId: 'step-1' },
+        traceId,
+        parentSpanId: workflowSpan.id,
       });
-      step1Span.traceId = 'workflow-1';
-      step1Span.parentSpanId = 'workflow-1';
 
       // Start workflow and step
       await exporter.exportTracingEvent({
@@ -1042,10 +1189,9 @@ describe('LangfuseExporter', () => {
         exportedSpan: step1Span,
       });
 
-      // Verify trace and spans are tracked
-      expect((exporter as any).traceMap.has('workflow-1')).toBe(true);
-      const traceInfo = (exporter as any).traceMap.get('workflow-1');
-      expect(traceInfo.spans.has('step-1')).toBe(true);
+      // Verify spans are tracked
+      const traceData = exporter._getTraceData(traceId);
+      expect(traceData.hasSpan({ spanId: 'step-1' })).toBe(true);
 
       // Clear mock calls to make assertions clearer
       mockTrace.span.mockClear();
@@ -1090,9 +1236,9 @@ describe('LangfuseExporter', () => {
         type: SpanType.WORKFLOW_STEP,
         isRoot: false,
         attributes: { stepId: 'step-2' },
+        traceId,
+        parentSpanId: workflowSpan.id,
       });
-      step2Span.traceId = 'workflow-1';
-      step2Span.parentSpanId = 'workflow-1';
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
@@ -1113,13 +1259,10 @@ describe('LangfuseExporter', () => {
         exportedSpan: workflowSpan,
       });
 
-      // Verify trace is still in map because step-2 hasn't ended yet
-      expect((exporter as any).traceMap.has('workflow-1')).toBe(true);
-      const traceData = (exporter as any).traceMap.get('workflow-1');
       // step-2 should still be in activeSpans
-      expect(traceData.activeSpans.has('step-2')).toBe(true);
-      expect(traceData.activeSpans.has('step-1')).toBe(false); // step-1 already ended
-      expect(traceData.activeSpans.has('workflow-1')).toBe(false); // workflow ended
+      expect(traceData.isActiveSpan({ spanId: 'step-2' })).toBe(true);
+      expect(traceData.isActiveSpan({ spanId: 'step-1' })).toBe(false); // step-1 already ended
+      expect(traceData.isActiveSpan({ spanId: 'workflow-1' })).toBe(false); // workflow ended
 
       // Now end step-2 (the last active span) AFTER the root ended
       step2Span.endTime = new Date();
@@ -1129,12 +1272,12 @@ describe('LangfuseExporter', () => {
         exportedSpan: step2Span,
       });
 
-      // NOW the trace should be cleaned up since all spans have ended
-      expect((exporter as any).traceMap.has('workflow-1')).toBe(false);
-
       // Clear mocks for late event testing
       mockSpan.update.mockClear();
       mockTrace.update.mockClear();
+
+      // Wait for cleanup delay (config uses 10ms)
+      await new Promise(resolve => setTimeout(resolve, 20));
 
       // Now try to send late updates/ends for already completed trace
       const lateStep1Update = createMockSpan({
@@ -1143,10 +1286,10 @@ describe('LangfuseExporter', () => {
         type: SpanType.WORKFLOW_STEP,
         isRoot: false,
         attributes: { stepId: 'step-1', lateUpdate: true },
+        traceId,
+        parentSpanId: workflowSpan.id,
+        output: { result: 'late-update' },
       });
-      lateStep1Update.traceId = 'workflow-1';
-      lateStep1Update.parentSpanId = 'workflow-1';
-      lateStep1Update.output = { result: 'late-update' };
 
       // This should handle gracefully without errors
       await exporter.exportTracingEvent({
@@ -1172,6 +1315,9 @@ describe('LangfuseExporter', () => {
         type: TracingEventType.SPAN_STARTED,
         exportedSpan: rootSpan,
       });
+
+      // get a pointer to the initial traceData for trace
+      const traceData = exporter._getTraceData('root-1');
 
       // Create multiple child spans
       const childSpans: AnyExportedSpan[] = [];
@@ -1241,9 +1387,15 @@ describe('LangfuseExporter', () => {
         exportedSpan: rootSpan,
       });
 
+      // Wait for cleanup delay (config uses 10ms)
+      await new Promise(resolve => setTimeout(resolve, 20));
+
       // All operations should complete without errors
       // Trace should be cleaned up since all spans have ended
-      expect((exporter as any).traceMap.has('root-1')).toBe(false);
+      // (traceData is always created if it doesn't exist, but the old object
+      // should have been cleaned up.)
+      const newTraceData = exporter._getTraceData('root-1');
+      expect(traceData).not.toBe(newTraceData);
     });
   });
 
@@ -1312,26 +1464,38 @@ describe('LangfuseExporter', () => {
     });
 
     it('should not call Langfuse client when client is null', async () => {
-      // Create exporter with missing keys to disable client
-      const disabledExporter = new LangfuseExporter({
-        baseUrl: 'https://test-langfuse.com',
-      });
+      // Save and clear env vars to ensure exporter is truly disabled
+      const originalPublicKey = process.env.LANGFUSE_PUBLIC_KEY;
+      const originalSecretKey = process.env.LANGFUSE_SECRET_KEY;
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
 
-      const scoreData = {
-        traceId: 'trace-123',
-        spanId: 'span-456',
-        score: 0.8,
-        reason: 'Test score',
-        scorerName: 'test-scorer',
-        metadata: {
-          sessionId: 'session-789',
-        },
-      };
+      try {
+        // Create exporter with missing keys to disable client
+        const disabledExporter = new LangfuseExporter({
+          baseUrl: 'https://test-langfuse.com',
+        });
 
-      await disabledExporter.addScoreToTrace(scoreData);
+        const scoreData = {
+          traceId: 'trace-123',
+          spanId: 'span-456',
+          score: 0.8,
+          reason: 'Test score',
+          scorerName: 'test-scorer',
+          metadata: {
+            sessionId: 'session-789',
+          },
+        };
 
-      // Should not call Langfuse client
-      expect(mockLangfuseClient.score).not.toHaveBeenCalled();
+        await disabledExporter.addScoreToTrace(scoreData);
+
+        // Should not call Langfuse client
+        expect(mockLangfuseClient.score).not.toHaveBeenCalled();
+      } finally {
+        // Restore env vars
+        if (originalPublicKey) process.env.LANGFUSE_PUBLIC_KEY = originalPublicKey;
+        if (originalSecretKey) process.env.LANGFUSE_SECRET_KEY = originalSecretKey;
+      }
     });
 
     it('should handle Langfuse client errors gracefully', async () => {
@@ -1715,6 +1879,7 @@ describe('LangfuseExporter', () => {
     it('should inherit langfuse prompt from AGENT_RUN root span to child MODEL_GENERATION span', async () => {
       // First, create a root AGENT_RUN span with langfuse prompt metadata
       // (simulates: tracingOptions: buildTracingOptions(withLangfusePrompt(prompt)))
+      const traceId = 'traceId';
       const agentSpan = createMockSpan({
         id: 'agent-span-id',
         name: 'support-agent',
@@ -1733,6 +1898,7 @@ describe('LangfuseExporter', () => {
             },
           },
         },
+        traceId,
       });
 
       await exporter.exportTracingEvent({
@@ -1756,8 +1922,8 @@ describe('LangfuseExporter', () => {
           runId: 'run-123',
           threadId: 'thread-456',
         },
+        traceId,
       });
-      llmSpan.traceId = 'agent-span-id';
       llmSpan.parentSpanId = 'agent-span-id';
 
       await exporter.exportTracingEvent({
@@ -2863,8 +3029,8 @@ describe('LangfuseExporter', () => {
       });
 
       // Verify maps have data
-      expect((exporter as any).traceMap.size).toBeGreaterThan(0);
-      expect((exporter as any).traceMap.get('test-span').spans.size).toBeGreaterThan(0);
+      const traceData = exporter._getTraceData('test-span');
+      expect(traceData.activeSpanCount()).toBeGreaterThan(0);
 
       // Shutdown
       await exporter.shutdown();
@@ -2873,7 +3039,7 @@ describe('LangfuseExporter', () => {
       expect(mockLangfuseClient.shutdownAsync).toHaveBeenCalled();
 
       // Verify maps were cleared
-      expect((exporter as any).traceMap.size).toBe(0);
+      expect(exporter._traceMapSize).toBe(0);
     });
   });
 });

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -6,15 +6,16 @@
  * MODEL_GENERATION spans become Langfuse generations, all others become spans.
  */
 
-import type { TracingEvent, AnyExportedSpan, ModelGenerationAttributes, UsageStats } from '@mastra/core/observability';
+import type { AnyExportedSpan, ModelGenerationAttributes, SpanErrorInfo } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import { omitKeys } from '@mastra/core/utils';
-import { BaseExporter } from '@mastra/observability';
-import type { BaseExporterConfig } from '@mastra/observability';
+import { TrackingExporter } from '@mastra/observability';
+import type { TrackingExporterConfig, TraceData } from '@mastra/observability';
 import { Langfuse } from 'langfuse';
 import type { LangfuseTraceClient, LangfuseSpanClient, LangfuseGenerationClient, LangfuseEventClient } from 'langfuse';
+import { formatUsageMetrics } from './metrics';
 
-export interface LangfuseExporterConfig extends BaseExporterConfig {
+export interface LangfuseExporterConfig extends TrackingExporterConfig {
   /** Langfuse API key */
   publicKey?: string;
   /** Langfuse secret key */
@@ -29,88 +30,42 @@ export interface LangfuseExporterConfig extends BaseExporterConfig {
 
 type LangfusePromptData = { name?: string; version?: number; id?: string };
 
-type SpanMetadata = {
-  parentSpanId?: string;
-  langfusePrompt?: LangfusePromptData;
-};
-
-type TraceData = {
-  trace: LangfuseTraceClient; // Langfuse trace object
-  spans: Map<string, LangfuseSpanClient | LangfuseGenerationClient>; // Maps span.id to Langfuse span/generation
-  spanMetadata: Map<string, SpanMetadata>; // Maps span.id to span metadata for prompt inheritance
-  events: Map<string, LangfuseEventClient>; // Maps span.id to Langfuse event
-  activeSpans: Set<string>; // Tracks which spans haven't ended yet
-  rootSpanId?: string; // Track the root span ID
-};
-
-type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient | LangfuseEventClient;
-
 /**
- * Token usage format compatible with Langfuse.
+ * With Langfuse, data from the root span is stored in both the Root and the
+ * first span.
  */
-export interface LangfuseUsageMetrics {
-  input?: number;
-  output?: number;
-  total?: number;
-  reasoning?: number;
-  cache_read_input_tokens?: number;
-  cache_write_input_tokens?: number;
-}
 
-/**
- * Formats UsageStats to Langfuse's expected format.
- */
-export function formatUsageMetrics(usage?: UsageStats): LangfuseUsageMetrics {
-  if (!usage) return {};
+type LangfuseRoot = LangfuseTraceClient;
+type LangfuseSpan = LangfuseSpanClient | LangfuseGenerationClient;
+type LangfuseEvent = LangfuseEventClient;
+type LangfuseMetadata = { prompt?: LangfusePromptData };
+type LangfuseTraceData = TraceData<LangfuseRoot, LangfuseSpan, LangfuseEvent, LangfuseMetadata>;
 
-  const metrics: LangfuseUsageMetrics = {};
-
-  if (usage.inputTokens !== undefined) {
-    metrics.input = usage.inputTokens;
-
-    if (usage.inputDetails?.cacheWrite !== undefined) {
-      metrics.cache_write_input_tokens = usage.inputDetails.cacheWrite;
-      metrics.input -= metrics.cache_write_input_tokens;
-    }
-  }
-
-  if (usage.inputDetails?.cacheRead !== undefined) {
-    metrics.cache_read_input_tokens = usage.inputDetails.cacheRead;
-  }
-
-  if (usage.outputTokens !== undefined) {
-    metrics.output = usage.outputTokens;
-  }
-
-  if (usage.outputDetails?.reasoning !== undefined) {
-    metrics.reasoning = usage.outputDetails.reasoning;
-  }
-
-  if (metrics.input && metrics.output) {
-    metrics.total = metrics.input + metrics.output;
-    if (metrics.cache_write_input_tokens) {
-      metrics.total += metrics.cache_write_input_tokens;
-    }
-  }
-
-  return metrics;
-}
-
-export class LangfuseExporter extends BaseExporter {
+export class LangfuseExporter extends TrackingExporter<
+  LangfuseRoot,
+  LangfuseSpan,
+  LangfuseEvent,
+  LangfuseMetadata,
+  LangfuseExporterConfig
+> {
   name = 'langfuse';
-  private client: Langfuse;
-  private realtime: boolean;
-  private traceMap = new Map<string, TraceData>();
+  #client: Langfuse | undefined;
+  #realtime: boolean;
 
   constructor(config: LangfuseExporterConfig = {}) {
-    super(config);
-
-    this.realtime = config.realtime ?? false;
-
-    // Read credentials from config or environment variables
+    // Resolve env vars BEFORE calling super (config is readonly in base class)
     const publicKey = config.publicKey ?? process.env.LANGFUSE_PUBLIC_KEY;
     const secretKey = config.secretKey ?? process.env.LANGFUSE_SECRET_KEY;
     const baseUrl = config.baseUrl ?? process.env.LANGFUSE_BASE_URL;
+
+    super({
+      ...config,
+      publicKey,
+      secretKey,
+      baseUrl,
+    });
+
+    this.#realtime = config.realtime ?? false;
 
     if (!publicKey || !secretKey) {
       const publicKeySource = config.publicKey
@@ -127,12 +82,10 @@ export class LangfuseExporter extends BaseExporter {
         `Missing required credentials (publicKey: ${publicKeySource}, secretKey: ${secretKeySource}). ` +
           `Set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY environment variables or pass them in config.`,
       );
-      // Set client to null - safety is ensured by the isDisabled flag set above
-      this.client = null as any;
       return;
     }
 
-    this.client = new Langfuse({
+    this.#client = new Langfuse({
       publicKey,
       secretKey,
       baseUrl,
@@ -140,51 +93,46 @@ export class LangfuseExporter extends BaseExporter {
     });
   }
 
-  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
-    if (event.exportedSpan.isEvent) {
-      await this.handleEventSpan(event.exportedSpan);
-      return;
-    }
-
-    switch (event.type) {
-      case 'span_started':
-        await this.handleSpanStarted(event.exportedSpan);
-        break;
-      case 'span_updated':
-        await this.handleSpanUpdateOrEnd(event.exportedSpan, false);
-        break;
-      case 'span_ended':
-        await this.handleSpanUpdateOrEnd(event.exportedSpan, true);
-        break;
-    }
-
+  protected override async _postExportTracingEvent(): Promise<void> {
     // Flush immediately in realtime mode for instant visibility
-    if (this.realtime) {
-      await this.client.flushAsync();
+    if (this.#realtime) {
+      await this.#client?.flushAsync();
     }
   }
 
-  private async handleSpanStarted(span: AnyExportedSpan): Promise<void> {
-    if (span.isRootSpan) {
-      this.initTrace(span);
-    }
-    const method = 'handleSpanStarted';
+  protected override async _buildRoot(args: {
+    span: AnyExportedSpan;
+    traceData: LangfuseTraceData;
+  }): Promise<LangfuseTraceClient | undefined> {
+    const { span } = args;
+    // Note: If the traceId already exists in Langfuse (e.g., from a previous server instance
+    // or session), the Langfuse SDK handles this gracefully. Calling client.trace() with
+    // an existing ID is idempotent - it will update/continue the existing trace rather than
+    // failing or creating a duplicate. This is by design for distributed tracing scenarios.
+    // See: https://langfuse.com/docs/tracing-features/trace-ids
+    return this.#client?.trace(this.buildTracePayload(span));
+  }
 
-    const traceData = this.getTraceData({ span, method });
-    if (!traceData) {
+  protected override async _buildEvent(args: {
+    span: AnyExportedSpan;
+    traceData: LangfuseTraceData;
+  }): Promise<LangfuseEvent | undefined> {
+    const { span, traceData } = args;
+    const langfuseParent = traceData.getParentOrRoot({ span });
+    if (!langfuseParent) {
       return;
     }
 
-    // Store span metadata for prompt inheritance lookup (for non-root spans)
-    if (!span.isRootSpan) {
-      const langfuseData = span.metadata?.langfuse as { prompt?: LangfusePromptData } | undefined;
-      traceData.spanMetadata.set(span.id, {
-        parentSpanId: span.parentSpanId,
-        langfusePrompt: langfuseData?.prompt,
-      });
-    }
+    const payload = this.buildSpanPayload(span, true, traceData);
+    return langfuseParent.event(payload);
+  }
 
-    const langfuseParent = this.getLangfuseParent({ traceData, span, method });
+  protected override async _buildSpan(args: {
+    span: AnyExportedSpan;
+    traceData: LangfuseTraceData;
+  }): Promise<LangfuseSpan | undefined> {
+    const { span, traceData } = args;
+    const langfuseParent = traceData.getParentOrRoot({ span });
     if (!langfuseParent) {
       return;
     }
@@ -194,178 +142,51 @@ export class LangfuseExporter extends BaseExporter {
     const langfuseSpan =
       span.type === SpanType.MODEL_GENERATION ? langfuseParent.generation(payload) : langfuseParent.span(payload);
 
-    traceData.spans.set(span.id, langfuseSpan);
-    traceData.activeSpans.add(span.id); // Track as active
+    this.logger.debug(`${this.name}: built span`, {
+      traceId: span.traceId,
+      spanId: payload.id,
+      method: '_buildSpan',
+    });
+
+    return langfuseSpan;
   }
 
-  private async handleSpanUpdateOrEnd(span: AnyExportedSpan, isEnd: boolean): Promise<void> {
-    const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
-
-    const traceData = this.getTraceData({ span, method });
-    if (!traceData) {
-      return;
-    }
-
-    const langfuseSpan = traceData.spans.get(span.id);
-    if (!langfuseSpan) {
-      // For event spans that only send SPAN_ENDED, we might not have the span yet
-      if (isEnd && span.isEvent) {
-        // Just make sure it's not in active spans
-        traceData.activeSpans.delete(span.id);
-        if (traceData.activeSpans.size === 0) {
-          this.traceMap.delete(span.traceId);
-        }
-        return;
-      }
-
-      this.logger.warn('Langfuse exporter: No Langfuse span found for span update/end', {
+  protected override async _updateSpan(args: { span: AnyExportedSpan; traceData: LangfuseTraceData }): Promise<void> {
+    const { span, traceData } = args;
+    const langfuseSpan = traceData.getSpan({ spanId: span.id });
+    if (langfuseSpan) {
+      this.logger.debug(`${this.name}: found span for update`, {
         traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-        spanType: span.type,
-        isRootSpan: span.isRootSpan,
-        parentSpanId: span.parentSpanId,
-        method,
+        spanId: langfuseSpan.id,
+        method: '_updateSpan',
       });
-      return;
-    }
 
+      const updatePayload = this.buildSpanPayload(span, false, traceData);
+
+      // use update for both update & end, so that we can use the
+      // end time we set when ending the span.
+      langfuseSpan.update(updatePayload);
+    }
+  }
+
+  protected override async _finishSpan(args: { span: AnyExportedSpan; traceData: LangfuseTraceData }): Promise<void> {
+    const { span, traceData } = args;
+    const langfuseSpan = traceData.getSpan({ spanId: span.id });
     // use update for both update & end, so that we can use the
     // end time we set when ending the span.
-    langfuseSpan.update(this.buildSpanPayload(span, false, traceData));
+    langfuseSpan?.update(this.buildSpanPayload(span, false, traceData));
 
-    if (isEnd) {
-      // Remove from active spans
-      traceData.activeSpans.delete(span.id);
-
-      if (span.isRootSpan) {
-        traceData.trace.update({ output: span.output });
-      }
-
-      // Only clean up the trace when ALL spans have ended
-      if (traceData.activeSpans.size === 0) {
-        this.traceMap.delete(span.traceId);
-      }
-    }
-  }
-
-  private async handleEventSpan(span: AnyExportedSpan): Promise<void> {
     if (span.isRootSpan) {
-      this.logger.debug('Langfuse exporter: Creating trace', {
-        traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-        method: 'handleEventSpan',
-      });
-      this.initTrace(span);
-    }
-    const method = 'handleEventSpan';
-
-    const traceData = this.getTraceData({ span, method });
-    if (!traceData) {
-      return;
-    }
-
-    const langfuseParent = this.getLangfuseParent({ traceData, span, method });
-    if (!langfuseParent) {
-      return;
-    }
-
-    const payload = this.buildSpanPayload(span, true, traceData);
-
-    const langfuseEvent = langfuseParent.event(payload);
-
-    traceData.events.set(span.id, langfuseEvent);
-
-    // Event spans are typically immediately ended, but let's track them properly
-    if (!span.endTime) {
-      traceData.activeSpans.add(span.id);
+      const langfuseRoot = traceData.getRoot();
+      langfuseRoot?.update({ output: span.output });
     }
   }
 
-  private initTrace(span: AnyExportedSpan): void {
-    // Check if trace already exists in our local traceMap
-    // This allows multiple root spans (e.g., from multiple agent.stream calls)
-    // to be grouped under the same Langfuse trace
-    if (this.traceMap.has(span.traceId)) {
-      this.logger.debug('Langfuse exporter: Reusing existing trace from local map', {
-        traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-      });
-      return; // Reuse existing trace
-    }
-
-    // Note: If the traceId already exists in Langfuse (e.g., from a previous server instance
-    // or session), the Langfuse SDK handles this gracefully. Calling client.trace() with
-    // an existing ID is idempotent - it will update/continue the existing trace rather than
-    // failing or creating a duplicate. This is by design for distributed tracing scenarios.
-    // See: https://langfuse.com/docs/tracing-features/trace-ids
-    const trace = this.client.trace(this.buildTracePayload(span));
-
-    // Extract langfuse prompt data from root span
-    const langfuseData = span.metadata?.langfuse as { prompt?: LangfusePromptData } | undefined;
-    const spanMetadata = new Map<string, SpanMetadata>();
-
-    // Store root span metadata for prompt inheritance
-    spanMetadata.set(span.id, {
-      parentSpanId: undefined,
-      langfusePrompt: langfuseData?.prompt,
-    });
-
-    this.traceMap.set(span.traceId, {
-      trace,
-      spans: new Map(),
-      spanMetadata,
-      events: new Map(),
-      activeSpans: new Set(),
-      rootSpanId: span.id,
-    });
-  }
-
-  private getTraceData(options: { span: AnyExportedSpan; method: string }): TraceData | undefined {
-    const { span, method } = options;
-
-    if (this.traceMap.has(span.traceId)) {
-      return this.traceMap.get(span.traceId);
-    }
-
-    this.logger.warn('Langfuse exporter: No trace data found for span', {
-      traceId: span.traceId,
-      spanId: span.id,
-      spanName: span.name,
-      spanType: span.type,
-      isRootSpan: span.isRootSpan,
-      parentSpanId: span.parentSpanId,
-      method,
-    });
-  }
-
-  private getLangfuseParent(options: {
-    traceData: TraceData;
-    span: AnyExportedSpan;
-    method: string;
-  }): LangfuseParent | undefined {
-    const { traceData, span, method } = options;
-
-    const parentId = span.parentSpanId;
-    if (!parentId) {
-      return traceData.trace;
-    }
-    if (traceData.spans.has(parentId)) {
-      return traceData.spans.get(parentId);
-    }
-    if (traceData.events.has(parentId)) {
-      return traceData.events.get(parentId);
-    }
-    this.logger.warn('Langfuse exporter: No parent data found for span', {
-      traceId: span.traceId,
-      spanId: span.id,
-      spanName: span.name,
-      spanType: span.type,
-      isRootSpan: span.isRootSpan,
-      parentSpanId: span.parentSpanId,
-      method,
+  protected override async _abortSpan(args: { span: LangfuseSpan; reason: SpanErrorInfo }): Promise<void> {
+    const { span, reason } = args;
+    span.end({
+      level: 'ERROR',
+      statusMessage: reason.message,
     });
   }
 
@@ -393,54 +214,55 @@ export class LangfuseExporter extends BaseExporter {
   }
 
   /**
-   * Look up the Langfuse prompt from the closest parent span that has one.
+   * Look up the Langfuse prompt from the closest span that has one.
    * This enables prompt inheritance for MODEL_GENERATION spans when the prompt
    * is set on a parent span (e.g., AGENT_RUN) rather than directly on the generation.
+   * This enables prompt linking when:
+   * - A workflow calls multiple agents, each with different prompts
+   * - Nested agents have different prompts
+   * - The prompt is set on AGENT_RUN but MODEL_GENERATION inherits it
    */
-  private findParentLangfusePrompt(traceData: TraceData, span: AnyExportedSpan): LangfusePromptData | undefined {
-    let currentSpanId = span.parentSpanId;
+  private findLangfusePrompt(traceData: LangfuseTraceData, span: AnyExportedSpan): LangfusePromptData | undefined {
+    let currentSpanId: string | undefined = span.id;
 
     while (currentSpanId) {
-      const parentMetadata = traceData.spanMetadata.get(currentSpanId);
-      if (parentMetadata?.langfusePrompt) {
-        return parentMetadata.langfusePrompt;
+      const providerMetadata = traceData.getMetadata({ spanId: currentSpanId });
+
+      if (providerMetadata?.prompt) {
+        this.logger.debug(`${this.name}: found prompt in provider metadata`, {
+          traceId: span.traceId,
+          spanId: span.id,
+          prompt: providerMetadata?.prompt,
+        });
+        return providerMetadata.prompt;
       }
-      currentSpanId = parentMetadata?.parentSpanId;
+      currentSpanId = traceData.getParentId({ spanId: currentSpanId });
     }
 
     return undefined;
   }
 
-  private buildSpanPayload(span: AnyExportedSpan, isCreate: boolean, traceData?: TraceData): Record<string, any> {
+  private buildSpanPayload(
+    span: AnyExportedSpan,
+    isCreate: boolean,
+    traceData: LangfuseTraceData,
+  ): Record<string, any> {
     const payload: Record<string, any> = {};
 
     if (isCreate) {
       payload.id = span.id;
       payload.name = span.name;
       payload.startTime = span.startTime;
-      if (span.input !== undefined) payload.input = span.input;
     }
 
+    if (span.input !== undefined) payload.input = span.input;
     if (span.output !== undefined) payload.output = span.output;
     if (span.endTime !== undefined) payload.endTime = span.endTime;
 
     const attributes = (span.attributes ?? {}) as Record<string, any>;
 
-    // For MODEL_GENERATION spans without langfuse metadata, look up the closest
-    // parent span that has langfuse prompt data. This enables prompt linking when:
-    // - A workflow calls multiple agents, each with different prompts
-    // - Nested agents have different prompts
-    // - The prompt is set on AGENT_RUN but MODEL_GENERATION inherits it
-    const resolvedTraceData = traceData ?? this.traceMap.get(span.traceId);
-    let inheritedLangfusePrompt: LangfusePromptData | undefined;
-
-    if (span.type === SpanType.MODEL_GENERATION && !span.metadata?.langfuse && resolvedTraceData) {
-      inheritedLangfusePrompt = this.findParentLangfusePrompt(resolvedTraceData, span);
-    }
-
     const metadata: Record<string, any> = {
       ...span.metadata,
-      ...(inheritedLangfusePrompt ? { langfuse: { prompt: inheritedLangfusePrompt } } : {}),
     };
 
     // Strip special fields from metadata if used in top-level keys
@@ -465,16 +287,12 @@ export class LangfuseExporter extends BaseExporter {
         attributesToOmit.push('parameters');
       }
 
-      // Handle Langfuse prompt linking
       // Users can set metadata.langfuse.prompt to link generations to Langfuse Prompt Management
       // Supported formats:
       // - { id } - link by prompt UUID alone
       // - { name, version } - link by name and version
       // - { name, version, id } - link with all fields
-      const langfuseData = metadata.langfuse as
-        | { prompt?: { name?: string; version?: number; id?: string } }
-        | undefined;
-      const promptData = langfuseData?.prompt;
+      const promptData = this.findLangfusePrompt(traceData, span);
       const hasNameAndVersion = promptData?.name !== undefined && promptData?.version !== undefined;
       const hasId = promptData?.id !== undefined;
 
@@ -524,10 +342,10 @@ export class LangfuseExporter extends BaseExporter {
     scorerName: string;
     metadata?: Record<string, any>;
   }): Promise<void> {
-    if (!this.client) return;
+    if (!this.#client) return;
 
     try {
-      await this.client.score({
+      await this.#client.score({
         id: `${traceId}-${scorerName}`,
         traceId,
         observationId: spanId,
@@ -547,11 +365,9 @@ export class LangfuseExporter extends BaseExporter {
     }
   }
 
-  async shutdown(): Promise<void> {
-    if (this.client) {
-      await this.client.shutdownAsync();
+  override async _postShutdown(): Promise<void> {
+    if (this.#client) {
+      await this.#client.shutdownAsync();
     }
-    this.traceMap.clear();
-    await super.shutdown();
   }
 }

--- a/observability/langsmith/package.json
+++ b/observability/langsmith/package.json
@@ -39,6 +39,7 @@
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
+    "@observability/test-utils": "workspace:*",
     "@types/node": "22.13.17",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",

--- a/observability/langsmith/src/tracing.early-data.test.ts
+++ b/observability/langsmith/src/tracing.early-data.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Early Data Handling Tests for LangSmith Exporter
+ *
+ * These tests verify that the LangSmith exporter correctly handles:
+ * - Out-of-order span arrival
+ * - Root spans arriving after children
+ * - Deep hierarchy cascading
+ * - Late events during cleanup delay
+ * - Orphaned span handling
+ *
+ * LangSmith uses skipBuildRootTask = true, meaning:
+ * - Root spans do NOT create a separate trace wrapper
+ * - Root spans are just top-level RunTrees
+ * - Child spans still wait for their parent (including root) before processing
+ */
+
+import { describe, beforeEach, afterEach, vi, it, expect } from 'vitest';
+import {
+  runAllEarlyDataTests,
+  runLateEventTests,
+  runOrphanedSpanTests,
+  type ExporterFactory,
+} from '@observability/test-utils';
+import { LangSmithExporter } from './tracing';
+
+// Mock LangSmith to avoid real API calls
+vi.mock('langsmith', () => {
+  // Use classes for proper `new` support
+  class MockRunTree {
+    id: string;
+    name: string;
+    inputs: Record<string, unknown> = {};
+    outputs: Record<string, unknown> = {};
+    metadata: Record<string, unknown> = {};
+    error?: string;
+
+    constructor() {
+      this.id = `mock-run-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      this.name = 'mock-run';
+    }
+
+    createChild = vi.fn().mockImplementation(() => new MockRunTree());
+    postRun = vi.fn().mockResolvedValue(undefined);
+    patchRun = vi.fn().mockResolvedValue(undefined);
+    end = vi.fn().mockResolvedValue(undefined);
+    addEvent = vi.fn();
+  }
+
+  class MockClient {
+    createRun = vi.fn().mockResolvedValue(undefined);
+    updateRun = vi.fn().mockResolvedValue(undefined);
+  }
+
+  return {
+    Client: MockClient,
+    RunTree: MockRunTree,
+  };
+});
+
+describe('LangSmithExporter Early Data Handling', () => {
+  const factory: ExporterFactory = () => {
+    return new LangSmithExporter({
+      apiKey: 'test-api-key',
+      // Use long cleanup delay to prevent cleanup during tests
+      traceCleanupDelayMs: 60 * 60 * 1000,
+    });
+  };
+
+  // Run shared early data test scenarios
+  runAllEarlyDataTests(factory, 'LangSmithExporter');
+  runLateEventTests(factory, 'LangSmithExporter');
+  runOrphanedSpanTests(factory, 'LangSmithExporter');
+
+  // LangSmith-specific tests
+  describe('LangSmith-specific behavior', () => {
+    let exporter: LangSmithExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory() as LangSmithExporter;
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should handle root spans as top-level RunTrees (no trace wrapper)', async () => {
+      // LangSmith uses skipBuildRootTask = true, so root spans
+      // are processed directly as RunTrees without a wrapper
+      const { generateTrace, sendWithDelays } = await import('@observability/test-utils');
+
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+      const rootStart = events.find(e => e.type === 'span_started' && e.exportedSpan.isRootSpan);
+
+      expect(rootStart).toBeDefined();
+      expect(rootStart!.exportedSpan.isRootSpan).toBe(true);
+
+      await sendWithDelays(exporter, [rootStart!]);
+      // Use vi.advanceTimersToNextTimerAsync for fake timers
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersToNextTimerAsync();
+      }
+    });
+  });
+});

--- a/observability/langsmith/src/tracing.ts
+++ b/observability/langsmith/src/tracing.ts
@@ -6,17 +6,17 @@
  * Events are handled as zero-duration RunTrees with matching start/end times.
  */
 
-import type { TracingEvent, AnyExportedSpan, ModelGenerationAttributes } from '@mastra/core/observability';
+import type { AnyExportedSpan, ModelGenerationAttributes, SpanErrorInfo } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import { omitKeys } from '@mastra/core/utils';
-import { BaseExporter } from '@mastra/observability';
-import type { BaseExporterConfig } from '@mastra/observability';
+import { TrackingExporter } from '@mastra/observability';
+import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
 import type { ClientConfig, RunTreeConfig } from 'langsmith';
 import { Client, RunTree } from 'langsmith';
 import type { KVMap } from 'langsmith/schemas';
 import { formatUsageMetrics } from './metrics';
 
-export interface LangSmithExporterConfig extends ClientConfig, BaseExporterConfig {
+export interface LangSmithExporterConfig extends ClientConfig, TrackingExporterConfig {
   /** LangSmith client instance */
   client?: Client;
   /**
@@ -27,10 +27,11 @@ export interface LangSmithExporterConfig extends ClientConfig, BaseExporterConfi
   projectName?: string;
 }
 
-type SpanData = {
-  spans: Map<string, RunTree>; // Maps span.id to LangSmith RunTrees
-  activeIds: Set<string>; // Tracks started (non-event) spans not yet ended, including root
-};
+type LangSmithRoot = undefined;
+type LangSmithSpan = RunTree;
+type LangSmithEvent = RunTree;
+type LangSmithMetadata = unknown;
+type LangSmithTraceData = TraceData<LangSmithRoot, LangSmithSpan, LangSmithEvent, LangSmithMetadata>;
 
 // Default span type for all spans
 const DEFAULT_SPAN_TYPE = 'chain';
@@ -53,140 +54,134 @@ function isKVMap(value: unknown): value is KVMap {
   return value != null && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date);
 }
 
-export class LangSmithExporter extends BaseExporter {
-  name = 'langsmith';
-  private traceMap = new Map<string, SpanData>();
-  private config: LangSmithExporterConfig;
-  private client: Client;
+export class LangSmithExporter extends TrackingExporter<
+  LangSmithRoot,
+  LangSmithSpan,
+  LangSmithEvent,
+  LangSmithMetadata,
+  LangSmithExporterConfig
+> {
+  override name = 'langsmith';
+  #client: Client | undefined;
 
-  constructor(config: LangSmithExporterConfig) {
-    super(config);
+  constructor(config: LangSmithExporterConfig = {}) {
+    // Resolve env vars BEFORE calling super (config is readonly in base class)
+    const apiKey = config.apiKey ?? process.env.LANGSMITH_API_KEY;
 
-    config.apiKey = config.apiKey ?? process.env.LANGSMITH_API_KEY;
+    super({
+      ...config,
+      apiKey,
+    });
 
-    if (!config.apiKey) {
-      this.setDisabled(`Missing required credentials (apiKey: ${!!config.apiKey})`);
-      this.config = null as any;
-      this.client = null as any;
+    if (!apiKey) {
+      this.setDisabled(`Missing required credentials (apiKey: ${!!apiKey})`);
       return;
     }
 
-    this.client = config.client ?? new Client(config);
-    this.config = config;
+    this.#client = config.client ?? new Client(this.config);
   }
 
-  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
-    if (event.exportedSpan.isEvent) {
-      await this.handleEventSpan(event.exportedSpan);
-      return;
-    }
-
-    switch (event.type) {
-      case 'span_started':
-        await this.handleSpanStarted(event.exportedSpan);
-        break;
-      case 'span_updated':
-        await this.handleSpanUpdateOrEnd(event.exportedSpan, false);
-        break;
-      case 'span_ended':
-        await this.handleSpanUpdateOrEnd(event.exportedSpan, true);
-        break;
-    }
+  protected override skipBuildRootTask = true;
+  protected override async _buildRoot(_args: {
+    span: AnyExportedSpan;
+    traceData: LangSmithTraceData;
+  }): Promise<LangSmithRoot | undefined> {
+    throw new Error('Method not implemented.');
   }
 
-  private initializeRootSpan(span: AnyExportedSpan) {
-    // Check if trace already exists - reuse existing trace data
-    if (this.traceMap.has(span.traceId)) {
-      this.logger.debug('LangSmith exporter: Reusing existing trace from local map', {
-        traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-      });
+  protected override async _buildSpan(args: {
+    span: AnyExportedSpan;
+    traceData: LangSmithTraceData;
+  }): Promise<LangSmithSpan | undefined> {
+    const { span, traceData } = args;
+
+    const parent = span.isRootSpan ? undefined : traceData.getParent(args);
+
+    if (!span.isRootSpan && !parent) {
+      // parent doesn't exist and not creating rootSpan, return early data
       return;
-    }
-
-    this.traceMap.set(span.traceId, { spans: new Map(), activeIds: new Set() });
-  }
-
-  private async handleSpanStarted(span: AnyExportedSpan): Promise<void> {
-    this.logger.debug('LangSmith exporter: handleSpanStarted', span.id, span.name);
-    if (span.isRootSpan) {
-      this.initializeRootSpan(span);
-    }
-
-    const method = 'handleSpanStarted';
-    const spanData = this.getSpanData({ span, method });
-    if (!spanData) {
-      return;
-    }
-
-    // Refcount: track active non-event spans (including root)
-    if (!span.isEvent) {
-      spanData.activeIds.add(span.id);
     }
 
     const payload = {
       name: span.name,
-      run_type: mapSpanType(span.type),
-      ...this.buildRunTreePayload(span),
+      ...this.buildRunTreePayload(span, true),
     };
 
-    const langsmithParent = this.getLangSmithParent({ spanData, span, method });
-    let langsmithRunTree: RunTree;
-    if (!langsmithParent) {
-      langsmithRunTree = new RunTree(payload);
-    } else {
-      langsmithRunTree = langsmithParent.createChild(payload);
-    }
+    const langSmithSpan = span.isRootSpan ? new RunTree(payload) : parent!.createChild(payload);
 
-    spanData.spans.set(span.id, langsmithRunTree);
-
-    await langsmithRunTree.postRun();
+    await langSmithSpan.postRun();
+    return langSmithSpan;
   }
 
-  private async handleSpanUpdateOrEnd(span: AnyExportedSpan, isEnd: boolean): Promise<void> {
-    this.logger.debug('LangSmith exporter: handleSpanUpdateOrEnd', span.id, span.name, 'isEnd:', isEnd);
-    const method = isEnd ? 'handleSpanEnd' : 'handleSpanUpdate';
+  protected override async _buildEvent(args: {
+    span: AnyExportedSpan;
+    traceData: LangSmithTraceData;
+  }): Promise<LangSmithEvent | undefined> {
+    const langSmithSpan = await this._buildSpan(args);
 
-    const spanData = this.getSpanData({ span, method });
-    if (!spanData) {
+    if (!langSmithSpan) {
+      // parent doesn't exist and not creating rootSpan, return early data
       return;
     }
 
-    const langsmithRunTree = spanData.spans.get(span.id);
-    if (!langsmithRunTree) {
-      this.logger.warn('LangSmith exporter: No LangSmith span found for span update/end', {
-        traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-        spanType: span.type,
-        isRootSpan: span.isRootSpan,
-        parentSpanId: span.parentSpanId,
-        method,
-      });
+    // use start-time as end-time to make an event span.
+    await langSmithSpan.end({ endTime: args.span.startTime.getTime() / 1000 });
+    await langSmithSpan.patchRun();
+  }
+
+  protected override async _updateSpan(args: { span: AnyExportedSpan; traceData: LangSmithTraceData }): Promise<void> {
+    await this.handleSpanUpdateOrEnd({ ...args, isEnd: false });
+  }
+
+  protected override async _finishSpan(args: { span: AnyExportedSpan; traceData: LangSmithTraceData }): Promise<void> {
+    await this.handleSpanUpdateOrEnd({ ...args, isEnd: true });
+  }
+
+  protected override async _abortSpan(args: { span: LangSmithSpan; reason: SpanErrorInfo }): Promise<void> {
+    const { span, reason } = args;
+    span.error = reason.message;
+    span.metadata = {
+      ...span.metadata,
+      errorDetails: reason,
+    };
+    await span.end();
+    await span.patchRun();
+  }
+
+  private async handleSpanUpdateOrEnd(args: {
+    span: AnyExportedSpan;
+    traceData: LangSmithTraceData;
+    isEnd: boolean;
+  }): Promise<void> {
+    const { span, traceData, isEnd } = args;
+
+    const langSmithSpan = traceData.getSpan({ spanId: span.id });
+    if (!langSmithSpan) {
+      //update occurred before span start, return early data
       return;
     }
 
     const updatePayload = this.buildRunTreePayload(span);
-    langsmithRunTree.metadata = {
-      ...langsmithRunTree.metadata,
+
+    langSmithSpan.metadata = {
+      ...langSmithSpan.metadata,
       ...updatePayload.metadata,
     };
     if (updatePayload.inputs != null) {
-      langsmithRunTree.inputs = updatePayload.inputs;
+      langSmithSpan.inputs = updatePayload.inputs;
     }
     if (updatePayload.outputs != null) {
-      langsmithRunTree.outputs = updatePayload.outputs;
+      langSmithSpan.outputs = updatePayload.outputs;
     }
     if (updatePayload.error != null) {
-      langsmithRunTree.error = updatePayload.error;
+      langSmithSpan.error = updatePayload.error;
     }
 
     // Add new_token event for TTFT tracking on MODEL_GENERATION spans
     if (span.type === SpanType.MODEL_GENERATION) {
       const modelAttr = (span.attributes ?? {}) as ModelGenerationAttributes;
       if (modelAttr.completionStartTime !== undefined) {
-        langsmithRunTree.addEvent({
+        langSmithSpan.addEvent({
           name: 'new_token',
           time: modelAttr.completionStartTime.toISOString(),
         });
@@ -196,120 +191,27 @@ export class LangSmithExporter extends BaseExporter {
     if (isEnd) {
       // End the span with the correct endTime (convert milliseconds to seconds)
       if (span.endTime) {
-        await langsmithRunTree.end({ endTime: span.endTime.getTime() / 1000 });
+        await langSmithSpan.end({ endTime: span.endTime.getTime() / 1000 });
       } else {
-        await langsmithRunTree.end();
-      }
-      await langsmithRunTree.patchRun();
-
-      // Refcount: mark this span as ended
-      if (!span.isEvent) {
-        spanData.activeIds.delete(span.id);
-      }
-
-      // If no more active spans remain for this trace, clean up the trace entry
-      if (spanData.activeIds.size === 0) {
-        this.traceMap.delete(span.traceId);
+        await langSmithSpan.end();
       }
     }
+    await langSmithSpan.patchRun();
   }
 
-  private async handleEventSpan(span: AnyExportedSpan): Promise<void> {
-    if (span.isRootSpan) {
-      this.logger.debug('LangSmith exporter: Creating logger for event', {
-        traceId: span.traceId,
-        spanId: span.id,
-        spanName: span.name,
-        method: 'handleEventSpan',
-      });
-      this.initializeRootSpan(span);
-    }
-
-    const method = 'handleEventSpan';
-    const spanData = this.getSpanData({ span, method });
-    if (!spanData) {
-      return;
-    }
-
-    const langsmithParent = this.getLangSmithParent({ spanData, span, method });
-    const payload = {
-      ...this.buildRunTreePayload(span),
-      name: span.name,
-      type: mapSpanType(span.type),
-      startTime: span.startTime.getTime() / 1000,
-    };
-
-    let langsmithRunTree: RunTree;
-    if (!langsmithParent) {
-      langsmithRunTree = new RunTree(payload);
-    } else {
-      langsmithRunTree = langsmithParent.createChild(payload);
-    }
-
-    await langsmithRunTree.postRun();
-
-    await langsmithRunTree.end({ endTime: span.startTime.getTime() / 1000 });
-    await langsmithRunTree.patchRun();
-  }
-
-  private getSpanData(options: { span: AnyExportedSpan; method: string }): SpanData | undefined {
-    const { span, method } = options;
-    if (this.traceMap.has(span.traceId)) {
-      return this.traceMap.get(span.traceId);
-    }
-
-    this.logger.warn('LangSmith exporter: No span data found for span', {
-      traceId: span.traceId,
-      spanId: span.id,
-      spanName: span.name,
-      spanType: span.type,
-      isRootSpan: span.isRootSpan,
-      parentSpanId: span.parentSpanId,
-      method,
-    });
-  }
-
-  private getLangSmithParent(options: {
-    spanData: SpanData;
-    span: AnyExportedSpan;
-    method: string;
-  }): RunTree | undefined {
-    const { spanData, span, method } = options;
-
-    const parentId = span.parentSpanId;
-    if (!parentId) {
-      return undefined;
-    }
-
-    if (spanData.spans.has(parentId)) {
-      return spanData.spans.get(parentId);
-    }
-
-    if (parentId && !spanData.spans.has(parentId)) {
-      // This means the parent exists but isn't tracked as a LangSmith span,
-      // which happens when the parent is the root span
-      return undefined;
-    }
-
-    this.logger.warn('LangSmith exporter: No parent data found for span', {
-      traceId: span.traceId,
-      spanId: span.id,
-      spanName: span.name,
-      spanType: span.type,
-      isRootSpan: span.isRootSpan,
-      parentSpanId: span.parentSpanId,
-      method,
-    });
-  }
-
-  private buildRunTreePayload(span: AnyExportedSpan): Partial<RunTreeConfig> {
+  private buildRunTreePayload(span: AnyExportedSpan, isNew = false): Partial<RunTreeConfig> {
     const payload: Partial<RunTreeConfig> & { metadata: KVMap } = {
-      client: this.client,
+      client: this.#client,
       metadata: {
         mastra_span_type: span.type,
         ...span.metadata,
       },
     };
+
+    if (isNew) {
+      payload.run_type = mapSpanType(span.type);
+      payload.start_time = span.startTime.getTime() / 1000;
+    }
 
     // Add project name if configured
     if (this.config.projectName) {
@@ -378,21 +280,5 @@ export class LangSmithExporter extends BaseExporter {
     }
 
     return payload;
-  }
-
-  async shutdown(): Promise<void> {
-    if (!this.config) {
-      return;
-    }
-
-    // End all active spans
-    for (const [_traceId, spanData] of this.traceMap) {
-      for (const [_spanId, runTree] of spanData.spans) {
-        await runTree.end();
-        await runTree.patchRun();
-      }
-    }
-    this.traceMap.clear();
-    await super.shutdown();
   }
 }

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -59,7 +59,12 @@ export abstract class BaseExporter implements ObservabilityExporter {
   protected logger: IMastraLogger;
 
   /** Whether this exporter is disabled */
-  protected isDisabled: boolean = false;
+  #disabled: boolean = false;
+
+  /** Public getter for disabled state */
+  get isDisabled(): boolean {
+    return this.#disabled;
+  }
 
   /**
    * Initialize the base exporter with logger
@@ -110,7 +115,7 @@ export abstract class BaseExporter implements ObservabilityExporter {
    * @param reason - Reason why the exporter is disabled
    */
   protected setDisabled(reason: string): void {
-    this.isDisabled = true;
+    this.#disabled = true;
     this.logger.warn(`${this.name} disabled: ${reason}`);
   }
 

--- a/observability/mastra/src/exporters/index.ts
+++ b/observability/mastra/src/exporters/index.ts
@@ -4,10 +4,10 @@
 
 // Base exporter classes and types
 export * from './base';
+export * from './tracking';
 
 // Core types and interfaces
-export { CloudExporter } from './cloud';
-export type { CloudExporterConfig } from './cloud';
+export * from './cloud';
 export * from './console';
 export * from './default';
 export * from './test';

--- a/observability/mastra/src/exporters/tracking.test.ts
+++ b/observability/mastra/src/exporters/tracking.test.ts
@@ -1,0 +1,1025 @@
+/**
+ * Unit tests for TrackingExporter base class.
+ *
+ * These tests verify:
+ * - Early queue processing (waiting for root, waiting for parent)
+ * - Cascading async processing
+ * - TTL and max attempts limits
+ * - Delayed cleanup scheduling
+ * - Soft and hard cap enforcement
+ * - Shutdown behavior
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { TracingEvent, AnyExportedSpan, SpanErrorInfo } from '@mastra/core/observability';
+import { SpanType } from '@mastra/core/observability';
+import { TrackingExporter } from './tracking';
+import type { TraceData, TrackingExporterConfig } from './tracking';
+
+// ============================================================================
+// Inline Test Utilities (avoid cyclic dependency with @observability/test-utils)
+// ============================================================================
+
+interface TestTrackingExporterConfig extends TrackingExporterConfig {
+  /** Simulate _buildSpan returning undefined for specific span IDs */
+  failBuildSpanFor?: string[];
+  /** Simulate _buildEvent returning undefined for specific span IDs */
+  failBuildEventFor?: string[];
+  /** Skip building root (like LangSmith) */
+  skipRoot?: boolean;
+}
+
+type TestRootData = { type: 'root'; spanId: string };
+type TestSpanData = { type: 'span'; spanId: string };
+type TestEventData = { type: 'event'; spanId: string };
+type TestMetadata = Record<string, unknown>;
+type TestTraceData = TraceData<TestRootData, TestSpanData, TestEventData, TestMetadata>;
+
+interface MethodCall {
+  method: string;
+  spanId: string;
+  traceId: string;
+  timestamp: Date;
+  args?: Record<string, unknown>;
+}
+
+class TestTrackingExporter extends TrackingExporter<
+  TestRootData,
+  TestSpanData,
+  TestEventData,
+  TestMetadata,
+  TestTrackingExporterConfig
+> {
+  name = 'test-exporter';
+
+  // Track all method calls for verification
+  public calls: MethodCall[] = [];
+
+  // Track built spans/events for verification
+  public builtRoots: Map<string, TestRootData> = new Map();
+  public builtSpans: Map<string, TestSpanData> = new Map();
+  public builtEvents: Map<string, TestEventData> = new Map();
+  public abortedSpans: Map<string, SpanErrorInfo> = new Map();
+
+  // Track root span ID for parent checking
+  private rootSpanId?: string;
+
+  private failBuildSpanFor: Set<string>;
+  private failBuildEventFor: Set<string>;
+
+  constructor(config: TestTrackingExporterConfig = {}) {
+    super(config);
+
+    this.failBuildSpanFor = new Set(config.failBuildSpanFor ?? []);
+    this.failBuildEventFor = new Set(config.failBuildEventFor ?? []);
+
+    if (config.skipRoot) {
+      this.skipBuildRootTask = true;
+    }
+  }
+
+  // Allow test access to protected method
+  public async exportTracingEvent(event: Parameters<typeof this._exportTracingEvent>[0]): Promise<void> {
+    return this._exportTracingEvent(event);
+  }
+
+  // Get trace map size for verification
+  public getTraceMapSize(): number {
+    return this.traceMapSize();
+  }
+
+  protected override async _buildRoot(args: {
+    span: AnyExportedSpan;
+    traceData: TestTraceData;
+  }): Promise<TestRootData | undefined> {
+    this.calls.push({
+      method: '_buildRoot',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+
+    const rootData: TestRootData = { type: 'root', spanId: args.span.id };
+    this.builtRoots.set(args.span.id, rootData);
+    this.rootSpanId = args.span.id;
+    return rootData;
+  }
+
+  protected override async _buildSpan(args: {
+    span: AnyExportedSpan;
+    traceData: TestTraceData;
+  }): Promise<TestSpanData | undefined> {
+    this.calls.push({
+      method: '_buildSpan',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+
+    // Simulate failure if configured
+    if (this.failBuildSpanFor.has(args.span.id)) {
+      return undefined;
+    }
+
+    // Check if parent exists (simulate real exporter behavior)
+    // For non-root spans, we need the actual parent to exist (not just root)
+    if (!args.span.isRootSpan) {
+      const parentId = args.span.parentSpanId;
+      if (parentId) {
+        // Check if specific parent exists in spans
+        const parent = args.traceData.getSpan({ spanId: parentId });
+        // If parent doesn't exist in spans, check if parent is root
+        if (!parent && parentId !== this.rootSpanId) {
+          return undefined;
+        }
+      } else {
+        // No parentId means direct child of root, check root exists
+        if (!args.traceData.hasRoot() && !args.traceData.isRootProcessed()) {
+          return undefined;
+        }
+      }
+    }
+
+    const spanData: TestSpanData = { type: 'span', spanId: args.span.id };
+    this.builtSpans.set(args.span.id, spanData);
+
+    // If this is a root span (skipRoot=true mode), track the root ID
+    if (args.span.isRootSpan) {
+      this.rootSpanId = args.span.id;
+    }
+
+    return spanData;
+  }
+
+  protected override async _buildEvent(args: {
+    span: AnyExportedSpan;
+    traceData: TestTraceData;
+  }): Promise<TestEventData | undefined> {
+    this.calls.push({
+      method: '_buildEvent',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+
+    // Simulate failure if configured
+    if (this.failBuildEventFor.has(args.span.id)) {
+      return undefined;
+    }
+
+    // Check if parent exists (simulate real exporter behavior)
+    const parent = args.traceData.getParentOrRoot({ span: args.span });
+    if (!parent) {
+      return undefined;
+    }
+
+    const eventData: TestEventData = { type: 'event', spanId: args.span.id };
+    this.builtEvents.set(args.span.id, eventData);
+    return eventData;
+  }
+
+  protected override async _updateSpan(args: { span: AnyExportedSpan; traceData: TestTraceData }): Promise<void> {
+    this.calls.push({
+      method: '_updateSpan',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+  }
+
+  protected override async _finishSpan(args: { span: AnyExportedSpan; traceData: TestTraceData }): Promise<void> {
+    this.calls.push({
+      method: '_finishSpan',
+      spanId: args.span.id,
+      traceId: args.span.traceId,
+      timestamp: new Date(),
+    });
+  }
+
+  protected override async _abortSpan(args: {
+    span: TestSpanData;
+    traceData: TestTraceData;
+    reason: SpanErrorInfo;
+  }): Promise<void> {
+    this.calls.push({
+      method: '_abortSpan',
+      spanId: args.span.spanId,
+      traceId: 'unknown',
+      timestamp: new Date(),
+      args: { reason: args.reason },
+    });
+
+    this.abortedSpans.set(args.span.spanId, args.reason);
+  }
+
+  // Helper methods for test assertions
+  public wasMethodCalledForSpan(method: string, spanId: string): boolean {
+    return this.calls.some(c => c.method === method && c.spanId === spanId);
+  }
+}
+
+// Trace generator utilities
+
+interface GenerateTraceOptions {
+  depth?: number;
+  breadth?: number;
+  includeEvents?: boolean;
+  traceId?: string;
+  baseTime?: Date;
+  timeIncrementMs?: number;
+}
+
+interface SpanInfo {
+  id: string;
+  parentId?: string;
+  depth: number;
+  isRoot: boolean;
+  isEvent: boolean;
+}
+
+let spanCounter = 0;
+
+function generateSpanId(): string {
+  return `span-${++spanCounter}-${Date.now()}`;
+}
+
+function generateTraceId(): string {
+  return `trace-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+function createExportedSpan(args: {
+  id: string;
+  traceId: string;
+  parentSpanId?: string;
+  name: string;
+  type: SpanType;
+  isRootSpan: boolean;
+  isEvent: boolean;
+  startTime: Date;
+  endTime?: Date;
+  input?: unknown;
+  output?: unknown;
+}): AnyExportedSpan {
+  return {
+    id: args.id,
+    traceId: args.traceId,
+    parentSpanId: args.parentSpanId,
+    name: args.name,
+    type: args.type,
+    isRootSpan: args.isRootSpan,
+    isEvent: args.isEvent,
+    startTime: args.startTime,
+    endTime: args.endTime,
+    input: args.input,
+    output: args.output,
+    tags: args.isRootSpan ? ['test-trace'] : undefined,
+  };
+}
+
+function createTracingEvent(type: 'span_started' | 'span_updated' | 'span_ended', span: AnyExportedSpan): TracingEvent {
+  return { type, exportedSpan: span };
+}
+
+function generateSpanTree(opts: GenerateTraceOptions): SpanInfo[] {
+  const depth = opts.depth ?? 3;
+  const breadth = opts.breadth ?? 2;
+  const includeEvents = opts.includeEvents ?? true;
+
+  const spans: SpanInfo[] = [];
+
+  function addSpan(parentId: string | undefined, currentDepth: number, isEvent: boolean = false): string {
+    const id = generateSpanId();
+    spans.push({
+      id,
+      parentId,
+      depth: currentDepth,
+      isRoot: currentDepth === 0 && !isEvent,
+      isEvent,
+    });
+    return id;
+  }
+
+  function buildTree(parentId: string | undefined, currentDepth: number): void {
+    if (currentDepth >= depth) return;
+
+    for (let i = 0; i < breadth; i++) {
+      const spanId = addSpan(parentId, currentDepth);
+
+      if (includeEvents && currentDepth > 0) {
+        addSpan(spanId, currentDepth, true);
+      }
+
+      buildTree(spanId, currentDepth + 1);
+    }
+  }
+
+  const rootId = addSpan(undefined, 0);
+  buildTree(rootId, 1);
+
+  return spans;
+}
+
+function generateTrace(opts: GenerateTraceOptions = {}): TracingEvent[] {
+  const traceId = opts.traceId ?? generateTraceId();
+  const baseTime = opts.baseTime ?? new Date();
+  const timeIncrement = opts.timeIncrementMs ?? 100;
+
+  const spanTree = generateSpanTree(opts);
+  const events: TracingEvent[] = [];
+  let currentTime = baseTime.getTime();
+
+  for (const spanInfo of spanTree) {
+    const startTime = new Date(currentTime);
+    currentTime += timeIncrement;
+
+    const span = createExportedSpan({
+      id: spanInfo.id,
+      traceId,
+      parentSpanId: spanInfo.parentId,
+      name: spanInfo.isEvent ? `event-${spanInfo.id}` : `span-${spanInfo.id}`,
+      type: spanInfo.isEvent ? SpanType.EVENT : spanInfo.isRoot ? SpanType.AGENT_RUN : SpanType.TOOL_CALL,
+      isRootSpan: spanInfo.isRoot,
+      isEvent: spanInfo.isEvent,
+      startTime,
+      input: { test: 'input' },
+    });
+
+    if (spanInfo.isEvent) {
+      events.push(createTracingEvent('span_ended', { ...span, endTime: startTime }));
+    } else {
+      events.push(createTracingEvent('span_started', span));
+    }
+  }
+
+  const nonEventSpans = spanTree.filter(s => !s.isEvent);
+  for (let i = nonEventSpans.length - 1; i >= 0; i--) {
+    const spanInfo = nonEventSpans[i];
+    const endTime = new Date(currentTime);
+    currentTime += timeIncrement;
+
+    const span = createExportedSpan({
+      id: spanInfo.id,
+      traceId,
+      parentSpanId: spanInfo.parentId,
+      name: `span-${spanInfo.id}`,
+      type: spanInfo.isRoot ? SpanType.AGENT_RUN : SpanType.TOOL_CALL,
+      isRootSpan: spanInfo.isRoot,
+      isEvent: false,
+      startTime: new Date(baseTime.getTime()),
+      endTime,
+      output: { test: 'output' },
+    });
+
+    events.push(createTracingEvent('span_ended', span));
+  }
+
+  return events;
+}
+
+function reverseHierarchyOrder(events: TracingEvent[]): TracingEvent[] {
+  const startEvents = events.filter(e => e.type === 'span_started');
+  const endEvents = events.filter(e => e.type === 'span_ended' && !e.exportedSpan.isEvent);
+  const eventSpans = events.filter(e => e.exportedSpan.isEvent);
+
+  const reversedStarts = [...startEvents].reverse();
+  const reversedEvents = [...eventSpans].reverse();
+
+  return [...reversedStarts, ...reversedEvents, ...endEvents];
+}
+
+async function sendWithDelays(
+  exporter: { exportTracingEvent: (event: TracingEvent) => Promise<void> },
+  events: TracingEvent[],
+  delayMs: number = 0,
+): Promise<void> {
+  for (const event of events) {
+    await exporter.exportTracingEvent(event);
+    if (delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/**
+ * Flush async processing (setImmediate callbacks) with fake timers.
+ * Uses advanceTimersToNextTimerAsync to run each scheduled timer one at a time.
+ * For tests that don't want cleanup timers to fire, use long cleanup delays.
+ */
+async function flushAsync(times: number = 1): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    // advanceTimersToNextTimer runs the next scheduled timer/immediate
+    // This includes both setImmediate and setTimeout callbacks
+    await vi.advanceTimersToNextTimerAsync();
+  }
+}
+
+describe('TrackingExporter', () => {
+  let exporter: TestTrackingExporter;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    if (exporter) {
+      await exporter.shutdown();
+    }
+    vi.useRealTimers();
+  });
+
+  describe('Root span processing', () => {
+    beforeEach(() => {
+      // Use a very long cleanup delay to prevent cleanup from firing during queue processing
+      exporter = new TestTrackingExporter({ traceCleanupDelayMs: 60 * 60 * 1000 });
+    });
+
+    it('should process root span and trigger queue processing', async () => {
+      const events = generateTrace({ depth: 2, breadth: 1, includeEvents: false });
+      const rootEvent = events.find(e => e.type === 'span_started' && e.exportedSpan.isRootSpan)!;
+
+      await exporter.exportTracingEvent(rootEvent);
+      await flushAsync(3);
+
+      expect(exporter.builtRoots.size).toBe(1);
+      expect(exporter.wasMethodCalledForSpan('_buildRoot', rootEvent.exportedSpan.id)).toBe(true);
+    });
+
+    it('should queue child spans until root arrives', async () => {
+      const events = generateTrace({ depth: 2, breadth: 1, includeEvents: false });
+      const starts = events.filter(e => e.type === 'span_started');
+      const rootStart = starts.find(e => e.exportedSpan.isRootSpan)!;
+      const childStarts = starts.filter(e => !e.exportedSpan.isRootSpan);
+
+      // Send child first
+      await exporter.exportTracingEvent(childStarts[0]);
+      await flushAsync(3);
+
+      // Child should be queued, not built
+      expect(exporter.builtSpans.size).toBe(0);
+
+      // Now send root
+      await exporter.exportTracingEvent(rootStart);
+      await flushAsync(5);
+
+      // Root should be built (in both builtRoots and builtSpans) and child should be processed
+      // Root goes through _buildRoot (builtRoots) AND _buildSpan (builtSpans)
+      expect(exporter.builtRoots.size).toBe(1);
+      expect(exporter.builtSpans.size).toBe(2); // root + child
+    });
+
+    it('should handle multiple children waiting for root', async () => {
+      const events = generateTrace({ depth: 2, breadth: 3, includeEvents: false });
+      const starts = events.filter(e => e.type === 'span_started');
+      const rootStart = starts.find(e => e.exportedSpan.isRootSpan)!;
+      const childStarts = starts.filter(e => !e.exportedSpan.isRootSpan);
+
+      // Send all children first
+      for (const child of childStarts) {
+        await exporter.exportTracingEvent(child);
+      }
+      await flushAsync(3);
+
+      // No children should be built yet
+      expect(exporter.builtSpans.size).toBe(0);
+
+      // Send root
+      await exporter.exportTracingEvent(rootStart);
+      await flushAsync(10);
+
+      // All should now be built
+      // Root goes through _buildRoot (builtRoots) AND _buildSpan (builtSpans)
+      expect(exporter.builtRoots.size).toBe(1);
+      expect(exporter.builtSpans.size).toBe(childStarts.length + 1); // children + root
+    });
+  });
+
+  describe('Cascading queue processing', () => {
+    beforeEach(() => {
+      // Use a very long cleanup delay to prevent cleanup from firing during queue processing
+      exporter = new TestTrackingExporter({ traceCleanupDelayMs: 60 * 60 * 1000 });
+    });
+
+    it('should cascade processing through deep hierarchy', async () => {
+      // Create A (root) -> B -> C -> D hierarchy manually
+      const traceId = `test-trace-${Date.now()}`;
+      const now = new Date();
+
+      const spanA: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-A',
+          traceId,
+          name: 'span-A',
+          type: 'AGENT_RUN' as any,
+          isRootSpan: true,
+          isEvent: false,
+          startTime: now,
+        },
+      };
+
+      const spanB: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-B',
+          traceId,
+          parentSpanId: 'span-A',
+          name: 'span-B',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 100),
+        },
+      };
+
+      const spanC: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-C',
+          traceId,
+          parentSpanId: 'span-B',
+          name: 'span-C',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 200),
+        },
+      };
+
+      const spanD: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-D',
+          traceId,
+          parentSpanId: 'span-C',
+          name: 'span-D',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 300),
+        },
+      };
+
+      // Send in reverse order: D, C, B, A
+      await exporter.exportTracingEvent(spanD);
+      await exporter.exportTracingEvent(spanC);
+      await exporter.exportTracingEvent(spanB);
+      await exporter.exportTracingEvent(spanA);
+
+      // Allow cascading: A enables B, B enables C, C enables D
+      await flushAsync(15);
+
+      // All should be built
+      expect(exporter.builtRoots.has('span-A')).toBe(true);
+      expect(exporter.builtSpans.has('span-B')).toBe(true);
+      expect(exporter.builtSpans.has('span-C')).toBe(true);
+      expect(exporter.builtSpans.has('span-D')).toBe(true);
+    });
+
+    it('should handle D->B->C->A arrival order', async () => {
+      const traceId = `test-trace-${Date.now()}`;
+      const now = new Date();
+
+      const spanA: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-A',
+          traceId,
+          name: 'span-A',
+          type: 'AGENT_RUN' as any,
+          isRootSpan: true,
+          isEvent: false,
+          startTime: now,
+        },
+      };
+
+      const spanB: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-B',
+          traceId,
+          parentSpanId: 'span-A',
+          name: 'span-B',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 100),
+        },
+      };
+
+      const spanC: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-C',
+          traceId,
+          parentSpanId: 'span-B',
+          name: 'span-C',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 200),
+        },
+      };
+
+      const spanD: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'span-D',
+          traceId,
+          parentSpanId: 'span-C',
+          name: 'span-D',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(now.getTime() + 300),
+        },
+      };
+
+      // Send in order: D, B, C, A (worst case)
+      await exporter.exportTracingEvent(spanD);
+      await exporter.exportTracingEvent(spanB);
+      await exporter.exportTracingEvent(spanC);
+      await exporter.exportTracingEvent(spanA);
+
+      // Allow cascading
+      await flushAsync(15);
+
+      // All should be built
+      expect(exporter.builtRoots.has('span-A')).toBe(true);
+      expect(exporter.builtSpans.has('span-B')).toBe(true);
+      expect(exporter.builtSpans.has('span-C')).toBe(true);
+      expect(exporter.builtSpans.has('span-D')).toBe(true);
+    });
+  });
+
+  describe('Out-of-order event arrival', () => {
+    beforeEach(() => {
+      // Use a very long cleanup delay to prevent cleanup from firing during queue processing
+      exporter = new TestTrackingExporter({ traceCleanupDelayMs: 60 * 60 * 1000 });
+    });
+
+    it('should process spans when children arrive before parents', async () => {
+      const events = generateTrace({ depth: 3, breadth: 2, includeEvents: false });
+      const reversedEvents = reverseHierarchyOrder(events);
+
+      await sendWithDelays(exporter, reversedEvents);
+      await flushAsync(15);
+
+      // All spans should eventually be processed
+      expect(exporter.builtRoots.size).toBe(1);
+      expect(exporter.builtSpans.size).toBeGreaterThan(0);
+    });
+  });
+
+  describe('TTL and max attempts limits', () => {
+    it('should drop events after TTL expiry', async () => {
+      exporter = new TestTrackingExporter({
+        earlyQueueTTLMs: 1000, // 1 second TTL
+        earlyQueueMaxAttempts: 100, // High max attempts so TTL is the limiting factor
+        traceCleanupDelayMs: 60 * 60 * 1000, // Long cleanup delay
+      });
+
+      const traceId = `test-trace-${Date.now()}`;
+      const orphanSpan: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'orphan-span',
+          traceId,
+          parentSpanId: 'non-existent-parent',
+          name: 'orphan-span',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(),
+        },
+      };
+
+      // Send root so queue processing can happen
+      const rootSpan: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'root-span',
+          traceId,
+          name: 'root-span',
+          type: 'AGENT_RUN' as any,
+          isRootSpan: true,
+          isEvent: false,
+          startTime: new Date(),
+        },
+      };
+
+      await exporter.exportTracingEvent(rootSpan);
+      await exporter.exportTracingEvent(orphanSpan);
+      await flushAsync(3);
+
+      // Advance time past TTL
+      vi.advanceTimersByTime(2000);
+      await flushAsync(5);
+
+      // The orphan span should NOT be built (parent never arrives)
+      expect(exporter.builtSpans.has('orphan-span')).toBe(false);
+    });
+
+    it('should drop events after max attempts', async () => {
+      exporter = new TestTrackingExporter({
+        earlyQueueMaxAttempts: 2,
+        earlyQueueTTLMs: 60000, // Long TTL so max attempts is the limiting factor
+        traceCleanupDelayMs: 60 * 60 * 1000, // Long cleanup delay
+      });
+
+      const traceId = `test-trace-${Date.now()}`;
+      const orphanSpan: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'orphan-span',
+          traceId,
+          parentSpanId: 'non-existent-parent',
+          name: 'orphan-span',
+          type: 'TOOL_CALL' as any,
+          isRootSpan: false,
+          isEvent: false,
+          startTime: new Date(),
+        },
+      };
+
+      // Send root so queue processing can happen
+      const rootSpan: TracingEvent = {
+        type: 'span_started',
+        exportedSpan: {
+          id: 'root-span',
+          traceId,
+          name: 'root-span',
+          type: 'AGENT_RUN' as any,
+          isRootSpan: true,
+          isEvent: false,
+          startTime: new Date(),
+        },
+      };
+
+      await exporter.exportTracingEvent(rootSpan);
+      await exporter.exportTracingEvent(orphanSpan);
+
+      // Trigger multiple processing attempts
+      for (let i = 0; i < 5; i++) {
+        await flushAsync(3);
+        vi.advanceTimersByTime(100);
+      }
+
+      // The orphan span should NOT be built
+      expect(exporter.builtSpans.has('orphan-span')).toBe(false);
+    });
+  });
+
+  describe('Delayed cleanup', () => {
+    // These tests use real timers with short delays to test actual timer behavior
+    // We restore real timers specifically for these tests
+
+    it('should schedule cleanup after all spans end', async () => {
+      // Use real timers for this test
+      vi.useRealTimers();
+
+      exporter = new TestTrackingExporter({
+        traceCleanupDelayMs: 100, // Short delay for testing
+      });
+
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+
+      await sendWithDelays(exporter, events);
+      // Give async processing time to complete
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      // Trace should still exist (cleanup timer scheduled but not fired yet)
+      expect(exporter.getTraceMapSize()).toBe(1);
+
+      // Wait past cleanup delay
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      // Trace should be cleaned up
+      expect(exporter.getTraceMapSize()).toBe(0);
+
+      // Restore fake timers for afterEach cleanup
+      vi.useFakeTimers();
+    });
+
+    it('should reset cleanup timer on new data arrival', async () => {
+      // Use real timers for this test
+      vi.useRealTimers();
+
+      exporter = new TestTrackingExporter({
+        traceCleanupDelayMs: 100, // Short delay for testing
+      });
+
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+
+      await sendWithDelays(exporter, events);
+      // Give async processing time to complete
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      // Trace should still exist
+      expect(exporter.getTraceMapSize()).toBe(1);
+
+      // Wait halfway through cleanup delay
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Send a late event (this should reset the timer)
+      const rootEvent = events.find(e => e.exportedSpan.isRootSpan)!;
+      const lateEvent: TracingEvent = {
+        type: 'span_ended',
+        exportedSpan: {
+          id: 'late-event',
+          traceId: rootEvent.exportedSpan.traceId,
+          parentSpanId: rootEvent.exportedSpan.id,
+          name: 'late-event',
+          type: 'EVENT' as any,
+          isRootSpan: false,
+          isEvent: true,
+          startTime: new Date(),
+          endTime: new Date(),
+        },
+      };
+
+      await exporter.exportTracingEvent(lateEvent);
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      // Wait another 50ms (total 100ms from start, but only 50ms from late event)
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Trace should still exist (timer was reset when late event arrived)
+      expect(exporter.getTraceMapSize()).toBe(1);
+
+      // Wait past the new cleanup delay (need 100ms from last reset)
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Now trace should be cleaned up
+      expect(exporter.getTraceMapSize()).toBe(0);
+
+      // Restore fake timers for afterEach cleanup
+      vi.useFakeTimers();
+    });
+  });
+
+  describe('Cap enforcement', () => {
+    it('should enforce soft cap on pending cleanups', async () => {
+      exporter = new TestTrackingExporter({
+        traceCleanupDelayMs: 60 * 60 * 1000, // Long cleanup delay
+        maxPendingCleanupTraces: 3,
+      });
+
+      // Create 5 traces that all end immediately
+      for (let i = 0; i < 5; i++) {
+        const traceId = `trace-${i}`;
+        const rootStart: TracingEvent = {
+          type: 'span_started',
+          exportedSpan: {
+            id: `root-${i}`,
+            traceId,
+            name: `root-${i}`,
+            type: 'AGENT_RUN' as any,
+            isRootSpan: true,
+            isEvent: false,
+            startTime: new Date(),
+          },
+        };
+        const rootEnd: TracingEvent = {
+          type: 'span_ended',
+          exportedSpan: {
+            ...rootStart.exportedSpan,
+            endTime: new Date(),
+          },
+        };
+
+        await exporter.exportTracingEvent(rootStart);
+        await exporter.exportTracingEvent(rootEnd);
+        await flushAsync(3);
+      }
+
+      // Soft cap is 3, so oldest 2 should be cleaned up immediately
+      expect(exporter.getTraceMapSize()).toBeLessThanOrEqual(3);
+    });
+
+    it('should enforce hard cap on total traces', async () => {
+      exporter = new TestTrackingExporter({
+        maxTotalTraces: 3,
+        traceCleanupDelayMs: 60 * 60 * 1000, // Long cleanup delay
+      });
+
+      // Create 5 traces that stay active
+      for (let i = 0; i < 5; i++) {
+        const traceId = `trace-${i}`;
+        const rootStart: TracingEvent = {
+          type: 'span_started',
+          exportedSpan: {
+            id: `root-${i}`,
+            traceId,
+            name: `root-${i}`,
+            type: 'AGENT_RUN' as any,
+            isRootSpan: true,
+            isEvent: false,
+            startTime: new Date(),
+          },
+        };
+
+        await exporter.exportTracingEvent(rootStart);
+        await flushAsync(3);
+      }
+
+      // Hard cap is 3, so oldest traces should be killed
+      expect(exporter.getTraceMapSize()).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('Shutdown behavior', () => {
+    it('should cancel pending cleanups on shutdown', async () => {
+      // Use real timers for this test
+      vi.useRealTimers();
+
+      exporter = new TestTrackingExporter({
+        traceCleanupDelayMs: 1000, // 1 second - enough time to shutdown before cleanup fires
+      });
+
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+      await sendWithDelays(exporter, events);
+      // Give async processing time to complete
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      // Trace should exist (cleanup not triggered yet due to delay)
+      expect(exporter.getTraceMapSize()).toBe(1);
+
+      // Shutdown - should clean up immediately without waiting for timer
+      await exporter.shutdown();
+
+      // Trace should be cleaned up immediately by shutdown
+      expect(exporter.getTraceMapSize()).toBe(0);
+
+      // Restore fake timers for afterEach cleanup
+      vi.useFakeTimers();
+    });
+
+    it('should stop processing after shutdown starts', async () => {
+      exporter = new TestTrackingExporter({ traceCleanupDelayMs: 60 * 60 * 1000 });
+
+      // Start shutdown
+      await exporter.shutdown();
+
+      // Try to send an event
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+      await exporter.exportTracingEvent(events[0]);
+      await flushAsync(3);
+
+      // Nothing should be built
+      expect(exporter.builtRoots.size).toBe(0);
+      expect(exporter.builtSpans.size).toBe(0);
+    });
+  });
+
+  describe('Skip root task mode (like LangSmith)', () => {
+    it('should process root span through _buildSpan when skipRoot=true', async () => {
+      exporter = new TestTrackingExporter({ skipRoot: true, traceCleanupDelayMs: 60 * 60 * 1000 });
+
+      const events = generateTrace({ depth: 2, breadth: 1, includeEvents: false });
+      const rootStart = events.find(e => e.type === 'span_started' && e.exportedSpan.isRootSpan)!;
+
+      await exporter.exportTracingEvent(rootStart);
+      await flushAsync(3);
+
+      // Root should be built as a span, not as root
+      expect(exporter.builtRoots.size).toBe(0);
+      expect(exporter.builtSpans.has(rootStart.exportedSpan.id)).toBe(true);
+    });
+
+    it('should still trigger queue processing when root marked processed via _buildSpan', async () => {
+      // Use real timers for this test to ensure setImmediate callbacks run properly
+      vi.useRealTimers();
+
+      exporter = new TestTrackingExporter({ skipRoot: true, traceCleanupDelayMs: 60 * 60 * 1000 });
+
+      const events = generateTrace({ depth: 2, breadth: 1, includeEvents: false });
+      const starts = events.filter(e => e.type === 'span_started');
+      const rootStart = starts.find(e => e.exportedSpan.isRootSpan)!;
+      const childStarts = starts.filter(e => !e.exportedSpan.isRootSpan);
+
+      // Send child first
+      await exporter.exportTracingEvent(childStarts[0]);
+      // Give async processing time to complete
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      // Child should be queued (waiting for root)
+      expect(exporter.builtSpans.has(childStarts[0].exportedSpan.id)).toBe(false);
+
+      // Send root
+      await exporter.exportTracingEvent(rootStart);
+      // Give async processing time to cascade through queues
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Both should now be built
+      expect(exporter.builtSpans.has(rootStart.exportedSpan.id)).toBe(true);
+      expect(exporter.builtSpans.has(childStarts[0].exportedSpan.id)).toBe(true);
+
+      // Restore fake timers for afterEach cleanup
+      vi.useFakeTimers();
+    });
+  });
+});

--- a/observability/mastra/src/exporters/tracking.ts
+++ b/observability/mastra/src/exporters/tracking.ts
@@ -1,0 +1,1322 @@
+/**
+ * =============================================================================
+ * TRACKING EXPORTER - IMPLEMENTATION PLAN
+ * =============================================================================
+ *
+ * This file contains the TrackingExporter base class which caches trace data
+ * in a local memory map for vendor-specific exporters (Braintrust, Langfuse,
+ * LangSmith, PostHog, etc.).
+ *
+ * -----------------------------------------------------------------------------
+ * PROBLEM: EARLY DATA QUEUE
+ * -----------------------------------------------------------------------------
+ *
+ * Currently, if span data arrives before its dependencies are ready, we queue
+ * it to `earlyData`. However, this queue is never processed - events accumulate
+ * and are lost.
+ *
+ * Spans can be queued to earlyData when:
+ * 1. Root span doesn't exist yet (for exporters with skipBuildRootTask = false)
+ * 2. Parent span doesn't exist yet (_buildSpan/_buildEvent returns undefined)
+ *
+ * Key insight: If the root span doesn't exist, no child spans can be processed
+ * because parent spans can't exist without root. Therefore, we should NOT
+ * attempt to process earlyData until the root span has been processed.
+ *
+ * -----------------------------------------------------------------------------
+ * PROBLEM: IMMEDIATE CLEANUP
+ * -----------------------------------------------------------------------------
+ *
+ * Currently, clearTraceData() is called immediately when activeSpanCount == 0.
+ * This causes issues with:
+ * - Late-arriving data (updates, events) having nowhere to go
+ * - Early queue items still processing async when we clear
+ * - Race conditions between setImmediate processing and cleanup
+ *
+ * -----------------------------------------------------------------------------
+ * IMPLEMENTATION PLAN
+ * -----------------------------------------------------------------------------
+ *
+ * ## 1. New Config Options (TrackingExporterConfig)
+ *
+ * ```typescript
+ * interface TrackingExporterConfig extends BaseExporterConfig {
+ *   // Early queue settings
+ *   earlyQueueMaxAttempts?: number;      // default: 5
+ *   earlyQueueTTLMs?: number;            // default: 30000 (30s)
+ *
+ *   // Cleanup settings
+ *   traceCleanupDelayMs?: number;        // default: 30000 (30s)
+ *   maxPendingCleanupTraces?: number;    // default: 100 (soft cap, activeSpanCount == 0 only)
+ *   maxTotalTraces?: number;             // default: 500 (hard cap, kills oldest even if active)
+ * }
+ * ```
+ *
+ * ## 2. TraceData Changes
+ *
+ * ### New flag for root tracking:
+ * - Add `#rootSpanProcessed: boolean`
+ * - Set to true when span with `isRootSpan = true` is successfully processed
+ * - Works for both `_buildRoot` path and `_buildSpan` path (skipBuildRootTask = true)
+ * - Add method `isRootProcessed(): boolean`
+ *
+ * ### New early queue structure (replaces simple array):
+ * ```typescript
+ * interface QueuedEvent {
+ *   event: TracingEvent;
+ *   waitingFor: 'root' | string;  // 'root' or specific parentSpanId
+ *   attempts: number;
+ *   queuedAt: Date;
+ * }
+ *
+ * #waitingForRoot: QueuedEvent[];
+ * #waitingForParent: Map<string, QueuedEvent[]>;  // parentSpanId -> events
+ * ```
+ *
+ * This Map structure enables O(1) lookups instead of O(n) queue scans.
+ * When span X is created, we only look at `waitingForParent.get(X.id)`.
+ *
+ * ### New methods:
+ * - `isRootProcessed(): boolean`
+ * - `addToWaitingQueue(event, waitingFor): void`
+ * - `getEventsWaitingFor(spanId): QueuedEvent[]`
+ * - `getEventsWaitingForRoot(): QueuedEvent[]`
+ * - `removeFromWaitingQueue(event): void`
+ *
+ * ## 3. TrackingExporter Changes
+ *
+ * ### Early queue processing (async via setImmediate):
+ *
+ * Trigger points:
+ * - After root span is processed → `setImmediate(() => processWaitingForRoot())`
+ * - After any span/event created → `setImmediate(() => processWaitingFor(spanId))`
+ *
+ * Processing logic:
+ * ```
+ * processWaitingFor(spanId):
+ *   events = getEventsWaitingFor(spanId)
+ *   for each event in events:
+ *     if event.attempts >= maxAttempts || event.queuedAt + TTL < now:
+ *       log warning, remove from queue
+ *       continue
+ *     event.attempts++
+ *     result = tryProcess(event)
+ *     if successful:
+ *       remove from queue
+ *       // Cascade: new span might unblock others
+ *       setImmediate(() => processWaitingFor(newSpanId))
+ * ```
+ *
+ * ### Delayed cleanup:
+ *
+ * ```
+ * When activeSpanCount() == 0:
+ *   scheduleCleanup(traceId)
+ *
+ * scheduleCleanup(traceId):
+ *   if already scheduled for this traceId:
+ *     cancel existing timer
+ *   #pendingCleanups.set(traceId, setTimeout(() => {
+ *     // Final flush of remaining early queue items
+ *     // Log warnings for orphaned events
+ *     clearTraceData(traceId)
+ *   }, traceCleanupDelayMs))
+ *
+ * If new data arrives for traceId:
+ *   cancel scheduled cleanup
+ *   process the data
+ *   if activeSpanCount() == 0:
+ *     reschedule cleanup (timer reset)
+ * ```
+ *
+ * ### Caps enforcement:
+ *
+ * Soft cap (maxPendingCleanupTraces):
+ * - Only affects traces with activeSpanCount == 0
+ * - When exceeded, force cleanup of oldest pending traces
+ *
+ * Hard cap (maxTotalTraces):
+ * - Affects ALL traces, even active ones
+ * - When exceeded, kill oldest traces first (call _abortSpan for active spans)
+ * - Safety valve for memory leaks
+ *
+ * ### Shutdown behavior:
+ * - Clear everything immediately (existing behavior)
+ * - Cancel all pending cleanup timers
+ * - Abort all active spans
+ * - Log warnings for any remaining early queue items
+ *
+ * -----------------------------------------------------------------------------
+ * EXPORTER BEHAVIOR REFERENCE
+ * -----------------------------------------------------------------------------
+ *
+ * | Exporter   | skipBuildRootTask | When _buildSpan returns undefined      |
+ * |------------|-------------------|----------------------------------------|
+ * | Braintrust | false             | Parent span doesn't exist              |
+ * | Langfuse   | false             | getParentOrRoot returns nothing        |
+ * | LangSmith  | true              | Not root AND parent doesn't exist      |
+ * | PostHog    | true              | Never returns undefined                |
+ *
+ * -----------------------------------------------------------------------------
+ * TESTING PLAN
+ * -----------------------------------------------------------------------------
+ *
+ * ## File Structure
+ *
+ * ```
+ * observability/
+ * ├── _test-utils/                    # Shared test utilities (new package)
+ * │   ├── src/
+ * │   │   ├── index.ts                # Exports all utilities
+ * │   │   ├── trace-generator.ts      # Generate test traces
+ * │   │   ├── test-exporter.ts        # TestTrackingExporter class
+ * │   │   └── test-scenarios.ts       # Shared test scenario runners
+ * │   └── package.json
+ * │
+ * ├── mastra/src/exporters/
+ * │   ├── tracking.ts                 # This file
+ * │   └── tracking.test.ts            # Unit tests for TrackingExporter
+ * │
+ * ├── braintrust/src/
+ * │   └── tracing.early-data.test.ts  # Braintrust-specific early data tests
+ * │
+ * ├── langfuse/src/
+ * │   └── tracing.early-data.test.ts  # Langfuse-specific early data tests
+ * │
+ * ├── langsmith/src/
+ * │   └── tracing.early-data.test.ts  # LangSmith-specific early data tests
+ * │
+ * └── posthog/src/
+ *     └── tracing.early-data.test.ts  # PostHog-specific early data tests
+ * ```
+ *
+ * ## 1. Shared Test Utilities (observability/_test-utils)
+ *
+ * ### trace-generator.ts
+ * ```typescript
+ * // Generate a trace with configurable depth and breadth
+ * function generateTrace(opts: {
+ *   depth: number;
+ *   breadth: number;
+ *   includeEvents?: boolean;
+ * }): TracingEvent[]
+ *
+ * // Shuffle events to simulate out-of-order arrival
+ * function shuffleEvents(events: TracingEvent[]): TracingEvent[]
+ *
+ * // Send events with configurable delays
+ * async function sendWithDelays(
+ *   exporter: BaseExporter,
+ *   events: TracingEvent[],
+ *   delayMs: number
+ * ): Promise<void>
+ * ```
+ *
+ * ### test-exporter.ts
+ * ```typescript
+ * // Concrete test implementation of TrackingExporter for isolated testing
+ * class TestTrackingExporter extends TrackingExporter<...> {
+ *   // Expose internals for testing
+ *   // Track calls to _buildRoot, _buildSpan, _buildEvent, etc.
+ *   public buildRootCalls: Array<{span, traceData}>
+ *   public buildSpanCalls: Array<{span, traceData}>
+ *   public buildEventCalls: Array<{span, traceData}>
+ *   // ... etc
+ * }
+ * ```
+ *
+ * ### test-scenarios.ts
+ * ```typescript
+ * // Shared test scenario runners that each exporter can use
+ * export function runOutOfOrderSpanTests(exporterFactory: () => BaseExporter): void
+ * export function runRootArrivesLastTests(exporterFactory: () => BaseExporter): void
+ * export function runDeepHierarchyTests(exporterFactory: () => BaseExporter): void
+ * export function runLateEventTests(exporterFactory: () => BaseExporter): void
+ * export function runOrphanedSpanTests(exporterFactory: () => BaseExporter): void
+ * export function runAllEarlyDataTests(exporterFactory: () => BaseExporter): void
+ * ```
+ *
+ * ## 2. TrackingExporter Unit Tests (mastra/src/exporters/tracking.test.ts)
+ *
+ * Uses TestTrackingExporter from _test-utils for isolated testing.
+ *
+ * Test cases:
+ * - Early queue structure (waitingForRoot, waitingForParent Map)
+ * - rootSpanProcessed flag is set correctly for both paths
+ * - Events queued when root missing (skipBuildRootTask = false)
+ * - Events queued when parent missing
+ * - Async processing triggers after root processed
+ * - Async processing triggers after span/event created
+ * - Cascading processing (A unblocks B, B unblocks C)
+ * - Max attempts limit respected, events dropped with warning
+ * - TTL limit respected, stale events dropped with warning
+ * - Delayed cleanup scheduling and cancellation
+ * - Timer reset on new data arrival
+ * - Soft cap enforcement (pending cleanup traces)
+ * - Hard cap enforcement (all traces, oldest killed first)
+ * - Shutdown cancels timers and clears everything
+ * - Orphaned events logged on final cleanup
+ *
+ * ## 3. Exporter-Specific Tests (in each exporter package)
+ *
+ * Each exporter package imports shared utilities and runs scenarios:
+ *
+ * ```typescript
+ * // observability/braintrust/src/tracing.early-data.test.ts
+ * import { runAllEarlyDataTests, generateTrace } from '@mastra/observability-test-utils';
+ * import { BraintrustExporter } from './tracing';
+ *
+ * describe('BraintrustExporter early data handling', () => {
+ *   runAllEarlyDataTests(() => new BraintrustExporter({ apiKey: 'test' }));
+ *
+ *   // Braintrust-specific tests if needed
+ *   it('should handle braintrust-specific edge case', () => { ... });
+ * });
+ * ```
+ *
+ * ### Shared Scenarios (run by each exporter)
+ *
+ * - Out-of-order span arrival: child before parent, grandchild before child
+ * - Root arrives last: multiple children, then root
+ * - Deep hierarchy out of order: D, B, C, A (root) → cascade A→B→C→D
+ * - Late event after span ended: event during cleanup delay window
+ * - Very late data after cleanup: warning logged, handled gracefully
+ * - Orphaned spans: parent never arrives, dropped after max attempts/TTL
+ * - Mixed events and spans out of order
+ *
+ * =============================================================================
+ */
+
+import type { TracingEvent, AnyExportedSpan, SpanErrorInfo } from '@mastra/core/observability';
+import type { BaseExporterConfig } from './base';
+import { BaseExporter } from './base';
+
+/**
+ * Represents an event waiting in the early queue for its dependencies.
+ */
+export interface QueuedEvent {
+  /** The original tracing event */
+  event: TracingEvent;
+  /** What this event is waiting for: 'root' or a specific parentSpanId */
+  waitingFor: 'root' | string;
+  /** Number of times we've attempted to process this event */
+  attempts: number;
+  /** When this event was queued */
+  queuedAt: Date;
+}
+
+export interface TrackingExporterConfig extends BaseExporterConfig {
+  /**
+   * Maximum number of attempts to process a queued event before dropping it.
+   * @default 5
+   */
+  earlyQueueMaxAttempts?: number;
+
+  /**
+   * Time-to-live in milliseconds for queued events. Events older than this are dropped.
+   * @default 30000 (30 seconds)
+   */
+  earlyQueueTTLMs?: number;
+
+  /**
+   * Delay in milliseconds before cleaning up trace data after all spans have ended.
+   * This allows late-arriving data to still be processed.
+   * @default 30000 (30 seconds)
+   */
+  traceCleanupDelayMs?: number;
+
+  /**
+   * Soft cap on number of traces with activeSpanCount == 0 awaiting cleanup.
+   * When exceeded, oldest pending traces are force-cleaned.
+   * @default 100
+   */
+  maxPendingCleanupTraces?: number;
+
+  /**
+   * Hard cap on total number of traces (including active ones).
+   * When exceeded, oldest traces are killed (active spans aborted).
+   * Safety valve for memory leaks.
+   * @default 500
+   */
+  maxTotalTraces?: number;
+}
+
+export class TraceData<TRootData, TSpanData, TEventData, TMetadata> {
+  #rootSpan?: TRootData;
+  #rootSpanId?: string;
+  #rootSpanProcessed: boolean; // Whether a span with isRootSpan=true has been processed
+  #events: Map<string, TEventData>; // Maps eventId to vendor-specific events
+  #spans: Map<string, TSpanData>; // Maps spanId to vendor-specific spans
+  #tree: Map<string, string | undefined>; // Maps spanId to parentSpanId
+  #activeSpanIds: Set<string>; // Set of span IDs that have started but not yet ended
+  #metadata: Map<string, TMetadata>; // Map of id to vendor-specific metadata
+  #extraData: Map<string, unknown>; // Any extra data to be stored on a per-trace level
+
+  // Early queue: events waiting for dependencies
+  #waitingForRoot: QueuedEvent[]; // Events waiting for root span to be processed
+  #waitingForParent: Map<string, QueuedEvent[]>; // Events waiting for specific parent spanId
+
+  // Timestamp for tracking trace age (for cap enforcement)
+  readonly createdAt: Date;
+
+  constructor() {
+    this.#events = new Map();
+    this.#spans = new Map();
+    this.#activeSpanIds = new Set();
+    this.#tree = new Map();
+    this.#metadata = new Map();
+    this.#extraData = new Map();
+    this.#rootSpanProcessed = false;
+    this.#waitingForRoot = [];
+    this.#waitingForParent = new Map();
+    this.createdAt = new Date();
+  }
+
+  hasRoot(): boolean {
+    return !!this.#rootSpanId;
+  }
+
+  addRoot(args: { rootId: string; rootData: TRootData }): void {
+    this.#rootSpanId = args.rootId;
+    this.#rootSpan = args.rootData;
+    this.#rootSpanProcessed = true;
+  }
+
+  getRoot(): TRootData | undefined {
+    return this.#rootSpan;
+  }
+
+  /**
+   * Returns true if a span with isRootSpan=true has been successfully processed.
+   * This is set via addRoot() or markRootSpanProcessed().
+   */
+  isRootProcessed(): boolean {
+    return this.#rootSpanProcessed;
+  }
+
+  /**
+   * Mark that the root span has been processed.
+   * Used by exporters with skipBuildRootTask=true where root goes through _buildSpan.
+   */
+  markRootSpanProcessed(): void {
+    this.#rootSpanProcessed = true;
+  }
+
+  setExtraValue(key: string, value: unknown): void {
+    this.#extraData.set(key, value);
+  }
+
+  hasExtraValue(key: string): boolean {
+    return this.#extraData.has(key);
+  }
+
+  getExtraValue(key: string): unknown | undefined {
+    return this.#extraData.get(key);
+  }
+
+  // ============================================================================
+  // Early Queue Methods
+  // ============================================================================
+
+  /**
+   * Add an event to the waiting queue.
+   * @param event - The tracing event to queue
+   * @param waitingFor - 'root' or a specific parentSpanId
+   */
+  addToWaitingQueue(args: { event: TracingEvent; waitingFor: 'root' | string }): void {
+    const queuedEvent: QueuedEvent = {
+      event: args.event,
+      waitingFor: args.waitingFor,
+      attempts: 0,
+      queuedAt: new Date(),
+    };
+
+    if (args.waitingFor === 'root') {
+      this.#waitingForRoot.push(queuedEvent);
+    } else {
+      const queue = this.#waitingForParent.get(args.waitingFor) ?? [];
+      queue.push(queuedEvent);
+      this.#waitingForParent.set(args.waitingFor, queue);
+    }
+  }
+
+  /**
+   * Get all events waiting for the root span.
+   * Returns the array (which can be mutated for processing).
+   */
+  getEventsWaitingForRoot(): QueuedEvent[] {
+    return this.#waitingForRoot;
+  }
+
+  /**
+   * Get all events waiting for a specific parent span.
+   * Returns the array (which can be mutated for processing).
+   */
+  getEventsWaitingFor(args: { spanId: string }): QueuedEvent[] {
+    return this.#waitingForParent.get(args.spanId) ?? [];
+  }
+
+  /**
+   * Clear the waiting-for-root queue.
+   */
+  clearWaitingForRoot(): void {
+    this.#waitingForRoot = [];
+  }
+
+  /**
+   * Clear the waiting queue for a specific parent span.
+   */
+  clearWaitingFor(args: { spanId: string }): void {
+    this.#waitingForParent.delete(args.spanId);
+  }
+
+  /**
+   * Get total count of events in all waiting queues.
+   */
+  waitingQueueSize(): number {
+    let count = this.#waitingForRoot.length;
+    for (const queue of this.#waitingForParent.values()) {
+      count += queue.length;
+    }
+    return count;
+  }
+
+  /**
+   * Get all queued events (for cleanup/logging purposes).
+   */
+  getAllQueuedEvents(): QueuedEvent[] {
+    const all: QueuedEvent[] = [...this.#waitingForRoot];
+    for (const queue of this.#waitingForParent.values()) {
+      all.push(...queue);
+    }
+    return all;
+  }
+
+  /**
+   * @deprecated Use addToWaitingQueue instead. This is kept for backward compatibility.
+   */
+  addEarly(args: { event: TracingEvent }): void {
+    // Determine what this event is waiting for
+    const parentSpanId = args.event.exportedSpan.parentSpanId;
+    if (!this.#rootSpanProcessed) {
+      this.addToWaitingQueue({ event: args.event, waitingFor: 'root' });
+    } else if (parentSpanId) {
+      this.addToWaitingQueue({ event: args.event, waitingFor: parentSpanId });
+    } else {
+      // Root span but root already processed - shouldn't happen, queue for root anyway
+      this.addToWaitingQueue({ event: args.event, waitingFor: 'root' });
+    }
+  }
+
+  addBranch(args: { spanId: string; parentSpanId: string | undefined }): void {
+    this.#tree.set(args.spanId, args.parentSpanId);
+  }
+
+  getParentId(args: { spanId: string }): string | undefined {
+    return this.#tree.get(args.spanId);
+  }
+
+  addSpan(args: { spanId: string; spanData: TSpanData }): void {
+    this.#spans.set(args.spanId, args.spanData);
+    this.#activeSpanIds.add(args.spanId); //Track span as active
+  }
+
+  hasSpan(args: { spanId: string }): boolean {
+    const { spanId } = args;
+    return this.#spans.has(spanId);
+  }
+
+  getSpan(args: { spanId: string }): TSpanData | undefined {
+    const { spanId } = args;
+    return this.#spans.get(spanId);
+  }
+
+  endSpan(args: { spanId: string }): void {
+    this.#activeSpanIds.delete(args.spanId);
+  }
+
+  isActiveSpan(args: { spanId: string }): boolean {
+    return this.#activeSpanIds.has(args.spanId);
+  }
+
+  activeSpanCount(): number {
+    return this.#activeSpanIds.size;
+  }
+
+  get activeSpanIds(): string[] {
+    return [...this.#activeSpanIds];
+  }
+
+  addEvent(args: { eventId: string; eventData: TEventData }) {
+    this.#events.set(args.eventId, args.eventData);
+  }
+
+  // TODO: ideally this would add to the span metadata if it already existed
+  // and not just completely overwrite it.
+  // Maybe the type here should be different?
+  addMetadata(args: { spanId: string; metadata: TMetadata }): void {
+    this.#metadata.set(args.spanId, args.metadata);
+  }
+
+  getMetadata(args: { spanId: string }): TMetadata | undefined {
+    return this.#metadata.get(args.spanId);
+  }
+
+  getParent(args: { span: AnyExportedSpan }): TSpanData | TEventData | undefined {
+    const parentId = args.span.parentSpanId;
+    // if parentId is undefined, then span is the rootSpan (and has no parent)
+    if (parentId) {
+      if (this.#spans.has(parentId)) {
+        return this.#spans.get(parentId);
+      }
+      if (this.#events.has(parentId)) {
+        return this.#events.get(parentId);
+      }
+    }
+    return undefined;
+  }
+
+  getParentOrRoot(args: { span: AnyExportedSpan }): TRootData | TSpanData | TEventData | undefined {
+    return this.getParent(args) ?? this.getRoot();
+  }
+}
+
+/**
+ * Abstract base class for exporters that track trace/span state.
+ *
+ * @typeParam TTraceData - The type of data stored per trace (must extend BaseTraceData)
+ * @typeParam TConfig - Configuration type (must extend TrackingExporterConfig)
+ */
+// Default configuration values
+const DEFAULT_EARLY_QUEUE_MAX_ATTEMPTS = 5;
+const DEFAULT_EARLY_QUEUE_TTL_MS = 30000; // 30 seconds
+const DEFAULT_TRACE_CLEANUP_DELAY_MS = 30000; // 30 seconds
+const DEFAULT_MAX_PENDING_CLEANUP_TRACES = 100;
+const DEFAULT_MAX_TOTAL_TRACES = 500;
+
+export abstract class TrackingExporter<
+  TRootData,
+  TSpanData,
+  TEventData,
+  TMetadata,
+  TConfig extends TrackingExporterConfig,
+> extends BaseExporter {
+  /**
+   * Map of traceId to trace-specific data.
+   * Contains vendor SDK objects, span maps, and active span tracking.
+   */
+  #traceMap = new Map<string, TraceData<TRootData, TSpanData, TEventData, TMetadata>>();
+  #shutdownStarted = false;
+
+  /**
+   * Map of traceId to scheduled cleanup timeout.
+   * Used for delayed cleanup after all spans end.
+   */
+  #pendingCleanups = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /**
+   * Tracks insertion order of traces for cap enforcement.
+   * Oldest traces are at the beginning.
+   */
+  #traceInsertionOrder: string[] = [];
+
+  /**
+   * Subclass configuration (typed for subclass-specific options)
+   */
+  protected readonly config: TConfig;
+
+  // Resolved config values with defaults
+  readonly #earlyQueueMaxAttempts: number;
+  readonly #earlyQueueTTLMs: number;
+  readonly #traceCleanupDelayMs: number;
+  readonly #maxPendingCleanupTraces: number;
+  readonly #maxTotalTraces: number;
+
+  constructor(config: TConfig) {
+    super(config);
+    this.config = config;
+
+    // Resolve config with defaults
+    this.#earlyQueueMaxAttempts = config.earlyQueueMaxAttempts ?? DEFAULT_EARLY_QUEUE_MAX_ATTEMPTS;
+    this.#earlyQueueTTLMs = config.earlyQueueTTLMs ?? DEFAULT_EARLY_QUEUE_TTL_MS;
+    this.#traceCleanupDelayMs = config.traceCleanupDelayMs ?? DEFAULT_TRACE_CLEANUP_DELAY_MS;
+    this.#maxPendingCleanupTraces = config.maxPendingCleanupTraces ?? DEFAULT_MAX_PENDING_CLEANUP_TRACES;
+    this.#maxTotalTraces = config.maxTotalTraces ?? DEFAULT_MAX_TOTAL_TRACES;
+  }
+
+  // ============================================================================
+  // Early Queue Processing
+  // ============================================================================
+
+  /**
+   * Schedule async processing of events waiting for root span.
+   * Called after root span is successfully processed.
+   */
+  #scheduleProcessWaitingForRoot(traceId: string): void {
+    setImmediate(() => {
+      this.#processWaitingForRoot(traceId).catch(error => {
+        this.logger.error(`${this.name}: Error processing waiting-for-root queue`, { error, traceId });
+      });
+    });
+  }
+
+  /**
+   * Schedule async processing of events waiting for a specific parent span.
+   * Called after a span/event is successfully created.
+   */
+  #scheduleProcessWaitingFor(traceId: string, spanId: string): void {
+    setImmediate(() => {
+      this.#processWaitingFor(traceId, spanId).catch(error => {
+        this.logger.error(`${this.name}: Error processing waiting queue`, { error, traceId, spanId });
+      });
+    });
+  }
+
+  /**
+   * Process all events waiting for root span.
+   */
+  async #processWaitingForRoot(traceId: string): Promise<void> {
+    if (this.#shutdownStarted) return;
+
+    const traceData = this.#traceMap.get(traceId);
+    if (!traceData) return;
+
+    const queue = traceData.getEventsWaitingForRoot();
+    if (queue.length === 0) return;
+
+    this.logger.debug(`${this.name}: Processing ${queue.length} events waiting for root`, { traceId });
+
+    // Process events, collecting ones to keep
+    const toKeep: QueuedEvent[] = [];
+    const now = Date.now();
+
+    for (const queuedEvent of queue) {
+      // Check TTL
+      if (now - queuedEvent.queuedAt.getTime() > this.#earlyQueueTTLMs) {
+        this.logger.warn(`${this.name}: Dropping event due to TTL expiry`, {
+          traceId,
+          spanId: queuedEvent.event.exportedSpan.id,
+          waitingFor: queuedEvent.waitingFor,
+          queuedAt: queuedEvent.queuedAt,
+          attempts: queuedEvent.attempts,
+        });
+        continue;
+      }
+
+      // Check max attempts
+      if (queuedEvent.attempts >= this.#earlyQueueMaxAttempts) {
+        this.logger.warn(`${this.name}: Dropping event due to max attempts`, {
+          traceId,
+          spanId: queuedEvent.event.exportedSpan.id,
+          waitingFor: queuedEvent.waitingFor,
+          attempts: queuedEvent.attempts,
+        });
+        continue;
+      }
+
+      // Try to process
+      queuedEvent.attempts++;
+      const processed = await this.#tryProcessQueuedEvent(queuedEvent, traceData);
+
+      if (!processed) {
+        // Move to waiting-for-parent if we now know the parent
+        const parentId = queuedEvent.event.exportedSpan.parentSpanId;
+        if (parentId && traceData.isRootProcessed()) {
+          traceData.addToWaitingQueue({ event: queuedEvent.event, waitingFor: parentId });
+        } else {
+          toKeep.push(queuedEvent);
+        }
+      }
+    }
+
+    // Update the queue with remaining events
+    traceData.clearWaitingForRoot();
+    for (const event of toKeep) {
+      traceData.addToWaitingQueue({ event: event.event, waitingFor: 'root' });
+    }
+  }
+
+  /**
+   * Process events waiting for a specific parent span.
+   */
+  async #processWaitingFor(traceId: string, spanId: string): Promise<void> {
+    if (this.#shutdownStarted) return;
+
+    const traceData = this.#traceMap.get(traceId);
+    if (!traceData) return;
+
+    const queue = traceData.getEventsWaitingFor({ spanId });
+    if (queue.length === 0) return;
+
+    this.logger.debug(`${this.name}: Processing ${queue.length} events waiting for span`, { traceId, spanId });
+
+    const toKeep: QueuedEvent[] = [];
+    const now = Date.now();
+
+    for (const queuedEvent of queue) {
+      // Check TTL
+      if (now - queuedEvent.queuedAt.getTime() > this.#earlyQueueTTLMs) {
+        this.logger.warn(`${this.name}: Dropping event due to TTL expiry`, {
+          traceId,
+          spanId: queuedEvent.event.exportedSpan.id,
+          waitingFor: queuedEvent.waitingFor,
+          queuedAt: queuedEvent.queuedAt,
+          attempts: queuedEvent.attempts,
+        });
+        continue;
+      }
+
+      // Check max attempts
+      if (queuedEvent.attempts >= this.#earlyQueueMaxAttempts) {
+        this.logger.warn(`${this.name}: Dropping event due to max attempts`, {
+          traceId,
+          spanId: queuedEvent.event.exportedSpan.id,
+          waitingFor: queuedEvent.waitingFor,
+          attempts: queuedEvent.attempts,
+        });
+        continue;
+      }
+
+      // Try to process
+      queuedEvent.attempts++;
+      const processed = await this.#tryProcessQueuedEvent(queuedEvent, traceData);
+
+      if (!processed) {
+        toKeep.push(queuedEvent);
+      }
+    }
+
+    // Update the queue
+    traceData.clearWaitingFor({ spanId });
+    for (const event of toKeep) {
+      traceData.addToWaitingQueue({ event: event.event, waitingFor: spanId });
+    }
+  }
+
+  /**
+   * Try to process a queued event.
+   * Returns true if successfully processed, false if still waiting for dependencies.
+   */
+  async #tryProcessQueuedEvent(
+    queuedEvent: QueuedEvent,
+    traceData: TraceData<TRootData, TSpanData, TEventData, TMetadata>,
+  ): Promise<boolean> {
+    const { event } = queuedEvent;
+    const { exportedSpan } = event;
+
+    // Determine method
+    const method = this.getMethod(event);
+
+    try {
+      switch (method) {
+        case 'handleEventSpan': {
+          traceData.addBranch({ spanId: exportedSpan.id, parentSpanId: exportedSpan.parentSpanId });
+          const eventData = await this._buildEvent({ span: exportedSpan, traceData });
+          if (eventData) {
+            if (!this.skipCachingEventSpans) {
+              traceData.addEvent({ eventId: exportedSpan.id, eventData });
+            }
+            // Successfully processed - schedule processing of events waiting for this one
+            this.#scheduleProcessWaitingFor(exportedSpan.traceId, exportedSpan.id);
+            return true;
+          }
+          return false;
+        }
+
+        case 'handleSpanStart': {
+          traceData.addBranch({ spanId: exportedSpan.id, parentSpanId: exportedSpan.parentSpanId });
+          const spanData = await this._buildSpan({ span: exportedSpan, traceData });
+          if (spanData) {
+            traceData.addSpan({ spanId: exportedSpan.id, spanData });
+            // Mark root as processed if this is the root span
+            if (exportedSpan.isRootSpan) {
+              traceData.markRootSpanProcessed();
+            }
+            // Successfully processed - schedule processing of events waiting for this one
+            this.#scheduleProcessWaitingFor(exportedSpan.traceId, exportedSpan.id);
+            return true;
+          }
+          return false;
+        }
+
+        case 'handleSpanUpdate': {
+          await this._updateSpan({ span: exportedSpan, traceData });
+          return true;
+        }
+
+        case 'handleSpanEnd': {
+          traceData.endSpan({ spanId: exportedSpan.id });
+          await this._finishSpan({ span: exportedSpan, traceData });
+          // Check if we should schedule cleanup
+          if (traceData.activeSpanCount() === 0) {
+            this.#scheduleCleanup(exportedSpan.traceId);
+          }
+          return true;
+        }
+        default:
+          // Should never happen - exhaustive switch
+          return false;
+      }
+    } catch (error) {
+      this.logger.error(`${this.name}: Error processing queued event`, { error, event, method });
+      return false;
+    }
+  }
+
+  // ============================================================================
+  // Delayed Cleanup
+  // ============================================================================
+
+  /**
+   * Schedule cleanup of trace data after a delay.
+   * Allows late-arriving data to still be processed.
+   */
+  #scheduleCleanup(traceId: string): void {
+    // Cancel any existing scheduled cleanup for this trace
+    this.#cancelScheduledCleanup(traceId);
+
+    this.logger.debug(`${this.name}: Scheduling cleanup in ${this.#traceCleanupDelayMs}ms`, { traceId });
+
+    const timeout = setTimeout(() => {
+      this.#pendingCleanups.delete(traceId);
+      this.#performCleanup(traceId);
+    }, this.#traceCleanupDelayMs);
+
+    this.#pendingCleanups.set(traceId, timeout);
+
+    // Enforce soft cap on pending cleanups
+    this.#enforcePendingCleanupCap();
+  }
+
+  /**
+   * Cancel a scheduled cleanup for a trace.
+   */
+  #cancelScheduledCleanup(traceId: string): void {
+    const existingTimeout = this.#pendingCleanups.get(traceId);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+      this.#pendingCleanups.delete(traceId);
+      this.logger.debug(`${this.name}: Cancelled scheduled cleanup`, { traceId });
+    }
+  }
+
+  /**
+   * Perform the actual cleanup of trace data.
+   */
+  #performCleanup(traceId: string): void {
+    const traceData = this.#traceMap.get(traceId);
+    if (!traceData) return;
+
+    // Log any orphaned events in the queue
+    const orphanedEvents = traceData.getAllQueuedEvents();
+    if (orphanedEvents.length > 0) {
+      this.logger.warn(`${this.name}: Dropping ${orphanedEvents.length} orphaned events on cleanup`, {
+        traceId,
+        orphanedEvents: orphanedEvents.map(e => ({
+          spanId: e.event.exportedSpan.id,
+          waitingFor: e.waitingFor,
+          attempts: e.attempts,
+          queuedAt: e.queuedAt,
+        })),
+      });
+    }
+
+    // Remove from trace map and insertion order
+    this.#traceMap.delete(traceId);
+    const orderIndex = this.#traceInsertionOrder.indexOf(traceId);
+    if (orderIndex !== -1) {
+      this.#traceInsertionOrder.splice(orderIndex, 1);
+    }
+
+    this.logger.debug(`${this.name}: Cleaned up trace data`, { traceId });
+  }
+
+  // ============================================================================
+  // Cap Enforcement
+  // ============================================================================
+
+  /**
+   * Enforce soft cap on pending cleanup traces.
+   * Only removes traces with activeSpanCount == 0.
+   */
+  #enforcePendingCleanupCap(): void {
+    if (this.#pendingCleanups.size <= this.#maxPendingCleanupTraces) {
+      return;
+    }
+
+    const toRemove = this.#pendingCleanups.size - this.#maxPendingCleanupTraces;
+    this.logger.warn(`${this.name}: Pending cleanup cap exceeded, force-cleaning ${toRemove} traces`, {
+      pendingCount: this.#pendingCleanups.size,
+      cap: this.#maxPendingCleanupTraces,
+    });
+
+    // Remove oldest pending cleanups
+    let removed = 0;
+    for (const traceId of this.#traceInsertionOrder) {
+      if (removed >= toRemove) break;
+
+      if (this.#pendingCleanups.has(traceId)) {
+        this.#cancelScheduledCleanup(traceId);
+        this.#performCleanup(traceId);
+        removed++;
+      }
+    }
+  }
+
+  /**
+   * Enforce hard cap on total traces.
+   * Will kill even active traces if necessary.
+   */
+  async #enforceHardCap(): Promise<void> {
+    if (this.#traceMap.size <= this.#maxTotalTraces) {
+      return;
+    }
+
+    const toRemove = this.#traceMap.size - this.#maxTotalTraces;
+    this.logger.warn(`${this.name}: Total trace cap exceeded, killing ${toRemove} oldest traces`, {
+      traceCount: this.#traceMap.size,
+      cap: this.#maxTotalTraces,
+    });
+
+    const reason: SpanErrorInfo = {
+      id: 'TRACE_CAP_EXCEEDED',
+      message: 'Trace killed due to memory cap enforcement.',
+      domain: 'MASTRA_OBSERVABILITY',
+      category: 'SYSTEM',
+    };
+
+    let removed = 0;
+    // Use a copy of the array since we're modifying it
+    for (const traceId of [...this.#traceInsertionOrder]) {
+      if (removed >= toRemove) break;
+
+      const traceData = this.#traceMap.get(traceId);
+      if (traceData) {
+        // Abort any active spans
+        for (const spanId of traceData.activeSpanIds) {
+          const span = traceData.getSpan({ spanId });
+          if (span) {
+            await this._abortSpan({ span, traceData, reason });
+          }
+        }
+
+        // Cancel any pending cleanup and remove
+        this.#cancelScheduledCleanup(traceId);
+        this.#performCleanup(traceId);
+        removed++;
+      }
+    }
+  }
+
+  // ============================================================================
+  // Lifecycle Hooks
+  // ============================================================================
+
+  protected async _preExportTracingEvent(event: TracingEvent): Promise<TracingEvent> {
+    return event;
+  }
+
+  protected async _postExportTracingEvent(): Promise<void> {}
+
+  protected abstract _buildRoot(args: {
+    span: AnyExportedSpan;
+    traceData: TraceData<TRootData, TSpanData, TEventData, TMetadata>;
+  }): Promise<TRootData | undefined>;
+
+  protected abstract _buildEvent(args: {
+    span: AnyExportedSpan;
+    traceData: TraceData<TRootData, TSpanData, TEventData, TMetadata>;
+  }): Promise<TEventData | undefined>;
+
+  protected abstract _buildSpan(args: {
+    span: AnyExportedSpan;
+    traceData: TraceData<TRootData, TSpanData, TEventData, TMetadata>;
+  }): Promise<TSpanData | undefined>;
+
+  protected abstract _updateSpan(args: {
+    span: AnyExportedSpan;
+    traceData: TraceData<TRootData, TSpanData, TEventData, TMetadata>;
+  }): Promise<void>;
+
+  protected abstract _finishSpan(args: {
+    span: AnyExportedSpan;
+    traceData: TraceData<TRootData, TSpanData, TEventData, TMetadata>;
+  }): Promise<void>;
+
+  protected abstract _abortSpan(args: {
+    span: TSpanData;
+    traceData: TraceData<TRootData, TSpanData, TEventData, TMetadata>;
+    reason: SpanErrorInfo;
+  }): Promise<void>;
+
+  protected skipBuildRootTask = false;
+  protected skipSpanUpdateEvents = false;
+  protected skipCachingEventSpans = false;
+
+  private getMethod(event: TracingEvent): 'handleEventSpan' | 'handleSpanStart' | 'handleSpanUpdate' | 'handleSpanEnd' {
+    if (!event.exportedSpan.isEvent) {
+      switch (event.type) {
+        case 'span_started':
+          return 'handleSpanStart';
+        case 'span_updated':
+          return 'handleSpanUpdate';
+        case 'span_ended':
+          return 'handleSpanEnd';
+      }
+    }
+    return 'handleEventSpan';
+  }
+
+  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
+    if (this.#shutdownStarted) {
+      return;
+    }
+
+    const method = this.getMethod(event);
+    if (method == 'handleSpanUpdate' && this.skipSpanUpdateEvents) {
+      return;
+    }
+
+    const traceId = event.exportedSpan.traceId;
+    const traceData = this.getTraceData({ traceId, method });
+
+    const { exportedSpan } = await this._preExportTracingEvent(event);
+
+    // Handle root span building for exporters that need it
+    if (!this.skipBuildRootTask && !traceData.hasRoot()) {
+      if (exportedSpan.isRootSpan) {
+        this.logger.debug(`${this.name}: Building root`, {
+          traceId: exportedSpan.traceId,
+          spanId: exportedSpan.id,
+        });
+        const rootData = await this._buildRoot({ span: exportedSpan, traceData });
+        if (rootData) {
+          this.logger.debug(`${this.name}: Adding root`, {
+            traceId: exportedSpan.traceId,
+            spanId: exportedSpan.id,
+          });
+          traceData.addRoot({ rootId: exportedSpan.id, rootData });
+          // Root is now processed, trigger async processing of waiting events
+          this.#scheduleProcessWaitingForRoot(traceId);
+        }
+        // Note: Root span still continues to handleSpanStart below to track
+        // the span as active and call _buildSpan for vendor-specific handling
+      } else {
+        this.logger.debug(`${this.name}: Root does not exist, adding span to waiting queue.`, {
+          traceId: exportedSpan.traceId,
+          spanId: exportedSpan.id,
+        });
+        traceData.addToWaitingQueue({ event, waitingFor: 'root' });
+        return;
+      }
+    }
+
+    if (exportedSpan.metadata && this.name in exportedSpan.metadata) {
+      const metadata = exportedSpan.metadata[this.name] as TMetadata;
+      this.logger.debug(`${this.name}: Found provider metadata in span`, {
+        traceId: exportedSpan.traceId,
+        spanId: exportedSpan.id,
+        metadata,
+      });
+      traceData.addMetadata({ spanId: exportedSpan.id, metadata });
+    }
+
+    try {
+      switch (method) {
+        case 'handleEventSpan': {
+          this.logger.debug(`${this.name}: handling event`, {
+            traceId: exportedSpan.traceId,
+            spanId: exportedSpan.id,
+          });
+          traceData.addBranch({ spanId: exportedSpan.id, parentSpanId: exportedSpan.parentSpanId });
+          const eventData = await this._buildEvent({ span: exportedSpan, traceData });
+          if (eventData) {
+            if (!this.skipCachingEventSpans) {
+              this.logger.debug(`${this.name}: adding event to traceData`, {
+                traceId: exportedSpan.traceId,
+                spanId: exportedSpan.id,
+              });
+              traceData.addEvent({ eventId: exportedSpan.id, eventData });
+            }
+            // Event created successfully, trigger processing of any waiting events
+            this.#scheduleProcessWaitingFor(traceId, exportedSpan.id);
+          } else {
+            // Parent doesn't exist, queue for later
+            const parentId = exportedSpan.parentSpanId;
+            this.logger.debug(`${this.name}: adding event to waiting queue`, {
+              traceId: exportedSpan.traceId,
+              spanId: exportedSpan.id,
+              waitingFor: parentId ?? 'root',
+            });
+            traceData.addToWaitingQueue({ event, waitingFor: parentId ?? 'root' });
+          }
+          break;
+        }
+        case 'handleSpanStart': {
+          this.logger.debug(`${this.name}: handling span start`, {
+            traceId: exportedSpan.traceId,
+            spanId: exportedSpan.id,
+          });
+          traceData.addBranch({ spanId: exportedSpan.id, parentSpanId: exportedSpan.parentSpanId });
+          const spanData = await this._buildSpan({ span: exportedSpan, traceData });
+          if (spanData) {
+            this.logger.debug(`${this.name}: adding span to traceData`, {
+              traceId: exportedSpan.traceId,
+              spanId: exportedSpan.id,
+            });
+            traceData.addSpan({ spanId: exportedSpan.id, spanData });
+            // Mark root as processed for skipBuildRootTask exporters
+            if (exportedSpan.isRootSpan) {
+              traceData.markRootSpanProcessed();
+              this.#scheduleProcessWaitingForRoot(traceId);
+            }
+            // Span created successfully, trigger processing of any waiting events
+            this.#scheduleProcessWaitingFor(traceId, exportedSpan.id);
+          } else {
+            // Parent doesn't exist, queue for later
+            const parentId = exportedSpan.parentSpanId;
+            this.logger.debug(`${this.name}: adding span to waiting queue`, {
+              traceId: exportedSpan.traceId,
+              waitingFor: parentId ?? 'root',
+            });
+            traceData.addToWaitingQueue({ event, waitingFor: parentId ?? 'root' });
+          }
+          break;
+        }
+        case 'handleSpanUpdate':
+          this.logger.debug(`${this.name}: handling span update`, {
+            traceId: exportedSpan.traceId,
+            spanId: exportedSpan.id,
+          });
+          await this._updateSpan({ span: exportedSpan, traceData });
+          break;
+        case 'handleSpanEnd':
+          this.logger.debug(`${this.name}: handling span end`, {
+            traceId: exportedSpan.traceId,
+            spanId: exportedSpan.id,
+          });
+          traceData.endSpan({ spanId: exportedSpan.id });
+          await this._finishSpan({ span: exportedSpan, traceData });
+          // Schedule cleanup when all spans have ended
+          if (traceData.activeSpanCount() === 0) {
+            this.#scheduleCleanup(traceId);
+          }
+          break;
+      }
+    } catch (error) {
+      this.logger.error(`${this.name}: exporter error`, { error, event, method });
+    }
+
+    // Reschedule cleanup if all spans have ended
+    // This handles the case where late data arrives after all spans ended
+    // (getTraceData cancels any existing cleanup, so we need to reschedule)
+    if (traceData.activeSpanCount() === 0) {
+      this.#scheduleCleanup(traceId);
+    }
+
+    await this._postExportTracingEvent();
+  }
+
+  /**
+   * Get trace data for a span, creating one if not found.
+   * Also cancels any pending cleanup for this trace (new data arrived).
+   *
+   * @param context - The span context for logging
+   * @returns The trace data
+   */
+  protected getTraceData(args: {
+    traceId: string;
+    method: string;
+  }): TraceData<TRootData, TSpanData, TEventData, TMetadata> {
+    const { traceId, method } = args;
+
+    // Cancel any scheduled cleanup - new data has arrived
+    this.#cancelScheduledCleanup(traceId);
+
+    if (!this.#traceMap.has(traceId)) {
+      this.#traceMap.set(traceId, new TraceData());
+      // Track insertion order for cap enforcement
+      this.#traceInsertionOrder.push(traceId);
+      this.logger.debug(`${this.name}: Created new trace data cache`, {
+        traceId,
+        method,
+      });
+
+      // Enforce hard cap on total traces
+      this.#enforceHardCap().catch(error => {
+        this.logger.error(`${this.name}: Error enforcing hard cap`, { error });
+      });
+    }
+    return this.#traceMap.get(traceId)!;
+  }
+
+  /**
+   * @deprecated Use #scheduleCleanup instead. Immediate cleanup is no longer recommended.
+   * This method is kept for backward compatibility but now schedules cleanup instead.
+   */
+  protected clearTraceData(args: { traceId: string; method: string }): void {
+    const { traceId } = args;
+    // For backward compatibility, schedule cleanup instead of immediate deletion
+    this.#scheduleCleanup(traceId);
+  }
+
+  protected traceMapSize(): number {
+    return this.#traceMap.size;
+  }
+
+  protected async _preShutdown(): Promise<void> {}
+
+  protected async _postShutdown(): Promise<void> {}
+
+  async shutdown(): Promise<void> {
+    if (this.isDisabled) {
+      return;
+    }
+
+    this.#shutdownStarted = true;
+    await this._preShutdown();
+
+    // Cancel all pending cleanup timers
+    for (const [traceId, timeout] of this.#pendingCleanups) {
+      clearTimeout(timeout);
+      this.logger.debug(`${this.name}: Cancelled pending cleanup on shutdown`, { traceId });
+    }
+    this.#pendingCleanups.clear();
+
+    // End all active spans
+    const reason: SpanErrorInfo = {
+      id: 'SHUTDOWN',
+      message: 'Observability is shutting down.',
+      domain: 'MASTRA_OBSERVABILITY',
+      category: 'SYSTEM',
+    };
+
+    for (const [traceId, traceData] of this.#traceMap) {
+      // Log any orphaned events
+      const orphanedEvents = traceData.getAllQueuedEvents();
+      if (orphanedEvents.length > 0) {
+        this.logger.warn(`${this.name}: Dropping ${orphanedEvents.length} orphaned events on shutdown`, {
+          traceId,
+          orphanedEvents: orphanedEvents.map(e => ({
+            spanId: e.event.exportedSpan.id,
+            waitingFor: e.waitingFor,
+            attempts: e.attempts,
+          })),
+        });
+      }
+
+      // Abort active spans
+      for (const spanId of traceData.activeSpanIds) {
+        const span = traceData.getSpan({ spanId });
+        if (span) {
+          await this._abortSpan({ span, traceData, reason });
+        }
+      }
+    }
+
+    this.#traceMap.clear();
+    this.#traceInsertionOrder = [];
+    await this._postShutdown();
+    await super.shutdown();
+  }
+}

--- a/observability/otel-exporter/src/provider-configs.test.ts
+++ b/observability/otel-exporter/src/provider-configs.test.ts
@@ -92,14 +92,22 @@ describe('Provider Configurations', () => {
     });
 
     it('should require both apiKey and teamId', () => {
-      const config = resolveProviderConfig({
-        laminar: {
-          // apiKey missing
-          teamId: 'test-team',
-        },
-      });
+      // Clear env var to ensure config validation fails
+      const originalApiKey = process.env.LMNR_PROJECT_API_KEY;
+      delete process.env.LMNR_PROJECT_API_KEY;
 
-      expect(config).toBeNull();
+      try {
+        const config = resolveProviderConfig({
+          laminar: {
+            // apiKey missing
+            teamId: 'test-team',
+          },
+        });
+
+        expect(config).toBeNull();
+      } finally {
+        if (originalApiKey) process.env.LMNR_PROJECT_API_KEY = originalApiKey;
+      }
     });
   });
 

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -54,10 +54,9 @@ export class OtelExporter extends BaseExporter {
 
     // Provider configuration is required
     if (!this.config.provider) {
-      this.logger.error(
+      this.setDisabled(
         '[OtelExporter] Provider configuration is required. Use the "custom" provider for generic endpoints.',
       );
-      this.isDisabled = true;
       this.isSetup = true;
       return;
     }
@@ -66,7 +65,7 @@ export class OtelExporter extends BaseExporter {
     const resolved = resolveProviderConfig(this.config.provider);
     if (!resolved) {
       // Configuration validation failed, disable tracing
-      this.isDisabled = true;
+      this.setDisabled('[OtelExporter] Provider configuration validation failed.');
       this.isSetup = true;
       return;
     }
@@ -87,7 +86,7 @@ export class OtelExporter extends BaseExporter {
 
     if (!ExporterClass) {
       // Exporter not available, disable tracing
-      this.isDisabled = true;
+      this.setDisabled(`[OtelExporter] Exporter not available for protocol: ${protocol}`);
       this.isSetup = true;
       return;
     }
@@ -110,12 +109,11 @@ export class OtelExporter extends BaseExporter {
             metadata.set(key, value);
           });
         } catch (grpcError) {
-          this.logger.error(
+          this.setDisabled(
             `[OtelExporter] Failed to load gRPC metadata. Install required packages:\n` +
-              `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js\n`,
-            grpcError,
+              `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js`,
           );
-          this.isDisabled = true;
+          this.logger.error('[OtelExporter] gRPC error details:', grpcError);
           this.isSetup = true;
           return;
         }
@@ -134,8 +132,8 @@ export class OtelExporter extends BaseExporter {
         });
       }
     } catch (error) {
-      this.logger.error(`[OtelExporter] Failed to create exporter:`, error);
-      this.isDisabled = true;
+      this.setDisabled('[OtelExporter] Failed to create exporter.');
+      this.logger.error('[OtelExporter] Exporter creation error details:', error);
       this.isSetup = true;
       return;
     }

--- a/observability/posthog/package.json
+++ b/observability/posthog/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@mastra/core": "workspace:*",
+    "@observability/test-utils": "workspace:*",
     "@types/node": "^20.19.0",
     "eslint": "^9.37.0",
     "tsup": "^8.5.0",

--- a/observability/posthog/src/tracing.early-data.test.ts
+++ b/observability/posthog/src/tracing.early-data.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Early Data Handling Tests for PostHog Exporter
+ *
+ * These tests verify that the PostHog exporter correctly handles:
+ * - Out-of-order span arrival
+ * - Root spans arriving after children
+ * - Deep hierarchy cascading
+ * - Late events during cleanup delay
+ * - Orphaned span handling
+ *
+ * PostHog uses skipBuildRootTask = true, meaning:
+ * - Root spans do NOT create a separate trace wrapper
+ * - Root spans generate $ai_trace events directly
+ * - Child spans still wait for their parent (including root) before processing
+ */
+
+import { describe, beforeEach, afterEach, vi, it, expect } from 'vitest';
+import {
+  runAllEarlyDataTests,
+  runLateEventTests,
+  runOrphanedSpanTests,
+  type ExporterFactory,
+} from '@observability/test-utils';
+import { PosthogExporter } from './tracing';
+
+// Mock PostHog to avoid real API calls
+// Use a class constructor for proper `new` support
+vi.mock('posthog-node', () => {
+  return {
+    PostHog: class {
+      capture = vi.fn();
+      shutdown = vi.fn().mockResolvedValue(undefined);
+    },
+  };
+});
+
+describe('PosthogExporter Early Data Handling', () => {
+  const factory: ExporterFactory = () => {
+    return new PosthogExporter({
+      apiKey: 'test-api-key',
+      // Use long cleanup delay to prevent cleanup during tests
+      traceCleanupDelayMs: 60 * 60 * 1000,
+    });
+  };
+
+  // Run shared early data test scenarios
+  runAllEarlyDataTests(factory, 'PosthogExporter');
+  runLateEventTests(factory, 'PosthogExporter');
+  runOrphanedSpanTests(factory, 'PosthogExporter');
+
+  // PostHog-specific tests
+  describe('PostHog-specific behavior', () => {
+    let exporter: PosthogExporter;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      exporter = factory() as PosthogExporter;
+    });
+
+    afterEach(async () => {
+      await exporter.shutdown();
+      vi.useRealTimers();
+    });
+
+    it('should handle root spans without trace wrapper (skipBuildRootTask = true)', async () => {
+      // PostHog uses skipBuildRootTask = true, so root spans
+      // are processed directly without a wrapper
+      const { generateTrace, sendWithDelays } = await import('@observability/test-utils');
+
+      const events = generateTrace({ depth: 1, breadth: 1, includeEvents: false });
+      const rootStart = events.find(e => e.type === 'span_started' && e.exportedSpan.isRootSpan);
+
+      expect(rootStart).toBeDefined();
+      expect(rootStart!.exportedSpan.isRootSpan).toBe(true);
+
+      await sendWithDelays(exporter, [rootStart!]);
+      // Use vi.advanceTimersToNextTimerAsync for fake timers
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersToNextTimerAsync();
+      }
+    });
+  });
+});

--- a/observability/posthog/src/tracing.test.ts
+++ b/observability/posthog/src/tracing.test.ts
@@ -1,6 +1,8 @@
+import type { AnyExportedSpan } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+import type { PosthogExporterConfig } from './tracing';
 import { PosthogExporter } from './tracing';
 
 // Mock PostHog client
@@ -20,9 +22,24 @@ vi.mock('posthog-node', () => {
   };
 });
 
+class TestPosthogExporter extends PosthogExporter {
+  _getTraceData(traceId: string) {
+    return this.getTraceData({ traceId, method: 'test' });
+  }
+
+  get _traceMapSize(): number {
+    return this.traceMapSize();
+  }
+}
+
 describe('PosthogExporter', () => {
-  let exporter: PosthogExporter;
-  const validConfig = { apiKey: 'test-key' };
+  let exporter: TestPosthogExporter;
+  const validConfig: PosthogExporterConfig = {
+    apiKey: 'test-key',
+    logLevel: 'debug',
+    // Short cleanup delay for faster tests
+    traceCleanupDelayMs: 10,
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -37,7 +54,7 @@ describe('PosthogExporter', () => {
   // --- Initialization Tests ---
   describe('Initialization', () => {
     it('should initialize with valid config', () => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
       expect(mockPostHogConstructor).toHaveBeenCalledWith(
         'test-key',
         expect.objectContaining({
@@ -50,13 +67,13 @@ describe('PosthogExporter', () => {
 
     it('should disable when missing API key', () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      exporter = new PosthogExporter({ apiKey: '' });
+      exporter = new TestPosthogExporter({ apiKey: '' });
       expect(mockPostHogConstructor).not.toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
 
     it('should use custom host if provided', () => {
-      exporter = new PosthogExporter({ ...validConfig, host: 'https://eu.i.posthog.com' });
+      exporter = new TestPosthogExporter({ ...validConfig, host: 'https://eu.i.posthog.com' });
       expect(mockPostHogConstructor).toHaveBeenCalledWith(
         'test-key',
         expect.objectContaining({
@@ -66,7 +83,7 @@ describe('PosthogExporter', () => {
     });
 
     it('should auto-configure serverless defaults', () => {
-      exporter = new PosthogExporter({ ...validConfig, serverless: true });
+      exporter = new TestPosthogExporter({ ...validConfig, serverless: true });
       expect(mockPostHogConstructor).toHaveBeenCalledWith(
         'test-key',
         expect.objectContaining({
@@ -77,7 +94,7 @@ describe('PosthogExporter', () => {
     });
 
     it('should allow manual overrides in serverless mode', () => {
-      exporter = new PosthogExporter({
+      exporter = new TestPosthogExporter({
         ...validConfig,
         serverless: true,
         flushAt: 50,
@@ -94,45 +111,45 @@ describe('PosthogExporter', () => {
 
   // --- Span Lifecycle Tests ---
   describe('Span Lifecycle', () => {
-    const mockSpan = {
+    const startTime = new Date();
+    const mockSpan: AnyExportedSpan = {
       id: 'span-1',
       traceId: 'trace-1',
       type: SpanType.GENERIC,
       name: 'test-span',
-      startTime: Date.now(),
-      endTime: Date.now() + 100,
+      startTime,
+      endTime: new Date(startTime.getTime() + 100),
       attributes: {},
       metadata: {},
+      isRootSpan: false,
+      isEvent: false,
     };
 
     it('should cache span on start', async () => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: mockSpan as any,
+        exportedSpan: mockSpan,
       });
 
-      // Access private traceMap for verification (casting to any)
-      const traceMap = (exporter as any).traceMap;
-      expect(traceMap.has(mockSpan.traceId)).toBe(true);
-      const traceData = traceMap.get(mockSpan.traceId);
-      expect(traceData.spans.has(mockSpan.id)).toBe(true);
+      const traceData = exporter._getTraceData(mockSpan.traceId);
+      expect(traceData.hasSpan({ spanId: mockSpan.id })).toBe(true);
     });
 
     it('should capture event on end', async () => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
 
       // Start
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: mockSpan as any,
+        exportedSpan: mockSpan,
       });
 
       // End
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_ENDED,
-        exportedSpan: mockSpan as any,
+        exportedSpan: mockSpan,
       });
 
       expect(mockCapture).toHaveBeenCalledTimes(1);
@@ -150,65 +167,47 @@ describe('PosthogExporter', () => {
     });
 
     it('should cleanup span from cache after capture', async () => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
 
       // Start
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: mockSpan as any,
+        exportedSpan: mockSpan,
       });
+
+      const traceData = exporter._getTraceData(mockSpan.traceId);
 
       // End
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_ENDED,
-        exportedSpan: mockSpan as any,
+        exportedSpan: mockSpan,
       });
 
-      const traceMap = (exporter as any).traceMap;
-      // Trace should be gone if it was the only span
-      expect(traceMap.has(mockSpan.traceId)).toBe(false);
-    });
+      // Wait for cleanup delay (config uses 10ms)
+      await new Promise(resolve => setTimeout(resolve, 20));
 
-    it('should handle missing start event gracefully', async () => {
-      exporter = new PosthogExporter(validConfig);
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      // Only End
-      await exporter.exportTracingEvent({
-        type: TracingEventType.SPAN_ENDED,
-        exportedSpan: mockSpan as any,
-      });
-
-      expect(mockCapture).not.toHaveBeenCalled();
-      consoleSpy.mockRestore();
+      // Trace should be cleaned up since this was the only active span
+      // (traceData is always created if it doesn't exist, but the old object
+      // should have been cleaned up.)
+      const newTraceData = exporter._getTraceData(mockSpan.traceId);
+      expect(traceData).not.toBe(newTraceData);
     });
   });
 
   // --- Distinct ID Resolution Tests ---
   describe('Distinct ID Resolution', () => {
     it('should use userId from metadata if present', async () => {
-      exporter = new PosthogExporter(validConfig);
-      const spanWithUser = {
-        ...{
-          id: 'span-user',
-          traceId: 'trace-user',
-          type: SpanType.GENERIC,
-          name: 'user-span',
-          startTime: Date.now(),
-          endTime: Date.now() + 100,
-          attributes: {},
-        },
-        metadata: { userId: 'user-123' },
-      };
+      exporter = new TestPosthogExporter(validConfig);
+      const spanWithUser = createSpan({ metadata: { userId: 'user-123' } });
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: spanWithUser as any,
+        exportedSpan: spanWithUser,
       });
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_ENDED,
-        exportedSpan: spanWithUser as any,
+        exportedSpan: spanWithUser,
       });
 
       expect(mockCapture).toHaveBeenCalledWith(
@@ -219,26 +218,17 @@ describe('PosthogExporter', () => {
     });
 
     it('should use configured defaultDistinctId', async () => {
-      exporter = new PosthogExporter({ ...validConfig, defaultDistinctId: 'system' });
-      const spanNoUser = {
-        id: 'span-anon',
-        traceId: 'trace-anon',
-        type: SpanType.GENERIC,
-        name: 'anon-span',
-        startTime: Date.now(),
-        endTime: Date.now() + 100,
-        attributes: {},
-        metadata: {},
-      };
+      exporter = new TestPosthogExporter({ ...validConfig, defaultDistinctId: 'system' });
+      const spanNoUser = createSpan();
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: spanNoUser as any,
+        exportedSpan: spanNoUser,
       });
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_ENDED,
-        exportedSpan: spanNoUser as any,
+        exportedSpan: spanNoUser,
       });
 
       expect(mockCapture).toHaveBeenCalledWith(
@@ -252,31 +242,25 @@ describe('PosthogExporter', () => {
   // --- Cleanup Tests ---
   describe('Cleanup', () => {
     it('should clear resources on shutdown', async () => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
 
       // Add some data
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: {
-          id: 's1',
-          traceId: 't1',
-          startTime: Date.now(),
-          type: SpanType.GENERIC,
-        } as any,
+        exportedSpan: createSpan(),
       });
 
       await exporter.shutdown();
 
       expect(mockShutdown).toHaveBeenCalled();
-      const traceMap = (exporter as any).traceMap;
-      expect(traceMap.size).toBe(0);
+      expect(exporter._traceMapSize).toBe(0);
     });
   });
 
   // --- Priority 1: Core Functionality ---
   describe('Span Type Mapping', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should map MODEL_GENERATION to $ai_generation (non-root)', async () => {
@@ -334,7 +318,7 @@ describe('PosthogExporter', () => {
 
   describe('LLM Generation Properties', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should extract model, provider, and tokens from attributes', async () => {
@@ -392,7 +376,7 @@ describe('PosthogExporter', () => {
 
   describe('Span Hierarchy', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should set $ai_parent_id for child spans', async () => {
@@ -411,12 +395,13 @@ describe('PosthogExporter', () => {
       await exportSpanLifecycle(exporter, parent);
       await exportSpanLifecycle(exporter, child);
 
-      // Child should have parent_id
+      // Child should have parent_id = trace_id when parent is a root span
+      // (root spans create $ai_trace events, not $ai_span, so children reference trace_id)
       expect(mockCapture).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
           properties: expect.objectContaining({
-            $ai_parent_id: 'parent',
+            $ai_parent_id: 't1', // trace_id because parent is root span
             $ai_trace_id: 't1',
           }),
         }),
@@ -435,7 +420,7 @@ describe('PosthogExporter', () => {
   // --- Priority 2: Advanced Features ---
   describe('Privacy Mode', () => {
     it('should pass privacy mode config to SDK', async () => {
-      exporter = new PosthogExporter({
+      exporter = new TestPosthogExporter({
         ...validConfig,
         enablePrivacyMode: true,
       });
@@ -449,7 +434,7 @@ describe('PosthogExporter', () => {
     });
 
     it('should not apply privacy mode to non-generation spans', async () => {
-      exporter = new PosthogExporter({
+      exporter = new TestPosthogExporter({
         ...validConfig,
         enablePrivacyMode: true,
       });
@@ -475,7 +460,7 @@ describe('PosthogExporter', () => {
 
   describe('Error Handling', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should include error details in properties (non-root span)', async () => {
@@ -553,7 +538,7 @@ describe('PosthogExporter', () => {
   // --- Priority 3: Edge Cases ---
   describe('Event Span Handling', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should capture event spans immediately on start', async () => {
@@ -566,7 +551,7 @@ describe('PosthogExporter', () => {
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: eventSpan as any,
+        exportedSpan: eventSpan,
       });
 
       expect(mockCapture).toHaveBeenCalledTimes(1);
@@ -579,48 +564,24 @@ describe('PosthogExporter', () => {
       );
     });
 
-    it('should not re-capture event spans on end (no double counting)', async () => {
-      const eventSpan = createSpan({
-        id: 'event-1',
-        type: SpanType.GENERIC,
-        isEvent: true,
-      });
-
-      // Start (should capture)
-      await exporter.exportTracingEvent({
-        type: TracingEventType.SPAN_STARTED,
-        exportedSpan: eventSpan as any,
-      });
-
-      // End (should ignore)
-      await exporter.exportTracingEvent({
-        type: TracingEventType.SPAN_ENDED,
-        exportedSpan: eventSpan as any,
-      });
-
-      expect(mockCapture).toHaveBeenCalledTimes(1);
-    });
-
     it('should not cache event spans', async () => {
       const eventSpan = createSpan({ isEvent: true });
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: eventSpan as any,
+        exportedSpan: eventSpan,
       });
 
-      const traceMap = (exporter as any).traceMap;
-      const traceData = traceMap.get(eventSpan.traceId);
+      const traceData = exporter._getTraceData(eventSpan.traceId);
 
       // Event spans should not create trace data at all
-      const hasSpan = traceData?.spans.has(eventSpan.id) ?? false;
-      expect(hasSpan).toBe(false);
+      expect(traceData?.hasSpan({ spanId: eventSpan.id })).toBe(false);
     });
   });
 
   describe('Message Formatting', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should format string input as user message array', async () => {
@@ -684,18 +645,20 @@ describe('PosthogExporter', () => {
   // --- Priority 4: Integration Scenarios ---
   describe('Out-of-Order Events', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should keep trace until last child ends when root ends first', async () => {
+      const traceId = 't1';
+
       const root = createSpan({
         id: 'root',
-        traceId: 't1',
+        traceId,
         type: SpanType.AGENT_RUN,
       });
       const child = createSpan({
         id: 'child',
-        traceId: 't1',
+        traceId,
         parentSpanId: 'root',
         type: SpanType.TOOL_CALL,
       });
@@ -703,46 +666,49 @@ describe('PosthogExporter', () => {
       // Start both
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: root as any,
+        exportedSpan: root,
       });
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: child as any,
+        exportedSpan: child,
       });
 
       // End root BEFORE child
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_ENDED,
-        exportedSpan: root as any,
+        exportedSpan: root,
       });
 
-      const traceMap = (exporter as any).traceMap;
-      expect(traceMap.has('t1')).toBe(true); // Still there
+      const traceData = exporter._getTraceData(traceId);
+      expect(traceData.activeSpanCount()).toBe(1); // Still there
 
       // End child
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_ENDED,
-        exportedSpan: child as any,
+        exportedSpan: child,
       });
 
-      expect(traceMap.has('t1')).toBe(false); // Now cleaned up
+      expect(traceData.activeSpanCount()).toBe(0); // Now cleaned up
     });
   });
 
   describe('Concurrent Traces', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should handle multiple traces concurrently without mixing data', async () => {
+      const traceId = 't1';
       const trace1 = createSpan({
-        traceId: 't1',
+        traceId,
         metadata: { userId: 'user-1' },
       });
       const trace2 = createSpan({
-        traceId: 't2',
+        traceId,
         metadata: { userId: 'user-2' },
       });
+
+      const traceData = exporter._getTraceData(traceId);
 
       await exportSpanLifecycle(exporter, trace1);
       await exportSpanLifecycle(exporter, trace2);
@@ -750,8 +716,7 @@ describe('PosthogExporter', () => {
       expect(mockCapture).toHaveBeenNthCalledWith(1, expect.objectContaining({ distinctId: 'user-1' }));
       expect(mockCapture).toHaveBeenNthCalledWith(2, expect.objectContaining({ distinctId: 'user-2' }));
 
-      const traceMap = (exporter as any).traceMap;
-      expect(traceMap.size).toBe(0); // Both cleaned up
+      expect(traceData.activeSpanCount()).toBe(0); // Both cleaned up
     });
   });
 
@@ -760,7 +725,7 @@ describe('PosthogExporter', () => {
   // rather than as an array under $ai_tags
   describe('Tags Support', () => {
     beforeEach(() => {
-      exporter = new PosthogExporter(validConfig);
+      exporter = new TestPosthogExporter(validConfig);
     });
 
     it('should include tags as individual boolean properties for root spans', async () => {
@@ -880,7 +845,7 @@ describe('PosthogExporter', () => {
 
       await exporter.exportTracingEvent({
         type: TracingEventType.SPAN_STARTED,
-        exportedSpan: eventSpan as any,
+        exportedSpan: eventSpan,
       });
 
       expect(mockCapture).toHaveBeenCalledWith(
@@ -956,8 +921,8 @@ describe('PosthogExporter', () => {
 /**
  * Helper to create mock spans with defaults
  */
-function createSpan(overrides: Partial<any> = {}): any {
-  const now = Date.now();
+function createSpan(overrides: Partial<any> = {}): AnyExportedSpan {
+  const startTime = new Date();
   const id = overrides.id || `span-${Math.random()}`;
   const traceId = overrides.traceId || `trace-${Math.random()}`;
 
@@ -966,8 +931,8 @@ function createSpan(overrides: Partial<any> = {}): any {
     traceId,
     type: SpanType.GENERIC,
     name: 'test-span',
-    startTime: now,
-    endTime: now + 100,
+    startTime,
+    endTime: new Date(startTime.getTime() + 1000),
     isRootSpan: overrides.parentSpanId === undefined,
     isEvent: false,
     attributes: {},
@@ -979,7 +944,7 @@ function createSpan(overrides: Partial<any> = {}): any {
 /**
  * Helper to export complete span lifecycle
  */
-async function exportSpanLifecycle(exporter: PosthogExporter, span: any): Promise<void> {
+async function exportSpanLifecycle(exporter: PosthogExporter, span: AnyExportedSpan): Promise<void> {
   await exporter.exportTracingEvent({
     type: TracingEventType.SPAN_STARTED,
     exportedSpan: span,

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -372,6 +372,14 @@ export type AnySpanAttributes = SpanTypeMap[keyof SpanTypeMap];
 // Span Interfaces
 // ============================================================================
 
+export interface SpanErrorInfo {
+  message: string;
+  id?: string;
+  domain?: string;
+  category?: string;
+  details?: Record<string, any>;
+}
+
 /**
  * Base Span interface
  */
@@ -405,13 +413,7 @@ interface BaseSpan<TType extends SpanType> {
   /** Output generated at the end of the span */
   output?: any;
   /** Error information if span failed */
-  errorInfo?: {
-    message: string;
-    id?: string;
-    domain?: string;
-    category?: string;
-    details?: Record<string, any>;
-  };
+  errorInfo?: SpanErrorInfo;
   /** Is an event span? (event occurs at startTime, has no endTime) */
   isEvent: boolean;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,12 +972,18 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/observability':
+        specifier: workspace:*
+        version: link:../mastra
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.12(vitest@4.0.16)
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.12(vitest@4.0.16)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.13.17)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.13.17)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/arize:
     dependencies:
@@ -1055,6 +1061,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@observability/test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
       '@types/node':
         specifier: 22.13.17
         version: 22.13.17
@@ -1138,6 +1147,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@observability/test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
       '@types/node':
         specifier: 22.13.17
         version: 22.13.17
@@ -1181,6 +1193,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@observability/test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
       '@types/node':
         specifier: 22.13.17
         version: 22.13.17
@@ -1383,6 +1398,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@observability/test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
       '@types/node':
         specifier: 22.13.17
         version: 22.13.17


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified tracking lifecycle for observability exporters; Langfuse usage-metrics formatter added.

* **Improvements**
  * Consistent init/shutdown, lazy/external logger support, centralized disablement getter, and structured span error info.

* **Bug Fixes**
  * More robust out-of-order, nested, multi-root and late-span handling; improved credential and provider resolution behavior.

* **Tests**
  * Shared test utilities, configurable test exporters, and extensive early-data/out-of-order test suites added.

* **Chores**
  * Test tooling and package manifests updated; consolidated test entry exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->