### PR TITLE
fix(core): remove tools from step output

### DIFF
--- a/.changeset/fresh-planets-hope.md
+++ b/.changeset/fresh-planets-hope.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+removed "tools" from model_step span output on observability

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1119,7 +1119,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT e
         output: {
           text,
           toolCalls: shouldRetry ? [] : toolCalls, // Clear tool calls on retry
-          tools: stepTools,
           usage: usage ?? inputData.output?.usage,
           steps,
           ...(object ? { object } : {}),


### PR DESCRIPTION
## Summary

Removes the `tools` field from the step-finish output payload.

## Problem

The `tools: stepTools` field was incorrectly being included in the step output. This field contains tool **definitions** (name, description, parameters schema), not execution results.

This caused:
- Verbose tool definition data leaking into observability spans
- Unnecessary data in traces and logs
- Confusion in the `LLMIterationOutput` type which doesn't include `tools`

<img width="1541" height="1108" alt="image" src="https://github.com/user-attachments/assets/61dfcb16-50e2-4c68-9b06-285433deb854" />


## Fix

Remove the `tools: stepTools` line from the output object in `llm-execution-step.ts`.

## Files Changed

- `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The public output of LLM execution steps no longer includes the `tools` field. Tool data remains available internally for processing, but is no longer exposed in step results, iteration payloads, or observability/tripwire outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->