### PR TITLE
feat(rag): rename keepSeparator to separatorPosition

### DIFF
--- a/.changeset/strong-flowers-camp.md
+++ b/.changeset/strong-flowers-camp.md
@@ -1,0 +1,49 @@
+---
+'@mastra/rag': minor
+---
+
+Renamed `keepSeparator` parameter to `separatorPosition` with a cleaner type.
+
+The `keepSeparator` parameter had a confusing `boolean | 'start' | 'end'` type where `true` was secretly an alias for `'start'`. The new `separatorPosition` parameter uses explicit `'start' | 'end'` values, and omitting the parameter discards the separator (previous default behavior).
+
+**Migration**
+
+```typescript
+// Before
+await doc.chunk({
+  strategy: 'character',
+  separator: '.',
+  keepSeparator: true,      // or 'start'
+});
+
+await doc.chunk({
+  strategy: 'character',
+  separator: '.',
+  keepSeparator: 'end',
+});
+
+await doc.chunk({
+  strategy: 'character',
+  separator: '.',
+  keepSeparator: false,     // or omit entirely
+});
+
+// After
+await doc.chunk({
+  strategy: 'character',
+  separator: '.',
+  separatorPosition: 'start',
+});
+
+await doc.chunk({
+  strategy: 'character',
+  separator: '.',
+  separatorPosition: 'end',
+});
+
+await doc.chunk({
+  strategy: 'character',
+  separator: '.',
+  // omit separatorPosition to discard separator
+});
+```

