### PR TITLE
feat(playground): add agent source badge, empty state CTA, create button, and edit button

### DIFF
--- a/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
@@ -1,19 +1,39 @@
+import { useState } from 'react';
 import { EntityHeader } from '@/components/ui/entity-header';
 import { Badge } from '@/ds/components/Badge';
-import { CopyIcon } from 'lucide-react';
+import { Button } from '@/ds/components/Button';
+import { CopyIcon, Pencil } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { useAgent } from '../hooks/use-agent';
+import { EditAgentDialog } from './create-agent';
+import { useLinkComponent } from '@/lib/framework';
+import { toast } from '@/lib/toast';
 
 export interface AgentEntityHeaderProps {
   agentId: string;
 }
 
 export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const { data: agent, isLoading } = useAgent(agentId);
   const { handleCopy } = useCopyToClipboard({ text: agentId });
+  const { navigate, paths } = useLinkComponent();
+
   const agentName = agent?.name || '';
+  const isStoredAgent = agent?.source === 'stored';
+
+  const handleEditSuccess = () => {
+    setIsEditDialogOpen(false);
+    toast.success('Agent updated successfully');
+  };
+
+  const handleDelete = () => {
+    setIsEditDialogOpen(false);
+    toast.success('Agent deleted');
+    navigate(paths.agentsLink());
+  };
 
   return (
     <TooltipProvider>
@@ -28,7 +48,24 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
           </TooltipTrigger>
           <TooltipContent>Copy Agent ID for use in code</TooltipContent>
         </Tooltip>
+
+        {isStoredAgent && (
+          <Button variant="outline" size="md" onClick={() => setIsEditDialogOpen(true)}>
+            <Pencil className="w-4 h-4 mr-1" />
+            Edit
+          </Button>
+        )}
       </EntityHeader>
+
+      {isStoredAgent && (
+        <EditAgentDialog
+          agentId={agentId}
+          open={isEditDialogOpen}
+          onOpenChange={setIsEditDialogOpen}
+          onSuccess={handleEditSuccess}
+          onDelete={handleDelete}
+        />
+      )}
     </TooltipProvider>
   );
 };

--- a/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
@@ -7,6 +7,7 @@ import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { Icon } from '@/ds/icons/Icon';
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import React, { useMemo, useState } from 'react';
+import { Plus, BookOpen } from 'lucide-react';
 
 import { ScrollableContainer } from '@/components/scrollable-container';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -19,9 +20,10 @@ import { Searchbar, SearchbarWrapper } from '@/components/ui/searchbar';
 export interface AgentsTableProps {
   agents: Record<string, GetAgentResponse>;
   isLoading: boolean;
+  onCreateClick?: () => void;
 }
 
