### PR TITLE
fix(schema-compat): structuredOutput with optional/default fields

### DIFF
--- a/.changeset/fix-structured-output-optional-default.md
+++ b/.changeset/fix-structured-output-optional-default.md
@@ -1,0 +1,5 @@
+---
+"@mastra/schema-compat": patch
+---
+
+Fix structuredOutput with optional and default fields throwing "schema must have a 'type' key" error


### PR DESCRIPTION
Fixes #11766

When using `structuredOutput` with `.optional()` or `.default()` fields in Zod v4, you'd get this error:

```
APICallError: Invalid schema for response_format 'response': 
In context=('properties', 'phone'), schema must have a 'type' key.
```

**Before:**
```ts
const schema = z.object({
  name: z.string(),
  age: z.number().default(0),  // ❌ Produces {} in JSON Schema
  phone: z.string().optional(), // ❌ Produces {} in JSON Schema
});
```

The issue: OpenAI compat layer converts `.optional()` to `.nullable().transform()`. In Zod v4, transforms create a `ZodPipe` type that was being output as `{}` (empty schema) instead of preserving type info.

**After:** The fix uses the input schema (before transform) for JSON Schema conversion, so you get proper type definitions that OpenAI accepts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema validation errors when using structuredOutput with optional and default fields.
  * Improved JSON Schema conversion to properly preserve type information for optional and default field configurations.

* **Tests**
  * Added test coverage for optional and default field handling in schema conversions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->