### PR TITLE
feat(playground-ui): add Storybook stories for all design system components

### DIFF
--- a/.changeset/add-storybook-stories-playground-ui.md
+++ b/.changeset/add-storybook-stories-playground-ui.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground-ui": patch
+---
+
+Add Storybook stories for all design system components. Includes stories for 48 components organized by category (Elements, Feedback, Navigation, DataDisplay, Layout, Composite) plus an Icons showcase displaying all 41 icons.

--- a/packages/playground-ui/src/ds/components/Alert/alert.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Alert/alert.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Alert, AlertTitle, AlertDescription } from './Alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'Elements/Alert',
+  component: Alert,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['warning', 'destructive', 'info'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Default: Story = {
+  args: {
+    variant: 'destructive',
+    children: 'This is an alert message',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: 'warning',
+    children: 'This is a warning alert',
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    variant: 'destructive',
+    children: 'This is a destructive alert',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    variant: 'info',
+    children: 'This is an info alert',
+  },
+};
+
+export const WithTitleAndDescription: Story = {
+  render: args => (
+    <Alert {...args}>
+      <AlertTitle>Alert Title</AlertTitle>
+      <AlertDescription as="p">This is the alert description with more details about the issue.</AlertDescription>
+    </Alert>
+  ),
+  args: {
+    variant: 'warning',
+  },
+};

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AlertDialog } from './alert-dialog';
+import { Button } from '../Button';
+
+const meta: Meta<typeof AlertDialog> = {
+  title: 'Feedback/AlertDialog',
+  component: AlertDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AlertDialog>;
+
+export const Default: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialog.Trigger asChild>
+        <Button>Open Alert Dialog</Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content>
+        <AlertDialog.Header>
+          <AlertDialog.Title>Are you sure?</AlertDialog.Title>
+          <AlertDialog.Description>
+            This action cannot be undone. This will permanently delete your account and remove your data from our
+            servers.
+          </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+          <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+          <AlertDialog.Action>Continue</AlertDialog.Action>
+        </AlertDialog.Footer>
+      </AlertDialog.Content>
+    </AlertDialog>
+  ),
+};
+
+export const DeleteConfirmation: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialog.Trigger asChild>
+        <Button variant="outline">Delete Item</Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content>
+        <AlertDialog.Header>
+          <AlertDialog.Title>Delete this item?</AlertDialog.Title>
+          <AlertDialog.Description>
+            This will permanently delete the selected item. You cannot undo this action.
+          </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+          <AlertDialog.Cancel>Keep Item</AlertDialog.Cancel>
+          <AlertDialog.Action>Delete</AlertDialog.Action>
+        </AlertDialog.Footer>
+      </AlertDialog.Content>
+    </AlertDialog>
+  ),
+};
+
+export const LogoutConfirmation: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialog.Trigger asChild>
+        <Button variant="ghost">Log out</Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content>
+        <AlertDialog.Header>
+          <AlertDialog.Title>Log out of your account?</AlertDialog.Title>
+          <AlertDialog.Description>You will need to sign in again to access your data.</AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+          <AlertDialog.Cancel>Stay signed in</AlertDialog.Cancel>
+          <AlertDialog.Action>Log out</AlertDialog.Action>
+        </AlertDialog.Footer>
+      </AlertDialog.Content>
+    </AlertDialog>
+  ),
+};
+
+export const DiscardChanges: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialog.Trigger asChild>
+        <Button variant="outline">Discard changes</Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content>
+        <AlertDialog.Header>
+          <AlertDialog.Title>Discard unsaved changes?</AlertDialog.Title>
+          <AlertDialog.Description>
+            You have unsaved changes that will be lost. Are you sure you want to discard them?
+          </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+          <AlertDialog.Cancel>Keep editing</AlertDialog.Cancel>
+          <AlertDialog.Action>Discard</AlertDialog.Action>
+        </AlertDialog.Footer>
+      </AlertDialog.Content>
+    </AlertDialog>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Avatar/avatar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Avatar/avatar.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Avatar } from './Avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Elements/Avatar',
+  component: Avatar,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Default: Story = {
+  args: {
+    name: 'John Doe',
+    size: 'sm',
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    name: 'Jane Smith',
+    src: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop&crop=face',
+    size: 'md',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    name: 'Alice',
+    size: 'sm',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    name: 'Bob',
+    size: 'md',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    name: 'Charlie',
+    size: 'lg',
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Avatar name="Small" size="sm" />
+      <Avatar name="Medium" size="md" />
+      <Avatar name="Large" size="lg" />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Badge } from './Badge';
+import { Check, AlertCircle, Info as InfoIcon } from 'lucide-react';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Elements/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'success', 'error', 'info'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {
+  args: {
+    children: 'Badge',
+    variant: 'default',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    children: 'Success',
+    variant: 'success',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    children: 'Error',
+    variant: 'error',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    children: 'Info',
+    variant: 'info',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    children: 'Completed',
+    icon: <Check className="h-3 w-3" />,
+    variant: 'success',
+  },
+};
+
+export const WithErrorIcon: Story = {
+  args: {
+    children: 'Failed',
+    icon: <AlertCircle className="h-3 w-3" />,
+    variant: 'error',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Badge variant="default">Default</Badge>
+      <Badge variant="success">Success</Badge>
+      <Badge variant="error">Error</Badge>
+      <Badge variant="info">Info</Badge>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Breadcrumb, Crumb } from './Breadcrumb';
+import { ChevronDown } from 'lucide-react';
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: 'Navigation/Breadcrumb',
+  component: Breadcrumb,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Breadcrumb>;
+
+export const Default: Story = {
+  render: () => (
+    <Breadcrumb label="Navigation">
+      <Crumb as="a" to="/home">
+        Home
+      </Crumb>
+      <Crumb as="a" to="/products">
+        Products
+      </Crumb>
+      <Crumb as="span" to="/products/item" isCurrent>
+        Item Details
+      </Crumb>
+    </Breadcrumb>
+  ),
+};
+
+export const TwoLevels: Story = {
+  render: () => (
+    <Breadcrumb label="Navigation">
+      <Crumb as="a" to="/dashboard">
+        Dashboard
+      </Crumb>
+      <Crumb as="span" to="/dashboard/settings" isCurrent>
+        Settings
+      </Crumb>
+    </Breadcrumb>
+  ),
+};
+
+export const ManyLevels: Story = {
+  render: () => (
+    <Breadcrumb label="Navigation">
+      <Crumb as="a" to="/home">
+        Home
+      </Crumb>
+      <Crumb as="a" to="/workspace">
+        Workspace
+      </Crumb>
+      <Crumb as="a" to="/workspace/projects">
+        Projects
+      </Crumb>
+      <Crumb as="a" to="/workspace/projects/mastra">
+        Mastra
+      </Crumb>
+      <Crumb as="span" to="/workspace/projects/mastra/agents" isCurrent>
+        Agents
+      </Crumb>
+    </Breadcrumb>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <Breadcrumb label="Navigation">
+      <Crumb as="a" to="/agents">
+        Agents
+      </Crumb>
+      <Crumb
+        as="span"
+        to="/agents/my-agent"
+        isCurrent
+        action={
+          <button className="p-1 hover:bg-surface2 rounded">
+            <ChevronDown className="h-4 w-4 text-icon3" />
+          </button>
+        }
+      >
+        My Agent
+      </Crumb>
+    </Breadcrumb>
+  ),
+};
+
+export const SingleItem: Story = {
+  render: () => (
+    <Breadcrumb label="Navigation">
+      <Crumb as="span" to="/dashboard" isCurrent>
+        Dashboard
+      </Crumb>
+    </Breadcrumb>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Button/button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Button/button.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './Button';
+import { Plus, Settings, Trash } from 'lucide-react';
+
+const meta: Meta<typeof Button> = {
+  title: 'Elements/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'light', 'outline', 'ghost'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['md', 'lg'],
+    },
+    disabled: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: {
+    children: 'Button',
+    variant: 'default',
+    size: 'md',
+  },
+};
+
+export const Light: Story = {
+  args: {
+    children: 'Light Button',
+    variant: 'light',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    children: 'Outline Button',
+    variant: 'outline',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    children: 'Ghost Button',
+    variant: 'ghost',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    children: 'Large Button',
+    size: 'lg',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled Button',
+    disabled: true,
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        <Plus className="h-4 w-4" />
+        Add Item
+      </>
+    ),
+  },
+};
+
+export const IconOnly: Story = {
+  args: {
+    children: <Settings className="h-4 w-4" />,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Button variant="default">Default</Button>
+      <Button variant="light">Light</Button>
+      <Button variant="outline">Outline</Button>
+      <Button variant="ghost">Ghost</Button>
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ButtonsGroup } from './buttons-group';
+import { Button } from '../Button';
+
+const meta: Meta<typeof ButtonsGroup> = {
+  title: 'Composite/ButtonsGroup',
+  component: ButtonsGroup,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonsGroup>;
+
+export const Default: Story = {
+  render: () => (
+    <ButtonsGroup>
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const TwoButtons: Story = {
+  render: () => (
+    <ButtonsGroup>
+      <Button variant="outline">Cancel</Button>
+      <Button>Save</Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const ManyButtons: Story = {
+  render: () => (
+    <ButtonsGroup>
+      <Button variant="ghost">Reset</Button>
+      <Button variant="outline">Cancel</Button>
+      <Button variant="light">Draft</Button>
+      <Button>Submit</Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const ActionButtons: Story = {
+  render: () => (
+    <ButtonsGroup>
+      <Button variant="outline">Edit</Button>
+      <Button variant="outline">Duplicate</Button>
+      <Button>Run</Button>
+    </ButtonsGroup>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Checkbox } from './checkbox';
+import { Label } from '../Label';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Elements/Checkbox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+    },
+    checked: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
+};
+
+export const WithLabel: Story = {
+  render: args => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="terms" {...args} />
+      <Label htmlFor="terms">Accept terms and conditions</Label>
+    </div>
+  ),
+};
+
+export const CheckboxGroup: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Checkbox id="option1" />
+        <Label htmlFor="option1">Option 1</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox id="option2" checked />
+        <Label htmlFor="option2">Option 2</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox id="option3" />
+        <Label htmlFor="option3">Option 3</Label>
+      </div>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CodeEditor } from './code-editor';
+
+const meta: Meta<typeof CodeEditor> = {
+  title: 'Composite/CodeEditor',
+  component: CodeEditor,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    showCopyButton: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CodeEditor>;
+
+export const Default: Story = {
+  args: {
+    data: {
+      name: 'my-agent',
+      model: 'gpt-4',
+      temperature: 0.7,
+    },
+    className: 'w-[400px]',
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: `{
+  "name": "workflow-1",
+  "steps": [
+    { "id": "step-1", "type": "trigger" },
+    { "id": "step-2", "type": "action" }
+  ]
+}`,
+    className: 'w-[400px]',
+  },
+};
+
+export const ComplexData: Story = {
+  args: {
+    data: {
+      agent: {
+        name: 'Customer Support',
+        model: 'gpt-4-turbo',
+        settings: {
+          temperature: 0.7,
+          maxTokens: 4096,
+          topP: 1,
+        },
+      },
+      tools: ['search', 'calculator', 'web-browser'],
+      memory: {
+        enabled: true,
+        type: 'conversation',
+      },
+    },
+    className: 'w-[500px]',
+  },
+};
+
+export const ArrayData: Story = {
+  args: {
+    data: [
+      { id: 1, name: 'Agent 1', status: 'active' },
+      { id: 2, name: 'Agent 2', status: 'inactive' },
+      { id: 3, name: 'Agent 3', status: 'active' },
+    ],
+    className: 'w-[400px]',
+  },
+};
+
+export const WithoutCopyButton: Story = {
+  args: {
+    data: { message: 'Hello, World!' },
+    showCopyButton: false,
+    className: 'w-[300px]',
+  },
+};
+
+export const LargeContent: Story = {
+  args: {
+    data: {
+      workflow: {
+        id: 'wf-123',
+        name: 'Data Processing Pipeline',
+        description: 'A workflow that processes and transforms data',
+        steps: [
+          { id: 's1', type: 'trigger', config: { event: 'webhook' } },
+          { id: 's2', type: 'transform', config: { operation: 'map' } },
+          { id: 's3', type: 'validate', config: { schema: 'output' } },
+          { id: 's4', type: 'output', config: { destination: 'database' } },
+        ],
+        metadata: {
+          created: '2026-01-14',
+          updated: '2026-01-14',
+          version: '1.0.0',
+        },
+      },
+    },
+    className: 'w-[600px] max-h-[400px] overflow-auto',
+  },
+};

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible';
+import { Button } from '../Button';
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+
+const meta: Meta<typeof Collapsible> = {
+  title: 'Layout/Collapsible',
+  component: Collapsible,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Collapsible>;
+
+export const Default: Story = {
+  render: () => (
+    <Collapsible className="w-[350px]">
+      <CollapsibleTrigger asChild>
+        <Button variant="outline" className="w-full justify-between">
+          Click to expand
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 p-4 rounded-md border border-border1 bg-surface2">
+        <p className="text-sm text-icon5">This is the collapsible content. It can contain any elements.</p>
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+export const DefaultOpen: Story = {
+  render: () => (
+    <Collapsible defaultOpen className="w-[350px]">
+      <CollapsibleTrigger asChild>
+        <Button variant="outline" className="w-full justify-between">
+          Section Title
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 p-4 rounded-md border border-border1 bg-surface2">
+        <p className="text-sm text-icon5">This section is open by default.</p>
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+export const SettingsSection: Story = {
+  render: () => (
+    <div className="w-[400px] space-y-2">
+      <Collapsible>
+        <CollapsibleTrigger asChild>
+          <button className="flex w-full items-center justify-between py-2 text-sm font-medium text-icon6 hover:text-white">
+            Advanced Settings
+            <ChevronDown className="h-4 w-4" />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-3 pt-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-icon5">Debug mode</span>
+            <span className="text-sm text-icon3">Disabled</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-icon5">Verbose logging</span>
+            <span className="text-sm text-icon3">Off</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-icon5">Cache timeout</span>
+            <span className="text-sm text-icon3">300s</span>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  ),
+};
+
+export const MultipleCollapsibles: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-2">
+      <Collapsible>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" className="w-full justify-between">
+            Section 1
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="p-2">
+          <p className="text-sm text-icon5">Content for section 1</p>
+        </CollapsibleContent>
+      </Collapsible>
+      <Collapsible>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" className="w-full justify-between">
+            Section 2
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="p-2">
+          <p className="text-sm text-icon5">Content for section 2</p>
+        </CollapsibleContent>
+      </Collapsible>
+      <Collapsible>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" className="w-full justify-between">
+            Section 3
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="p-2">
+          <p className="text-sm text-icon5">Content for section 3</p>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CombinedButtons } from './combined-buttons';
+import { Button } from '../Button';
+import { ChevronDown, Plus, Settings, Trash } from 'lucide-react';
+
+const meta: Meta<typeof CombinedButtons> = {
+  title: 'Composite/CombinedButtons',
+  component: CombinedButtons,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CombinedButtons>;
+
+export const Default: Story = {
+  render: () => (
+    <CombinedButtons>
+      <Button>Action</Button>
+      <Button>
+        <ChevronDown className="h-4 w-4" />
+      </Button>
+    </CombinedButtons>
+  ),
+};
+
+export const ThreeButtons: Story = {
+  render: () => (
+    <CombinedButtons>
+      <Button>Edit</Button>
+      <Button>Copy</Button>
+      <Button>Delete</Button>
+    </CombinedButtons>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <CombinedButtons>
+      <Button>
+        <Plus className="h-4 w-4" />
+        Add
+      </Button>
+      <Button>
+        <Settings className="h-4 w-4" />
+      </Button>
+    </CombinedButtons>
+  ),
+};
+
+export const IconOnly: Story = {
+  render: () => (
+    <CombinedButtons>
+      <Button>
+        <Plus className="h-4 w-4" />
+      </Button>
+      <Button>
+        <Settings className="h-4 w-4" />
+      </Button>
+      <Button>
+        <Trash className="h-4 w-4" />
+      </Button>
+    </CombinedButtons>
+  ),
+};
+
+export const SplitButton: Story = {
+  render: () => (
+    <CombinedButtons>
+      <Button variant="light">Save draft</Button>
+      <Button variant="light">
+        <ChevronDown className="h-4 w-4" />
+      </Button>
+    </CombinedButtons>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Combobox } from './combobox';
+
+const meta: Meta<typeof Combobox> = {
+  title: 'Composite/Combobox',
+  component: Combobox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'light', 'outline', 'ghost'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Combobox>;
+
+const frameworkOptions = [
+  { label: 'React', value: 'react' },
+  { label: 'Vue', value: 'vue' },
+  { label: 'Angular', value: 'angular' },
+  { label: 'Svelte', value: 'svelte' },
+  { label: 'Next.js', value: 'nextjs' },
+  { label: 'Nuxt', value: 'nuxt' },
+];
+
+const modelOptions = [
+  { label: 'GPT-4', value: 'gpt-4' },
+  { label: 'GPT-4 Turbo', value: 'gpt-4-turbo' },
+  { label: 'GPT-3.5 Turbo', value: 'gpt-3.5-turbo' },
+  { label: 'Claude 3 Opus', value: 'claude-3-opus' },
+  { label: 'Claude 3 Sonnet', value: 'claude-3-sonnet' },
+  { label: 'Claude 3 Haiku', value: 'claude-3-haiku' },
+];
+
+export const Default: Story = {
+  args: {
+    options: frameworkOptions,
+    placeholder: 'Select a framework...',
+    className: 'w-[200px]',
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    options: frameworkOptions,
+    value: 'react',
+    placeholder: 'Select a framework...',
+    className: 'w-[200px]',
+  },
+};
+
+export const ModelSelector: Story = {
+  args: {
+    options: modelOptions,
+    placeholder: 'Select a model...',
+    searchPlaceholder: 'Search models...',
+    className: 'w-[220px]',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options: frameworkOptions,
+    placeholder: 'Select a framework...',
+    disabled: true,
+    className: 'w-[200px]',
+  },
+};
+
+export const CustomEmptyText: Story = {
+  args: {
+    options: [],
+    placeholder: 'Select an option...',
+    emptyText: 'No options available',
+    className: 'w-[200px]',
+  },
+};
+
+export const LightVariant: Story = {
+  args: {
+    options: frameworkOptions,
+    placeholder: 'Select a framework...',
+    variant: 'light',
+    className: 'w-[200px]',
+  },
+};
+
+export const OutlineVariant: Story = {
+  args: {
+    options: frameworkOptions,
+    placeholder: 'Select a framework...',
+    variant: 'outline',
+    className: 'w-[200px]',
+  },
+};
+
+export const ManyOptions: Story = {
+  args: {
+    options: [
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+      { label: 'Option 3', value: '3' },
+      { label: 'Option 4', value: '4' },
+      { label: 'Option 5', value: '5' },
+      { label: 'Option 6', value: '6' },
+      { label: 'Option 7', value: '7' },
+      { label: 'Option 8', value: '8' },
+      { label: 'Option 9', value: '9' },
+      { label: 'Option 10', value: '10' },
+      { label: 'Option 11', value: '11' },
+      { label: 'Option 12', value: '12' },
+    ],
+    placeholder: 'Select an option...',
+    className: 'w-[200px]',
+  },
+};

--- a/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CopyButton } from './copy-button';
+import { TooltipProvider } from '../Tooltip';
+
+const meta: Meta<typeof CopyButton> = {
+  title: 'Composite/CopyButton',
+  component: CopyButton,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CopyButton>;
+
+export const Default: Story = {
+  args: {
+    content: 'Hello, World!',
+  },
+};
+
+export const WithCustomTooltip: Story = {
+  args: {
+    content: 'npm install @mastra/core',
+    tooltip: 'Copy command',
+  },
+};
+
+export const WithCopyMessage: Story = {
+  args: {
+    content: 'agent-id-12345',
+    copyMessage: 'Agent ID copied!',
+  },
+};
+
+export const SmallIcon: Story = {
+  args: {
+    content: 'some-text',
+    iconSize: 'sm',
+  },
+};
+
+export const LargeIcon: Story = {
+  args: {
+    content: 'some-text',
+    iconSize: 'lg',
+  },
+};
+
+export const InContext: Story = {
+  render: () => (
+    <div className="flex items-center gap-2 p-3 bg-surface4 rounded-md">
+      <code className="text-sm font-mono text-icon5">npm install @mastra/core</code>
+      <CopyButton content="npm install @mastra/core" />
+    </div>
+  ),
+};
+
+export const CodeBlock: Story = {
+  render: () => (
+    <div className="relative p-4 bg-surface4 rounded-md w-[300px]">
+      <CopyButton content="const agent = new Agent()" className="absolute top-2 right-2" />
+      <pre className="text-sm font-mono text-icon5">const agent = new Agent()</pre>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DateTimePicker } from './date-time-picker';
+import { useState } from 'react';
+
+const meta: Meta<typeof DateTimePicker> = {
+  title: 'Composite/DateTimePicker',
+  component: DateTimePicker,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DateTimePicker>;
+
+const DateTimePickerDemo = ({ initialValue }: { initialValue?: Date }) => {
+  const [value, setValue] = useState<Date | undefined>(initialValue);
+
+  return (
+    <div className="w-[280px]">
+      <DateTimePicker value={value} onValueChange={setValue} />
+      {value && <p className="mt-2 text-sm text-icon5">Selected: {value.toLocaleString()}</p>}
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <DateTimePickerDemo />,
+};
+
+export const WithValue: Story = {
+  render: () => <DateTimePickerDemo initialValue={new Date()} />,
+};
+
+export const WithPlaceholder: Story = {
+  render: () => {
+    const [value, setValue] = useState<Date | undefined>();
+    return (
+      <div className="w-[280px]">
+        <DateTimePicker value={value} onValueChange={setValue} placeholder="Select date and time..." />
+      </div>
+    );
+  },
+};
+
+export const WithMinValue: Story = {
+  render: () => {
+    const [value, setValue] = useState<Date | undefined>();
+    const minDate = new Date();
+    minDate.setDate(minDate.getDate() - 7);
+
+    return (
+      <div className="w-[280px]">
+        <DateTimePicker
+          value={value}
+          onValueChange={setValue}
+          minValue={minDate}
+          placeholder="Select a date (min: 7 days ago)"
+        />
+      </div>
+    );
+  },
+};
+
+export const WithMaxValue: Story = {
+  render: () => {
+    const [value, setValue] = useState<Date | undefined>();
+    const maxDate = new Date();
+    maxDate.setDate(maxDate.getDate() + 7);
+
+    return (
+      <div className="w-[280px]">
+        <DateTimePicker
+          value={value}
+          onValueChange={setValue}
+          maxValue={maxDate}
+          placeholder="Select a date (max: 7 days ahead)"
+        />
+      </div>
+    );
+  },
+};
+
+export const WithDefaultTime: Story = {
+  render: () => {
+    const [value, setValue] = useState<Date | undefined>();
+
+    return (
+      <div className="w-[280px]">
+        <DateTimePicker value={value} onValueChange={setValue} defaultTimeStrValue="09:00 AM" />
+      </div>
+    );
+  },
+};

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
+import { Button } from '../Button';
+import { Input } from '../Input';
+import { Label } from '../Label';
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Feedback/Dialog',
+  component: Dialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+export const Default: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open Dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Dialog Title</DialogTitle>
+          <DialogDescription>This is a description of the dialog content.</DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <p className="text-sm text-icon5">Dialog body content goes here.</p>
+        </div>
+        <DialogFooter>
+          <Button variant="outline">Cancel</Button>
+          <Button>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const WithForm: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Edit Profile</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>Make changes to your profile here. Click save when you are done.</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="name" className="text-right">
+              Name
+            </Label>
+            <Input id="name" defaultValue="John Doe" className="col-span-3" />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="username" className="text-right">
+              Username
+            </Label>
+            <Input id="username" defaultValue="@johndoe" className="col-span-3" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button>Save changes</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const LongContent: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>View Terms</Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Terms of Service</DialogTitle>
+          <DialogDescription>Please read these terms carefully.</DialogDescription>
+        </DialogHeader>
+        <div className="py-4 space-y-4">
+          <p className="text-sm text-icon5">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua.
+          </p>
+          <p className="text-sm text-icon5">
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          </p>
+          <p className="text-sm text-icon5">
+            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+          </p>
+          <p className="text-sm text-icon5">
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+            laborum.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button variant="outline">Decline</Button>
+          <Button>Accept</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const MinimalDialog: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost">Info</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Information</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-icon5">This is a simple informational dialog.</p>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { EmptyState } from './EmptyState';
+import { Button } from '../Button';
+import { FileX, Inbox, Search, Users } from 'lucide-react';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Feedback/EmptyState',
+  component: EmptyState,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const Default: Story = {
+  args: {
+    iconSlot: <Inbox className="w-[126px] h-auto text-icon3" />,
+    titleSlot: 'No items yet',
+    descriptionSlot: 'Get started by creating your first item.',
+    actionSlot: <Button>Create Item</Button>,
+  },
+};
+
+export const NoResults: Story = {
+  args: {
+    iconSlot: <Search className="w-[126px] h-auto text-icon3" />,
+    titleSlot: 'No results found',
+    descriptionSlot: 'Try adjusting your search or filters to find what you are looking for.',
+    actionSlot: <Button variant="outline">Clear filters</Button>,
+  },
+};
+
+export const NoFiles: Story = {
+  args: {
+    iconSlot: <FileX className="w-[126px] h-auto text-icon3" />,
+    titleSlot: 'No files',
+    descriptionSlot: 'Upload your first file to get started.',
+    actionSlot: <Button>Upload File</Button>,
+  },
+};
+
+export const NoTeamMembers: Story = {
+  args: {
+    iconSlot: <Users className="w-[126px] h-auto text-icon3" />,
+    titleSlot: 'No team members',
+    descriptionSlot: 'Invite your team members to collaborate on this project.',
+    actionSlot: <Button>Invite Members</Button>,
+  },
+};
+
+export const WithoutAction: Story = {
+  args: {
+    iconSlot: <Inbox className="w-[126px] h-auto text-icon3" />,
+    titleSlot: 'All caught up!',
+    descriptionSlot: 'You have no pending notifications.',
+    actionSlot: null,
+  },
+};
+
+export const CustomHeading: Story = {
+  args: {
+    as: 'h1',
+    iconSlot: <Inbox className="w-[126px] h-auto text-icon3" />,
+    titleSlot: 'Welcome to the App',
+    descriptionSlot: 'This is your dashboard. Start by exploring the features.',
+    actionSlot: <Button>Get Started</Button>,
+  },
+};

--- a/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Entity, EntityIcon, EntityName, EntityDescription, EntityContent } from './entity';
+import { Bot, Workflow, Database, Settings } from 'lucide-react';
+
+const meta: Meta<typeof Entity> = {
+  title: 'Composite/Entity',
+  component: Entity,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Entity>;
+
+export const Default: Story = {
+  render: () => (
+    <Entity className="w-[300px]">
+      <EntityIcon>
+        <Bot />
+      </EntityIcon>
+      <EntityContent>
+        <EntityName>My Agent</EntityName>
+        <EntityDescription>A helpful AI assistant</EntityDescription>
+      </EntityContent>
+    </Entity>
+  ),
+};
+
+export const Clickable: Story = {
+  render: () => (
+    <Entity className="w-[300px]" onClick={() => console.log('Entity clicked')}>
+      <EntityIcon>
+        <Workflow />
+      </EntityIcon>
+      <EntityContent>
+        <EntityName>Data Pipeline</EntityName>
+        <EntityDescription>Click to view workflow details</EntityDescription>
+      </EntityContent>
+    </Entity>
+  ),
+};
+
+export const WithCustomContent: Story = {
+  render: () => (
+    <Entity className="w-[350px]">
+      <EntityIcon>
+        <Database />
+      </EntityIcon>
+      <EntityContent>
+        <EntityName>Production Database</EntityName>
+        <EntityDescription>PostgreSQL • 2.5GB</EntityDescription>
+        <div className="mt-2 flex gap-2">
+          <span className="text-xs bg-surface4 px-2 py-1 rounded">Active</span>
+          <span className="text-xs bg-surface4 px-2 py-1 rounded">Primary</span>
+        </div>
+      </EntityContent>
+    </Entity>
+  ),
+};
+
+export const EntityList: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2 w-[300px]">
+      <Entity onClick={() => console.log('Agent 1 clicked')}>
+        <EntityIcon>
+          <Bot />
+        </EntityIcon>
+        <EntityContent>
+          <EntityName>Customer Support</EntityName>
+          <EntityDescription>Handles customer inquiries</EntityDescription>
+        </EntityContent>
+      </Entity>
+
+      <Entity onClick={() => console.log('Agent 2 clicked')}>
+        <EntityIcon>
+          <Bot />
+        </EntityIcon>
+        <EntityContent>
+          <EntityName>Sales Assistant</EntityName>
+          <EntityDescription>Helps with sales queries</EntityDescription>
+        </EntityContent>
+      </Entity>
+
+      <Entity onClick={() => console.log('Agent 3 clicked')}>
+        <EntityIcon>
+          <Settings />
+        </EntityIcon>
+        <EntityContent>
+          <EntityName>Configuration</EntityName>
+          <EntityDescription>System settings</EntityDescription>
+        </EntityContent>
+      </Entity>
+    </div>
+  ),
+};
+
+export const MinimalEntity: Story = {
+  render: () => (
+    <Entity className="w-[200px]">
+      <EntityContent>
+        <EntityName>Simple Entity</EntityName>
+      </EntityContent>
+    </Entity>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Entity, EntityIcon, EntityName, EntityDescription, EntityContent } from './entity';
+import { Entity, EntityIcon, EntityName, EntityDescription, EntityContent } from './Entity';
 import { Bot, Workflow, Database, Settings } from 'lucide-react';
 
 const meta: Meta<typeof Entity> = {

--- a/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { EntityHeader } from './entity-header';
+import { Bot, Workflow, Database, Settings } from 'lucide-react';
+import { Badge } from '../Badge';
+
+const meta: Meta<typeof EntityHeader> = {
+  title: 'Composite/EntityHeader',
+  component: EntityHeader,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof EntityHeader>;
+
+export const Default: Story = {
+  args: {
+    icon: <Bot />,
+    title: 'Customer Support Agent',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    icon: <Bot />,
+    title: 'Loading Agent',
+    isLoading: true,
+  },
+};
+
+export const WithChildren: Story = {
+  render: () => (
+    <div className="w-[400px] bg-surface3 rounded-lg">
+      <EntityHeader icon={<Workflow />} title="Data Processing Pipeline">
+        <p className="text-sm text-icon3">Processes incoming data and transforms it for analysis</p>
+      </EntityHeader>
+    </div>
+  ),
+};
+
+export const WithBadge: Story = {
+  render: () => (
+    <div className="w-[400px] bg-surface3 rounded-lg">
+      <EntityHeader icon={<Database />} title="Production Database">
+        <div className="flex gap-2">
+          <Badge variant="success">Active</Badge>
+          <Badge variant="default">PostgreSQL</Badge>
+        </div>
+      </EntityHeader>
+    </div>
+  ),
+};
+
+export const LongTitle: Story = {
+  render: () => (
+    <div className="w-[300px] bg-surface3 rounded-lg">
+      <EntityHeader
+        icon={<Settings />}
+        title="This is a very long title that should be truncated when it exceeds the available width"
+      />
+    </div>
+  ),
+};
+
+export const WithRichContent: Story = {
+  render: () => (
+    <div className="w-[450px] bg-surface3 rounded-lg">
+      <EntityHeader icon={<Bot />} title="AI Assistant">
+        <div className="space-y-2">
+          <p className="text-sm text-icon3">An intelligent assistant for customer support tasks</p>
+          <div className="flex items-center gap-4 text-xs text-icon3">
+            <span>Model: GPT-4</span>
+            <span>Temperature: 0.7</span>
+            <span>Max Tokens: 4096</span>
+          </div>
+        </div>
+      </EntityHeader>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Entry } from './entry';
+import { Txt } from '../Txt';
+import { Badge } from '../Badge';
+
+const meta: Meta<typeof Entry> = {
+  title: 'DataDisplay/Entry',
+  component: Entry,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Entry>;
+
+export const Default: Story = {
+  args: {
+    label: 'Label',
+    children: <Txt variant="ui-md">Value content</Txt>,
+  },
+};
+
+export const WithText: Story = {
+  args: {
+    label: 'Name',
+    children: (
+      <Txt variant="ui-md" className="text-icon6">
+        John Doe
+      </Txt>
+    ),
+  },
+};
+
+export const WithBadge: Story = {
+  args: {
+    label: 'Status',
+    children: <Badge variant="success">Active</Badge>,
+  },
+};
+
+export const WithLongContent: Story = {
+  args: {
+    label: 'Description',
+    children: (
+      <Txt variant="ui-md" className="text-icon6">
+        This is a longer description that contains multiple lines of text to show how the component handles longer
+        content.
+      </Txt>
+    ),
+  },
+};
+
+export const MultipleEntries: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-[300px]">
+      <Entry label="Name">
+        <Txt variant="ui-md" className="text-icon6">
+          My Agent
+        </Txt>
+      </Entry>
+      <Entry label="Status">
+        <Badge variant="success">Running</Badge>
+      </Entry>
+      <Entry label="Created">
+        <Txt variant="ui-md" className="text-icon6">
+          Jan 14, 2026
+        </Txt>
+      </Entry>
+    </div>
+  ),
+};
+
+export const WithComplexContent: Story = {
+  args: {
+    label: 'Configuration',
+    children: (
+      <div className="flex flex-col gap-1">
+        <Txt variant="ui-sm" className="text-icon5">
+          Model: GPT-4
+        </Txt>
+        <Txt variant="ui-sm" className="text-icon5">
+          Temperature: 0.7
+        </Txt>
+        <Txt variant="ui-sm" className="text-icon5">
+          Max tokens: 4096
+        </Txt>
+      </div>
+    ),
+  },
+};

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { EntryList } from './entry-list';
+import { Badge } from '../Badge';
+import { Bot, Workflow } from 'lucide-react';
+
+const meta: Meta<typeof EntryList> = {
+  title: 'DataDisplay/EntryList',
+  component: EntryList,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof EntryList>;
+
+const columns = [
+  { key: 'name', label: 'Name', width: '1fr' },
+  { key: 'status', label: 'Status', width: 'auto' },
+];
+
+const agentColumns = [
+  { key: 'name', label: 'Agent', width: '1fr' },
+  { key: 'model', label: 'Model', width: '120px' },
+  { key: 'status', label: 'Status', width: '100px' },
+];
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[500px]">
+      <EntryList>
+        <EntryList.Header title="Items" count={3} />
+        <EntryList.Entries>
+          <EntryList.Entry columns={columns} entry={{ id: '1' }} onClick={id => console.log('Clicked:', id)}>
+            <EntryList.EntryText>Item One</EntryList.EntryText>
+            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+          </EntryList.Entry>
+          <EntryList.Entry columns={columns} entry={{ id: '2' }} onClick={id => console.log('Clicked:', id)}>
+            <EntryList.EntryText>Item Two</EntryList.EntryText>
+            <EntryList.EntryStatus status="warning">Pending</EntryList.EntryStatus>
+          </EntryList.Entry>
+          <EntryList.Entry columns={columns} entry={{ id: '3' }} onClick={id => console.log('Clicked:', id)}>
+            <EntryList.EntryText>Item Three</EntryList.EntryText>
+            <EntryList.EntryStatus status="error">Error</EntryList.EntryStatus>
+          </EntryList.Entry>
+        </EntryList.Entries>
+      </EntryList>
+    </div>
+  ),
+};
+
+export const WithSelectedItem: Story = {
+  render: () => (
+    <div className="w-[500px]">
+      <EntryList>
+        <EntryList.Header title="Items" count={3} />
+        <EntryList.Entries>
+          <EntryList.Entry columns={columns} entry={{ id: '1' }}>
+            <EntryList.EntryText>Item One</EntryList.EntryText>
+            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+          </EntryList.Entry>
+          <EntryList.Entry columns={columns} entry={{ id: '2' }} isSelected>
+            <EntryList.EntryText>Item Two (Selected)</EntryList.EntryText>
+            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+          </EntryList.Entry>
+          <EntryList.Entry columns={columns} entry={{ id: '3' }}>
+            <EntryList.EntryText>Item Three</EntryList.EntryText>
+            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+          </EntryList.Entry>
+        </EntryList.Entries>
+      </EntryList>
+    </div>
+  ),
+};
+
+export const EmptyList: Story = {
+  render: () => (
+    <div className="w-[500px]">
+      <EntryList>
+        <EntryList.Header title="Items" count={0} />
+        <EntryList.Message>No items found. Create your first item to get started.</EntryList.Message>
+      </EntryList>
+    </div>
+  ),
+};
+
+export const WithPagination: Story = {
+  render: () => (
+    <div className="w-[500px]">
+      <EntryList>
+        <EntryList.Header title="Items" count={100} />
+        <EntryList.Entries>
+          <EntryList.Entry columns={columns} entry={{ id: '1' }}>
+            <EntryList.EntryText>Item 1</EntryList.EntryText>
+            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+          </EntryList.Entry>
+          <EntryList.Entry columns={columns} entry={{ id: '2' }}>
+            <EntryList.EntryText>Item 2</EntryList.EntryText>
+            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+          </EntryList.Entry>
+        </EntryList.Entries>
+        <EntryList.Pagination currentPage={1} totalPages={10} onPageChange={page => console.log('Page:', page)} />
+      </EntryList>
+    </div>
+  ),
+};
+
+export const AgentsList: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <EntryList>
+        <EntryList.Header title="Agents" count={2} />
+        <EntryList.Entries>
+          <EntryList.Entry columns={agentColumns} entry={{ id: 'agent-1' }}>
+            <EntryList.EntryText>Customer Support Agent</EntryList.EntryText>
+            <EntryList.EntryText>GPT-4</EntryList.EntryText>
+            <EntryList.EntryStatus status="success">Online</EntryList.EntryStatus>
+          </EntryList.Entry>
+          <EntryList.Entry columns={agentColumns} entry={{ id: 'agent-2' }}>
+            <EntryList.EntryText>Data Analysis Agent</EntryList.EntryText>
+            <EntryList.EntryText>Claude 3</EntryList.EntryText>
+            <EntryList.EntryStatus status="warning">Idle</EntryList.EntryStatus>
+          </EntryList.Entry>
+        </EntryList.Entries>
+      </EntryList>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EntryList } from './entry-list';
-import { Badge } from '../Badge';
-import { Bot, Workflow } from 'lucide-react';
+import type { Column } from './types';
 
 const meta: Meta<typeof EntryList> = {
   title: 'DataDisplay/EntryList',
@@ -15,34 +14,34 @@ const meta: Meta<typeof EntryList> = {
 export default meta;
 type Story = StoryObj<typeof EntryList>;
 
-const columns = [
-  { key: 'name', label: 'Name', width: '1fr' },
-  { key: 'status', label: 'Status', width: 'auto' },
+const columns: Column[] = [
+  { name: 'name', label: 'Name', size: '1fr' },
+  { name: 'status', label: 'Status', size: '100px' },
 ];
 
-const agentColumns = [
-  { key: 'name', label: 'Agent', width: '1fr' },
-  { key: 'model', label: 'Model', width: '120px' },
-  { key: 'status', label: 'Status', width: '100px' },
+const agentColumns: Column[] = [
+  { name: 'name', label: 'Agent', size: '1fr' },
+  { name: 'model', label: 'Model', size: '120px' },
+  { name: 'status', label: 'Status', size: '100px' },
 ];
 
 export const Default: Story = {
   render: () => (
     <div className="w-[500px]">
       <EntryList>
-        <EntryList.Header title="Items" count={3} />
+        <EntryList.Header columns={columns} />
         <EntryList.Entries>
           <EntryList.Entry columns={columns} entry={{ id: '1' }} onClick={id => console.log('Clicked:', id)}>
             <EntryList.EntryText>Item One</EntryList.EntryText>
-            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
           <EntryList.Entry columns={columns} entry={{ id: '2' }} onClick={id => console.log('Clicked:', id)}>
             <EntryList.EntryText>Item Two</EntryList.EntryText>
-            <EntryList.EntryStatus status="warning">Pending</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="failed" />
           </EntryList.Entry>
           <EntryList.Entry columns={columns} entry={{ id: '3' }} onClick={id => console.log('Clicked:', id)}>
             <EntryList.EntryText>Item Three</EntryList.EntryText>
-            <EntryList.EntryStatus status="error">Error</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
         </EntryList.Entries>
       </EntryList>
@@ -54,19 +53,19 @@ export const WithSelectedItem: Story = {
   render: () => (
     <div className="w-[500px]">
       <EntryList>
-        <EntryList.Header title="Items" count={3} />
+        <EntryList.Header columns={columns} />
         <EntryList.Entries>
           <EntryList.Entry columns={columns} entry={{ id: '1' }}>
             <EntryList.EntryText>Item One</EntryList.EntryText>
-            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
           <EntryList.Entry columns={columns} entry={{ id: '2' }} isSelected>
             <EntryList.EntryText>Item Two (Selected)</EntryList.EntryText>
-            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
           <EntryList.Entry columns={columns} entry={{ id: '3' }}>
             <EntryList.EntryText>Item Three</EntryList.EntryText>
-            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
         </EntryList.Entries>
       </EntryList>
@@ -78,7 +77,7 @@ export const EmptyList: Story = {
   render: () => (
     <div className="w-[500px]">
       <EntryList>
-        <EntryList.Header title="Items" count={0} />
+        <EntryList.Header columns={columns} />
         <EntryList.Message>No items found. Create your first item to get started.</EntryList.Message>
       </EntryList>
     </div>
@@ -89,18 +88,18 @@ export const WithPagination: Story = {
   render: () => (
     <div className="w-[500px]">
       <EntryList>
-        <EntryList.Header title="Items" count={100} />
+        <EntryList.Header columns={columns} />
         <EntryList.Entries>
           <EntryList.Entry columns={columns} entry={{ id: '1' }}>
             <EntryList.EntryText>Item 1</EntryList.EntryText>
-            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
           <EntryList.Entry columns={columns} entry={{ id: '2' }}>
             <EntryList.EntryText>Item 2</EntryList.EntryText>
-            <EntryList.EntryStatus status="success">Active</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
         </EntryList.Entries>
-        <EntryList.Pagination currentPage={1} totalPages={10} onPageChange={page => console.log('Page:', page)} />
+        <EntryList.Pagination currentPage={0} hasMore={true} onNextPage={() => console.log('Next')} />
       </EntryList>
     </div>
   ),
@@ -110,17 +109,17 @@ export const AgentsList: Story = {
   render: () => (
     <div className="w-[600px]">
       <EntryList>
-        <EntryList.Header title="Agents" count={2} />
+        <EntryList.Header columns={agentColumns} />
         <EntryList.Entries>
           <EntryList.Entry columns={agentColumns} entry={{ id: 'agent-1' }}>
             <EntryList.EntryText>Customer Support Agent</EntryList.EntryText>
             <EntryList.EntryText>GPT-4</EntryList.EntryText>
-            <EntryList.EntryStatus status="success">Online</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="success" />
           </EntryList.Entry>
           <EntryList.Entry columns={agentColumns} entry={{ id: 'agent-2' }}>
             <EntryList.EntryText>Data Analysis Agent</EntryList.EntryText>
             <EntryList.EntryText>Claude 3</EntryList.EntryText>
-            <EntryList.EntryStatus status="warning">Idle</EntryList.EntryStatus>
+            <EntryList.EntryStatus status="failed" />
           </EntryList.Entry>
         </EntryList.Entries>
       </EntryList>

--- a/packages/playground-ui/src/ds/components/Header/header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Header/header.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Header, HeaderTitle, HeaderAction, HeaderGroup } from './Header';
+import { Button } from '../Button';
+import { Settings, Bell, Plus, Search } from 'lucide-react';
+
+const meta: Meta<typeof Header> = {
+  title: 'Layout/Header',
+  component: Header,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    border: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  render: () => (
+    <Header>
+      <HeaderTitle>Dashboard</HeaderTitle>
+    </Header>
+  ),
+};
+
+export const WithActions: Story = {
+  render: () => (
+    <Header>
+      <HeaderTitle>Agents</HeaderTitle>
+      <HeaderAction>
+        <Button variant="ghost" size="md">
+          <Search className="h-4 w-4" />
+        </Button>
+        <Button size="md">
+          <Plus className="h-4 w-4" />
+          New Agent
+        </Button>
+      </HeaderAction>
+    </Header>
+  ),
+};
+
+export const WithGroup: Story = {
+  render: () => (
+    <Header>
+      <HeaderGroup>
+        <HeaderTitle>Workflows</HeaderTitle>
+        <span className="text-sm text-icon3">12 total</span>
+      </HeaderGroup>
+      <HeaderAction>
+        <Button variant="outline" size="md">
+          <Settings className="h-4 w-4" />
+        </Button>
+      </HeaderAction>
+    </Header>
+  ),
+};
+
+export const NoBorder: Story = {
+  render: () => (
+    <Header border={false}>
+      <HeaderTitle>Settings</HeaderTitle>
+    </Header>
+  ),
+};
+
+export const ComplexHeader: Story = {
+  render: () => (
+    <Header>
+      <HeaderGroup>
+        <HeaderTitle>My Workspace</HeaderTitle>
+      </HeaderGroup>
+      <HeaderAction>
+        <Button variant="ghost" size="md">
+          <Bell className="h-4 w-4" />
+        </Button>
+        <Button variant="ghost" size="md">
+          <Settings className="h-4 w-4" />
+        </Button>
+        <Button size="md">
+          <Plus className="h-4 w-4" />
+          Create
+        </Button>
+      </HeaderAction>
+    </Header>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Input/input.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Input/input.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Input } from './input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Elements/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'filled', 'unstyled'],
+    },
+    customSize: {
+      control: { type: 'select' },
+      options: ['default', 'sm', 'lg'],
+    },
+    disabled: {
+      control: { type: 'boolean' },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['text', 'email', 'password', 'number', 'url'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter text...',
+    variant: 'default',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    placeholder: 'Filled variant',
+    variant: 'filled',
+  },
+};
+
+export const Unstyled: Story = {
+  args: {
+    placeholder: 'Unstyled variant',
+    variant: 'unstyled',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    placeholder: 'Small input',
+    customSize: 'sm',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    placeholder: 'Large input',
+    customSize: 'lg',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Disabled input',
+    disabled: true,
+    value: 'Cannot edit',
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: 'Hello World',
+  },
+};
+
+export const Email: Story = {
+  args: {
+    type: 'email',
+    placeholder: 'email@example.com',
+  },
+};
+
+export const Password: Story = {
+  args: {
+    type: 'password',
+    placeholder: 'Enter password',
+  },
+};
+
+export const Number: Story = {
+  args: {
+    type: 'number',
+    placeholder: '0',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-64">
+      <Input variant="default" placeholder="Default" />
+      <Input variant="filled" placeholder="Filled" />
+      <Input variant="unstyled" placeholder="Unstyled" />
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-64">
+      <Input customSize="sm" placeholder="Small" />
+      <Input customSize="default" placeholder="Default" />
+      <Input customSize="lg" placeholder="Large" />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Kbd/kbd.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Kbd/kbd.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Kbd } from './kbd';
+
+const meta: Meta<typeof Kbd> = {
+  title: 'Elements/Kbd',
+  component: Kbd,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    theme: {
+      control: { type: 'select' },
+      options: ['light', 'dark'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Kbd>;
+
+export const Default: Story = {
+  args: {
+    children: 'K',
+    theme: 'dark',
+  },
+};
+
+export const Light: Story = {
+  args: {
+    children: 'K',
+    theme: 'light',
+  },
+};
+
+export const Dark: Story = {
+  args: {
+    children: 'K',
+    theme: 'dark',
+  },
+};
+
+export const ModifierKey: Story = {
+  args: {
+    children: 'Ctrl',
+  },
+};
+
+export const KeyCombination: Story = {
+  render: () => (
+    <div className="flex items-center gap-1">
+      <Kbd>Ctrl</Kbd>
+      <span className="text-icon3">+</span>
+      <Kbd>K</Kbd>
+    </div>
+  ),
+};
+
+export const CommonShortcuts: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <Kbd>Ctrl</Kbd>
+          <span className="text-icon3">+</span>
+          <Kbd>C</Kbd>
+        </div>
+        <span className="text-icon5">Copy</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <Kbd>Ctrl</Kbd>
+          <span className="text-icon3">+</span>
+          <Kbd>V</Kbd>
+        </div>
+        <span className="text-icon5">Paste</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <Kbd>Ctrl</Kbd>
+          <span className="text-icon3">+</span>
+          <Kbd>Z</Kbd>
+        </div>
+        <span className="text-icon5">Undo</span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Label/label.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.stories.tsx
@@ -29,17 +29,6 @@ export const WithInput: Story = {
   ),
 };
 
-export const Required: Story = {
-  render: () => (
-    <div className="flex flex-col gap-2">
-      <Label htmlFor="name">
-        Name <span className="text-red-500">*</span>
-      </Label>
-      <Input id="name" placeholder="Enter your name" />
-    </div>
-  ),
-};
-
 export const WithDescription: Story = {
   render: () => (
     <div className="flex flex-col gap-1">

--- a/packages/playground-ui/src/ds/components/Label/label.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Label } from './label';
+import { Input } from '../Input';
+
+const meta: Meta<typeof Label> = {
+  title: 'Elements/Label',
+  component: Label,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+  args: {
+    children: 'Label',
+  },
+};
+
+export const WithInput: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor="email">Email address</Label>
+      <Input id="email" type="email" placeholder="email@example.com" />
+    </div>
+  ),
+};
+
+export const Required: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor="name">
+        Name <span className="text-red-500">*</span>
+      </Label>
+      <Input id="name" placeholder="Enter your name" />
+    </div>
+  ),
+};
+
+export const WithDescription: Story = {
+  render: () => (
+    <div className="flex flex-col gap-1">
+      <Label htmlFor="username">Username</Label>
+      <span className="text-xs text-icon3">Choose a unique username</span>
+      <Input id="username" placeholder="@username" />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MainContentLayout, MainContentContent } from './main-content';
+import { PageHeader } from '../PageHeader';
+
+const meta: Meta<typeof MainContentLayout> = {
+  title: 'Layout/MainContent',
+  component: MainContentLayout,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof MainContentLayout>;
+
+export const Default: Story = {
+  render: () => (
+    <MainContentLayout className="h-[400px] bg-surface1">
+      <PageHeader title="Page Title" description="This is the page description" />
+      <MainContentContent>
+        <div className="p-4">
+          <p className="text-icon5">Main content area</p>
+        </div>
+      </MainContentContent>
+    </MainContentLayout>
+  ),
+};
+
+export const Centered: Story = {
+  render: () => (
+    <MainContentLayout className="h-[400px] bg-surface1">
+      <PageHeader title="Empty State" />
+      <MainContentContent isCentered>
+        <div className="text-center">
+          <p className="text-icon5 text-lg">No items found</p>
+          <p className="text-icon3 text-sm">Create your first item to get started</p>
+        </div>
+      </MainContentContent>
+    </MainContentLayout>
+  ),
+};
+
+export const Divided: Story = {
+  render: () => (
+    <MainContentLayout className="h-[400px] bg-surface1">
+      <PageHeader title="Split View" />
+      <MainContentContent isDivided>
+        <div className="p-4 border-r border-border1">
+          <p className="text-icon5">Left column content</p>
+        </div>
+        <div className="p-4">
+          <p className="text-icon5">Right column content</p>
+        </div>
+      </MainContentContent>
+    </MainContentLayout>
+  ),
+};
+
+export const WithLeftServiceColumn: Story = {
+  render: () => (
+    <MainContentLayout className="h-[400px] bg-surface1">
+      <PageHeader title="With Navigation" />
+      <MainContentContent hasLeftServiceColumn>
+        <div className="p-2 border-r border-border1 bg-surface2">
+          <p className="text-icon3 text-sm">Nav</p>
+        </div>
+        <div className="p-4">
+          <p className="text-icon5">Main content</p>
+        </div>
+      </MainContentContent>
+    </MainContentLayout>
+  ),
+};
+
+export const DividedWithServiceColumn: Story = {
+  render: () => (
+    <MainContentLayout className="h-[400px] bg-surface1">
+      <PageHeader title="Three Column Layout" />
+      <MainContentContent isDivided hasLeftServiceColumn>
+        <div className="p-2 border-r border-border1 bg-surface2">
+          <p className="text-icon3 text-sm">Nav</p>
+        </div>
+        <div className="p-4 border-r border-border1">
+          <p className="text-icon5">Center column</p>
+        </div>
+        <div className="p-4">
+          <p className="text-icon5">Right column</p>
+        </div>
+      </MainContentContent>
+    </MainContentLayout>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MainSidebar, MainSidebarProvider } from './main-sidebar';
+import { TooltipProvider } from '../Tooltip';
+import { Home, Bot, Workflow, Settings, Database, FileText, Users, Bell } from 'lucide-react';
+
+const meta: Meta<typeof MainSidebar> = {
+  title: 'Layout/MainSidebar',
+  component: MainSidebar,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <MainSidebarProvider>
+          <div className="flex h-[500px] bg-surface1 border border-border1 rounded-lg overflow-hidden">
+            <Story />
+            <div className="flex-1 p-4">
+              <p className="text-icon5">Main content area</p>
+            </div>
+          </div>
+        </MainSidebarProvider>
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof MainSidebar>;
+
+export const Default: Story = {
+  render: () => (
+    <MainSidebar className="border-r border-border1 bg-surface2">
+      <MainSidebar.Nav>
+        <MainSidebar.NavSection>
+          <MainSidebar.NavList>
+            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
+              Home
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
+              Agents
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
+              Workflows
+            </MainSidebar.NavLink>
+          </MainSidebar.NavList>
+        </MainSidebar.NavSection>
+      </MainSidebar.Nav>
+    </MainSidebar>
+  ),
+};
+
+export const WithSections: Story = {
+  render: () => (
+    <MainSidebar className="border-r border-border1 bg-surface2">
+      <MainSidebar.Nav>
+        <MainSidebar.NavSection>
+          <MainSidebar.NavHeader>Main</MainSidebar.NavHeader>
+          <MainSidebar.NavList>
+            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
+              Dashboard
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
+              Agents
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
+              Workflows
+            </MainSidebar.NavLink>
+          </MainSidebar.NavList>
+        </MainSidebar.NavSection>
+
+        <MainSidebar.NavSeparator />
+
+        <MainSidebar.NavSection>
+          <MainSidebar.NavHeader>Data</MainSidebar.NavHeader>
+          <MainSidebar.NavList>
+            <MainSidebar.NavLink href="/storage" icon={<Database />}>
+              Storage
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/logs" icon={<FileText />}>
+              Logs
+            </MainSidebar.NavLink>
+          </MainSidebar.NavList>
+        </MainSidebar.NavSection>
+      </MainSidebar.Nav>
+    </MainSidebar>
+  ),
+};
+
+export const WithBottom: Story = {
+  render: () => (
+    <MainSidebar className="border-r border-border1 bg-surface2">
+      <MainSidebar.Nav>
+        <MainSidebar.NavSection>
+          <MainSidebar.NavList>
+            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
+              Home
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
+              Agents
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
+              Workflows
+            </MainSidebar.NavLink>
+          </MainSidebar.NavList>
+        </MainSidebar.NavSection>
+      </MainSidebar.Nav>
+
+      <MainSidebar.Bottom>
+        <MainSidebar.NavList>
+          <MainSidebar.NavLink href="/team" icon={<Users />}>
+            Team
+          </MainSidebar.NavLink>
+          <MainSidebar.NavLink href="/notifications" icon={<Bell />}>
+            Notifications
+          </MainSidebar.NavLink>
+          <MainSidebar.NavLink href="/settings" icon={<Settings />}>
+            Settings
+          </MainSidebar.NavLink>
+        </MainSidebar.NavList>
+      </MainSidebar.Bottom>
+    </MainSidebar>
+  ),
+};
+
+export const FullSidebar: Story = {
+  render: () => (
+    <MainSidebar className="border-r border-border1 bg-surface2">
+      <MainSidebar.Nav>
+        <MainSidebar.NavSection>
+          <MainSidebar.NavHeader>Workspace</MainSidebar.NavHeader>
+          <MainSidebar.NavList>
+            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
+              Overview
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
+              Agents
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
+              Workflows
+            </MainSidebar.NavLink>
+          </MainSidebar.NavList>
+        </MainSidebar.NavSection>
+
+        <MainSidebar.NavSeparator />
+
+        <MainSidebar.NavSection>
+          <MainSidebar.NavHeader>Resources</MainSidebar.NavHeader>
+          <MainSidebar.NavList>
+            <MainSidebar.NavLink href="/storage" icon={<Database />}>
+              Storage
+            </MainSidebar.NavLink>
+            <MainSidebar.NavLink href="/logs" icon={<FileText />}>
+              Logs
+            </MainSidebar.NavLink>
+          </MainSidebar.NavList>
+        </MainSidebar.NavSection>
+      </MainSidebar.Nav>
+
+      <MainSidebar.Bottom>
+        <MainSidebar.NavSeparator />
+        <MainSidebar.NavList>
+          <MainSidebar.NavLink href="/settings" icon={<Settings />}>
+            Settings
+          </MainSidebar.NavLink>
+        </MainSidebar.NavList>
+      </MainSidebar.Bottom>
+    </MainSidebar>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
@@ -35,15 +35,9 @@ export const Default: Story = {
       <MainSidebar.Nav>
         <MainSidebar.NavSection>
           <MainSidebar.NavList>
-            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
-              Home
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
-              Agents
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
-              Workflows
-            </MainSidebar.NavLink>
+            <MainSidebar.NavLink link={{ name: 'Home', url: '/', icon: <Home /> }} isActive />
+            <MainSidebar.NavLink link={{ name: 'Agents', url: '/agents', icon: <Bot /> }} />
+            <MainSidebar.NavLink link={{ name: 'Workflows', url: '/workflows', icon: <Workflow /> }} />
           </MainSidebar.NavList>
         </MainSidebar.NavSection>
       </MainSidebar.Nav>
@@ -58,15 +52,9 @@ export const WithSections: Story = {
         <MainSidebar.NavSection>
           <MainSidebar.NavHeader>Main</MainSidebar.NavHeader>
           <MainSidebar.NavList>
-            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
-              Dashboard
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
-              Agents
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
-              Workflows
-            </MainSidebar.NavLink>
+            <MainSidebar.NavLink link={{ name: 'Dashboard', url: '/', icon: <Home /> }} isActive />
+            <MainSidebar.NavLink link={{ name: 'Agents', url: '/agents', icon: <Bot /> }} />
+            <MainSidebar.NavLink link={{ name: 'Workflows', url: '/workflows', icon: <Workflow /> }} />
           </MainSidebar.NavList>
         </MainSidebar.NavSection>
 
@@ -75,12 +63,8 @@ export const WithSections: Story = {
         <MainSidebar.NavSection>
           <MainSidebar.NavHeader>Data</MainSidebar.NavHeader>
           <MainSidebar.NavList>
-            <MainSidebar.NavLink href="/storage" icon={<Database />}>
-              Storage
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/logs" icon={<FileText />}>
-              Logs
-            </MainSidebar.NavLink>
+            <MainSidebar.NavLink link={{ name: 'Storage', url: '/storage', icon: <Database /> }} />
+            <MainSidebar.NavLink link={{ name: 'Logs', url: '/logs', icon: <FileText /> }} />
           </MainSidebar.NavList>
         </MainSidebar.NavSection>
       </MainSidebar.Nav>
@@ -94,30 +78,18 @@ export const WithBottom: Story = {
       <MainSidebar.Nav>
         <MainSidebar.NavSection>
           <MainSidebar.NavList>
-            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
-              Home
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
-              Agents
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
-              Workflows
-            </MainSidebar.NavLink>
+            <MainSidebar.NavLink link={{ name: 'Home', url: '/', icon: <Home /> }} isActive />
+            <MainSidebar.NavLink link={{ name: 'Agents', url: '/agents', icon: <Bot /> }} />
+            <MainSidebar.NavLink link={{ name: 'Workflows', url: '/workflows', icon: <Workflow /> }} />
           </MainSidebar.NavList>
         </MainSidebar.NavSection>
       </MainSidebar.Nav>
 
       <MainSidebar.Bottom>
         <MainSidebar.NavList>
-          <MainSidebar.NavLink href="/team" icon={<Users />}>
-            Team
-          </MainSidebar.NavLink>
-          <MainSidebar.NavLink href="/notifications" icon={<Bell />}>
-            Notifications
-          </MainSidebar.NavLink>
-          <MainSidebar.NavLink href="/settings" icon={<Settings />}>
-            Settings
-          </MainSidebar.NavLink>
+          <MainSidebar.NavLink link={{ name: 'Team', url: '/team', icon: <Users /> }} />
+          <MainSidebar.NavLink link={{ name: 'Notifications', url: '/notifications', icon: <Bell /> }} />
+          <MainSidebar.NavLink link={{ name: 'Settings', url: '/settings', icon: <Settings /> }} />
         </MainSidebar.NavList>
       </MainSidebar.Bottom>
     </MainSidebar>
@@ -131,15 +103,9 @@ export const FullSidebar: Story = {
         <MainSidebar.NavSection>
           <MainSidebar.NavHeader>Workspace</MainSidebar.NavHeader>
           <MainSidebar.NavList>
-            <MainSidebar.NavLink href="/" icon={<Home />} isActive>
-              Overview
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/agents" icon={<Bot />}>
-              Agents
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/workflows" icon={<Workflow />}>
-              Workflows
-            </MainSidebar.NavLink>
+            <MainSidebar.NavLink link={{ name: 'Overview', url: '/', icon: <Home /> }} isActive />
+            <MainSidebar.NavLink link={{ name: 'Agents', url: '/agents', icon: <Bot /> }} />
+            <MainSidebar.NavLink link={{ name: 'Workflows', url: '/workflows', icon: <Workflow /> }} />
           </MainSidebar.NavList>
         </MainSidebar.NavSection>
 
@@ -148,12 +114,8 @@ export const FullSidebar: Story = {
         <MainSidebar.NavSection>
           <MainSidebar.NavHeader>Resources</MainSidebar.NavHeader>
           <MainSidebar.NavList>
-            <MainSidebar.NavLink href="/storage" icon={<Database />}>
-              Storage
-            </MainSidebar.NavLink>
-            <MainSidebar.NavLink href="/logs" icon={<FileText />}>
-              Logs
-            </MainSidebar.NavLink>
+            <MainSidebar.NavLink link={{ name: 'Storage', url: '/storage', icon: <Database /> }} />
+            <MainSidebar.NavLink link={{ name: 'Logs', url: '/logs', icon: <FileText /> }} />
           </MainSidebar.NavList>
         </MainSidebar.NavSection>
       </MainSidebar.Nav>
@@ -161,9 +123,7 @@ export const FullSidebar: Story = {
       <MainSidebar.Bottom>
         <MainSidebar.NavSeparator />
         <MainSidebar.NavList>
-          <MainSidebar.NavLink href="/settings" icon={<Settings />}>
-            Settings
-          </MainSidebar.NavLink>
+          <MainSidebar.NavLink link={{ name: 'Settings', url: '/settings', icon: <Settings /> }} />
         </MainSidebar.NavList>
       </MainSidebar.Bottom>
     </MainSidebar>

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.stories.tsx
@@ -1,0 +1,161 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MarkdownRenderer } from './markdown-renderer';
+import { TooltipProvider } from '../Tooltip';
+
+const meta: Meta<typeof MarkdownRenderer> = {
+  title: 'Composite/MarkdownRenderer',
+  component: MarkdownRenderer,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <div className="w-[600px] p-4">
+          <Story />
+        </div>
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof MarkdownRenderer>;
+
+export const Default: Story = {
+  args: {
+    children: 'This is a simple paragraph of **markdown** text with some *emphasis*.',
+  },
+};
+
+export const Headings: Story = {
+  args: {
+    children: `# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+
+Regular paragraph text.`,
+  },
+};
+
+export const Lists: Story = {
+  args: {
+    children: `## Unordered List
+- First item
+- Second item
+- Third item with **bold**
+
+## Ordered List
+1. Step one
+2. Step two
+3. Step three`,
+  },
+};
+
+export const CodeBlocks: Story = {
+  args: {
+    children: `Here's an inline \`code\` example.
+
+\`\`\`javascript
+const agent = new Agent({
+  name: 'MyAgent',
+  model: 'gpt-4',
+  temperature: 0.7,
+});
+
+await agent.run('Hello, world!');
+\`\`\`
+
+And here's some Python:
+
+\`\`\`python
+def greet(name):
+    return f"Hello, {name}!"
+\`\`\``,
+  },
+};
+
+export const Links: Story = {
+  args: {
+    children: `Check out the [Mastra documentation](https://mastra.ai/docs) for more information.
+
+You can also visit [GitHub](https://github.com) for source code.`,
+  },
+};
+
+export const Blockquotes: Story = {
+  args: {
+    children: `> This is a blockquote that contains some important information.
+> It can span multiple lines.
+
+Regular text after the quote.`,
+  },
+};
+
+export const Tables: Story = {
+  args: {
+    children: `## Agent Comparison
+
+| Agent Name | Model | Temperature | Max Tokens |
+|------------|-------|-------------|------------|
+| Support | GPT-4 | 0.7 | 4096 |
+| Sales | GPT-4-Turbo | 0.5 | 2048 |
+| Research | Claude-3 | 0.9 | 8192 |`,
+  },
+};
+
+export const ComplexDocument: Story = {
+  args: {
+    children: `# Getting Started with Mastra
+
+Mastra is a **powerful framework** for building AI agents.
+
+## Installation
+
+First, install the package:
+
+\`\`\`bash
+npm install @mastra/core
+\`\`\`
+
+## Quick Start
+
+Here's a simple example:
+
+\`\`\`typescript
+import { Agent } from '@mastra/core';
+
+const agent = new Agent({
+  name: 'MyAgent',
+  model: 'gpt-4',
+});
+\`\`\`
+
+## Features
+
+- **Easy setup** - Get started in minutes
+- **Flexible** - Works with any LLM
+- **Extensible** - Add custom tools and integrations
+
+> Note: Make sure you have your API keys configured before running.
+
+For more details, check out the [documentation](https://mastra.ai/docs).`,
+  },
+};
+
+export const HorizontalRule: Story = {
+  args: {
+    children: `## Section One
+
+Some content here.
+
+---
+
+## Section Two
+
+More content after the divider.`,
+  },
+};

--- a/packages/playground-ui/src/ds/components/Notification/notification.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Notification/notification.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Notification } from './notification';
+import { Info, AlertCircle, Check } from 'lucide-react';
+
+const meta: Meta<typeof Notification> = {
+  title: 'Feedback/Notification',
+  component: Notification,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['info', 'error'],
+    },
+    isVisible: {
+      control: { type: 'boolean' },
+    },
+    autoDismiss: {
+      control: { type: 'boolean' },
+    },
+    dismissible: {
+      control: { type: 'boolean' },
+    },
+    dismissTime: {
+      control: { type: 'number' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Notification>;
+
+export const Default: Story = {
+  args: {
+    isVisible: true,
+    autoDismiss: false,
+    children: 'This is a notification message',
+  },
+};
+
+export const InfoNotification: Story = {
+  args: {
+    isVisible: true,
+    autoDismiss: false,
+    type: 'info',
+    children: (
+      <>
+        <Info />
+        Your changes have been saved successfully.
+      </>
+    ),
+  },
+};
+
+export const ErrorNotification: Story = {
+  args: {
+    isVisible: true,
+    autoDismiss: false,
+    type: 'error',
+    children: (
+      <>
+        <AlertCircle />
+        An error occurred while saving your changes.
+      </>
+    ),
+  },
+};
+
+export const SuccessMessage: Story = {
+  args: {
+    isVisible: true,
+    autoDismiss: false,
+    type: 'info',
+    children: (
+      <>
+        <Check />
+        Operation completed successfully!
+      </>
+    ),
+  },
+};
+
+export const NotDismissible: Story = {
+  args: {
+    isVisible: true,
+    dismissible: false,
+    autoDismiss: false,
+    children: 'This notification cannot be dismissed',
+  },
+};
+
+export const AutoDismiss: Story = {
+  args: {
+    isVisible: true,
+    autoDismiss: true,
+    dismissTime: 3000,
+    children: 'This notification will auto-dismiss in 3 seconds',
+  },
+};
+
+export const LongContent: Story = {
+  args: {
+    isVisible: true,
+    autoDismiss: false,
+    children:
+      'This is a longer notification message that contains more detailed information about what happened in the application.',
+  },
+};

--- a/packages/playground-ui/src/ds/components/PageHeader/page-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PageHeader/page-header.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PageHeader } from './page-header';
+import { Bot, Workflow, Settings, Database } from 'lucide-react';
+
+const meta: Meta<typeof PageHeader> = {
+  title: 'Layout/PageHeader',
+  component: PageHeader,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PageHeader>;
+
+export const Default: Story = {
+  args: {
+    title: 'Page Title',
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: 'Agents',
+    description: 'Create and manage AI agents for your workflows',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    title: 'Agents',
+    description: 'Create and manage AI agents for your workflows',
+    icon: <Bot />,
+  },
+};
+
+export const WorkflowHeader: Story = {
+  args: {
+    title: 'Workflows',
+    description: 'Build and automate complex processes with visual workflows',
+    icon: <Workflow />,
+  },
+};
+
+export const SettingsHeader: Story = {
+  args: {
+    title: 'Settings',
+    description: 'Configure your workspace preferences',
+    icon: <Settings />,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: 'loading',
+    description: 'loading',
+  },
+};
+
+export const TitleLoading: Story = {
+  args: {
+    title: 'loading',
+    description: 'This description is already loaded',
+  },
+};
+
+export const LongDescription: Story = {
+  args: {
+    title: 'Data Storage',
+    description:
+      'Configure your data storage settings including database connections, caching strategies, and backup schedules. These settings affect how your application stores and retrieves data.',
+    icon: <Database />,
+  },
+};

--- a/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+import { Button } from '../Button';
+import { Input } from '../Input';
+import { Label } from '../Label';
+import { Settings } from 'lucide-react';
+
+const meta: Meta<typeof Popover> = {
+  title: 'Feedback/Popover',
+  component: Popover,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open Popover</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">Dimensions</h4>
+            <p className="text-sm text-icon3">Set the dimensions for the layer.</p>
+          </div>
+          <div className="grid gap-2">
+            <div className="grid grid-cols-3 items-center gap-4">
+              <Label htmlFor="width">Width</Label>
+              <Input id="width" defaultValue="100%" className="col-span-2 h-8" />
+            </div>
+            <div className="grid grid-cols-3 items-center gap-4">
+              <Label htmlFor="height">Height</Label>
+              <Input id="height" defaultValue="25px" className="col-span-2 h-8" />
+            </div>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const WithIconTrigger: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="md">
+          <Settings className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80">
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">Settings</h4>
+            <p className="text-sm text-icon3">Manage your preferences.</p>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const AlignStart: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Align Start</Button>
+      </PopoverTrigger>
+      <PopoverContent align="start">
+        <p className="text-sm">This popover is aligned to the start.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const AlignEnd: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Align End</Button>
+      </PopoverTrigger>
+      <PopoverContent align="end">
+        <p className="text-sm">This popover is aligned to the end.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const SideTop: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open Above</Button>
+      </PopoverTrigger>
+      <PopoverContent side="top">
+        <p className="text-sm">This popover opens above the trigger.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const SideRight: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open Right</Button>
+      </PopoverTrigger>
+      <PopoverContent side="right">
+        <p className="text-sm">This popover opens to the right.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const SimpleText: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost">?</Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-60">
+        <p className="text-sm text-icon5">This is helpful information about the feature.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RadioGroup, RadioGroupItem } from './radio-group';
+import { Label } from '../Label';
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Elements/RadioGroup',
+  component: RadioGroup,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioGroup>;
+
+export const Default: Story = {
+  render: args => (
+    <RadioGroup defaultValue="option-1" {...args}>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="option-1" id="option-1" />
+        <Label htmlFor="option-1">Option 1</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="option-2" id="option-2" />
+        <Label htmlFor="option-2">Option 2</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="option-3" id="option-3" />
+        <Label htmlFor="option-3">Option 3</Label>
+      </div>
+    </RadioGroup>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <RadioGroup defaultValue="option-1" disabled>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="option-1" id="disabled-1" />
+        <Label htmlFor="disabled-1">Option 1</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="option-2" id="disabled-2" />
+        <Label htmlFor="disabled-2">Option 2</Label>
+      </div>
+    </RadioGroup>
+  ),
+};
+
+export const Horizontal: Story = {
+  render: () => (
+    <RadioGroup defaultValue="small" className="flex flex-row gap-4">
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="small" id="small" />
+        <Label htmlFor="small">Small</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="medium" id="medium" />
+        <Label htmlFor="medium">Medium</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="large" id="large" />
+        <Label htmlFor="large">Large</Label>
+      </div>
+    </RadioGroup>
+  ),
+};
+
+export const WithDescriptions: Story = {
+  render: () => (
+    <RadioGroup defaultValue="startup">
+      <div className="flex items-start space-x-2">
+        <RadioGroupItem value="startup" id="startup" className="mt-1" />
+        <div className="grid gap-1">
+          <Label htmlFor="startup">Startup</Label>
+          <p className="text-xs text-icon3">Best for small teams just getting started</p>
+        </div>
+      </div>
+      <div className="flex items-start space-x-2">
+        <RadioGroupItem value="business" id="business" className="mt-1" />
+        <div className="grid gap-1">
+          <Label htmlFor="business">Business</Label>
+          <p className="text-xs text-icon3">For growing companies with advanced needs</p>
+        </div>
+      </div>
+      <div className="flex items-start space-x-2">
+        <RadioGroupItem value="enterprise" id="enterprise" className="mt-1" />
+        <div className="grid gap-1">
+          <Label htmlFor="enterprise">Enterprise</Label>
+          <p className="text-xs text-icon3">For large organizations requiring customization</p>
+        </div>
+      </div>
+    </RadioGroup>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ScrollArea } from './scroll-area';
+
+const meta: Meta<typeof ScrollArea> = {
+  title: 'Layout/ScrollArea',
+  component: ScrollArea,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ScrollArea>;
+
+export const Default: Story = {
+  render: () => (
+    <ScrollArea className="h-[200px] w-[300px] rounded-md border border-border1 p-4">
+      <div className="space-y-4">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <p key={i} className="text-sm text-icon5">
+            Item {i + 1} - Lorem ipsum dolor sit amet
+          </p>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};
+
+export const WithMaxHeight: Story = {
+  render: () => (
+    <ScrollArea maxHeight="150px" className="w-[300px] rounded-md border border-border1 p-4">
+      <div className="space-y-4">
+        {Array.from({ length: 15 }).map((_, i) => (
+          <p key={i} className="text-sm text-icon5">
+            Line {i + 1}
+          </p>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};
+
+export const HorizontalScroll: Story = {
+  render: () => (
+    <ScrollArea className="h-[100px] w-[300px] rounded-md border border-border1 p-4">
+      <div className="flex gap-4 w-[800px]">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <div key={i} className="h-16 w-16 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
+            <span className="text-sm text-icon5">{i + 1}</span>
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};
+
+export const CodeBlock: Story = {
+  render: () => (
+    <ScrollArea className="h-[200px] w-[400px] rounded-md border border-border1 bg-surface2">
+      <pre className="p-4 text-sm font-mono text-icon5">
+        {`function example() {
+  const data = fetchData();
+
+  if (data.isValid) {
+    processData(data);
+  } else {
+    handleError(data.error);
+  }
+
+  return {
+    status: 'success',
+    timestamp: Date.now(),
+    results: data.results,
+    metadata: {
+      version: '1.0',
+      format: 'json',
+      encoding: 'utf-8'
+    }
+  };
+}
+
+// Additional code to show scrolling
+const config = {
+  apiKey: 'xxx',
+  endpoint: '/api/v1',
+  timeout: 5000,
+  retries: 3
+};`}
+      </pre>
+    </ScrollArea>
+  ),
+};
+
+export const ChatMessages: Story = {
+  render: () => (
+    <ScrollArea className="h-[300px] w-[350px] rounded-md border border-border1 p-4">
+      <div className="space-y-4">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} className={`p-3 rounded-lg ${i % 2 === 0 ? 'bg-surface3 ml-8' : 'bg-surface4 mr-8'}`}>
+            <p className="text-sm text-icon5">
+              {i % 2 === 0
+                ? 'This is a user message with some content'
+                : 'This is an assistant response with helpful information'}
+            </p>
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ScrollableContainer } from './scrollable-container';
+
+const meta: Meta<typeof ScrollableContainer> = {
+  title: 'Layout/ScrollableContainer',
+  component: ScrollableContainer,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    scrollSpeed: {
+      control: { type: 'number' },
+    },
+    scrollIntervalTime: {
+      control: { type: 'number' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ScrollableContainer>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[400px] h-[100px] border border-border1 rounded-md">
+      <ScrollableContainer className="h-full">
+        <div className="flex gap-4 p-4 w-[1000px]">
+          {Array.from({ length: 20 }).map((_, i) => (
+            <div key={i} className="h-16 w-24 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
+              <span className="text-sm text-icon5">Item {i + 1}</span>
+            </div>
+          ))}
+        </div>
+      </ScrollableContainer>
+    </div>
+  ),
+};
+
+export const CardGallery: Story = {
+  render: () => (
+    <div className="w-[500px] border border-border1 rounded-md">
+      <ScrollableContainer>
+        <div className="flex gap-4 p-4">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-32 w-48 shrink-0 rounded-lg bg-surface3 border border-border1 p-4 flex flex-col justify-between"
+            >
+              <span className="text-sm font-medium text-icon6">Card {i + 1}</span>
+              <span className="text-xs text-icon3">Description text</span>
+            </div>
+          ))}
+        </div>
+      </ScrollableContainer>
+    </div>
+  ),
+};
+
+export const FastScroll: Story = {
+  render: () => (
+    <div className="w-[400px] h-[80px] border border-border1 rounded-md">
+      <ScrollableContainer scrollSpeed={200} scrollIntervalTime={10}>
+        <div className="flex gap-2 p-2 w-[1200px]">
+          {Array.from({ length: 30 }).map((_, i) => (
+            <div key={i} className="h-12 w-12 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
+              <span className="text-xs text-icon5">{i + 1}</span>
+            </div>
+          ))}
+        </div>
+      </ScrollableContainer>
+    </div>
+  ),
+};
+
+export const SlowScroll: Story = {
+  render: () => (
+    <div className="w-[400px] h-[80px] border border-border1 rounded-md">
+      <ScrollableContainer scrollSpeed={30} scrollIntervalTime={50}>
+        <div className="flex gap-2 p-2 w-[1000px]">
+          {Array.from({ length: 25 }).map((_, i) => (
+            <div key={i} className="h-12 w-12 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
+              <span className="text-xs text-icon5">{i + 1}</span>
+            </div>
+          ))}
+        </div>
+      </ScrollableContainer>
+    </div>
+  ),
+};
+
+export const Badges: Story = {
+  render: () => (
+    <div className="w-[350px] border border-border1 rounded-md p-2">
+      <ScrollableContainer>
+        <div className="flex gap-2 py-1">
+          {[
+            'React',
+            'TypeScript',
+            'Node.js',
+            'GraphQL',
+            'PostgreSQL',
+            'Redis',
+            'Docker',
+            'Kubernetes',
+            'AWS',
+            'Vercel',
+            'Next.js',
+            'Tailwind',
+          ].map(tech => (
+            <span key={tech} className="shrink-0 px-3 py-1 text-xs rounded-full bg-surface4 text-icon5">
+              {tech}
+            </span>
+          ))}
+        </div>
+      </ScrollableContainer>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Searchbar, SearchbarWrapper } from './searchbar';
+import { useState } from 'react';
+
+const meta: Meta<typeof Searchbar> = {
+  title: 'Composite/Searchbar',
+  component: Searchbar,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Searchbar>;
+
+export const Default: Story = {
+  args: {
+    label: 'Search',
+    placeholder: 'Search...',
+    onSearch: (value: string) => console.log('Search:', value),
+  },
+  render: args => (
+    <div className="w-[300px]">
+      <Searchbar {...args} />
+    </div>
+  ),
+};
+
+export const AgentSearch: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Searchbar
+        label="Search agents"
+        placeholder="Search agents..."
+        onSearch={value => console.log('Search:', value)}
+      />
+    </div>
+  ),
+};
+
+export const WithCustomDebounce: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Searchbar
+        label="Search"
+        placeholder="Search (500ms debounce)..."
+        debounceMs={500}
+        onSearch={value => console.log('Search:', value)}
+      />
+    </div>
+  ),
+};
+
+export const WithWrapper: Story = {
+  render: () => (
+    <div className="w-[300px] bg-surface2 rounded-lg">
+      <SearchbarWrapper>
+        <Searchbar
+          label="Search workflows"
+          placeholder="Search workflows..."
+          onSearch={value => console.log('Search:', value)}
+        />
+      </SearchbarWrapper>
+    </div>
+  ),
+};
+
+const InteractiveSearchDemo = () => {
+  const [results, setResults] = useState<string[]>([]);
+  const allItems = ['Customer Support Agent', 'Sales Assistant', 'Data Processor', 'Code Reviewer', 'Research Bot'];
+
+  const handleSearch = (value: string) => {
+    if (!value.trim()) {
+      setResults([]);
+      return;
+    }
+    const filtered = allItems.filter(item => item.toLowerCase().includes(value.toLowerCase()));
+    setResults(filtered);
+  };
+
+  return (
+    <div className="w-[300px] space-y-2">
+      <Searchbar
+        label="Search agents"
+        placeholder="Type to search agents..."
+        onSearch={handleSearch}
+        debounceMs={200}
+      />
+      {results.length > 0 && (
+        <ul className="bg-surface3 rounded-md p-2 space-y-1">
+          {results.map(result => (
+            <li key={result} className="text-sm text-icon5 p-1">
+              {result}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export const InteractiveSearch: Story = {
+  render: () => <InteractiveSearchDemo />,
+};
+
+export const InSidebarContext: Story = {
+  render: () => (
+    <div className="w-[280px] bg-surface2 border border-border1 rounded-lg">
+      <SearchbarWrapper>
+        <Searchbar label="Search" placeholder="Search..." onSearch={value => console.log('Search:', value)} />
+      </SearchbarWrapper>
+      <div className="p-4 space-y-2">
+        <div className="h-8 bg-surface3 rounded" />
+        <div className="h-8 bg-surface3 rounded" />
+        <div className="h-8 bg-surface3 rounded" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Section/section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Section } from './section';
+import { Button } from '../Button';
+import { Plus } from 'lucide-react';
+
+const meta: Meta<typeof Section> = {
+  title: 'Layout/Section',
+  component: Section,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Section>;
+
+export const Default: Story = {
+  render: () => (
+    <Section className="w-[500px]">
+      <Section.Header>
+        <Section.Heading>Section Title</Section.Heading>
+      </Section.Header>
+      <div className="p-4 rounded-md border border-border1 bg-surface2">
+        <p className="text-sm text-icon5">Section content goes here</p>
+      </div>
+    </Section>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <Section className="w-[500px]">
+      <Section.Header>
+        <Section.Heading>Agents</Section.Heading>
+        <Button size="md">
+          <Plus className="h-4 w-4" />
+          Add Agent
+        </Button>
+      </Section.Header>
+      <div className="p-4 rounded-md border border-border1 bg-surface2">
+        <p className="text-sm text-icon5">List of agents would go here</p>
+      </div>
+    </Section>
+  ),
+};
+
+export const ConfigurationSection: Story = {
+  render: () => (
+    <Section className="w-[500px]">
+      <Section.Header>
+        <Section.Heading>Configuration</Section.Heading>
+        <Button variant="outline" size="md">
+          Edit
+        </Button>
+      </Section.Header>
+      <div className="space-y-3 p-4 rounded-md border border-border1 bg-surface2">
+        <div className="flex justify-between">
+          <span className="text-sm text-icon3">Model</span>
+          <span className="text-sm text-icon6">GPT-4</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-sm text-icon3">Temperature</span>
+          <span className="text-sm text-icon6">0.7</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-sm text-icon3">Max Tokens</span>
+          <span className="text-sm text-icon6">4096</span>
+        </div>
+      </div>
+    </Section>
+  ),
+};
+
+export const MultipleSections: Story = {
+  render: () => (
+    <div className="w-[500px] space-y-8">
+      <Section>
+        <Section.Header>
+          <Section.Heading>General</Section.Heading>
+        </Section.Header>
+        <div className="p-4 rounded-md border border-border1 bg-surface2">
+          <p className="text-sm text-icon5">General settings content</p>
+        </div>
+      </Section>
+      <Section>
+        <Section.Header>
+          <Section.Heading>Advanced</Section.Heading>
+        </Section.Header>
+        <div className="p-4 rounded-md border border-border1 bg-surface2">
+          <p className="text-sm text-icon5">Advanced settings content</p>
+        </div>
+      </Section>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Sections } from './sections';
+import { Section } from '../Section';
+import { Button } from '../Button';
+
+const meta: Meta<typeof Sections> = {
+  title: 'Layout/Sections',
+  component: Sections,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Sections>;
+
+export const Default: Story = {
+  render: () => (
+    <Sections className="w-[500px]">
+      <Section>
+        <Section.Header>
+          <Section.Heading>Section One</Section.Heading>
+        </Section.Header>
+        <div className="p-4 rounded-md border border-border1 bg-surface2">
+          <p className="text-sm text-icon5">First section content</p>
+        </div>
+      </Section>
+      <Section>
+        <Section.Header>
+          <Section.Heading>Section Two</Section.Heading>
+        </Section.Header>
+        <div className="p-4 rounded-md border border-border1 bg-surface2">
+          <p className="text-sm text-icon5">Second section content</p>
+        </div>
+      </Section>
+      <Section>
+        <Section.Header>
+          <Section.Heading>Section Three</Section.Heading>
+        </Section.Header>
+        <div className="p-4 rounded-md border border-border1 bg-surface2">
+          <p className="text-sm text-icon5">Third section content</p>
+        </div>
+      </Section>
+    </Sections>
+  ),
+};
+
+export const SettingsPage: Story = {
+  render: () => (
+    <Sections className="w-[600px]">
+      <Section>
+        <Section.Header>
+          <Section.Heading>Profile</Section.Heading>
+          <Button variant="outline" size="md">
+            Edit
+          </Button>
+        </Section.Header>
+        <div className="space-y-3 p-4 rounded-md border border-border1 bg-surface2">
+          <div className="flex justify-between">
+            <span className="text-sm text-icon3">Name</span>
+            <span className="text-sm text-icon6">John Doe</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-sm text-icon3">Email</span>
+            <span className="text-sm text-icon6">john@example.com</span>
+          </div>
+        </div>
+      </Section>
+      <Section>
+        <Section.Header>
+          <Section.Heading>Notifications</Section.Heading>
+        </Section.Header>
+        <div className="space-y-3 p-4 rounded-md border border-border1 bg-surface2">
+          <div className="flex justify-between">
+            <span className="text-sm text-icon3">Email notifications</span>
+            <span className="text-sm text-icon6">Enabled</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-sm text-icon3">Push notifications</span>
+            <span className="text-sm text-icon6">Disabled</span>
+          </div>
+        </div>
+      </Section>
+      <Section>
+        <Section.Header>
+          <Section.Heading>Danger Zone</Section.Heading>
+        </Section.Header>
+        <div className="p-4 rounded-md border border-red-900 bg-red-900/10">
+          <p className="text-sm text-red-400">Irreversible actions that affect your account</p>
+        </div>
+      </Section>
+    </Sections>
+  ),
+};
+
+export const DocumentationSections: Story = {
+  render: () => (
+    <Sections className="w-[600px]">
+      <Section>
+        <Section.Header>
+          <Section.Heading>Overview</Section.Heading>
+        </Section.Header>
+        <p className="text-sm text-icon5">This section provides an overview of the feature and its capabilities.</p>
+      </Section>
+      <Section>
+        <Section.Header>
+          <Section.Heading>Installation</Section.Heading>
+        </Section.Header>
+        <pre className="p-4 rounded-md bg-surface2 text-sm font-mono text-icon5 overflow-x-auto">
+          npm install @mastra/core
+        </pre>
+      </Section>
+      <Section>
+        <Section.Header>
+          <Section.Heading>Usage</Section.Heading>
+        </Section.Header>
+        <pre className="p-4 rounded-md bg-surface2 text-sm font-mono text-icon5 overflow-x-auto">
+          {`import { Mastra } from '@mastra/core';
+
+const mastra = new Mastra({
+  // configuration
+});`}
+        </pre>
+      </Section>
+    </Sections>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Select/select.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Select/select.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from './select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Elements/Select',
+  component: Select,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Select option" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="option1">Option 1</SelectItem>
+        <SelectItem value="option2">Option 2</SelectItem>
+        <SelectItem value="option3">Option 3</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const WithValue: Story = {
+  render: () => (
+    <Select defaultValue="option2">
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Select option" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="option1">Option 1</SelectItem>
+        <SelectItem value="option2">Option 2</SelectItem>
+        <SelectItem value="option3">Option 3</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Select disabled>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Select option" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="option1">Option 1</SelectItem>
+        <SelectItem value="option2">Option 2</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const WithGroups: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="Select a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="orange">Orange</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const LongOptions: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select a timezone" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="pst">Pacific Standard Time (PST)</SelectItem>
+        <SelectItem value="mst">Mountain Standard Time (MST)</SelectItem>
+        <SelectItem value="cst">Central Standard Time (CST)</SelectItem>
+        <SelectItem value="est">Eastern Standard Time (EST)</SelectItem>
+        <SelectItem value="utc">Coordinated Universal Time (UTC)</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const ManyOptions: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="Select a country" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="us">United States</SelectItem>
+        <SelectItem value="uk">United Kingdom</SelectItem>
+        <SelectItem value="ca">Canada</SelectItem>
+        <SelectItem value="au">Australia</SelectItem>
+        <SelectItem value="de">Germany</SelectItem>
+        <SelectItem value="fr">France</SelectItem>
+        <SelectItem value="jp">Japan</SelectItem>
+        <SelectItem value="br">Brazil</SelectItem>
+        <SelectItem value="in">India</SelectItem>
+        <SelectItem value="cn">China</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/SelectElement/select-element.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SelectElement/select-element.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = {
 export const WithValue: Story = {
   args: {
     name: 'select-value',
-    value: '1',
+    value: 'Banana',
     options: ['Apple', 'Banana', 'Cherry'],
   },
 };

--- a/packages/playground-ui/src/ds/components/SelectElement/select-element.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SelectElement/select-element.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ElementSelect } from './select';
+
+const meta: Meta<typeof ElementSelect> = {
+  title: 'Elements/ElementSelect',
+  component: ElementSelect,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ElementSelect>;
+
+export const Default: Story = {
+  args: {
+    name: 'select',
+    placeholder: 'Select an option',
+    options: ['Option 1', 'Option 2', 'Option 3'],
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    name: 'select-value',
+    value: '1',
+    options: ['Apple', 'Banana', 'Cherry'],
+  },
+};
+
+export const CustomPlaceholder: Story = {
+  args: {
+    name: 'custom',
+    placeholder: 'Choose a fruit...',
+    options: ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'],
+  },
+};
+
+export const FewOptions: Story = {
+  args: {
+    name: 'few',
+    placeholder: 'Select',
+    options: ['Yes', 'No'],
+  },
+};
+
+export const ManyOptions: Story = {
+  args: {
+    name: 'many',
+    placeholder: 'Select a color',
+    options: ['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet', 'Pink', 'Brown', 'Gray'],
+  },
+};

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SideDialog } from './side-dialog';
+import { Button } from '../Button';
+import { useState } from 'react';
+
+const meta: Meta<typeof SideDialog> = {
+  title: 'Layout/SideDialog',
+  component: SideDialog,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SideDialog>;
+
+const SideDialogDemo = ({
+  variant = 'default',
+  level = 1,
+}: {
+  variant?: 'default' | 'confirmation';
+  level?: 1 | 2 | 3;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="p-8">
+      <Button onClick={() => setIsOpen(true)}>Open Side Dialog</Button>
+      <SideDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        dialogTitle="Dialog Title"
+        dialogDescription="Dialog description"
+        variant={variant}
+        level={level}
+      >
+        <SideDialog.Top>
+          <SideDialog.Header>
+            <SideDialog.Heading>Side Dialog</SideDialog.Heading>
+          </SideDialog.Header>
+          <SideDialog.Nav>
+            <button className="px-3 py-1 text-sm text-icon5 border-b-2 border-icon5">Overview</button>
+            <button className="px-3 py-1 text-sm text-icon3">Details</button>
+            <button className="px-3 py-1 text-sm text-icon3">Settings</button>
+          </SideDialog.Nav>
+        </SideDialog.Top>
+        <SideDialog.Content>
+          <div className="p-6">
+            <p className="text-icon5">This is the side dialog content area.</p>
+            <p className="text-icon3 mt-2">You can put any content here.</p>
+          </div>
+        </SideDialog.Content>
+      </SideDialog>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <SideDialogDemo />,
+};
+
+export const Level2: Story = {
+  render: () => <SideDialogDemo level={2} />,
+};
+
+export const Level3: Story = {
+  render: () => <SideDialogDemo level={3} />,
+};
+
+const SideDialogWithCodeDemo = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="p-8">
+      <Button onClick={() => setIsOpen(true)}>Open with Code Section</Button>
+      <SideDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        dialogTitle="Agent Details"
+        dialogDescription="View agent configuration and code"
+      >
+        <SideDialog.Top>
+          <SideDialog.Header>
+            <SideDialog.Heading>Customer Support Agent</SideDialog.Heading>
+          </SideDialog.Header>
+        </SideDialog.Top>
+        <SideDialog.Content>
+          <div className="p-6 space-y-6">
+            <div>
+              <h3 className="text-sm font-medium text-icon6 mb-2">Configuration</h3>
+              <div className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-icon3">Model</span>
+                  <span className="text-icon5">GPT-4</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-icon3">Temperature</span>
+                  <span className="text-icon5">0.7</span>
+                </div>
+              </div>
+            </div>
+            <SideDialog.CodeSection>
+              <pre className="text-sm font-mono text-icon5">
+                {`{
+  "name": "customer-support",
+  "model": "gpt-4",
+  "temperature": 0.7
+}`}
+              </pre>
+            </SideDialog.CodeSection>
+          </div>
+        </SideDialog.Content>
+      </SideDialog>
+    </div>
+  );
+};
+
+export const WithCodeSection: Story = {
+  render: () => <SideDialogWithCodeDemo />,
+};
+
+const ConfirmationDialogDemo = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="p-8">
+      <Button onClick={() => setIsOpen(true)}>Open Confirmation</Button>
+      <SideDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        dialogTitle="Confirm Action"
+        dialogDescription="Please confirm your action"
+        variant="confirmation"
+      >
+        <SideDialog.Content>
+          <div className="p-6 flex flex-col items-center justify-center h-full">
+            <h3 className="text-lg font-medium text-icon6 mb-2">Confirm deletion?</h3>
+            <p className="text-sm text-icon3 mb-6 text-center">
+              This action cannot be undone. The agent will be permanently deleted.
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setIsOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={() => setIsOpen(false)}>Delete</Button>
+            </div>
+          </div>
+        </SideDialog.Content>
+      </SideDialog>
+    </div>
+  );
+};
+
+export const Confirmation: Story = {
+  render: () => <ConfirmationDialogDemo />,
+};

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
@@ -39,11 +39,7 @@ const SideDialogDemo = ({
           <SideDialog.Header>
             <SideDialog.Heading>Side Dialog</SideDialog.Heading>
           </SideDialog.Header>
-          <SideDialog.Nav>
-            <button className="px-3 py-1 text-sm text-icon5 border-b-2 border-icon5">Overview</button>
-            <button className="px-3 py-1 text-sm text-icon3">Details</button>
-            <button className="px-3 py-1 text-sm text-icon3">Settings</button>
-          </SideDialog.Nav>
+          <SideDialog.Nav onNext={() => console.log('Next')} onPrevious={() => console.log('Previous')} />
         </SideDialog.Top>
         <SideDialog.Content>
           <div className="p-6">
@@ -100,15 +96,14 @@ const SideDialogWithCodeDemo = () => {
                 </div>
               </div>
             </div>
-            <SideDialog.CodeSection>
-              <pre className="text-sm font-mono text-icon5">
-                {`{
+            <SideDialog.CodeSection
+              title="Agent Configuration"
+              codeStr={`{
   "name": "customer-support",
   "model": "gpt-4",
   "temperature": 0.7
 }`}
-              </pre>
-            </SideDialog.CodeSection>
+            />
           </div>
         </SideDialog.Content>
       </SideDialog>

--- a/packages/playground-ui/src/ds/components/Skeleton/skeleton.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Skeleton/skeleton.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Skeleton } from './skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Elements/Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  args: {
+    className: 'h-4 w-[200px]',
+  },
+};
+
+export const Circle: Story = {
+  args: {
+    className: 'h-12 w-12 rounded-full',
+  },
+};
+
+export const Card: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 p-4 border border-border1 rounded-lg w-[300px]">
+      <Skeleton className="h-32 w-full rounded-lg" />
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  ),
+};
+
+export const ListItem: Story = {
+  render: () => (
+    <div className="flex items-center gap-3 p-3 w-[300px]">
+      <Skeleton className="h-10 w-10 rounded-full" />
+      <div className="flex flex-col gap-2 flex-1">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-3 w-1/2" />
+      </div>
+    </div>
+  ),
+};
+
+export const TableRows: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-[400px]">
+      {[1, 2, 3].map(i => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-4 w-[100px]" />
+          <Skeleton className="h-4 w-[150px]" />
+          <Skeleton className="h-4 w-[80px]" />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const TextBlock: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2 w-[300px]">
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Slider/slider.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Slider/slider.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Slider } from './slider';
+
+const meta: Meta<typeof Slider> = {
+  title: 'Elements/Slider',
+  component: Slider,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Slider>;
+
+export const Default: Story = {
+  args: {
+    defaultValue: [50],
+    max: 100,
+    step: 1,
+    className: 'w-[200px]',
+  },
+};
+
+export const WithRange: Story = {
+  args: {
+    defaultValue: [25, 75],
+    max: 100,
+    step: 1,
+    className: 'w-[200px]',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    defaultValue: [50],
+    max: 100,
+    disabled: true,
+    className: 'w-[200px]',
+  },
+};
+
+export const CustomRange: Story = {
+  args: {
+    defaultValue: [0],
+    min: -10,
+    max: 10,
+    step: 1,
+    className: 'w-[200px]',
+  },
+};
+
+export const FineGrained: Story = {
+  args: {
+    defaultValue: [0.5],
+    min: 0,
+    max: 1,
+    step: 0.01,
+    className: 'w-[200px]',
+  },
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2 w-[250px]">
+      <div className="flex justify-between">
+        <span className="text-sm text-icon5">Volume</span>
+        <span className="text-sm text-icon3">50%</span>
+      </div>
+      <Slider defaultValue={[50]} max={100} step={1} />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Spinner } from './spinner';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Elements/Spinner',
+  component: Spinner,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    color: {
+      control: { type: 'color' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const White: Story = {
+  args: {
+    color: '#ffffff',
+  },
+};
+
+export const Blue: Story = {
+  args: {
+    color: '#3b82f6',
+  },
+};
+
+export const Green: Story = {
+  args: {
+    color: '#22c55e',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    className: 'h-4 w-4',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    className: 'h-8 w-8',
+  },
+};
+
+export const InButton: Story = {
+  render: () => (
+    <button className="flex items-center gap-2 px-4 py-2 bg-surface2 border border-border1 rounded-md text-icon6">
+      <Spinner className="h-4 w-4" />
+      Loading...
+    </button>
+  ),
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Spinner className="h-4 w-4" />
+      <Spinner className="h-6 w-6" />
+      <Spinner className="h-8 w-8" />
+      <Spinner className="h-12 w-12" />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Steps/steps.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Steps/steps.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ProcessStepList } from './process-step-list';
+import type { ProcessStep } from './shared';
+
+const meta: Meta<typeof ProcessStepList> = {
+  title: 'Navigation/Steps',
+  component: ProcessStepList,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ProcessStepList>;
+
+const pendingSteps: ProcessStep[] = [
+  { id: 'setup', status: 'pending', description: 'Initialize the project', title: 'Setup', isActive: false },
+  { id: 'configure', status: 'pending', description: 'Configure settings', title: 'Configure', isActive: false },
+  { id: 'deploy', status: 'pending', description: 'Deploy to production', title: 'Deploy', isActive: false },
+];
+
+const inProgressSteps: ProcessStep[] = [
+  { id: 'setup', status: 'success', description: 'Initialize the project', title: 'Setup', isActive: false },
+  { id: 'configure', status: 'running', description: 'Configure settings', title: 'Configure', isActive: true },
+  { id: 'deploy', status: 'pending', description: 'Deploy to production', title: 'Deploy', isActive: false },
+];
+
+const completedSteps: ProcessStep[] = [
+  { id: 'setup', status: 'success', description: 'Initialize the project', title: 'Setup', isActive: false },
+  { id: 'configure', status: 'success', description: 'Configure settings', title: 'Configure', isActive: false },
+  { id: 'deploy', status: 'success', description: 'Deploy to production', title: 'Deploy', isActive: false },
+];
+
+const failedSteps: ProcessStep[] = [
+  { id: 'setup', status: 'success', description: 'Initialize the project', title: 'Setup', isActive: false },
+  { id: 'configure', status: 'failed', description: 'Configure settings', title: 'Configure', isActive: false },
+  { id: 'deploy', status: 'pending', description: 'Deploy to production', title: 'Deploy', isActive: false },
+];
+
+export const Default: Story = {
+  args: {
+    steps: pendingSteps,
+    currentStep: null,
+  },
+};
+
+export const InProgress: Story = {
+  args: {
+    steps: inProgressSteps,
+    currentStep: inProgressSteps[1],
+  },
+};
+
+export const AllCompleted: Story = {
+  args: {
+    steps: completedSteps,
+    currentStep: null,
+  },
+};
+
+export const WithFailure: Story = {
+  args: {
+    steps: failedSteps,
+    currentStep: null,
+  },
+};
+
+export const ManySteps: Story = {
+  args: {
+    steps: [
+      { id: 'init', status: 'success', description: 'Initialize', title: 'Init', isActive: false },
+      { id: 'validate', status: 'success', description: 'Validate inputs', title: 'Validate', isActive: false },
+      { id: 'process', status: 'running', description: 'Process data', title: 'Process', isActive: true },
+      { id: 'transform', status: 'pending', description: 'Transform results', title: 'Transform', isActive: false },
+      { id: 'output', status: 'pending', description: 'Generate output', title: 'Output', isActive: false },
+      { id: 'cleanup', status: 'pending', description: 'Clean up resources', title: 'Cleanup', isActive: false },
+    ],
+    currentStep: {
+      id: 'process',
+      status: 'running',
+      description: 'Process data',
+      title: 'Process',
+      isActive: true,
+    },
+  },
+};
+
+export const SingleStep: Story = {
+  args: {
+    steps: [{ id: 'single-task', status: 'running', description: 'Processing...', title: 'Task', isActive: true }],
+    currentStep: { id: 'single-task', status: 'running', description: 'Processing...', title: 'Task', isActive: true },
+  },
+};

--- a/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Switch } from './switch';
+import { Label } from '../Label';
+
+const meta: Meta<typeof Switch> = {
+  title: 'Elements/Switch',
+  component: Switch,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+    },
+    checked: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Switch>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
+};
+
+export const WithLabel: Story = {
+  render: args => (
+    <div className="flex items-center gap-2">
+      <Switch id="notifications" {...args} />
+      <Label htmlFor="notifications">Enable notifications</Label>
+    </div>
+  ),
+};
+
+export const SettingsList: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-[300px]">
+      <div className="flex items-center justify-between">
+        <Label htmlFor="email">Email notifications</Label>
+        <Switch id="email" defaultChecked />
+      </div>
+      <div className="flex items-center justify-between">
+        <Label htmlFor="push">Push notifications</Label>
+        <Switch id="push" />
+      </div>
+      <div className="flex items-center justify-between">
+        <Label htmlFor="sms">SMS notifications</Label>
+        <Switch id="sms" disabled />
+      </div>
+    </div>
+  ),
+};
+
+export const WithDescription: Story = {
+  render: () => (
+    <div className="flex items-start justify-between gap-4 w-[350px]">
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="dark-mode">Dark mode</Label>
+        <span className="text-xs text-icon3">Switch to a darker color scheme</span>
+      </div>
+      <Switch id="dark-mode" />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Table/table.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Table/table.stories.tsx
@@ -1,0 +1,201 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Table, Thead, Th, Tbody, Row } from './Table';
+import { Cell, TxtCell, DateTimeCell, EntryCell } from './Cells';
+import { Badge } from '../Badge';
+import { Bot, Workflow } from 'lucide-react';
+
+const meta: Meta<typeof Table> = {
+  title: 'DataDisplay/Table',
+  component: Table,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['default', 'small'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <Table>
+        <Thead>
+          <Th>Name</Th>
+          <Th>Status</Th>
+          <Th>Created</Th>
+        </Thead>
+        <Tbody>
+          <Row>
+            <TxtCell>Item One</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+            <TxtCell>Jan 14, 2026</TxtCell>
+          </Row>
+          <Row>
+            <TxtCell>Item Two</TxtCell>
+            <Cell>
+              <Badge variant="default">Pending</Badge>
+            </Cell>
+            <TxtCell>Jan 13, 2026</TxtCell>
+          </Row>
+          <Row>
+            <TxtCell>Item Three</TxtCell>
+            <Cell>
+              <Badge variant="error">Error</Badge>
+            </Cell>
+            <TxtCell>Jan 12, 2026</TxtCell>
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};
+
+export const SmallSize: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <Table size="small">
+        <Thead>
+          <Th>Name</Th>
+          <Th>Status</Th>
+        </Thead>
+        <Tbody>
+          <Row>
+            <TxtCell>Item One</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+          </Row>
+          <Row>
+            <TxtCell>Item Two</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};
+
+export const WithDateTimeCell: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <Table>
+        <Thead>
+          <Th>Event</Th>
+          <Th>Timestamp</Th>
+        </Thead>
+        <Tbody>
+          <Row>
+            <TxtCell>Agent started</TxtCell>
+            <DateTimeCell dateTime={new Date()} />
+          </Row>
+          <Row>
+            <TxtCell>Workflow completed</TxtCell>
+            <DateTimeCell dateTime={new Date(Date.now() - 3600000)} />
+          </Row>
+          <Row>
+            <TxtCell>Error logged</TxtCell>
+            <DateTimeCell dateTime={new Date(Date.now() - 86400000)} />
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};
+
+export const WithEntryCell: Story = {
+  render: () => (
+    <div className="w-[700px]">
+      <Table>
+        <Thead>
+          <Th>Agent</Th>
+          <Th>Status</Th>
+        </Thead>
+        <Tbody>
+          <Row>
+            <EntryCell name="Customer Support Agent" description="Handles customer inquiries" icon={<Bot />} />
+            <Cell>
+              <Badge variant="success">Online</Badge>
+            </Cell>
+          </Row>
+          <Row>
+            <EntryCell name="Data Analysis Agent" description="Processes analytics data" icon={<Bot />} />
+            <Cell>
+              <Badge variant="default">Idle</Badge>
+            </Cell>
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};
+
+export const ClickableRows: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <Table>
+        <Thead>
+          <Th>Name</Th>
+          <Th>Type</Th>
+        </Thead>
+        <Tbody>
+          <Row onClick={() => console.log('Row 1 clicked')}>
+            <TxtCell>Clickable Row 1</TxtCell>
+            <TxtCell>Type A</TxtCell>
+          </Row>
+          <Row onClick={() => console.log('Row 2 clicked')}>
+            <TxtCell>Clickable Row 2</TxtCell>
+            <TxtCell>Type B</TxtCell>
+          </Row>
+          <Row onClick={() => console.log('Row 3 clicked')}>
+            <TxtCell>Clickable Row 3</TxtCell>
+            <TxtCell>Type C</TxtCell>
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};
+
+export const SelectedRow: Story = {
+  render: () => (
+    <div className="w-[600px]">
+      <Table>
+        <Thead>
+          <Th>Name</Th>
+          <Th>Status</Th>
+        </Thead>
+        <Tbody>
+          <Row>
+            <TxtCell>Regular Row</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+          </Row>
+          <Row selected>
+            <TxtCell>Selected Row</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+          </Row>
+          <Row>
+            <TxtCell>Regular Row</TxtCell>
+            <Cell>
+              <Badge variant="success">Active</Badge>
+            </Cell>
+          </Row>
+        </Tbody>
+      </Table>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Tabs } from './tabs-root';
+import { TabList } from './tabs-list';
+import { Tab } from './tabs-tab';
+import { TabContent } from './tabs-content';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Navigation/Tabs',
+  component: Tabs,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultTab="tab1" className="w-[400px]">
+      <TabList>
+        <Tab value="tab1">Overview</Tab>
+        <Tab value="tab2">Details</Tab>
+        <Tab value="tab3">Settings</Tab>
+      </TabList>
+      <TabContent value="tab1">
+        <div className="p-4 text-icon5">Overview content goes here</div>
+      </TabContent>
+      <TabContent value="tab2">
+        <div className="p-4 text-icon5">Details content goes here</div>
+      </TabContent>
+      <TabContent value="tab3">
+        <div className="p-4 text-icon5">Settings content goes here</div>
+      </TabContent>
+    </Tabs>
+  ),
+};
+
+export const ButtonsVariant: Story = {
+  render: () => (
+    <Tabs defaultTab="code" className="w-[400px]">
+      <TabList variant="buttons">
+        <Tab value="code">Code</Tab>
+        <Tab value="preview">Preview</Tab>
+        <Tab value="output">Output</Tab>
+      </TabList>
+      <TabContent value="code">
+        <div className="p-4 text-icon5 font-mono text-sm">const hello = world;</div>
+      </TabContent>
+      <TabContent value="preview">
+        <div className="p-4 text-icon5">Preview content</div>
+      </TabContent>
+      <TabContent value="output">
+        <div className="p-4 text-icon5">Output content</div>
+      </TabContent>
+    </Tabs>
+  ),
+};
+
+export const TwoTabs: Story = {
+  render: () => (
+    <Tabs defaultTab="input" className="w-[300px]">
+      <TabList>
+        <Tab value="input">Input</Tab>
+        <Tab value="output">Output</Tab>
+      </TabList>
+      <TabContent value="input">
+        <div className="p-4 text-icon5">Input content</div>
+      </TabContent>
+      <TabContent value="output">
+        <div className="p-4 text-icon5">Output content</div>
+      </TabContent>
+    </Tabs>
+  ),
+};
+
+export const ManyTabs: Story = {
+  render: () => (
+    <Tabs defaultTab="tab1" className="w-[500px]">
+      <TabList>
+        <Tab value="tab1">Tab 1</Tab>
+        <Tab value="tab2">Tab 2</Tab>
+        <Tab value="tab3">Tab 3</Tab>
+        <Tab value="tab4">Tab 4</Tab>
+        <Tab value="tab5">Tab 5</Tab>
+      </TabList>
+      <TabContent value="tab1">
+        <div className="p-4 text-icon5">Content 1</div>
+      </TabContent>
+      <TabContent value="tab2">
+        <div className="p-4 text-icon5">Content 2</div>
+      </TabContent>
+      <TabContent value="tab3">
+        <div className="p-4 text-icon5">Content 3</div>
+      </TabContent>
+      <TabContent value="tab4">
+        <div className="p-4 text-icon5">Content 4</div>
+      </TabContent>
+      <TabContent value="tab5">
+        <div className="p-4 text-icon5">Content 5</div>
+      </TabContent>
+    </Tabs>
+  ),
+};
+
+export const WithClosableTabs: Story = {
+  render: () => (
+    <Tabs defaultTab="file1" className="w-[400px]">
+      <TabList>
+        <Tab value="file1" onClose={() => console.log('Close file1')}>
+          index.ts
+        </Tab>
+        <Tab value="file2" onClose={() => console.log('Close file2')}>
+          utils.ts
+        </Tab>
+        <Tab value="file3" onClose={() => console.log('Close file3')}>
+          types.ts
+        </Tab>
+      </TabList>
+      <TabContent value="file1">
+        <div className="p-4 text-icon5">index.ts content</div>
+      </TabContent>
+      <TabContent value="file2">
+        <div className="p-4 text-icon5">utils.ts content</div>
+      </TabContent>
+      <TabContent value="file3">
+        <div className="p-4 text-icon5">types.ts content</div>
+      </TabContent>
+    </Tabs>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Text/text.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Text/text.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TextAndIcon } from './text-and-icon';
+import { Clock, User, MapPin, Mail, Phone, Calendar } from 'lucide-react';
+
+const meta: Meta<typeof TextAndIcon> = {
+  title: 'DataDisplay/TextAndIcon',
+  component: TextAndIcon,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof TextAndIcon>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        <Clock />5 minutes ago
+      </>
+    ),
+  },
+};
+
+export const WithUser: Story = {
+  args: {
+    children: (
+      <>
+        <User />
+        John Doe
+      </>
+    ),
+  },
+};
+
+export const WithLocation: Story = {
+  args: {
+    children: (
+      <>
+        <MapPin />
+        San Francisco, CA
+      </>
+    ),
+  },
+};
+
+export const WithEmail: Story = {
+  args: {
+    children: (
+      <>
+        <Mail />
+        hello@example.com
+      </>
+    ),
+  },
+};
+
+export const AllExamples: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <TextAndIcon>
+        <User />
+        John Doe
+      </TextAndIcon>
+      <TextAndIcon>
+        <Mail />
+        john@example.com
+      </TextAndIcon>
+      <TextAndIcon>
+        <Phone />
+        +1 (555) 123-4567
+      </TextAndIcon>
+      <TextAndIcon>
+        <MapPin />
+        San Francisco, CA
+      </TextAndIcon>
+      <TextAndIcon>
+        <Calendar />
+        January 14, 2026
+      </TextAndIcon>
+      <TextAndIcon>
+        <Clock />
+        Last updated 5 minutes ago
+      </TextAndIcon>
+    </div>
+  ),
+};
+
+export const CustomClassName: Story = {
+  args: {
+    className: 'text-accent1',
+    children: (
+      <>
+        <Clock />
+        Custom styled text
+      </>
+    ),
+  },
+};

--- a/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
@@ -123,7 +123,7 @@ export const EmptyThreadList: Story = {
   render: () => (
     <div className="w-[280px] h-[400px]">
       <Threads>
-        <ThreadList>{/* Empty list */}</ThreadList>
+        <ThreadList>{null}</ThreadList>
       </Threads>
     </div>
   ),

--- a/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Threads, ThreadList, ThreadItem, ThreadLink, ThreadDeleteButton } from './threads';
+
+const meta: Meta<typeof Threads> = {
+  title: 'Composite/Threads',
+  component: Threads,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Threads>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[280px] h-[400px]">
+      <Threads>
+        <ThreadList>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5">New conversation</span>
+            </ThreadLink>
+          </ThreadItem>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5">Help with code review</span>
+            </ThreadLink>
+          </ThreadItem>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5">API integration question</span>
+            </ThreadLink>
+          </ThreadItem>
+        </ThreadList>
+      </Threads>
+    </div>
+  ),
+};
+
+export const WithActiveThread: Story = {
+  render: () => (
+    <div className="w-[280px] h-[400px]">
+      <Threads>
+        <ThreadList>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5">Previous chat</span>
+            </ThreadLink>
+          </ThreadItem>
+          <ThreadItem isActive>
+            <ThreadLink href="#">
+              <span className="text-icon5">Current conversation</span>
+            </ThreadLink>
+          </ThreadItem>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5">Another chat</span>
+            </ThreadLink>
+          </ThreadItem>
+        </ThreadList>
+      </Threads>
+    </div>
+  ),
+};
+
+export const WithDeleteButtons: Story = {
+  render: () => (
+    <div className="w-[280px] h-[400px]">
+      <Threads>
+        <ThreadList>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">Debugging session</span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete thread 1')} />
+          </ThreadItem>
+          <ThreadItem isActive>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">Feature discussion</span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete thread 2')} />
+          </ThreadItem>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">Code review feedback</span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete thread 3')} />
+          </ThreadItem>
+        </ThreadList>
+      </Threads>
+    </div>
+  ),
+};
+
+export const LongThreadNames: Story = {
+  render: () => (
+    <div className="w-[280px] h-[400px]">
+      <Threads>
+        <ThreadList>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">
+                This is a very long thread name that should be truncated when displayed
+              </span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete')} />
+          </ThreadItem>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">Another extremely long conversation title that exceeds width</span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete')} />
+          </ThreadItem>
+        </ThreadList>
+      </Threads>
+    </div>
+  ),
+};
+
+export const EmptyThreadList: Story = {
+  render: () => (
+    <div className="w-[280px] h-[400px]">
+      <Threads>
+        <ThreadList>{/* Empty list */}</ThreadList>
+      </Threads>
+    </div>
+  ),
+};
+
+export const ManyThreads: Story = {
+  render: () => (
+    <div className="w-[280px] h-[400px] overflow-auto">
+      <Threads>
+        <ThreadList>
+          {Array.from({ length: 10 }, (_, i) => (
+            <ThreadItem key={i} isActive={i === 2}>
+              <ThreadLink href="#">
+                <span className="text-icon5">Conversation {i + 1}</span>
+              </ThreadLink>
+              <ThreadDeleteButton onClick={() => console.log(`Delete thread ${i + 1}`)} />
+            </ThreadItem>
+          ))}
+        </ThreadList>
+      </Threads>
+    </div>
+  ),
+};
+
+export const WithTimestamps: Story = {
+  render: () => (
+    <div className="w-[280px] h-[400px]">
+      <Threads>
+        <ThreadList>
+          <ThreadItem isActive>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">Current discussion</span>
+              <span className="text-xs text-icon3">Just now</span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete')} />
+          </ThreadItem>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">API design review</span>
+              <span className="text-xs text-icon3">2 hours ago</span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete')} />
+          </ThreadItem>
+          <ThreadItem>
+            <ThreadLink href="#">
+              <span className="text-icon5 truncate">Bug investigation</span>
+              <span className="text-xs text-icon3">Yesterday</span>
+            </ThreadLink>
+            <ThreadDeleteButton onClick={() => console.log('Delete')} />
+          </ThreadItem>
+        </ThreadList>
+      </Threads>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
+import { Button } from '../Button';
+import { Info } from 'lucide-react';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Elements/Tooltip',
+  component: Tooltip,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Hover me</Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>This is a tooltip</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button className="p-1 rounded hover:bg-surface2">
+          <Info className="h-4 w-4 text-icon3" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>More information</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+export const TopSide: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Top tooltip</Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p>Tooltip on top</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+export const RightSide: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Right tooltip</Button>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        <p>Tooltip on right</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+export const BottomSide: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Bottom tooltip</Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <p>Tooltip on bottom</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+export const LeftSide: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Left tooltip</Button>
+      </TooltipTrigger>
+      <TooltipContent side="left">
+        <p>Tooltip on left</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+export const LongContent: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Hover for details</Button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[200px]">
+        <p>This is a longer tooltip that contains more detailed information about the element.</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Txt/txt.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Txt/txt.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Txt } from './Txt';
+
+const meta: Meta<typeof Txt> = {
+  title: 'Elements/Txt',
+  component: Txt,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    as: {
+      control: { type: 'select' },
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'label'],
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['header-md', 'ui-lg', 'ui-md', 'ui-sm', 'ui-xs'],
+    },
+    font: {
+      control: { type: 'select' },
+      options: [undefined, 'mono'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Txt>;
+
+export const Default: Story = {
+  args: {
+    children: 'Default text',
+    variant: 'ui-md',
+  },
+};
+
+export const HeaderMd: Story = {
+  args: {
+    children: 'Header Medium',
+    variant: 'header-md',
+    as: 'h2',
+  },
+};
+
+export const UiLg: Story = {
+  args: {
+    children: 'UI Large text',
+    variant: 'ui-lg',
+  },
+};
+
+export const UiMd: Story = {
+  args: {
+    children: 'UI Medium text',
+    variant: 'ui-md',
+  },
+};
+
+export const UiSm: Story = {
+  args: {
+    children: 'UI Small text',
+    variant: 'ui-sm',
+  },
+};
+
+export const UiXs: Story = {
+  args: {
+    children: 'UI Extra Small text',
+    variant: 'ui-xs',
+  },
+};
+
+export const Monospace: Story = {
+  args: {
+    children: 'const code = "monospace"',
+    variant: 'ui-md',
+    font: 'mono',
+  },
+};
+
+export const AsHeading: Story = {
+  args: {
+    children: 'This is a heading',
+    as: 'h1',
+    variant: 'header-md',
+  },
+};
+
+export const AsLabel: Story = {
+  args: {
+    children: 'Form Label',
+    as: 'label',
+    variant: 'ui-sm',
+    htmlFor: 'input-field',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <Txt variant="header-md" as="h2">
+        Header Medium
+      </Txt>
+      <Txt variant="ui-lg">UI Large</Txt>
+      <Txt variant="ui-md">UI Medium</Txt>
+      <Txt variant="ui-sm">UI Small</Txt>
+      <Txt variant="ui-xs">UI Extra Small</Txt>
+    </div>
+  ),
+};
+
+export const MonospaceVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Txt variant="ui-md" font="mono">
+        Regular monospace
+      </Txt>
+      <Txt variant="ui-sm" font="mono">
+        Small monospace
+      </Txt>
+      <Txt variant="ui-xs" font="mono">
+        Extra small monospace
+      </Txt>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/icons/icons.stories.tsx
+++ b/packages/playground-ui/src/ds/icons/icons.stories.tsx
@@ -1,0 +1,285 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Icon } from './Icon';
+import {
+  AgentIcon,
+  AgentCoinIcon,
+  AgentNetworkCoinIcon,
+  AiIcon,
+  ApiIcon,
+  BranchIcon,
+  CheckIcon,
+  ChevronIcon,
+  CommitIcon,
+  CrossIcon,
+  DbIcon,
+  DebugIcon,
+  DeploymentIcon,
+  DividerIcon,
+  DocsIcon,
+  EnvIcon,
+  FiltersIcon,
+  FolderIcon,
+  GithubCoinIcon,
+  GithubIcon,
+  GoogleIcon,
+  HomeIcon,
+  InfoIcon,
+  JudgeIcon,
+  LatencyIcon,
+  LogsIcon,
+  McpCoinIcon,
+  McpServerIcon,
+  MemoryIcon,
+  OpenAIIcon,
+  PromptIcon,
+  RepoIcon,
+  SettingsIcon,
+  SlashIcon,
+  ToolCoinIcon,
+  ToolsIcon,
+  TraceIcon,
+  TsIcon,
+  VariablesIcon,
+  WorkflowCoinIcon,
+  WorkflowIcon,
+} from './index';
+
+const meta: Meta<typeof Icon> = {
+  title: 'Icons/All Icons',
+  component: Icon,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Icon>;
+
+const icons = [
+  { name: 'AgentIcon', component: AgentIcon },
+  { name: 'AgentCoinIcon', component: AgentCoinIcon },
+  { name: 'AgentNetworkCoinIcon', component: AgentNetworkCoinIcon },
+  { name: 'AiIcon', component: AiIcon },
+  { name: 'ApiIcon', component: ApiIcon },
+  { name: 'BranchIcon', component: BranchIcon },
+  { name: 'CheckIcon', component: CheckIcon },
+  { name: 'ChevronIcon', component: ChevronIcon },
+  { name: 'CommitIcon', component: CommitIcon },
+  { name: 'CrossIcon', component: CrossIcon },
+  { name: 'DbIcon', component: DbIcon },
+  { name: 'DebugIcon', component: DebugIcon },
+  { name: 'DeploymentIcon', component: DeploymentIcon },
+  { name: 'DividerIcon', component: DividerIcon },
+  { name: 'DocsIcon', component: DocsIcon },
+  { name: 'EnvIcon', component: EnvIcon },
+  { name: 'FiltersIcon', component: FiltersIcon },
+  { name: 'FolderIcon', component: FolderIcon },
+  { name: 'GithubCoinIcon', component: GithubCoinIcon },
+  { name: 'GithubIcon', component: GithubIcon },
+  { name: 'GoogleIcon', component: GoogleIcon },
+  { name: 'HomeIcon', component: HomeIcon },
+  { name: 'InfoIcon', component: InfoIcon },
+  { name: 'JudgeIcon', component: JudgeIcon },
+  { name: 'LatencyIcon', component: LatencyIcon },
+  { name: 'LogsIcon', component: LogsIcon },
+  { name: 'McpCoinIcon', component: McpCoinIcon },
+  { name: 'McpServerIcon', component: McpServerIcon },
+  { name: 'MemoryIcon', component: MemoryIcon },
+  { name: 'OpenAIIcon', component: OpenAIIcon },
+  { name: 'PromptIcon', component: PromptIcon },
+  { name: 'RepoIcon', component: RepoIcon },
+  { name: 'SettingsIcon', component: SettingsIcon },
+  { name: 'SlashIcon', component: SlashIcon },
+  { name: 'ToolCoinIcon', component: ToolCoinIcon },
+  { name: 'ToolsIcon', component: ToolsIcon },
+  { name: 'TraceIcon', component: TraceIcon },
+  { name: 'TsIcon', component: TsIcon },
+  { name: 'VariablesIcon', component: VariablesIcon },
+  { name: 'WorkflowCoinIcon', component: WorkflowCoinIcon },
+  { name: 'WorkflowIcon', component: WorkflowIcon },
+];
+
+const IconGrid = ({ size = 'default' }: { size?: 'sm' | 'default' | 'lg' }) => (
+  <div className="grid grid-cols-6 gap-4">
+    {icons.map(({ name, component: IconComponent }) => (
+      <div
+        key={name}
+        className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg hover:bg-surface4 transition-colors"
+      >
+        <Icon size={size} className="text-icon5">
+          <IconComponent />
+        </Icon>
+        <span className="text-xs text-icon3 text-center">{name.replace('Icon', '')}</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const AllIcons: Story = {
+  render: () => (
+    <div className="w-[800px]">
+      <IconGrid />
+    </div>
+  ),
+};
+
+export const SmallIcons: Story = {
+  render: () => (
+    <div className="w-[800px]">
+      <IconGrid size="sm" />
+    </div>
+  ),
+};
+
+export const LargeIcons: Story = {
+  render: () => (
+    <div className="w-[800px]">
+      <IconGrid size="lg" />
+    </div>
+  ),
+};
+
+export const IconSizes: Story = {
+  render: () => (
+    <div className="flex items-end gap-8">
+      <div className="flex flex-col items-center gap-2">
+        <Icon size="sm" className="text-icon5">
+          <AgentIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Small</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Icon size="default" className="text-icon5">
+          <AgentIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Default</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Icon size="lg" className="text-icon5">
+          <AgentIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Large</span>
+      </div>
+    </div>
+  ),
+};
+
+export const IconColors: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Icon className="text-icon3">
+        <AgentIcon />
+      </Icon>
+      <Icon className="text-icon5">
+        <AgentIcon />
+      </Icon>
+      <Icon className="text-icon6">
+        <AgentIcon />
+      </Icon>
+      <Icon className="text-accent1">
+        <AgentIcon />
+      </Icon>
+      <Icon className="text-success">
+        <AgentIcon />
+      </Icon>
+      <Icon className="text-error">
+        <AgentIcon />
+      </Icon>
+    </div>
+  ),
+};
+
+export const AgentIcons: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <AgentIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Agent</span>
+      </div>
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <AgentCoinIcon />
+        </Icon>
+        <span className="text-xs text-icon3">AgentCoin</span>
+      </div>
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <AgentNetworkCoinIcon />
+        </Icon>
+        <span className="text-xs text-icon3">AgentNetworkCoin</span>
+      </div>
+    </div>
+  ),
+};
+
+export const WorkflowIcons: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <WorkflowIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Workflow</span>
+      </div>
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <WorkflowCoinIcon />
+        </Icon>
+        <span className="text-xs text-icon3">WorkflowCoin</span>
+      </div>
+    </div>
+  ),
+};
+
+export const ToolIcons: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <ToolsIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Tools</span>
+      </div>
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <ToolCoinIcon />
+        </Icon>
+        <span className="text-xs text-icon3">ToolCoin</span>
+      </div>
+    </div>
+  ),
+};
+
+export const BrandIcons: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <GithubIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Github</span>
+      </div>
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <GithubCoinIcon />
+        </Icon>
+        <span className="text-xs text-icon3">GithubCoin</span>
+      </div>
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <GoogleIcon />
+        </Icon>
+        <span className="text-xs text-icon3">Google</span>
+      </div>
+      <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
+        <Icon size="lg" className="text-icon5">
+          <OpenAIIcon />
+        </Icon>
+        <span className="text-xs text-icon3">OpenAI</span>
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
Adds Storybook stories for all 48 design system components in playground-ui. Previously only 3 components had stories.

Stories are organized into categories:
- Elements (17): Alert, Avatar, Badge, Button, Checkbox, Input, Label, Kbd, RadioGroup, Select, SelectElement, Skeleton, Slider, Spinner, Switch, Tooltip, Txt
- Feedback (5): AlertDialog, Dialog, Notification, Popover, EmptyState
- Navigation (3): Breadcrumb, Tabs, Steps
- Data Display (4): Entry, EntryList, Table, Text
- Layout (10): Collapsible, Header, MainContent, MainSidebar, PageHeader, ScrollArea, ScrollableContainer, Section, Sections, SideDialog
- Composite (11): ButtonsGroup, CodeEditor, CombinedButtons, Combobox, CopyButton, DateTimePicker, Entity, EntityHeader, MarkdownRenderer, Searchbar, Threads
- Icons showcase with all 41 icons

Run `pnpm storybook` from packages/playground-ui to view.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Storybook stories for all 48 design-system components with multiple usage examples and interactive demos.
  * Included an icons showcase featuring 41 icons with size and color variations.
  * Organized component stories into functional categories (Elements, Feedback, Navigation, DataDisplay, Layout, Composite) for easier discovery and exploration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->