### PR TITLE
refactor(playground-ui): simplify Storybook configuration

### DIFF
--- a/.changeset/storybook-config-cleanup.md
+++ b/.changeset/storybook-config-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground-ui": patch
+---
+
+Simplify Storybook configuration by removing Radix UI module resolution hacks and creating a dedicated CSS file for Storybook

--- a/packages/playground-ui/.storybook/main.ts
+++ b/packages/playground-ui/.storybook/main.ts
@@ -1,11 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import { dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
-import tailwindcss from 'tailwindcss';
-import autoprefixer from 'autoprefixer';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import autoprefixer from 'autoprefixer';
+import tailwindcss from 'tailwindcss';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -16,101 +12,11 @@ const config: StorybookConfig = {
   },
   // Ensure Tailwind CSS is processed and modules are properly resolved
   viteFinal: async config => {
-    // Add resolve configuration to handle module resolution
-    config.resolve = {
-      ...config.resolve,
-      alias: {
-        ...config.resolve?.alias,
-        '@': resolve(__dirname, '../src'),
-        // Force Radix UI modules to be resolved from node_modules
-        '@radix-ui/react-hover-card': resolve(__dirname, '../node_modules/@radix-ui/react-hover-card/dist/index.js'),
-        '@radix-ui/react-alert-dialog': resolve(
-          __dirname,
-          '../node_modules/@radix-ui/react-alert-dialog/dist/index.js',
-        ),
-        '@radix-ui/react-checkbox': resolve(__dirname, '../node_modules/@radix-ui/react-checkbox/dist/index.js'),
-        '@radix-ui/react-collapsible': resolve(__dirname, '../node_modules/@radix-ui/react-collapsible/dist/index.js'),
-        '@radix-ui/react-dialog': resolve(__dirname, '../node_modules/@radix-ui/react-dialog/dist/index.js'),
-        '@radix-ui/react-label': resolve(__dirname, '../node_modules/@radix-ui/react-label/dist/index.js'),
-        '@radix-ui/react-popover': resolve(__dirname, '../node_modules/@radix-ui/react-popover/dist/index.js'),
-        '@radix-ui/react-radio-group': resolve(__dirname, '../node_modules/@radix-ui/react-radio-group/dist/index.js'),
-        '@radix-ui/react-scroll-area': resolve(__dirname, '../node_modules/@radix-ui/react-scroll-area/dist/index.js'),
-        '@radix-ui/react-select': resolve(__dirname, '../node_modules/@radix-ui/react-select/dist/index.js'),
-        '@radix-ui/react-slider': resolve(__dirname, '../node_modules/@radix-ui/react-slider/dist/index.js'),
-        '@radix-ui/react-switch': resolve(__dirname, '../node_modules/@radix-ui/react-switch/dist/index.js'),
-        '@radix-ui/react-tabs': resolve(__dirname, '../node_modules/@radix-ui/react-tabs/dist/index.js'),
-        '@radix-ui/react-tooltip': resolve(__dirname, '../node_modules/@radix-ui/react-tooltip/dist/index.js'),
-        '@radix-ui/react-visually-hidden': resolve(
-          __dirname,
-          '../node_modules/@radix-ui/react-visually-hidden/dist/index.js',
-        ),
-        // Force lucide-react to be resolved from node_modules
-        'lucide-react': resolve(__dirname, '../node_modules/lucide-react/dist/esm/lucide-react.js'),
-      },
-    };
-
-    // Ensure external dependencies are properly handled
-    config.optimizeDeps = {
-      ...config.optimizeDeps,
-      include: [
-        ...(config.optimizeDeps?.include || []),
-        // Radix UI packages used in playground-ui
-        '@radix-ui/react-hover-card',
-        '@radix-ui/react-alert-dialog',
-        '@radix-ui/react-checkbox',
-        '@radix-ui/react-collapsible',
-        '@radix-ui/react-dialog',
-        '@radix-ui/react-label',
-        '@radix-ui/react-popover',
-        '@radix-ui/react-radio-group',
-        '@radix-ui/react-scroll-area',
-        '@radix-ui/react-select',
-        '@radix-ui/react-slider',
-        '@radix-ui/react-switch',
-        '@radix-ui/react-tabs',
-        '@radix-ui/react-tooltip',
-        '@radix-ui/react-visually-hidden',
-        // Other dependencies
-        'react',
-        'react-dom',
-        'lucide-react',
-        'tailwindcss',
-        'autoprefixer',
-      ],
-      exclude: [...(config.optimizeDeps?.exclude || [])],
-    };
-
     // Add CSS processing
     config.css = {
       ...config.css,
       postcss: {
-        plugins: [tailwindcss(resolve(__dirname, './tailwind.config.ts')), autoprefixer()],
-      },
-    };
-
-    // Force bundling of all modules
-    config.ssr = {
-      ...config.ssr,
-      noExternal: ['@radix-ui/*', 'lucide-react'],
-    };
-
-    // Ensure proper bundling for production builds
-    config.build = {
-      ...config.build,
-      rollupOptions: {
-        ...config.build?.rollupOptions,
-        // Don't externalize any modules - bundle everything
-        external: (id: string) => {
-          // Don't externalize Radix UI packages
-          if (id.startsWith('@radix-ui/')) {
-            return false;
-          }
-          // Don't externalize lucide-react
-          if (id === 'lucide-react') {
-            return false;
-          }
-          return false;
-        },
+        plugins: [tailwindcss(), autoprefixer()],
       },
     };
 

--- a/packages/playground-ui/.storybook/preview.ts
+++ b/packages/playground-ui/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import type { Preview } from '@storybook/react-vite';
 import { themes } from 'storybook/theming';
-import '../src/index.css';
-import '../../../packages/playground/src/index.css';
+import './tailwind.css';
+import { Colors } from '@/ds/tokens/colors';
 
 const preview: Preview = {
   parameters: {
@@ -15,17 +15,10 @@ const preview: Preview = {
       },
     },
     backgrounds: {
-      default: 'dark',
-      values: [
-        {
-          name: 'dark',
-          value: '#1a1a1a',
-        },
-        {
-          name: 'light',
-          value: '#ffffff',
-        },
-      ],
+      options: {
+        dark: { name: 'Dark', value: Colors.surface1 },
+        light: { name: 'Light', value: Colors.surface1 },
+      },
     },
   },
   initialGlobals: {

--- a/packages/playground-ui/.storybook/tailwind.css
+++ b/packages/playground-ui/.storybook/tailwind.css
@@ -1,0 +1,87 @@
+@tailwind base;
+@import '../src/index.css';
+@tailwind utilities;
+
+:root {
+  --font-inter: 'Inter', sans-serif;
+  --tasa-explorer: 'TasaExplorer', sans-serif;
+  --geist-mono: 'GeistMonoVF', monospace;
+
+  --background: 0 0% 3.92% 1;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 3.9%;
+  --primary: 240 5.9% 10%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 5.9% 10%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --accent: 240 4.8% 95.9%;
+  --accent-blue: 210 60% 53.1%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 20.4%;
+  --input: 240 5.9% 90%;
+  --ring: 240 10% 3.9%;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+  --radius: 0.5rem;
+  --sidebar-background: 0 0% 98%;
+  --sidebar-foreground: 240 5.3% 26.1%;
+  --sidebar-primary: 240 5.9% 10%;
+  --sidebar-primary-foreground: 0 0% 98%;
+  --sidebar-accent: 240 4.8% 95.9%;
+  --sidebar-accent-foreground: 240 5.9% 10%;
+  --sidebar-black: 0 0% 100%;
+  --sidebar-border: 220 13% 91%;
+  --sidebar-ring: 217.2 91.2% 59.8%;
+  --top-bar-height: 40px;
+}
+
+.dark,
+:root {
+  --background: 0 0% 3.92% 1;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --popover: 240 10% 3.9%;
+  --popover-foreground: 0 0% 98%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --accent: 0 0% 16.08/50%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 20.4%;
+  --input: 240 3.7% 15.9%;
+  --ring: 240 4.9% 83.9%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+  --sidebar-background: 0 0% 9.02%;
+  --sidebar-foreground: 240 4.8% 95.9%;
+  --sidebar-primary: 224.3 76.3% 48%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent: 240 3.7% 15.9%;
+  --sidebar-accent-foreground: 240 4.8% 95.9%;
+  --sidebar-black: 0 0% 0%;
+  --sidebar-border: 240 3.7% 15.9%;
+  --sidebar-ring: 217.2 91.2% 59.8%;
+
+  --color-thumb: rgb(64, 64, 64);
+  --color-thumb-hover: rgb(96, 96, 96);
+  --color-track: transparent;
+}

--- a/packages/playground-ui/.storybook/tailwind.css
+++ b/packages/playground-ui/.storybook/tailwind.css
@@ -1,5 +1,5 @@
-@tailwind base;
 @import '../src/index.css';
+@tailwind base;
 @tailwind utilities;
 
 :root {

--- a/packages/playground-ui/tailwind.config.ts
+++ b/packages/playground-ui/tailwind.config.ts
@@ -11,6 +11,9 @@ import {
   Spacings,
   Sizes,
 } from './src/ds/tokens';
+import animate from 'tailwindcss-animate';
+import assistantUi from '@assistant-ui/react-ui/tailwindcss';
+import containerQueries from '@tailwindcss/container-queries';
 
 export default {
   darkMode: ['class'],
@@ -202,9 +205,5 @@ export default {
       },
     },
   },
-  plugins: [
-    require('tailwindcss-animate'),
-    require('@assistant-ui/react-ui/tailwindcss'),
-    require('@tailwindcss/container-queries'),
-  ],
+  plugins: [animate, assistantUi, containerQueries],
 } satisfies Config;


### PR DESCRIPTION
Removes the verbose Radix UI and lucide-react module resolution hacks from Storybook's Vite config. These workarounds were added previously but are no longer needed.

Changes:
- Removed explicit path aliases for all Radix UI packages
- Removed `optimizeDeps.include` for Radix and other dependencies
- Removed `ssr.noExternal` and `build.rollupOptions` overrides
- Created a dedicated `tailwind.css` for Storybook that imports the design system
- Updated preview.ts to use design system colors for backgrounds
- Switched from `require()` to ESM imports in tailwind.config.ts

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified Storybook configuration by removing bespoke build-time customizations.
  * Added a dedicated Storybook Tailwind stylesheet with comprehensive light/dark theme tokens.
  * Switched Storybook preview to use token-based color options for backgrounds.

* **Refactor**
  * Modernized Tailwind configuration by adopting cleaner, static plugin imports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->