### PR TITLE
Add dynamic scorers API and storage backend

### DIFF
--- a/packages/core/src/evals/index.ts
+++ b/packages/core/src/evals/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './base';
 export * from './run';
+export * from './resolve-stored-scorer';

--- a/packages/core/src/evals/resolve-stored-scorer.ts
+++ b/packages/core/src/evals/resolve-stored-scorer.ts
@@ -1,0 +1,255 @@
+import { z } from 'zod';
+import { ErrorCategory, ErrorDomain, MastraError } from '../error';
+import type { StorageScorerType, StorageScorerStepConfig } from '../storage/types';
+import { createScorer } from './base';
+import type { MastraScorer } from './base';
+
+/**
+ * Interpolates a template string with values from the context.
+ *
+ * Supports:
+ * - {{run.output}} - Access run output
+ * - {{run.input}} - Access run input
+ * - {{run.groundTruth}} - Access ground truth
+ * - {{results.preprocessStepResult}} - Access preprocess step result
+ * - {{results.analyzeStepResult}} - Access analyze step result
+ * - {{score}} - Access score (only in generateReason context)
+ *
+ * @example
+ * ```
+ * const template = "Analyze this output: {{run.output}}";
+ * const result = interpolateTemplate(template, { run: { output: "Hello" } });
+ * // result: "Analyze this output: Hello"
+ * ```
+ */
+function interpolateTemplate(template: string, context: Record<string, any>): string {
+  return template.replace(/\{\{([^}]+)\}\}/g, (_, path: string) => {
+    const parts = path.trim().split('.');
+    let value: any = context;
+
+    for (const part of parts) {
+      if (value === undefined || value === null) {
+        return '';
+      }
+      value = value[part];
+    }
+
+    // Convert value to string representation
+    if (value === undefined || value === null) {
+      return '';
+    }
+
+    if (typeof value === 'object') {
+      return JSON.stringify(value, null, 2);
+    }
+
+    return String(value);
+  });
+}
+
+/**
+ * Converts a JSON Schema object to a Zod schema.
+ * Supports basic types: string, number, boolean, object, array.
+ *
+ * @param jsonSchema - JSON Schema object
+ * @returns Zod schema
+ */
+function jsonSchemaToZod(jsonSchema: Record<string, unknown>): z.ZodTypeAny {
+  const type = jsonSchema.type as string;
+
+  switch (type) {
+    case 'string':
+      return z.string();
+    case 'number':
+    case 'integer':
+      return z.number();
+    case 'boolean':
+      return z.boolean();
+    case 'array': {
+      const items = jsonSchema.items as Record<string, unknown> | undefined;
+      if (items) {
+        return z.array(jsonSchemaToZod(items));
+      }
+      return z.array(z.any());
+    }
+    case 'object': {
+      const properties = jsonSchema.properties as Record<string, Record<string, unknown>> | undefined;
+      const required = (jsonSchema.required as string[]) || [];
+
+      if (!properties) {
+        return z.record(z.string(), z.any());
+      }
+
+      const shape: Record<string, z.ZodTypeAny> = {};
+      for (const [key, propSchema] of Object.entries(properties)) {
+        const propZod = jsonSchemaToZod(propSchema);
+        shape[key] = required.includes(key) ? propZod : propZod.optional();
+      }
+
+      return z.object(shape);
+    }
+    default:
+      return z.any();
+  }
+}
+
+/**
+ * Creates a prompt object compatible with MastraScorer from a stored step config.
+ */
+function createPromptObjectFromStep(step: StorageScorerStepConfig, defaultJudge?: StorageScorerType['judge']) {
+  const judge = step.judge
+    ? {
+        model: step.judge.model,
+        instructions: step.judge.instructions ?? defaultJudge?.instructions ?? '',
+      }
+    : defaultJudge
+      ? {
+          model: defaultJudge.model,
+          instructions: defaultJudge.instructions,
+        }
+      : undefined;
+
+  // generateScore and generateReason don't have outputSchema
+  if (step.name === 'generateScore' || step.name === 'generateReason') {
+    return {
+      description: step.description,
+      judge,
+      createPrompt: (context: Record<string, any>) => interpolateTemplate(step.promptTemplate, context),
+    };
+  }
+
+  // preprocess and analyze have outputSchema
+  const outputSchema = step.outputSchema ? jsonSchemaToZod(step.outputSchema) : z.any();
+
+  return {
+    description: step.description,
+    outputSchema,
+    judge,
+    createPrompt: (context: Record<string, any>) => interpolateTemplate(step.promptTemplate, context),
+  };
+}
+
+/**
+ * Resolves a stored scorer configuration to a runnable MastraScorer instance.
+ *
+ * This function takes a scorer definition stored in the database and converts it
+ * to a fully functional MastraScorer that can be used to evaluate agent runs.
+ *
+ * @param storedScorer - The stored scorer configuration from the database
+ * @returns A MastraScorer instance ready to run
+ *
+ * @example
+ * ```typescript
+ * const storedScorer = await storage.getStore('storedScorers').getScorerById({ id: 'my-scorer' });
+ * const scorer = resolveStoredScorer(storedScorer);
+ *
+ * const result = await scorer.run({
+ *   output: agentRun.output,
+ *   input: agentRun.input,
+ * });
+ * ```
+ */
+export function resolveStoredScorer(storedScorer: StorageScorerType): MastraScorer<string, any, any, any> {
+  // Validate that we have at least a generateScore step
+  const hasGenerateScore = storedScorer.steps.some(step => step.name === 'generateScore');
+  if (!hasGenerateScore) {
+    throw new MastraError({
+      id: 'MASTR_STORED_SCORER_MISSING_GENERATE_SCORE',
+      domain: ErrorDomain.SCORER,
+      category: ErrorCategory.USER,
+      text: `Stored scorer "${storedScorer.id}" must have a generateScore step`,
+      details: {
+        scorerId: storedScorer.id,
+        steps: storedScorer.steps.map(s => s.name).join(', '),
+      },
+    });
+  }
+
+  // Validate that generateScore has a judge configured (either step-level or scorer-level)
+  const generateScoreStep = storedScorer.steps.find(step => step.name === 'generateScore');
+  if (!generateScoreStep?.judge && !storedScorer.judge) {
+    throw new MastraError({
+      id: 'MASTR_STORED_SCORER_MISSING_JUDGE',
+      domain: ErrorDomain.SCORER,
+      category: ErrorCategory.USER,
+      text: `Stored scorer "${storedScorer.id}" requires a judge configuration for prompt-based steps`,
+      details: {
+        scorerId: storedScorer.id,
+      },
+    });
+  }
+
+  // Convert the stored type to the format expected by createScorer
+  let scorerType: 'agent' | { input: z.ZodTypeAny; output: z.ZodTypeAny } | undefined;
+  if (storedScorer.type === 'agent') {
+    scorerType = 'agent';
+  } else if (storedScorer.type && typeof storedScorer.type === 'object') {
+    scorerType = {
+      input: storedScorer.type.inputSchema ? jsonSchemaToZod(storedScorer.type.inputSchema) : z.any(),
+      output: storedScorer.type.outputSchema ? jsonSchemaToZod(storedScorer.type.outputSchema) : z.any(),
+    };
+  }
+
+  // Create the base scorer
+  let scorer = createScorer({
+    id: storedScorer.id,
+    name: storedScorer.name,
+    description: storedScorer.description,
+    judge: storedScorer.judge
+      ? {
+          model: storedScorer.judge.model,
+          instructions: storedScorer.judge.instructions,
+        }
+      : undefined,
+    type: scorerType,
+  });
+
+  // Sort steps in the correct pipeline order
+  const stepOrder = ['preprocess', 'analyze', 'generateScore', 'generateReason'] as const;
+  const sortedSteps = [...storedScorer.steps].sort((a, b) => stepOrder.indexOf(a.name) - stepOrder.indexOf(b.name));
+
+  // Add each step to the scorer pipeline
+  for (const step of sortedSteps) {
+    const promptObject = createPromptObjectFromStep(step, storedScorer.judge);
+
+    switch (step.name) {
+      case 'preprocess':
+        scorer = scorer.preprocess(promptObject as any);
+        break;
+      case 'analyze':
+        scorer = scorer.analyze(promptObject as any);
+        break;
+      case 'generateScore':
+        scorer = scorer.generateScore(promptObject as any);
+        break;
+      case 'generateReason':
+        scorer = scorer.generateReason(promptObject as any);
+        break;
+    }
+  }
+
+  return scorer;
+}
+
+/**
+ * Resolves multiple stored scorer configurations to MastraScorer instances.
+ *
+ * @param storedScorers - Array of stored scorer configurations
+ * @returns Map of scorer ID to MastraScorer instance
+ */
+export function resolveStoredScorers(
+  storedScorers: StorageScorerType[],
+): Map<string, MastraScorer<string, any, any, any>> {
+  const scorers = new Map<string, MastraScorer<string, any, any, any>>();
+
+  for (const storedScorer of storedScorers) {
+    try {
+      scorers.set(storedScorer.id, resolveStoredScorer(storedScorer));
+    } catch (error) {
+      // Log warning but continue with other scorers
+      console.warn(`Failed to resolve stored scorer "${storedScorer.id}":`, error);
+    }
+  }
+
+  return scorers;
+}

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -1,6 +1,13 @@
 import { MastraBase } from '../base';
 