--- a/docs/src/content/en/docs/rag/chunking-and-embedding.mdx
+++ b/docs/src/content/en/docs/rag/chunking-and-embedding.mdx
@@ -58,7 +58,6 @@ const chunks = await doc.chunk({
   minSize: 50,
   overlap: 0,
   sentenceEnders: ["."],
-  keepSeparator: true,
 });
 ```
 

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/overview.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/overview.mdx
@@ -58,6 +58,7 @@ npx @mastra/codemod@beta v1
 - **[Memory](/guides/v1/migrations/upgrade-to-v1/memory)** - Configuration now requires explicit parameters and defaults changed.
 - **[Storage](/guides/v1/migrations/upgrade-to-v1/storage)** - Pagination standardized and methods renamed to list pattern.
 - **[Vectors](/guides/v1/migrations/upgrade-to-v1/vectors)** - Vector store methods renamed to list pattern.
+- **[RAG](/guides/v1/migrations/upgrade-to-v1/rag)** - Parameter naming updated for clarity.
 - **[MCP](/guides/v1/migrations/upgrade-to-v1/mcp)** - Tool context reorganized and deprecated client classes removed.
 - **[Tracing](/guides/v1/migrations/upgrade-to-v1/tracing)** - OTEL telemetry replaced with dedicated observability package and exporters.
 - **[Evals & Scorers](/guides/v1/migrations/upgrade-to-v1/evals)** - Scorers API consolidated with new naming conventions.
@@ -102,6 +103,7 @@ npx @mastra/codemod@beta v1
 
 ### Low Impact Changes
 
+- Rename `keepSeparator` to `separatorPosition` in chunk options - [RAG](/guides/v1/migrations/upgrade-to-v1/rag)
 - Rename `createRunAsync` to `createRun` - [Workflows](/guides/v1/migrations/upgrade-to-v1/workflows)
 - Update voice package names from `@mastra/speech-*` to `@mastra/voice-*` - [Voice Packages](/guides/v1/migrations/upgrade-to-v1/voice)
 - Update scorer methods: `runExperiment` → `runEvals`, `getScorerByName` → `getScorerById` - [Evals & Scorers](/guides/v1/migrations/upgrade-to-v1/evals)

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/rag.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/rag.mdx
@@ -1,0 +1,47 @@
+---
+title: "RAG | v1 Migration Guide"
+description: "Learn how to migrate RAG-related changes when upgrading to v1."
+---
+
+# RAG
+
+The RAG package has updated parameter naming for improved clarity and type safety.
+
+## Changed
+
+### `keepSeparator` to `separatorPosition`
+
+The `keepSeparator` parameter has been renamed to `separatorPosition` with a simplified type. The old parameter had a confusing `boolean | 'start' | 'end'` type where `true` was secretly an alias for `'start'`. The new parameter uses explicit `'start' | 'end'` values, and omitting the parameter discards the separator.
+
+To migrate, replace `keepSeparator` with `separatorPosition` using the mapping below:
+
+| Old value | New value |
+|-----------|-----------|
+| `keepSeparator: true` | `separatorPosition: 'start'` |
+| `keepSeparator: 'start'` | `separatorPosition: 'start'` |
+| `keepSeparator: 'end'` | `separatorPosition: 'end'` |
+| `keepSeparator: false` | Remove the parameter |
+| Parameter omitted | No change needed |
+
+```diff
+  await doc.chunk({
+    strategy: 'character',
+    separator: '.',
+-   keepSeparator: true,
++   separatorPosition: 'start',
+  });
+
+  await doc.chunk({
+    strategy: 'character',
+    separator: '.',
+-   keepSeparator: 'end',
++   separatorPosition: 'end',
+  });
+
+  await doc.chunk({
+    strategy: 'character',
+    separator: '.',
+-   keepSeparator: false,
++   // Parameter removed - separator is discarded by default
+  });
+```

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/rag.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/rag.mdx
@@ -1,11 +1,11 @@
 ---
 title: "RAG | v1 Migration Guide"
-description: "Learn how to migrate RAG-related changes when upgrading to v1."
+description: "Migrate RAG-related breaking changes when upgrading to v1."
 ---
 
 # RAG
 
-The RAG package has updated parameter naming for improved clarity and type safety.
+The RAG package has renamed chunking parameters and narrowed their types.
 
 ## Changed
 

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: Reference: .chunk() | RAG"
+title: "Reference: .chunk() | RAG"
 description: Documentation for the chunk function in Mastra, which splits documents into smaller segments using various strategies.
 packages:
   - "@mastra/rag"

--- a/docs/src/content/en/reference/rag/chunk.mdx
+++ b/docs/src/content/en/reference/rag/chunk.mdx
@@ -79,11 +79,11 @@ The following parameters are available for all chunking strategies.
         "Function to calculate text length. Defaults to character count.",
     },
     {
-      name: "keepSeparator",
-      type: "boolean | 'start' | 'end'",
+      name: "separatorPosition",
+      type: "'start' | 'end'",
       isOptional: true,
       description:
-        "Whether to keep the separator at the start or end of chunks",
+        "Where to position the separator in chunks. 'start' attaches to beginning of next chunk, 'end' attaches to end of current chunk. If not specified, separators are discarded.",
     },
     {
       name: "addStartIndex",
@@ -138,7 +138,6 @@ const chunks = await doc.chunk({
   minSize: 50, // Sentence-specific option
   sentenceEnders: ["."], // Sentence-specific option
   fallbackToCharacters: false, // Sentence-specific option
-  keepSeparator: true, // general option
 });
 
 // HTML strategy example

--- a/packages/rag/src/document/document.test.ts
+++ b/packages/rag/src/document/document.test.ts
@@ -197,7 +197,7 @@ describe('MDocument', () => {
         isSeparatorRegex: false,
         maxSize: 50,
         overlap: 5,
-        keepSeparator: 'end',
+        separatorPosition: 'end',
       });
       const chunks = doc.getText();
 
@@ -217,7 +217,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           maxSize: 50,
           overlap: 5,
-          keepSeparator: 'end',
+          separatorPosition: 'end',
         });
 
         const chunks = doc.getText();
@@ -238,7 +238,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           maxSize: 50,
           overlap: 5,
-          keepSeparator: 'start',
+          separatorPosition: 'start',
         });
 
         const chunks = doc.getText();
@@ -260,7 +260,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           maxSize: 50,
           overlap: 5,
-          keepSeparator: 'end',
+          separatorPosition: 'end',
         });
 
         const chunks = doc.getText();
@@ -280,7 +280,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           maxSize: 50,
           overlap: 5,
-          keepSeparator: 'end',
+          separatorPosition: 'end',
         });
 
         const chunks = doc.getText();
@@ -300,7 +300,7 @@ describe('MDocument', () => {
           isSeparatorRegex: false,
           maxSize: 50,
           overlap: 5,
-          keepSeparator: 'start',
+          separatorPosition: 'start',
         });
 
         const chunks = doc.getText();
@@ -1906,7 +1906,7 @@ describe('MDocument', () => {
         strategy: 'latex',
         maxSize: 100,
         overlap: 10,
-        keepSeparator: 'start',
+        separatorPosition: 'start',
       });
 
       const chunks = doc.getText();
@@ -1936,7 +1936,7 @@ describe('MDocument', () => {
         strategy: 'latex',
         maxSize: 100,
         overlap: 10,
-        keepSeparator: 'start',
+        separatorPosition: 'start',
       });
 
       const chunks = doc.getText();
@@ -1944,7 +1944,7 @@ describe('MDocument', () => {
       expect(chunks.some(chunk => chunk.includes('E = mc^2'))).toBe(true);
     });
 
-    it('should split with keepSeparator at end', async () => {
+    it('should split with separatorPosition at end', async () => {
       const text = `Intro text here.
         \\section{First}
         Content A.
