### PR TITLE
feat(playground-ui): add JSON diff modal for version comparison

### DIFF
--- a/packages/playground-ui/src/domains/agents/components/agent-versions/agent-versions-list.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-versions/agent-versions-list.tsx
@@ -9,6 +9,7 @@ import { Check, GitCompare, RotateCcw, Trash2 } from 'lucide-react';
 import type { AgentVersionResponse } from '@mastra/client-js';
 import { useAgentVersions, useActivateAgentVersion, useDeleteAgentVersion } from '../../hooks/use-agent-versions';
 import { SaveVersionDialog } from './save-version-dialog';
+import { VersionCompareDialog } from './version-compare-dialog';
 import { toast } from '@/lib/toast';
 
 interface AgentVersionsListProps {
@@ -66,6 +67,7 @@ function VersionListItem({ version, isActive, onActivate, onDelete }: VersionLis
 
 export function AgentVersionsList({ agentId, activeVersionId }: AgentVersionsListProps) {
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
+  const [isCompareDialogOpen, setIsCompareDialogOpen] = useState(false);
   const [page, setPage] = useState(0);
 
   const { data, isLoading } = useAgentVersions({ agentId, params: { page, perPage: 10 } });
@@ -115,9 +117,16 @@ export function AgentVersionsList({ agentId, activeVersionId }: AgentVersionsLis
     <div className="h-full flex flex-col">
       <div className="p-4 border-b border-border1 flex items-center justify-between">
         <h3 className="text-sm font-medium text-icon6">Versions ({total})</h3>
-        <Button size="md" onClick={() => setIsSaveDialogOpen(true)}>
-          Save Version
-        </Button>
+        <div className="flex items-center gap-2">
+          {versions.length >= 2 && (
+            <Button variant="ghost" size="md" onClick={() => setIsCompareDialogOpen(true)} title="Compare Versions">
+              <GitCompare className="w-4 h-4" />
+            </Button>
+          )}
+          <Button size="md" onClick={() => setIsSaveDialogOpen(true)}>
+            Save Version
+          </Button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto">
@@ -161,6 +170,7 @@ export function AgentVersionsList({ agentId, activeVersionId }: AgentVersionsLis
       )}
 
       <SaveVersionDialog agentId={agentId} open={isSaveDialogOpen} onOpenChange={setIsSaveDialogOpen} />
+      <VersionCompareDialog agentId={agentId} open={isCompareDialogOpen} onOpenChange={setIsCompareDialogOpen} />
     </div>
   );
 }

--- a/packages/playground-ui/src/domains/agents/components/agent-versions/index.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-versions/index.ts
@@ -1,3 +1,4 @@
 export { AgentVersionsList } from './agent-versions-list';
 export { SaveVersionDialog } from './save-version-dialog';
 export { VersionCompareDialog } from './version-compare-dialog';
+export { JsonDiffModal } from './json-diff-modal';

--- a/packages/playground-ui/src/domains/agents/components/agent-versions/json-diff-modal.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-versions/json-diff-modal.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useMemo } from 'react';
+import { ExternalLink } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/ds/components/Button';
+
+interface JsonDiffModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  fieldName: string;
+  previousValue: unknown;
+  currentValue: unknown;
+}
+
+/**
+ * Encodes a value as a JSON string for the diffs.com URL.
+ */
+function encodeJsonValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Modal component that displays a JSON diff using diffs.com in an iframe.
+ * Uses the diffs.com URL format: https://diffs.com/?left=<encoded>&right=<encoded>
+ */
+export function JsonDiffModal({ open, onOpenChange, fieldName, previousValue, currentValue }: JsonDiffModalProps) {
+  const diffUrl = useMemo(() => {
+    const leftContent = encodeJsonValue(previousValue);
+    const rightContent = encodeJsonValue(currentValue);
+
+    // diffs.com accepts left and right parameters with base64 encoded content
+    const leftEncoded = btoa(unescape(encodeURIComponent(leftContent)));
+    const rightEncoded = btoa(unescape(encodeURIComponent(rightContent)));
+
+    return `https://diffs.com/?left=${leftEncoded}&right=${rightEncoded}`;
+  }, [previousValue, currentValue]);
+
+  const handleOpenExternal = () => {
+    window.open(diffUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[90vw] sm:max-h-[90vh] w-[90vw] h-[85vh] overflow-hidden flex flex-col">
+        <DialogHeader className="flex-shrink-0">
+          <div className="flex items-center justify-between">
+            <div>
+              <DialogTitle>JSON Diff: {fieldName}</DialogTitle>
+              <DialogDescription>Comparing previous and current values</DialogDescription>
+            </div>
+            <Button variant="ghost" size="md" onClick={handleOpenExternal} title="Open in new tab">
+              <ExternalLink className="w-4 h-4 mr-2" />
+              Open in new tab
+            </Button>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 min-h-0 rounded-md overflow-hidden border border-border1 bg-white">
+          <iframe
+            src={diffUrl}
+            title={`JSON Diff for ${fieldName}`}
+            className="w-full h-full border-0"
+            sandbox="allow-scripts allow-same-origin"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Compare Versions button (GitCompare icon) to AgentVersionsList that appears when 2+ versions exist
- Create JsonDiffModal component that embeds diffs.com in an iframe for line-by-line JSON diff visualization
- Add "View Diff" button to DiffRow for fields containing complex objects/arrays
- Include "Open in new tab" option for full diffs.com experience

## Changes
- `agent-versions-list.tsx`: Added compare button and VersionCompareDialog integration
- `version-compare-dialog.tsx`: Enhanced DiffRow with JSON diff button and modal
- `json-diff-modal.tsx`: New component using diffs.com iframe
- `index.ts`: Export new JsonDiffModal component