### PR TITLE
feat(playground-ui): add ModelPicker component with shared model selection primitives

### DIFF
--- a/packages/playground-ui/src/domains/agents/components/create-agent/index.ts
+++ b/packages/playground-ui/src/domains/agents/components/create-agent/index.ts
@@ -1,0 +1,2 @@
+export { ModelPicker } from './model-picker';
+export type { ModelPickerProps } from './model-picker';

--- a/packages/playground-ui/src/domains/agents/components/create-agent/model-picker.tsx
+++ b/packages/playground-ui/src/domains/agents/components/create-agent/model-picker.tsx
@@ -1,0 +1,96 @@
+import { useRef, useCallback } from 'react';
+import Spinner from '@/components/ui/spinner';
+import { Alert, AlertDescription } from '@/ds/components/Alert';
+import { cleanProviderId } from '../agent-metadata/utils';
+import { Provider } from '@mastra/client-js';
+import {
+  ProviderSelect,
+  ModelSelect,
+  ModelSelectHandle,
+  ProviderNotConnectedAlert,
+  useModelPickerData,
+} from '../model-picker';
+
+export interface ModelPickerProps {
+  value: { provider: string; name: string };
+  onChange: (value: { provider: string; name: string }) => void;
+  error?: string;
+}
+
+export const ModelPicker = ({ value, onChange, error }: ModelPickerProps) => {
+  const modelSelectRef = useRef<ModelSelectHandle>(null);
+  const providerInputRef = useRef<HTMLInputElement>(null);
+
+  const { providers, providersLoading, allModels, currentModelProvider, currentProvider } = useModelPickerData(
+    value.provider,
+  );
+
+  const handleProviderSelect = useCallback(
+    (provider: Provider) => {
+      const cleanedProvider = cleanProviderId(provider.id);
+
+      // Clear model when switching providers
+      if (provider.id !== currentModelProvider) {
+        onChange({ provider: cleanedProvider, name: '' });
+      }
+
+      // Auto-focus model input if provider is connected
+      if (provider.connected) {
+        setTimeout(() => {
+          modelSelectRef.current?.focus();
+        }, 100);
+      }
+    },
+    [currentModelProvider, onChange],
+  );
+
+  const handleModelSelect = useCallback(
+    (modelId: string) => {
+      const providerToUse = currentModelProvider || value.provider;
+      if (modelId && providerToUse) {
+        onChange({ provider: providerToUse, name: modelId });
+      }
+    },
+    [currentModelProvider, value.provider, onChange],
+  );
+
+  const handleShiftTab = useCallback(() => {
+    providerInputRef.current?.focus();
+  }, []);
+
+  if (providersLoading) {
+    return (
+      <div className="flex items-center gap-2">
+        <Spinner />
+        <span className="text-sm text-gray-500">Loading providers...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="@container">
+      <div className="flex flex-col @xs:flex-row items-stretch @xs:items-center gap-2 w-full">
+        <ProviderSelect providers={providers} selectedProvider={value.provider} onSelect={handleProviderSelect} />
+
+        <ModelSelect
+          ref={modelSelectRef}
+          allModels={allModels}
+          currentProvider={currentModelProvider}
+          selectedModel={value.name}
+          onSelect={handleModelSelect}
+          onShiftTab={handleShiftTab}
+        />
+      </div>
+
+      {currentProvider && <ProviderNotConnectedAlert provider={currentProvider} />}
+
+      {error && (
+        <div className="pt-2 p-2">
+          <Alert variant="destructive">
+            <AlertDescription as="p">{error}</AlertDescription>
+          </Alert>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/playground-ui/src/domains/agents/components/model-picker/index.ts
+++ b/packages/playground-ui/src/domains/agents/components/model-picker/index.ts
@@ -1,0 +1,11 @@
+export { ProviderSelect } from './provider-select';
+export type { ProviderSelectProps } from './provider-select';
+
+export { ModelSelect } from './model-select';
+export type { ModelSelectProps, ModelSelectHandle } from './model-select';
+
+export { ProviderNotConnectedAlert } from './provider-not-connected-alert';
+export type { ProviderNotConnectedAlertProps } from './provider-not-connected-alert';
+
+export { useModelPickerData, useAllModels, useFilteredProviders, useFilteredModels } from './use-model-picker';
+export type { ModelInfo } from './use-model-picker';

--- a/packages/playground-ui/src/domains/agents/components/model-picker/model-select.tsx
+++ b/packages/playground-ui/src/domains/agents/components/model-picker/model-select.tsx
@@ -1,0 +1,175 @@
+import { useState, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useFilteredModels, ModelInfo } from './use-model-picker';
+
+export interface ModelSelectProps {
+  allModels: ModelInfo[];
+  currentProvider: string;
+  selectedModel: string;
+  onSelect: (modelId: string) => void;
+  onShiftTab?: () => void;
+  className?: string;
+}
+
+export interface ModelSelectHandle {
+  focus: () => void;
+}
+
+export const ModelSelect = forwardRef<ModelSelectHandle, ModelSelectProps>(
+  ({ allModels, currentProvider, selectedModel, onSelect, onShiftTab, className = 'w-full @xs:w-3/5' }, ref) => {
+    const [search, setSearch] = useState('');
+    const [isSearching, setIsSearching] = useState(false);
+    const [showSuggestions, setShowSuggestions] = useState(false);
+    const [highlightedIndex, setHighlightedIndex] = useState(-1);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const filteredModels = useFilteredModels(allModels, currentProvider, search, isSearching);
+
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputRef.current?.focus();
+        inputRef.current?.click();
+      },
+    }));
+
+    const handleSelect = useCallback(
+      (modelId: string) => {
+        setShowSuggestions(false);
+        setSearch('');
+        setIsSearching(false);
+        onSelect(modelId);
+      },
+      [onSelect],
+    );
+
+    const scrollToHighlighted = useCallback(() => {
+      setTimeout(() => {
+        const element = document.querySelector('[data-model-highlighted="true"]');
+        element?.scrollIntoView({ block: 'nearest' });
+      }, 0);
+    }, []);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Tab' && e.shiftKey) {
+          e.preventDefault();
+          onShiftTab?.();
+          return;
+        }
+
+        switch (e.key) {
+          case 'ArrowDown':
+            e.preventDefault();
+            setHighlightedIndex(prev => (prev < filteredModels.length - 1 ? prev + 1 : prev));
+            scrollToHighlighted();
+            break;
+          case 'ArrowUp':
+            e.preventDefault();
+            setHighlightedIndex(prev => (prev > 0 ? prev - 1 : filteredModels.length - 1));
+            scrollToHighlighted();
+            break;
+          case 'Enter':
+            e.preventDefault();
+            if (highlightedIndex >= 0 && highlightedIndex < filteredModels.length) {
+              handleSelect(filteredModels[highlightedIndex].model);
+            } else if (isSearching && search.trim()) {
+              // Custom model ID support
+              handleSelect(search.trim());
+            }
+            break;
+          case 'Escape':
+            e.preventDefault();
+            setShowSuggestions(false);
+            setHighlightedIndex(-1);
+            setIsSearching(false);
+            setSearch('');
+            break;
+        }
+      },
+      [filteredModels, highlightedIndex, isSearching, search, handleSelect, onShiftTab, scrollToHighlighted],
+    );
+
+    const handleFocus = useCallback(() => {
+      if (!showSuggestions) {
+        setShowSuggestions(true);
+      }
+
+      const currentIndex = filteredModels.findIndex(m => m.model === selectedModel);
+      setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
+      scrollToHighlighted();
+    }, [showSuggestions, filteredModels, selectedModel, scrollToHighlighted]);
+
+    return (
+      <Popover
+        open={showSuggestions}
+        onOpenChange={open => {
+          setShowSuggestions(open);
+          if (!open) {
+            setSearch('');
+            setIsSearching(false);
+          }
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Input
+            aria-label="Search models"
+            spellCheck="false"
+            ref={inputRef}
+            className={className}
+            type="text"
+            value={isSearching ? search : selectedModel}
+            onChange={e => {
+              setSearch(e.target.value);
+              setIsSearching(true);
+              setHighlightedIndex(0);
+            }}
+            onClick={e => {
+              e.preventDefault();
+              if (!showSuggestions) {
+                setShowSuggestions(true);
+              }
+            }}
+            onFocus={handleFocus}
+            onKeyDown={handleKeyDown}
+            placeholder="Enter model name or select from suggestions..."
+          />
+        </PopoverTrigger>
+
+        {allModels.length > 0 && (
+          <PopoverContent
+            className="flex flex-col gap-0 w-[var(--radix-popover-trigger-width)] max-h-[calc(var(--radix-popover-content-available-height)-50px)] overflow-y-auto p-2"
+            onOpenAutoFocus={e => e.preventDefault()}
+          >
+            {filteredModels.length === 0 ? (
+              <div className="p-4 text-center text-sm text-muted-foreground">No models found</div>
+            ) : (
+              filteredModels.map((model, index) => {
+                const isHighlighted = index === highlightedIndex;
+                const isSelected = model.model === selectedModel;
+                return (
+                  <div
+                    key={`${model.provider}-${model.model}`}
+                    data-model-highlighted={isHighlighted}
+                    className={`flex items-center gap-2 px-4 py-3 cursor-pointer rounded hover:bg-surface5 ${
+                      isHighlighted ? 'outline outline-2 outline-blue-500' : ''
+                    } ${isSelected ? 'bg-surface5' : ''}`}
+                    onMouseDown={e => {
+                      e.preventDefault();
+                      handleSelect(model.model);
+                      inputRef.current?.blur();
+                    }}
+                  >
+                    {model.model}
+                  </div>
+                );
+              })
+            )}
+          </PopoverContent>
+        )}
+      </Popover>
+    );
+  },
+);
+
+ModelSelect.displayName = 'ModelSelect';

