### PR TITLE
feat: add e2e-frontend-validation skill for playground packages

### DIFF
--- a/.claude/skills/e2e-frontend-validation/SKILL.md
+++ b/.claude/skills/e2e-frontend-validation/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: e2e-frontend-validation
+description: E2E validation workflow for frontend changes in playground packages using Playwright MCP
+model: claude-opus-4-5
+---
+
+# E2E Validation for Frontend Modifications
+
+## Prerequisites
+
+Requires Playwright MCP server. If the `browser_navigate` tool is unavailable, instruct the user to add it:
+
+```sh
+claude mcp add playwright -- npx @playwright/mcp@latest
+```
+
+## Validation Steps
+
+After completing frontend changes:
+
+1. **Build the CLI**
+
+```sh
+   pnpm build:cli
+```
+
+2. **Start the dev server**
+
+```sh
+   cd examples/agent && node ../../packages/cli/dist/index.js dev
+```
+
+3. **Verify server is running**
+   - URL: http://localhost:4111
+   - Wait for the server to be ready before proceeding
+
+4. **Identify impacted routes**
+   - Routes are defined in `packages/playground/src/App.tsx`
+   - Determine which routes are affected by your changes
+
+5. **Test with Playwright MCP**
+   - Use `browser_navigate` to visit each impacted route
+   - Visually verify the changes render correctly
+   - Test any interactive elements modified
+   - Use `browser_screenshot` to capture results for the user
+
+## Quick Reference
+
+| Step    | Command/Action                                                   |
+| ------- | ---------------------------------------------------------------- |
+| Build   | `pnpm build:cli`                                                 |
+| Start   | `cd examples/agent && node ../../packages/cli/dist/index.js dev` |
+| App URL | http://localhost:4111                                            |
+| Routes  | `@packages/playground/src/App.tsx`                               |

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ mastra-cli.json
 *storybook.log
 storybook-static
 test-output.log
+
+.playwright-mcp

--- a/packages/playground-ui/CLAUDE.md
+++ b/packages/playground-ui/CLAUDE.md
@@ -182,3 +182,8 @@ export function App({ a, b }: AppProps) {
 - Prioritize design system tokens for consistency
 - Minimize side effects and state management
 - Use TanStack Query for all server state
+
+
+## E2E Testing (MUST DO)
+
+On every change to this package, you MUST use the `e2e-frontend-validation` skill

--- a/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/components/ui/elements/main-sidebar/main-sidebar-nav-link.tsx
@@ -45,9 +45,9 @@ export function MainSidebarNavLink({
           '[&_svg]:text-icon5': isActive,
           '[&>a]:justify-start ': !isCollapsed,
           '[&_svg]:text-icon3': isCollapsed,
-          '[&>a]:rounded-md [&>a]:my-[0.5rem] [&>a]:bg-accent1/75 [&>a:hover]:bg-accent1/85 [&>a]:text-black [&>a:hover]:text-black':
+          '[&>a]:rounded-md [&>a]:my-[0.5rem] [&>a]:bg-gradient-to-r [&>a]:from-pink-500 [&>a]:to-orange-500 [&>a:hover]:from-pink-600 [&>a:hover]:to-orange-600 [&>a]:text-white [&>a:hover]:text-white':
             isFeatured,
-          '[&_svg]:text-black/75 [&>a:hover_svg]:text-black': isFeatured,
+          '[&_svg]:text-white/90 [&>a:hover_svg]:text-white': isFeatured,
         },
         className,
       )}

--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -175,3 +175,8 @@ export function App({ a, b }: AppProps) {
 - All data-fetching hooks must come from `packages/playground-ui`
 - Pages should be thin wrappers around `playground-ui` components
 - When in doubt, add functionality to `playground-ui` instead
+
+
+## E2E Testing (MUST DO)
+
+On every change to this package, you MUST use the `e2e-frontend-validation` skill


### PR DESCRIPTION


https://github.com/user-attachments/assets/cd9716db-4f90-47ae-b282-75884035a12c



Adds a Claude Code skill that uses Playwright MCP to visually verify frontend changes in the playground packages.

When modifying `packages/playground` or `packages/playground-ui`, Claude will now automatically test the affected routes in a browser to catch visual/functional regressions before committing.

The skill:
- Starts the dev server if needed
- Navigates to impacted routes with Playwright MCP
- Verifies changes render correctly
- Captures screenshots for review

Also updated both playground package CLAUDE.md files to reference the new skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive end-to-end frontend validation workflow using Playwright, including prerequisites and step-by-step testing guidance.
  * Established mandatory E2E testing requirements for the frontend and playground packages.

* **Chores**
  * Ignored local Playwright MCP artifacts to keep working directories clean.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->