### PR TITLE
docs: add memoization guidelines to playground CLAUDE.md files

### DIFF
--- a/packages/playground-ui/CLAUDE.md
+++ b/packages/playground-ui/CLAUDE.md
@@ -172,6 +172,49 @@ export function App({ a, b }: AppProps) {
 }
 ```
 
+### Memoization & Performance
+
+- **FORBIDDEN**: Using `useCallback` or `useMemo` for typical operations
+- Only use `useCallback`/`useMemo` as a **last resort** for very expensive computations (e.g., processing 200+ entries)
+- **REQUIRED**: Use React 19.2's `useEffectEvent` instead of `useCallback` for event handlers
+
+```tsx
+// ✅ Good - useEffectEvent for event handlers (React 19.2+)
+import { useEffectEvent } from 'react';
+
+export function App() {
+  const onSubmit = useEffectEvent((data: FormData) => {
+    // handle submission
+  });
+
+  return <Form onSubmit={onSubmit} />;
+}
+
+// ❌ Bad - useCallback for simple event handlers
+export function App() {
+  const onSubmit = useCallback((data: FormData) => {
+    // handle submission
+  }, []);
+
+  return <Form onSubmit={onSubmit} />;
+}
+```
+
+```tsx
+// ✅ Good - useMemo ONLY for expensive computations (200+ items)
+const sortedItems = useMemo(() => {
+  return hugeDataset.sort((a, b) => a.value - b.value);
+}, [hugeDataset]); // hugeDataset has 500+ entries
+
+// ❌ Bad - useMemo for simple derivations
+const fullName = useMemo(() => {
+  return `${firstName} ${lastName}`;
+}, [firstName, lastName]);
+
+// ✅ Good - derive directly instead
+const fullName = `${firstName} ${lastName}`;
+```
+
 ---
 
 ## Key Principles

--- a/packages/playground-ui/CLAUDE.md
+++ b/packages/playground-ui/CLAUDE.md
@@ -215,6 +215,35 @@ const fullName = useMemo(() => {
 const fullName = `${firstName} ${lastName}`;
 ```
 
+### Side Effects
+
+- **REQUIRED**: Isolate every `useEffect` into a custom hook
+- Direct `useEffect` usage in components creates noise and reduces readability
+- Custom hooks encapsulate side effects and make components cleaner
+
+```tsx
+// ✅ Good - useEffect isolated in custom hook
+function useDocumentTitle(title: string) {
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+}
+
+export function AgentPage({ agent }: AgentPageProps) {
+  useDocumentTitle(`Agent: ${agent.name}`);
+  return <div>{agent.name}</div>;
+}
+
+// ❌ Bad - useEffect directly in component
+export function AgentPage({ agent }: AgentPageProps) {
+  useEffect(() => {
+    document.title = `Agent: ${agent.name}`;
+  }, [agent.name]);
+
+  return <div>{agent.name}</div>;
+}
+```
+
 ---
 
 ## Key Principles

--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -209,6 +209,35 @@ const fullName = useMemo(() => {
 const fullName = `${firstName} ${lastName}`;
 ```
 
+### Side Effects
+
+- **REQUIRED**: Isolate every `useEffect` into a custom hook
+- Direct `useEffect` usage in components creates noise and reduces readability
+- Custom hooks encapsulate side effects and make components cleaner
+
+```tsx
+// ✅ Good - useEffect isolated in custom hook
+function useDocumentTitle(title: string) {
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+}
+
+export function AgentPage({ agent }: AgentPageProps) {
+  useDocumentTitle(`Agent: ${agent.name}`);
+  return <div>{agent.name}</div>;
+}
+
+// ❌ Bad - useEffect directly in component
+export function AgentPage({ agent }: AgentPageProps) {
+  useEffect(() => {
+    document.title = `Agent: ${agent.name}`;
+  }, [agent.name]);
+
+  return <div>{agent.name}</div>;
+}
+```
+
 ---
 
 ## Key Principles

--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -166,6 +166,49 @@ export function App({ a, b }: AppProps) {
 }
 ```
 
+### Memoization & Performance
+
+- **FORBIDDEN**: Using `useCallback` or `useMemo` for typical operations
+- Only use `useCallback`/`useMemo` as a **last resort** for very expensive computations (e.g., processing 200+ entries)
+- **REQUIRED**: Use React 19.2's `useEffectEvent` instead of `useCallback` for event handlers
+
+```tsx
+// ✅ Good - useEffectEvent for event handlers (React 19.2+)
+import { useEffectEvent } from 'react';
+
+export function App() {
+  const onSubmit = useEffectEvent((data: FormData) => {
+    // handle submission
+  });
+
+  return <Form onSubmit={onSubmit} />;
+}
+
+// ❌ Bad - useCallback for simple event handlers
+export function App() {
+  const onSubmit = useCallback((data: FormData) => {
+    // handle submission
+  }, []);
+
+  return <Form onSubmit={onSubmit} />;
+}
+```
+
+```tsx
+// ✅ Good - useMemo ONLY for expensive computations (200+ items)
+const sortedItems = useMemo(() => {
+  return hugeDataset.sort((a, b) => a.value - b.value);
+}, [hugeDataset]); // hugeDataset has 500+ entries
+
+// ❌ Bad - useMemo for simple derivations
+const fullName = useMemo(() => {
+  return `${firstName} ${lastName}`;
+}, [firstName, lastName]);
+
+// ✅ Good - derive directly instead
+const fullName = `${firstName} ${lastName}`;
+```
+
 ---
 
 ## Key Principles


### PR DESCRIPTION
Adds guidelines for `useCallback`, `useMemo`, and `useEffectEvent` to both playground CLAUDE.md files.

The gist: avoid `useCallback`/`useMemo` unless you're processing 200+ items, and prefer React 19.2's `useEffectEvent` for event handlers.

```tsx
// instead of this
const onSubmit = useCallback((data) => { ... }, []);

// do this
const onSubmit = useEffectEvent((data) => { ... });
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Memoization & Performance" section to developer docs with guidance on memoization: avoid useCallback/useMemo for routine handlers, prefer useEffectEvent (React 19.2+) for event handlers, reserve useMemo for expensive computations, and isolate side effects in custom hooks with examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->