### PR TITLE
Update ssri to ^6.0.2

### DIFF
--- a/e2e-tests/no-bundling/package.json
+++ b/e2e-tests/no-bundling/package.json
@@ -22,5 +22,8 @@
   },
   "dependencies": {
     "form-data": "^2.5.5"
+  },
+  "resolutions": {
+    "ssri": "^6.0.2"
   }
 }

--- a/e2e-tests/no-bundling/pnpm-lock.yaml
+++ b/e2e-tests/no-bundling/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ssri: ^6.0.2
+
 importers:
 
   .:
@@ -920,6 +923,10 @@ packages:
       picomatch:
         optional: true
 
+  figgy-pudding@3.5.2:
+    resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -1764,8 +1771,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  ssri@5.3.0:
-    resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
+  ssri@6.0.2:
+    resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2966,6 +2973,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  figgy-pudding@3.5.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -3448,7 +3457,7 @@ snapshots:
       safe-buffer: 5.2.1
       semver: 5.7.2
       slide: 1.1.6
-      ssri: 5.3.0
+      ssri: 6.0.2
     optionalDependencies:
       npmlog: 4.1.2
 
@@ -3873,9 +3882,9 @@ snapshots:
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
 
-  ssri@5.3.0:
+  ssri@6.0.2:
     dependencies:
-      safe-buffer: 5.2.1
+      figgy-pudding: 3.5.2
 
   stackback@0.0.2: {}
 

--- a/e2e-tests/type-check/package.json
+++ b/e2e-tests/type-check/package.json
@@ -19,5 +19,8 @@
     "onlyBuiltDependencies": [
       "esbuild"
     ]
+  },
+  "resolutions": {
+    "ssri": "^6.0.2"
   }
 }

--- a/e2e-tests/type-check/pnpm-lock.yaml
+++ b/e2e-tests/type-check/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ssri: ^6.0.2
+
 importers:
 
   .:
@@ -731,6 +734,10 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  figgy-pudding@3.5.2:
+    resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -1541,8 +1548,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  ssri@5.3.0:
-    resolution: {integrity: sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==}
+  ssri@6.0.2:
+    resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -2514,6 +2521,8 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  figgy-pudding@3.5.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -2985,7 +2994,7 @@ snapshots:
       safe-buffer: 5.2.1
       semver: 5.7.2
       slide: 1.1.6
-      ssri: 5.3.0
+      ssri: 6.0.2
     optionalDependencies:
       npmlog: 4.1.2
 
@@ -3366,9 +3375,9 @@ snapshots:
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
 
-  ssri@5.3.0:
+  ssri@6.0.2:
     dependencies:
-      safe-buffer: 5.2.1
+      figgy-pudding: 3.5.2
 
   statuses@2.0.1: {}
 


### PR DESCRIPTION
## Description

Updates transitive dependency ssri to 6.0.2 

## Related Issue(s)
https://github.com/mastra-ai/mastra/security/dependabot/693
https://github.com/mastra-ai/mastra/security/dependabot/726

## Type of Change

- [ X] Vuln patch 

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a transitive dependency version to improve stability and reproducibility of test runs across environments. This change reduces variance in dependency resolution and helps ensure consistent test behavior during end-to-end and type-check test suites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->