-import type { AgentsStorage, ScoresStorage, WorkflowsStorage, MemoryStorage, ObservabilityStorage } from './domains';
+import type {
+  AgentsStorage,
+  ScoresStorage,
+  StoredScorersStorage,
+  WorkflowsStorage,
+  MemoryStorage,
+  ObservabilityStorage,
+} from './domains';
 
 export type StorageDomains = {
   workflows: WorkflowsStorage;
@@ -8,6 +15,8 @@ export type StorageDomains = {
   memory: MemoryStorage;
   observability?: ObservabilityStorage;
   agents?: AgentsStorage;
+  /** Storage for stored scorer definitions and agent-scorer assignments */
+  storedScorers?: StoredScorersStorage;
 };
 
 /**
@@ -195,6 +204,7 @@ export class MastraStorage extends MastraBase {
         scores: domainOverrides.scores ?? defaultStores?.scores,
         observability: domainOverrides.observability ?? defaultStores?.observability,
         agents: domainOverrides.agents ?? defaultStores?.agents,
+        storedScorers: domainOverrides.storedScorers ?? defaultStores?.storedScorers,
       } as StorageDomains;
     }
     // Otherwise, subclasses set stores themselves
@@ -249,6 +259,10 @@ export class MastraStorage extends MastraBase {
 
     if (this.stores?.agents) {
       initTasks.push(this.stores.agents.init());
+    }
+
+    if (this.stores?.storedScorers) {
+      initTasks.push(this.stores.storedScorers.init());
     }
 
     this.hasInitialized = Promise.all(initTasks).then(() => true);

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -10,6 +10,10 @@ export const TABLE_RESOURCES = 'mastra_resources';
 export const TABLE_SCORERS = 'mastra_scorers';
 export const TABLE_SPANS = 'mastra_ai_spans';
 export const TABLE_AGENTS = 'mastra_agents';
+/** Table for stored scorer definitions (not score results) */
+export const TABLE_STORED_SCORERS = 'mastra_stored_scorers';
+/** Table for dynamic agent-scorer assignments */
+export const TABLE_AGENT_SCORER_ASSIGNMENTS = 'mastra_agent_scorer_assignments';
 
 export type TABLE_NAMES =
   | typeof TABLE_WORKFLOW_SNAPSHOT
@@ -19,7 +23,9 @@ export type TABLE_NAMES =
   | typeof TABLE_RESOURCES
   | typeof TABLE_SCORERS
   | typeof TABLE_SPANS
-  | typeof TABLE_AGENTS;
+  | typeof TABLE_AGENTS
+  | typeof TABLE_STORED_SCORERS
+  | typeof TABLE_AGENT_SCORER_ASSIGNMENTS;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
@@ -105,6 +111,39 @@ export const AGENTS_SCHEMA: Record<string, StorageColumn> = {
   updatedAt: { type: 'timestamp', nullable: false },
 };
 
+/**
+ * Schema for stored scorer definitions.
+ * These are scorer configurations that can be created via API and instantiated at runtime.
+ */
+export const STORED_SCORERS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: false },
+  type: { type: 'jsonb', nullable: true }, // 'agent' string or { inputSchema, outputSchema } object
+  judge: { type: 'jsonb', nullable: true }, // { model: string, instructions: string }
+  steps: { type: 'jsonb', nullable: false }, // Array of step configurations
+  sampling: { type: 'jsonb', nullable: true }, // { type: 'ratio'|'count', rate?, count? }
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+/**
+ * Schema for dynamic agent-scorer assignments.
+ * Links agents to stored scorers for UI-based scorer management.
+ */
+export const AGENT_SCORER_ASSIGNMENTS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  agentId: { type: 'text', nullable: false },
+  scorerId: { type: 'text', nullable: false }, // References TABLE_STORED_SCORERS
+  sampling: { type: 'jsonb', nullable: true }, // Override sampling config for this assignment
+  enabled: { type: 'boolean', nullable: false },
+  priority: { type: 'integer', nullable: true }, // Lower = higher priority
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
 export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> = {
   [TABLE_WORKFLOW_SNAPSHOT]: {
     workflow_name: {
@@ -167,4 +206,6 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     updatedAt: { type: 'timestamp', nullable: false },
   },
   [TABLE_AGENTS]: AGENTS_SCHEMA,
+  [TABLE_STORED_SCORERS]: STORED_SCORERS_SCHEMA,
+  [TABLE_AGENT_SCORER_ASSIGNMENTS]: AGENT_SCORER_ASSIGNMENTS_SCHEMA,
 };

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -1,6 +1,7 @@
 export * from './base';
 export * from './agents';
 export * from './scores';
+export * from './stored-scorers';
 export * from './observability';
 export * from './operations';
 export * from './workflows';

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -1,6 +1,13 @@
 import type { ScoreRowData } from '../../evals/types';
 import type { StorageThreadType } from '../../memory/types';
-import type { StorageAgentType, StorageMessageType, StorageResourceType, StorageWorkflowRun } from '../types';
+import type {
+  StorageAgentType,
+  StorageAgentScorerAssignment,
+  StorageMessageType,
+  StorageResourceType,
+  StorageScorerType,
+  StorageWorkflowRun,
+} from '../types';
 import type { TraceEntry } from './observability';
 
 /**
@@ -18,6 +25,8 @@ export class InMemoryDB {
   readonly scores = new Map<string, ScoreRowData>();
   readonly traces = new Map<string, TraceEntry>();
   readonly agents = new Map<string, StorageAgentType>();
+  readonly storedScorers = new Map<string, StorageScorerType>();
+  readonly agentScorerAssignments = new Map<string, StorageAgentScorerAssignment>();
 
   /**
    * Clears all data from all collections.
@@ -31,5 +40,7 @@ export class InMemoryDB {
     this.scores.clear();
     this.traces.clear();
     this.agents.clear();
+    this.storedScorers.clear();
+    this.agentScorerAssignments.clear();
   }
 }

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -17,6 +17,8 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_scorers: new Map(),
       mastra_ai_spans: new Map(),
       mastra_agents: new Map(),
+      mastra_stored_scorers: new Map(),
+      mastra_agent_scorer_assignments: new Map(),
     };
   }
 

--- a/packages/core/src/storage/domains/stored-scorers/base.ts
+++ b/packages/core/src/storage/domains/stored-scorers/base.ts
@@ -1,0 +1,147 @@
+import type {
+  StorageScorerType,
+  StorageCreateScorerInput,
+  StorageUpdateScorerInput,
+  StorageListScorersInput,
+  StorageListScorersOutput,
+  StorageAgentScorerAssignment,
+  StorageCreateAgentScorerAssignmentInput,
+  StorageUpdateAgentScorerAssignmentInput,
+  StorageListAgentScorerAssignmentsInput,
+  StorageListAgentScorerAssignmentsOutput,
+  StorageOrderBy,
+  ThreadOrderBy,
+  ThreadSortDirection,
+} from '../../types';
+import { StorageDomain } from '../base';
+
+/**
+ * Abstract base class for stored scorer storage operations.
+ *
+ * This domain handles:
+ * 1. CRUD operations for stored scorer definitions
+ * 2. Agent-scorer assignment management for dynamic scorer binding
+ *
+ * Note: This is different from the `scores` domain which stores score execution results.
+ * This domain stores scorer *definitions* that can be instantiated at runtime.
+ */
+export abstract class StoredScorersStorage extends StorageDomain {
+  constructor() {
+    super({
+      component: 'STORAGE',
+      name: 'STORED_SCORERS',
+    });
+  }
+
+  // ============================================================================
+  // Scorer Definition CRUD
+  // ============================================================================
+
+  /**
+   * Retrieves a stored scorer by its unique identifier.
+   * @param id - The unique identifier of the scorer
+   * @returns The scorer if found, null otherwise
+   */
+  abstract getScorerById({ id }: { id: string }): Promise<StorageScorerType | null>;
+
+  /**
+   * Creates a new stored scorer definition.
+   * @param scorer - The scorer configuration to create
+   * @returns The created scorer with timestamps
+   */
+  abstract createScorer({ scorer }: { scorer: StorageCreateScorerInput }): Promise<StorageScorerType>;
+
+  /**
+   * Updates an existing stored scorer definition.
+   * @param id - The unique identifier of the scorer to update
+   * @param updates - The fields to update
+   * @returns The updated scorer
+   */
+  abstract updateScorer({ id, ...updates }: StorageUpdateScorerInput): Promise<StorageScorerType>;
+
+  /**
+   * Deletes a stored scorer definition.
+   * This will also delete any agent-scorer assignments referencing this scorer.
+   * @param id - The unique identifier of the scorer to delete
+   */
+  abstract deleteScorer({ id }: { id: string }): Promise<void>;
+
+  /**
+   * Lists all stored scorers with optional pagination.
+   * @param args - Pagination and ordering options
+   * @returns Paginated list of scorers
+   */
+  abstract listScorers(args?: StorageListScorersInput): Promise<StorageListScorersOutput>;
+
+  // ============================================================================
+  // Agent-Scorer Assignments
+  // ============================================================================
+
+  /**
+   * Assigns a stored scorer to an agent.
+   * This creates a dynamic binding that allows the scorer to run on the agent
+   * without modifying the agent's code-defined scorers.
+   * @param input - Assignment configuration
+   * @returns The created assignment
+   */
+  abstract assignScorerToAgent(input: StorageCreateAgentScorerAssignmentInput): Promise<StorageAgentScorerAssignment>;
+
+  /**
+   * Removes a scorer assignment from an agent.
+   * @param params - Agent and scorer IDs
+   */
+  abstract unassignScorerFromAgent(params: { agentId: string; scorerId: string }): Promise<void>;
+
+  /**
+   * Lists all scorer assignments for an agent.
+   * @param input - Query parameters including agent ID and filters
+   * @returns Paginated list of assignments
+   */
+  abstract listAgentScorerAssignments(
+    input: StorageListAgentScorerAssignmentsInput,
+  ): Promise<StorageListAgentScorerAssignmentsOutput>;
+
+  /**
+   * Updates an existing agent-scorer assignment.
+   * @param params - Assignment ID and fields to update
+   * @returns The updated assignment
+   */
+  abstract updateAgentScorerAssignment(
+    params: StorageUpdateAgentScorerAssignmentInput,
+  ): Promise<StorageAgentScorerAssignment>;
+
+  /**
+   * Gets a specific assignment by ID.
+   * @param id - The assignment ID
+   * @returns The assignment if found, null otherwise
+   */
+  abstract getAssignmentById({ id }: { id: string }): Promise<StorageAgentScorerAssignment | null>;
+
+  // ============================================================================
+  // Helper Methods
+  // ============================================================================
+
+  /**
+   * Parses orderBy input for consistent sorting behavior.
+   */
+  protected parseOrderBy(
+    orderBy?: StorageOrderBy,
+    defaultDirection: ThreadSortDirection = 'DESC',
+  ): { field: ThreadOrderBy; direction: ThreadSortDirection } {
+    return {
+      field: orderBy?.field && orderBy.field in SCORER_ORDER_BY_SET ? orderBy.field : 'createdAt',
+      direction:
+        orderBy?.direction && orderBy.direction in SCORER_SORT_DIRECTION_SET ? orderBy.direction : defaultDirection,
+    };
+  }
+}
+
+const SCORER_ORDER_BY_SET: Record<ThreadOrderBy, true> = {
+  createdAt: true,
+  updatedAt: true,
+};
+
+const SCORER_SORT_DIRECTION_SET: Record<ThreadSortDirection, true> = {
+  ASC: true,
+  DESC: true,
+};

--- a/packages/core/src/storage/domains/stored-scorers/index.ts
+++ b/packages/core/src/storage/domains/stored-scorers/index.ts
@@ -1,0 +1,2 @@
+export { StoredScorersStorage } from './base';
+export { InMemoryStoredScorersStorage } from './inmemory';

--- a/packages/core/src/storage/domains/stored-scorers/inmemory.ts
+++ b/packages/core/src/storage/domains/stored-scorers/inmemory.ts
@@ -1,0 +1,297 @@
+import { randomUUID } from 'crypto';
+
+import { normalizePerPage, calculatePagination } from '../../base';
+import type {
+  StorageScorerType,
+  StorageCreateScorerInput,
+  StorageUpdateScorerInput,
+  StorageListScorersInput,
+  StorageListScorersOutput,
+  StorageAgentScorerAssignment,
+  StorageCreateAgentScorerAssignmentInput,
+  StorageUpdateAgentScorerAssignmentInput,
+  StorageListAgentScorerAssignmentsInput,
+  StorageListAgentScorerAssignmentsOutput,
+  ThreadOrderBy,
+  ThreadSortDirection,
+} from '../../types';
+import type { InMemoryDB } from '../inmemory-db';
+import { StoredScorersStorage } from './base';
+
+/**
+ * In-memory implementation of StoredScorersStorage.
+ * Useful for development, testing, and scenarios where persistence isn't required.
+ */
+export class InMemoryStoredScorersStorage extends StoredScorersStorage {
+  private db: InMemoryDB;
+
+  constructor({ db }: { db: InMemoryDB }) {
+    super();
+    this.db = db;
+    // The InMemoryDB already initializes the maps in its class definition
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    this.db.storedScorers.clear();
+    this.db.agentScorerAssignments.clear();
+  }
+
+  // ============================================================================
+  // Scorer Definition CRUD
+  // ============================================================================
+
+  async getScorerById({ id }: { id: string }): Promise<StorageScorerType | null> {
+    this.logger.debug(`InMemoryStoredScorersStorage: getScorerById called for ${id}`);
+    const scorer = this.db.storedScorers.get(id);
+    return scorer ? this.cloneScorer(scorer) : null;
+  }
+
+  async createScorer({ scorer }: { scorer: StorageCreateScorerInput }): Promise<StorageScorerType> {
+    this.logger.debug(`InMemoryStoredScorersStorage: createScorer called for ${scorer.id}`);
+
+    if (this.db.storedScorers.has(scorer.id)) {
+      throw new Error(`Scorer with id ${scorer.id} already exists`);
+    }
+
+    const now = new Date();
+    const newScorer: StorageScorerType = {
+      ...scorer,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db.storedScorers.set(scorer.id, newScorer);
+    return this.cloneScorer(newScorer);
+  }
+
+  async updateScorer({ id, ...updates }: StorageUpdateScorerInput): Promise<StorageScorerType> {
+    this.logger.debug(`InMemoryStoredScorersStorage: updateScorer called for ${id}`);
+
+    const existingScorer = this.db.storedScorers.get(id);
+    if (!existingScorer) {
+      throw new Error(`Scorer with id ${id} not found`);
+    }
+
+    const updatedScorer: StorageScorerType = {
+      ...existingScorer,
+      ...(updates.name !== undefined && { name: updates.name }),
+      ...(updates.description !== undefined && { description: updates.description }),
+      ...(updates.type !== undefined && { type: updates.type }),
+      ...(updates.judge !== undefined && { judge: updates.judge }),
+      ...(updates.steps !== undefined && { steps: updates.steps }),
+      ...(updates.sampling !== undefined && { sampling: updates.sampling }),
+      ...(updates.metadata !== undefined && {
+        metadata: { ...existingScorer.metadata, ...updates.metadata },
+      }),
+      updatedAt: new Date(),
+    };
+
+    this.db.storedScorers.set(id, updatedScorer);
+    return this.cloneScorer(updatedScorer);
+  }
+
+  async deleteScorer({ id }: { id: string }): Promise<void> {
+    this.logger.debug(`InMemoryStoredScorersStorage: deleteScorer called for ${id}`);
+
+    // Delete the scorer
+    this.db.storedScorers.delete(id);
+
+    // Also delete any assignments referencing this scorer
+    for (const [assignmentId, assignment] of this.db.agentScorerAssignments.entries()) {
+      if (assignment.scorerId === id) {
+        this.db.agentScorerAssignments.delete(assignmentId);
+      }
+    }
+  }
+
+  async listScorers(args?: StorageListScorersInput): Promise<StorageListScorersOutput> {
+    const { page = 0, perPage: perPageInput, orderBy } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    this.logger.debug(`InMemoryStoredScorersStorage: listScorers called`);
+
+    const perPage = normalizePerPage(perPageInput, 100);
+
+    if (page < 0) {
+      throw new Error('page must be >= 0');
+    }
+
+    const maxOffset = Number.MAX_SAFE_INTEGER / 2;
+    if (page * perPage > maxOffset) {
+      throw new Error('page value too large');
+    }
+
+    const scorers = Array.from(this.db.storedScorers.values());
+    const sortedScorers = this.sortScorers(scorers, field, direction);
+    const clonedScorers = sortedScorers.map(s => this.cloneScorer(s));
+
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    return {
+      scorers: clonedScorers.slice(offset, offset + perPage),
+      total: clonedScorers.length,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + perPage < clonedScorers.length,
+    };
+  }
+
+  // ============================================================================
+  // Agent-Scorer Assignments
+  // ============================================================================
+
+  async assignScorerToAgent(input: StorageCreateAgentScorerAssignmentInput): Promise<StorageAgentScorerAssignment> {
+    this.logger.debug(
+      `InMemoryStoredScorersStorage: assignScorerToAgent called for agent ${input.agentId}, scorer ${input.scorerId}`,
+    );
+
+    // Check if scorer exists
+    if (!this.db.storedScorers.has(input.scorerId)) {
+      throw new Error(`Scorer with id ${input.scorerId} not found`);
+    }
+
+    // Check for existing assignment
+    for (const assignment of this.db.agentScorerAssignments.values()) {
+      if (assignment.agentId === input.agentId && assignment.scorerId === input.scorerId) {
+        throw new Error(`Assignment already exists for agent ${input.agentId} and scorer ${input.scorerId}`);
+      }
+    }
+
+    const now = new Date();
+    const assignment: StorageAgentScorerAssignment = {
+      id: randomUUID(),
+      agentId: input.agentId,
+      scorerId: input.scorerId,
+      sampling: input.sampling,
+      enabled: input.enabled,
+      priority: input.priority,
+      metadata: input.metadata,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db.agentScorerAssignments.set(assignment.id, assignment);
+    return this.cloneAssignment(assignment);
+  }
+
+  async unassignScorerFromAgent(params: { agentId: string; scorerId: string }): Promise<void> {
+    this.logger.debug(
+      `InMemoryStoredScorersStorage: unassignScorerFromAgent called for agent ${params.agentId}, scorer ${params.scorerId}`,
+    );
+
+    for (const [id, assignment] of this.db.agentScorerAssignments.entries()) {
+      if (assignment.agentId === params.agentId && assignment.scorerId === params.scorerId) {
+        this.db.agentScorerAssignments.delete(id);
+        return;
+      }
+    }
+  }
+
+  async listAgentScorerAssignments(
+    input: StorageListAgentScorerAssignmentsInput,
+  ): Promise<StorageListAgentScorerAssignmentsOutput> {
+    const { agentId, enabledOnly, page = 0, perPage: perPageInput } = input;
+
+    this.logger.debug(`InMemoryStoredScorersStorage: listAgentScorerAssignments called for agent ${agentId}`);
+
+    const perPage = normalizePerPage(perPageInput, 100);
+
+    if (page < 0) {
+      throw new Error('page must be >= 0');
+    }
+
+    let assignments = Array.from(this.db.agentScorerAssignments.values()).filter(a => a.agentId === agentId);
+
+    if (enabledOnly) {
+      assignments = assignments.filter(a => a.enabled);
+    }
+
+    // Sort by priority (lower = higher priority), then by createdAt
+    assignments.sort((a, b) => {
+      const priorityA = a.priority ?? Number.MAX_SAFE_INTEGER;
+      const priorityB = b.priority ?? Number.MAX_SAFE_INTEGER;
+      if (priorityA !== priorityB) {
+        return priorityA - priorityB;
+      }
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+
+    const clonedAssignments = assignments.map(a => this.cloneAssignment(a));
+
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    return {
+      assignments: clonedAssignments.slice(offset, offset + perPage),
+      total: clonedAssignments.length,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + perPage < clonedAssignments.length,
+    };
+  }
+
+  async updateAgentScorerAssignment(
+    params: StorageUpdateAgentScorerAssignmentInput,
+  ): Promise<StorageAgentScorerAssignment> {
+    this.logger.debug(`InMemoryStoredScorersStorage: updateAgentScorerAssignment called for ${params.id}`);
+
+    const existingAssignment = this.db.agentScorerAssignments.get(params.id);
+    if (!existingAssignment) {
+      throw new Error(`Assignment with id ${params.id} not found`);
+    }
+
+    const updatedAssignment: StorageAgentScorerAssignment = {
+      ...existingAssignment,
+      ...(params.enabled !== undefined && { enabled: params.enabled }),
+      ...(params.sampling !== undefined && { sampling: params.sampling }),
+      ...(params.priority !== undefined && { priority: params.priority }),
+      ...(params.metadata !== undefined && {
+        metadata: { ...existingAssignment.metadata, ...params.metadata },
+      }),
+      updatedAt: new Date(),
+    };
+
+    this.db.agentScorerAssignments.set(params.id, updatedAssignment);
+    return this.cloneAssignment(updatedAssignment);
+  }
+
+  async getAssignmentById({ id }: { id: string }): Promise<StorageAgentScorerAssignment | null> {
+    this.logger.debug(`InMemoryStoredScorersStorage: getAssignmentById called for ${id}`);
+    const assignment = this.db.agentScorerAssignments.get(id);
+    return assignment ? this.cloneAssignment(assignment) : null;
+  }
+
+  // ============================================================================
+  // Helper Methods
+  // ============================================================================
+
+  private sortScorers(
+    scorers: StorageScorerType[],
+    field: ThreadOrderBy,
+    direction: ThreadSortDirection,
+  ): StorageScorerType[] {
+    return scorers.sort((a, b) => {
+      const aValue = new Date(a[field]).getTime();
+      const bValue = new Date(b[field]).getTime();
+      return direction === 'ASC' ? aValue - bValue : bValue - aValue;
+    });
+  }
+
+  private cloneScorer(scorer: StorageScorerType): StorageScorerType {
+    return {
+      ...scorer,
+      type: scorer.type ? (typeof scorer.type === 'string' ? scorer.type : { ...scorer.type }) : scorer.type,
+      judge: scorer.judge ? { ...scorer.judge } : scorer.judge,
+      steps: scorer.steps.map(s => ({ ...s, judge: s.judge ? { ...s.judge } : s.judge })),
+      sampling: scorer.sampling ? { ...scorer.sampling } : scorer.sampling,
+      metadata: scorer.metadata ? { ...scorer.metadata } : scorer.metadata,
+    };
+  }
+
+  private cloneAssignment(assignment: StorageAgentScorerAssignment): StorageAgentScorerAssignment {
+    return {
+      ...assignment,
+      sampling: assignment.sampling ? { ...assignment.sampling } : assignment.sampling,
+      metadata: assignment.metadata ? { ...assignment.metadata } : assignment.metadata,
+    };
+  }
+}

--- a/packages/server/src/server/handlers/stored-scorers.ts
+++ b/packages/server/src/server/handlers/stored-scorers.ts
@@ -1,0 +1,413 @@
+import { HTTPException } from '../http-exception';
+import {
+  storedScorerIdPathParams,
+  agentIdPathParams,
+  agentScorerPathParams,
+  assignmentIdPathParams,
+  listStoredScorersQuerySchema,
+  listAgentScorerAssignmentsQuerySchema,
+  createStoredScorerBodySchema,
+  updateStoredScorerBodySchema,
+  assignScorerToAgentBodySchema,
+  updateAgentScorerAssignmentBodySchema,
+  listStoredScorersResponseSchema,
+  getStoredScorerResponseSchema,
+  createStoredScorerResponseSchema,
+  updateStoredScorerResponseSchema,
+  deleteStoredScorerResponseSchema,
+  listAgentScorerAssignmentsResponseSchema,
+  assignScorerToAgentResponseSchema,
+  updateAgentScorerAssignmentResponseSchema,
+  unassignScorerFromAgentResponseSchema,
+} from '../schemas/stored-scorers';
+import { createRoute } from '../server-adapter/routes/route-builder';
+
+import { handleError } from './error';
+
+// ============================================================================
+// Stored Scorers CRUD Routes
+// ============================================================================
+
+/**
+ * GET /api/stored/scorers - List all stored scorers
+ */
+export const LIST_STORED_SCORERS_ROUTE = createRoute({
+  method: 'GET',
+  path: '/api/stored/scorers',
+  responseType: 'json',
+  queryParamSchema: listStoredScorersQuerySchema,
+  responseSchema: listStoredScorersResponseSchema,
+  summary: 'List stored scorers',
+  description: 'Returns a paginated list of all scorer definitions stored in the database',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, page, perPage, orderBy }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      const result = await storedScorersStore.listScorers({
+        page,
+        perPage,
+        orderBy,
+      });
+
+      return result;
+    } catch (error) {
+      return handleError(error, 'Error listing stored scorers');
+    }
+  },
+});
+
+/**
+ * GET /api/stored/scorers/:storedScorerId - Get a stored scorer by ID
+ */
+export const GET_STORED_SCORER_ROUTE = createRoute({
+  method: 'GET',
+  path: '/api/stored/scorers/:storedScorerId',
+  responseType: 'json',
+  pathParamSchema: storedScorerIdPathParams,
+  responseSchema: getStoredScorerResponseSchema,
+  summary: 'Get stored scorer by ID',
+  description: 'Returns a specific scorer definition from storage by its unique identifier',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, storedScorerId }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      const scorer = await storedScorersStore.getScorerById({ id: storedScorerId });
+
+      if (!scorer) {
+        throw new HTTPException(404, { message: `Stored scorer with id ${storedScorerId} not found` });
+      }
+
+      return scorer;
+    } catch (error) {
+      return handleError(error, 'Error getting stored scorer');
+    }
+  },
+});
+
+/**
+ * POST /api/stored/scorers - Create a new stored scorer
+ */
+export const CREATE_STORED_SCORER_ROUTE = createRoute({
+  method: 'POST',
+  path: '/api/stored/scorers',
+  responseType: 'json',
+  bodySchema: createStoredScorerBodySchema,
+  responseSchema: createStoredScorerResponseSchema,
+  summary: 'Create stored scorer',
+  description: 'Creates a new scorer definition in storage with the provided configuration',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, id, name, description, type, judge, steps, sampling, metadata }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      // Check if scorer with this ID already exists
+      const existing = await storedScorersStore.getScorerById({ id });
+      if (existing) {
+        throw new HTTPException(409, { message: `Scorer with id ${id} already exists` });
+      }
+
+      const scorer = await storedScorersStore.createScorer({
+        scorer: {
+          id,
+          name,
+          description,
+          type,
+          judge,
+          steps,
+          sampling,
+          metadata,
+        },
+      });
+
+      return scorer;
+    } catch (error) {
+      return handleError(error, 'Error creating stored scorer');
+    }
+  },
+});
+
+/**
+ * PATCH /api/stored/scorers/:storedScorerId - Update a stored scorer
+ */
+export const UPDATE_STORED_SCORER_ROUTE = createRoute({
+  method: 'PATCH',
+  path: '/api/stored/scorers/:storedScorerId',
+  responseType: 'json',
+  pathParamSchema: storedScorerIdPathParams,
+  bodySchema: updateStoredScorerBodySchema,
+  responseSchema: updateStoredScorerResponseSchema,
+  summary: 'Update stored scorer',
+  description: 'Updates an existing scorer definition in storage with the provided fields',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, storedScorerId, name, description, type, judge, steps, sampling, metadata }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      // Check if scorer exists
+      const existing = await storedScorersStore.getScorerById({ id: storedScorerId });
+      if (!existing) {
+        throw new HTTPException(404, { message: `Stored scorer with id ${storedScorerId} not found` });
+      }
+
+      const scorer = await storedScorersStore.updateScorer({
+        id: storedScorerId,
+        name,
+        description,
+        type,
+        judge,
+        steps,
+        sampling,
+        metadata,
+      });
+
+      return scorer;
+    } catch (error) {
+      return handleError(error, 'Error updating stored scorer');
+    }
+  },
+});
+
+/**
+ * DELETE /api/stored/scorers/:storedScorerId - Delete a stored scorer
+ */
+export const DELETE_STORED_SCORER_ROUTE = createRoute({
+  method: 'DELETE',
+  path: '/api/stored/scorers/:storedScorerId',
+  responseType: 'json',
+  pathParamSchema: storedScorerIdPathParams,
+  responseSchema: deleteStoredScorerResponseSchema,
+  summary: 'Delete stored scorer',
+  description: 'Deletes a scorer definition from storage by its unique identifier. Also removes any agent assignments.',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, storedScorerId }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      // Check if scorer exists
+      const existing = await storedScorersStore.getScorerById({ id: storedScorerId });
+      if (!existing) {
+        throw new HTTPException(404, { message: `Stored scorer with id ${storedScorerId} not found` });
+      }
+
+      await storedScorersStore.deleteScorer({ id: storedScorerId });
+
+      return { success: true, message: `Scorer ${storedScorerId} deleted successfully` };
+    } catch (error) {
+      return handleError(error, 'Error deleting stored scorer');
+    }
+  },
+});
+
+// ============================================================================
+// Agent-Scorer Assignment Routes
+// ============================================================================
+
+/**
+ * GET /api/stored/scorers/agents/:agentId/assignments - List scorer assignments for an agent
+ */
+export const LIST_AGENT_SCORER_ASSIGNMENTS_ROUTE = createRoute({
+  method: 'GET',
+  path: '/api/stored/scorers/agents/:agentId/assignments',
+  responseType: 'json',
+  pathParamSchema: agentIdPathParams,
+  queryParamSchema: listAgentScorerAssignmentsQuerySchema,
+  responseSchema: listAgentScorerAssignmentsResponseSchema,
+  summary: 'List agent scorer assignments',
+  description: 'Returns a paginated list of scorer assignments for a specific agent',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, agentId, page, perPage, enabledOnly }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      const result = await storedScorersStore.listAgentScorerAssignments({
+        agentId,
+        page,
+        perPage,
+        enabledOnly,
+      });
+
+      return result;
+    } catch (error) {
+      return handleError(error, 'Error listing agent scorer assignments');
+    }
+  },
+});
+
+/**
+ * POST /api/stored/scorers/agents/:agentId/assignments - Assign a scorer to an agent
+ */
+export const ASSIGN_SCORER_TO_AGENT_ROUTE = createRoute({
+  method: 'POST',
+  path: '/api/stored/scorers/agents/:agentId/assignments',
+  responseType: 'json',
+  pathParamSchema: agentIdPathParams,
+  bodySchema: assignScorerToAgentBodySchema,
+  responseSchema: assignScorerToAgentResponseSchema,
+  summary: 'Assign scorer to agent',
+  description: 'Creates a new assignment linking a stored scorer to an agent',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, agentId, scorerId, sampling, enabled, priority, metadata }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      const assignment = await storedScorersStore.assignScorerToAgent({
+        agentId,
+        scorerId,
+        sampling,
+        enabled: enabled ?? true,
+        priority,
+        metadata,
+      });
+
+      return assignment;
+    } catch (error) {
+      return handleError(error, 'Error assigning scorer to agent');
+    }
+  },
+});
+
+/**
+ * PATCH /api/stored/scorers/assignments/:assignmentId - Update an agent-scorer assignment
+ */
+export const UPDATE_AGENT_SCORER_ASSIGNMENT_ROUTE = createRoute({
+  method: 'PATCH',
+  path: '/api/stored/scorers/assignments/:assignmentId',
+  responseType: 'json',
+  pathParamSchema: assignmentIdPathParams,
+  bodySchema: updateAgentScorerAssignmentBodySchema,
+  responseSchema: updateAgentScorerAssignmentResponseSchema,
+  summary: 'Update agent scorer assignment',
+  description: 'Updates an existing agent-scorer assignment',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, assignmentId, sampling, enabled, priority, metadata }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      // Check if assignment exists
+      const existing = await storedScorersStore.getAssignmentById({ id: assignmentId });
+      if (!existing) {
+        throw new HTTPException(404, { message: `Assignment with id ${assignmentId} not found` });
+      }
+
+      const assignment = await storedScorersStore.updateAgentScorerAssignment({
+        id: assignmentId,
+        sampling,
+        enabled,
+        priority,
+        metadata,
+      });
+
+      return assignment;
+    } catch (error) {
+      return handleError(error, 'Error updating agent scorer assignment');
+    }
+  },
+});
+
+/**
+ * DELETE /api/stored/scorers/agents/:agentId/scorers/:scorerId - Unassign a scorer from an agent
+ */
+export const UNASSIGN_SCORER_FROM_AGENT_ROUTE = createRoute({
+  method: 'DELETE',
+  path: '/api/stored/scorers/agents/:agentId/scorers/:scorerId',
+  responseType: 'json',
+  pathParamSchema: agentScorerPathParams,
+  responseSchema: unassignScorerFromAgentResponseSchema,
+  summary: 'Unassign scorer from agent',
+  description: 'Removes a scorer assignment from an agent',
+  tags: ['Stored Scorers'],
+  handler: async ({ mastra, agentId, scorerId }) => {
+    try {
+      const storage = mastra.getStorage();
+
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+
+      const storedScorersStore = await storage.getStore('storedScorers');
+      if (!storedScorersStore) {
+        throw new HTTPException(500, { message: 'Stored scorers storage domain is not available' });
+      }
+
+      await storedScorersStore.unassignScorerFromAgent({ agentId, scorerId });
+
+      return { success: true, message: `Scorer ${scorerId} unassigned from agent ${agentId} successfully` };
+    } catch (error) {
+      return handleError(error, 'Error unassigning scorer from agent');
+    }
+  },
+});

