### PR TITLE
feat(react): add useWorkflowActions and useWorkflowRun hooks

### DIFF
--- a/client-sdks/react/src/index.ts
+++ b/client-sdks/react/src/index.ts
@@ -4,4 +4,5 @@ export * from './agent/types';
 export { useMastraClient } from './mastra-client-context';
 export * from './lib/ai-sdk';
 export * from './ui';
+export * from './workflows';
 import './ui/index.css';

--- a/client-sdks/react/src/workflows/build-request-context.ts
+++ b/client-sdks/react/src/workflows/build-request-context.ts
@@ -1,0 +1,17 @@
+import { RequestContext } from '@mastra/core/request-context';
+
+/**
+ * Builds a RequestContext from a plain object.
+ * This extracts the common context building logic.
+ */
+export function buildRequestContext(contextData?: Record<string, unknown>): RequestContext {
+  const requestContext = new RequestContext();
+
+  if (contextData) {
+    Object.entries(contextData).forEach(([key, value]) => {
+      requestContext.set(key as keyof RequestContext, value);
+    });
+  }
+
+  return requestContext;
+}

--- a/client-sdks/react/src/workflows/index.ts
+++ b/client-sdks/react/src/workflows/index.ts
@@ -1,0 +1,27 @@
+// Hooks
+export { useWorkflowActions } from './use-workflow-actions';
+export type { UseWorkflowActionsOptions, UseWorkflowActionsReturn } from './use-workflow-actions';
+
+export { useWorkflowRun } from './use-workflow-run';
+export type { UseWorkflowRunOptions, UseWorkflowRunReturn } from './use-workflow-run';
+
+// Types
+export type {
+  WorkflowStreamResult,
+  StreamOperation,
+  WorkflowStreamReader,
+  StreamParams,
+  ObserveParams,
+  ResumeParams,
+  TimeTravelStreamParams,
+  CreateRunParams,
+  StartRunParams,
+  StartAsyncRunParams,
+  CancelRunParams,
+} from './types';
+
+// Utilities (for advanced use cases)
+export { StreamReaderManager } from './stream-reader-manager';
+export { processWorkflowStream } from './process-stream';
+export type { ProcessStreamOptions, ProcessStreamResult } from './process-stream';
+export { buildRequestContext } from './build-request-context';

--- a/client-sdks/react/src/workflows/process-stream.ts
+++ b/client-sdks/react/src/workflows/process-stream.ts
@@ -1,0 +1,79 @@
+import type { StreamVNextChunkType } from '@mastra/client-js';
+import { mapWorkflowStreamChunkToWatchResult } from '../lib/ai-sdk';
+import type { StreamOperation, WorkflowStreamResult, WorkflowStreamReader } from './types';
+
+export interface ProcessStreamOptions {
+  stream: { getReader(): WorkflowStreamReader };
+  onChunk: (updater: (prev: WorkflowStreamResult) => WorkflowStreamResult) => void;
+  onStreamingChange: (isStreaming: boolean) => void;
+  onError?: (error: Error, context: { operation: StreamOperation }) => void;
+  isMounted: () => boolean;
+  operation: StreamOperation;
+}
+
+export interface ProcessStreamResult {
+  reader: WorkflowStreamReader;
+}
+
+/**
+ * Processes a workflow stream, reading chunks and updating state.
+ * This extracts the common stream reading logic used across all stream operations.
+ */
+export async function processWorkflowStream({
+  stream,
+  onChunk,
+  onStreamingChange,
+  onError,
+  isMounted,
+  operation,
+}: ProcessStreamOptions): Promise<ProcessStreamResult> {
+  const reader = stream.getReader();
+
+  try {
+    while (true) {
+      if (!isMounted()) break;
+
+      const { done, value } = await reader.read();
+      if (done || !value) break;
+
+      if (isMounted()) {
+        onChunk(prev => mapWorkflowStreamChunkToWatchResult(prev, value));
+
+        if (value.type === 'workflow-step-start') {
+          onStreamingChange(true);
+        }
+
+        if (value.type === 'workflow-step-suspended') {
+          onStreamingChange(false);
+        }
+
+        if (value.type === 'workflow-finish') {
+          const status = value.payload?.workflowStatus;
+          onChunk(prev => ({ ...prev, status }));
+
+          if (status === 'failed') {
+            const errorMessage = value.payload?.metadata?.errorMessage || 'Workflow execution failed';
+            throw new Error(errorMessage);
+          }
+        }
+      }
+    }
+  } catch (err) {
+    // TypeError during cleanup is expected when component unmounts
+    if (!(err instanceof TypeError)) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      onError?.(error, { operation });
+    }
+  } finally {
+    if (isMounted()) {
+      onStreamingChange(false);
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // Already released
+    }
+  }
+
+  return { reader };
+}

