### PR TITLE
refactor(playground-ui): merge IconColors into Colors object

### DIFF
--- a/.changeset/playground-ui-merge-icon-colors.md
+++ b/.changeset/playground-ui-merge-icon-colors.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground-ui": patch
+---
+
+Merge `IconColors` into `Colors` object in design tokens. Icon color tokens (`icon1` through `icon6`) are now part of the main `Colors` export.

--- a/packages/playground-ui/src/ds/tokens/colors.ts
+++ b/packages/playground-ui/src/ds/tokens/colors.ts
@@ -20,18 +20,15 @@ export const Colors = {
   accent3Darker: '#14141a',
   accent5Darker: '#14161a',
   accent6Darker: '#1a1a14',
-};
-
-export const BorderColors = {
-  border1: 'rgba(48, 48, 48, 1)',
-  border2: 'rgba(66, 66, 66, 1)',
-};
-
-export const IconColors = {
   icon1: '#5C5C5C',
   icon2: '#707070',
   icon3: '#939393',
   icon4: '#A9A9A9',
   icon5: '#E6E6E6',
   icon6: '#FFFFFF',
+};
+
+export const BorderColors = {
+  border1: 'rgba(48, 48, 48, 1)',
+  border2: 'rgba(66, 66, 66, 1)',
 };

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/loading-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/loading-badge.tsx
@@ -1,12 +1,12 @@
 import { Spinner } from '@/ds/components/Spinner';
 import { BadgeWrapper } from './badge-wrapper';
 import { Skeleton } from '@/ds/components/Skeleton';
-import { IconColors } from '@/ds/tokens';
+import { Colors } from '@/ds/tokens';
 
 export const LoadingBadge = () => {
   return (
     <BadgeWrapper
-      icon={<Spinner color={IconColors.icon3} />}
+      icon={<Spinner color={Colors.icon3} />}
       title={<Skeleton className="ml-2 w-12 h-2" />}
       collapsible={false}
     />

--- a/packages/playground-ui/tailwind.config.ts
+++ b/packages/playground-ui/tailwind.config.ts
@@ -3,7 +3,6 @@ import defaultFont from 'tailwindcss/defaultTheme';
 import {
   FontSizes,
   LineHeights,
-  IconColors,
   BorderColors,
   Colors,
   BorderRadius,
@@ -66,7 +65,6 @@ export default {
       },
       colors: {
         ...Colors,
-        ...IconColors,
         ...BorderColors,
       },
       fontFamily: {


### PR DESCRIPTION
Consolidates the `IconColors` token export into the main `Colors` object for simpler imports.

Before:
```ts
import { Colors, IconColors } from '@/ds/tokens';
// use Colors.surface1, IconColors.icon3
```

After:
```ts
import { Colors } from '@/ds/tokens';
// use Colors.surface1, Colors.icon3
```

Tailwind classes like `text-icon3` continue to work since the colors are still registered in the theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated design token organization by merging icon color tokens into the primary Colors export, improving token structure and maintainability across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->