### PR TITLE
fix(cli): Detect Bun usage when bun.lockb file is found

### DIFF
--- a/.changeset/angry-coins-lick.md
+++ b/.changeset/angry-coins-lick.md
@@ -1,0 +1,5 @@
+---
+"mastra": patch
+---
+
+Improve Bun detection logic by looking for `.lockb`, too

--- a/packages/cli/src/services/service.deps.ts
+++ b/packages/cli/src/services/service.deps.ts
@@ -13,7 +13,7 @@ export class DepsService {
   }
 
   private findLockFile(dir: string): string | null {
-    const lockFiles = ['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'bun.lock'];
+    const lockFiles = ['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'bun.lock', 'bun.lockb'];
     for (const file of lockFiles) {
       if (fs.existsSync(path.join(dir, file))) {
         return file;

--- a/packages/cli/src/services/service.deps.ts
+++ b/packages/cli/src/services/service.deps.ts
@@ -36,6 +36,7 @@ export class DepsService {
       case 'yarn.lock':
         return 'yarn';
       case 'bun.lock':
+      case 'bun.lockb':
         return 'bun';
       default:
         return 'npm';


### PR DESCRIPTION
## Description

I've been using Bun for my project. When I tried to install Mastra using the CLI with bunx (bunx mastra@beta init), I encountered multiple dependency installation errors.

Upon investigation, I found that some dependencies were being installed in node_modules using npm style. After examining the Mastra CLI logic, I discovered that the CLI only detects Bun when `bun.lock` is present, not `bun.lockb`.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Bun lock files to ensure better package lock recognition and compatibility.

* **Chores**
  * Added release metadata to trigger a patch release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->