--- a/client-sdks/react/src/workflows/stream-reader-manager.ts
+++ b/client-sdks/react/src/workflows/stream-reader-manager.ts
@@ -1,0 +1,55 @@
+import type { StreamOperation, WorkflowStreamReader } from './types';
+
+/**
+ * Manages multiple stream readers with automatic cleanup.
+ * Uses a Map to track readers by operation type instead of separate refs.
+ */
+export class StreamReaderManager {
+  private readers = new Map<StreamOperation, WorkflowStreamReader>();
+
+  /**
+   * Sets a reader for a specific operation, releasing any existing reader first.
+   */
+  set(key: StreamOperation, reader: WorkflowStreamReader): void {
+    this.release(key);
+    this.readers.set(key, reader);
+  }
+
+  /**
+   * Gets a reader for a specific operation.
+   */
+  get(key: StreamOperation): WorkflowStreamReader | undefined {
+    return this.readers.get(key);
+  }
+
+  /**
+   * Releases a specific reader by key.
+   */
+  release(key: StreamOperation): void {
+    const reader = this.readers.get(key);
+    if (reader) {
+      try {
+        reader.releaseLock();
+      } catch {
+        // Reader might already be released, ignore
+      }
+      this.readers.delete(key);
+    }
+  }
+
+  /**
+   * Releases all readers.
+   */
+  releaseAll(): void {
+    for (const key of this.readers.keys()) {
+      this.release(key);
+    }
+  }
+
+  /**
+   * Checks if any reader is active.
+   */
+  hasActiveReaders(): boolean {
+    return this.readers.size > 0;
+  }
+}

