### PR TITLE
Cleaned up model_step span output for better observability.

### DIFF
--- a/.changeset/clean-model-step-span-output.md
+++ b/.changeset/clean-model-step-span-output.md
@@ -2,4 +2,4 @@
 "@mastra/observability": patch
 ---
 
-Clean up model_step span output for better observability. Tools are now serialized with only essential fields (type, id, description, inputSchema, outputSchema) instead of full objects with Zod internals. Empty text fields are omitted from output.
+Clean up model_step span output for better observability. Tools are now serialized with only essential fields (type, id, description, inputSchema, outputSchema) instead of full objects with Zod internals.

--- a/.changeset/clean-model-step-span-output.md
+++ b/.changeset/clean-model-step-span-output.md
@@ -2,4 +2,4 @@
 "@mastra/observability": patch
 ---
 
-Clean up model_step span output for better observability. Tools are now serialized with only essential fields (type, id, description, inputSchema, outputSchema) instead of full objects with Zod internals.
+Clean up model_step span output by removing tools (already present in input via request.body).

--- a/.changeset/clean-model-step-span-output.md
+++ b/.changeset/clean-model-step-span-output.md
@@ -1,0 +1,5 @@
+---
+"@mastra/observability": patch
+---
+
+Clean up model_step span output for better observability. Tools are now serialized with only essential fields (type, id, description, inputSchema, outputSchema) instead of full objects with Zod internals. Empty text fields are omitted from output.

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -173,11 +173,7 @@ export class ModelSpanTracker {
 
     // Clean output for observability:
     // - Clean tools to only include essential fields (type, id, description, schemas)
-    // - Omit empty text field
-    const cleanOutput: Record<string, any> = { ...restOutput };
-    if (text) {
-      cleanOutput.text = text;
-    }
+    const cleanOutput: Record<string, any> = { ...restOutput, text };
     const cleanedTools = cleanToolsForObservability(tools);
     if (cleanedTools) {
       cleanOutput.tools = cleanedTools;

--- a/observability/mastra/src/spans/serialization.test.ts
+++ b/observability/mastra/src/spans/serialization.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import { cleanToolsForObservability, deepClean } from './serialization';
+
+describe('cleanToolsForObservability', () => {
+  it('should return undefined for undefined input', () => {
+    expect(cleanToolsForObservability(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined for null input', () => {
+    expect(cleanToolsForObservability(null as any)).toBeUndefined();
+  });
+
+  it('should return undefined for empty object', () => {
+    expect(cleanToolsForObservability({})).toBeUndefined();
+  });
+
+  it('should extract essential fields from a simple tool', () => {
+    const tools = {
+      myTool: {
+        type: 'function',
+        id: 'my-tool-id',
+        description: 'A simple tool',
+        parameters: {
+          jsonSchema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+          validate: () => {},
+        },
+        outputSchema: {
+          jsonSchema: {
+            type: 'string',
+          },
+          validate: () => {},
+        },
+        execute: () => {},
+        someInternalField: 'should be stripped',
+      },
+    };
+
+    const result = cleanToolsForObservability(tools);
+
+    expect(result).toEqual({
+      myTool: {
+        type: 'function',
+        id: 'my-tool-id',
+        description: 'A simple tool',
+        inputSchema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+        outputSchema: {
+          type: 'string',
+        },
+      },
+    });
+  });
+
+  it('should not include id if it matches the tool name', () => {
+    const tools = {
+      myTool: {
+        type: 'function',
+        id: 'myTool',
+        description: 'A tool',
+      },
+    };
+
+    const result = cleanToolsForObservability(tools);
+
+    expect(result).toEqual({
+      myTool: {
+        type: 'function',
+        description: 'A tool',
+      },
+    });
+  });
+
+  it('should default type to function if not specified', () => {
+    const tools = {
+      myTool: {
+        description: 'A tool without type',
+      },
+    };
+
+    const result = cleanToolsForObservability(tools);
+
+    expect(result).toEqual({
+      myTool: {
+        type: 'function',
+        description: 'A tool without type',
+      },
+    });
+  });
+
+  it('should handle Zod schemas by extracting typeName', () => {
+    const tools = {
+      zodTool: {
+        type: 'function',
+        description: 'A tool with Zod schema',
+        parameters: {
+          _def: {
+            typeName: 'ZodObject',
+            shape: () => {},
+          },
+          parse: () => {},
+          safeParse: () => {},
+        },
+      },
+    };
+
+    const result = cleanToolsForObservability(tools);
+
+    expect(result).toEqual({
+      zodTool: {
+        type: 'function',
+        description: 'A tool with Zod schema',
+        inputSchema: {
+          _zodType: 'ZodObject',
+        },
+      },
+    });
+  });
+
+  it('should handle raw JSON schemas (with type property)', () => {
+    const tools = {
+      rawSchemaTool: {
+        type: 'function',
+        description: 'A tool with raw JSON schema',
+        parameters: {
+          type: 'object',
+          properties: { value: { type: 'number' } },
+        },
+      },
+    };
+
+    const result = cleanToolsForObservability(tools);
+
+    expect(result).toEqual({
+      rawSchemaTool: {
+        type: 'function',
+        description: 'A tool with raw JSON schema',
+        inputSchema: {
+          type: 'object',
+          properties: { value: { type: 'number' } },
+        },
+      },
+    });
+  });
+
+  it('should handle multiple tools', () => {
+    const tools = {
+      tool1: {
+        type: 'function',
+        description: 'First tool',
+      },
+      tool2: {
+        type: 'function',
+        id: 'different-id',
+        description: 'Second tool',
+      },
+    };
+
+    const result = cleanToolsForObservability(tools);
+
+    expect(result).toEqual({
+      tool1: {
+        type: 'function',
+        description: 'First tool',
+      },
+      tool2: {
+        type: 'function',
+        id: 'different-id',
+        description: 'Second tool',
+      },
+    });
+  });
+
+  it('should skip non-object tool values', () => {
+    const tools = {
+      validTool: {
+        type: 'function',
+        description: 'A valid tool',
+      },
+      invalidTool: null,
+      anotherInvalid: 'string',
+    };
+
+    const result = cleanToolsForObservability(tools as any);
+
+    expect(result).toEqual({
+      validTool: {
+        type: 'function',
+        description: 'A valid tool',
+      },
+    });
+  });
+});
+
+describe('deepClean', () => {
+  it('should handle functions by replacing with [Function]', () => {
+    const obj = {
+      name: 'test',
+      execute: () => {},
+    };
+
+    const result = deepClean(obj);
+
+    expect(result).toEqual({
+      name: 'test',
+      execute: '[Function]',
+    });
+  });
+
+  it('should truncate long strings', () => {
+    const longString = 'a'.repeat(2000);
+    const result = deepClean(longString);
+
+    expect(result.length).toBeLessThan(2000);
+    expect(result).toContain('[truncated]');
+  });
+
+  it('should handle max depth', () => {
+    // Default maxDepth is 6, so level 7 should be truncated
+    const deepObject = {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {
+                level6: {
+                  level7: 'too deep',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = deepClean(deepObject);
+
+    // At depth 6 (level6), the value is still an object but its children are truncated
+    expect(result.level1.level2.level3.level4.level5.level6.level7).toBe('[MaxDepth]');
+  });
+});

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -40,9 +40,7 @@ function extractJsonSchema(schema: any): Record<string, any> | undefined {
  * @param tools - The tools object (Record<string, Tool>)
  * @returns A cleaned tools object suitable for observability
  */
-export function cleanToolsForObservability(
-  tools: Record<string, any> | undefined,
-): Record<string, any> | undefined {
+export function cleanToolsForObservability(tools: Record<string, any> | undefined): Record<string, any> | undefined {
   if (!tools || typeof tools !== 'object') return undefined;
 
   const cleaned: Record<string, any> = {};


### PR DESCRIPTION
## Description

Tools are now serialized with only essential fields (type, id, description, inputSchema, outputSchema) instead of full objects with Zod internals. Empty text fields are omitted from output.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined tool serialization for observability: only essential fields retained (type, id when applicable, description, input/output schemas); sensible defaults for missing type.

* **Bug Fixes**
  * Step outputs no longer include embedded tool payloads, reducing duplicated/verbose data in traces.

* **Tests**
  * Added comprehensive unit tests covering tool sanitization, schema extraction, string truncation, function replacement, and max-depth truncation.

* **Chores**
  * Added a changeset documenting the patch release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->