--- a/packages/playground-ui/src/domains/agents/components/model-picker/provider-not-connected-alert.tsx
+++ b/packages/playground-ui/src/domains/agents/components/model-picker/provider-not-connected-alert.tsx
@@ -1,0 +1,28 @@
+import { Alert, AlertDescription, AlertTitle } from '@/ds/components/Alert';
+import { Provider } from '@mastra/client-js';
+
+export interface ProviderNotConnectedAlertProps {
+  provider: Provider;
+}
+
+export const ProviderNotConnectedAlert = ({ provider }: ProviderNotConnectedAlertProps) => {
+  if (provider.connected) {
+    return null;
+  }
+
+  return (
+    <div className="pt-2 p-2">
+      <Alert variant="warning">
+        <AlertTitle as="h5">Provider not connected</AlertTitle>
+        <AlertDescription as="p">
+          Set the{' '}
+          <code className="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900/50 rounded">
+            {Array.isArray(provider.envVar) ? provider.envVar.join(', ') : provider.envVar}
+          </code>{' '}
+          environment {Array.isArray(provider.envVar) && provider.envVar.length > 1 ? 'variables' : 'variable'} to use
+          this provider.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+};

--- a/packages/playground-ui/src/domains/agents/components/model-picker/provider-select.tsx
+++ b/packages/playground-ui/src/domains/agents/components/model-picker/provider-select.tsx
@@ -1,0 +1,223 @@
+import { useState, useRef, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { Info } from 'lucide-react';
+import { ProviderLogo } from '../agent-metadata/provider-logo';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cleanProviderId } from '../agent-metadata/utils';
+import { Provider } from '@mastra/client-js';
+import { useFilteredProviders } from './use-model-picker';
+
+export interface ProviderSelectProps {
+  providers: Provider[];
+  selectedProvider: string;
+  onSelect: (provider: Provider) => void;
+  className?: string;
+}
+
+export const ProviderSelect = ({
+  providers,
+  selectedProvider,
+  onSelect,
+  className = 'w-full @xs:w-2/5',
+}: ProviderSelectProps) => {
+  const [search, setSearch] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const currentProvider = cleanProviderId(selectedProvider);
+  const filteredProviders = useFilteredProviders(providers, search, isSearching);
+  const selectedProviderData = providers.find(p => p.id === currentProvider);
+
+  const handleSelect = useCallback(
+    (provider: Provider) => {
+      setSearch('');
+      setIsSearching(false);
+      setShowSuggestions(false);
+      setHighlightedIndex(-1);
+      onSelect(provider);
+    },
+    [onSelect],
+  );
+
+  const scrollToHighlighted = useCallback(() => {
+    setTimeout(() => {
+      const element = document.querySelector('[data-provider-highlighted="true"]');
+      element?.scrollIntoView({ block: 'nearest' });
+    }, 0);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isSearching && e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+        setIsSearching(true);
+        setSearch('');
+        setHighlightedIndex(0);
+        return;
+      }
+
+      if (!showSuggestions) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex(prev => (prev < filteredProviders.length - 1 ? prev + 1 : 0));
+          scrollToHighlighted();
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex(prev => (prev > 0 ? prev - 1 : filteredProviders.length - 1));
+          scrollToHighlighted();
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < filteredProviders.length) {
+            handleSelect(filteredProviders[highlightedIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setIsSearching(false);
+          setSearch('');
+          setHighlightedIndex(-1);
+          setShowSuggestions(false);
+          break;
+      }
+    },
+    [isSearching, showSuggestions, filteredProviders, highlightedIndex, handleSelect, scrollToHighlighted],
+  );
+
+  const handleFocus = useCallback(() => {
+    if (!showSuggestions) {
+      setShowSuggestions(true);
+      const currentIndex = filteredProviders.findIndex(p => p.id === currentProvider);
+      setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
+      scrollToHighlighted();
+    }
+  }, [showSuggestions, filteredProviders, currentProvider, scrollToHighlighted]);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (!showSuggestions) {
+        setShowSuggestions(true);
+        const currentIndex = filteredProviders.findIndex(p => p.id === currentProvider);
+        setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
+      }
+    },
+    [showSuggestions, filteredProviders, currentProvider],
+  );
+
+  return (
+    <Popover
+      open={showSuggestions}
+      onOpenChange={open => {
+        setShowSuggestions(open);
+        if (!open) {
+          setSearch('');
+          setIsSearching(false);
+        }
+      }}
+    >
+      <PopoverTrigger asChild>
+        <div className={`relative ${className}`}>
+          {!isSearching && currentProvider && (
+            <>
+              <div className="absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none z-10">
+                <div className="relative">
+                  <ProviderLogo providerId={currentProvider} size={16} />
+                  {selectedProviderData && (
+                    <div
+                      className={`absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full ${
+                        selectedProviderData.connected ? 'bg-green-500' : 'bg-red-500'
+                      }`}
+                      title={selectedProviderData.connected ? 'Connected' : 'Not connected'}
+                    />
+                  )}
+                </div>
+              </div>
+              {selectedProviderData?.docUrl && (
+                <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">
+                  <Info
+                    className="w-3.5 h-3.5 text-gray-500 hover:text-gray-700 cursor-pointer"
+                    onClick={e => {
+                      e.stopPropagation();
+                      window.open(selectedProviderData.docUrl, '_blank');
+                    }}
+                  />
+                </div>
+              )}
+            </>
+          )}
+          <Input
+            aria-label="Search providers"
+            spellCheck="false"
+            ref={inputRef}
+            className={`w-full ${!isSearching && currentProvider ? 'pl-8 pr-8' : ''}`}
+            type="text"
+            value={isSearching ? search : selectedProviderData?.name || currentProvider || ''}
+            onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
+            onChange={e => {
+              setIsSearching(true);
+              setSearch(e.target.value);
+              setHighlightedIndex(0);
+            }}
+            onClick={handleClick}
+            placeholder="Search providers..."
+          />
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        onOpenAutoFocus={e => e.preventDefault()}
+        className="flex flex-col gap-0.5 w-[var(--radix-popover-trigger-width)] max-h-[300px] overflow-y-auto p-2"
+      >
+        {filteredProviders.length === 0 ? (
+          <div className="text-sm text-gray-500 p-2">No providers found</div>
+        ) : (
+          filteredProviders.map((provider, index) => {
+            const isSelected = provider.id === currentProvider;
+            const isHighlighted = index === highlightedIndex;
+
+            return (
+              <div
+                key={provider.id}
+                data-provider-highlighted={isHighlighted}
+                className={`flex items-center gap-2 cursor-pointer hover:bg-surface5 px-3 py-4 rounded ${
+                  isHighlighted ? 'outline outline-2 outline-blue-500' : ''
+                } ${isSelected ? 'bg-surface5' : ''}`}
+                onClick={() => handleSelect(provider)}
+              >
+                <div className="relative">
+                  <ProviderLogo providerId={provider.id} size={20} />
+                  <div
+                    className={`absolute -top-1 -right-1 w-2 h-2 rounded-full ${
+                      provider.connected ? 'bg-green-500' : 'bg-red-500'
+                    }`}
+                    title={provider.connected ? 'Connected' : 'Not connected'}
+                  />
+                </div>
+                <div className="flex-1">
+                  <div className="text-sm font-medium">{provider.name}</div>
+                </div>
+                <Info
+                  className="w-4 h-4 text-gray-500 hover:text-gray-700 cursor-pointer"
+                  onClick={e => {
+                    e.stopPropagation();
+                    window.open(provider.docUrl || '#', '_blank');
+                  }}
+                />
+              </div>
+            );
+          })
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+// Export ref handle for parent components to focus the input
+export const useProviderSelectRef = () => {
+  return useRef<HTMLInputElement>(null);
+};

--- a/packages/playground-ui/src/domains/agents/components/model-picker/use-model-picker.ts
+++ b/packages/playground-ui/src/domains/agents/components/model-picker/use-model-picker.ts
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import { useAgentsModelProviders } from '../../hooks/use-agents-model-providers';
+import { cleanProviderId } from '../agent-metadata/utils';
+import { Provider } from '@mastra/client-js';
+
+export interface ModelInfo {
+  provider: string;
+  providerName: string;
+  model: string;
+}
+
+/**
+ * Hook to get all models flattened with their provider info
+ */
+export const useAllModels = (providers: Provider[]): ModelInfo[] => {
+  return useMemo(() => {
+    return providers.flatMap(provider =>
+      provider.models.map(model => ({
+        provider: provider.id,
+        providerName: provider.name,
+        model: model,
+      })),
+    );
+  }, [providers]);
+};
+
+/**
+ * Hook to filter and sort providers based on search and connection status
+ */
+export const useFilteredProviders = (providers: Provider[], searchTerm: string, isSearching: boolean): Provider[] => {
+  return useMemo(() => {
+    const term = isSearching ? searchTerm : '';
+
+    let filtered = providers;
+    if (term) {
+      filtered = providers.filter(
+        p => p.id.toLowerCase().includes(term.toLowerCase()) || p.name.toLowerCase().includes(term.toLowerCase()),
+      );
+    }
+
+    // Define popular providers in order
+    const popularProviders = ['openai', 'anthropic', 'google', 'openrouter', 'netlify'];
+
+    const getPopularityIndex = (providerId: string) => {
+      const cleanId = providerId.toLowerCase().split('.')[0];
+      const index = popularProviders.indexOf(cleanId);
+      return index === -1 ? popularProviders.length : index;
+    };
+
+    // Sort by: 1) connection status, 2) popularity, 3) alphabetically
+    return [...filtered].sort((a, b) => {
+      if (a.connected && !b.connected) return -1;
+      if (!a.connected && b.connected) return 1;
+
+      const aPopularity = getPopularityIndex(a.id);
+      const bPopularity = getPopularityIndex(b.id);
+      if (aPopularity !== bPopularity) {
+        return aPopularity - bPopularity;
+      }
+
+      return a.name.localeCompare(b.name);
+    });
+  }, [providers, searchTerm, isSearching]);
+};
+
+/**
+ * Hook to filter models by provider and search term
+ */
+export const useFilteredModels = (
+  allModels: ModelInfo[],
+  currentProvider: string,
+  searchTerm: string,
+  isSearching: boolean,
+): ModelInfo[] => {
+  return useMemo(() => {
+    let filtered = allModels;
+
+    if (currentProvider) {
+      filtered = filtered.filter(m => m.provider === currentProvider);
+    }
+
+    if (isSearching && searchTerm) {
+      filtered = filtered.filter(m => m.model.toLowerCase().includes(searchTerm.toLowerCase()));
+    }
+
+    return [...filtered].sort((a, b) => a.model.localeCompare(b.model));
+  }, [allModels, searchTerm, currentProvider, isSearching]);
+};
+
+/**
+ * Combined hook for model picker data
+ */
+export const useModelPickerData = (selectedProvider: string) => {
+  const { data: dataProviders, isLoading: providersLoading } = useAgentsModelProviders();
+  const providers = dataProviders?.providers || [];
+  const currentModelProvider = cleanProviderId(selectedProvider);
+  const allModels = useAllModels(providers);
+  const currentProvider = providers.find(p => p.id === currentModelProvider);
+
+  return {
+    providers,
+    providersLoading,
+    allModels,
+    currentModelProvider,
+    currentProvider,
+  };
+};


### PR DESCRIPTION
## Summary

- Create reusable `ProviderSelect` and `ModelSelect` components for model selection UI
- Add shared hooks for provider/model filtering and sorting logic
- Add `ProviderNotConnectedAlert` component for disconnected provider warnings  
- Create simplified `ModelPicker` as a controlled component for the create-agent flow

## New Files

### Shared Components (`components/model-picker/`)

| File | Purpose |
|------|---------|
| `use-model-picker.ts` | Shared hooks for filtering/sorting providers and models |
| `provider-select.tsx` | Reusable provider dropdown with connection status, search, keyboard nav |
| `model-select.tsx` | Reusable model dropdown with search, keyboard nav, custom model support |
| `provider-not-connected-alert.tsx` | Alert component for disconnected providers |

### ModelPicker (`components/create-agent/`)

| File | Purpose |
|------|---------|
| `model-picker.tsx` | Simple controlled component using shared components (~90 lines) |

## Props Interface

```typescript
interface ModelPickerProps {
  value: { provider: string; name: string };
  onChange: (value: { provider: string; name: string }) => void;
  error?: string;
}
```

## Key Features

- Provider dropdown with connection status (green/red dot)
- Model dropdown filtered by selected provider
- Warning alert when provider not connected
- Custom model ID support
- Full keyboard navigation

## Design Decisions

- Shared components are simple and reusable (no API calls, no auto-save)
- `ModelPicker` is a thin wrapper composing shared components
- `AgentMetadataModelSwitcher` left unchanged (has complex behaviors like auto-save, reset context)