### PR TITLE
feat(cli): Add README during create-mastra

### DIFF
--- a/.changeset/curly-worlds-bet.md
+++ b/.changeset/curly-worlds-bet.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Add `README.md` file during `create-mastra` command. It contains basic project information and links to Mastra's docs.

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import util from 'node:util';
 import * as p from '@clack/prompts';
 import color from 'picocolors';
+import prettier from 'prettier';
 
 import { DepsService } from '../../services/service.deps.js';
 import { getPackageManagerAddCommand } from '../../utils/package-manager.js';
@@ -76,6 +77,46 @@ async function initializePackageJson(pm: PackageManager): Promise<void> {
 
   await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 }
+
+const writeReadmeFile = async ({ dirPath, projectName }: { dirPath: string; projectName: string }) => {
+  const packageManager = getPackageManager();
+  const readmePath = path.join(dirPath, 'README.md');
+
+  const content = `# ${projectName}
+
+Welcome to your new [Mastra](https://mastra.ai/) project! We're excited to see what you'll build.
+
+## Getting Started
+
+Start the development server:
+
+\`\`\`shell
+${packageManager} run dev
+\`\`\`
+
+Open [http://localhost:4111](http://localhost:4111) in your browser to access [Mastra Studio](https://mastra.ai/docs/v1/getting-started/studio). It provides an interactive UI for building and testing your agents, along with a REST API that exposes your Mastra application as a local service. This lets you start building without worrying about integration right away.
+
+You can start editing files inside the \`src/mastra\` directory. The development server will automatically reload whenever you make changes.
+
+## Learn more
+
+To learn more about Mastra, visit our [documentation](https://mastra.ai/docs/v1/). Your bootstrapped project includes example code for [agents](https://mastra.ai/docs/v1/agents/overview), [tools](https://mastra.ai/docs/v1/agents/using-tools), [workflows](https://mastra.ai/docs/v1/workflows/overview), [scorers](https://mastra.ai/docs/v1/evals/overview), and [observability](https://mastra.ai/docs/v1/observability/overview).
+
+If you're new to AI agents, check out our [course](https://mastra.ai/course) and [YouTube videos](https://youtube.com/@mastra-ai). You can also join our [Discord](https://discord.gg/BTYqqHKUrf) community to get help and share your projects.
+
+## Deploy on Mastra Cloud
+
+[Mastra Cloud](https://cloud.mastra.ai/) gives you a serverless agent environment with atomic deployments. Access your agents from anywhere and monitor performance. Make sure they don't go off the rails with evals and tracing.
+
+Check out the [deployment guide](https://mastra.ai/docs/v1/deployment/overview) for more details.`;
+
+  const formattedContent = await prettier.format(content, {
+    parser: 'markdown',
+    singleQuote: true,
+  });
+
+  await fs.writeFile(readmePath, formattedContent);
+};
 
 async function installMastraDependency(
   pm: PackageManager,
@@ -188,6 +229,7 @@ export const createMastraProject = async ({
         build: 'mastra build',
         start: 'mastra start',
       });
+      await writeReadmeFile({ dirPath: process.cwd(), projectName });
     } catch (error) {
       throw new Error(
         `Failed to initialize project structure: ${error instanceof Error ? error.message : 'Unknown error'}`,


### PR DESCRIPTION
## Description

Add `README.md` file during `create-mastra` command with project name and deploy instruction.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * README files are now automatically generated when creating a new Mastra project, including project overview, setup instructions, and documentation links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->