### PR TITLE
Make e2e_tests/client_js optional in CI

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -389,11 +389,12 @@ jobs:
         run: pnpm test:e2e
 
   e2e-client-js:
-    name: E2E client-js
+    name: E2E client-js (optional)
     needs: check-changes
     if: ${{ github.repository == 'mastra-ai/mastra' && needs.check-changes.outputs.e2e-changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     permissions:
       contents: read
     env:
@@ -445,9 +446,8 @@ jobs:
         e2e-kitchen-sink,
         e2e-no-bundling,
         e2e-type-check,
-        e2e-client-js,
       ]
-    if: ${{ always() && needs.check-changes.outputs.e2e-changed == 'true' && needs.e2e-monorepo.result == 'success' && needs.e2e-create-mastra.result == 'success' && needs.e2e-commonjs.result == 'success' && needs.e2e-deployers.result == 'success' && needs.e2e-kitchen-sink.result == 'success' && needs.e2e-no-bundling.result == 'success' && needs.e2e-type-check.result == 'success' && needs.e2e-client-js.result == 'success' }}
+    if: ${{ always() && needs.check-changes.outputs.e2e-changed == 'true' && needs.e2e-monorepo.result == 'success' && needs.e2e-create-mastra.result == 'success' && needs.e2e-commonjs.result == 'success' && needs.e2e-deployers.result == 'success' && needs.e2e-kitchen-sink.result == 'success' && needs.e2e-no-bundling.result == 'success' && needs.e2e-type-check.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -474,9 +474,8 @@ jobs:
         e2e-kitchen-sink,
         e2e-no-bundling,
         e2e-type-check,
-        e2e-client-js,
       ]
-    if: ${{ always() && needs.check-changes.outputs.e2e-changed == 'true' && (needs.e2e-monorepo.result == 'failure' || needs.e2e-create-mastra.result == 'failure' || needs.e2e-commonjs.result == 'failure' || needs.e2e-deployers.result == 'failure' || needs.e2e-kitchen-sink.result == 'failure' || needs.e2e-no-bundling.result == 'failure' || needs.e2e-type-check.result == 'failure' || needs.e2e-client-js.result == 'failure') }}
+    if: ${{ always() && needs.check-changes.outputs.e2e-changed == 'true' && (needs.e2e-monorepo.result == 'failure' || needs.e2e-create-mastra.result == 'failure' || needs.e2e-commonjs.result == 'failure' || needs.e2e-deployers.result == 'failure' || needs.e2e-kitchen-sink.result == 'failure' || needs.e2e-no-bundling.result == 'failure' || needs.e2e-type-check.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       statuses: write


### PR DESCRIPTION
## Description

The new `e2e-client-j` tests are currently failing in `main` branch.

This changes the tests to still run but won't block PR merges if they fail.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test orchestration to make client-JS E2E tests optional. Test failures no longer affect overall build success status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->