--- a/packages/server/src/server/schemas/stored-scorers.ts
+++ b/packages/server/src/server/schemas/stored-scorers.ts
@@ -1,0 +1,245 @@
+import z from 'zod';
+import { paginationInfoSchema, createPagePaginationSchema } from './common';
+
+// ============================================================================
+// Path Parameter Schemas
+// ============================================================================
+
+/**
+ * Path parameter for stored scorer ID
+ */
+export const storedScorerIdPathParams = z.object({
+  storedScorerId: z.string().describe('Unique identifier for the stored scorer'),
+});
+
+/**
+ * Path parameters for agent-scorer assignment (agentId and scorerId)
+ */
+export const agentScorerPathParams = z.object({
+  agentId: z.string().describe('Unique identifier for the agent'),
+  scorerId: z.string().describe('Unique identifier for the scorer'),
+});
+
+/**
+ * Path parameter for assignment ID
+ */
+export const assignmentIdPathParams = z.object({
+  assignmentId: z.string().describe('Unique identifier for the agent-scorer assignment'),
+});
+
+/**
+ * Path parameter for agent ID (for listing assignments)
+ */
+export const agentIdPathParams = z.object({
+  agentId: z.string().describe('Unique identifier for the agent'),
+});
+
+// ============================================================================
+// Query Parameter Schemas
+// ============================================================================
+
+/**
+ * Storage order by configuration
+ */
+const storageOrderBySchema = z.object({
+  field: z.enum(['createdAt', 'updatedAt']).optional(),
+  direction: z.enum(['ASC', 'DESC']).optional(),
+});
+
+/**
+ * GET /api/stored/scorers - List stored scorers
+ */
+export const listStoredScorersQuerySchema = createPagePaginationSchema(100).extend({
+  orderBy: storageOrderBySchema.optional(),
+});
+
+/**
+ * GET /api/stored/scorers/agents/:agentId/assignments - List agent scorer assignments
+ */
+export const listAgentScorerAssignmentsQuerySchema = createPagePaginationSchema(100).extend({
+  enabledOnly: z.coerce.boolean().optional(),
+});
+
+// ============================================================================
+// Body Parameter Schemas
+// ============================================================================
+
+/**
+ * Top-level judge configuration for scorer (instructions required)
+ */
+const judgeConfigSchema = z.object({
+  model: z.string().describe('Model identifier (e.g., "openai:gpt-4")'),
+  instructions: z.string().describe('System instructions for the judge model'),
+});
+
+/**
+ * Step-level judge configuration (instructions optional, inherits from top-level)
+ */
+const stepJudgeConfigSchema = z.object({
+  model: z.string().describe('Model identifier (e.g., "openai:gpt-4")'),
+  instructions: z.string().optional().describe('Optional instructions override for this step'),
+});
+
+/**
+ * Scorer step configuration
+ */
+const scorerStepConfigSchema = z.object({
+  name: z
+    .enum(['preprocess', 'analyze', 'generateScore', 'generateReason'])
+    .describe('Step name in the scorer pipeline'),
+  description: z.string().describe('Human-readable description of what this step does'),
+  outputSchema: z.record(z.string(), z.unknown()).optional().describe('JSON Schema for step output validation'),
+  promptTemplate: z.string().describe('Prompt template with {{variable}} placeholders'),
+  judge: stepJudgeConfigSchema.optional().describe('Optional step-specific judge configuration'),
+});
+
+/**
+ * Sampling configuration for scorers
+ */
+const samplingConfigSchema = z.object({
+  type: z.enum(['ratio', 'count']).describe('Sampling strategy'),
+  rate: z.number().min(0).max(1).optional().describe('Sampling rate (0-1) when type is "ratio"'),
+  count: z.number().int().positive().optional().describe('Fixed sample count when type is "count"'),
+});
+
+/**
+ * Scorer type configuration
+ */
+const scorerTypeSchema = z.union([
+  z.literal('agent').describe('Agent scorer that evaluates agent runs'),
+  z
+    .object({
+      inputSchema: z.record(z.string(), z.unknown()).optional().describe('JSON Schema for scorer input'),
+      outputSchema: z.record(z.string(), z.unknown()).optional().describe('JSON Schema for scorer output'),
+    })
+    .describe('Custom scorer with input/output schemas'),
+]);
+
+/**
+ * Base stored scorer schema (shared fields)
+ */
+const storedScorerBaseSchema = z.object({
+  name: z.string().describe('Name of the scorer'),
+  description: z.string().describe('Description of what this scorer evaluates'),
+  type: scorerTypeSchema.optional().describe('Scorer type configuration'),
+  judge: judgeConfigSchema.optional().describe('Default judge configuration for all steps'),
+  steps: z.array(scorerStepConfigSchema).describe('Pipeline steps for the scorer'),
+  sampling: samplingConfigSchema.optional().describe('Sampling configuration'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Additional metadata'),
+});
+
+/**
+ * POST /api/stored/scorers - Create stored scorer body
+ */
+export const createStoredScorerBodySchema = storedScorerBaseSchema.extend({
+  id: z.string().describe('Unique identifier for the scorer'),
+});
+
+/**
+ * PATCH /api/stored/scorers/:storedScorerId - Update stored scorer body
+ */
+export const updateStoredScorerBodySchema = storedScorerBaseSchema.partial();
+
+/**
+ * POST /api/stored/scorers/agents/:agentId/assignments - Assign scorer to agent body
+ */
+export const assignScorerToAgentBodySchema = z.object({
+  scorerId: z.string().describe('ID of the scorer to assign'),
+  sampling: samplingConfigSchema.optional().describe('Override sampling for this assignment'),
+  enabled: z.boolean().default(true).describe('Whether the assignment is active'),
+  priority: z.number().int().optional().describe('Priority order (lower = higher priority)'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Additional metadata'),
+});
+
+/**
+ * PATCH /api/stored/scorers/assignments/:assignmentId - Update assignment body
+ */
+export const updateAgentScorerAssignmentBodySchema = z.object({
+  sampling: samplingConfigSchema.optional().describe('Override sampling for this assignment'),
+  enabled: z.boolean().optional().describe('Whether the assignment is active'),
+  priority: z.number().int().optional().describe('Priority order (lower = higher priority)'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Additional metadata'),
+});
+
+// ============================================================================
+// Response Schemas
+// ============================================================================
+
+/**
+ * Stored scorer object schema (full response)
+ */
+export const storedScorerSchema = storedScorerBaseSchema.extend({
+  id: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+/**
+ * Agent-scorer assignment object schema (full response)
+ */
+export const agentScorerAssignmentSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  scorerId: z.string(),
+  sampling: samplingConfigSchema.optional(),
+  enabled: z.boolean(),
+  priority: z.number().int().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+/**
+ * Response for GET /api/stored/scorers
+ */
+export const listStoredScorersResponseSchema = paginationInfoSchema.extend({
+  scorers: z.array(storedScorerSchema),
+});
+
+/**
+ * Response for GET /api/stored/scorers/:storedScorerId
+ */
+export const getStoredScorerResponseSchema = storedScorerSchema;
+
+/**
+ * Response for POST /api/stored/scorers
+ */
+export const createStoredScorerResponseSchema = storedScorerSchema;
+
+/**
+ * Response for PATCH /api/stored/scorers/:storedScorerId
+ */
+export const updateStoredScorerResponseSchema = storedScorerSchema;
+
+/**
+ * Response for DELETE /api/stored/scorers/:storedScorerId
+ */
+export const deleteStoredScorerResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+/**
+ * Response for GET /api/stored/scorers/agents/:agentId/assignments
+ */
+export const listAgentScorerAssignmentsResponseSchema = paginationInfoSchema.extend({
+  assignments: z.array(agentScorerAssignmentSchema),
+});
+
+/**
+ * Response for POST /api/stored/scorers/agents/:agentId/assignments
+ */
+export const assignScorerToAgentResponseSchema = agentScorerAssignmentSchema;
+
+/**
+ * Response for PATCH /api/stored/scorers/assignments/:assignmentId
+ */
+export const updateAgentScorerAssignmentResponseSchema = agentScorerAssignmentSchema;
+
+/**
+ * Response for DELETE /api/stored/scorers/agents/:agentId/scorers/:scorerId
+ */
+export const unassignScorerFromAgentResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -14,6 +14,7 @@ import { MEMORY_ROUTES } from './memory';
 import { OBSERVABILITY_ROUTES } from './observability';
 import { SCORES_ROUTES } from './scorers';
 import { STORED_AGENTS_ROUTES } from './stored-agents';
+import { STORED_SCORERS_ROUTES } from './stored-scorers';
 import type { MastraStreamReturn } from './stream-types';
 import { SYSTEM_ROUTES } from './system';
 import { TOOLS_ROUTES } from './tools';
@@ -100,6 +101,7 @@ export const SERVER_ROUTES: ServerRoute<any, any, any>[] = [
   ...LEGACY_ROUTES,
   ...MCP_ROUTES,
   ...STORED_AGENTS_ROUTES,
+  ...STORED_SCORERS_ROUTES,
   ...SYSTEM_ROUTES,
 ];
 

--- a/packages/server/src/server/server-adapter/routes/stored-scorers.ts
+++ b/packages/server/src/server/server-adapter/routes/stored-scorers.ts
@@ -1,0 +1,36 @@
+import {
+  LIST_STORED_SCORERS_ROUTE,
+  GET_STORED_SCORER_ROUTE,
+  CREATE_STORED_SCORER_ROUTE,
+  UPDATE_STORED_SCORER_ROUTE,
+  DELETE_STORED_SCORER_ROUTE,
+  LIST_AGENT_SCORER_ASSIGNMENTS_ROUTE,
+  ASSIGN_SCORER_TO_AGENT_ROUTE,
+  UPDATE_AGENT_SCORER_ASSIGNMENT_ROUTE,
+  UNASSIGN_SCORER_FROM_AGENT_ROUTE,
+} from '../../handlers/stored-scorers';
+import type { ServerRoute } from '.';
+
+/**
+ * Routes for stored scorers CRUD operations and agent-scorer assignments.
+ * These routes provide API access to scorer definitions stored in the database,
+ * enabling dynamic creation and management of scorers via Mastra Studio.
+ */
+export const STORED_SCORERS_ROUTES: ServerRoute<any, any, any>[] = [
+  // ============================================================================
+  // Stored Scorers CRUD Routes
+  // ============================================================================
+  LIST_STORED_SCORERS_ROUTE,
+  GET_STORED_SCORER_ROUTE,
+  CREATE_STORED_SCORER_ROUTE,
+  UPDATE_STORED_SCORER_ROUTE,
+  DELETE_STORED_SCORER_ROUTE,
+
+  // ============================================================================
+  // Agent-Scorer Assignment Routes
+  // ============================================================================
+  LIST_AGENT_SCORER_ASSIGNMENTS_ROUTE,
+  ASSIGN_SCORER_TO_AGENT_ROUTE,
+  UPDATE_AGENT_SCORER_ASSIGNMENT_ROUTE,
+  UNASSIGN_SCORER_FROM_AGENT_ROUTE,
+];

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -8,6 +8,8 @@ import {
   TABLE_WORKFLOW_SNAPSHOT,
   safelyParseJSON,
   TABLE_SPANS,
+  TABLE_STORED_SCORERS,
+  TABLE_AGENT_SCORER_ASSIGNMENTS,
 } from '@mastra/core/storage';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
@@ -20,6 +22,8 @@ export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   // TODO: verify this is the correct engine for Spans when implementing clickhouse storage
   [TABLE_SPANS]: `ReplacingMergeTree()`,
   mastra_agents: `ReplacingMergeTree()`,
+  [TABLE_STORED_SCORERS]: `ReplacingMergeTree()`,
+  [TABLE_AGENT_SCORER_ASSIGNMENTS]: `ReplacingMergeTree()`,
 };
 
 export const COLUMN_TYPES: Record<StorageColumn['type'], string> = {

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -12,8 +12,12 @@ import type {
   TABLE_SCORERS,
   TABLE_SPANS,
   TABLE_AGENTS,
+  TABLE_STORED_SCORERS,
+  TABLE_AGENT_SCORER_ASSIGNMENTS,
   SpanRecord,
   StorageAgentType,
+  StorageScorerType,
+  StorageAgentScorerAssignment,
 } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import type Cloudflare from 'cloudflare';
@@ -109,6 +113,8 @@ export type RecordTypes = {
   [TABLE_RESOURCES]: StorageResourceType;
   [TABLE_SPANS]: SpanRecord;
   [TABLE_AGENTS]: StorageAgentType;
+  [TABLE_STORED_SCORERS]: StorageScorerType;
+  [TABLE_AGENT_SCORER_ASSIGNMENTS]: StorageAgentScorerAssignment;
 };
 
 export type ListOptions = {

--- a/stores/libsql/src/storage/domains/stored-scorers/index.ts
+++ b/stores/libsql/src/storage/domains/stored-scorers/index.ts
@@ -1,0 +1,583 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  StoredScorersStorage,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_STORED_SCORERS,
+  TABLE_AGENT_SCORER_ASSIGNMENTS,
+  STORED_SCORERS_SCHEMA,
+  AGENT_SCORER_ASSIGNMENTS_SCHEMA,
+} from '@mastra/core/storage';
+import type {
+  StorageScorerType,
+  StorageCreateScorerInput,
+  StorageUpdateScorerInput,
+  StorageListScorersInput,
+  StorageListScorersOutput,
+  StorageAgentScorerAssignment,
+  StorageCreateAgentScorerAssignmentInput,
+  StorageUpdateAgentScorerAssignmentInput,
+  StorageListAgentScorerAssignmentsInput,
+  StorageListAgentScorerAssignmentsOutput,
+} from '@mastra/core/storage';
+import { randomUUID } from 'crypto';
+import { LibSQLDB, resolveClient } from '../../db';
+import type { LibSQLDomainConfig } from '../../db';
+
+export class StoredScorersLibSQL extends StoredScorersStorage {
+  #db: LibSQLDB;
+
+  constructor(config: LibSQLDomainConfig) {
+    super();
+    const client = resolveClient(config);
+    this.#db = new LibSQLDB({ client, maxRetries: config.maxRetries, initialBackoffMs: config.initialBackoffMs });
+  }
+
+  async init(): Promise<void> {
+    await this.#db.createTable({ tableName: TABLE_STORED_SCORERS, schema: STORED_SCORERS_SCHEMA });
+    await this.#db.createTable({ tableName: TABLE_AGENT_SCORER_ASSIGNMENTS, schema: AGENT_SCORER_ASSIGNMENTS_SCHEMA });
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.#db.deleteData({ tableName: TABLE_STORED_SCORERS });
+    await this.#db.deleteData({ tableName: TABLE_AGENT_SCORER_ASSIGNMENTS });
+  }
+
+  private parseJson(value: any, fieldName?: string): any {
+    if (!value) return undefined;
+    if (typeof value !== 'string') return value;
+
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      const details: Record<string, string> = {
+        value: value.length > 100 ? value.substring(0, 100) + '...' : value,
+      };
+      if (fieldName) {
+        details.field = fieldName;
+      }
+
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'PARSE_JSON', 'INVALID_JSON'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Failed to parse JSON${fieldName ? ` for field "${fieldName}"` : ''}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          details,
+        },
+        error,
+      );
+    }
+  }
+
+  private parseScorerRow(row: any): StorageScorerType {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      description: row.description as string,
+      type: this.parseJson(row.type, 'type'),
+      judge: this.parseJson(row.judge, 'judge'),
+      steps: this.parseJson(row.steps, 'steps') || [],
+      sampling: this.parseJson(row.sampling, 'sampling'),
+      metadata: this.parseJson(row.metadata, 'metadata'),
+      createdAt: new Date(row.createdAt as string),
+      updatedAt: new Date(row.updatedAt as string),
+    };
+  }
+
+  private parseAssignmentRow(row: any): StorageAgentScorerAssignment {
+    return {
+      id: row.id as string,
+      agentId: row.agentId as string,
+      scorerId: row.scorerId as string,
+      sampling: this.parseJson(row.sampling, 'sampling'),
+      enabled: Boolean(row.enabled),
+      priority: row.priority != null ? Number(row.priority) : undefined,
+      metadata: this.parseJson(row.metadata, 'metadata'),
+      createdAt: new Date(row.createdAt as string),
+      updatedAt: new Date(row.updatedAt as string),
+    };
+  }
+
+  // ============================================================================
+  // Scorer Definition CRUD
+  // ============================================================================
+
+  async getScorerById({ id }: { id: string }): Promise<StorageScorerType | null> {
+    try {
+      const result = await this.#db.select<Record<string, any>>({
+        tableName: TABLE_STORED_SCORERS,
+        keys: { id },
+      });
+
+      return result ? this.parseScorerRow(result) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_SCORER_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async createScorer({ scorer }: { scorer: StorageCreateScorerInput }): Promise<StorageScorerType> {
+    try {
+      const now = new Date();
+
+      await this.#db.insert({
+        tableName: TABLE_STORED_SCORERS,
+        record: {
+          id: scorer.id,
+          name: scorer.name,
+          description: scorer.description,
+          type: scorer.type ? JSON.stringify(scorer.type) : null,
+          judge: scorer.judge ? JSON.stringify(scorer.judge) : null,
+          steps: JSON.stringify(scorer.steps),
+          sampling: scorer.sampling ? JSON.stringify(scorer.sampling) : null,
+          metadata: scorer.metadata ? JSON.stringify(scorer.metadata) : null,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+        },
+      });
+
+      return {
+        ...scorer,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'CREATE_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: scorer.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateScorer({ id, ...updates }: StorageUpdateScorerInput): Promise<StorageScorerType> {
+    try {
+      const existingScorer = await this.getScorerById({ id });
+      if (!existingScorer) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'UPDATE_SCORER', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Scorer ${id} not found`,
+          details: { scorerId: id },
+        });
+      }
+
+      const data: Record<string, any> = {
+        updatedAt: new Date().toISOString(),
+      };
+
+      if (updates.name !== undefined) data.name = updates.name;
+      if (updates.description !== undefined) data.description = updates.description;
+      if (updates.type !== undefined) data.type = JSON.stringify(updates.type);
+      if (updates.judge !== undefined) data.judge = JSON.stringify(updates.judge);
+      if (updates.steps !== undefined) data.steps = JSON.stringify(updates.steps);
+      if (updates.sampling !== undefined) data.sampling = JSON.stringify(updates.sampling);
+      if (updates.metadata !== undefined) {
+        data.metadata = JSON.stringify({ ...existingScorer.metadata, ...updates.metadata });
+      }
+
+      if (Object.keys(data).length > 1) {
+        await this.#db.update({
+          tableName: TABLE_STORED_SCORERS,
+          keys: { id },
+          data,
+        });
+      }
+
+      const updatedScorer = await this.getScorerById({ id });
+      if (!updatedScorer) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'UPDATE_SCORER', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Scorer ${id} not found after update`,
+          details: { scorerId: id },
+        });
+      }
+
+      return updatedScorer;
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'UPDATE_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteScorer({ id }: { id: string }): Promise<void> {
+    try {
+      // Delete all assignments for this scorer first
+      const assignments = await this.#db.selectMany<Record<string, any>>({
+        tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        whereClause: { sql: 'WHERE "scorerId" = ?', args: [id] },
+      });
+
+      if (assignments.length > 0) {
+        await this.#db.batchDelete({
+          tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+          keys: assignments.map(a => ({ id: a.id })),
+        });
+      }
+
+      // Delete the scorer
+      await this.#db.delete({
+        tableName: TABLE_STORED_SCORERS,
+        keys: { id },
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'DELETE_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listScorers(args?: StorageListScorersInput): Promise<StorageListScorersOutput> {
+    const { page = 0, perPage: perPageInput, orderBy } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_SCORERS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const total = await this.#db.selectTotalCount({ tableName: TABLE_STORED_SCORERS });
+
+      if (total === 0) {
+        return {
+          scorers: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const limitValue = perPageInput === false ? total : perPage;
+      const rows = await this.#db.selectMany<Record<string, any>>({
+        tableName: TABLE_STORED_SCORERS,
+        orderBy: `"${field}" ${direction}`,
+        limit: limitValue,
+        offset,
+      });
+
+      const scorers = rows.map(row => this.parseScorerRow(row));
+
+      return {
+        scorers,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_SCORERS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // ============================================================================
+  // Agent-Scorer Assignments
+  // ============================================================================
+
+  async assignScorerToAgent(input: StorageCreateAgentScorerAssignmentInput): Promise<StorageAgentScorerAssignment> {
+    try {
+      // Verify scorer exists
+      const scorer = await this.getScorerById({ id: input.scorerId });
+      if (!scorer) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'ASSIGN_SCORER', 'SCORER_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Scorer ${input.scorerId} not found`,
+          details: { scorerId: input.scorerId },
+        });
+      }
+
+      // Check for existing assignment
+      const existingRows = await this.#db.selectMany<Record<string, any>>({
+        tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        whereClause: { sql: 'WHERE "agentId" = ? AND "scorerId" = ?', args: [input.agentId, input.scorerId] },
+        limit: 1,
+      });
+
+      if (existingRows.length > 0) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'ASSIGN_SCORER', 'ALREADY_EXISTS'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Assignment already exists for agent ${input.agentId} and scorer ${input.scorerId}`,
+          details: { agentId: input.agentId, scorerId: input.scorerId },
+        });
+      }
+
+      const now = new Date();
+      const id = randomUUID();
+
+      await this.#db.insert({
+        tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        record: {
+          id,
+          agentId: input.agentId,
+          scorerId: input.scorerId,
+          sampling: input.sampling ? JSON.stringify(input.sampling) : null,
+          enabled: input.enabled ? 1 : 0,
+          priority: input.priority ?? null,
+          metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+        },
+      });
+
+      return {
+        id,
+        agentId: input.agentId,
+        scorerId: input.scorerId,
+        sampling: input.sampling,
+        enabled: input.enabled,
+        priority: input.priority,
+        metadata: input.metadata,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'ASSIGN_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: input.agentId, scorerId: input.scorerId },
+        },
+        error,
+      );
+    }
+  }
+
+  async unassignScorerFromAgent(params: { agentId: string; scorerId: string }): Promise<void> {
+    try {
+      const rows = await this.#db.selectMany<Record<string, any>>({
+        tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        whereClause: { sql: 'WHERE "agentId" = ? AND "scorerId" = ?', args: [params.agentId, params.scorerId] },
+        limit: 1,
+      });
+
+      if (rows.length > 0 && rows[0]) {
+        await this.#db.delete({
+          tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+          keys: { id: rows[0].id as string },
+        });
+      }
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'UNASSIGN_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: params.agentId, scorerId: params.scorerId },
+        },
+        error,
+      );
+    }
+  }
+
+  async listAgentScorerAssignments(
+    input: StorageListAgentScorerAssignmentsInput,
+  ): Promise<StorageListAgentScorerAssignmentsOutput> {
+    const { agentId, enabledOnly, page = 0, perPage: perPageInput } = input;
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_ASSIGNMENTS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      let whereClause: { sql: string; args: any[] };
+      if (enabledOnly) {
+        whereClause = { sql: 'WHERE "agentId" = ? AND "enabled" = 1', args: [agentId] };
+      } else {
+        whereClause = { sql: 'WHERE "agentId" = ?', args: [agentId] };
+      }
+
+      const total = await this.#db.selectTotalCount({ tableName: TABLE_AGENT_SCORER_ASSIGNMENTS, whereClause });
+
+      if (total === 0) {
+        return {
+          assignments: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const limitValue = perPageInput === false ? total : perPage;
+      const rows = await this.#db.selectMany<Record<string, any>>({
+        tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        whereClause,
+        orderBy: 'COALESCE("priority", 2147483647) ASC, "createdAt" ASC',
+        limit: limitValue,
+        offset,
+      });
+
+      const assignments = rows.map(row => this.parseAssignmentRow(row));
+
+      return {
+        assignments,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_ASSIGNMENTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateAgentScorerAssignment(
+    params: StorageUpdateAgentScorerAssignmentInput,
+  ): Promise<StorageAgentScorerAssignment> {
+    try {
+      const existing = await this.getAssignmentById({ id: params.id });
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'UPDATE_ASSIGNMENT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Assignment ${params.id} not found`,
+          details: { assignmentId: params.id },
+        });
+      }
+
+      const data: Record<string, any> = {
+        updatedAt: new Date().toISOString(),
+      };
+
+      if (params.enabled !== undefined) data.enabled = params.enabled ? 1 : 0;
+      if (params.sampling !== undefined) data.sampling = JSON.stringify(params.sampling);
+      if (params.priority !== undefined) data.priority = params.priority;
+      if (params.metadata !== undefined) {
+        data.metadata = JSON.stringify({ ...existing.metadata, ...params.metadata });
+      }
+
+      if (Object.keys(data).length > 1) {
+        await this.#db.update({
+          tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+          keys: { id: params.id },
+          data,
+        });
+      }
+
+      const updated = await this.getAssignmentById({ id: params.id });
+      if (!updated) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'UPDATE_ASSIGNMENT', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Assignment ${params.id} not found after update`,
+          details: { assignmentId: params.id },
+        });
+      }
+
+      return updated;
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'UPDATE_ASSIGNMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { assignmentId: params.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getAssignmentById({ id }: { id: string }): Promise<StorageAgentScorerAssignment | null> {
+    try {
+      const result = await this.#db.select<Record<string, any>>({
+        tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        keys: { id },
+      });
+
+      return result ? this.parseAssignmentRow(result) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_ASSIGNMENT_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { assignmentId: id },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -7,10 +7,11 @@ import { AgentsLibSQL } from './domains/agents';
 import { MemoryLibSQL } from './domains/memory';
 import { ObservabilityLibSQL } from './domains/observability';
 import { ScoresLibSQL } from './domains/scores';
+import { StoredScorersLibSQL } from './domains/stored-scorers';
 import { WorkflowsLibSQL } from './domains/workflows';
 
 // Export domain classes for direct use with MastraStorage composition
-export { AgentsLibSQL, MemoryLibSQL, ObservabilityLibSQL, ScoresLibSQL, WorkflowsLibSQL };
+export { AgentsLibSQL, MemoryLibSQL, ObservabilityLibSQL, ScoresLibSQL, StoredScorersLibSQL, WorkflowsLibSQL };
 export type { LibSQLDomainConfig } from './db';
 
 /**
@@ -131,6 +132,7 @@ export class LibSQLStore extends MastraStorage {
     const memory = new MemoryLibSQL(domainConfig);
     const observability = new ObservabilityLibSQL(domainConfig);
     const agents = new AgentsLibSQL(domainConfig);
+    const storedScorers = new StoredScorersLibSQL(domainConfig);
 
     this.stores = {
       scores,
@@ -138,6 +140,7 @@ export class LibSQLStore extends MastraStorage {
       memory,
       observability,
       agents,
+      storedScorers,
     };
   }
 }

--- a/stores/pg/src/storage/domains/stored-scorers/index.ts
+++ b/stores/pg/src/storage/domains/stored-scorers/index.ts
@@ -1,0 +1,747 @@
+import { randomUUID } from 'crypto';
+
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  StoredScorersStorage,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_STORED_SCORERS,
+  TABLE_AGENT_SCORER_ASSIGNMENTS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
+import type {
+  StorageScorerType,
+  StorageCreateScorerInput,
+  StorageUpdateScorerInput,
+  StorageListScorersInput,
+  StorageListScorersOutput,
+  StorageAgentScorerAssignment,
+  StorageCreateAgentScorerAssignmentInput,
+  StorageUpdateAgentScorerAssignmentInput,
+  StorageListAgentScorerAssignmentsInput,
+  StorageListAgentScorerAssignmentsOutput,
+  CreateIndexOptions,
+} from '@mastra/core/storage';
+import { PgDB, resolvePgConfig } from '../../db';
+import type { PgDomainConfig } from '../../db';
+import { getTableName, getSchemaName } from '../utils';
+
+export class StoredScorersPG extends StoredScorersStorage {
+  #db: PgDB;
+  #schema: string;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: CreateIndexOptions[];
+
+  /** Tables managed by this domain */
+  static readonly MANAGED_TABLES = [TABLE_STORED_SCORERS, TABLE_AGENT_SCORER_ASSIGNMENTS] as const;
+
+  constructor(config: PgDomainConfig) {
+    super();
+    const { client, schemaName, skipDefaultIndexes, indexes } = resolvePgConfig(config);
+    this.#db = new PgDB({ client, schemaName, skipDefaultIndexes });
+    this.#schema = schemaName || 'public';
+    this.#skipDefaultIndexes = skipDefaultIndexes;
+    this.#indexes = indexes?.filter(idx => (StoredScorersPG.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  /**
+   * Returns default index definitions for the stored scorers domain tables.
+   */
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        name: 'idx_agent_scorer_assignments_agent_id',
+        table: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        columns: ['agentId'],
+      },
+      {
+        name: 'idx_agent_scorer_assignments_enabled',
+        table: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        columns: ['agentId', 'enabled'],
+      },
+      {
+        name: 'idx_agent_scorer_assignments_unique',
+        table: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        columns: ['agentId', 'scorerId'],
+        unique: true,
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) {
+      return;
+    }
+
+    const indexes = this.getDefaultIndexDefinitions();
+    for (const indexDef of indexes) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        // Log but continue - indexes are performance optimizations
+        this.logger?.warn?.(`Failed to create default index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async init(): Promise<void> {
+    await this.#db.createTable({
+      tableName: TABLE_STORED_SCORERS,
+      schema: TABLE_SCHEMAS[TABLE_STORED_SCORERS],
+    });
+    await this.#db.createTable({
+      tableName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+      schema: TABLE_SCHEMAS[TABLE_AGENT_SCORER_ASSIGNMENTS],
+    });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) {
+      return;
+    }
+
+    for (const indexDef of this.#indexes) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    // Clear assignments first due to foreign key reference
+    await this.#db.clearTable({ tableName: TABLE_AGENT_SCORER_ASSIGNMENTS });
+    await this.#db.clearTable({ tableName: TABLE_STORED_SCORERS });
+  }
+
+  private parseJson(value: any, fieldName?: string): any {
+    if (!value) return undefined;
+    if (typeof value !== 'string') return value;
+
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      const details: Record<string, string> = {
+        value: value.length > 100 ? value.substring(0, 100) + '...' : value,
+      };
+      if (fieldName) {
+        details.field = fieldName;
+      }
+
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'PARSE_JSON', 'INVALID_JSON'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Failed to parse JSON${fieldName ? ` for field "${fieldName}"` : ''}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          details,
+        },
+        error,
+      );
+    }
+  }
+
+  private parseScorerRow(row: any): StorageScorerType {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      description: row.description as string,
+      type: this.parseJson(row.type, 'type'),
+      judge: this.parseJson(row.judge, 'judge'),
+      steps: this.parseJson(row.steps, 'steps') || [],
+      sampling: this.parseJson(row.sampling, 'sampling'),
+      metadata: this.parseJson(row.metadata, 'metadata'),
+      createdAt: row.createdAtZ || row.createdAt,
+      updatedAt: row.updatedAtZ || row.updatedAt,
+    };
+  }
+
+  private parseAssignmentRow(row: any): StorageAgentScorerAssignment {
+    return {
+      id: row.id as string,
+      agentId: row.agentId as string,
+      scorerId: row.scorerId as string,
+      sampling: this.parseJson(row.sampling, 'sampling'),
+      enabled: row.enabled as boolean,
+      priority: row.priority as number | undefined,
+      metadata: this.parseJson(row.metadata, 'metadata'),
+      createdAt: row.createdAtZ || row.createdAt,
+      updatedAt: row.updatedAtZ || row.updatedAt,
+    };
+  }
+
+  // ============================================================================
+  // Scorer CRUD
+  // ============================================================================
+
+  async getScorerById({ id }: { id: string }): Promise<StorageScorerType | null> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_STORED_SCORERS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      const result = await this.#db.client.oneOrNone(`SELECT * FROM ${tableName} WHERE id = $1`, [id]);
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseScorerRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_SCORER_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async createScorer({ scorer }: { scorer: StorageCreateScorerInput }): Promise<StorageScorerType> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_STORED_SCORERS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const now = new Date();
+      const nowIso = now.toISOString();
+
+      await this.#db.client.none(
+        `INSERT INTO ${tableName} (
+          id, name, description, type, judge, steps, sampling, metadata,
+          "createdAt", "createdAtZ", "updatedAt", "updatedAtZ"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+        [
+          scorer.id,
+          scorer.name,
+          scorer.description,
+          scorer.type ? JSON.stringify(scorer.type) : null,
+          scorer.judge ? JSON.stringify(scorer.judge) : null,
+          JSON.stringify(scorer.steps),
+          scorer.sampling ? JSON.stringify(scorer.sampling) : null,
+          scorer.metadata ? JSON.stringify(scorer.metadata) : null,
+          nowIso,
+          nowIso,
+          nowIso,
+          nowIso,
+        ],
+      );
+
+      return {
+        ...scorer,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'CREATE_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: scorer.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateScorer({ id, ...updates }: StorageUpdateScorerInput): Promise<StorageScorerType> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_STORED_SCORERS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      const existingScorer = await this.getScorerById({ id });
+      if (!existingScorer) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_SCORER', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Scorer ${id} not found`,
+          details: { scorerId: id },
+        });
+      }
+
+      const setClauses: string[] = [];
+      const values: any[] = [];
+      let paramIndex = 1;
+
+      if (updates.name !== undefined) {
+        setClauses.push(`name = $${paramIndex++}`);
+        values.push(updates.name);
+      }
+
+      if (updates.description !== undefined) {
+        setClauses.push(`description = $${paramIndex++}`);
+        values.push(updates.description);
+      }
+
+      if (updates.type !== undefined) {
+        setClauses.push(`type = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.type));
+      }
+
+      if (updates.judge !== undefined) {
+        setClauses.push(`judge = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.judge));
+      }
+
+      if (updates.steps !== undefined) {
+        setClauses.push(`steps = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.steps));
+      }
+
+      if (updates.sampling !== undefined) {
+        setClauses.push(`sampling = $${paramIndex++}`);
+        values.push(JSON.stringify(updates.sampling));
+      }
+
+      if (updates.metadata !== undefined) {
+        const mergedMetadata = { ...existingScorer.metadata, ...updates.metadata };
+        setClauses.push(`metadata = $${paramIndex++}`);
+        values.push(JSON.stringify(mergedMetadata));
+      }
+
+      // Always update the updatedAt timestamp
+      const now = new Date().toISOString();
+      setClauses.push(`"updatedAt" = $${paramIndex++}`);
+      values.push(now);
+      setClauses.push(`"updatedAtZ" = $${paramIndex++}`);
+      values.push(now);
+
+      values.push(id);
+
+      if (setClauses.length > 2) {
+        await this.#db.client.none(
+          `UPDATE ${tableName} SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`,
+          values,
+        );
+      }
+
+      const updatedScorer = await this.getScorerById({ id });
+      if (!updatedScorer) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_SCORER', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Scorer ${id} not found after update`,
+          details: { scorerId: id },
+        });
+      }
+
+      return updatedScorer;
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'UPDATE_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteScorer({ id }: { id: string }): Promise<void> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_STORED_SCORERS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      // Assignments will be deleted via cascade (if using foreign keys)
+      // or we can delete them explicitly
+      const assignmentsTable = getTableName({
+        indexName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      await this.#db.client.none(`DELETE FROM ${assignmentsTable} WHERE "scorerId" = $1`, [id]);
+
+      await this.#db.client.none(`DELETE FROM ${tableName} WHERE id = $1`, [id]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'DELETE_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { scorerId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listScorers(args?: StorageListScorersInput): Promise<StorageListScorersOutput> {
+    const { page = 0, perPage: perPageInput, orderBy } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_SCORERS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_STORED_SCORERS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      const countResult = await this.#db.client.one(`SELECT COUNT(*) as count FROM ${tableName}`);
+      const total = parseInt(countResult.count, 10);
+
+      if (total === 0) {
+        return {
+          scorers: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const limitValue = perPageInput === false ? total : perPage;
+      const dataResult = await this.#db.client.manyOrNone(
+        `SELECT * FROM ${tableName} ORDER BY "${field}" ${direction} LIMIT $1 OFFSET $2`,
+        [limitValue, offset],
+      );
+
+      const scorers = (dataResult || []).map(row => this.parseScorerRow(row));
+
+      return {
+        scorers,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_SCORERS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // ============================================================================
+  // Agent-Scorer Assignments
+  // ============================================================================
+
+  async assignScorerToAgent(input: StorageCreateAgentScorerAssignmentInput): Promise<StorageAgentScorerAssignment> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      // Check if scorer exists
+      const scorer = await this.getScorerById({ id: input.scorerId });
+      if (!scorer) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'ASSIGN_SCORER', 'SCORER_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Scorer ${input.scorerId} not found`,
+          details: { scorerId: input.scorerId },
+        });
+      }
+
+      const now = new Date();
+      const nowIso = now.toISOString();
+      const id = randomUUID();
+
+      await this.#db.client.none(
+        `INSERT INTO ${tableName} (
+          id, "agentId", "scorerId", sampling, enabled, priority, metadata,
+          "createdAt", "createdAtZ", "updatedAt", "updatedAtZ"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+        [
+          id,
+          input.agentId,
+          input.scorerId,
+          input.sampling ? JSON.stringify(input.sampling) : null,
+          input.enabled,
+          input.priority ?? null,
+          input.metadata ? JSON.stringify(input.metadata) : null,
+          nowIso,
+          nowIso,
+          nowIso,
+          nowIso,
+        ],
+      );
+
+      return {
+        id,
+        agentId: input.agentId,
+        scorerId: input.scorerId,
+        sampling: input.sampling,
+        enabled: input.enabled,
+        priority: input.priority,
+        metadata: input.metadata,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'ASSIGN_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: input.agentId, scorerId: input.scorerId },
+        },
+        error,
+      );
+    }
+  }
+
+  async unassignScorerFromAgent(params: { agentId: string; scorerId: string }): Promise<void> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      await this.#db.client.none(`DELETE FROM ${tableName} WHERE "agentId" = $1 AND "scorerId" = $2`, [
+        params.agentId,
+        params.scorerId,
+      ]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'UNASSIGN_SCORER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId: params.agentId, scorerId: params.scorerId },
+        },
+        error,
+      );
+    }
+  }
+
+  async listAgentScorerAssignments(
+    input: StorageListAgentScorerAssignmentsInput,
+  ): Promise<StorageListAgentScorerAssignmentsOutput> {
+    const { agentId, enabledOnly, page = 0, perPage: perPageInput } = input;
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_ASSIGNMENTS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      let whereClause = `"agentId" = $1`;
+      const countParams: any[] = [agentId];
+      const queryParams: any[] = [agentId];
+
+      if (enabledOnly) {
+        whereClause += ` AND enabled = true`;
+      }
+
+      const countResult = await this.#db.client.one(
+        `SELECT COUNT(*) as count FROM ${tableName} WHERE ${whereClause}`,
+        countParams,
+      );
+      const total = parseInt(countResult.count, 10);
+
+      if (total === 0) {
+        return {
+          assignments: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const limitValue = perPageInput === false ? total : perPage;
+      queryParams.push(limitValue, offset);
+
+      const dataResult = await this.#db.client.manyOrNone(
+        `SELECT * FROM ${tableName}
+         WHERE ${whereClause}
+         ORDER BY COALESCE(priority, 2147483647) ASC, "createdAt" ASC
+         LIMIT $2 OFFSET $3`,
+        queryParams,
+      );
+
+      const assignments = (dataResult || []).map(row => this.parseAssignmentRow(row));
+
+      return {
+        assignments,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_ASSIGNMENTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateAgentScorerAssignment(
+    params: StorageUpdateAgentScorerAssignmentInput,
+  ): Promise<StorageAgentScorerAssignment> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      const existingAssignment = await this.getAssignmentById({ id: params.id });
+      if (!existingAssignment) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_ASSIGNMENT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Assignment ${params.id} not found`,
+          details: { assignmentId: params.id },
+        });
+      }
+
+      const setClauses: string[] = [];
+      const values: any[] = [];
+      let paramIndex = 1;
+
+      if (params.enabled !== undefined) {
+        setClauses.push(`enabled = $${paramIndex++}`);
+        values.push(params.enabled);
+      }
+
+      if (params.sampling !== undefined) {
+        setClauses.push(`sampling = $${paramIndex++}`);
+        values.push(JSON.stringify(params.sampling));
+      }
+
+      if (params.priority !== undefined) {
+        setClauses.push(`priority = $${paramIndex++}`);
+        values.push(params.priority);
+      }
+
+      if (params.metadata !== undefined) {
+        const mergedMetadata = { ...existingAssignment.metadata, ...params.metadata };
+        setClauses.push(`metadata = $${paramIndex++}`);
+        values.push(JSON.stringify(mergedMetadata));
+      }
+
+      const now = new Date().toISOString();
+      setClauses.push(`"updatedAt" = $${paramIndex++}`);
+      values.push(now);
+      setClauses.push(`"updatedAtZ" = $${paramIndex++}`);
+      values.push(now);
+
+      values.push(params.id);
+
+      if (setClauses.length > 2) {
+        await this.#db.client.none(
+          `UPDATE ${tableName} SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`,
+          values,
+        );
+      }
+
+      const updatedAssignment = await this.getAssignmentById({ id: params.id });
+      if (!updatedAssignment) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_ASSIGNMENT', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Assignment ${params.id} not found after update`,
+          details: { assignmentId: params.id },
+        });
+      }
+
+      return updatedAssignment;
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'UPDATE_ASSIGNMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { assignmentId: params.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getAssignmentById({ id }: { id: string }): Promise<StorageAgentScorerAssignment | null> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_AGENT_SCORER_ASSIGNMENTS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      const result = await this.#db.client.oneOrNone(`SELECT * FROM ${tableName} WHERE id = $1`, [id]);
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseAssignmentRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_ASSIGNMENT_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { assignmentId: id },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -17,6 +17,7 @@ import { AgentsPG } from './domains/agents';
 import { MemoryPG } from './domains/memory';
 import { ObservabilityPG } from './domains/observability';
 import { ScoresPG } from './domains/scores';
