### PR TITLE
Revert "docs for copilot external"

### DIFF
--- a/docs/src/content/en/guides/build-your-ui/copilotkit.mdx
+++ b/docs/src/content/en/guides/build-your-ui/copilotkit.mdx
@@ -204,24 +204,3 @@ You should now be able to chat with your agent in the browser.
 </Steps>
 
 Congratulations! You have successfully integrated Mastra with CopilotKit using a separate server approach. Your CopilotKit frontend now communicates with a standalone Mastra agent server.
-
-## Deployment
-
-When deploying your Mastra server with CopilotKit, you must exclude `@copilotkit/runtime` from the bundle. This package contains dependencies that are not compatible with bundling and will cause 500 errors if included.
-
-:::note
-
-This issue doesn't occur during development with `mastra dev` since it doesn't require bundling. However, anyone running `mastra build` for deployment will encounter this issue.
-
-:::
-
-Add the `@copilotkit/runtime` package to your bundler externals configuration:
-
-```typescript title="src/mastra/index.ts" 
-export const mastra = new Mastra({
-  bundler: {
-    externals: ['@copilotkit/runtime'],
-  },
- // Rest of the configuration...
-});
-```


### PR DESCRIPTION
Reverts mastra-ai/mastra#11725

For Mastra v1 this is actually not necessary anymore since we externalize every package by default now. The user that opened the issue was using Mastra 0.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified deployment guidance by removing outdated bundler configuration instructions and related notes from the integration guide. This streamlines the documentation for a clearer user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->