### PR TITLE
fix: agent right sidepanel width fix

### DIFF
--- a/.changeset/thick-falcons-lie.md
+++ b/.changeset/thick-falcons-lie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Agent's right sidebar is now 30% wide before resizing. It makes it easier to read the information at a first glance

--- a/packages/playground-ui/src/domains/agents/components/agent-layout.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-layout.tsx
@@ -51,7 +51,7 @@ export const AgentLayout = ({ agentId, children, leftSlot, rightSlot }: AgentLay
             id="right-slot"
             minSize={300}
             maxSize={'50%'}
-            defaultSize={300}
+            defaultSize="30%"
             collapsedSize={60}
             collapsible={true}
           >


### PR DESCRIPTION
## Description

This pull request makes a minor UI adjustment to the agent layout in the `@mastra/playground-ui` package. The main change is increasing the default width of the agent's right sidebar to 30% of the container, which improves readability when users first open the sidebar.

* Increased the default width of the right sidebar in the agent layout to 30% before resizing, making information easier to read at a glance (`agent-layout.tsx`).
* Documented the UI change in the changeset file for `@mastra/playground-ui`.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the agent's right sidebar to 30% width for improved initial readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->