--- a/client-sdks/react/src/workflows/types.ts
+++ b/client-sdks/react/src/workflows/types.ts
@@ -1,0 +1,95 @@
+import type { StreamVNextChunkType, TimeTravelParams } from '@mastra/client-js';
+import type { TracingOptions } from '@mastra/core/observability';
+import type { WorkflowStreamResult as CoreWorkflowStreamResult } from '@mastra/core/workflows';
+
+/**
+ * Workflow stream result with generic type parameters set to any for flexibility.
+ */
+export type WorkflowStreamResult = CoreWorkflowStreamResult<any, any, any, any>;
+
+/**
+ * Stream operation types.
+ */
+export type StreamOperation = 'stream' | 'observe' | 'resume' | 'timeTravel';
+
+/**
+ * Stream reader type alias for workflow streams.
+ * Uses a generic interface to handle both browser and Node.js ReadableStream types.
+ */
+export interface WorkflowStreamReader {
+  read(): Promise<{ done: boolean; value?: StreamVNextChunkType }>;
+  releaseLock(): void;
+}
+
+/**
+ * Parameters for streaming a workflow execution.
+ */
+export interface StreamParams {
+  runId: string;
+  inputData: Record<string, unknown>;
+  initialState?: Record<string, unknown>;
+  requestContext?: Record<string, unknown>;
+  tracingOptions?: TracingOptions;
+  perStep?: boolean;
+  closeOnSuspend?: boolean;
+}
+
+/**
+ * Parameters for observing an existing workflow run.
+ */
+export interface ObserveParams {
+  runId: string;
+  storeRunResult?: WorkflowStreamResult | null;
+}
+
+/**
+ * Parameters for resuming a suspended workflow.
+ */
+export interface ResumeParams {
+  runId: string;
+  step: string | string[];
+  resumeData: Record<string, unknown>;
+  requestContext?: Record<string, unknown>;
+  tracingOptions?: TracingOptions;
+  perStep?: boolean;
+}
+
+/**
+ * Parameters for time-traveling through workflow execution.
+ */
+export interface TimeTravelStreamParams extends Omit<TimeTravelParams, 'requestContext'> {
+  runId?: string;
+  requestContext?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for creating a new workflow run.
+ */
+export interface CreateRunParams {
+  prevRunId?: string;
+}
+
+/**
+ * Parameters for starting a workflow run.
+ */
+export interface StartRunParams {
+  runId: string;
+  input: Record<string, unknown>;
+  requestContext?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for starting an async workflow run.
+ */
+export interface StartAsyncRunParams {
+  runId?: string;
+  input: Record<string, unknown>;
+  requestContext?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for canceling a workflow run.
+ */
+export interface CancelRunParams {
+  runId: string;
+}

--- a/client-sdks/react/src/workflows/use-workflow-actions.ts
+++ b/client-sdks/react/src/workflows/use-workflow-actions.ts
@@ -1,0 +1,242 @@
+import { useState, useRef, useEffect, useCallback, type Dispatch, type SetStateAction } from 'react';
+import { useMastraClient } from '../mastra-client-context';
+import { buildRequestContext } from './build-request-context';
+import { processWorkflowStream } from './process-stream';
+import { StreamReaderManager } from './stream-reader-manager';
+import type {
+  WorkflowStreamResult,
+  StreamOperation,
+  StreamParams,
+  ObserveParams,
+  ResumeParams,
+  TimeTravelStreamParams,
+} from './types';
+
+export interface UseWorkflowActionsOptions {
+  workflowId: string;
+  initialStreamResult?: WorkflowStreamResult;
+  onError?: (error: Error, context: { operation: StreamOperation }) => void;
+}
+
+export interface UseWorkflowActionsReturn {
+  streamResult: WorkflowStreamResult;
+  isStreaming: boolean;
+  stream: (params: StreamParams) => Promise<void>;
+  observe: (params: ObserveParams) => Promise<void>;
+  resume: (params: ResumeParams) => Promise<void>;
+  timeTravel: (params: TimeTravelStreamParams) => Promise<void>;
+  reset: () => void;
+  setStreamResult: Dispatch<SetStateAction<WorkflowStreamResult>>;
+}
+
+/**
+ * Hook for managing workflow streaming operations.
+ * Provides unified API for streaming, observing, resuming, and time-traveling workflows.
+ */
+export function useWorkflowActions({
+  workflowId,
+  initialStreamResult = {} as WorkflowStreamResult,
+  onError,
+}: UseWorkflowActionsOptions): UseWorkflowActionsReturn {
+  const client = useMastraClient();
+  const [streamResult, setStreamResult] = useState<WorkflowStreamResult>(initialStreamResult);
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  const isMountedRef = useRef(true);
+  const readerManagerRef = useRef(new StreamReaderManager());
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      readerManagerRef.current.releaseAll();
+    };
+  }, []);
+
+  const isMounted = useCallback(() => isMountedRef.current, []);
+
+  const stream = useCallback(
+    async ({
+      runId,
+      inputData,
+      initialState,
+      requestContext: contextData,
+      tracingOptions,
+      perStep,
+      closeOnSuspend = true,
+    }: StreamParams): Promise<void> => {
+      readerManagerRef.current.release('stream');
+      if (!isMounted()) return;
+
+      setIsStreaming(true);
+      setStreamResult({ input: inputData } as WorkflowStreamResult);
+
+      const requestContext = buildRequestContext(contextData);
+      const workflow = client.getWorkflow(workflowId);
+      const run = await workflow.createRun({ runId });
+
+      const readableStream = await run.stream({
+        inputData,
+        initialState,
+        requestContext,
+        tracingOptions,
+        perStep,
+        closeOnSuspend,
+      });
+
+      if (!readableStream) {
+        onError?.(new Error('No stream returned'), { operation: 'stream' });
+        setIsStreaming(false);
+        return;
+      }
+
+      const { reader } = await processWorkflowStream({
+        stream: readableStream,
+        onChunk: setStreamResult,
+        onStreamingChange: setIsStreaming,
+        onError,
+        isMounted,
+        operation: 'stream',
+      });
+
+      readerManagerRef.current.set('stream', reader);
+    },
+    [client, workflowId, onError, isMounted],
+  );
+
+  const observe = useCallback(
+    async ({ runId, storeRunResult }: ObserveParams): Promise<void> => {
+      readerManagerRef.current.release('observe');
+      if (!isMounted()) return;
+
+      setIsStreaming(true);
+      setStreamResult((storeRunResult || {}) as WorkflowStreamResult);
+
+      if (storeRunResult?.status === 'suspended') {
+        setIsStreaming(false);
+        return;
+      }
+
+      const workflow = client.getWorkflow(workflowId);
+      const run = await workflow.createRun({ runId });
+      const readableStream = await run.observeStream();
+
+      if (!readableStream) {
+        onError?.(new Error('No stream returned'), { operation: 'observe' });
+        setIsStreaming(false);
+        return;
+      }
+
+      const { reader } = await processWorkflowStream({
+        stream: readableStream,
+        onChunk: setStreamResult,
+        onStreamingChange: setIsStreaming,
+        onError,
+        isMounted,
+        operation: 'observe',
+      });
+
+      readerManagerRef.current.set('observe', reader);
+    },
+    [client, workflowId, onError, isMounted],
+  );
+
+  const resume = useCallback(
+    async ({
+      runId,
+      step,
+      resumeData,
+      requestContext: contextData,
+      tracingOptions,
+      perStep,
+    }: ResumeParams): Promise<void> => {
+      readerManagerRef.current.release('resume');
+      if (!isMounted()) return;
+
+      setIsStreaming(true);
+
+      const requestContext = buildRequestContext(contextData);
+      const workflow = client.getWorkflow(workflowId);
+      const run = await workflow.createRun({ runId });
+
+      const readableStream = await run.resumeStream({
+        step,
+        resumeData,
+        requestContext,
+        tracingOptions,
+        perStep,
+      });
+
+      if (!readableStream) {
+        onError?.(new Error('No stream returned'), { operation: 'resume' });
+        setIsStreaming(false);
+        return;
+      }
+
+      const { reader } = await processWorkflowStream({
+        stream: readableStream,
+        onChunk: setStreamResult,
+        onStreamingChange: setIsStreaming,
+        onError,
+        isMounted,
+        operation: 'resume',
+      });
+
+      readerManagerRef.current.set('resume', reader);
+    },
+    [client, workflowId, onError, isMounted],
+  );
+
+  const timeTravel = useCallback(
+    async ({ runId, requestContext: contextData, ...params }: TimeTravelStreamParams): Promise<void> => {
+      readerManagerRef.current.release('timeTravel');
+      if (!isMounted()) return;
+
+      setIsStreaming(true);
+
+      const requestContext = buildRequestContext(contextData);
+      const workflow = client.getWorkflow(workflowId);
+      const run = await workflow.createRun({ runId });
+
+      const readableStream = await run.timeTravelStream({
+        ...params,
+        requestContext,
+      });
+
+      if (!readableStream) {
+        onError?.(new Error('No stream returned'), { operation: 'timeTravel' });
+        setIsStreaming(false);
+        return;
+      }
+
+      const { reader } = await processWorkflowStream({
+        stream: readableStream,
+        onChunk: setStreamResult,
+        onStreamingChange: setIsStreaming,
+        onError,
+        isMounted,
+        operation: 'timeTravel',
+      });
+
+      readerManagerRef.current.set('timeTravel', reader);
+    },
+    [client, workflowId, onError, isMounted],
+  );
+
+  const reset = useCallback(() => {
+    setIsStreaming(false);
+    setStreamResult({} as WorkflowStreamResult);
+    readerManagerRef.current.releaseAll();
+  }, []);
+
+  return {
+    streamResult,
+    isStreaming,
+    stream,
+    observe,
+    resume,
+    timeTravel,
+    reset,
+    setStreamResult,
+  };
+}

