### PR TITLE
Make Datadog exporter zero config compatible

### DIFF
--- a/.changeset/datadog-zero-config.md
+++ b/.changeset/datadog-zero-config.md
@@ -1,0 +1,17 @@
+---
+'@mastra/datadog': patch
+---
+
+Make Datadog exporter zero-config compatible
+
+The Datadog exporter can now be instantiated without any configuration by reading credentials from environment variables:
+
+- `DD_LLMOBS_ML_APP` - ML application name
+- `DD_API_KEY` - Datadog API key
+- `DD_SITE` - Datadog site (defaults to `datadoghq.com`)
+- `DD_ENV` - Environment name
+
+```typescript
+// Zero-config usage - reads from environment variables
+const exporter = new DatadogExporter();
+```

--- a/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
@@ -28,7 +28,30 @@ DD_SITE=datadoghq.com  # Optional: defaults to datadoghq.com
 DD_ENV=production      # Optional: environment name
 ```
 
-### Basic Setup
+### Zero-Config Setup
+
+With environment variables set, use the exporter with no configuration:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from "@mastra/core";
+import { Observability } from "@mastra/observability";
+import { DatadogExporter } from "@mastra/datadog";
+
+export const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      datadog: {
+        serviceName: "my-service",
+        exporters: [new DatadogExporter()],
+      },
+    },
+  }),
+});
+```
+
+### Explicit Configuration
+
+You can also pass credentials directly (takes precedence over environment variables):
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";

--- a/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
@@ -100,6 +100,17 @@ Flushes pending data and shuts down the exporter. Cancels any pending cleanup ti
 
 ## Usage
 
+### Zero-Config (using environment variables)
+
+```typescript
+import { DatadogExporter } from "@mastra/datadog";
+
+// Reads from DD_LLMOBS_ML_APP, DD_API_KEY, DD_SITE, DD_ENV
+const exporter = new DatadogExporter();
+```
+
+### Explicit Configuration
+
 ```typescript
 import { DatadogExporter } from "@mastra/datadog";
 

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -158,9 +158,7 @@ export class DatadogExporter extends BaseExporter {
 
     // Validate required configuration
     if (!mlApp) {
-      this.setDisabled(
-        `Missing required mlApp. Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`,
-      );
+      this.setDisabled(`Missing required mlApp. Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`);
       this.config = config as any;
       return;
     }

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -146,9 +146,10 @@ export class DatadogExporter extends BaseExporter {
     super(config);
 
     // Resolve configuration from config object and environment variables
-    const mlApp = config.mlApp || process.env.DD_LLMOBS_ML_APP;
-    const apiKey = config.apiKey || process.env.DD_API_KEY;
-    const site = config.site || process.env.DD_SITE || 'datadoghq.com';
+    const mlApp = config.mlApp ?? process.env.DD_LLMOBS_ML_APP;
+    const apiKey = config.apiKey ?? process.env.DD_API_KEY;
+    const site = config.site ?? process.env.DD_SITE ?? 'datadoghq.com';
+    const env = config.env ?? process.env.DD_ENV;
 
     // Default to agentless mode (true) for consistency with other Mastra exporters
     // Only disable if explicitly set to false via config or env var
@@ -157,18 +158,26 @@ export class DatadogExporter extends BaseExporter {
 
     // Validate required configuration
     if (!mlApp) {
-      this.setDisabled('Missing required mlApp (set config.mlApp or DD_LLMOBS_ML_APP)');
+      const mlAppSource = config.mlApp ? 'from config' : process.env.DD_LLMOBS_ML_APP ? 'from env' : 'missing';
+      this.setDisabled(
+        `Missing required mlApp (mlApp: ${mlAppSource}). ` +
+          `Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`,
+      );
       this.config = config as any;
       return;
     }
 
     if (agentless && !apiKey) {
-      this.setDisabled('Missing required apiKey (set config.apiKey or DD_API_KEY)');
+      const apiKeySource = config.apiKey ? 'from config' : process.env.DD_API_KEY ? 'from env' : 'missing';
+      this.setDisabled(
+        `Missing required apiKey for agentless mode (apiKey: ${apiKeySource}). ` +
+          `Set DD_API_KEY environment variable or pass apiKey in config.`,
+      );
       this.config = config as any;
       return;
     }
 
-    this.config = { ...config, mlApp, site, apiKey, agentless };
+    this.config = { ...config, mlApp, site, apiKey, agentless, env };
 
     // Initialize tracer and enable LLM Observability
     ensureTracer({
@@ -177,7 +186,7 @@ export class DatadogExporter extends BaseExporter {
       apiKey,
       agentless,
       service: config.service,
-      env: config.env,
+      env,
       integrationsEnabled: config.integrationsEnabled,
     });
 

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -158,20 +158,16 @@ export class DatadogExporter extends BaseExporter {
 
     // Validate required configuration
     if (!mlApp) {
-      const mlAppSource = config.mlApp ? 'from config' : process.env.DD_LLMOBS_ML_APP ? 'from env' : 'missing';
       this.setDisabled(
-        `Missing required mlApp (mlApp: ${mlAppSource}). ` +
-          `Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`,
+        `Missing required mlApp. Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`,
       );
       this.config = config as any;
       return;
     }
 
     if (agentless && !apiKey) {
-      const apiKeySource = config.apiKey ? 'from config' : process.env.DD_API_KEY ? 'from env' : 'missing';
       this.setDisabled(
-        `Missing required apiKey for agentless mode (apiKey: ${apiKeySource}). ` +
-          `Set DD_API_KEY environment variable or pass apiKey in config.`,
+        `Missing required apiKey for agentless mode. Set DD_API_KEY environment variable or pass apiKey in config.`,
       );
       this.config = config as any;
       return;


### PR DESCRIPTION
## Description

Similar to recent changes in other exporters:

The Datadog exporter can now be instantiated without any configuration by reading credentials from environment variables:

- `DD_LLMOBS_ML_APP` - ML application name
- `DD_API_KEY` - Datadog API key
- `DD_SITE` - Datadog site (defaults to `datadoghq.com`)
- `DD_ENV` - Environment name

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datadog exporter supports zero-configuration via environment variables (DD_LLMOBS_ML_APP, DD_API_KEY, DD_SITE with default datadoghq.com, DD_ENV).

* **Documentation**
  * Added zero-config setup examples and preserved explicit-configuration guides.

* **Improvements**
  * Environment selection is more consistently applied and validation/error messages were clarified for easier troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->