### PR TITLE
feat(playground-ui): add model selector to prompt enhancer

### DIFF
--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -198,10 +198,14 @@ export class Agent extends BaseResource {
     return this.request(`/api/agents/${this.agentId}${requestContextQueryString(requestContext)}`);
   }
 
-  enhanceInstructions(instructions: string, comment: string): Promise<{ explanation: string; new_prompt: string }> {
+  enhanceInstructions(
+    instructions: string,
+    comment: string,
+    model?: { provider: string; modelId: string },
+  ): Promise<{ explanation: string; new_prompt: string }> {
     return this.request(`/api/agents/${this.agentId}/instructions/enhance`, {
       method: 'POST',
-      body: { instructions, comment },
+      body: { instructions, comment, model },
     });
   }
 

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-instructions-enhancer.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-instructions-enhancer.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useCallback } from 'react';
 import CodeMirror, { EditorView } from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
@@ -7,13 +8,16 @@ import { useAgentPromptExperiment } from '../../context';
 import { Alert, AlertDescription, AlertTitle } from '@/ds/components/Alert';
 import { Button } from '@/ds/components/Button';
 import { Icon } from '@/ds/icons';
-import { RefreshCcwIcon } from 'lucide-react';
+import { RefreshCcwIcon, ChevronDown } from 'lucide-react';
 import { usePromptEnhancer } from '../../hooks/use-prompt-enhancer';
 import Spinner from '@/components/ui/spinner';
 import { Input } from '@/components/ui/input';
 import { useAgent } from '../../hooks/use-agent';
 import { useAgentsModelProviders } from '../../hooks/use-agents-model-providers';
 import { cleanProviderId } from '../agent-metadata/utils';
+import { ProviderLogo } from '../agent-metadata/provider-logo';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useAllModels, ModelInfo } from '../model-picker/use-model-picker';
 
 export const PromptEnhancer = ({ agentId }: { agentId: string }) => {
   const { isDirty, prompt, setPrompt, resetPrompt } = useAgentPromptExperiment();
@@ -63,13 +67,155 @@ export const PromptEnhancer = ({ agentId }: { agentId: string }) => {
   );
 };
 