--- a/client-sdks/react/src/workflows/use-workflow-run.ts
+++ b/client-sdks/react/src/workflows/use-workflow-run.ts
@@ -1,0 +1,121 @@
+import { useState, useCallback } from 'react';
+import { useMastraClient } from '../mastra-client-context';
+import { buildRequestContext } from './build-request-context';
+import type { CreateRunParams, StartRunParams, StartAsyncRunParams, CancelRunParams } from './types';
+
+export interface UseWorkflowRunOptions {
+  workflowId: string;
+  onError?: (error: Error, context: { operation: string }) => void;
+}
+
+export interface UseWorkflowRunReturn {
+  createRun: (params?: CreateRunParams) => Promise<{ runId: string }>;
+  startRun: (params: StartRunParams) => Promise<void>;
+  startAsync: (params: StartAsyncRunParams) => Promise<unknown>;
+  cancelRun: (params: CancelRunParams) => Promise<{ message: string }>;
+  isPending: {
+    createRun: boolean;
+    startRun: boolean;
+    startAsync: boolean;
+    cancelRun: boolean;
+  };
+}
+
+/**
+ * Hook for managing workflow run lifecycle operations.
+ * Provides unified API for creating, starting, and canceling workflow runs.
+ */
+export function useWorkflowRun({ workflowId, onError }: UseWorkflowRunOptions): UseWorkflowRunReturn {
+  const client = useMastraClient();
+
+  const [isPending, setIsPending] = useState({
+    createRun: false,
+    startRun: false,
+    startAsync: false,
+    cancelRun: false,
+  });
+
+  const createRun = useCallback(
+    async (params?: CreateRunParams): Promise<{ runId: string }> => {
+      setIsPending(prev => ({ ...prev, createRun: true }));
+      try {
+        const workflow = client.getWorkflow(workflowId);
+        const { runId } = await workflow.createRun({ runId: params?.prevRunId });
+        return { runId };
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        onError?.(err, { operation: 'createRun' });
+        throw error;
+      } finally {
+        setIsPending(prev => ({ ...prev, createRun: false }));
+      }
+    },
+    [client, workflowId, onError],
+  );
+
+  const startRun = useCallback(
+    async ({ runId, input, requestContext: contextData }: StartRunParams): Promise<void> => {
+      setIsPending(prev => ({ ...prev, startRun: true }));
+      try {
+        const requestContext = buildRequestContext(contextData);
+        const workflow = client.getWorkflow(workflowId);
+        const run = await workflow.createRun({ runId });
+        await run.start({ inputData: input || {}, requestContext });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        onError?.(err, { operation: 'startRun' });
+        throw error;
+      } finally {
+        setIsPending(prev => ({ ...prev, startRun: false }));
+      }
+    },
+    [client, workflowId, onError],
+  );
+
+  const startAsync = useCallback(
+    async ({ runId, input, requestContext: contextData }: StartAsyncRunParams): Promise<unknown> => {
+      setIsPending(prev => ({ ...prev, startAsync: true }));
+      try {
+        const requestContext = buildRequestContext(contextData);
+        const workflow = client.getWorkflow(workflowId);
+        const run = await workflow.createRun({ runId });
+        const result = await run.startAsync({ inputData: input || {}, requestContext });
+        return result;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        onError?.(err, { operation: 'startAsync' });
+        throw error;
+      } finally {
+        setIsPending(prev => ({ ...prev, startAsync: false }));
+      }
+    },
+    [client, workflowId, onError],
+  );
+
+  const cancelRun = useCallback(
+    async ({ runId }: CancelRunParams): Promise<{ message: string }> => {
+      setIsPending(prev => ({ ...prev, cancelRun: true }));
+      try {
+        const workflow = client.getWorkflow(workflowId);
+        const run = await workflow.createRun({ runId });
+        const response = await run.cancel();
+        return response;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        onError?.(err, { operation: 'cancelRun' });
+        throw error;
+      } finally {
+        setIsPending(prev => ({ ...prev, cancelRun: false }));
+      }
+    },
+    [client, workflowId, onError],
+  );
+
+  return {
+    createRun,
+    startRun,
+    startAsync,
+    cancelRun,
+    isPending,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract workflow execution logic from playground-ui into reusable hooks in `@mastra/react` SDK
- Add `useWorkflowActions` hook for streaming operations (stream, observe, resume, timeTravel)
- Add `useWorkflowRun` hook for run lifecycle operations (create, start, startAsync, cancel)
- Add `StreamReaderManager` class for consolidated reader management (replaces 4 separate refs)
- Add `processWorkflowStream` utility for generic stream processing
- Add `buildRequestContext` helper for RequestContext building
- Refactor playground-ui to use the new SDK utilities, reducing code from 569 to 323 lines

## Test plan
- [x] React SDK builds successfully
- [x] Playground-ui builds successfully
- [x] E2E validation passed - workflow streaming, step execution, and suspend/resume work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)