### PR TITLE
feat(storage): add AgentVersionsStorage domain implementation

### DIFF
--- a/packages/core/src/storage/domains/agent-versions/base.ts
+++ b/packages/core/src/storage/domains/agent-versions/base.ts
@@ -1,0 +1,179 @@
+import type { StorageAgentType, ThreadSortDirection } from '../../types';
+import { StorageDomain } from '../base';
+
+/**
+ * Represents a stored version of an agent configuration.
+ */
+export interface AgentVersion {
+  /** ULID identifier for this version */
+  id: string;
+  /** ID of the agent this version belongs to */
+  agentId: string;
+  /** Sequential version number (1, 2, 3, ...) */
+  versionNumber: number;
+  /** Optional vanity name for this version */
+  name?: string;
+  /** Full agent configuration snapshot */
+  snapshot: StorageAgentType;
+  /** Array of field names that changed from the previous version */
+  changedFields?: string[];
+  /** Optional message describing the changes */
+  changeMessage?: string;
+  /** When this version was created */
+  createdAt: Date;
+}
+
+/**
+ * Input for creating a new agent version.
+ */
+export interface CreateVersionInput {
+  /** ULID identifier for this version */
+  id: string;
+  /** ID of the agent this version belongs to */
+  agentId: string;
+  /** Sequential version number */
+  versionNumber: number;
+  /** Optional vanity name for this version */
+  name?: string;
+  /** Full agent configuration snapshot */
+  snapshot: StorageAgentType;
+  /** Array of field names that changed from the previous version */
+  changedFields?: string[];
+  /** Optional message describing the changes */
+  changeMessage?: string;
+}
+
+/**
+ * Sort direction for version listings.
+ */
+export type VersionSortDirection = ThreadSortDirection;
+
+/**
+ * Fields that can be used for ordering version listings.
+ */
+export type VersionOrderBy = 'versionNumber' | 'createdAt';
+
+/**
+ * Input for listing agent versions with pagination and sorting.
+ */
+export interface ListVersionsInput {
+  /** ID of the agent to list versions for */
+  agentId: string;
+  /** Page number (0-indexed) */
+  page?: number;
+  /** Number of items per page */
+  perPage?: number;
+  /** Sorting options */
+  orderBy?: {
+    field: VersionOrderBy;
+    direction: VersionSortDirection;
+  };
+}
+
+/**
+ * Output for listing agent versions with pagination info.
+ */
+export interface ListVersionsOutput {
+  /** Array of versions for the current page */
+  versions: AgentVersion[];
+  /** Total number of versions */
+  total: number;
+  /** Current page number */
+  page: number;
+  /** Items per page */
+  perPage: number;
+  /** Whether there are more pages */
+  hasMore: boolean;
+}
+
+const VERSION_ORDER_BY_SET: Record<VersionOrderBy, true> = {
+  versionNumber: true,
+  createdAt: true,
+};
+
+const VERSION_SORT_DIRECTION_SET: Record<VersionSortDirection, true> = {
+  ASC: true,
+  DESC: true,
+};
+
+/**
+ * Abstract base class for agent versions storage.
+ * Provides interface for storing and retrieving agent configuration versions.
+ */
+export abstract class AgentVersionsStorage extends StorageDomain {
+  constructor() {
+    super({
+      component: 'STORAGE',
+      name: 'AGENT_VERSIONS',
+    });
+  }
+
+  /**
+   * Creates a new version record for an agent.
+   * @param input - The version data to create
+   * @returns The created version with timestamp
+   */
+  abstract createVersion(input: CreateVersionInput): Promise<AgentVersion>;
+
+  /**
+   * Retrieves a version by its unique ID.
+   * @param id - The ULID of the version
+   * @returns The version if found, null otherwise
+   */
+  abstract getVersion(id: string): Promise<AgentVersion | null>;
+
+  /**
+   * Retrieves a version by agent ID and version number.
+   * @param agentId - The ID of the agent
+   * @param versionNumber - The sequential version number
+   * @returns The version if found, null otherwise
+   */
+  abstract getVersionByNumber(agentId: string, versionNumber: number): Promise<AgentVersion | null>;
+
+  /**
+   * Retrieves the latest (highest version number) version for an agent.
+   * @param agentId - The ID of the agent
+   * @returns The latest version if found, null otherwise
+   */
+  abstract getLatestVersion(agentId: string): Promise<AgentVersion | null>;
+
+  /**
+   * Lists versions for an agent with pagination and sorting.
+   * @param input - Pagination and filter options
+   * @returns Paginated list of versions
+   */
+  abstract listVersions(input: ListVersionsInput): Promise<ListVersionsOutput>;
+
+  /**
+   * Deletes a specific version by ID.
+   * @param id - The ULID of the version to delete
+   */
+  abstract deleteVersion(id: string): Promise<void>;
+
+  /**
+   * Deletes all versions for an agent.
+   * @param agentId - The ID of the agent
+   */
+  abstract deleteVersionsByAgentId(agentId: string): Promise<void>;
+
+  /**
+   * Counts the total number of versions for an agent.
+   * @param agentId - The ID of the agent
+   * @returns The count of versions
+   */
+  abstract countVersions(agentId: string): Promise<number>;
+
+  /**
+   * Parses orderBy input for consistent sorting behavior.
+   */
+  protected parseOrderBy(
+    orderBy?: ListVersionsInput['orderBy'],
+    defaultDirection: VersionSortDirection = 'DESC',
+  ): { field: VersionOrderBy; direction: VersionSortDirection } {
+    return {
+      field: orderBy?.field && orderBy.field in VERSION_ORDER_BY_SET ? orderBy.field : 'versionNumber',
+      direction:
+        orderBy?.direction && orderBy.direction in VERSION_SORT_DIRECTION_SET ? orderBy.direction : defaultDirection,
+    };
+  }
+}

