### PR TITLE
fix list messages order

### DIFF
--- a/.changeset/fast-lands-rescue.md
+++ b/.changeset/fast-lands-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed orderBy query parameter parsing for memory endpoints. The listMessages and listThreads endpoints now correctly parse orderBy when passed as a JSON string in URL query parameters, matching the existing behavior for include and filter parameters.

--- a/packages/server/src/server/schemas/memory.test.ts
+++ b/packages/server/src/server/schemas/memory.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { listMessagesQuerySchema, listThreadsQuerySchema } from './memory';
+
+/**
+ * Regression tests for GitHub Issue #11761
+ *
+ * When the client sends query parameters with JSON objects like `orderBy`,
+ * they are URL-encoded as JSON strings (e.g., '{"field":"createdAt","direction":"ASC"}').
+ *
+ * The schema validation must be able to parse these JSON strings back into objects.
+ * All object-type query parameters (`orderBy`, `include`, `filter`) use z.preprocess
+ * to handle JSON string parsing from query strings.
+ */
+describe('Memory Schema Query Parameter Parsing', () => {
+  describe('listMessagesQuerySchema', () => {
+    describe('orderBy parameter parsing', () => {
+      it('should parse orderBy when passed as an object', () => {
+        const result = listMessagesQuerySchema.safeParse({
+          page: 0,
+          perPage: 50,
+          orderBy: { field: 'createdAt', direction: 'ASC' },
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.orderBy).toEqual({ field: 'createdAt', direction: 'ASC' });
+        }
+      });
+
+      /**
+       * Regression test: Ensures orderBy JSON strings from URL query params are parsed correctly.
+       *
+       * When the client sends a request like:
+       * GET /api/memory/threads/xxx/messages?orderBy=%7B%22field%22%3A%22createdAt%22%2C%22direction%22%3A%22ASC%22%7D
+       *
+       * The `orderBy` value arrives at the server as a string: '{"field":"createdAt","direction":"ASC"}'
+       * The schema must parse this JSON string back into an object.
+       */
+      it('should parse orderBy when passed as a JSON string (from URL query params)', () => {
+        // This is what happens when the client sends orderBy as a query parameter
+        // The value is JSON.stringify'd by the client, then URL-encoded
+        const jsonString = JSON.stringify({ field: 'createdAt', direction: 'ASC' });
+
+        const result = listMessagesQuerySchema.safeParse({
+          page: 0,
+          perPage: 50,
+          orderBy: jsonString, // This is a string, not an object
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.orderBy).toEqual({ field: 'createdAt', direction: 'ASC' });
+        }
+      });
+
+      it('should handle orderBy with only field specified as JSON string', () => {
+        const jsonString = JSON.stringify({ field: 'createdAt' });
+
+        const result = listMessagesQuerySchema.safeParse({
+          page: 0,
+          perPage: 50,
+          orderBy: jsonString,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.orderBy).toEqual({ field: 'createdAt' });
+        }
+      });
+
+      it('should handle orderBy with only direction specified as JSON string', () => {
+        const jsonString = JSON.stringify({ direction: 'DESC' });
+
+        const result = listMessagesQuerySchema.safeParse({
+          page: 0,
+          perPage: 50,
+          orderBy: jsonString,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.orderBy).toEqual({ direction: 'DESC' });
+        }
+      });
+    });
+
+    describe('include parameter parsing (reference - this already works)', () => {
+      it('should parse include when passed as a JSON string', () => {
+        const includeArray = [{ id: 'msg-1', withPreviousMessages: 5 }];
+        const jsonString = JSON.stringify(includeArray);
+
+        const result = listMessagesQuerySchema.safeParse({
+          page: 0,
+          perPage: 50,
+          include: jsonString,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.include).toEqual(includeArray);
+        }
+      });
+    });
+
+    describe('filter parameter parsing (reference - this already works)', () => {
+      it('should parse filter when passed as a JSON string', () => {
+        const filterObj = {
+          dateRange: {
+            start: '2024-01-01T00:00:00.000Z',
+            end: '2024-12-31T23:59:59.999Z',
+          },
+        };
+        const jsonString = JSON.stringify(filterObj);
+
+        const result = listMessagesQuerySchema.safeParse({
+          page: 0,
+          perPage: 50,
+          filter: jsonString,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.filter).toBeDefined();
+          expect(result.data.filter?.dateRange).toBeDefined();
+        }
+      });
+    });
+  });
+
+  describe('listThreadsQuerySchema', () => {
+    describe('orderBy parameter parsing', () => {
+      it('should parse orderBy when passed as an object', () => {
+        const result = listThreadsQuerySchema.safeParse({
+          resourceId: 'test-resource',
+          page: 0,
+          perPage: 100,
+          orderBy: { field: 'updatedAt', direction: 'DESC' },
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.orderBy).toEqual({ field: 'updatedAt', direction: 'DESC' });
+        }
+      });
+
+      /**
+       * Regression test: Same as listMessagesQuerySchema - orderBy JSON strings must be parsed.
+       */
+      it('should parse orderBy when passed as a JSON string (from URL query params)', () => {
+        const jsonString = JSON.stringify({ field: 'updatedAt', direction: 'DESC' });
+
+        const result = listThreadsQuerySchema.safeParse({
+          resourceId: 'test-resource',
+          page: 0,
+          perPage: 100,
+          orderBy: jsonString,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.orderBy).toEqual({ field: 'updatedAt', direction: 'DESC' });
+        }
+      });
+
+      it('should handle createdAt field in orderBy as JSON string', () => {
+        const jsonString = JSON.stringify({ field: 'createdAt', direction: 'ASC' });
+
+        const result = listThreadsQuerySchema.safeParse({
+          resourceId: 'test-resource',
+          page: 0,
+          perPage: 100,
+          orderBy: jsonString,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.orderBy).toEqual({ field: 'createdAt', direction: 'ASC' });
+        }
+      });
+    });
+  });
+});

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -23,19 +23,49 @@ export const optionalAgentIdQuerySchema = z.object({
 
 /**
  * Storage order by configuration for threads and agents (have both createdAt and updatedAt)
+ * Handles JSON parsing from query strings
  */
-const storageOrderBySchema = z.object({
-  field: z.enum(['createdAt', 'updatedAt']).optional(),
-  direction: z.enum(['ASC', 'DESC']).optional(),
-});
+const storageOrderBySchema = z.preprocess(
+  val => {
+    if (typeof val === 'string') {
+      try {
+        return JSON.parse(val);
+      } catch {
+        return undefined;
+      }
+    }
+    return val;
+  },
+  z
+    .object({
+      field: z.enum(['createdAt', 'updatedAt']).optional(),
+      direction: z.enum(['ASC', 'DESC']).optional(),
+    })
+    .optional(),
+);
 
 /**
  * Storage order by configuration for messages (only have createdAt)
+ * Handles JSON parsing from query strings
  */
-const messageOrderBySchema = z.object({
-  field: z.enum(['createdAt']).optional(),
-  direction: z.enum(['ASC', 'DESC']).optional(),
-});
+const messageOrderBySchema = z.preprocess(
+  val => {
+    if (typeof val === 'string') {
+      try {
+        return JSON.parse(val);
+      } catch {
+        return undefined;
+      }
+    }
+    return val;
+  },
+  z
+    .object({
+      field: z.enum(['createdAt']).optional(),
+      direction: z.enum(['ASC', 'DESC']).optional(),
+    })
+    .optional(),
+);
 
 /**
  * Include schema for message listing - handles JSON parsing from query strings
@@ -148,7 +178,7 @@ export const getMemoryConfigQuerySchema = agentIdQuerySchema;
 export const listThreadsQuerySchema = createPagePaginationSchema(100).extend({
   agentId: z.string().optional(),
   resourceId: z.string(),
-  orderBy: storageOrderBySchema.optional(),
+  orderBy: storageOrderBySchema,
 });
 
 /**
@@ -164,7 +194,7 @@ export const getThreadByIdQuerySchema = optionalAgentIdQuerySchema;
 export const listMessagesQuerySchema = createPagePaginationSchema(40).extend({
   agentId: z.string().optional(),
   resourceId: z.string().optional(),
-  orderBy: messageOrderBySchema.optional(),
+  orderBy: messageOrderBySchema,
   include: includeSchema,
   filter: filterSchema,
 });
@@ -194,7 +224,7 @@ export const getMemoryStatusNetworkQuerySchema = agentIdQuerySchema;
 export const listThreadsNetworkQuerySchema = createPagePaginationSchema(100).extend({
   agentId: z.string().optional(),
   resourceId: z.string(),
-  orderBy: storageOrderBySchema.optional(),
+  orderBy: storageOrderBySchema,
 });
 
 /**
@@ -210,7 +240,7 @@ export const getThreadByIdNetworkQuerySchema = optionalAgentIdQuerySchema;
 export const listMessagesNetworkQuerySchema = createPagePaginationSchema(40).extend({
   agentId: z.string().optional(),
   resourceId: z.string().optional(),
-  orderBy: messageOrderBySchema.optional(),
+  orderBy: messageOrderBySchema,
   include: includeSchema,
   filter: filterSchema,
 });


### PR DESCRIPTION
## Description

Fix `orderBy` query parameter parsing for memory endpoints. When the client sends `orderBy` as a JSON string in URL query parameters (e.g., `?orderBy={"field":"createdAt","direction":"ASC"}`), the server now correctly parses it back into an object.

The `messageOrderBySchema` and `storageOrderBySchema` now use `z.preprocess` to handle JSON string parsing, matching the existing pattern used by `includeSchema` and `filterSchema`.

## Related Issue(s)

Fixes #11761

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed orderBy query parameter parsing for memory endpoints. The listMessages and listThreads endpoints now correctly parse orderBy when provided as JSON strings in URL query parameters, ensuring consistent behavior with other parameter types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->