+interface EnhancerModelSelectorProps {
+  selectedModel: { provider: string; modelId: string } | null;
+  onModelSelect: (model: { provider: string; modelId: string } | null) => void;
+  connectedModels: ModelInfo[];
+  disabled?: boolean;
+}
+
+const EnhancerModelSelector = ({
+  selectedModel,
+  onModelSelect,
+  connectedModels,
+  disabled,
+}: EnhancerModelSelectorProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filteredModels = connectedModels.filter(
+    m =>
+      m.model.toLowerCase().includes(search.toLowerCase()) ||
+      m.providerName.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const handleSelect = useCallback(
+    (model: ModelInfo | null) => {
+      if (model) {
+        onModelSelect({ provider: model.provider, modelId: model.model });
+      } else {
+        onModelSelect(null);
+      }
+      setIsOpen(false);
+      setSearch('');
+    },
+    [onModelSelect],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isOpen) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex(prev => Math.min(prev + 1, filteredModels.length));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex(prev => Math.max(prev - 1, 0));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (highlightedIndex === 0) {
+            handleSelect(null);
+          } else if (highlightedIndex <= filteredModels.length) {
+            handleSelect(filteredModels[highlightedIndex - 1]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setIsOpen(false);
+          setSearch('');
+          break;
+      }
+    },
+    [isOpen, filteredModels, highlightedIndex, handleSelect],
+  );
+
+  const displayValue = selectedModel ? `${selectedModel.provider}/${selectedModel.modelId}` : 'Default (agent model)';
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className="flex items-center gap-1.5 text-xs text-icon4 hover:text-icon5 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {selectedModel && <ProviderLogo providerId={selectedModel.provider} size={12} />}
+          <span className="truncate max-w-[180px]">{displayValue}</span>
+          <ChevronDown className="h-3 w-3 flex-shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[280px] max-h-[300px] overflow-y-auto p-2"
+        onOpenAutoFocus={e => {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }}
+      >
+        <Input
+          ref={inputRef}
+          value={search}
+          onChange={e => {
+            setSearch(e.target.value);
+            setHighlightedIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="Search models..."
+          className="mb-2"
+        />
+        <div className="space-y-0.5">
+          <div
+            className={`flex items-center gap-2 px-3 py-2 cursor-pointer rounded hover:bg-surface5 text-sm ${
+              highlightedIndex === 0 ? 'bg-surface5' : ''
+            } ${!selectedModel ? 'text-accent1' : ''}`}
+            onClick={() => handleSelect(null)}
+          >
+            Default (agent model)
+          </div>
+          {filteredModels.map((model, index) => {
+            const isHighlighted = index + 1 === highlightedIndex;
+            const isSelected = selectedModel?.provider === model.provider && selectedModel?.modelId === model.model;
+            return (
+              <div
+                key={`${model.provider}-${model.model}`}
+                className={`flex items-center gap-2 px-3 py-2 cursor-pointer rounded hover:bg-surface5 text-sm ${
+                  isHighlighted ? 'bg-surface5' : ''
+                } ${isSelected ? 'text-accent1' : ''}`}
+                onClick={() => handleSelect(model)}
+              >
+                <ProviderLogo providerId={model.provider} size={14} />
+                <span className="truncate">{model.model}</span>
+              </div>
+            );
+          })}
+          {filteredModels.length === 0 && search && <div className="text-xs text-icon3 px-3 py-2">No models found</div>}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
 const PromptEnhancerTextarea = ({ agentId }: { agentId: string }) => {
   const { prompt, setPrompt } = useAgentPromptExperiment();
   const { mutateAsync: enhancePrompt, isPending } = usePromptEnhancer({ agentId });
   const { data: agent, isLoading: isAgentLoading, isError: isAgentError } = useAgent(agentId);
   const { data: providersData, isLoading: isProvidersLoading } = useAgentsModelProviders();
+  const [selectedModel, setSelectedModel] = useState<{ provider: string; modelId: string } | null>(null);
 
   const providers = providersData?.providers || [];
+  const allModels = useAllModels(providers);
+
+  // Get only models from connected providers
+  const connectedModels = allModels.filter(m => {
+    const cleanId = cleanProviderId(m.provider);
+    const provider = providers.find(p => cleanProviderId(p.id) === cleanId);
+    return provider?.connected === true;
+  });
 
   // Check if a provider has an API key configured
   const isProviderConnected = (providerId: string) => {
@@ -88,7 +234,8 @@ const PromptEnhancerTextarea = ({ agentId }: { agentId: string }) => {
 
   const isDataLoading = isAgentLoading || isProvidersLoading;
   // If agent fetch errored (e.g., all models disabled), treat as no valid model
-  const hasValidModel = !isDataLoading && !isAgentError && hasConnectedModel();
+  // But if user selected a custom model, we can still proceed
+  const hasValidModel = !isDataLoading && (selectedModel || (!isAgentError && hasConnectedModel()));
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -96,7 +243,11 @@ const PromptEnhancerTextarea = ({ agentId }: { agentId: string }) => {
     const formData = new FormData(form);
     const userComment = formData.get('userComment') as string;
     try {
-      const result = await enhancePrompt({ instructions: prompt, userComment });
+      const result = await enhancePrompt({
+        instructions: prompt,
+        userComment,
+        model: selectedModel || undefined,
+      });
       form.reset();
       setPrompt(result.new_prompt);
     } catch {
@@ -105,7 +256,7 @@ const PromptEnhancerTextarea = ({ agentId }: { agentId: string }) => {
   };
 
   const isDisabled = isPending || !hasValidModel;
-  const showWarning = !isDataLoading && !hasValidModel;
+  const showWarning = !isDataLoading && !selectedModel && !hasConnectedModel();
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
@@ -116,12 +267,23 @@ const PromptEnhancerTextarea = ({ agentId }: { agentId: string }) => {
         disabled={isDisabled}
       />
 
-      <div className="flex justify-end items-center gap-2">
-        {showWarning && <span className="text-xs text-yellow-200">No model with a configured API key found.</span>}
-        <Button variant="light" type="submit" disabled={isDisabled}>
-          <Icon>{isPending ? <Spinner /> : <RefreshCcwIcon />}</Icon>
-          Enhance prompt
-        </Button>
+      <div className="flex justify-between items-center gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-icon3">Model:</span>
+          <EnhancerModelSelector
+            selectedModel={selectedModel}
+            onModelSelect={setSelectedModel}
+            connectedModels={connectedModels}
+            disabled={isPending || isDataLoading}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          {showWarning && <span className="text-xs text-yellow-200">No model with a configured API key found.</span>}
+          <Button variant="light" type="submit" disabled={isDisabled}>
+            <Icon>{isPending ? <Spinner /> : <RefreshCcwIcon />}</Icon>
+            Enhance prompt
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/packages/playground-ui/src/domains/agents/components/create-agent/instructions-enhancer.tsx
+++ b/packages/playground-ui/src/domains/agents/components/create-agent/instructions-enhancer.tsx
@@ -1,18 +1,154 @@
 'use client';
 
 import * as React from 'react';
-import { RefreshCcwIcon, Sparkles } from 'lucide-react';
+import { RefreshCcwIcon, Sparkles, ChevronDown } from 'lucide-react';
 
 import { Button } from '@/ds/components/Button';
 import { Icon } from '@/ds/icons';
 import { Input } from '@/components/ui/input';
 import Spinner from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 import { usePromptEnhancer } from '../../hooks/use-prompt-enhancer';
 import { useAgent } from '../../hooks/use-agent';
 import { useAgentsModelProviders } from '../../hooks/use-agents-model-providers';
 import { cleanProviderId } from '../agent-metadata/utils';
+import { ProviderLogo } from '../agent-metadata/provider-logo';
+import { useAllModels, ModelInfo } from '../model-picker/use-model-picker';
+
+interface EnhancerModelSelectorProps {
+  selectedModel: { provider: string; modelId: string } | null;
+  onModelSelect: (model: { provider: string; modelId: string } | null) => void;
+  connectedModels: ModelInfo[];
+  disabled?: boolean;
+}
+
+const EnhancerModelSelector = ({
+  selectedModel,
+  onModelSelect,
+  connectedModels,
+  disabled,
+}: EnhancerModelSelectorProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [highlightedIndex, setHighlightedIndex] = React.useState(0);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const filteredModels = connectedModels.filter(
+    m =>
+      m.model.toLowerCase().includes(search.toLowerCase()) ||
+      m.providerName.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const handleSelect = React.useCallback(
+    (model: ModelInfo | null) => {
+      if (model) {
+        onModelSelect({ provider: model.provider, modelId: model.model });
+      } else {
+        onModelSelect(null);
+      }
+      setIsOpen(false);
+      setSearch('');
+    },
+    [onModelSelect],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isOpen) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex(prev => Math.min(prev + 1, filteredModels.length));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex(prev => Math.max(prev - 1, 0));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (highlightedIndex === 0) {
+            handleSelect(null);
+          } else if (highlightedIndex <= filteredModels.length) {
+            handleSelect(filteredModels[highlightedIndex - 1]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setIsOpen(false);
+          setSearch('');
+          break;
+      }
+    },
+    [isOpen, filteredModels, highlightedIndex, handleSelect],
+  );
+
+  const displayValue = selectedModel ? `${selectedModel.provider}/${selectedModel.modelId}` : 'Default (agent model)';
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className="flex items-center gap-1.5 text-xs text-icon4 hover:text-icon5 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {selectedModel && <ProviderLogo providerId={selectedModel.provider} size={12} />}
+          <span className="truncate max-w-[180px]">{displayValue}</span>
+          <ChevronDown className="h-3 w-3 flex-shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[280px] max-h-[300px] overflow-y-auto p-2"
+        onOpenAutoFocus={e => {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }}
+      >
+        <Input
+          ref={inputRef}
+          value={search}
+          onChange={e => {
+            setSearch(e.target.value);
+            setHighlightedIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="Search models..."
+          className="mb-2"
+        />
+        <div className="space-y-0.5">
+          <div
+            className={`flex items-center gap-2 px-3 py-2 cursor-pointer rounded hover:bg-surface5 text-sm ${
+              highlightedIndex === 0 ? 'bg-surface5' : ''
+            } ${!selectedModel ? 'text-accent1' : ''}`}
+            onClick={() => handleSelect(null)}
+          >
+            Default (agent model)
+          </div>
+          {filteredModels.map((model, index) => {
+            const isHighlighted = index + 1 === highlightedIndex;
+            const isSelected = selectedModel?.provider === model.provider && selectedModel?.modelId === model.model;
+            return (
+              <div
+                key={`${model.provider}-${model.model}`}
+                className={`flex items-center gap-2 px-3 py-2 cursor-pointer rounded hover:bg-surface5 text-sm ${
+                  isHighlighted ? 'bg-surface5' : ''
+                } ${isSelected ? 'text-accent1' : ''}`}
+                onClick={() => handleSelect(model)}
+              >
+                <ProviderLogo providerId={model.provider} size={14} />
+                <span className="truncate">{model.model}</span>
+              </div>
+            );
+          })}
+          {filteredModels.length === 0 && search && <div className="text-xs text-icon3 px-3 py-2">No models found</div>}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
 
 export interface InstructionsEnhancerProps {
   /** Current instructions value */
@@ -43,6 +179,7 @@ export function InstructionsEnhancer({
 }: InstructionsEnhancerProps) {
   const [enhanceComment, setEnhanceComment] = React.useState('');
   const [showEnhanceInput, setShowEnhanceInput] = React.useState(false);
+  const [selectedModel, setSelectedModel] = React.useState<{ provider: string; modelId: string } | null>(null);
 
   // Only fetch data if we have an agentId (edit mode)
   const { mutateAsync: enhancePrompt, isPending } = usePromptEnhancer({ agentId: agentId || '' });
@@ -50,6 +187,14 @@ export function InstructionsEnhancer({
   const { data: providersData, isLoading: isProvidersLoading } = useAgentsModelProviders();
 
   const providers = providersData?.providers || [];
+  const allModels = useAllModels(providers);
+
+  // Get only models from connected providers
+  const connectedModels = allModels.filter(m => {
+    const cleanId = cleanProviderId(m.provider);
+    const provider = providers.find(p => cleanProviderId(p.id) === cleanId);
+    return provider?.connected === true;
+  });
 
   // Check if a provider has an API key configured
   const isProviderConnected = (providerId: string) => {
@@ -68,17 +213,22 @@ export function InstructionsEnhancer({
   };
 
   const isDataLoading = isAgentLoading || isProvidersLoading;
-  const hasValidModel = !isDataLoading && !isAgentError && hasConnectedModel();
+  // If user selected a custom model, we can still proceed even if agent has no valid model
+  const hasValidModel = !isDataLoading && (selectedModel || (!isAgentError && hasConnectedModel()));
 
   // Enhance is only available in edit mode with a valid model
   const canEnhance = !!agentId && hasValidModel;
-  const showEnhanceWarning = !!agentId && !isDataLoading && !hasValidModel;
+  const showEnhanceWarning = !!agentId && !isDataLoading && !selectedModel && !hasConnectedModel();
 
   const handleEnhance = async () => {
     if (!canEnhance) return;
 
     try {
-      const result = await enhancePrompt({ instructions: value, userComment: enhanceComment });
+      const result = await enhancePrompt({
+        instructions: value,
+        userComment: enhanceComment,
+        model: selectedModel || undefined,
+      });
       onChange(result.new_prompt);
       setEnhanceComment('');
       setShowEnhanceInput(false);
@@ -121,30 +271,46 @@ export function InstructionsEnhancer({
       {agentId && (
         <div className="flex flex-col gap-2">
           {showEnhanceInput ? (
-            <div className="flex gap-2" onKeyDown={handleKeyDown}>
-              <Input
-                value={enhanceComment}
-                onChange={e => setEnhanceComment(e.target.value)}
-                placeholder="Describe how to improve the instructions..."
-                disabled={isPending || !canEnhance}
-                className="flex-1"
-                autoFocus
-              />
-              <Button type="button" variant="light" onClick={handleEnhance} disabled={isPending || !canEnhance}>
-                <Icon>{isPending ? <Spinner /> : <RefreshCcwIcon />}</Icon>
-                Enhance
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => {
-                  setShowEnhanceInput(false);
-                  setEnhanceComment('');
-                }}
-                disabled={isPending}
-              >
-                Cancel
-              </Button>
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-2" onKeyDown={handleKeyDown}>
+                <Input
+                  value={enhanceComment}
+                  onChange={e => setEnhanceComment(e.target.value)}
+                  placeholder="Describe how to improve the instructions..."
+                  disabled={isPending || !canEnhance}
+                  className="flex-1"
+                  autoFocus
+                />
+                <Button type="button" variant="light" onClick={handleEnhance} disabled={isPending || !canEnhance}>
+                  <Icon>{isPending ? <Spinner /> : <RefreshCcwIcon />}</Icon>
+                  Enhance
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    setShowEnhanceInput(false);
+                    setEnhanceComment('');
+                  }}
+                  disabled={isPending}
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div className="flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-icon3">Model:</span>
+                  <EnhancerModelSelector
+                    selectedModel={selectedModel}
+                    onModelSelect={setSelectedModel}
+                    connectedModels={connectedModels}
+                    disabled={isPending || isDataLoading}
+                  />
+                </div>
+                {showEnhanceWarning && (
+                  <span className="text-xs text-yellow-200">No model with a configured API key found.</span>
+                )}
+              </div>
             </div>
           ) : (
             <div className="flex justify-end items-center gap-2">
@@ -156,7 +322,7 @@ export function InstructionsEnhancer({
                 variant="ghost"
                 size="md"
                 onClick={() => setShowEnhanceInput(true)}
-                disabled={!canEnhance}
+                disabled={!agentId}
                 className="text-icon3 hover:text-icon5"
               >
                 <Icon>

--- a/packages/playground-ui/src/domains/agents/hooks/use-prompt-enhancer.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-prompt-enhancer.ts
@@ -6,12 +6,18 @@ interface UsePromptEnhancerProps {
   agentId: string;
 }
 
+interface EnhancePromptParams {
+  instructions: string;
+  userComment: string;
+  model?: { provider: string; modelId: string };
+}
+
 export function usePromptEnhancer({ agentId }: UsePromptEnhancerProps) {
   const client = useMastraClient();
   return useMutation({
-    mutationFn: async ({ instructions, userComment }: { instructions: string; userComment: string }) => {
+    mutationFn: async ({ instructions, userComment, model }: EnhancePromptParams) => {
       try {
-        return await client.getAgent(agentId).enhanceInstructions(instructions, userComment);
+        return await client.getAgent(agentId).enhanceInstructions(instructions, userComment, model);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Error enhancing prompt';
         toast.error(errorMessage);

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -420,6 +420,13 @@ export const executeToolResponseSchema = z.any(); // Tool execution result varie
 export const enhanceInstructionsBodySchema = z.object({
   instructions: z.string().describe('The current agent instructions to enhance'),
   comment: z.string().describe('User comment describing how to enhance the instructions'),
+  model: z
+    .object({
+      provider: z.string().describe('The provider ID (e.g., "openai", "anthropic")'),
+      modelId: z.string().describe('The model ID (e.g., "gpt-4o", "claude-3-5-sonnet")'),
+    })
+    .optional()
+    .describe('Optional model to use for enhancement. If not provided, uses the agent default model.'),
 });
 
 /**


### PR DESCRIPTION
## Summary
Add ability for users to select which model to use when enhancing agent instructions with AI.

- Add optional model parameter to enhance instructions API endpoint
- Update backend handler to use custom model if provided, falling back to agent default
- Add `EnhancerModelSelector` component to both prompt enhancer UIs
- Show only models from connected providers with search functionality
- Display provider logos for visual identification

## Changes
- `packages/server/src/server/schemas/agents.ts` - Add optional `model` parameter to schema
- `packages/server/src/server/handlers/agents.ts` - Use custom model if provided
- `client-sdks/client-js/src/resources/agent.ts` - Add model parameter to client method
- `packages/playground-ui/src/domains/agents/hooks/use-prompt-enhancer.ts` - Accept model in hook
- `packages/playground-ui/src/domains/agents/components/agent-information/agent-instructions-enhancer.tsx` - Add model selector UI
- `packages/playground-ui/src/domains/agents/components/create-agent/instructions-enhancer.tsx` - Add model selector UI

## How it works
The model selector appears in the prompt enhancer footer and allows users to:
1. Use "Default (agent model)" - uses the agent's configured model
2. Select any model from connected providers
3. Search through available models