### PR TITLE
fix(semantic-recall): validate vector index dimensions on embedder switch

### DIFF
--- a/.changeset/every-colts-bow.md
+++ b/.changeset/every-colts-bow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix dimension mismatch error when switching embedders in SemanticRecall. The processor now properly validates vector index dimensions when an index already exists, preventing runtime errors when switching between embedders with different dimensions (e.g., fastembed 384 dims → OpenAI 1536 dims).

--- a/packages/core/src/processors/memory/semantic-recall.test.ts
+++ b/packages/core/src/processors/memory/semantic-recall.test.ts
@@ -2137,4 +2137,409 @@ describe('SemanticRecall', () => {
       expect(localMockVector.upsert).not.toHaveBeenCalled();
     });
   });
+
+  describe('Dimension Validation', () => {
+    it('should fail when querying index with mismatched dimensions (reproduces user issue #11854)', async () => {
+      // Reproduces issue #11854: Create index with 384 dims, switch embedder to 1536 dims
+      const customIndexName = 'atlas_project_memories';
+
+      const createdIndexes = new Map<string, { dimension: number; metric: string; vectors: number[][] }>();
+
+      const mockVector = {
+        listIndexes: vi.fn().mockImplementation(async () => {
+          return Array.from(createdIndexes.keys());
+        }),
+        createIndex: vi.fn().mockImplementation(async ({ indexName, dimension, metric }) => {
+          if (!createdIndexes.has(indexName)) {
+            createdIndexes.set(indexName, { dimension, metric, vectors: [] });
+          }
+        }),
+        upsert: vi.fn().mockImplementation(async ({ indexName, vectors }) => {
+          const index = createdIndexes.get(indexName);
+          if (!index) {
+            throw new Error(`Index "${indexName}" does not exist`);
+          }
+          // Store vectors
+          index.vectors.push(...vectors);
+          return vectors.map((_, i) => `vec-${i}`);
+        }),
+        query: vi.fn().mockImplementation(async ({ indexName, queryVector }) => {
+          const index = createdIndexes.get(indexName);
+          if (!index) {
+            throw new Error(`Index "${indexName}" does not exist`);
+          }
+          // Validate query vector dimensions match index
+          if (queryVector.length !== index.dimension) {
+            throw new Error(
+              `vector field is indexed with ${index.dimension} dimensions but queried with ${queryVector.length}`,
+            );
+          }
+          return [];
+        }),
+        describeIndex: vi.fn().mockImplementation(async ({ indexName }) => {
+          const index = createdIndexes.get(indexName);
+          if (!index) {
+            throw new Error(`Index "${indexName}" does not exist`);
+          }
+          return {
+            dimension: index.dimension,
+            metric: index.metric,
+            count: index.vectors.length,
+          };
+        }),
+      } as any;
+
+      const mockStorage = {
+        listMessages: vi.fn().mockResolvedValue({
+          messages: [],
+          total: 0,
+          page: 1,
+          perPage: false,
+          hasMore: false,
+        }),
+      } as any;
+
+      const requestContext = new RequestContext();
+      requestContext.set('MastraMemory', {
+        thread: { id: 'thread-1' },
+        resourceId: 'resource-1',
+      });
+
+      // Step 1: Create processor with fastembed (384 dims)
+      const fastembedEmbedder = {
+        doEmbed: vi.fn().mockResolvedValue({
+          embeddings: [Array(384).fill(0.1)],
+        }),
+        modelId: 'fastembed-base',
+      } as any;
+
+      const fastembedProcessor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: fastembedEmbedder,
+        indexName: customIndexName,
+        topK: 3,
+      });
+
+      const message1: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          content: 'Hello world',
+          parts: [{ type: 'text', text: 'Hello world' }],
+        },
+        createdAt: new Date(),
+      };
+
+      const messageList1 = new MessageList();
+      messageList1.add([message1], 'input');
+
+      await fastembedProcessor.processOutputResult({
+        messages: [message1],
+        messageList: messageList1,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      expect(createdIndexes.get(customIndexName)?.dimension).toBe(384);
+      expect(createdIndexes.get(customIndexName)?.vectors.length).toBe(1);
+
+      // Step 2: Switch to OpenAI embedder (1536 dims) with same index name
+      const openaiEmbedder = {
+        doEmbed: vi.fn().mockResolvedValue({
+          embeddings: [Array(1536).fill(0.1)],
+        }),
+        modelId: 'text-embedding-3-small',
+      } as any;
+
+      const openaiProcessor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: openaiEmbedder,
+        indexName: customIndexName,
+        topK: 3,
+      });
+
+      const message2: MastraDBMessage = {
+        id: 'msg-2',
+        role: 'user',
+        content: {
+          format: 2,
+          content: 'What is the weather?',
+          parts: [{ type: 'text', text: 'What is the weather?' }],
+        },
+        createdAt: new Date(),
+      };
+
+      const messageList2 = new MessageList();
+      messageList2.add([message2], 'input');
+
+      // After fix: ensureVectorIndex should call createIndex, which catches mismatch early
+      const result = await openaiProcessor.processInput({
+        messages: [message2],
+        messageList: messageList2,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      expect(mockVector.createIndex).toHaveBeenCalledWith({
+        indexName: customIndexName,
+        dimension: 1536,
+        metric: 'cosine',
+      });
+
+      // createIndex should have thrown, preventing query from happening
+      expect(mockVector.query).not.toHaveBeenCalled();
+      expect(result).toBe(messageList2);
+    });
+
+    it('should throw error when switching embedders with different dimensions on same index', async () => {
+      // Tests that createIndex validates dimensions and throws on mismatch
+      const customIndexName = 'atlas_project_memories';
+      const createdIndexes = new Map<string, { dimension: number; metric: string }>();
+
+      const mockVector = {
+        listIndexes: vi.fn().mockImplementation(async () => {
+          return Array.from(createdIndexes.keys());
+        }),
+        createIndex: vi.fn().mockImplementation(async ({ indexName, dimension, metric }) => {
+          if (createdIndexes.has(indexName)) {
+            const existing = createdIndexes.get(indexName)!;
+            if (existing.dimension !== dimension) {
+              throw new Error(
+                `Index "${indexName}" already exists with ${existing.dimension} dimensions, but ${dimension} dimensions were requested`,
+              );
+            }
+            return;
+          }
+          createdIndexes.set(indexName, { dimension, metric });
+        }),
+        describeIndex: vi.fn().mockImplementation(async ({ indexName }) => {
+          const index = createdIndexes.get(indexName);
+          if (!index) {
+            throw new Error(`Index "${indexName}" does not exist`);
+          }
+          return {
+            dimension: index.dimension,
+            metric: index.metric,
+            count: 0,
+          };
+        }),
+        query: vi.fn().mockResolvedValue([]),
+        upsert: vi.fn().mockResolvedValue([]),
+      } as any;
+
+      const mockStorage = {
+        listMessages: vi.fn().mockResolvedValue({
+          messages: [],
+          total: 0,
+          page: 1,
+          perPage: false,
+          hasMore: false,
+        }),
+      } as any;
+
+      const fastembedEmbedder = {
+        doEmbed: vi.fn().mockResolvedValue({
+          embeddings: [Array(384).fill(0.1)],
+        }),
+        modelId: 'fastembed-base',
+      } as any;
+
+      const fastembedProcessor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: fastembedEmbedder,
+        indexName: customIndexName,
+        topK: 3,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('MastraMemory', {
+        thread: { id: 'thread-1' },
+        resourceId: 'resource-1',
+      });
+
+      const inputMessage: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          content: 'Hello world',
+          parts: [{ type: 'text', text: 'Hello world' }],
+        },
+        createdAt: new Date(),
+      };
+
+      const messageList1 = new MessageList();
+      messageList1.add([inputMessage], 'input');
+
+      await fastembedProcessor.processInput({
+        messages: [inputMessage],
+        messageList: messageList1,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      expect(mockVector.createIndex).toHaveBeenCalledWith({
+        indexName: customIndexName,
+        dimension: 384,
+        metric: 'cosine',
+      });
+      expect(createdIndexes.get(customIndexName)?.dimension).toBe(384);
+
+      const openaiEmbedder = {
+        doEmbed: vi.fn().mockResolvedValue({
+          embeddings: [Array(1536).fill(0.1)],
+        }),
+        modelId: 'text-embedding-3-small',
+      } as any;
+
+      const openaiProcessor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: openaiEmbedder,
+        indexName: customIndexName,
+        topK: 3,
+      });
+
+      const inputMessage2: MastraDBMessage = {
+        id: 'msg-2',
+        role: 'user',
+        content: {
+          format: 2,
+          content: 'What is the weather?',
+          parts: [{ type: 'text', text: 'What is the weather?' }],
+        },
+        createdAt: new Date(),
+      };
+
+      const messageList2 = new MessageList();
+      messageList2.add([inputMessage2], 'input');
+
+      // Should throw dimension mismatch error
+      await expect(
+        openaiProcessor.processInput({
+          messages: [inputMessage2],
+          messageList: messageList2,
+          abort: vi.fn() as any,
+          requestContext,
+        }),
+      ).rejects.toThrow(/already exists with 384 dimensions.*1536 dimensions/i);
+    });
+
+    it('should succeed when using same embedder dimensions on existing index', async () => {
+      // Verifies idempotent createIndex when dimensions match
+      const customIndexName = 'test_index';
+      const createdIndexes = new Map<string, { dimension: number; metric: string }>();
+
+      const mockVector = {
+        listIndexes: vi.fn().mockImplementation(async () => {
+          return Array.from(createdIndexes.keys());
+        }),
+        createIndex: vi.fn().mockImplementation(async ({ indexName, dimension, metric }) => {
+          if (createdIndexes.has(indexName)) {
+            const existing = createdIndexes.get(indexName)!;
+            if (existing.dimension !== dimension) {
+              throw new Error(
+                `Index "${indexName}" already exists with ${existing.dimension} dimensions, but ${dimension} dimensions were requested`,
+              );
+            }
+            return;
+          }
+          createdIndexes.set(indexName, { dimension, metric });
+        }),
+        describeIndex: vi.fn().mockImplementation(async ({ indexName }) => {
+          const index = createdIndexes.get(indexName);
+          if (!index) {
+            throw new Error(`Index "${indexName}" does not exist`);
+          }
+          return {
+            dimension: index.dimension,
+            metric: index.metric,
+            count: 0,
+          };
+        }),
+        query: vi.fn().mockResolvedValue([]),
+        upsert: vi.fn().mockResolvedValue([]),
+      } as any;
+
+      const mockStorage = {
+        listMessages: vi.fn().mockResolvedValue({
+          messages: [],
+          total: 0,
+          page: 1,
+          perPage: false,
+          hasMore: false,
+        }),
+      } as any;
+
+      const embedder = {
+        doEmbed: vi.fn().mockResolvedValue({
+          embeddings: [Array(384).fill(0.1)],
+        }),
+        modelId: 'test-embedder',
+      } as any;
+
+      const processor1 = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: embedder,
+        indexName: customIndexName,
+        topK: 3,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('MastraMemory', {
+        thread: { id: 'thread-1' },
+        resourceId: 'resource-1',
+      });
+
+      const inputMessage: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          content: 'Hello',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+        createdAt: new Date(),
+      };
+
+      const messageList1 = new MessageList();
+      messageList1.add([inputMessage], 'input');
+
+      await processor1.processInput({
+        messages: [inputMessage],
+        messageList: messageList1,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      expect(createdIndexes.get(customIndexName)?.dimension).toBe(384);
+
+      const processor2 = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: embedder,
+        indexName: customIndexName,
+        topK: 3,
+      });
+
+      const messageList2 = new MessageList();
+      messageList2.add([inputMessage], 'input');
+
+      await expect(
+        processor2.processInput({
+          messages: [inputMessage],
+          messageList: messageList2,
+          abort: vi.fn() as any,
+          requestContext,
+        }),
+      ).resolves.not.toThrow();
+
+      expect(mockVector.createIndex).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes dimension mismatch error when switching between embedders with different dimensions while using the same index name in SemanticRecall.

When users switched from fastembed (384 dims) to OpenAI (1536 dims) with the same `indexName`, the system would fail at query time with:
```
vector field is indexed with 384 dimensions but queried with 1536
```

The issue was that `ensureVectorIndex()` used `listIndexes()` pre-check and skipped `createIndex()` when the index existed, bypassing dimension validation that exists in vector stores.

**Solution:**
- Remove `listIndexes()` pre-check in `ensureVectorIndex()`
- Always call `createIndex()` which has built-in dimension validation
- Add in-memory cache to prevent redundant validation API calls

This makes semantic-recall consistent with regular vector usage, where `createIndex()` is idempotent and validates dimensions when index exists.

**Performance:**
- First call: 1-2 API calls (createIndex + optional describeIndex)
- Subsequent calls: 0 API calls (in-memory cache)
- Same or better performance than before

## Related Issue(s)

Fixes #11854

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime errors that occurred when switching between embedders with different vector dimensions in semantic recall functionality. Vector index dimensions are now validated to ensure compatibility and prevent mismatches during embedder transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->