+import { StoredScorersPG } from './domains/stored-scorers';
 import { WorkflowsPG } from './domains/workflows';
 
 /** Default maximum number of connections in the pool */
@@ -26,7 +27,7 @@ const DEFAULT_IDLE_TIMEOUT_MS = 30000;
 
 export { exportSchemas } from './db';
 // Export domain classes for direct use with MastraStorage composition
-export { AgentsPG, MemoryPG, ObservabilityPG, ScoresPG, WorkflowsPG };
+export { AgentsPG, MemoryPG, ObservabilityPG, ScoresPG, StoredScorersPG, WorkflowsPG };
 export { PoolAdapter } from './client';
 export type { DbClient, TxClient, QueryValues, Pool, PoolClient, QueryResult } from './client';
 export type { PgDomainConfig, PgDomainClientConfig, PgDomainPoolConfig, PgDomainRestConfig } from './db';
@@ -92,6 +93,7 @@ export class PostgresStore extends MastraStorage {
         memory: new MemoryPG(domainConfig),
         observability: new ObservabilityPG(domainConfig),
         agents: new AgentsPG(domainConfig),
+        storedScorers: new StoredScorersPG(domainConfig),
       };
     } catch (e) {
       throw new MastraError(


### PR DESCRIPTION
## Description

Implement stored scorers pattern across all storage backends enabling API-based scorer management. This allows scorers to be created, updated, and deleted via HTTP API endpoints for eventual UI integration in Mastra Studio.

## Changes

- Add stored scorers storage domain with CRUD operations across all backends (PostgreSQL, LibSQL, in-memory, ClickHouse, Cloudflare)
- Add HTTP API routes for scorer management and agent-scorer assignments
- Add runtime resolution utility to convert stored configurations to MastraScorer instances
- Enhance Agent class to dynamically fetch and merge stored scorers at runtime (code-defined scorers take precedence)

## Related Issue(s)

Dynamic scorer management for Mastra Studio UI integration

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now support dynamic scorer assignment. Scorers can be created and assigned to agents through APIs, which agents will automatically discover and use alongside code-defined scorers.
  * Added comprehensive API endpoints for managing stored scorers and their assignments to agents.
  * New storage support for scorer definitions and agent-scorer assignments across in-memory, LibSQL, and PostgreSQL backends.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->