### PR TITLE
chore: add missing changeset for #11752

### DIFF
--- a/.changeset/fix-text-parts-merging-tool-calls.md
+++ b/.changeset/fix-text-parts-merging-tool-calls.md
@@ -1,0 +1,9 @@
+---
+"@mastra/react": patch
+---
+
+Fix text parts incorrectly merging across tool calls
+
+Previously, when an agent produced text before and after a tool call (e.g., "Let me search for that" → tool call → "Here's what I found"), the text parts would be merged into a single part, losing the separation. This fix introduces a `textId` property to track separate text streams, ensuring each text stream maintains its own text part in the UI message.
+
+Fixes #11577


### PR DESCRIPTION
Adds the changeset for #11752 which fixed text parts incorrectly merging across tool calls in `@mastra/react`.

The original PR was merged without a changeset, so this ensures the fix gets included in the next release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where messages were being incorrectly merged in the conversation stream when agents emitted text before and after executing tool calls. Text segments are now properly separated and displayed distinctly, improving clarity of agent interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->