### PR TITLE
refactor(playground-ui): remove unused keyframes and animations

### DIFF
--- a/.changeset/remove-unused-keyframes-animations.md
+++ b/.changeset/remove-unused-keyframes-animations.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Remove unused keyframes and animations from tailwind config

--- a/packages/playground-ui/tailwind.config.ts
+++ b/packages/playground-ui/tailwind.config.ts
@@ -74,48 +74,6 @@ export default {
         mono: ['var(--geist-mono)', ...defaultFont.fontFamily.mono],
         sans: ['var(--font-inter)', ...defaultFont.fontFamily.sans],
       },
-      animation: {
-        ripple: 'ripple var(--duration,2s) ease calc(var(--i, 0)*.2s) infinite',
-        'icon-right': 'animate-icon-right ease-out 250ms',
-        'typing-dot-bounce': 'typing-dot-bounce 1.4s infinite ease-in-out',
-        'fade-in': 'fade-in 1s ease-out',
-      },
-      keyframes: {
-        ripple: {
-          '0%, 100%': {
-            transform: 'translate(-50%, -50%) scale(1)',
-          },
-          '50%': {
-            transform: 'translate(-50%, -50%) scale(0.9)',
-          },
-        },
-        'animate-icon-right': {
-          '0%': {
-            transform: 'translateX(-6px)',
-          },
-          '100%': {
-            transform: 'translateX(0px)',
-          },
-        },
-        'typing-dot-bounce': {
-          '0%, 100%': {
-            transform: 'translateY(0)',
-          },
-          '50%': {
-            transform: 'translateY(-4px)',
-          },
-        },
-        'fade-in': {
-          '0%': {
-            opacity: '0.8',
-            backgroundColor: '#1A1A1A',
-          },
-          '100%': {
-            opacity: '1',
-            backgroundColor: 'transparent',
-          },
-        },
-      },
     },
   },
   plugins: [animate, assistantUi, containerQueries],


### PR DESCRIPTION
Removed custom animation and keyframes definitions from tailwind config that weren't being used anywhere in the codebase:

- `animate-ripple`
- `animate-icon-right`
- `animate-typing-dot-bounce`
- `animate-fade-in`

The `tailwindcss-animate` plugin is still there and provides the animations actually in use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused keyframes and animations to optimize bundle size and improve configuration maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->