@@ -1958,7 +1958,7 @@ describe('MDocument', () => {
         strategy: 'latex',
         maxSize: 50,
         overlap: 0,
-        keepSeparator: 'end',
+        separatorPosition: 'end',
       });
 
       const chunks = doc.getText();
@@ -2461,7 +2461,7 @@ describe('MDocument', () => {
         maxSize: 450,
         overlap: 0,
         sentenceEnders: ['.'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       expect(chunks.length).toBeGreaterThan(1);
@@ -2498,7 +2498,7 @@ describe('MDocument', () => {
         strategy: 'sentence',
         maxSize: 100,
         sentenceEnders: ['.', '!', '?'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       expect(chunks.length).toBeGreaterThan(1);
@@ -2520,7 +2520,7 @@ describe('MDocument', () => {
         maxSize: 120,
         overlap: 50,
         sentenceEnders: ['.'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       expect(chunks.length).toBeGreaterThan(1);
@@ -2568,7 +2568,7 @@ describe('MDocument', () => {
         minSize: 5,
         maxSize: 100,
         sentenceEnders: ['.'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       expect(chunks.length).toBe(1);
@@ -2586,7 +2586,7 @@ describe('MDocument', () => {
         maxSize: 100,
         targetSize: 40,
         sentenceEnders: ['.'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       // Should group multiple short sentences together
@@ -2609,7 +2609,7 @@ describe('MDocument', () => {
         strategy: 'sentence',
         maxSize: 100,
         sentenceEnders: ['.'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       expect(chunks.length).toBeGreaterThan(1);
@@ -2629,7 +2629,7 @@ describe('MDocument', () => {
         strategy: 'sentence',
         maxSize: 200,
         sentenceEnders: ['.'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       expect(chunks.length).toBeGreaterThanOrEqual(1);
@@ -2686,7 +2686,7 @@ describe('MDocument', () => {
         strategy: 'sentence',
         maxSize: 200,
         sentenceEnders: ['.', '?'],
-        keepSeparator: true,
+        separatorPosition: 'start',
       });
 
       expect(chunks.length).toBeGreaterThanOrEqual(1);

--- a/packages/rag/src/document/document.ts
+++ b/packages/rag/src/document/document.ts
@@ -214,7 +214,7 @@ export class MDocument {
         const textSplitter = new RecursiveCharacterTransformer({
           maxSize: options.maxSize,
           overlap: options.overlap,
-          keepSeparator: options.keepSeparator,
+          separatorPosition: options.separatorPosition,
           addStartIndex: options.addStartIndex,
           stripWhitespace: options.stripWhitespace,
         });
@@ -235,7 +235,7 @@ export class MDocument {
         const textSplitter = new RecursiveCharacterTransformer({
           maxSize: options.maxSize,
           overlap: options.overlap,
-          keepSeparator: options.keepSeparator,
+          separatorPosition: options.separatorPosition,
           addStartIndex: options.addStartIndex,
           stripWhitespace: options.stripWhitespace,
         });
@@ -310,7 +310,7 @@ export class MDocument {
       sentenceEnders: options?.sentenceEnders,
       fallbackToWords: options?.fallbackToWords,
       fallbackToCharacters: options?.fallbackToCharacters,
-      keepSeparator: options?.keepSeparator,
+      separatorPosition: options?.separatorPosition,
       lengthFunction: options?.lengthFunction,
       addStartIndex: options?.addStartIndex,
       stripWhitespace: options?.stripWhitespace,

--- a/packages/rag/src/document/transformers/character.ts
+++ b/packages/rag/src/document/transformers/character.ts
@@ -3,12 +3,12 @@ import type { BaseChunkOptions, CharacterChunkOptions, RecursiveChunkOptions } f
 
 import { TextTransformer } from './text';
 
-function splitTextWithRegex(text: string, separator: string, keepSeparator: boolean | 'start' | 'end'): string[] {
+function splitTextWithRegex(text: string, separator: string, separatorPosition?: 'start' | 'end'): string[] {
   if (!separator) {
     return text.split('');
   }
 
-  if (!keepSeparator) {
+  if (!separatorPosition) {
     return text.split(new RegExp(separator)).filter(s => s !== '');
   }
 
@@ -20,7 +20,7 @@ function splitTextWithRegex(text: string, separator: string, keepSeparator: bool
   const splits = text.split(new RegExp(`(${separator})`));
   const result: string[] = [];
 
-  if (keepSeparator === 'end') {
+  if (separatorPosition === 'end') {
     // Process all complete pairs
     for (let i = 0; i < splits.length - 1; i += 2) {
       if (i + 1 < splits.length) {
@@ -62,7 +62,7 @@ export class CharacterTransformer extends TextTransformer {
     // First, split the text into initial chunks
     const separator = this.isSeparatorRegex ? this.separator : this.separator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-    const initialSplits = splitTextWithRegex(text, separator, this.keepSeparator);
+    const initialSplits = splitTextWithRegex(text, separator, this.separatorPosition);
 
     // If length of any split is greater than chunk size, perform additional splitting
     const chunks: string[] = [];
@@ -140,10 +140,10 @@ export class RecursiveCharacterTransformer extends TextTransformer {
 
     const _separator = this.isSeparatorRegex ? separator : separator?.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-    const splits = splitTextWithRegex(text, _separator, this.keepSeparator);
+    const splits = splitTextWithRegex(text, _separator, this.separatorPosition);
 
     const goodSplits: string[] = [];
-    const mergeSeparator = this.keepSeparator ? '' : separator;
+    const mergeSeparator = this.separatorPosition ? '' : separator;
 
     for (const s of splits) {
       if (this.lengthFunction(s) < this.maxSize) {

--- a/packages/rag/src/document/transformers/sentence.ts
+++ b/packages/rag/src/document/transformers/sentence.ts
@@ -8,7 +8,6 @@ export class SentenceTransformer extends TextTransformer {
   protected sentenceEnders: string[];
   protected fallbackToWords: boolean;
   protected fallbackToCharacters: boolean;
-  protected keepSeparator: boolean | 'start' | 'end';
 
   constructor(options: SentenceChunkOptions) {
     // Ensure overlap doesn't exceed maxSize for parent validation
@@ -27,7 +26,6 @@ export class SentenceTransformer extends TextTransformer {
     this.sentenceEnders = options.sentenceEnders ?? ['.', '!', '?'];
     this.fallbackToWords = options.fallbackToWords ?? true;
     this.fallbackToCharacters = options.fallbackToCharacters ?? true;
-    this.keepSeparator = options.keepSeparator ?? false;
 
     // Override with original overlap for our sentence logic
     this.overlap = options.overlap ?? 0;

--- a/packages/rag/src/document/transformers/text.ts
+++ b/packages/rag/src/document/transformers/text.ts
@@ -8,7 +8,7 @@ export abstract class TextTransformer implements Transformer {
   protected maxSize: number;
   protected overlap: number;
   protected lengthFunction: (text: string) => number;
-  protected keepSeparator: boolean | 'start' | 'end';
+  protected separatorPosition?: 'start' | 'end';
   protected addStartIndex: boolean;
   protected stripWhitespace: boolean;
 
@@ -16,7 +16,7 @@ export abstract class TextTransformer implements Transformer {
     maxSize = 4000,
     overlap = 200,
     lengthFunction = (text: string) => text.length,
-    keepSeparator = false,
+    separatorPosition,
     addStartIndex = false,
     stripWhitespace = true,
   }: BaseChunkOptions) {
@@ -26,7 +26,7 @@ export abstract class TextTransformer implements Transformer {
     this.maxSize = maxSize;
     this.overlap = overlap;
     this.lengthFunction = lengthFunction;
-    this.keepSeparator = keepSeparator;
+    this.separatorPosition = separatorPosition;
     this.addStartIndex = addStartIndex;
     this.stripWhitespace = stripWhitespace;
   }

--- a/packages/rag/src/document/types.ts
+++ b/packages/rag/src/document/types.ts
@@ -46,7 +46,7 @@ export type BaseChunkOptions = {
   maxSize?: number;
   overlap?: number;
   lengthFunction?: (text: string) => number;
-  keepSeparator?: boolean | 'start' | 'end';
+  separatorPosition?: 'start' | 'end';
   addStartIndex?: boolean;
   stripWhitespace?: boolean;
 };

--- a/packages/rag/src/document/validation.ts
+++ b/packages/rag/src/document/validation.ts
@@ -6,7 +6,7 @@ const baseChunkOptionsSchema = z.object({
   maxSize: z.number().positive().optional(),
   overlap: z.number().min(0).optional(),
   lengthFunction: z.function().optional(),
-  keepSeparator: z.union([z.boolean(), z.literal('start'), z.literal('end')]).optional(),
+  separatorPosition: z.enum(['start', 'end']).optional(),
   addStartIndex: z.boolean().optional(),
   stripWhitespace: z.boolean().optional(),
 });


### PR DESCRIPTION
## Description

Renamed the `keepSeparator` parameter to `separatorPosition` with a cleaner type.

The `keepSeparator` parameter had a confusing `boolean | 'start' | 'end'` type where `true` was secretly an alias for `'start'`. The new `separatorPosition` parameter uses explicit `'start' | 'end'` values, and omitting the parameter discards the separator (previous default behavior).

**Migration:**
| Old | New |
|-----|-----|
| `keepSeparator: true` / `'start'` | `separatorPosition: 'start'` |
| `keepSeparator: 'end'` | `separatorPosition: 'end'` |
| `keepSeparator: false` / omitted | omit `separatorPosition` |

## Related Issue(s)

None

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed doc.chunk() option from keepSeparator to separatorPosition. It now accepts only 'start' | 'end'; omitting it discards separators by default (boolean values removed).

* **Documentation**
  * Added migration guide with before/after examples and updated reference and guide content.

* **Tests**
  * Updated tests to reflect the new separatorPosition option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->