--- a/packages/core/src/storage/domains/agent-versions/index.ts
+++ b/packages/core/src/storage/domains/agent-versions/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './inmemory';

--- a/packages/core/src/storage/domains/agent-versions/inmemory.ts
+++ b/packages/core/src/storage/domains/agent-versions/inmemory.ts
@@ -1,0 +1,160 @@
+import { normalizePerPage, calculatePagination } from '../../base';
+import type { InMemoryDB } from '../inmemory-db';
+import type {
+  AgentVersion,
+  CreateVersionInput,
+  ListVersionsInput,
+  ListVersionsOutput,
+  VersionOrderBy,
+  VersionSortDirection,
+} from './base';
+import { AgentVersionsStorage } from './base';
+
+export class InMemoryAgentVersionsStorage extends AgentVersionsStorage {
+  private db: InMemoryDB;
+
+  constructor({ db }: { db: InMemoryDB }) {
+    super();
+    this.db = db;
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    this.db.agentVersions.clear();
+  }
+
+  async createVersion(input: CreateVersionInput): Promise<AgentVersion> {
+    this.logger.debug(`InMemoryAgentVersionsStorage: createVersion called for agent ${input.agentId}`);
+
+    const version: AgentVersion = {
+      ...input,
+      createdAt: new Date(),
+    };
+
+    this.db.agentVersions.set(input.id, version);
+    return { ...version };
+  }
+
+  async getVersion(id: string): Promise<AgentVersion | null> {
+    this.logger.debug(`InMemoryAgentVersionsStorage: getVersion called for ${id}`);
+    const version = this.db.agentVersions.get(id);
+    return version ? { ...version } : null;
+  }
+
+  async getVersionByNumber(agentId: string, versionNumber: number): Promise<AgentVersion | null> {
+    this.logger.debug(
+      `InMemoryAgentVersionsStorage: getVersionByNumber called for agent ${agentId}, v${versionNumber}`,
+    );
+
+    for (const version of this.db.agentVersions.values()) {
+      if (version.agentId === agentId && version.versionNumber === versionNumber) {
+        return { ...version };
+      }
+    }
+    return null;
+  }
+
+  async getLatestVersion(agentId: string): Promise<AgentVersion | null> {
+    this.logger.debug(`InMemoryAgentVersionsStorage: getLatestVersion called for agent ${agentId}`);
+
+    let latest: AgentVersion | null = null;
+    for (const version of this.db.agentVersions.values()) {
+      if (version.agentId === agentId) {
+        if (!latest || version.versionNumber > latest.versionNumber) {
+          latest = version;
+        }
+      }
+    }
+    return latest ? { ...latest } : null;
+  }
+
+  async listVersions(input: ListVersionsInput): Promise<ListVersionsOutput> {
+    const { agentId, page = 0, perPage: perPageInput, orderBy } = input;
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    this.logger.debug(`InMemoryAgentVersionsStorage: listVersions called for agent ${agentId}`);
+
+    // Normalize perPage for query (false -> MAX_SAFE_INTEGER, 0 -> 0, undefined -> 20)
+    const perPage = normalizePerPage(perPageInput, 20);
+
+    if (page < 0) {
+      throw new Error('page must be >= 0');
+    }
+
+    // Prevent unreasonably large page values
+    const maxOffset = Number.MAX_SAFE_INTEGER / 2;
+    if (page * perPage > maxOffset) {
+      throw new Error('page value too large');
+    }
+
+    // Filter versions by agentId
+    let versions = Array.from(this.db.agentVersions.values()).filter(v => v.agentId === agentId);
+
+    // Sort versions
+    versions = this.sortVersions(versions, field, direction);
+
+    // Clone versions to avoid mutation
+    const clonedVersions = versions.map(v => ({ ...v }));
+
+    const total = clonedVersions.length;
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    const paginatedVersions = clonedVersions.slice(offset, offset + perPage);
+
+    return {
+      versions: paginatedVersions,
+      total,
+      page,
+      perPage: perPageForResponse === false ? total : perPageForResponse,
+      hasMore: offset + perPage < total,
+    };
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    this.logger.debug(`InMemoryAgentVersionsStorage: deleteVersion called for ${id}`);
+    // Idempotent delete - no-op if version doesn't exist
+    this.db.agentVersions.delete(id);
+  }
+
+  async deleteVersionsByAgentId(agentId: string): Promise<void> {
+    this.logger.debug(`InMemoryAgentVersionsStorage: deleteVersionsByAgentId called for agent ${agentId}`);
+
+    for (const [id, version] of this.db.agentVersions.entries()) {
+      if (version.agentId === agentId) {
+        this.db.agentVersions.delete(id);
+      }
+    }
+  }
+
+  async countVersions(agentId: string): Promise<number> {
+    this.logger.debug(`InMemoryAgentVersionsStorage: countVersions called for agent ${agentId}`);
+
+    let count = 0;
+    for (const version of this.db.agentVersions.values()) {
+      if (version.agentId === agentId) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private sortVersions(
+    versions: AgentVersion[],
+    field: VersionOrderBy,
+    direction: VersionSortDirection,
+  ): AgentVersion[] {
+    return versions.sort((a, b) => {
+      let aVal: number;
+      let bVal: number;
+
+      if (field === 'createdAt') {
+        aVal = a.createdAt.getTime();
+        bVal = b.createdAt.getTime();
+      } else {
+        // versionNumber
+        aVal = a.versionNumber;
+        bVal = b.versionNumber;
+      }
+
+      return direction === 'ASC' ? aVal - bVal : bVal - aVal;
+    });
+  }
+}

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -1,5 +1,6 @@
 export * from './base';
 export * from './agents';
+export * from './agent-versions';
 export * from './scores';
 export * from './observability';
 export * from './operations';

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -1,6 +1,7 @@
 import type { ScoreRowData } from '../../evals/types';
 import type { StorageThreadType } from '../../memory/types';
 import type { StorageAgentType, StorageMessageType, StorageResourceType, StorageWorkflowRun } from '../types';
+import type { AgentVersion } from './agent-versions/base';
 import type { TraceEntry } from './observability';
 
 /**
@@ -18,6 +19,7 @@ export class InMemoryDB {
   readonly scores = new Map<string, ScoreRowData>();
   readonly traces = new Map<string, TraceEntry>();
   readonly agents = new Map<string, StorageAgentType>();
+  readonly agentVersions = new Map<string, AgentVersion>();
 
   /**
    * Clears all data from all collections.
@@ -31,5 +33,6 @@ export class InMemoryDB {
     this.scores.clear();
     this.traces.clear();
     this.agents.clear();
+    this.agentVersions.clear();
   }
 }

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -17,6 +17,7 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_scorers: new Map(),
       mastra_ai_spans: new Map(),
       mastra_agents: new Map(),
+      mastra_agent_versions: new Map(),
     };
   }
 

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -8,6 +8,8 @@ import {
   TABLE_WORKFLOW_SNAPSHOT,
   safelyParseJSON,
   TABLE_SPANS,
+  TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
@@ -19,7 +21,8 @@ export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_RESOURCES]: `ReplacingMergeTree()`,
   // TODO: verify this is the correct engine for Spans when implementing clickhouse storage
   [TABLE_SPANS]: `ReplacingMergeTree()`,
-  mastra_agents: `ReplacingMergeTree()`,
+  [TABLE_AGENTS]: `ReplacingMergeTree()`,
+  [TABLE_AGENT_VERSIONS]: `ReplacingMergeTree()`,
 };
 
 export const COLUMN_TYPES: Record<StorageColumn['type'], string> = {

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -12,8 +12,10 @@ import type {
   TABLE_SCORERS,
   TABLE_SPANS,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
   SpanRecord,
   StorageAgentType,
+  AgentVersion,
 } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import type Cloudflare from 'cloudflare';
@@ -109,6 +111,7 @@ export type RecordTypes = {
   [TABLE_RESOURCES]: StorageResourceType;
   [TABLE_SPANS]: SpanRecord;
   [TABLE_AGENTS]: StorageAgentType;
+  [TABLE_AGENT_VERSIONS]: AgentVersion;
 };
 
 export type ListOptions = {

--- a/stores/pg/src/storage/domains/agent-versions/index.ts
+++ b/stores/pg/src/storage/domains/agent-versions/index.ts
@@ -1,0 +1,389 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  AgentVersionsStorage,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_AGENT_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
+import type {
+  AgentVersion,
+  CreateVersionInput,
+  ListVersionsInput,
+  ListVersionsOutput,
+  CreateIndexOptions,
+} from '@mastra/core/storage';
+import { PgDB, resolvePgConfig } from '../../db';
+import type { PgDomainConfig } from '../../db';
+import { getTableName, getSchemaName } from '../utils';
+
+export class AgentVersionsPG extends AgentVersionsStorage {
+  #db: PgDB;
+  #schema: string;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: CreateIndexOptions[];
+
+  /** Tables managed by this domain */
+  static readonly MANAGED_TABLES = [TABLE_AGENT_VERSIONS] as const;
+
+  constructor(config: PgDomainConfig) {
+    super();
+    const { client, schemaName, skipDefaultIndexes, indexes } = resolvePgConfig(config);
+    this.#db = new PgDB({ client, schemaName, skipDefaultIndexes });
+    this.#schema = schemaName || 'public';
+    this.#skipDefaultIndexes = skipDefaultIndexes;
+    // Filter indexes to only those for tables managed by this domain
+    this.#indexes = indexes?.filter(idx => (AgentVersionsPG.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  /**
+   * Returns default index definitions for the agent versions domain tables.
+   */
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        name: 'idx_agent_versions_agent_id',
+        table: TABLE_AGENT_VERSIONS,
+        columns: ['agentId'],
+      },
+      {
+        name: 'idx_agent_versions_agent_version',
+        table: TABLE_AGENT_VERSIONS,
+        columns: ['agentId', 'versionNumber'],
+        unique: true,
+      },
+    ];
+  }
+
+  /**
+   * Creates default indexes for optimal query performance.
+   */
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) {
+      return;
+    }
+
+    const defaultIndexes = this.getDefaultIndexDefinitions();
+    for (const indexDef of defaultIndexes) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        // Log but continue - indexes are performance optimizations
+        this.logger?.warn?.(`Failed to create default index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async init(): Promise<void> {
+    await this.#db.createTable({ tableName: TABLE_AGENT_VERSIONS, schema: TABLE_SCHEMAS[TABLE_AGENT_VERSIONS] });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  /**
+   * Creates custom user-defined indexes for this domain's tables.
+   */
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) {
+      return;
+    }
+
+    for (const indexDef of this.#indexes) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        // Log but continue - indexes are performance optimizations
+        this.logger?.warn?.(`Failed to create custom index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.#db.clearTable({ tableName: TABLE_AGENT_VERSIONS });
+  }
+
+  private parseJson(value: unknown, fieldName?: string): unknown {
+    if (!value) return undefined;
+    if (typeof value !== 'string') return value;
+
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      const details: Record<string, string> = {
+        value: value.length > 100 ? value.substring(0, 100) + '...' : value,
+      };
+      if (fieldName) {
+        details.field = fieldName;
+      }
+
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'PARSE_JSON', 'INVALID_JSON'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Failed to parse JSON${fieldName ? ` for field "${fieldName}"` : ''}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          details,
+        },
+        error,
+      );
+    }
+  }
+
+  private parseRow(row: Record<string, unknown>): AgentVersion {
+    return {
+      id: row.id as string,
+      agentId: row.agentId as string,
+      versionNumber: row.versionNumber as number,
+      name: (row.name as string) || undefined,
+      snapshot: this.parseJson(row.snapshot, 'snapshot') as AgentVersion['snapshot'],
+      changedFields: row.changedFields ? (this.parseJson(row.changedFields, 'changedFields') as string[]) : undefined,
+      changeMessage: (row.changeMessage as string) || undefined,
+      createdAt: (row.createdAtZ as Date) || (row.createdAt as Date),
+    };
+  }
+
+  async createVersion(input: CreateVersionInput): Promise<AgentVersion> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+      const now = new Date();
+      const nowIso = now.toISOString();
+
+      await this.#db.client.none(
+        `INSERT INTO ${tableName} (
+          id, "agentId", "versionNumber", name, snapshot, "changedFields", "changeMessage",
+          "createdAt", "createdAtZ"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+        [
+          input.id,
+          input.agentId,
+          input.versionNumber,
+          input.name ?? null,
+          JSON.stringify(input.snapshot),
+          input.changedFields ? JSON.stringify(input.changedFields) : null,
+          input.changeMessage ?? null,
+          nowIso,
+          nowIso,
+        ],
+      );
+
+      return {
+        ...input,
+        createdAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'CREATE_AGENT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: input.id, agentId: input.agentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersion(id: string): Promise<AgentVersion | null> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+
+      const result = await this.#db.client.oneOrNone(`SELECT * FROM ${tableName} WHERE id = $1`, [id]);
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_AGENT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersionByNumber(agentId: string, versionNumber: number): Promise<AgentVersion | null> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+
+      const result = await this.#db.client.oneOrNone(
+        `SELECT * FROM ${tableName} WHERE "agentId" = $1 AND "versionNumber" = $2`,
+        [agentId, versionNumber],
+      );
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_AGENT_VERSION_BY_NUMBER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId, versionNumber },
+        },
+        error,
+      );
+    }
+  }
+
+  async getLatestVersion(agentId: string): Promise<AgentVersion | null> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+
+      const result = await this.#db.client.oneOrNone(
+        `SELECT * FROM ${tableName} WHERE "agentId" = $1 ORDER BY "versionNumber" DESC LIMIT 1`,
+        [agentId],
+      );
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_LATEST_AGENT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async listVersions(input: ListVersionsInput): Promise<ListVersionsOutput> {
+    const { agentId, page = 0, perPage: perPageInput, orderBy } = input;
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_AGENT_VERSIONS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 20);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+
+      // Get total count
+      const countResult = await this.#db.client.one(`SELECT COUNT(*) as count FROM ${tableName} WHERE "agentId" = $1`, [
+        agentId,
+      ]);
+      const total = parseInt(countResult.count, 10);
+
+      if (total === 0) {
+        return {
+          versions: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse === false ? 0 : perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      // Get paginated results
+      const fieldColumn = field === 'createdAt' ? '"createdAt"' : '"versionNumber"';
+      const dataResult = await this.#db.client.manyOrNone(
+        `SELECT * FROM ${tableName} WHERE "agentId" = $1 ORDER BY ${fieldColumn} ${direction} LIMIT $2 OFFSET $3`,
+        [agentId, perPage, offset],
+      );
+
+      const versions = (dataResult || []).map(row => this.parseRow(row));
+
+      return {
+        versions,
+        total,
+        page,
+        perPage: perPageForResponse === false ? total : perPageForResponse,
+        hasMore: offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_AGENT_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+
+      await this.#db.client.none(`DELETE FROM ${tableName} WHERE id = $1`, [id]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'DELETE_AGENT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersionsByAgentId(agentId: string): Promise<void> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+
+      await this.#db.client.none(`DELETE FROM ${tableName} WHERE "agentId" = $1`, [agentId]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'DELETE_AGENT_VERSIONS_BY_AGENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async countVersions(agentId: string): Promise<number> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_AGENT_VERSIONS, schemaName: getSchemaName(this.#schema) });
+
+      const result = await this.#db.client.one(`SELECT COUNT(*) as count FROM ${tableName} WHERE "agentId" = $1`, [
+        agentId,
+      ]);
+
+      return parseInt(result.count, 10);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'COUNT_AGENT_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { agentId },
+        },
+        error,
+      );
+    }
+  }
+}

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -14,6 +14,7 @@ import { PoolAdapter } from './client';
 import type { DbClient } from './client';
 import type { PgDomainClientConfig } from './db';
 import { AgentsPG } from './domains/agents';
+import { AgentVersionsPG } from './domains/agent-versions';
 import { MemoryPG } from './domains/memory';
 import { ObservabilityPG } from './domains/observability';
 import { ScoresPG } from './domains/scores';
@@ -26,7 +27,7 @@ const DEFAULT_IDLE_TIMEOUT_MS = 30000;
 
 export { exportSchemas } from './db';
 // Export domain classes for direct use with MastraStorage composition
-export { AgentsPG, MemoryPG, ObservabilityPG, ScoresPG, WorkflowsPG };
+export { AgentsPG, AgentVersionsPG, MemoryPG, ObservabilityPG, ScoresPG, WorkflowsPG };
 export { PoolAdapter } from './client';
 export type { DbClient, TxClient, QueryValues, Pool, PoolClient, QueryResult } from './client';
 export type { PgDomainConfig, PgDomainClientConfig, PgDomainPoolConfig, PgDomainRestConfig } from './db';


### PR DESCRIPTION
## Summary

This PR implements the AgentVersionsStorage domain for the AgentCMS versioning feature (Tasks V2, V3, V4 from the versioning plan).

### Changes

- **Core Package** (`packages/core/src/storage/domains/agent-versions/`)
  - Add `AgentVersionsStorage` abstract base class with types (`AgentVersion`, `CreateVersionInput`, `ListVersionsInput`, `ListVersionsOutput`)
  - Add `InMemoryAgentVersionsStorage` implementation
  - Update `InMemoryDB` to include `agentVersions` map
  - Export new domain from `domains/index.ts`

- **PostgreSQL Store** (`stores/pg/src/storage/domains/agent-versions/`)
  - Add `AgentVersionsPG` implementation with full CRUD operations
  - Add default indexes on `agentId` and unique index on `(agentId, versionNumber)`

- **Store Fixes** (to support `TABLE_AGENT_VERSIONS` added in previous PR)
  - Update `stores/cloudflare/src/storage/types.ts` to include `TABLE_AGENT_VERSIONS` in `RecordTypes`
  - Update `stores/clickhouse/src/storage/db/utils.ts` to include `TABLE_AGENT_VERSIONS` in `TABLE_ENGINES`

### API

The `AgentVersionsStorage` provides these methods:
- `createVersion(input)` - Create a new version record
- `getVersion(id)` - Get version by ULID
- `getVersionByNumber(agentId, versionNumber)` - Get version by agent and version number
- `getLatestVersion(agentId)` - Get the highest version number for an agent
- `listVersions(input)` - List versions with pagination and sorting
- `deleteVersion(id)` - Delete a specific version
- `deleteVersionsByAgentId(agentId)` - Delete all versions for an agent
- `countVersions(agentId)` - Count versions for an agent