-export function AgentsTable({ agents, isLoading }: AgentsTableProps) {
+export function AgentsTable({ agents, isLoading, onCreateClick }: AgentsTableProps) {
   const [search, setSearch] = useState('');
   const { navigate, paths } = useLinkComponent();
   const projectData: AgentTableData[] = useMemo(() => Object.values(agents), [agents]);
@@ -36,7 +38,7 @@ export function AgentsTable({ agents, isLoading }: AgentsTableProps) {
   const rows = table.getRowModel().rows.concat();
 
   if (rows.length === 0 && !isLoading) {
-    return <EmptyAgentsTable />;
+    return <EmptyAgentsTable onCreateClick={onCreateClick} />;
   }
 
   const filteredRows = rows.filter(row => row.original.name.toLowerCase().includes(search.toLowerCase()));
@@ -104,26 +106,40 @@ const AgentsTableSkeleton = () => (
   </Table>
 );
 
-const EmptyAgentsTable = () => (
+interface EmptyAgentsTableProps {
+  onCreateClick?: () => void;
+}
+
+const EmptyAgentsTable = ({ onCreateClick }: EmptyAgentsTableProps) => (
   <div className="flex h-full items-center justify-center">
     <EmptyState
       iconSlot={<AgentCoinIcon />}
-      titleSlot="Configure Agents"
-      descriptionSlot="Mastra agents are not configured yet. You can find more information in the documentation."
+      titleSlot="No Agents Yet"
+      descriptionSlot="Create your first agent or configure agents in code."
       actionSlot={
-        <Button
-          size="lg"
-          className="w-full"
-          variant="light"
-          as="a"
-          href="https://mastra.ai/en/docs/agents/overview"
-          target="_blank"
-        >
-          <Icon>
-            <AgentIcon />
-          </Icon>
-          Docs
-        </Button>
+        <div className="flex flex-col sm:flex-row gap-2">
+          {onCreateClick && (
+            <Button size="lg" onClick={onCreateClick}>
+              <Icon>
+                <Plus />
+              </Icon>
+              Create Agent
+            </Button>
+          )}
+          <Button
+            size="lg"
+            variant="outline"
+            as="a"
+            href="https://mastra.ai/docs/agents"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Icon>
+              <BookOpen />
+            </Icon>
+            Documentation
+          </Button>
+        </div>
       }
     />
   </div>

--- a/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
@@ -3,6 +3,7 @@ import { Cell, EntryCell } from '@/ds/components/Table';
 import { OpenAIIcon } from '@/ds/icons/OpenAIIcon';
 import { ColumnDef, Row } from '@tanstack/react-table';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
+import { Database } from 'lucide-react';
 
 import { AgentTableData } from './types';
 import { useLinkComponent } from '@/lib/framework';
@@ -18,13 +19,26 @@ export type AgentTableColumn = {
 
 const NameCell = ({ row }: { row: Row<AgentTableColumn> }) => {
   const { Link, paths } = useLinkComponent();
+  const isStored = row.original.source === 'stored';
 
   return (
     <EntryCell
       name={
-        <Link className="w-full space-y-0" href={paths.agentLink(row.original.id)}>
-          {row.original.name}
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link className="w-full space-y-0" href={paths.agentLink(row.original.id)}>
+            {row.original.name}
+          </Link>
+          {isStored && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Database className="w-4 h-4 text-muted-foreground" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Stored agent - can be edited</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       }
       description={extractPrompt(row.original.instructions)}
     />

--- a/packages/playground-ui/src/domains/agents/components/agent-table/types.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/types.ts
@@ -2,4 +2,5 @@ import { GetAgentResponse, GetToolResponse } from '@mastra/client-js';
 
 export type AgentTableData = GetAgentResponse & {
   id: string;
+  source?: 'code' | 'stored';
 };

--- a/packages/playground-ui/src/domains/agents/components/create-agent/index.ts
+++ b/packages/playground-ui/src/domains/agents/components/create-agent/index.ts
@@ -4,6 +4,9 @@ export type { AgentFormProps } from './agent-form';
 export { ModelPicker } from './model-picker';
 export type { ModelPickerProps } from './model-picker';
 
+export { MultiSelectPicker } from './multi-select-picker';
+export type { MultiSelectPickerProps } from './multi-select-picker';
+
 export { CreateAgentDialog } from './create-agent-dialog';
 export type { CreateAgentDialogProps } from './create-agent-dialog';
 
@@ -12,3 +15,6 @@ export type { DeleteAgentConfirmProps } from './delete-agent-confirm';
 
 export { EditAgentDialog } from './edit-agent-dialog';
 export type { EditAgentDialogProps } from './edit-agent-dialog';
+
+export { agentFormSchema } from './form-validation';
+export type { AgentFormValues } from './form-validation';

--- a/packages/playground-ui/src/domains/agents/index.tsx
+++ b/packages/playground-ui/src/domains/agents/index.tsx
@@ -17,3 +17,5 @@ export * from './components/agent-information/agent-information';
 export * from './components/agent-entity-header';
 export * from './components/agent-information/agent-memory';
 export * from './components/agent-layout';
+export * from './components/create-agent';
+export * from './hooks/use-stored-agents';

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
 import {
   Header,
   HeaderTitle,
@@ -9,14 +11,20 @@ import {
   useLinkComponent,
   DocsIcon,
   useAgents,
+  AgentsTable,
+  AgentIcon,
+  CreateAgentDialog,
 } from '@mastra/playground-ui';
 
-import { AgentsTable } from '@mastra/playground-ui';
-import { AgentIcon } from '@mastra/playground-ui';
-
 function Agents() {
-  const { Link } = useLinkComponent();
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const { Link, navigate, paths } = useLinkComponent();
   const { data: agents = {}, isLoading } = useAgents();
+
+  const handleAgentCreated = (agentId: string) => {
+    setIsCreateDialogOpen(false);
+    navigate(`${paths.agentLink(agentId)}/chat`);
+  };
 
   return (
     <MainContentLayout>
@@ -29,7 +37,13 @@ function Agents() {
         </HeaderTitle>
 
         <HeaderAction>
-          <Button as={Link} to="https://mastra.ai/en/docs/agents/overview" target="_blank">
+          <Button onClick={() => setIsCreateDialogOpen(true)}>
+            <Icon>
+              <Plus />
+            </Icon>
+            Create Agent
+          </Button>
+          <Button variant="outline" as={Link} to="https://mastra.ai/en/docs/agents/overview" target="_blank">
             <Icon>
               <DocsIcon />
             </Icon>
@@ -39,8 +53,14 @@ function Agents() {
       </Header>
 
       <MainContentContent isCentered={!isLoading && Object.keys(agents || {}).length === 0}>
-        <AgentsTable agents={agents} isLoading={isLoading} />
+        <AgentsTable agents={agents} isLoading={isLoading} onCreateClick={() => setIsCreateDialogOpen(true)} />
       </MainContentContent>
+
+      <CreateAgentDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+        onSuccess={handleAgentCreated}
+      />
     </MainContentLayout>
   );
 }


### PR DESCRIPTION
## Summary

This PR implements Tasks 11-15 from the Worker E page integration plan for AgentCMS:

- **Task 11**: Add source badge to agents table - Shows a Database icon with tooltip for stored agents
- **Task 12**: Update empty state with Create CTA - Adds "Create Agent" button to empty state
- **Task 13**: Add Create Agent button to agents page - Wires up CreateAgentDialog with navigation
- **Task 14**: Add Edit button to agent header - Shows Edit button only for stored agents
- **Task 15**: Export all new components - Exports MultiSelectPicker, agentFormSchema, use-stored-agents

## Changes

### packages/playground-ui
- `agent-table/types.ts`: Add `source` field to `AgentTableData`
- `agent-table/columns.tsx`: Add Database icon with tooltip for stored agents
- `agent-table/agent-table.tsx`: Add `onCreateClick` prop and update empty state
- `agent-entity-header.tsx`: Add Edit button for stored agents with EditAgentDialog
- `create-agent/index.ts`: Export MultiSelectPicker, agentFormSchema, AgentFormValues
- `agents/index.tsx`: Export create-agent components and use-stored-agents hook

### packages/playground
- `pages/agents/index.tsx`: Add Create Agent button and wire up CreateAgentDialog