### PR TITLE
feat(docs): Use Kapa group ID

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -52,6 +52,7 @@ const config: Config = {
     posthogApiKey: process.env.POSTHOG_API_KEY,
     posthogHost: process.env.POSTHOG_HOST,
     kapaIntegrationId: process.env.KAPA_INTEGRATION_ID,
+    kapaGroupId: process.env.KAPA_GROUP_ID,
   },
 
   // Preconnect to Google Fonts

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -9,6 +9,7 @@ import { ChatbotSidebarProvider } from "./DocRoot/Layout/ChatbotSidebar/context"
 export default function Root({ children }: { children: React.ReactNode }) {
   const { siteConfig } = useDocusaurusContext();
   const kapaIntegrationId = siteConfig.customFields.kapaIntegrationId as string;
+  const kapaGroupId = siteConfig.customFields.kapaGroupId as string;
   const posthogApiKey = siteConfig.customFields.posthogApiKey as string;
   const posthogHost =
     (siteConfig.customFields.posthogHost as string) ||
@@ -21,7 +22,10 @@ export default function Root({ children }: { children: React.ReactNode }) {
         api_host: posthogHost,
       }}
     >
-      <KapaProvider integrationId={kapaIntegrationId || ""}>
+      <KapaProvider
+        integrationId={kapaIntegrationId || ""}
+        sourceGroupIDsInclude={[kapaGroupId]}
+      >
         <Toaster />
         <CookieConsent />
         <ChatbotSidebarProvider defaultHidden={true}>

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -9,7 +9,7 @@ import { ChatbotSidebarProvider } from "./DocRoot/Layout/ChatbotSidebar/context"
 export default function Root({ children }: { children: React.ReactNode }) {
   const { siteConfig } = useDocusaurusContext();
   const kapaIntegrationId = siteConfig.customFields.kapaIntegrationId as string;
-  const kapaGroupId = siteConfig.customFields.kapaGroupId as string;
+  const kapaGroupId = siteConfig.customFields.kapaGroupId as string | undefined;
   const posthogApiKey = siteConfig.customFields.posthogApiKey as string;
   const posthogHost =
     (siteConfig.customFields.posthogHost as string) ||
@@ -24,7 +24,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
     >
       <KapaProvider
         integrationId={kapaIntegrationId || ""}
-        sourceGroupIDsInclude={[kapaGroupId]}
+        {...(kapaGroupId && { sourceGroupIDsInclude: [kapaGroupId] })}
       >
         <Toaster />
         <CookieConsent />


### PR DESCRIPTION
## Description

I created source groups for Kapa: https://docs.kapa.ai/data-sources/manage

We now pass the group id of the v1 docs to the provider: https://docs.kapa.ai/data-sources/manage#react-sdk

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation platform now reads an optional group identifier from the environment to enable group-specific integrations and content.
* **Chores**
  * Under-the-hood provider integration updated to apply group-based settings when the identifier is present.
* **Behavior**
  * No changes occur for users if the optional group identifier is not set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->