### PR TITLE
Rename DefaultExporter to LocalExporter with alias

### DIFF
--- a/.changeset/deprecate-default-observability-config.md
+++ b/.changeset/deprecate-default-observability-config.md
@@ -5,7 +5,7 @@
 
 Deprecate `default: { enabled: true }` observability configuration
 
-The shorthand `default: { enabled: true }` configuration is now deprecated and will be removed in a future version. Users should migrate to explicit configuration with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`.
+The shorthand `default: { enabled: true }` configuration is now deprecated and will be removed in a future version. Users should migrate to explicit configuration with `LocalExporter`, `CloudExporter`, and `SensitiveDataFilter`.
 
 **Before (deprecated):**
 ```typescript
@@ -22,7 +22,7 @@ const mastra = new Mastra({
 ```typescript
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from '@mastra/observability';
@@ -33,7 +33,7 @@ const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(),
+          new LocalExporter(),
           new CloudExporter(),
         ],
         spanOutputProcessors: [

--- a/.changeset/deprecate-default-observability-config.md
+++ b/.changeset/deprecate-default-observability-config.md
@@ -5,7 +5,7 @@
 
 Deprecate `default: { enabled: true }` observability configuration
 
-The shorthand `default: { enabled: true }` configuration is now deprecated and will be removed in a future version. Users should migrate to explicit configuration with `LocalExporter`, `CloudExporter`, and `SensitiveDataFilter`.
+The shorthand `default: { enabled: true }` configuration is now deprecated and will be removed in a future version. Users should migrate to explicit configuration with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`.
 
 **Before (deprecated):**
 ```typescript
@@ -22,7 +22,7 @@ const mastra = new Mastra({
 ```typescript
 import {
   Observability,
-  LocalExporter,
+  DefaultExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from '@mastra/observability';
@@ -33,7 +33,7 @@ const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new LocalExporter(),
+          new DefaultExporter(),
           new CloudExporter(),
         ],
         spanOutputProcessors: [

--- a/.changeset/rename-default-to-local-exporter.md
+++ b/.changeset/rename-default-to-local-exporter.md
@@ -1,0 +1,32 @@
+---
+'@mastra/observability': minor
+---
+
+Rename `DefaultExporter` to `LocalExporter`
+
+The `DefaultExporter` class has been renamed to `LocalExporter` to better reflect its purpose of persisting traces to local storage for viewing in Mastra Studio.
+
+**Migration:**
+
+```typescript
+// Before
+import { DefaultExporter } from '@mastra/observability';
+new DefaultExporter();
+
+// After
+import { LocalExporter } from '@mastra/observability';
+new LocalExporter();
+```
+
+**Backward Compatibility:**
+
+`DefaultExporter` is still available as a deprecated alias for backward compatibility and will continue to work. However, we recommend updating to `LocalExporter` as the old name will be removed in a future major version.
+
+```typescript
+// This still works but shows a deprecation warning in TypeScript
+import { DefaultExporter } from '@mastra/observability';
+```
+
+**Related Changes:**
+- `DefaultExporterConfig` type renamed to `LocalExporterConfig` (with deprecated alias)
+- Internal exporter name changed from `mastra-default-observability-exporter` to `mastra-local-observability-exporter`

--- a/docs/src/content/en/docs/observability/overview.mdx
+++ b/docs/src/content/en/docs/observability/overview.mdx
@@ -33,7 +33,7 @@ import { PinoLogger } from "@mastra/loggers";
 import { LibSQLStore } from "@mastra/libsql";
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from "@mastra/observability";
@@ -49,7 +49,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: "mastra",
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -50,7 +50,7 @@ Include CloudExporter in your observability configuration:
 import { Mastra } from "@mastra/core";
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from "@mastra/observability";
@@ -61,7 +61,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: "mastra",
         exporters: [
-          new DefaultExporter(),
+          new LocalExporter(),
           new CloudExporter(), // Sends traces to Mastra Cloud (requires MASTRA_CLOUD_ACCESS_TOKEN)
         ],
         spanOutputProcessors: [
@@ -130,5 +130,5 @@ CloudExporter uses intelligent batching to optimize network usage. Traces are bu
 ## Related
 
 - [Tracing Overview](/docs/v1/observability/tracing/overview)
-- [DefaultExporter](/docs/v1/observability/tracing/exporters/default)
+- [LocalExporter](/docs/v1/observability/tracing/exporters/local)
 - [Mastra Cloud Documentation](/docs/v1/mastra-cloud/overview)

--- a/docs/src/content/en/docs/observability/tracing/exporters/local.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/local.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Default Exporter | Tracing | Observability"
+title: "Local Exporter | Tracing | Observability"
 description: "Store traces locally for development and debugging"
 packages:
   - "@mastra/core"
@@ -7,9 +7,11 @@ packages:
   - "@mastra/observability"
 ---
 
-# Default Exporter
+# Local Exporter
 
-The `DefaultExporter` persists traces to your configured storage backend, making them accessible through Studio. It's automatically enabled when using the default observability configuration and requires no external services.
+The `LocalExporter` persists traces to your configured storage backend, making them accessible through Studio. It's automatically enabled when using the default observability configuration and requires no external services.
+
+> **Note:** `LocalExporter` was previously named `DefaultExporter`. The old name is still available as an alias for backward compatibility but is deprecated.
 
 ## Configuration
 
@@ -22,7 +24,7 @@ The `DefaultExporter` persists traces to your configured storage backend, making
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
-import { Observability, DefaultExporter } from "@mastra/observability";
+import { Observability, LocalExporter } from "@mastra/observability";
 import { LibSQLStore } from "@mastra/libsql";
 
 export const mastra = new Mastra({
@@ -34,7 +36,7 @@ export const mastra = new Mastra({
     configs: {
       local: {
         serviceName: "my-service",
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),
@@ -43,13 +45,13 @@ export const mastra = new Mastra({
 
 ### Recommended Configuration
 
-Include DefaultExporter in your observability configuration:
+Include LocalExporter in your observability configuration:
 
 ```typescript
 import { Mastra } from "@mastra/core";
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from "@mastra/observability";
@@ -65,7 +67,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: "mastra",
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (requires MASTRA_CLOUD_ACCESS_TOKEN)
         ],
         spanOutputProcessors: [
@@ -90,7 +92,7 @@ Access your traces through Studio:
 
 ## Tracing Strategies
 
-DefaultExporter automatically selects the optimal tracing strategy based on your storage provider. You can also override this selection if needed.
+LocalExporter automatically selects the optimal tracing strategy based on your storage provider. You can also override this selection if needed.
 
 ### Available Strategies
 
@@ -103,7 +105,7 @@ DefaultExporter automatically selects the optimal tracing strategy based on your
 ### Strategy Configuration
 
 ```typescript
-new DefaultExporter({
+new LocalExporter({
   strategy: "auto", // Default - let storage provider decide
   // or explicitly set:
   // strategy: 'realtime' | 'batch-with-updates' | 'insert-only'
@@ -119,7 +121,7 @@ new DefaultExporter({
 
 Different storage providers support different tracing strategies.
 
-If you set the strategy to `'auto'`, the `DefaultExporter` automatically selects the optimal strategy for the storage provider. If you set the strategy to a mode that the storage provider doesn't support, you will get an error message.
+If you set the strategy to `'auto'`, the `LocalExporter` automatically selects the optimal strategy for the storage provider. If you set the strategy to a mode that the storage provider doesn't support, you will get an error message.
 
 | Storage Provider                                | Preferred Strategy | Supported Strategies                      | Notes                                 |
 | ----------------------------------------------- | ------------------ | ----------------------------------------- | ------------------------------------- |
@@ -145,7 +147,7 @@ For both batch strategies (`batch-with-updates` and `insert-only`), traces are f
 
 ### Error Handling
 
-The DefaultExporter includes robust error handling for production use:
+The LocalExporter includes robust error handling for production use:
 
 - **Retry Logic**: Exponential backoff (500ms, 1s, 2s, 4s)
 - **Transient Failures**: Automatic retry with backoff
@@ -156,22 +158,22 @@ The DefaultExporter includes robust error handling for production use:
 
 ```typescript
 // Zero config - recommended for most users
-new DefaultExporter();
+new LocalExporter();
 
 // Development override
-new DefaultExporter({
+new LocalExporter({
   strategy: "realtime", // Immediate visibility for debugging
 });
 
 // High-throughput production
-new DefaultExporter({
+new LocalExporter({
   maxBatchSize: 2000, // Larger batches
   maxBatchWaitMs: 10000, // Wait longer to fill batches
   maxBufferSize: 50000, // Handle longer outages
 });
 
 // Low-latency production
-new DefaultExporter({
+new LocalExporter({
   maxBatchSize: 100, // Smaller batches
   maxBatchWaitMs: 1000, // Flush quickly
 });

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -29,7 +29,7 @@ Traces are created by:
 import { Mastra } from "@mastra/core";
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from "@mastra/observability";
@@ -40,7 +40,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: "mastra",
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
@@ -61,7 +61,7 @@ This configuration includes:
 - **Service Name**: `"mastra"` - identifies your service in traces
 - **Sampling**: `"always"` by default (100% of traces)
 - **Exporters**:
-  - `DefaultExporter` - Persists traces to your configured storage for Mastra Studio
+  - `LocalExporter` - Persists traces to your configured storage for Mastra Studio
   - `CloudExporter` - Sends traces to Mastra Cloud (requires `MASTRA_CLOUD_ACCESS_TOKEN`)
 - **Span Output Processors**: `SensitiveDataFilter` - Redacts sensitive fields
 
@@ -73,7 +73,7 @@ Exporters determine where your trace data is sent and how it's stored. They inte
 
 Mastra provides two built-in exporters:
 
-- **[Default](/docs/v1/observability/tracing/exporters/default)** - Persists traces to local storage for viewing in Studio
+- **[Local](/docs/v1/observability/tracing/exporters/local)** - Persists traces to local storage for viewing in Studio
 - **[Cloud](/docs/v1/observability/tracing/exporters/cloud)** - Sends traces to Mastra Cloud for production monitoring and collaboration
 
 ### External Exporters
@@ -173,7 +173,7 @@ export const mastra = new Mastra({
           type: "ratio",
           probability: 0.1,
         },
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),
@@ -217,7 +217,7 @@ export const mastra = new Mastra({
       debug: {
         serviceName: "debug-service",
         sampling: { type: "always" },
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
     configSelector: (context, availableTracers) => {
@@ -254,7 +254,7 @@ export const mastra = new Mastra({
       development: {
         serviceName: "my-service-dev",
         sampling: { type: "always" },
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
       staging: {
         serviceName: "my-service-staging",
@@ -279,12 +279,12 @@ export const mastra = new Mastra({
 
 #### Maintaining Studio and Cloud Access
 
-When adding external exporters, include `DefaultExporter` and `CloudExporter` to maintain access to Studio and Mastra Cloud:
+When adding external exporters, include `LocalExporter` and `CloudExporter` to maintain access to Studio and Mastra Cloud:
 
 ```ts title="src/mastra/index.ts"
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from "@mastra/observability";
@@ -300,7 +300,7 @@ export const mastra = new Mastra({
             endpoint: process.env.PHOENIX_ENDPOINT,
             apiKey: process.env.PHOENIX_API_KEY,
           }),
-          new DefaultExporter(), // Keep Studio access
+          new LocalExporter(), // Keep Studio access
           new CloudExporter(), // Keep Cloud access
         ],
         spanOutputProcessors: [
@@ -315,7 +315,7 @@ export const mastra = new Mastra({
 This configuration sends traces to all three destinations simultaneously:
 
 - **Arize Phoenix/AX** for external observability
-- **DefaultExporter** for Studio
+- **LocalExporter** for Studio
 - **CloudExporter** for Mastra Cloud dashboard
 
 :::info
@@ -367,7 +367,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: "my-service",
         requestContextKeys: ["userId", "environment", "tenantId"],
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),
@@ -420,7 +420,7 @@ export const mastra = new Mastra({
     configs: {
       default: {
         requestContextKeys: ["user.id", "session.data.experimentId"],
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),
@@ -596,7 +596,7 @@ export const mastra = new Mastra({
     configs: {
       development: {
         spanOutputProcessors: [new LowercaseInputProcessor(), new SensitiveDataFilter()],
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),
@@ -631,7 +631,7 @@ export const mastra = new Mastra({
           maxArrayLength: 100,     // Maximum number of items in arrays (default: 50)
           maxObjectKeys: 75,       // Maximum number of keys in objects (default: 50)
         },
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),
@@ -867,7 +867,7 @@ Mastra automatically creates spans for:
 
 ### Exporters
 
-- [DefaultExporter](/reference/v1/observability/tracing/exporters/default-exporter) - Storage persistence
+- [LocalExporter](/reference/v1/observability/tracing/exporters/local-exporter) - Storage persistence
 - [CloudExporter](/reference/v1/observability/tracing/exporters/cloud-exporter) - Mastra Cloud integration
 - [ConsoleExporter](/reference/v1/observability/tracing/exporters/console-exporter) - Debug output
 - [Arize](/reference/v1/observability/tracing/exporters/arize) - Arize Phoenix and Arize AX integration

--- a/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
+++ b/docs/src/content/en/docs/observability/tracing/processors/sensitive-data-filter.mdx
@@ -16,7 +16,7 @@ The Sensitive Data Filter is included in the recommended observability configura
 ```ts title="src/mastra/index.ts"
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from "@mastra/observability";
@@ -27,7 +27,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: "mastra",
         exporters: [
-          new DefaultExporter(),
+          new LocalExporter(),
           new CloudExporter(),
         ],
         spanOutputProcessors: [
@@ -84,14 +84,14 @@ When a sensitive field is detected, its value is replaced with `[REDACTED]` by d
 You can customize which fields are redacted and how redaction appears:
 
 ```ts title="src/mastra/index.ts"
-import { SensitiveDataFilter, DefaultExporter, Observability } from "@mastra/observability";
+import { SensitiveDataFilter, LocalExporter, Observability } from "@mastra/observability";
 
 export const mastra = new Mastra({
   observability: new Observability({
     configs: {
       production: {
         serviceName: "my-service",
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
         spanOutputProcessors: [
           new SensitiveDataFilter({
             // Add custom sensitive fields
@@ -237,7 +237,7 @@ export const mastra = new Mastra({
       debug: {
         serviceName: "debug-service",
         spanOutputProcessors: [], // No processors, including no SensitiveDataFilter
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -466,8 +466,8 @@ const sidebars = {
               items: [
                 {
                   type: "doc",
-                  id: "observability/tracing/exporters/default",
-                  label: "Default",
+                  id: "observability/tracing/exporters/local",
+                  label: "Local",
                 },
                 {
                   type: "doc",

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
@@ -39,7 +39,7 @@ export const mastra = new Mastra({
 import { Mastra } from '@mastra/core';
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from '@mastra/observability';
@@ -50,7 +50,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
@@ -62,7 +62,7 @@ export const mastra = new Mastra({
 });
 ```
 
-This configuration includes `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter` processor. See the [observability tracing documentation](/docs/v1/observability/tracing/overview) for full configuration options.
+This configuration includes `LocalExporter`, `CloudExporter`, and `SensitiveDataFilter` processor. See the [observability tracing documentation](/docs/v1/observability/tracing/overview) for full configuration options.
 
 **After (v1 with custom configuration):**
 
@@ -102,7 +102,7 @@ export const mastra = new Mastra({
 Key changes:
 1. Install `@mastra/observability` package
 2. Replace `telemetry:` with `observability: new Observability()`
-3. Use explicit `configs:` with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`
+3. Use explicit `configs:` with `LocalExporter`, `CloudExporter`, and `SensitiveDataFilter`
 4. Export types change from string literals (`'otlp'`) to exporter class instances (`new OtelExporter()`)
 
 See the [exporters documentation](/docs/v1/observability/tracing/overview#exporters) for all available exporters.
@@ -129,7 +129,7 @@ export const mastra = new Mastra({
 import { Mastra } from '@mastra/core';
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from '@mastra/observability';
@@ -140,7 +140,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(),
+          new LocalExporter(),
           new CloudExporter(),
         ],
         spanOutputProcessors: [
@@ -155,7 +155,7 @@ export const mastra = new Mastra({
 Key changes:
 1. Install `@mastra/observability` package
 2. Import `Observability`, exporters, and processors from `@mastra/observability`
-3. Use explicit `configs` with `DefaultExporter`, `CloudExporter`, and `SensitiveDataFilter`
+3. Use explicit `configs` with `LocalExporter`, `CloudExporter`, and `SensitiveDataFilter`
 
 ## Changed
 
@@ -183,7 +183,7 @@ To migrate, use `new Observability()` with explicit exporters and processors.
 ```diff
 + import {
 +   Observability,
-+   DefaultExporter,
++   LocalExporter,
 +   CloudExporter,
 +   SensitiveDataFilter,
 + } from '@mastra/observability';
@@ -196,7 +196,7 @@ To migrate, use `new Observability()` with explicit exporters and processors.
 +     configs: {
 +       default: {
 +         serviceName: 'mastra',
-+         exporters: [new DefaultExporter(), new CloudExporter()],
++         exporters: [new LocalExporter(), new CloudExporter()],
 +         spanOutputProcessors: [new SensitiveDataFilter()],
 +       },
 +     },
@@ -282,7 +282,7 @@ Simply remove the `instrumentation.mjs` file and configure observability in your
 // src/mastra/index.ts
 import {
   Observability,
-  DefaultExporter,
+  LocalExporter,
   CloudExporter,
   SensitiveDataFilter,
 } from '@mastra/observability';
@@ -292,7 +292,7 @@ export const mastra = new Mastra({
     configs: {
       default: {
         serviceName: 'mastra',
-        exporters: [new DefaultExporter(), new CloudExporter()],
+        exporters: [new LocalExporter(), new CloudExporter()],
         spanOutputProcessors: [new SensitiveDataFilter()],
       },
     },

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -213,7 +213,7 @@ Visit the [Observability documentation](/docs/v1/observability/overview) to lear
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
-import { Observability, DefaultExporter } from "@mastra/observability";
+import { Observability, LocalExporter } from "@mastra/observability";
 
 export const mastra = new Mastra({
   storage: new LibSQLStore({
@@ -224,7 +224,7 @@ export const mastra = new Mastra({
     configs: {
       default: {
         serviceName: "my-app",
-        exporters: [new DefaultExporter()],
+        exporters: [new LocalExporter()],
       },
     },
   }),

--- a/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
@@ -118,7 +118,7 @@ The bridge can be used alongside exporters. The bridge handles OTEL context, whi
 
 ```typescript
 import { Mastra } from "@mastra/core";
-import { Observability, DefaultExporter } from "@mastra/observability";
+import { Observability, LocalExporter } from "@mastra/observability";
 import { OtelBridge } from "@mastra/otel-bridge";
 import { LangfuseExporter } from "@mastra/langfuse";
 
@@ -129,7 +129,7 @@ const mastra = new Mastra({
         serviceName: "my-service",
         bridge: new OtelBridge(), // Handles OTEL context
         exporters: [
-          new DefaultExporter(), // Studio access
+          new LocalExporter(), // Studio access
           new LangfuseExporter({
             // Additional destination
             publicKey: process.env.LANGFUSE_PUBLIC_KEY,

--- a/docs/src/content/en/reference/observability/tracing/configuration.mdx
+++ b/docs/src/content/en/reference/observability/tracing/configuration.mdx
@@ -24,7 +24,7 @@ interface ObservabilityRegistryConfig {
     {
       name: "default",
       type: "{ enabled?: boolean }",
-      description: "Enable default configuration with DefaultExporter and CloudExporter",
+      description: "Enable default configuration with LocalExporter and CloudExporter",
       required: false,
     },
     {
@@ -285,7 +285,7 @@ Shuts down all observability instances and clears the registry.
 
 ### Exporters
 
-- [DefaultExporter](/reference/v1/observability/tracing/exporters/default-exporter) - Storage configuration
+- [LocalExporter](/reference/v1/observability/tracing/exporters/local-exporter) - Storage configuration
 - [CloudExporter](/reference/v1/observability/tracing/exporters/cloud-exporter) - Cloud setup
 - [Braintrust](/reference/v1/observability/tracing/exporters/braintrust) - Braintrust integration
 - [Langfuse](/reference/v1/observability/tracing/exporters/langfuse) - Langfuse integration

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -174,7 +174,7 @@ const customExporter = new CloudExporter({
 
 ### Other Exporters
 
-- [DefaultExporter](/reference/v1/observability/tracing/exporters/default-exporter) - Storage persistence
+- [LocalExporter](/reference/v1/observability/tracing/exporters/local-exporter) - Storage persistence
 - [ConsoleExporter](/reference/v1/observability/tracing/exporters/console-exporter) - Debug output
 - [Langfuse](/reference/v1/observability/tracing/exporters/langfuse) - Langfuse integration
 - [Braintrust](/reference/v1/observability/tracing/exporters/braintrust) - Braintrust integration

--- a/docs/src/content/en/reference/observability/tracing/exporters/console-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/console-exporter.mdx
@@ -176,7 +176,7 @@ const exporterWithLogger = new ConsoleExporter({
 
 ### Other Exporters
 
-- [DefaultExporter](/reference/v1/observability/tracing/exporters/default-exporter) - Storage persistence
+- [LocalExporter](/reference/v1/observability/tracing/exporters/local-exporter) - Storage persistence
 - [CloudExporter](/reference/v1/observability/tracing/exporters/cloud-exporter) - Mastra Cloud
 - [Langfuse](/reference/v1/observability/tracing/exporters/langfuse) - Langfuse integration
 - [Braintrust](/reference/v1/observability/tracing/exporters/braintrust) - Braintrust integration

--- a/docs/src/content/en/reference/observability/tracing/exporters/local-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/local-exporter.mdx
@@ -1,37 +1,39 @@
 ---
-title: "Reference: DefaultExporter | Observability"
-description: API reference for the DefaultExporter
+title: "Reference: LocalExporter | Observability"
+description: API reference for the LocalExporter
 packages:
   - "@mastra/observability"
 ---
 
 import PropertiesTable from "@site/src/components/PropertiesTable";
 
-# DefaultExporter
+# LocalExporter
 
 Persists traces to Mastra's configured storage with automatic batching and retry logic.
+
+> **Note:** `LocalExporter` was previously named `DefaultExporter`. The old name is still available as an alias for backward compatibility but is deprecated.
 
 ## Constructor
 
 ```typescript
-new DefaultExporter(config?: DefaultExporterConfig)
+new LocalExporter(config?: LocalExporterConfig)
 ```
 
 <PropertiesTable
   props={[
     {
       name: "config",
-      type: "DefaultExporterConfig",
+      type: "LocalExporterConfig",
       description: "Batching and configuration options",
       required: false,
     },
   ]}
 />
 
-## DefaultExporterConfig
+## LocalExporterConfig
 
 ```typescript
-interface DefaultExporterConfig extends BaseExporterConfig {
+interface LocalExporterConfig extends BaseExporterConfig {
   /** Maximum number of spans per batch. Default: 1000 */
   maxBatchSize?: number;
 
@@ -71,7 +73,7 @@ type TracingStorageStrategy = "realtime" | "batch-with-updates" | "insert-only";
 ## Properties
 
 ```typescript
-readonly name = 'mastra-default-observability-exporter';
+readonly name = 'mastra-local-observability-exporter';
 ```
 
 ## Methods
@@ -173,13 +175,13 @@ For `batch-with-updates` strategy:
 ## Usage
 
 ```typescript
-import { DefaultExporter } from "@mastra/observability";
+import { LocalExporter } from "@mastra/observability";
 
 // Default configuration
-const exporter = new DefaultExporter();
+const exporter = new LocalExporter();
 
 // Custom batching configuration
-const customExporter = new DefaultExporter({
+const customExporter = new LocalExporter({
   maxBatchSize: 500,
   maxBatchWaitMs: 2000,
   strategy: "batch-with-updates",

--- a/docs/src/content/en/reference/observability/tracing/instances.mdx
+++ b/docs/src/content/en/reference/observability/tracing/instances.mdx
@@ -161,6 +161,6 @@ class CustomObservabilityInstance extends BaseObservabilityInstance {
 
 ### Exporters
 
-- [DefaultExporter](/reference/v1/observability/tracing/exporters/default-exporter) - Storage persistence
+- [LocalExporter](/reference/v1/observability/tracing/exporters/local-exporter) - Storage persistence
 - [CloudExporter](/reference/v1/observability/tracing/exporters/cloud-exporter) - Mastra Cloud integration
 - [ConsoleExporter](/reference/v1/observability/tracing/exporters/console-exporter) - Debug output

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -391,8 +391,8 @@ const sidebars = {
                 },
                 {
                   type: "doc",
-                  id: "observability/tracing/exporters/default-exporter",
-                  label: "DefaultExporter",
+                  id: "observability/tracing/exporters/local-exporter",
+                  label: "LocalExporter",
                 },
                 {
                   type: "doc",

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -559,6 +559,16 @@
       "source": "/examples/v1",
       "destination": "/docs/v1/getting-started/start",
       "permanent": true
+    },
+    {
+      "source": "/docs/v1/observability/tracing/exporters/default",
+      "destination": "/docs/v1/observability/tracing/exporters/local",
+      "permanent": true
+    },
+    {
+      "source": "/reference/v1/observability/tracing/exporters/default-exporter",
+      "destination": "/reference/v1/observability/tracing/exporters/local-exporter",
+      "permanent": true
     }
   ]
 }

--- a/e2e-tests/client-js/_test-utils/src/server-setup.ts
+++ b/e2e-tests/client-js/_test-utils/src/server-setup.ts
@@ -80,7 +80,7 @@ export function createTestServerSetup(config: TestServerSetupConfig) {
       { LibSQLStore },
       { MastraServer },
       { registerApiRoute },
-      { Observability, DefaultExporter },
+      { Observability, LocalExporter },
     ] = await Promise.all([
       import('@mastra/core/mastra'),
       import('@mastra/core/agent'),
@@ -116,7 +116,7 @@ export function createTestServerSetup(config: TestServerSetupConfig) {
           default: {
             serviceName,
             exporters: [
-              new DefaultExporter(), // Persists traces to storage
+              new LocalExporter(), // Persists traces to storage
             ],
           },
         },

--- a/e2e-tests/no-bundling/template/src/mastra/index.ts
+++ b/e2e-tests/no-bundling/template/src/mastra/index.ts
@@ -1,7 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { weatherWorkflow } from './workflows/weather-workflow';
 import { weatherAgent } from './agents/weather-agent';
 import { toolCallAppropriatenessScorer, completenessScorer, translationScorer } from './scorers/weather-scorer';
@@ -24,7 +24,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/examples/agent-v6/src/mastra/index.ts
+++ b/examples/agent-v6/src/mastra/index.ts
@@ -1,7 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { weatherAgent, weatherToolLoopAgent } from './agents';
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 
 const storage = new LibSQLStore({
   id: 'mastra-storage',
@@ -27,7 +27,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -1,7 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 
 import { agentThatHarassesYou, chefAgent, chefAgentResponses, dynamicAgent, evalAgent } from './agents/index';
 import { myMcpServer, myMcpServerTwo } from './mcp/server';
@@ -102,7 +102,7 @@ const config = {
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/observability/mastra/README.md
+++ b/observability/mastra/README.md
@@ -12,7 +12,7 @@ npm install @mastra/observability
 
 ```typescript
 import { Mastra } from '@mastra/core';
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 
 export const mastra = new Mastra({
   observability: new Observability({
@@ -20,7 +20,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'my-app',
         exporters: [
-          new DefaultExporter(), // Persists traces for Mastra Studio
+          new LocalExporter(), // Persists traces for Mastra Studio
           new CloudExporter(), // Sends to Mastra Cloud
         ],
         spanOutputProcessors: [new SensitiveDataFilter()],
@@ -29,6 +29,8 @@ export const mastra = new Mastra({
   }),
 });
 ```
+
+> **Note:** `DefaultExporter` is still available as an alias for backward compatibility but is deprecated. Please use `LocalExporter` instead.
 
 ## Features
 

--- a/observability/mastra/src/config.ts
+++ b/observability/mastra/src/config.ts
@@ -88,7 +88,7 @@ export interface ObservabilityInstanceConfig {
 export interface ObservabilityRegistryConfig {
   /**
    * Enables default exporters, with sampling: always, and sensitive data filtering
-   * @deprecated Use explicit `configs` with DefaultExporter, CloudExporter, and SensitiveDataFilter instead.
+   * @deprecated Use explicit `configs` with LocalExporter, CloudExporter, and SensitiveDataFilter instead.
    * This option will be removed in a future version.
    */
   default?: {

--- a/observability/mastra/src/default.ts
+++ b/observability/mastra/src/default.ts
@@ -11,7 +11,7 @@ import type {
 } from '@mastra/core/observability';
 import { SamplingStrategyType, observabilityRegistryConfigSchema, observabilityConfigValueSchema } from './config';
 import type { ObservabilityInstanceConfig, ObservabilityRegistryConfig } from './config';
-import { CloudExporter, DefaultExporter } from './exporters';
+import { CloudExporter, LocalExporter, DefaultExporter } from './exporters';
 import { BaseObservabilityInstance, DefaultObservabilityInstance } from './instances';
 import { ObservabilityRegistry } from './registry';
 import { SensitiveDataFilter } from './span_processors';
@@ -83,7 +83,7 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
     if (config.default?.enabled) {
       console.warn(
         '[Mastra Observability] The "default: { enabled: true }" configuration is deprecated and will be removed in a future version. ' +
-          'Please use explicit configs with DefaultExporter, CloudExporter, and SensitiveDataFilter instead. ' +
+          'Please use explicit configs with LocalExporter, CloudExporter, and SensitiveDataFilter instead. ' +
           'See https://mastra.ai/docs/observability/tracing/overview for the recommended configuration.',
       );
 
@@ -91,7 +91,7 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
         serviceName: 'mastra',
         name: 'default',
         sampling: { type: SamplingStrategyType.ALWAYS },
-        exporters: [new DefaultExporter(), new CloudExporter()],
+        exporters: [new LocalExporter(), new CloudExporter()],
         spanOutputProcessors: [new SensitiveDataFilter()],
       });
 

--- a/observability/mastra/src/exporters/default.test.ts
+++ b/observability/mastra/src/exporters/default.test.ts
@@ -261,7 +261,7 @@ describe('LocalExporter', () => {
         await expect(exporter.init({ mastra: mockMastraWithoutStorage })).resolves.not.toThrow();
 
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          'DefaultExporter disabled: Storage not available. Traces will not be persisted.',
+          'LocalExporter disabled: Storage not available. Traces will not be persisted.',
         );
       });
     });

--- a/observability/mastra/src/exporters/index.ts
+++ b/observability/mastra/src/exporters/index.ts
@@ -9,5 +9,9 @@ export * from './base';
 export { CloudExporter } from './cloud';
 export type { CloudExporterConfig } from './cloud';
 export * from './console';
-export * from './default';
+
+// Local exporter (formerly DefaultExporter)
+export { LocalExporter, DefaultExporter } from './default';
+export type { LocalExporterConfig, DefaultExporterConfig } from './default';
+
 export * from './test';

--- a/observability/mastra/src/registry.test.ts
+++ b/observability/mastra/src/registry.test.ts
@@ -9,7 +9,7 @@ import type {
 } from '@mastra/core/observability';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Observability } from './default';
-import { CloudExporter, DefaultExporter, TestExporter } from './exporters';
+import { CloudExporter, LocalExporter, TestExporter } from './exporters';
 import { BaseObservabilityInstance, DefaultObservabilityInstance } from './instances';
 import { SensitiveDataFilter } from './span_processors';
 
@@ -628,7 +628,7 @@ describe('Observability Registry', () => {
       const exporters = defaultInstance?.getExporters();
       expect(exporters).toHaveLength(2);
       console.log(exporters);
-      expect(exporters?.[0]).toBeInstanceOf(DefaultExporter);
+      expect(exporters?.[0]).toBeInstanceOf(LocalExporter);
       expect(exporters?.[1]).toBeInstanceOf(CloudExporter);
 
       // Verify processors

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -495,7 +495,7 @@ export const mastra = new Mastra()
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 ${addWorkflow ? `import { weatherWorkflow } from './workflows/weather-workflow';` : ''}
 ${addAgent ? `import { weatherAgent } from './agents/weather-agent';` : ''}
 ${addScorers ? `import { toolCallAppropriatenessScorer, completenessScorer, translationScorer } from './scorers/weather-scorer';` : ''}
@@ -516,7 +516,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/packages/codemod/src/codemods/v1/mastra-core-imports.ts
+++ b/packages/codemod/src/codemods/v1/mastra-core-imports.ts
@@ -47,7 +47,8 @@ const EXPORT_TO_SUBPATH: Record<string, string> = {
   registerApiRoute: '@mastra/core/server',
 
   // Tracing
-  DefaultExporter: '@mastra/observability',
+  LocalExporter: '@mastra/observability',
+  DefaultExporter: '@mastra/observability', // Deprecated alias for LocalExporter
   CloudExporter: '@mastra/observability',
 
   // Streaming

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -144,14 +144,14 @@ export interface Config<
    *
    * @example
    * ```typescript
-   * import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+   * import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
    *
    * new Mastra({
    *   observability: new Observability({
    *     configs: {
    *       default: {
    *         serviceName: 'mastra',
-   *         exporters: [new DefaultExporter(), new CloudExporter()],
+   *         exporters: [new LocalExporter(), new CloudExporter()],
    *         spanOutputProcessors: [new SensitiveDataFilter()],
    *       },
    *     },
@@ -408,7 +408,7 @@ export class Mastra<
    *   }),
    *   logger: new PinoLogger({ name: 'MyApp' }),
    *   observability: new Observability({
-   *     configs: { default: { serviceName: 'mastra', exporters: [new DefaultExporter()] } },
+   *     configs: { default: { serviceName: 'mastra', exporters: [new LocalExporter()] } },
    *   }),
    * });
    * ```
@@ -479,8 +479,8 @@ export class Mastra<
       } else {
         this.#logger?.warn(
           'Observability configuration error: Expected an Observability instance, but received a config object. ' +
-            'Import and instantiate: import { Observability, DefaultExporter } from "@mastra/observability"; ' +
-            'then pass: observability: new Observability({ configs: { default: { serviceName: "mastra", exporters: [new DefaultExporter()] } } }). ' +
+            'Import and instantiate: import { Observability, LocalExporter } from "@mastra/observability"; ' +
+            'then pass: observability: new Observability({ configs: { default: { serviceName: "mastra", exporters: [new LocalExporter()] } } }). ' +
             'Observability has been disabled.',
         );
         this.#observability = new NoOpObservability();

--- a/packages/core/src/storage/domains/observability/base.ts
+++ b/packages/core/src/storage/domains/observability/base.ts
@@ -34,7 +34,7 @@ export class ObservabilityStorage extends StorageDomain {
   }
 
   /**
-   * Provides hints for tracing strategy selection by the DefaultExporter.
+   * Provides hints for tracing strategy selection by the LocalExporter.
    * Storage adapters can override this to specify their preferred and supported strategies.
    */
   public get tracingStrategy(): {

--- a/templates/template-ad-copy-from-content/src/mastra/index.ts
+++ b/templates/template-ad-copy-from-content/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -35,7 +35,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-browsing-agent/src/mastra/index.ts
+++ b/templates/template-browsing-agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { PinoLogger } from '@mastra/loggers';
@@ -20,7 +20,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-coding-agent/src/mastra/index.ts
+++ b/templates/template-coding-agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { PinoLogger } from '@mastra/loggers';
@@ -16,7 +16,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-csv-to-questions/src/mastra/index.ts
+++ b/templates/template-csv-to-questions/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -28,7 +28,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-deep-research/src/mastra/index.ts
+++ b/templates/template-deep-research/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { researchWorkflow } from './workflows/researchWorkflow';
@@ -27,7 +27,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-docs-chatbot/apps/agent/src/mastra/index.ts
+++ b/templates/template-docs-chatbot/apps/agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { registerApiRoute } from '@mastra/core/server';
 import { PinoLogger } from '@mastra/loggers';
@@ -44,7 +44,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-flash-cards-from-pdf/src/mastra/index.ts
+++ b/templates/template-flash-cards-from-pdf/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -35,7 +35,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-google-sheets/src/mastra/index.ts
+++ b/templates/template-google-sheets/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { financialModelingAgent } from './agents/financial-modeling-agent';
@@ -91,7 +91,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-meeting-scheduler/src/mastra/index.ts
+++ b/templates/template-meeting-scheduler/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -39,7 +39,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-pdf-questions/src/mastra/index.ts
+++ b/templates/template-pdf-questions/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -28,7 +28,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-pdf-to-audio/src/mastra/index.ts
+++ b/templates/template-pdf-to-audio/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -27,7 +27,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/template-text-to-sql/src/mastra/index.ts
+++ b/templates/template-text-to-sql/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { LibSQLStore } from '@mastra/libsql';
 import { PinoLogger } from '@mastra/loggers';
@@ -25,7 +25,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [

--- a/templates/weather-agent/src/mastra/index.ts
+++ b/templates/weather-agent/src/mastra/index.ts
@@ -1,4 +1,4 @@
-import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { Observability, LocalExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
@@ -24,7 +24,7 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'mastra',
         exporters: [
-          new DefaultExporter(), // Persists traces to storage for Mastra Studio
+          new LocalExporter(), // Persists traces to storage for Mastra Studio
           new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [


### PR DESCRIPTION
## Description

`DefaultExporter` doesn't mean anything to me. `LocalExporter` means more.

`DefaultExporter` still exists as alias to `LocalExporter`

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the local observability exporter from `DefaultExporter` to `LocalExporter` for improved clarity.
  
* **Deprecations**
  * `DefaultExporter` remains as a deprecated alias for backward compatibility.

* **Documentation**
  * Updated all documentation and code examples to reference `LocalExporter`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->