### PR TITLE
refactor(playground-ui): rename icon color tokens to neutral

### DIFF
--- a/.changeset/rename-icon-to-neutral-tokens.md
+++ b/.changeset/rename-icon-to-neutral-tokens.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground-ui": patch
+---
+
+Rename icon color tokens to neutral for better semantic naming

--- a/packages/playground-ui/src/domains/agents/components/AgentToolPanel.tsx
+++ b/packages/playground-ui/src/domains/agents/components/AgentToolPanel.tsx
@@ -50,7 +50,7 @@ export const AgentToolPanel = ({ toolId, agentId }: AgentToolPanelProps) => {
   if (!tool)
     return (
       <div className="py-12 text-center px-6">
-        <Txt variant="header-md" className="text-icon3">
+        <Txt variant="header-md" className="text-neutral3">
           Tool not found
         </Txt>
       </div>

--- a/packages/playground-ui/src/domains/agents/components/agent-advanced-settings.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-advanced-settings.tsx
@@ -75,9 +75,9 @@ export const AgentAdvancedSettings = () => {
 
   const collapsibleClassName = 'rounded-lg border-sm border-border1 bg-surface3 overflow-clip';
   const collapsibleTriggerClassName =
-    'text-icon3 text-ui-lg font-medium flex items-center gap-2 w-full p-[10px] justify-between';
+    'text-neutral3 text-ui-lg font-medium flex items-center gap-2 w-full p-[10px] justify-between';
   const collapsibleContentClassName = 'bg-surface2 p-[10px] @container/collapsible';
-  const buttonClass = 'text-icon3 hover:text-icon6';
+  const buttonClass = 'text-neutral3 hover:text-neutral6';
 
   return (
     <TooltipProvider>
@@ -91,7 +91,7 @@ export const AgentAdvancedSettings = () => {
         <CollapsibleContent className={collapsibleContentClassName}>
           <div className="grid grid-cols-1 gap-2 pb-2 @xs/collapsible:grid-cols-2">
             <div className="space-y-1">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="frequency-penalty">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="frequency-penalty">
                 Frequency Penalty
               </Txt>
               <Input
@@ -114,7 +114,7 @@ export const AgentAdvancedSettings = () => {
             </div>
 
             <div className="space-y-1">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="presence-penalty">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="presence-penalty">
                 Presence Penalty
               </Txt>
               <Input
@@ -137,7 +137,7 @@ export const AgentAdvancedSettings = () => {
             </div>
 
             <div className="space-y-1">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="top-k">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="top-k">
                 Top K
               </Txt>
               <Input
@@ -157,7 +157,7 @@ export const AgentAdvancedSettings = () => {
             </div>
 
             <div className="space-y-1">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="max-tokens">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="max-tokens">
                 Max Tokens
               </Txt>
               <Input
@@ -177,7 +177,7 @@ export const AgentAdvancedSettings = () => {
             </div>
 
             <div className="space-y-1">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="max-steps">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="max-steps">
                 Max Steps
               </Txt>
               <Input
@@ -197,7 +197,7 @@ export const AgentAdvancedSettings = () => {
             </div>
 
             <div className="space-y-1">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="max-retries">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="max-retries">
                 Max Retries
               </Txt>
               <Input
@@ -217,7 +217,7 @@ export const AgentAdvancedSettings = () => {
             </div>
 
             <div className="space-y-1">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="seed">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="seed">
                 Seed
               </Txt>
               <Input
@@ -239,7 +239,7 @@ export const AgentAdvancedSettings = () => {
 
           <div className="space-y-1">
             <div className="flex justify-between items-center">
-              <Txt as="label" className="text-icon3" variant="ui-sm" htmlFor="provider-options">
+              <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="provider-options">
                 Provider Options
               </Txt>
 

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-memory-config.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-memory-config.tsx
@@ -112,7 +112,7 @@ export const AgentMemoryConfig = ({ agentId }: AgentMemoryConfigProps) => {
       return <span className={cn('text-xs font-medium px-2 py-0.5 rounded', badgeColors[badge])}>{value}</span>;
     }
 
-    return <span className="text-xs text-icon3">{value}</span>;
+    return <span className="text-xs text-neutral3">{value}</span>;
   };
 
   if (isLoading) {
@@ -126,15 +126,15 @@ export const AgentMemoryConfig = ({ agentId }: AgentMemoryConfigProps) => {
   if (!config || configSections.length === 0) {
     return (
       <div className="p-4">
-        <h3 className="text-sm font-medium text-icon5 mb-3">Memory Configuration</h3>
-        <p className="text-xs text-icon3">No memory configuration available</p>
+        <h3 className="text-sm font-medium text-neutral5 mb-3">Memory Configuration</h3>
+        <p className="text-xs text-neutral3">No memory configuration available</p>
       </div>
     );
   }
 
   return (
     <div className="p-4">
-      <h3 className="text-sm font-medium text-icon5 mb-3">Memory Configuration</h3>
+      <h3 className="text-sm font-medium text-neutral5 mb-3">Memory Configuration</h3>
       <div className="space-y-2">
         {configSections.map(section => (
           <div key={section.title} className="border border-border1 rounded-lg bg-surface3">
@@ -142,18 +142,18 @@ export const AgentMemoryConfig = ({ agentId }: AgentMemoryConfigProps) => {
               onClick={() => toggleSection(section.title)}
               className="w-full px-3 py-2 flex items-center justify-between hover:bg-surface4 transition-colors rounded-t-lg"
             >
-              <span className="text-xs font-medium text-icon5">{section.title}</span>
+              <span className="text-xs font-medium text-neutral5">{section.title}</span>
               {expandedSections.has(section.title) ? (
-                <ChevronDown className="w-3 h-3 text-icon3" />
+                <ChevronDown className="w-3 h-3 text-neutral3" />
               ) : (
-                <ChevronRight className="w-3 h-3 text-icon3" />
+                <ChevronRight className="w-3 h-3 text-neutral3" />
               )}
             </button>
             {expandedSections.has(section.title) && (
               <div className="px-3 pb-2 space-y-1">
                 {section.items.map(item => (
                   <div key={`${section.title}-${item.label}`} className="flex items-center justify-between py-1">
-                    <span className="text-xs text-icon3">{item.label}</span>
+                    <span className="text-xs text-neutral3">{item.label}</span>
                     {renderValue(item.value ?? '', item.badge)}
                   </div>
                 ))}

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-memory.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-memory.tsx
@@ -89,8 +89,8 @@ export function AgentMemory({ agentId, threadId }: AgentMemoryProps) {
         <div className="p-4 border-b border-border1">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-sm font-medium text-icon5">Clone Thread</h3>
-              <p className="text-xs text-icon3 mt-1">Create a copy of this conversation</p>
+              <h3 className="text-sm font-medium text-neutral5">Clone Thread</h3>
+              <p className="text-xs text-neutral3 mt-1">Create a copy of this conversation</p>
             </div>
             <Button onClick={handleCloneThread} disabled={isCloning}>
               <Copy className="w-4 h-4 mr-2" />
@@ -104,7 +104,7 @@ export function AgentMemory({ agentId, threadId }: AgentMemoryProps) {
       <div className="p-4 border-b border-border1">
         <div className="mb-2">
           <div className="flex items-center gap-2 mb-2">
-            <h3 className="text-sm font-medium text-icon5">Semantic Recall</h3>
+            <h3 className="text-sm font-medium text-neutral5">Semantic Recall</h3>
             {searchMemoryData?.searchScope && (
               <span
                 className={cn(
@@ -130,7 +130,7 @@ export function AgentMemory({ agentId, threadId }: AgentMemoryProps) {
           />
         ) : (
           <div className="bg-surface3 border border-border1 rounded-lg p-4">
-            <p className="text-sm text-icon3 mb-3">
+            <p className="text-sm text-neutral3 mb-3">
               Semantic recall is not enabled for this agent. Enable it to search through conversation history.
             </p>
             <a

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-working-memory.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-working-memory.tsx
@@ -45,7 +45,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
     <div className="flex flex-col gap-4 p-4">
       <div>
         <div className="flex items-center gap-2 mb-2">
-          <h3 className="text-sm font-medium text-icon5">Working Memory</h3>
+          <h3 className="text-sm font-medium text-neutral5">Working Memory</h3>
           {isWorkingMemoryEnabled && workingMemorySource && (
             <span
               className={cn(
@@ -65,7 +65,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
           )}
         </div>
         {isWorkingMemoryEnabled && !threadExists && (
-          <p className="text-xs text-icon3">Send a message to the agent to enable working memory.</p>
+          <p className="text-xs text-neutral3">Send a message to the agent to enable working memory.</p>
         )}
       </div>
 
@@ -96,7 +96,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                                 Copied!
                               </span>
                             )}
-                            <span className="absolute top-2 right-2 text-[10px] px-1.5 py-0.5 rounded-full bg-surface3 text-icon4 opacity-0 group-hover:opacity-100 transition-opacity">
+                            <span className="absolute top-2 right-2 text-[10px] px-1.5 py-0.5 rounded-full bg-surface3 text-neutral4 opacity-0 group-hover:opacity-100 transition-opacity">
                               Click to copy
                             </span>
                           </div>
@@ -106,14 +106,14 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                   )}
                 </>
               ) : (
-                <div className="text-sm text-icon3 font-mono">
+                <div className="text-sm text-neutral3 font-mono">
                   No working memory content yet. Click "Edit Working Memory" to add content.
                 </div>
               )}
             </>
           ) : (
             <textarea
-              className="w-full min-h-[150px] p-3 border border-border1 rounded-lg bg-surface3 font-mono text-sm text-icon5 resize-none"
+              className="w-full min-h-[150px] p-3 border border-border1 rounded-lg bg-surface3 font-mono text-sm text-neutral5 resize-none"
               value={editValue}
               onChange={e => setEditValue(e.target.value)}
               disabled={isUpdating}
@@ -175,7 +175,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
         </>
       ) : (
         <div className="bg-surface3 border border-border1 rounded-lg p-4">
-          <p className="text-sm text-icon3 mb-3">
+          <p className="text-sm text-neutral3 mb-3">
             Working memory is not enabled for this agent. Enable it to maintain context across conversations.
           </p>
           <a

--- a/packages/playground-ui/src/domains/agents/components/agent-information/code-display.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/code-display.tsx
@@ -35,7 +35,7 @@ export function CodeDisplay({
             </span>
           )}
           {onCopy && (
-            <span className="absolute top-2 right-2 text-[10px] px-1.5 py-0.5 rounded-full bg-surface4 text-icon4 opacity-0 group-hover:opacity-100 transition-opacity">
+            <span className="absolute top-2 right-2 text-[10px] px-1.5 py-0.5 rounded-full bg-surface4 text-neutral4 opacity-0 group-hover:opacity-100 transition-opacity">
               Click to copy
             </span>
           )}

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-list.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-list.tsx
@@ -22,7 +22,7 @@ export interface AgentMetadataListEmptyProps {
 
 export const AgentMetadataListEmpty = ({ children }: AgentMetadataListEmptyProps) => {
   return (
-    <Txt variant="ui-sm" className="text-icon6">
+    <Txt variant="ui-sm" className="text-neutral6">
       {children}
     </Txt>
   );

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-list.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-list.tsx
@@ -106,7 +106,7 @@ const AgentMetadataModelListItem = ({
     <div className="rounded-lg bg-surface1 hover:bg-surface4/50 transition-colors">
       <div className="flex items-center gap-2 p-2">
         {showDragHandle && (
-          <div {...dragHandleProps} className="text-icon3 cursor-grab active:cursor-grabbing flex-shrink-0">
+          <div {...dragHandleProps} className="text-neutral3 cursor-grab active:cursor-grabbing flex-shrink-0">
             <Icon>
               <GripVertical />
             </Icon>

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
@@ -610,7 +610,7 @@ export const AgentMetadataModelSwitcher = ({
                   <Loader2 className="h-4 w-4 animate-spin mx-auto" />
                 </div>
               ) : filteredModels.length === 0 ? (
-                <div className="p-4 text-center text-sm text-icon3">No models found</div>
+                <div className="p-4 text-center text-sm text-neutral3">No models found</div>
               ) : (
                 filteredModels.map((model, index) => {
                   const isHighlighted = index === highlightedModelIndex;
@@ -693,7 +693,7 @@ export const AgentMetadataModelSwitcher = ({
       {infoMsg && (
         <div
           className={cn(
-            'text-[0.75rem] text-icon3 flex gap-[.5rem] mt-[0.5rem] ml-[.5rem]',
+            'text-[0.75rem] text-neutral3 flex gap-[.5rem] mt-[0.5rem] ml-[.5rem]',
             '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:opacity-7 [&>svg]:flex-shrink-0 [&>svg]:mt-[0.1rem]',
           )}
         >

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-section.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-section.tsx
@@ -18,14 +18,14 @@ export const AgentMetadataSection = ({ title, children, hint }: AgentMetadataSec
   const { Link } = useLinkComponent();
   return (
     <section className="space-y-2 pb-7 last:pb-0">
-      <Txt as="h3" variant="ui-md" className="text-icon3 flex items-center gap-1">
+      <Txt as="h3" variant="ui-md" className="text-neutral3 flex items-center gap-1">
         {title}
         {hint && (
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Link href={hint.link} target="_blank" rel="noopener noreferrer">
-                  <Icon className="text-icon3" size="sm">
+                  <Icon className="text-neutral3" size="sm">
                     {hint.icon || <InfoIcon />}
                   </Icon>
                 </Link>

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -85,7 +85,7 @@ export const AgentMetadata = ({ agentId }: AgentMetadataProps) => {
     <AgentMetadataWrapper>
       {agent?.description && (
         <AgentMetadataSection title="Description">
-          <p className="text-sm text-icon3">{agent.description}</p>
+          <p className="text-sm text-neutral3">{agent.description}</p>
         </AgentMetadataSection>
       )}
       {agent.modelList ? (
@@ -273,7 +273,7 @@ export const AgentMetadataScorerList = ({ entityId, entityType }: AgentMetadataS
       {scorerList.map(scorer => (
         <AgentMetadataListItem key={scorer.id}>
           <Link href={paths.scorerLink(scorer.id)} data-testid="scorer-badge">
-            <Badge icon={<GaugeIcon className="text-icon3" />}>{scorer.scorer.config.name}</Badge>
+            <Badge icon={<GaugeIcon className="text-neutral3" />}>{scorer.scorer.config.name}</Badge>
           </Link>
         </AgentMetadataListItem>
       ))}

--- a/packages/playground-ui/src/domains/agents/components/agent-settings.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-settings.tsx
@@ -30,9 +30,9 @@ const NetworkCheckbox = ({ hasMemory, hasSubAgents }: { hasMemory: boolean; hasS
 
   const radio = (
     <div className="flex items-center gap-2">
-      <RadioGroupItem value="network" id="network" className="text-icon6" disabled={!isNetworkAvailable} />
+      <RadioGroupItem value="network" id="network" className="text-neutral6" disabled={!isNetworkAvailable} />
       <Label
-        className={clsx('text-icon6 text-ui-md', !isNetworkAvailable && '!text-icon3 cursor-not-allowed')}
+        className={clsx('text-neutral6 text-ui-md', !isNetworkAvailable && '!text-neutral3 cursor-not-allowed')}
         htmlFor="network"
       >
         Network
@@ -121,32 +121,32 @@ export const AgentSettings = ({ agentId }: AgentSettingsProps) => {
           >
             {!isSupportedModel && (
               <div className="flex items-center gap-2">
-                <RadioGroupItem value="generateLegacy" id="generateLegacy" className="text-icon6" />
-                <Label className="text-icon6 text-ui-md" htmlFor="generateLegacy">
+                <RadioGroupItem value="generateLegacy" id="generateLegacy" className="text-neutral6" />
+                <Label className="text-neutral6 text-ui-md" htmlFor="generateLegacy">
                   Generate (Legacy)
                 </Label>
               </div>
             )}
             {isSupportedModel && (
               <div className="flex items-center gap-2">
-                <RadioGroupItem value="generate" id="generate" className="text-icon6" />
-                <Label className="text-icon6 text-ui-md" htmlFor="generate">
+                <RadioGroupItem value="generate" id="generate" className="text-neutral6" />
+                <Label className="text-neutral6 text-ui-md" htmlFor="generate">
                   Generate
                 </Label>
               </div>
             )}
             {!isSupportedModel && (
               <div className="flex items-center gap-2">
-                <RadioGroupItem value="streamLegacy" id="streamLegacy" className="text-icon6" />
-                <Label className="text-icon6 text-ui-md" htmlFor="streamLegacy">
+                <RadioGroupItem value="streamLegacy" id="streamLegacy" className="text-neutral6" />
+                <Label className="text-neutral6 text-ui-md" htmlFor="streamLegacy">
                   Stream (Legacy)
                 </Label>
               </div>
             )}
             {isSupportedModel && (
               <div className="flex items-center gap-2">
-                <RadioGroupItem value="stream" id="stream" className="text-icon6" />
-                <Label className="text-icon6 text-ui-md" htmlFor="stream">
+                <RadioGroupItem value="stream" id="stream" className="text-neutral6" />
+                <Label className="text-neutral6 text-ui-md" htmlFor="stream">
                   Stream
                 </Label>
               </div>
@@ -168,7 +168,7 @@ export const AgentSettings = ({ agentId }: AgentSettingsProps) => {
 
         {hasSamplingRestriction &&
           (settings?.modelSettings?.temperature !== undefined || settings?.modelSettings?.topP !== undefined) && (
-            <div className="flex items-center gap-2 text-xs text-icon3 bg-surface3 rounded px-3 py-2">
+            <div className="flex items-center gap-2 text-xs text-neutral3 bg-surface3 rounded px-3 py-2">
               <Info className="w-3.5 h-3.5 flex-shrink-0" />
               <span>
                 {settings?.modelSettings?.temperature !== undefined
@@ -193,7 +193,7 @@ export const AgentSettings = ({ agentId }: AgentSettingsProps) => {
                   })
                 }
               />
-              <Txt as="p" variant="ui-sm" className="text-icon3">
+              <Txt as="p" variant="ui-sm" className="text-neutral3">
                 {settings?.modelSettings?.temperature ?? 'n/a'}
               </Txt>
             </div>
@@ -214,7 +214,7 @@ export const AgentSettings = ({ agentId }: AgentSettingsProps) => {
                 step={0.1}
               />
 
-              <Txt as="p" variant="ui-sm" className="text-icon3">
+              <Txt as="p" variant="ui-sm" className="text-neutral3">
                 {settings?.modelSettings?.topP ?? 'n/a'}
               </Txt>
             </div>

--- a/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
+++ b/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
@@ -44,7 +44,7 @@ export const ChatThreads = ({ threads, isLoading, threadId, onDelete, resourceId
           </ThreadItem>
 
           {threads.length === 0 && (
-            <Txt as="p" variant="ui-sm" className="text-icon3 py-3 px-5">
+            <Txt as="p" variant="ui-sm" className="text-neutral3 py-3 px-5">
               Your conversations will appear here once you start chatting!
             </Txt>
           )}
@@ -132,10 +132,10 @@ function ThreadTitle({ title, id }: { title?: string; id?: string }) {
   }
 
   if (isDefaultThreadName(title)) {
-    return <span className="text-icon3">Thread {id ? id.substring(id.length - 5) : null}</span>;
+    return <span className="text-neutral3">Thread {id ? id.substring(id.length - 5) : null}</span>;
   }
 
-  return <span className="truncate max-w-[14rem] text-icon3">{title}</span>;
+  return <span className="truncate max-w-[14rem] text-neutral3">{title}</span>;
 }
 
 const formatDay = (date: Date) => {

--- a/packages/playground-ui/src/domains/agents/components/request-context.tsx
+++ b/packages/playground-ui/src/domains/agents/components/request-context.tsx
@@ -48,7 +48,7 @@ export const RequestContext = () => {
     }
   };
 
-  const buttonClass = 'text-icon3 hover:text-icon6';
+  const buttonClass = 'text-neutral3 hover:text-neutral6';
 
   const formatRequestContext = async () => {
     if (!isValidJson(requestContextValue)) {
@@ -64,7 +64,7 @@ export const RequestContext = () => {
     <TooltipProvider>
       <div>
         <div className="flex items-center justify-between pb-2">
-          <Txt as="label" variant="ui-md" className="text-icon3">
+          <Txt as="label" variant="ui-md" className="text-neutral3">
             Request Context (JSON)
           </Txt>
 
@@ -115,7 +115,7 @@ export const RequestContextWrapper = ({ children }: { children: ReactNode }) => 
   return (
     <div className="max-w-3xl p-5 overflow-y-scroll h-full">
       <div className="rounded-lg p-4 pb-5 bg-surface4 shadow-md space-y-3 border border-border1 mb-5">
-        <Txt as="p" variant="ui-lg" className="text-icon3">
+        <Txt as="p" variant="ui-lg" className="text-neutral3">
           Mastra provides request context, which is a system based on dependency injection that enables you to configure
           your agents and tools with runtime variables. If you find yourself creating several different agents that do
           very similar things, request context allows you to combine them into one agent.

--- a/packages/playground-ui/src/domains/configuration/components/header-list-form.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/header-list-form.tsx
@@ -20,7 +20,7 @@ export interface HeaderListFormProps {
 export const HeaderListForm = ({ headers, onAddHeader, onRemoveHeader }: HeaderListFormProps) => {
   return (
     <div className="space-y-4">
-      <Txt as="h2" variant="header-md" className="text-icon6">
+      <Txt as="h2" variant="header-md" className="text-neutral6">
         Headers
       </Txt>
 

--- a/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
@@ -71,7 +71,7 @@ export const MastraVersionFooter = ({ collapsed }: MastraVersionFooterProps) => 
             </Txt>
           </div>
           <div className="flex items-center gap-2">
-            <Txt as="span" variant="ui-sm" className="text-icon3 font-mono">
+            <Txt as="span" variant="ui-sm" className="text-neutral3 font-mono">
               {mainVersion}
             </Txt>
             {isLoadingUpdates && <Spinner className="w-3 h-3" color="currentColor" />}
@@ -170,9 +170,9 @@ const PackagesModalContent = ({
       </DialogHeader>
 
       {/* Status summary */}
-      <div className="text-sm text-icon3 py-2">
+      <div className="text-sm text-neutral3 py-2">
         {isLoadingUpdates ? (
-          <span className="text-icon3">Checking for updates...</span>
+          <span className="text-neutral3">Checking for updates...</span>
         ) : !hasUpdates ? (
           <span className="text-accent1">✓ All packages are up to date</span>
         ) : (
@@ -209,7 +209,7 @@ const PackagesModalContent = ({
                   <ExternalLink className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
                 </a>
               </div>
-              <div className="py-2 px-3 font-mono text-icon3 flex items-center gap-1.5">
+              <div className="py-2 px-3 font-mono text-neutral3 flex items-center gap-1.5">
                 {pkg.isOutdated || pkg.isDeprecated ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -232,10 +232,10 @@ const PackagesModalContent = ({
                   <span>{pkg.version}</span>
                 )}
               </div>
-              <div className="py-2 px-3 font-mono text-icon3 flex items-center">
+              <div className="py-2 px-3 font-mono text-neutral3 flex items-center">
                 {(pkg.isOutdated || pkg.isDeprecated) && pkg.latestVersion && (
                   <>
-                    <MoveRight className="w-4 h-4 mx-2 text-icon3" />
+                    <MoveRight className="w-4 h-4 mx-2 text-neutral3" />
                     <span className="text-accent1">{pkg.latestVersion}</span>
                   </>
                 )}
@@ -248,7 +248,7 @@ const PackagesModalContent = ({
       {/* Copy current versions button - always visible */}
       <button
         onClick={handleCopyAll}
-        className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-icon3 hover:text-icon1 transition-colors"
+        className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
       >
         {isCopiedAll ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
         <Txt as="span" variant="ui-sm">
@@ -259,7 +259,7 @@ const PackagesModalContent = ({
       {/* Update command section */}
       {hasUpdates && updateCommand && (
         <div className="space-y-3 pt-2 border-t border-border1">
-          <div className="flex items-center gap-2 text-sm text-icon3 pt-3">
+          <div className="flex items-center gap-2 text-sm text-neutral3 pt-3">
             <Info className="w-4 h-4" />
             <span>Use the command below to update your packages</span>
           </div>
@@ -276,14 +276,14 @@ const PackagesModalContent = ({
               ]}
             />
 
-            <pre className="flex-1 text-sm text-icon3 bg-surface2 rounded-md px-3 py-1.5 overflow-x-auto whitespace-pre-wrap break-all">
+            <pre className="flex-1 text-sm text-neutral3 bg-surface2 rounded-md px-3 py-1.5 overflow-x-auto whitespace-pre-wrap break-all">
               {updateCommand}
             </pre>
           </div>
 
           <button
             onClick={handleCopyCommand}
-            className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-icon3 hover:text-icon1 transition-colors"
+            className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
           >
             {isCopiedCommand ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
             <Txt as="span" variant="ui-sm">

--- a/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
@@ -52,7 +52,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
   if (!server)
     return (
       <MainContentContent>
-        <Txt as="h1" variant="header-md" className="text-icon3 font-medium py-20 text-center">
+        <Txt as="h1" variant="header-md" className="text-neutral3 font-medium py-20 text-center">
           Server not found
         </Txt>
       </MainContentContent>
@@ -63,18 +63,18 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
   return (
     <MainContentContent isDivided={true}>
       <div className="px-8 py-12 mx-auto max-w-2xl w-full">
-        <Txt as="h1" variant="header-md" className="text-icon6 font-medium pb-4">
+        <Txt as="h1" variant="header-md" className="text-neutral6 font-medium pb-4">
           {server.name}
         </Txt>
 
         <div className="flex items-center gap-1 pb-6">
-          <Badge icon={<FolderIcon className="text-icon6" />} className="rounded-r-sm !text-icon4">
+          <Badge icon={<FolderIcon className="text-neutral6" />} className="rounded-r-sm !text-neutral4">
             Version
           </Badge>
-          <Badge className="rounded-l-sm !text-icon4">{server.version_detail.version}</Badge>
+          <Badge className="rounded-l-sm !text-neutral4">{server.version_detail.version}</Badge>
         </div>
 
-        <Txt className="text-icon3 pb-4">
+        <Txt className="text-neutral3 pb-4">
           This MCP server can be accessed through multiple transport methods. Choose the one that best fits your use
           case.
         </Txt>
@@ -86,7 +86,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
               Regular HTTP Endpoint
             </Badge>
 
-            <Txt className="text-icon3 pt-1 pb-2">Use for stateless HTTP transport with streamable responses.</Txt>
+            <Txt className="text-neutral3 pt-1 pb-2">Use for stateless HTTP transport with streamable responses.</Txt>
 
             <div className="flex items-start gap-2">
               <Txt className="px-2 py-1 bg-surface4 rounded-lg">{httpStreamUrl}</Txt>
@@ -102,7 +102,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
               Server-Sent Events
             </Badge>
 
-            <Txt className="text-icon3 pt-1 pb-2">Use for real-time communication via SSE.</Txt>
+            <Txt className="text-neutral3 pt-1 pb-2">Use for real-time communication via SSE.</Txt>
 
             <div className="flex items-start gap-2">
               <Txt className="px-2 py-1 bg-surface4 rounded-lg">{sseUrl}</Txt>
@@ -116,7 +116,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
           <div className="rounded-lg border-sm border-border1 bg-surface3 p-4">
             <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">CLI</span>}>Command Line</Badge>
 
-            <Txt className="text-icon3 pt-1 pb-2">Use for local command-line access via npx and mcp-remote.</Txt>
+            <Txt className="text-neutral3 pt-1 pb-2">Use for local command-line access via npx and mcp-remote.</Txt>
 
             <div className="flex items-start gap-2">
               <Txt className="px-2 py-1 bg-surface4 rounded-lg">{commandLineConfig}</Txt>
@@ -144,7 +144,7 @@ const McpToolList = ({ server }: { server: ServerInfo }) => {
 
   return (
     <div className="p-5 overflow-y-scroll">
-      <div className="text-icon6 flex gap-2 items-center">
+      <div className="text-neutral6 flex gap-2 items-center">
         <Icon size="lg" className="bg-surface4 rounded-md p-1">
           <McpServerIcon />
         </Icon>

--- a/packages/playground-ui/src/domains/mcps/components/MCPToolPanel.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/MCPToolPanel.tsx
@@ -45,7 +45,7 @@ export const MCPToolPanel = ({ toolId, serverId }: MCPToolPanelProps) => {
   if (!tool)
     return (
       <div className="py-12 text-center px-6">
-        <Txt variant="header-md" className="text-icon3">
+        <Txt variant="header-md" className="text-neutral3">
           Tool not found
         </Txt>
       </div>

--- a/packages/playground-ui/src/domains/observability/components/span-details.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-details.tsx
@@ -23,7 +23,7 @@ export function SpanDetails({ span }: SpanDetailsProps) {
             <AlertTriangleIcon className="text-yellow-200 mt-0.5 flex-shrink-0" size={20} />
             <div className="flex-1">
               <h4 className="font-semibold text-yellow-200 mb-1 text-sm">Token Limit Exceeded</h4>
-              <p className="text-sm text-icon3 whitespace-pre-line">{getTokenLimitMessage(span)}</p>
+              <p className="text-sm text-neutral3 whitespace-pre-line">{getTokenLimitMessage(span)}</p>
             </div>
           </div>
         </div>

--- a/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-scoring.tsx
@@ -102,7 +102,7 @@ export const SpanScoring = ({
             disabled={isWaiting}
           />
           {selectedScorerDescription && (
-            <TextAndIcon className="text-icon3">
+            <TextAndIcon className="text-neutral3">
               <InfoIcon /> {selectedScorerDescription}
             </TextAndIcon>
           )}

--- a/packages/playground-ui/src/domains/observability/components/timeline-expand-col.tsx
+++ b/packages/playground-ui/src/domains/observability/components/timeline-expand-col.tsx
@@ -59,7 +59,7 @@ function ExpandButton({ onClick, children, className }: ExpandButtonProps) {
     <button onClick={onClick} className={cn('h-full', className)}>
       <div
         className={cn(
-          'flex items-center gap-[0.1rem] text-[0.75rem] text-icon5 border border-border1 pl-2 pr-1 rounded-lg transition-all',
+          'flex items-center gap-[0.1rem] text-[0.75rem] text-neutral5 border border-border1 pl-2 pr-1 rounded-lg transition-all',
           'hover:text-yellow-500',
           '[&>svg]:shrink-0 [&>svg]:opacity-80 [&>svg]:w-[1rem] [&>svg]:h-[1rem] [&>svg]:transition-all',
         )}

--- a/packages/playground-ui/src/domains/observability/components/timeline-structure-sign.tsx
+++ b/packages/playground-ui/src/domains/observability/components/timeline-structure-sign.tsx
@@ -16,8 +16,8 @@ export function TimelineStructureSign({
     <div
       className={cn(
         'w-[3rem] h-[2.8rem] relative opacity-100',
-        'after:content-[""] after:absolute after:left-[-1px] after:top-0 after:bottom-0 after:w-[0px] after:border-l-[1px] after:border-icon3 after:border-dashed ',
-        'before:content-[""] before:absolute before:left-0 before:top-[50%] before:w-full before:h-[0px] before:border-b-[1px] before:border-icon3 before:border-dashed',
+        'after:content-[""] after:absolute after:left-[-1px] after:top-0 after:bottom-0 after:w-[0px] after:border-l-[1px] after:border-neutral3 after:border-dashed ',
+        'before:content-[""] before:absolute before:left-0 before:top-[50%] before:w-full before:h-[0px] before:border-b-[1px] before:border-neutral3 before:border-dashed',
         '[&_svg]:transition-all',
         '[&:hover_svg]:text-yellow-500 [&:hover_svg]:scale-[1.3] [&:hover_svg]:opacity-100',
         {

--- a/packages/playground-ui/src/domains/observability/components/timeline-timing-col.tsx
+++ b/packages/playground-ui/src/domains/observability/components/timeline-timing-col.tsx
@@ -48,7 +48,7 @@ export function TimelineTimingCol({
         <div className={cn('w-full p-[0.6rem] rounded-lg bg-surface4 transition-colors duration-[1s]')}>
           <div className="relative w-full h-[0.4rem] rounded-sm">
             <div
-              className={cn('bg-icon1 absolute rounded-sm h-[0.4rem] top-0')}
+              className={cn('bg-neutral1 absolute rounded-sm h-[0.4rem] top-0')}
               style={{
                 width: percentageSpanLatency ? `${percentageSpanLatency}%` : '2px',
                 left: `${percentageSpanStartTime || 0}%`,
@@ -58,13 +58,13 @@ export function TimelineTimingCol({
           </div>
         </div>
 
-        <div className={cn('flex justify-end text-icon3 text-[0.75rem]')}>
+        <div className={cn('flex justify-end text-neutral3 text-[0.75rem]')}>
           {(span.latency / 1000).toFixed(3)}&nbsp;s
         </div>
       </HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
-          className="z-[100] w-auto max-w-[25rem] rounded-md bg-[#222] p-[.5rem] px-[1rem] pr-[1.5rem] text-[.75rem] text-icon5 text-center border border-border1"
+          className="z-[100] w-auto max-w-[25rem] rounded-md bg-[#222] p-[.5rem] px-[1rem] pr-[1.5rem] text-[.75rem] text-neutral5 text-center border border-border1"
           sideOffset={5}
           side="top"
         >

--- a/packages/playground-ui/src/domains/observability/components/trace-span-usage.tsx
+++ b/packages/playground-ui/src/domains/observability/components/trace-span-usage.tsx
@@ -243,7 +243,7 @@ export function TraceSpanUsage({ traceUsage, traceSpans = [], spanUsage, classNa
                   return (
                     <dl
                       key={detailKey}
-                      className="grid grid-cols-[1fr_auto] gap-x-[1rem] gap-y-[.25rem] justify-between text-icon3"
+                      className="grid grid-cols-[1fr_auto] gap-x-[1rem] gap-y-[.25rem] justify-between text-neutral3"
                     >
                       <dt>{detailKeyLabels[detailKey] || detailKey}</dt>
                       <dd>{detailValue}</dd>
@@ -260,7 +260,7 @@ export function TraceSpanUsage({ traceUsage, traceSpans = [], spanUsage, classNa
                   return (
                     <dl
                       key={provider}
-                      className="grid grid-cols-[1fr_auto] gap-x-[1rem] gap-y-[.25rem]  justify-between text-icon3"
+                      className="grid grid-cols-[1fr_auto] gap-x-[1rem] gap-y-[.25rem]  justify-between text-neutral3"
                     >
                       <dt>{provider}</dt>
                       <dd>{tokenValue}</dd>

--- a/packages/playground-ui/src/domains/observability/components/trace-timeline.tsx
+++ b/packages/playground-ui/src/domains/observability/components/trace-timeline.tsx
@@ -33,7 +33,7 @@ export function TraceTimeline({
       {isLoading ? (
         <div
           className={cn(
-            'flex items-center text-[0.875rem] gap-[1rem] bg-surface3/50 rounded-md p-[1.5rem] justify-center text-icon3',
+            'flex items-center text-[0.875rem] gap-[1rem] bg-surface3/50 rounded-md p-[1.5rem] justify-center text-neutral3',
             '[&_svg]:w-[1.25em] [&_svg]:h-[1.25em] [&_svg]:opacity-50',
           )}
         >

--- a/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
@@ -52,7 +52,7 @@ export function TracesTools({
         disabled={isLoading}
       />
       <div className={cn('flex gap-[1rem] items-center flex-wrap')}>
-        <span className={cn('shrink-0 text-[0.875rem] text-icon3')}>Filter by Date & time range</span>
+        <span className={cn('shrink-0 text-[0.875rem] text-neutral3')}>Filter by Date & time range</span>
         <DateTimePicker
           placeholder="From"
           value={selectedDateFrom}

--- a/packages/playground-ui/src/domains/observability/components/tracing-run-options.tsx
+++ b/packages/playground-ui/src/domains/observability/components/tracing-run-options.tsx
@@ -31,7 +31,7 @@ export const TracingRunOptions = () => {
 
   return (
     <div className="space-y-2 px-5 py-2">
-      <Txt as="h3" variant="ui-md" className="text-icon3">
+      <Txt as="h3" variant="ui-md" className="text-neutral3">
         Tracing Options
       </Txt>
 

--- a/packages/playground-ui/src/domains/templates/template-failure.tsx
+++ b/packages/playground-ui/src/domains/templates/template-failure.tsx
@@ -37,7 +37,7 @@ export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureP
   const { icon, title } = getIconAndTitle();
 
   return (
-    <Container className="space-y-4 text-icon3 mb-[2rem] content-center">
+    <Container className="space-y-4 text-neutral3 mb-[2rem] content-center">
       {/* Main Error Display */}
       <div
         className={cn(
@@ -47,15 +47,15 @@ export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureP
       >
         {icon}
         <div className="text-center space-y-2">
-          <p className="text-[0.875rem] font-medium text-icon5">{title}</p>
-          <p className="text-[0.875rem] text-icon3">{getUserFriendlyMessage()}</p>
+          <p className="text-[0.875rem] font-medium text-neutral5">{title}</p>
+          <p className="text-[0.875rem] text-neutral3">{getUserFriendlyMessage()}</p>
         </div>
       </div>
 
       {/* Validation Errors */}
       {validationErrors && validationErrors.length > 0 && (
         <details className="text-xs">
-          <summary className="cursor-pointer text-icon3 hover:text-icon4 select-none text-center">
+          <summary className="cursor-pointer text-neutral3 hover:text-neutral4 select-none text-center">
             Show Validation Issues ({validationErrors.length})
           </summary>
           <div className="mt-4 p-3 bg-gray-100 dark:bg-gray-800 rounded text-xs overflow-auto max-h-60 text-left space-y-2">
@@ -76,7 +76,9 @@ export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureP
       {/* General Error Details */}
       {errorMsg && !isValidationError && (
         <details className="text-xs">
-          <summary className="cursor-pointer text-icon3 hover:text-icon4 select-none text-center">Show Details</summary>
+          <summary className="cursor-pointer text-neutral3 hover:text-neutral4 select-none text-center">
+            Show Details
+          </summary>
           <div className="mt-4 p-3 bg-gray-100 dark:bg-gray-800 rounded text-xs font-mono overflow-auto max-h-60 text-left">
             <div className="whitespace-pre-wrap break-words">{errorMsg}</div>
           </div>

--- a/packages/playground-ui/src/domains/templates/template-form.tsx
+++ b/packages/playground-ui/src/domains/templates/template-form.tsx
@@ -43,7 +43,7 @@ export function TemplateForm({
       <div className="max-w-[40rem] my-[1rem] p-[1rem] lg:p-[2rem] mx-auto gap-[2rem] grid">
         <h2
           className={cn(
-            'text-icon4 text-[1.125rem] font-semibold flex items-center gap-[0.5rem]',
+            'text-neutral4 text-[1.125rem] font-semibold flex items-center gap-[0.5rem]',
             '[&>svg]:w-[1.2em] [&_svg]:h-[1.2em] [&_svg]:opacity-70 ',
           )}
         >
@@ -59,12 +59,12 @@ export function TemplateForm({
 
         {selectedProvider && Object.entries(variables || {}).length > 0 && (
           <>
-            <h3 className="text-icon3 text-[0.875rem]">Set required Environmental Variables</h3>
+            <h3 className="text-neutral3 text-[0.875rem]">Set required Environmental Variables</h3>
             <div className="grid grid-cols-[1fr_1fr] gap-[1rem] items-start">
               {isLoadingEnvVars ? (
                 <div
                   className={cn(
-                    'flex items-center justify-center col-span-2 text-icon3 text-[0.75rem] gap-[1rem]',
+                    'flex items-center justify-center col-span-2 text-neutral3 text-[0.75rem] gap-[1rem]',
                     '[&_svg]:opacity-50 [&_svg]:w-[1.1em] [&_svg]:h-[1.1em]',
                     'animate-in fade-in duration-300',
                   )}
@@ -97,12 +97,12 @@ export function TemplateForm({
               )}
             </div>
             <div className="border-t border-border1 pt-[3rem] mt-[0.875rem] relative">
-              <div className="absolute w-[2rem] h-[2rem] rounded-full bg-surface2 top-0 left-[50%] translate-x-[-50%] translate-y-[-1rem] text-[0.75rem] text-icon3 flex items-center justify-center">
+              <div className="absolute w-[2rem] h-[2rem] rounded-full bg-surface2 top-0 left-[50%] translate-x-[-50%] translate-y-[-1rem] text-[0.75rem] text-neutral3 flex items-center justify-center">
                 And
               </div>
 
-              <h3 className="text-icon4 text-[1rem]">Set AI Model for Template Installation</h3>
-              <p className="text-icon3 text-[0.875rem] mt-[.5rem] mb-[2rem]">
+              <h3 className="text-neutral4 text-[1rem]">Set AI Model for Template Installation</h3>
+              <p className="text-neutral3 text-[0.875rem] mt-[.5rem] mb-[2rem]">
                 This model will be used by the workflow to process and install the template
               </p>
 
@@ -121,8 +121,8 @@ export function TemplateForm({
         {selectedProvider && !isLoadingEnvVars && (
           <Button
             className={cn(
-              'flex items-center gap-[0.5rem] mt-[1rem] justify-center text-[0.875rem] w-full bg-surface5 min-h-[2.5rem] rounded-lg text-icon5 hover:bg-surface6 transition-colors',
-              '[&>svg]:w-[1.1em] [&_svg]:h-[1.1em] [&_svg]:text-icon5',
+              'flex items-center gap-[0.5rem] mt-[1rem] justify-center text-[0.875rem] w-full bg-surface5 min-h-[2.5rem] rounded-lg text-neutral5 hover:bg-surface6 transition-colors',
+              '[&>svg]:w-[1.1em] [&_svg]:h-[1.1em] [&_svg]:text-neutral5',
             )}
             onClick={handleInstallTemplate}
             disabled={

--- a/packages/playground-ui/src/domains/templates/template-info.tsx
+++ b/packages/playground-ui/src/domains/templates/template-info.tsx
@@ -50,7 +50,7 @@ export function TemplateInfo({
       <div className="grid lg:grid-cols-[1fr_1fr] gap-x-[6rem] ">
         <div className="grid">
           <p
-            className={cn('mb-[1rem] text-[0.875rem] text-icon4 mt-[.5rem] leading-[1.75]', {
+            className={cn('mb-[1rem] text-[0.875rem] text-neutral4 mt-[.5rem] leading-[1.75]', {
               'bg-surface4 rounded-lg ': isLoading,
             })}
           >
@@ -70,10 +70,10 @@ export function TemplateInfo({
               </div>
               <div className="flex-1 space-y-[0.5rem]">
                 <div className="flex items-center gap-[0.5rem]">
-                  <GitBranchIcon className="w-[1em] h-[1em] text-icon4" />
-                  <span className="text-[0.875rem] font-medium text-icon5">A new Git branch will be created</span>
+                  <GitBranchIcon className="w-[1em] h-[1em] text-neutral4" />
+                  <span className="text-[0.875rem] font-medium text-neutral5">A new Git branch will be created</span>
                 </div>
-                <div className="text-[0.8125rem] text-icon4 space-y-[0.25rem]">
+                <div className="text-[0.8125rem] text-neutral4 space-y-[0.25rem]">
                   <div>
                     <span className="font-medium">Branch name:</span>{' '}
                     <code className="bg-surface3 px-[0.375rem] py-[0.125rem] rounded text-[0.75rem] font-mono">
@@ -93,7 +93,7 @@ export function TemplateInfo({
               href={githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-[.5rem] mt-auto text-icon3 text-[0.875rem] hover:text-icon5"
+              className="flex items-center gap-[.5rem] mt-auto text-neutral3 text-[0.875rem] hover:text-neutral5"
             >
               <GithubIcon />
               {githubUrl?.split('/')?.pop()}

--- a/packages/playground-ui/src/domains/templates/template-installation.tsx
+++ b/packages/playground-ui/src/domains/templates/template-installation.tsx
@@ -68,12 +68,12 @@ export function TemplateInstallation({ name, streamResult, runId, workflowInfo }
   }));
 
   return (
-    <Container className="space-y-6 text-icon3 mb-[2rem] content-center">
+    <Container className="space-y-6 text-neutral3 mb-[2rem] content-center">
       {/* Header */}
       <div className="text-center">
-        <h3 className="text-lg font-semibold text-icon5">{getPhaseMessage()}</h3>
+        <h3 className="text-lg font-semibold text-neutral5">{getPhaseMessage()}</h3>
         {streamResult?.runId && (
-          <div className="mt-[0.5rem] text-[0.75rem] text-icon3">Run ID: {streamResult.runId}</div>
+          <div className="mt-[0.5rem] text-[0.75rem] text-neutral3">Run ID: {streamResult.runId}</div>
         )}
       </div>
 
@@ -88,7 +88,7 @@ export function TemplateInstallation({ name, streamResult, runId, workflowInfo }
       {error && phase === 'error' && (
         <div
           className={cn(
-            'rounded-lg text-icon5 p-[1.5rem] flex items-center gap-[.75rem] text-[0.875rem] bg-red-500/10',
+            'rounded-lg text-neutral5 p-[1.5rem] flex items-center gap-[.75rem] text-[0.875rem] bg-red-500/10',
             '[&>svg]:w-[1.5rem] [&>svg]:h-[1.5rem] [&>svg]:opacity-70 [&>svg]:text-red-500',
           )}
         >
@@ -102,7 +102,7 @@ export function TemplateInstallation({ name, streamResult, runId, workflowInfo }
 
       {/* Simple loading state for initialization */}
       {!hasSteps && phase === 'initializing' && (
-        <div className="text-center text-sm text-icon3 grid gap-[1rem] justify-items-center">
+        <div className="text-center text-sm text-neutral3 grid gap-[1rem] justify-items-center">
           <Spinner />
           <p>This may take some time...</p>
         </div>

--- a/packages/playground-ui/src/domains/templates/template-success.tsx
+++ b/packages/playground-ui/src/domains/templates/template-success.tsx
@@ -21,8 +21,8 @@ export function TemplateSuccess({ name, installedEntities, linkComponent }: Temp
     >
       <PackageOpenIcon />
       <h2 className="text-[1.25rem ]">Done!</h2>
-      <p className="text-[0.875rem] text-center text-icon3 ">
-        The <b className="text-icon4">{name}</b> template has been successfully installed.
+      <p className="text-[0.875rem] text-center text-neutral3 ">
+        The <b className="text-neutral4">{name}</b> template has been successfully installed.
         {installedEntities && installedEntities.length > 0 && (
           <>
             <br /> Installed entities are listed below.

--- a/packages/playground-ui/src/domains/templates/templates-list.tsx
+++ b/packages/playground-ui/src/domains/templates/templates-list.tsx
@@ -53,7 +53,7 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
           >
             <LinkComponent
               to={`/templates/${template.slug}`}
-              className={cn('grid [&:hover_p]:text-icon5', {
+              className={cn('grid [&:hover_p]:text-neutral5', {
                 'grid-cols-[8rem_1fr] lg:grid-cols-[12rem_1fr]': template.imageURL,
               })}
             >
@@ -70,17 +70,17 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
               <div
                 className={cn(
                   'grid py-[.75rem] px-[1.5rem] w-full gap-[0.1rem]',
-                  '[&_svg]:w-[1em] [&_svg]:h-[1em] [&_svg]:text-icon3',
+                  '[&_svg]:w-[1em] [&_svg]:h-[1em] [&_svg]:text-neutral3',
                 )}
               >
-                <h2 className="text-[1rem] text-icon5">{template.title}</h2>
-                <p className="text-[0.875rem] text-icon4 transition-colors duration-500">{template.description}</p>
-                <div className="hidden 2xl:flex text-icon3 text-[0.875rem] flex-wrap items-center gap-[1rem] mt-[0.75rem]">
+                <h2 className="text-[1rem] text-neutral5">{template.title}</h2>
+                <p className="text-[0.875rem] text-neutral4 transition-colors duration-500">{template.description}</p>
+                <div className="hidden 2xl:flex text-neutral3 text-[0.875rem] flex-wrap items-center gap-[1rem] mt-[0.75rem]">
                   {hasMetaInfo && (
                     <ul
                       className={cn(
-                        'flex gap-[1rem] text-[0.875rem] text-icon3 m-0 p-0 list-none',
-                        '[&>li]:flex [&>li]:items-center [&>li]:gap-[0.1rem] text-icon4',
+                        'flex gap-[1rem] text-[0.875rem] text-neutral3 m-0 p-0 list-none',
+                        '[&>li]:flex [&>li]:items-center [&>li]:gap-[0.1rem] text-neutral4',
                       )}
                     >
                       {template?.agents && template.agents.length > 0 && (
@@ -111,7 +111,7 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
                     </ul>
                   )}
                   {hasMetaInfo && template.supportedProviders && <small>|</small>}
-                  <div className="flex items-center text-icon3 gap-[1rem]">
+                  <div className="flex items-center text-neutral3 gap-[1rem]">
                     {template.supportedProviders.map(provider => (
                       <span key={provider} className="">
                         {provider}
@@ -127,7 +127,7 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
               target="_blank"
               rel="noopener noreferrer"
             >
-              <span className="flex items-center gap-[0.5rem]  px-[0.5rem] py-[0.25rem] rounded bg-surface1 group-hover:bg-surface2 text-icon3 transition-colors group-hover:text-icon5 ">
+              <span className="flex items-center gap-[0.5rem]  px-[0.5rem] py-[0.25rem] rounded bg-surface1 group-hover:bg-surface2 text-neutral3 transition-colors group-hover:text-neutral5 ">
                 <GithubIcon /> {getRepoName(template.githubUrl)}
               </span>
             </a>

--- a/packages/playground-ui/src/domains/tools/components/ToolInformation.tsx
+++ b/packages/playground-ui/src/domains/tools/components/ToolInformation.tsx
@@ -14,7 +14,7 @@ export const ToolInformation = ({ toolDescription, toolId, toolType }: ToolInfor
 
   return (
     <div className="p-5 border-b-sm border-border1">
-      <div className="text-icon6 flex gap-2">
+      <div className="text-neutral6 flex gap-2">
         <div>
           <Icon size="lg" className="bg-surface4 rounded-md p-1">
             <ToolIconComponent />
@@ -26,7 +26,7 @@ export const ToolInformation = ({ toolDescription, toolId, toolType }: ToolInfor
             <Txt variant="header-md" as="h2" className="font-medium truncate">
               {toolId}
             </Txt>
-            <Txt variant="ui-sm" className="text-icon3">
+            <Txt variant="ui-sm" className="text-neutral3">
               {toolDescription}
             </Txt>
           </div>

--- a/packages/playground-ui/src/domains/tools/components/ToolPanel.tsx
+++ b/packages/playground-ui/src/domains/tools/components/ToolPanel.tsx
@@ -75,7 +75,7 @@ export const ToolPanel = ({ toolId }: ToolPanelProps) => {
   if (!tool)
     return (
       <div className="py-12 text-center px-6">
-        <Txt variant="header-md" className="text-icon3">
+        <Txt variant="header-md" className="text-neutral3">
           Tool not found
         </Txt>
       </div>

--- a/packages/playground-ui/src/domains/workflows/components/workflow-step-detail.tsx
+++ b/packages/playground-ui/src/domains/workflows/components/workflow-step-detail.tsx
@@ -29,11 +29,11 @@ export function WorkflowStepDetailContent() {
             <WorkflowIcon className="w-4 h-4" style={{ color: BADGE_COLORS.workflow }} />
           )}
           <div className="flex flex-col">
-            <Txt variant="ui-md" className="text-icon6 font-medium">
+            <Txt variant="ui-md" className="text-neutral6 font-medium">
               {stepDetail.type === 'map-config' ? `${stepDetail.stepName} Config` : `${stepDetail.stepName} Workflow`}
             </Txt>
             {stepDetail.type === 'map-config' && stepDetail.stepId && stepDetail.stepId !== stepDetail.stepName && (
-              <Txt variant="ui-xs" className="text-icon3">
+              <Txt variant="ui-xs" className="text-neutral3">
                 {stepDetail.stepId}
               </Txt>
             )}
@@ -44,7 +44,7 @@ export function WorkflowStepDetailContent() {
           className="p-1 hover:bg-surface3 rounded transition-colors"
           aria-label="Close"
         >
-          <X className="w-4 h-4 text-icon3" />
+          <X className="w-4 h-4 text-neutral3" />
         </button>
       </div>
 

--- a/packages/playground-ui/src/domains/workflows/runs/workflow-run-details.tsx
+++ b/packages/playground-ui/src/domains/workflows/runs/workflow-run-details.tsx
@@ -43,7 +43,7 @@ export const WorkflowRunDetail = ({
   if (!runSnapshot || !runId) {
     return (
       <div className="p-4">
-        <Txt variant="ui-md" className="text-icon6 text-center">
+        <Txt variant="ui-md" className="text-neutral6 text-center">
           No previous run
         </Txt>
       </div>

--- a/packages/playground-ui/src/domains/workflows/runs/workflow-run-list.tsx
+++ b/packages/playground-ui/src/domains/workflows/runs/workflow-run-list.tsx
@@ -61,7 +61,7 @@ export const WorkflowRunList = ({ workflowId, runId }: WorkflowRunListProps) => 
           </ThreadItem>
 
           {actualRuns.length === 0 && (
-            <Txt variant="ui-md" className="text-icon3 py-3 px-5">
+            <Txt variant="ui-md" className="text-neutral3 py-3 px-5">
               Your run history will appear here once you run the workflow
             </Txt>
           )}
@@ -74,7 +74,7 @@ export const WorkflowRunList = ({ workflowId, runId }: WorkflowRunListProps) => 
                     <WorkflowRunStatusBadge status={run.snapshot.status} />
                   </div>
                 )}
-                <span className="truncate max-w-32 text-icon3">{run.runId}</span>
+                <span className="truncate max-w-32 text-neutral3">{run.runId}</span>
                 <span>
                   {typeof run?.snapshot === 'string'
                     ? ''
@@ -135,7 +135,7 @@ const WorkflowRunStatusBadge = ({ status }: WorkflowRunStatusProps) => {
 
   if (status === 'canceled') {
     return (
-      <Badge variant="default" icon={<CircleSlash className="text-icon3" />}>
+      <Badge variant="default" icon={<CircleSlash className="text-neutral3" />}>
         {status}
       </Badge>
     );
@@ -143,7 +143,7 @@ const WorkflowRunStatusBadge = ({ status }: WorkflowRunStatusProps) => {
 
   if (status === 'pending' || status === 'waiting') {
     return (
-      <Badge variant="default" icon={<Clock className="text-icon3" />}>
+      <Badge variant="default" icon={<Clock className="text-neutral3" />}>
         {status}
       </Badge>
     );

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-after-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-after-node.tsx
@@ -34,7 +34,7 @@ export function WorkflowAfterNode({ data }: NodeProps<AfterNode>) {
         <Badge icon={<BADGE_ICONS.after className="text-current" style={{ color: BADGE_COLORS.after }} />}>AFTER</Badge>
         <Icon>
           <ChevronDown
-            className={cn('transition-transform text-icon3', {
+            className={cn('transition-transform text-neutral3', {
               'transform rotate-180': open,
             })}
           />
@@ -44,7 +44,7 @@ export function WorkflowAfterNode({ data }: NodeProps<AfterNode>) {
         {steps.map(step => (
           <div className="text-sm bg-surface5 flex items-center gap-[6px] rounded-sm  p-2" key={step}>
             <Footprints className="text-current w-4 h-4" />
-            <Txt variant="ui-xs" className="text-icon6 capitalize">
+            <Txt variant="ui-xs" className="text-neutral6 capitalize">
               {step}
             </Txt>
           </div>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-card.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-card.tsx
@@ -16,7 +16,7 @@ export const WorkflowCard = ({ header, children, footer }: WorkflowCardProps) =>
       <button className="py-1 px-2 flex items-center gap-3 justify-between w-full" onClick={() => setExpanded(s => !s)}>
         <div className="w-full">{header}</div>
         <Icon>
-          <ChevronDownIcon className={cn('text-icon3 transition-transform -rotate-90', expanded && 'rotate-0')} />
+          <ChevronDownIcon className={cn('text-neutral3 transition-transform -rotate-90', expanded && 'rotate-0')} />
         </Icon>
       </button>
       {children && expanded && (

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-clock.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-clock.tsx
@@ -19,5 +19,5 @@ export const Clock = ({ startedAt, endedAt }: ClockProps) => {
 
   const timeDiff = endedAt ? endedAt - startedAt : time - startedAt;
 
-  return <span className="text-xs text-icon3">{toSigFigs(timeDiff, 3)}ms</span>;
+  return <span className="text-xs text-neutral3">{toSigFigs(timeDiff, 3)}ms</span>;
 };

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -83,7 +83,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
             {isCollapsible && (
               <Icon>
                 <ChevronDown
-                  className={cn('transition-transform text-icon3', {
+                  className={cn('transition-transform text-neutral3', {
                     'transform rotate-180': open,
                   })}
                 />
@@ -130,7 +130,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                         >
                           {tokens.map((line, i) => (
                             <div key={i} {...getLineProps({ line })}>
-                              <span className="inline-block mr-2 text-icon3">{i + 1}</span>
+                              <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
                               {line.map((token, key) => (
                                 <span key={key} {...getTokenProps({ token })} />
                               ))}
@@ -160,7 +160,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                               >
                                 {tokens.map((line, i) => (
                                   <div key={i} {...getLineProps({ line })}>
-                                    <span className="inline-block mr-2 text-icon3">{i + 1}</span>
+                                    <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
                                     {line.map((token, key) => (
                                       <span key={key} {...getTokenProps({ token })} />
                                     ))}
@@ -179,7 +179,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                       <div className="flex items-center gap-1">
                         {conjBadge}
 
-                        <Txt variant="ui-xs" className=" text-icon3 flex-1">
+                        <Txt variant="ui-xs" className=" text-neutral3 flex-1">
                           {(condition.ref.step as any).id || condition.ref.step}'s {condition.ref.path}{' '}
                           {Object.entries(condition.query).map(([key, value]) => `${key} ${String(value)}`)}
                         </Txt>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-default-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-default-node.tsx
@@ -132,27 +132,30 @@ export function WorkflowDefaultNode({
             {displayStatus === 'suspended' && <PauseIcon className="text-accent3" />}
             {displayStatus === 'waiting' && <HourglassIcon className="text-accent5" />}
             {displayStatus === 'running' && <Loader2 className="text-accent6 animate-spin" />}
-            {!step && <CircleDashed className="text-icon2" />}
+            {!step && <CircleDashed className="text-neutral2" />}
           </Icon>
 
-          <Txt variant="ui-lg" className="text-icon6 font-medium inline-flex items-center gap-1 justify-between w-full">
+          <Txt
+            variant="ui-lg"
+            className="text-neutral6 font-medium inline-flex items-center gap-1 justify-between w-full"
+          >
             {label} {step?.startedAt && <Clock startedAt={step.startedAt} endedAt={step.endedAt} />}
           </Txt>
         </div>
 
         {description && (
-          <Txt variant="ui-sm" className="text-icon3 px-3 pb-2">
+          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
             {description}
           </Txt>
         )}
         {duration && (
-          <Txt variant="ui-sm" className="text-icon3 px-3 pb-2">
+          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
             sleeps for <strong>{duration}ms</strong>
           </Txt>
         )}
 
         {date && (
-          <Txt variant="ui-sm" className="text-icon3 px-3 pb-2">
+          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
             sleeps until <strong>{new Date(date).toLocaleString()}</strong>
           </Txt>
         )}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-input-data.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-input-data.tsx
@@ -43,13 +43,13 @@ export const WorkflowInputData = ({
         <div className="flex flex-row gap-4">
           <div className="flex items-center gap-3">
             <RadioGroupItem value="form" id="form" />
-            <Label htmlFor="form" className="!text-icon3 text-ui-sm">
+            <Label htmlFor="form" className="!text-neutral3 text-ui-sm">
               Form
             </Label>
           </div>
           <div className="flex items-center gap-3">
             <RadioGroupItem value="json" id="json" />
-            <Label htmlFor="json" className="!text-icon3 text-ui-sm">
+            <Label htmlFor="json" className="!text-neutral3 text-ui-sm">
               JSON
             </Label>
           </div>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-loop-result-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-loop-result-node.tsx
@@ -25,7 +25,7 @@ export function WorkflowLoopResultNode({ data }: NodeProps<LoopResultNode>) {
       <div className="p-2">
         <div className="text-sm bg-surface5 flex items-center gap-[6px] rounded-sm  p-2">
           {result ? <CircleCheck className="text-current w-4 h-4" /> : <CircleX className="text-current w-4 h-4" />}
-          <Txt variant="ui-xs" className="text-icon6 capitalize">
+          <Txt variant="ui-xs" className="text-neutral6 capitalize">
             {String(result)}
           </Txt>
         </div>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-nested-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-nested-node.tsx
@@ -125,16 +125,19 @@ export function WorkflowNestedNode({
             {displayStatus === 'suspended' && <PauseIcon className="text-accent3" />}
             {displayStatus === 'waiting' && <HourglassIcon className="text-accent5" />}
             {displayStatus === 'running' && <Loader2 className="text-accent6 animate-spin" />}
-            {!step && <CircleDashed className="text-icon2" />}
+            {!step && <CircleDashed className="text-neutral2" />}
           </Icon>
 
-          <Txt variant="ui-lg" className="text-icon6 font-medium inline-flex items-center gap-1 justify-between w-full">
+          <Txt
+            variant="ui-lg"
+            className="text-neutral6 font-medium inline-flex items-center gap-1 justify-between w-full"
+          >
             {label} {step?.startedAt && <Clock startedAt={step.startedAt} endedAt={step.endedAt} />}
           </Txt>
         </div>
 
         {description && (
-          <Txt variant="ui-sm" className="text-icon3 px-3 pb-2">
+          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
             {description}
           </Txt>
         )}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-run-options.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-run-options.tsx
@@ -7,7 +7,7 @@ export const WorkflowRunOptions = () => {
   const { debugMode, setDebugMode } = useContext(WorkflowRunContext);
   return (
     <>
-      <Txt as="h3" variant="ui-md" className="text-icon3">
+      <Txt as="h3" variant="ui-md" className="text-neutral3">
         Debug Mode
       </Txt>
 

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-status.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-status.tsx
@@ -48,7 +48,7 @@ export const WorkflowStatus = ({ stepId, status, result, tripwire }: WorkflowSta
             {status === 'waiting' && <HourglassIcon className="text-accent5" />}
             {status === 'running' && <Loader2 className="text-accent6 animate-spin" />}
           </Icon>
-          <Txt as="span" variant="ui-lg" className="text-icon6 font-medium">
+          <Txt as="span" variant="ui-lg" className="text-neutral6 font-medium">
             {stepId.charAt(0).toUpperCase() + stepId.slice(1)}
           </Txt>
         </div>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-time-travel-form.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-time-travel-form.tsx
@@ -18,7 +18,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ds/compon
 import { cn } from '@/lib/utils';
 import { usePlaygroundStore } from '@/store/playground-store';
 
-const buttonClass = 'text-icon3 hover:text-icon6';
+const buttonClass = 'text-neutral3 hover:text-neutral6';
 
 export type WorkflowTimeTravelFormProps = {
   stepKey: string;
@@ -84,7 +84,7 @@ const JsonField = ({
       {isExampleOpen && (
         <div className="border border-border1 rounded-lg bg-surface3 p-3 space-y-2">
           <div className="flex items-center gap-2">
-            <Txt as="p" variant="ui-sm" className="text-icon3">
+            <Txt as="p" variant="ui-sm" className="text-neutral3">
               Example {label}
             </Txt>
             <Tooltip>
@@ -114,11 +114,11 @@ const JsonField = ({
       <Collapsible className="border border-border1 rounded-lg bg-surface3" open={isOpen} onOpenChange={setIsOpen}>
         <div className="flex items-center justify-between w-full px-3">
           <div>
-            <Txt as="label" variant="ui-md" className="text-icon3">
+            <Txt as="label" variant="ui-md" className="text-neutral3">
               {label}
             </Txt>
             {helperText && (
-              <Txt variant="ui-xs" className="text-icon3">
+              <Txt variant="ui-xs" className="text-neutral3">
                 {helperText}
               </Txt>
             )}
@@ -288,10 +288,10 @@ export const WorkflowTimeTravelForm = ({
     <TooltipProvider>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Txt as="p" variant="ui-lg" className="text-icon3">
+          <Txt as="p" variant="ui-lg" className="text-neutral3">
             Input data
           </Txt>
-          <Txt variant="ui-xs" className="text-icon3">
+          <Txt variant="ui-xs" className="text-neutral3">
             Step: {stepKey}
           </Txt>
         </div>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -216,7 +216,7 @@ export function WorkflowTrigger({
         {isSuspendedSteps && isStreamingWorkflow && (
           <div className="py-2 px-5 flex items-center gap-2 bg-surface5 -mx-5 -mt-5 border-b-sm border-border1">
             <Icon>
-              <Loader2 className="animate-spin text-icon6" />
+              <Loader2 className="animate-spin text-neutral6" />
             </Icon>
             <Txt>Resuming workflow</Txt>
           </div>
@@ -266,7 +266,7 @@ export function WorkflowTrigger({
               : z.record(z.string(), z.any());
             return (
               <div className="flex flex-col px-4" key={step.stepId}>
-                <Txt variant="ui-xs" className="text-icon3">
+                <Txt variant="ui-xs" className="text-neutral3">
                   {step.stepId}
                 </Txt>
                 {step.suspendPayload && (
@@ -326,7 +326,7 @@ export function WorkflowTrigger({
           <>
             <hr className="border-border1 border-sm my-5" />
             <div className="flex flex-col gap-2">
-              <Txt variant="ui-xs" className="px-4 text-icon3">
+              <Txt variant="ui-xs" className="px-4 text-neutral3">
                 Status
               </Txt>
               <div className="px-4 flex flex-col gap-4">
@@ -396,7 +396,7 @@ const WorkflowJsonDialog = ({ result }: { result: Record<string, unknown> }) => 
     <>
       <Button variant="light" onClick={() => setOpen(true)} className="w-full" size="lg">
         <Icon>
-          <Braces className="text-icon3" />
+          <Braces className="text-neutral3" />
         </Icon>
         Open Workflow Execution (JSON)
       </Button>

--- a/packages/playground-ui/src/domains/workflows/workflow/zoom-slider.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/zoom-slider.tsx
@@ -12,7 +12,7 @@ export const ZoomSlider = forwardRef<HTMLDivElement, Omit<PanelProps, 'children'
   const { zoomTo, zoomIn, zoomOut, fitView } = useReactFlow();
 
   return (
-    <Panel className={cn('flex gap-1 rounded-md bg-surface2 p-1 text-icon6', className)} {...props}>
+    <Panel className={cn('flex gap-1 rounded-md bg-surface2 p-1 text-neutral6', className)} {...props}>
       <Button onClick={() => zoomOut({ duration: 300 })}>
         <Minus className="h-4 w-4" />
       </Button>

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
@@ -82,7 +82,7 @@ const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description ref={ref} className={cn('text-sm text-icon3', className)} {...props} />
+  <AlertDialogPrimitive.Description ref={ref} className={cn('text-sm text-neutral3', className)} {...props} />
 ));
 AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
 

--- a/packages/playground-ui/src/ds/components/Badge/Badge.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/Badge.tsx
@@ -11,7 +11,7 @@ export interface BadgeProps {
 }
 
 const variantClasses = {
-  default: 'text-icon3',
+  default: 'text-neutral3',
   success: 'text-accent1',
   error: 'text-accent2',
   info: 'text-accent3',
@@ -23,7 +23,7 @@ export const Badge = ({ icon, variant = 'default', className, children, ...props
       className={clsx(
         'font-mono bg-surface4 text-ui-sm gap-md h-badge-default inline-flex items-center rounded-md shrink-0',
         icon ? 'pl-md pr-1.5' : 'px-1.5',
-        icon || variant === 'default' ? 'text-icon5' : variantClasses[variant],
+        icon || variant === 'default' ? 'text-neutral5' : variantClasses[variant],
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -37,7 +37,7 @@ export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps
           aria-current={isCurrent ? 'page' : undefined}
           className={clsx(
             'text-ui-lg leading-ui-lg font-medium flex items-center gap-2',
-            isCurrent ? 'text-white' : 'text-icon3',
+            isCurrent ? 'text-white' : 'text-neutral3',
             className,
           )}
           {...props}
@@ -46,7 +46,7 @@ export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps
       </li>
       {!isCurrent && (
         <li role="separator" className="flex h-full items-center">
-          <Icon className="text-icon3">
+          <Icon className="text-neutral3">
             <SlashIcon />
           </Icon>
         </li>

--- a/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
@@ -77,7 +77,7 @@ export const WithAction: Story = {
         isCurrent
         action={
           <button className="p-1 hover:bg-surface2 rounded">
-            <ChevronDown className="h-4 w-4 text-icon3" />
+            <ChevronDown className="h-4 w-4 text-neutral3" />
           </button>
         }
       >

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -20,10 +20,10 @@ const sizeClasses = {
 };
 
 const variantClasses = {
-  default: 'bg-surface2 hover:bg-surface4 text-icon3 hover:text-icon6 disabled:opacity-50',
-  light: 'bg-surface3 hover:bg-surface5 text-icon6 disabled:opacity-50',
-  outline: 'bg-transparent hover:bg-surface2 text-icon3 hover:text-icon6 disabled:opacity-50',
-  ghost: 'bg-transparent border-transparent hover:bg-surface2 text-icon3 hover:text-icon6 disabled:opacity-50',
+  default: 'bg-surface2 hover:bg-surface4 text-neutral3 hover:text-neutral6 disabled:opacity-50',
+  light: 'bg-surface3 hover:bg-surface5 text-neutral6 disabled:opacity-50',
+  outline: 'bg-transparent hover:bg-surface2 text-neutral3 hover:text-neutral6 disabled:opacity-50',
+  ghost: 'bg-transparent border-transparent hover:bg-surface2 text-neutral3 hover:text-neutral6 disabled:opacity-50',
 };
 
 export function buttonVariants(options?: { variant?: ButtonProps['variant']; size?: ButtonProps['size'] }) {

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-icon6 shadow disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-icon6 data-[state=checked]:text-surface2',
+      'peer h-4 w-4 shrink-0 rounded-sm border border-neutral6 shadow disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-neutral6 data-[state=checked]:text-surface2',
       className,
     )}
     {...props}

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
@@ -26,7 +26,7 @@ export const Default: Story = {
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2 p-4 rounded-md border border-border1 bg-surface2">
-        <p className="text-sm text-icon5">This is the collapsible content. It can contain any elements.</p>
+        <p className="text-sm text-neutral5">This is the collapsible content. It can contain any elements.</p>
       </CollapsibleContent>
     </Collapsible>
   ),
@@ -42,7 +42,7 @@ export const DefaultOpen: Story = {
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2 p-4 rounded-md border border-border1 bg-surface2">
-        <p className="text-sm text-icon5">This section is open by default.</p>
+        <p className="text-sm text-neutral5">This section is open by default.</p>
       </CollapsibleContent>
     </Collapsible>
   ),
@@ -53,23 +53,23 @@ export const SettingsSection: Story = {
     <div className="w-[400px] space-y-2">
       <Collapsible>
         <CollapsibleTrigger asChild>
-          <button className="flex w-full items-center justify-between py-2 text-sm font-medium text-icon6 hover:text-white">
+          <button className="flex w-full items-center justify-between py-2 text-sm font-medium text-neutral6 hover:text-white">
             Advanced Settings
             <ChevronDown className="h-4 w-4" />
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent className="space-y-3 pt-2">
           <div className="flex items-center justify-between">
-            <span className="text-sm text-icon5">Debug mode</span>
-            <span className="text-sm text-icon3">Disabled</span>
+            <span className="text-sm text-neutral5">Debug mode</span>
+            <span className="text-sm text-neutral3">Disabled</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-sm text-icon5">Verbose logging</span>
-            <span className="text-sm text-icon3">Off</span>
+            <span className="text-sm text-neutral5">Verbose logging</span>
+            <span className="text-sm text-neutral3">Off</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-sm text-icon5">Cache timeout</span>
-            <span className="text-sm text-icon3">300s</span>
+            <span className="text-sm text-neutral5">Cache timeout</span>
+            <span className="text-sm text-neutral3">300s</span>
           </div>
         </CollapsibleContent>
       </Collapsible>
@@ -88,7 +88,7 @@ export const MultipleCollapsibles: Story = {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent className="p-2">
-          <p className="text-sm text-icon5">Content for section 1</p>
+          <p className="text-sm text-neutral5">Content for section 1</p>
         </CollapsibleContent>
       </Collapsible>
       <Collapsible>
@@ -99,7 +99,7 @@ export const MultipleCollapsibles: Story = {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent className="p-2">
-          <p className="text-sm text-icon5">Content for section 2</p>
+          <p className="text-sm text-neutral5">Content for section 2</p>
         </CollapsibleContent>
       </Collapsible>
       <Collapsible>
@@ -110,7 +110,7 @@ export const MultipleCollapsibles: Story = {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent className="p-2">
-          <p className="text-sm text-icon5">Content for section 3</p>
+          <p className="text-sm text-neutral5">Content for section 3</p>
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -129,12 +129,12 @@ export function Combobox({
         </DSButton>
       </PopoverTrigger>
       <PopoverContent className="p-0 w-fit" align="start">
-        <div className="flex h-full w-full flex-col overflow-hidden rounded-md bg-surface3 text-icon5">
+        <div className="flex h-full w-full flex-col overflow-hidden rounded-md bg-surface3 text-neutral5">
           <div className="flex items-center border-b px-3 py-2">
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
             <input
               ref={inputRef}
-              className="flex h-8 w-full rounded-md bg-transparent py-1 text-sm placeholder:text-icon3 disabled:cursor-not-allowed disabled:opacity-50 outline-none"
+              className="flex h-8 w-full rounded-md bg-transparent py-1 text-sm placeholder:text-neutral3 disabled:cursor-not-allowed disabled:opacity-50 outline-none"
               placeholder={searchPlaceholder}
               value={search}
               onChange={e => setSearch(e.target.value)}
@@ -164,8 +164,8 @@ export function Combobox({
                     aria-selected={isSelected}
                     className={cn(
                       'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm transition-colors',
-                      'hover:bg-surface5 hover:text-icon5',
-                      isHighlighted && 'bg-surface5 text-icon5',
+                      'hover:bg-surface5 hover:text-neutral5',
+                      isHighlighted && 'bg-surface5 text-neutral5',
                       isSelected && !isHighlighted && 'bg-surface5/50',
                     )}
                     onClick={() => handleSelect(option.value)}

--- a/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
@@ -58,7 +58,7 @@ export const LargeIcon: Story = {
 export const InContext: Story = {
   render: () => (
     <div className="flex items-center gap-2 p-3 bg-surface4 rounded-md">
-      <code className="text-sm font-mono text-icon5">npm install @mastra/core</code>
+      <code className="text-sm font-mono text-neutral5">npm install @mastra/core</code>
       <CopyButton content="npm install @mastra/core" />
     </div>
   ),
@@ -68,7 +68,7 @@ export const CodeBlock: Story = {
   render: () => (
     <div className="relative p-4 bg-surface4 rounded-md w-[300px]">
       <CopyButton content="const agent = new Agent()" className="absolute top-2 right-2" />
-      <pre className="text-sm font-mono text-icon5">const agent = new Agent()</pre>
+      <pre className="text-sm font-mono text-neutral5">const agent = new Agent()</pre>
     </div>
   ),
 };

--- a/packages/playground-ui/src/ds/components/CopyButton/copy-button.tsx
+++ b/packages/playground-ui/src/ds/components/CopyButton/copy-button.tsx
@@ -29,7 +29,10 @@ export function CopyButton({
     <Tooltip>
       <TooltipTrigger asChild>
         <button onClick={handleCopy} type="button" className={className}>
-          <Icon className="transition-colors hover:bg-surface4 rounded-lg text-icon3 hover:text-icon6" size={iconSize}>
+          <Icon
+            className="transition-colors hover:bg-surface4 rounded-lg text-neutral3 hover:text-neutral6"
+            size={iconSize}
+          >
             <CopyIcon />
           </Icon>
         </button>

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-picker.tsx
@@ -31,14 +31,14 @@ export function DatePicker({ className, classNames, showOutsideDays = true, ...p
         day_range_start: 'day-range-start',
         day_range_end: 'day-range-end',
         day_selected:
-          '!bg-icon6/50 !text-surface2 hover:bg-icon6 rounded-md hover:text-surface2 focus:bg-icon6 focus:text-surface2',
-        day_today: 'bg-icon6/10 text-icon5',
+          '!bg-neutral6/50 !text-surface2 hover:bg-neutral6 rounded-md hover:text-surface2 focus:bg-neutral6 focus:text-surface2',
+        day_today: 'bg-neutral6/10 text-neutral5',
         day_outside:
-          'day-outside text-icon3 opacity-50  aria-selected:bg-surface5/50 aria-selected:text-icon3 aria-selected:opacity-30',
-        day_disabled: 'text-icon3 opacity-50',
-        day_range_middle: 'aria-selected:bg-surface5 aria-selected:text-icon5',
+          'day-outside text-neutral3 opacity-50  aria-selected:bg-surface5/50 aria-selected:text-neutral3 aria-selected:opacity-30',
+        day_disabled: 'text-neutral3 opacity-50',
+        day_range_middle: 'aria-selected:bg-surface5 aria-selected:text-neutral5',
         day_hidden: 'invisible',
-        head_cell: 'text-[0.625rem] text-icon3',
+        head_cell: 'text-[0.625rem] text-neutral3',
         ...classNames,
       }}
       {...props}

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
@@ -20,7 +20,7 @@ const DateTimePickerDemo = ({ initialValue }: { initialValue?: Date }) => {
   return (
     <div className="w-[280px]">
       <DateTimePicker value={value} onValueChange={setValue} />
-      {value && <p className="mt-2 text-sm text-icon5">Selected: {value.toLocaleString()}</p>}
+      {value && <p className="mt-2 text-sm text-neutral5">Selected: {value.toLocaleString()}</p>}
     </div>
   );
 };

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.tsx
@@ -213,7 +213,7 @@ export const DateTimePickerContent = ({
       {localErrorMsg && (
         <div
           className={cn(
-            'text-[0.875rem] m-[1rem] mb-0 text-icon3',
+            'text-[0.875rem] m-[1rem] mb-0 text-neutral3',
             '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:mt-[0.2em] [&>svg]:text-red-500 [&>svg]:float-left [&>svg]:mr-[0.5rem]',
           )}
         >

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
@@ -36,7 +36,7 @@ export const Default: Story = {
           <DialogDescription>This is a description of the dialog content.</DialogDescription>
         </DialogHeader>
         <div className="py-4">
-          <p className="text-sm text-icon5">Dialog body content goes here.</p>
+          <p className="text-sm text-neutral5">Dialog body content goes here.</p>
         </div>
         <DialogFooter>
           <Button variant="outline">Cancel</Button>
@@ -92,17 +92,17 @@ export const LongContent: Story = {
           <DialogDescription>Please read these terms carefully.</DialogDescription>
         </DialogHeader>
         <div className="py-4 space-y-4">
-          <p className="text-sm text-icon5">
+          <p className="text-sm text-neutral5">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua.
           </p>
-          <p className="text-sm text-icon5">
+          <p className="text-sm text-neutral5">
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
           </p>
-          <p className="text-sm text-icon5">
+          <p className="text-sm text-neutral5">
             Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
           </p>
-          <p className="text-sm text-icon5">
+          <p className="text-sm text-neutral5">
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
             laborum.
           </p>
@@ -126,7 +126,7 @@ export const MinimalDialog: Story = {
         <DialogHeader>
           <DialogTitle>Information</DialogTitle>
         </DialogHeader>
-        <p className="text-sm text-icon5">This is a simple informational dialog.</p>
+        <p className="text-sm text-neutral5">This is a simple informational dialog.</p>
       </DialogContent>
     </Dialog>
   ),

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-surface5 data-[state=open]:text-icon3">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-surface5 data-[state=open]:text-neutral3">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -78,7 +78,7 @@ const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-icon3', className)} {...props} />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-neutral3', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 

--- a/packages/playground-ui/src/ds/components/EmptyState/EmptyState.tsx
+++ b/packages/playground-ui/src/ds/components/EmptyState/EmptyState.tsx
@@ -20,9 +20,9 @@ export const EmptyState = ({
   return (
     <div className="flex w-[340px] flex-col items-center justify-center text-center">
       <div className="h-auto [&>svg]:w-[126px]">{iconSlot}</div>
-      <Component className="text-icon6 pt-[34px] font-serif text-[1.75rem] font-semibold">{titleSlot}</Component>
+      <Component className="text-neutral6 pt-[34px] font-serif text-[1.75rem] font-semibold">{titleSlot}</Component>
 
-      <Txt variant="ui-lg" className="text-icon3 pb-[34px]">
+      <Txt variant="ui-lg" className="text-neutral3 pb-[34px]">
         {descriptionSlot}
       </Txt>
 

--- a/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof EmptyState>;
 
 export const Default: Story = {
   args: {
-    iconSlot: <Inbox className="w-[126px] h-auto text-icon3" />,
+    iconSlot: <Inbox className="w-[126px] h-auto text-neutral3" />,
     titleSlot: 'No items yet',
     descriptionSlot: 'Get started by creating your first item.',
     actionSlot: <Button>Create Item</Button>,
@@ -26,7 +26,7 @@ export const Default: Story = {
 
 export const NoResults: Story = {
   args: {
-    iconSlot: <Search className="w-[126px] h-auto text-icon3" />,
+    iconSlot: <Search className="w-[126px] h-auto text-neutral3" />,
     titleSlot: 'No results found',
     descriptionSlot: 'Try adjusting your search or filters to find what you are looking for.',
     actionSlot: <Button variant="outline">Clear filters</Button>,
@@ -35,7 +35,7 @@ export const NoResults: Story = {
 
 export const NoFiles: Story = {
   args: {
-    iconSlot: <FileX className="w-[126px] h-auto text-icon3" />,
+    iconSlot: <FileX className="w-[126px] h-auto text-neutral3" />,
     titleSlot: 'No files',
     descriptionSlot: 'Upload your first file to get started.',
     actionSlot: <Button>Upload File</Button>,
@@ -44,7 +44,7 @@ export const NoFiles: Story = {
 
 export const NoTeamMembers: Story = {
   args: {
-    iconSlot: <Users className="w-[126px] h-auto text-icon3" />,
+    iconSlot: <Users className="w-[126px] h-auto text-neutral3" />,
     titleSlot: 'No team members',
     descriptionSlot: 'Invite your team members to collaborate on this project.',
     actionSlot: <Button>Invite Members</Button>,
@@ -53,7 +53,7 @@ export const NoTeamMembers: Story = {
 
 export const WithoutAction: Story = {
   args: {
-    iconSlot: <Inbox className="w-[126px] h-auto text-icon3" />,
+    iconSlot: <Inbox className="w-[126px] h-auto text-neutral3" />,
     titleSlot: 'All caught up!',
     descriptionSlot: 'You have no pending notifications.',
     actionSlot: null,
@@ -63,7 +63,7 @@ export const WithoutAction: Story = {
 export const CustomHeading: Story = {
   args: {
     as: 'h1',
-    iconSlot: <Inbox className="w-[126px] h-auto text-icon3" />,
+    iconSlot: <Inbox className="w-[126px] h-auto text-neutral3" />,
     titleSlot: 'Welcome to the App',
     descriptionSlot: 'This is your dashboard. Start by exploring the features.',
     actionSlot: <Button>Get Started</Button>,

--- a/packages/playground-ui/src/ds/components/Entity/Entity.tsx
+++ b/packages/playground-ui/src/ds/components/Entity/Entity.tsx
@@ -33,7 +33,7 @@ export const Entity = ({ children, className, onClick }: EntityProps) => {
 
 export const EntityIcon = ({ children, className }: EntityProps) => {
   return (
-    <Icon size="lg" className={clsx('text-icon3 mt-1', className)}>
+    <Icon size="lg" className={clsx('text-neutral3 mt-1', className)}>
       {children}
     </Icon>
   );
@@ -41,7 +41,7 @@ export const EntityIcon = ({ children, className }: EntityProps) => {
 
 export const EntityName = ({ children, className }: EntityProps) => {
   return (
-    <Txt as="p" variant="ui-lg" className={clsx('text-icon6 font-medium', className)}>
+    <Txt as="p" variant="ui-lg" className={clsx('text-neutral6 font-medium', className)}>
       {children}
     </Txt>
   );
@@ -49,7 +49,7 @@ export const EntityName = ({ children, className }: EntityProps) => {
 
 export const EntityDescription = ({ children, className }: EntityProps) => {
   return (
-    <Txt as="p" variant="ui-sm" className={clsx('text-icon3', className)}>
+    <Txt as="p" variant="ui-sm" className={clsx('text-neutral3', className)}>
       {children}
     </Txt>
   );

--- a/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
@@ -34,7 +34,7 @@ export const WithChildren: Story = {
   render: () => (
     <div className="w-[400px] bg-surface3 rounded-lg">
       <EntityHeader icon={<Workflow />} title="Data Processing Pipeline">
-        <p className="text-sm text-icon3">Processes incoming data and transforms it for analysis</p>
+        <p className="text-sm text-neutral3">Processes incoming data and transforms it for analysis</p>
       </EntityHeader>
     </div>
   ),
@@ -69,8 +69,8 @@ export const WithRichContent: Story = {
     <div className="w-[450px] bg-surface3 rounded-lg">
       <EntityHeader icon={<Bot />} title="AI Assistant">
         <div className="space-y-2">
-          <p className="text-sm text-icon3">An intelligent assistant for customer support tasks</p>
-          <div className="flex items-center gap-4 text-xs text-icon3">
+          <p className="text-sm text-neutral3">An intelligent assistant for customer support tasks</p>
+          <div className="flex items-center gap-4 text-xs text-neutral3">
             <span>Model: GPT-4</span>
             <span>Temperature: 0.7</span>
             <span>Max Tokens: 4096</span>

--- a/packages/playground-ui/src/ds/components/EntityHeader/entity-header.tsx
+++ b/packages/playground-ui/src/ds/components/EntityHeader/entity-header.tsx
@@ -12,7 +12,7 @@ export type EntityHeaderProps = {
 export const EntityHeader = ({ icon, title, isLoading, children }: EntityHeaderProps) => {
   return (
     <div className="p-5 w-full overflow-x-hidden">
-      <div className="text-icon6 flex items-center gap-2">
+      <div className="text-neutral6 flex items-center gap-2">
         <Icon size="lg" className="bg-surface4 rounded-md p-1">
           {icon}
         </Icon>

--- a/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
@@ -26,7 +26,7 @@ export const WithText: Story = {
   args: {
     label: 'Name',
     children: (
-      <Txt variant="ui-md" className="text-icon6">
+      <Txt variant="ui-md" className="text-neutral6">
         John Doe
       </Txt>
     ),
@@ -44,7 +44,7 @@ export const WithLongContent: Story = {
   args: {
     label: 'Description',
     children: (
-      <Txt variant="ui-md" className="text-icon6">
+      <Txt variant="ui-md" className="text-neutral6">
         This is a longer description that contains multiple lines of text to show how the component handles longer
         content.
       </Txt>
@@ -56,7 +56,7 @@ export const MultipleEntries: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-[300px]">
       <Entry label="Name">
-        <Txt variant="ui-md" className="text-icon6">
+        <Txt variant="ui-md" className="text-neutral6">
           My Agent
         </Txt>
       </Entry>
@@ -64,7 +64,7 @@ export const MultipleEntries: Story = {
         <Badge variant="success">Running</Badge>
       </Entry>
       <Entry label="Created">
-        <Txt variant="ui-md" className="text-icon6">
+        <Txt variant="ui-md" className="text-neutral6">
           Jan 14, 2026
         </Txt>
       </Entry>
@@ -77,13 +77,13 @@ export const WithComplexContent: Story = {
     label: 'Configuration',
     children: (
       <div className="flex flex-col gap-1">
-        <Txt variant="ui-sm" className="text-icon5">
+        <Txt variant="ui-sm" className="text-neutral5">
           Model: GPT-4
         </Txt>
-        <Txt variant="ui-sm" className="text-icon5">
+        <Txt variant="ui-sm" className="text-neutral5">
           Temperature: 0.7
         </Txt>
-        <Txt variant="ui-sm" className="text-icon5">
+        <Txt variant="ui-sm" className="text-neutral5">
           Max tokens: 4096
         </Txt>
       </div>

--- a/packages/playground-ui/src/ds/components/Entry/entry.tsx
+++ b/packages/playground-ui/src/ds/components/Entry/entry.tsx
@@ -9,7 +9,7 @@ export type EntryProps = {
 export const Entry = ({ label, children }: EntryProps) => {
   return (
     <div className="space-y-2">
-      <Txt as="p" variant="ui-md" className="text-icon3">
+      <Txt as="p" variant="ui-md" className="text-neutral3">
         {label}
       </Txt>
 

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list-entry-col.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list-entry-col.tsx
@@ -8,7 +8,7 @@ export type EntryListEntryTextColProps = {
 
 export function EntryListEntryTextCol({ children, isLoading }: EntryListEntryTextColProps) {
   return (
-    <div className="text-icon4 text-[0.875rem] truncate ">
+    <div className="text-neutral4 text-[0.875rem] truncate ">
       {isLoading ? (
         <div className="bg-surface4 rounded-md animate-pulse text-transparent h-[1rem] select-none"></div>
       ) : (
@@ -33,7 +33,7 @@ export function EntryListEntryStatusCol({ status }: EntryListEntryStatusColProps
           })}
         ></div>
       ) : (
-        <div className="text-icon2 text-[0.75rem] leading-none">-</div>
+        <div className="text-neutral2 text-[0.75rem] leading-none">-</div>
       )}
       <VisuallyHidden>Status: {status ? status : 'not provided'}</VisuallyHidden>
     </div>

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list-header.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list-header.tsx
@@ -11,7 +11,7 @@ export function EntryListHeader({ columns }: EntryListHeaderProps) {
   return (
     <div className={cn('sticky top-0 bg-surface4 z-[1] rounded-t-lg px-[1.5rem]')}>
       <div
-        className={cn('grid gap-[1.5rem] text-left uppercase py-[.75rem] text-icon3 text-[0.75rem]')}
+        className={cn('grid gap-[1.5rem] text-left uppercase py-[.75rem] text-neutral3 text-[0.75rem]')}
         style={{ gridTemplateColumns: getColumnTemplate(columns) }}
       >
         {columns?.map(col => (

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list-message.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list-message.tsx
@@ -18,7 +18,7 @@ export function EntryListMessage({ children, message, className, type }: EntryLi
       {message ? (
         <p
           className={cn(
-            'text-icon3 text-[0.875rem] text-center grid p-[2rem] justify-center justify-items-center gap-[.5rem]',
+            'text-neutral3 text-[0.875rem] text-center grid p-[2rem] justify-center justify-items-center gap-[.5rem]',
             '[&>svg]:w-[1.5em] [&>svg]:h-[1.5em] [&>svg]:opacity-75',
             {
               '[&>svg]:text-red-500': type === 'error',

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list-next-page-loading.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list-next-page-loading.tsx
@@ -18,7 +18,7 @@ export function EntryListNextPageLoading({
   }
 
   return (
-    <div ref={setEndOfListElement} className="text-[0.875rem] text-icon3 opacity-50 flex mt-[2rem] justify-center">
+    <div ref={setEndOfListElement} className="text-[0.875rem] text-neutral3 opacity-50 flex mt-[2rem] justify-center">
       {isLoading && loadingText}
       {!hasMore && !isLoading && noMoreDataText}
     </div>

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list-pagination.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list-pagination.tsx
@@ -13,7 +13,7 @@ export function EntryListPagination({ currentPage, hasMore, onNextPage, onPrevPa
   const showNavigation = (typeof currentPage === 'number' && currentPage > 0) || hasMore;
 
   return (
-    <div className={cn('flex pt-[1.5rem] items-center justify-center text-icon3 text-[0.875rem] gap-[2rem] ')}>
+    <div className={cn('flex pt-[1.5rem] items-center justify-center text-neutral3 text-[0.875rem] gap-[2rem] ')}>
       <span>
         Page <b>{currentPage ? currentPage + 1 : '1'}</b>
       </span>
@@ -21,8 +21,8 @@ export function EntryListPagination({ currentPage, hasMore, onNextPage, onPrevPa
         <div
           className={cn(
             'flex gap-[1rem]',
-            '[&>button]:flex [&>button]:items-center [&>button]:gap-[0.5rem] [&>button]:text-icon4 [&>button:hover]:text-icon5 [&>button]:transition-colors [&>button]:border [&>button]:border-border1 [&>button]:p-[0.25rem] [&>button]:px-[0.5rem] [&>button]:rounded-md',
-            '[&_svg]:w-[1em] [&_svg]:h-[1em] [&_svg]:text-icon3',
+            '[&>button]:flex [&>button]:items-center [&>button]:gap-[0.5rem] [&>button]:text-neutral4 [&>button:hover]:text-neutral5 [&>button]:transition-colors [&>button]:border [&>button]:border-border1 [&>button]:p-[0.25rem] [&>button]:px-[0.5rem] [&>button]:rounded-md',
+            '[&_svg]:w-[1em] [&_svg]:h-[1em] [&_svg]:text-neutral3',
           )}
         >
           {typeof currentPage === 'number' && currentPage > 0 && (

--- a/packages/playground-ui/src/ds/components/FormFields/input-field.tsx
+++ b/packages/playground-ui/src/ds/components/FormFields/input-field.tsx
@@ -48,10 +48,10 @@ export function InputField({
       <LabelWrapper>
         <label
           htmlFor={`input-${name}`}
-          className={cn('text-[0.8125rem] text-icon3 flex justify-between items-center')}
+          className={cn('text-[0.8125rem] text-neutral3 flex justify-between items-center')}
         >
           {label}
-          {required && <i className="text-icon2 text-xs">(required)</i>}
+          {required && <i className="text-neutral2 text-xs">(required)</i>}
         </label>
       </LabelWrapper>
       <input
@@ -61,7 +61,7 @@ export function InputField({
         className={cn(
           'flex grow items-center cursor-pointer text-[0.875rem] text-[rgba(255,255,255,0.8)] border border-[rgba(255,255,255,0.15)] leading-none rounded-lg bg-transparent min-h-[2.5rem] px-[0.75rem] py-[0.5rem] w-full',
           'focus:outline-none focus:shadow-[inset_0_0_0_1px_#18fb6f]',
-          'placeholder:text-icon3 placeholder:text-[.8125rem]',
+          'placeholder:text-neutral3 placeholder:text-[.8125rem]',
           {
             'cursor-not-allowed opacity-50': disabled,
             'border-red-800 focus:border-[rgba(255,255,255,0.15)]': error || errorMsg,
@@ -70,11 +70,11 @@ export function InputField({
         data-testid={testId}
         {...props}
       />
-      {helpMsg && <p className="text-icon3 text-[0.75rem]">{helpMsg}</p>}
+      {helpMsg && <p className="text-neutral3 text-[0.75rem]">{helpMsg}</p>}
       {errorMsg && (
         <p
           className={cn(
-            'text-[0.75rem] text-icon4 flex items-center gap-[.5rem]',
+            'text-[0.75rem] text-neutral4 flex items-center gap-[.5rem]',
             '[&>svg]:w-[1.2em] [&>svg]:h-[1.2em] [&>svg]:opacity-70 [&>svg]:text-red-400',
           )}
         >

--- a/packages/playground-ui/src/ds/components/FormFields/search-field.tsx
+++ b/packages/playground-ui/src/ds/components/FormFields/search-field.tsx
@@ -24,9 +24,9 @@ export function SearchField({ onReset, ...props }: SearchFieldProps) {
         <button
           type="button"
           onClick={onReset}
-          className={cn('absolute top-1/2 right-2 -translate-y-1/2 p-1', '[&:hover>svg]:text-icon5')}
+          className={cn('absolute top-1/2 right-2 -translate-y-1/2 p-1', '[&:hover>svg]:text-neutral5')}
         >
-          <XIcon className="text-icon3 w-[1rem] h-[1rem]" />
+          <XIcon className="text-neutral3 w-[1rem] h-[1rem]" />
         </button>
       )}
     </div>

--- a/packages/playground-ui/src/ds/components/FormFields/select-field.tsx
+++ b/packages/playground-ui/src/ds/components/FormFields/select-field.tsx
@@ -40,9 +40,9 @@ export function SelectField({
       )}
     >
       {label && (
-        <label className={cn('text-[0.8125rem] text-icon3 flex justify-between items-center shrink-0')}>
+        <label className={cn('text-[0.8125rem] text-neutral3 flex justify-between items-center shrink-0')}>
           {label}
-          {required && <i className="text-icon2">(required)</i>}
+          {required && <i className="text-neutral2">(required)</i>}
         </label>
       )}
       <Select name={name} value={value} onValueChange={onValueChange} disabled={disabled}>
@@ -63,7 +63,7 @@ export function SelectField({
           ))}
         </SelectContent>
       </Select>
-      {helpMsg && <p className="text-icon3 text-[0.75rem]">{helpMsg}</p>}
+      {helpMsg && <p className="text-neutral3 text-[0.75rem]">{helpMsg}</p>}
     </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/Header/header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Header/header.stories.tsx
@@ -50,7 +50,7 @@ export const WithGroup: Story = {
     <Header>
       <HeaderGroup>
         <HeaderTitle>Workflows</HeaderTitle>
-        <span className="text-sm text-icon3">12 total</span>
+        <span className="text-sm text-neutral3">12 total</span>
       </HeaderGroup>
       <HeaderAction>
         <Button variant="outline" size="md">

--- a/packages/playground-ui/src/ds/components/Input/input.tsx
+++ b/packages/playground-ui/src/ds/components/Input/input.tsx
@@ -5,13 +5,13 @@ import * as React from 'react';
 import clsx from 'clsx';
 
 const inputVariants = cva(
-  'flex w-full text-icon6 rounded-lg border bg-transparent shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+  'flex w-full text-neutral6 rounded-lg border bg-transparent shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'border-sm border-border1 placeholder:text-icon3',
-        filled: 'border-sm bg-inputFill border-border1 placeholder:text-icon3',
-        unstyled: 'border-0 bg-transparent placeholder:text-icon3',
+        default: 'border-sm border-border1 placeholder:text-neutral3',
+        filled: 'border-sm bg-inputFill border-border1 placeholder:text-neutral3',
+        unstyled: 'border-0 bg-transparent placeholder:text-neutral3',
       },
       customSize: {
         default: 'px-[13px] text-[calc(13_/_16_*_1rem)] h-8',

--- a/packages/playground-ui/src/ds/components/Kbd/kbd.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Kbd/kbd.stories.tsx
@@ -50,7 +50,7 @@ export const KeyCombination: Story = {
   render: () => (
     <div className="flex items-center gap-1">
       <Kbd>Ctrl</Kbd>
-      <span className="text-icon3">+</span>
+      <span className="text-neutral3">+</span>
       <Kbd>K</Kbd>
     </div>
   ),
@@ -62,26 +62,26 @@ export const CommonShortcuts: Story = {
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1">
           <Kbd>Ctrl</Kbd>
-          <span className="text-icon3">+</span>
+          <span className="text-neutral3">+</span>
           <Kbd>C</Kbd>
         </div>
-        <span className="text-icon5">Copy</span>
+        <span className="text-neutral5">Copy</span>
       </div>
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1">
           <Kbd>Ctrl</Kbd>
-          <span className="text-icon3">+</span>
+          <span className="text-neutral3">+</span>
           <Kbd>V</Kbd>
         </div>
-        <span className="text-icon5">Paste</span>
+        <span className="text-neutral5">Paste</span>
       </div>
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1">
           <Kbd>Ctrl</Kbd>
-          <span className="text-icon3">+</span>
+          <span className="text-neutral3">+</span>
           <Kbd>Z</Kbd>
         </div>
-        <span className="text-icon5">Undo</span>
+        <span className="text-neutral5">Undo</span>
       </div>
     </div>
   ),

--- a/packages/playground-ui/src/ds/components/Kbd/kbd.tsx
+++ b/packages/playground-ui/src/ds/components/Kbd/kbd.tsx
@@ -7,7 +7,7 @@ export type KbdProps = {
 
 const themeClasses: Record<NonNullable<KbdProps['theme']>, string> = {
   light: 'bg-gray-100 border-gray-300 text-gray-700',
-  dark: 'bg-surface4 border-border1 text-icon6',
+  dark: 'bg-surface4 border-border1 text-neutral6',
 };
 
 export const Kbd = ({ children, theme = 'dark' }: KbdProps) => {

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
@@ -47,12 +47,14 @@ export function KeyValueList({ data, LinkComponent, className, labelsAreHidden, 
         return (
           <React.Fragment key={label + index}>
             <dt
-              className={cn('text-icon3 text-[0.875rem] flex items-center gap-[2rem] justify-between min-h-[2.25rem] ')}
+              className={cn(
+                'text-neutral3 text-[0.875rem] flex items-center gap-[2rem] justify-between min-h-[2.25rem] ',
+              )}
             >
               <span
                 className={cn(
                   'flex items-center gap-[0.5rem]',
-                  '[&>svg]:w-[1.4em] [&>svg]:h-[1.4em] [&>svg]:text-icon3 [&>svg]:opacity-50',
+                  '[&>svg]:w-[1.4em] [&>svg]:h-[1.4em] [&>svg]:text-neutral3 [&>svg]:opacity-50',
                   {
                     '[&>svg]:opacity-20': isLoading,
                   },
@@ -61,17 +63,17 @@ export function KeyValueList({ data, LinkComponent, className, labelsAreHidden, 
                 {icon} <LabelWrapper>{label}</LabelWrapper>
               </span>
               {!labelsAreHidden && (
-                <span className={cn('text-icon3', '[&>svg]:w-[1em] [&>svg]:h-[1em] [&>svg]:text-icon3')}>
+                <span className={cn('text-neutral3', '[&>svg]:w-[1em] [&>svg]:h-[1em] [&>svg]:text-neutral3')}>
                   {separator}
                 </span>
               )}
             </dt>
             <dd
               className={cn(
-                'flex flex-wrap gap-[.5rem] py-[0.25rem] min-h-[2.25rem] text-[0.875rem] items-center text-icon5 text-wrap',
-                '[&>a]:text-icon5 [&>a]:max-w-full [&>a]:w-auto truncate [&>a]:bg-[#222] [&>a]:transition-colors [&>a]:flex [&>a]:items-center [&>a]:gap-[0.5rem] [&>a]:pt-[0.15rem] [&>a]:pb-[0.2rem] [&>a]:px-[.5rem] [&>a]:rounded-md [&>a]:text-[0.875rem] [&>a]:min-h-[1.75rem] [&>a]:leading-0 ',
-                '[&>a:hover]:text-icon6 [&>a:hover]:bg-surface6',
-                '[&>a>svg]:w-[1em] [&>a>svg]:h-[1em] [&>a>svg]:text-icon3 [&>a>svg]:ml-[-0.5em]',
+                'flex flex-wrap gap-[.5rem] py-[0.25rem] min-h-[2.25rem] text-[0.875rem] items-center text-neutral5 text-wrap',
+                '[&>a]:text-neutral5 [&>a]:max-w-full [&>a]:w-auto truncate [&>a]:bg-[#222] [&>a]:transition-colors [&>a]:flex [&>a]:items-center [&>a]:gap-[0.5rem] [&>a]:pt-[0.15rem] [&>a]:pb-[0.2rem] [&>a]:px-[.5rem] [&>a]:rounded-md [&>a]:text-[0.875rem] [&>a]:min-h-[1.75rem] [&>a]:leading-0 ',
+                '[&>a:hover]:text-neutral6 [&>a:hover]:bg-surface6',
+                '[&>a>svg]:w-[1em] [&>a>svg]:h-[1em] [&>a>svg]:text-neutral3 [&>a>svg]:ml-[-0.5em]',
               )}
             >
               {isLoading ? (
@@ -94,7 +96,7 @@ export function KeyValueList({ data, LinkComponent, className, labelsAreHidden, 
                   );
                 })
               ) : (
-                <>{value ? value : <span className="text-icon3 text-[0.75rem]">n/a</span>}</>
+                <>{value ? value : <span className="text-neutral3 text-[0.75rem]">n/a</span>}</>
               )}
             </dd>
           </React.Fragment>
@@ -115,7 +117,7 @@ function RelationWrapper({ description, children }: RelationWrapperProps) {
       <HoverCard.Trigger asChild>{children}</HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
-          className="z-[100] w-auto max-w-[15rem] rounded-md bg-[#333] p-[.5rem] px-[1rem] text-[.75rem] text-icon5 text-center"
+          className="z-[100] w-auto max-w-[15rem] rounded-md bg-[#333] p-[.5rem] px-[1rem] text-[.75rem] text-neutral5 text-center"
           sideOffset={5}
           side="top"
         >

--- a/packages/playground-ui/src/ds/components/Label/label.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.stories.tsx
@@ -33,7 +33,7 @@ export const WithDescription: Story = {
   render: () => (
     <div className="flex flex-col gap-1">
       <Label htmlFor="username">Username</Label>
-      <span className="text-xs text-icon3">Choose a unique username</span>
+      <span className="text-xs text-neutral3">Choose a unique username</span>
       <Input id="username" placeholder="@username" />
     </div>
   ),

--- a/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
@@ -20,7 +20,7 @@ export const Default: Story = {
       <PageHeader title="Page Title" description="This is the page description" />
       <MainContentContent>
         <div className="p-4">
-          <p className="text-icon5">Main content area</p>
+          <p className="text-neutral5">Main content area</p>
         </div>
       </MainContentContent>
     </MainContentLayout>
@@ -33,8 +33,8 @@ export const Centered: Story = {
       <PageHeader title="Empty State" />
       <MainContentContent isCentered>
         <div className="text-center">
-          <p className="text-icon5 text-lg">No items found</p>
-          <p className="text-icon3 text-sm">Create your first item to get started</p>
+          <p className="text-neutral5 text-lg">No items found</p>
+          <p className="text-neutral3 text-sm">Create your first item to get started</p>
         </div>
       </MainContentContent>
     </MainContentLayout>
@@ -47,10 +47,10 @@ export const Divided: Story = {
       <PageHeader title="Split View" />
       <MainContentContent isDivided>
         <div className="p-4 border-r border-border1">
-          <p className="text-icon5">Left column content</p>
+          <p className="text-neutral5">Left column content</p>
         </div>
         <div className="p-4">
-          <p className="text-icon5">Right column content</p>
+          <p className="text-neutral5">Right column content</p>
         </div>
       </MainContentContent>
     </MainContentLayout>
@@ -63,10 +63,10 @@ export const WithLeftServiceColumn: Story = {
       <PageHeader title="With Navigation" />
       <MainContentContent hasLeftServiceColumn>
         <div className="p-2 border-r border-border1 bg-surface2">
-          <p className="text-icon3 text-sm">Nav</p>
+          <p className="text-neutral3 text-sm">Nav</p>
         </div>
         <div className="p-4">
-          <p className="text-icon5">Main content</p>
+          <p className="text-neutral5">Main content</p>
         </div>
       </MainContentContent>
     </MainContentLayout>
@@ -79,13 +79,13 @@ export const DividedWithServiceColumn: Story = {
       <PageHeader title="Three Column Layout" />
       <MainContentContent isDivided hasLeftServiceColumn>
         <div className="p-2 border-r border-border1 bg-surface2">
-          <p className="text-icon3 text-sm">Nav</p>
+          <p className="text-neutral3 text-sm">Nav</p>
         </div>
         <div className="p-4 border-r border-border1">
-          <p className="text-icon5">Center column</p>
+          <p className="text-neutral5">Center column</p>
         </div>
         <div className="p-4">
-          <p className="text-icon5">Right column</p>
+          <p className="text-neutral5">Right column</p>
         </div>
       </MainContentContent>
     </MainContentLayout>

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-header.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-header.tsx
@@ -14,7 +14,7 @@ export function MainSidebarNavHeader({ children, className, state = 'default' }:
   return (
     <div className={cn('grid grid-cols-[auto_1fr] items-center min-h-[2.8rem] ', className)}>
       <header
-        className={cn('text-[0.6875rem] uppercase text-icon3/75 tracking-widest', {
+        className={cn('text-[0.6875rem] uppercase text-neutral3/75 tracking-widest', {
           'pl-[0.75rem]': isDefaultState,
         })}
       >

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -37,14 +37,14 @@ export function MainSidebarNavLink({
     <li
       className={cn(
         'flex ',
-        '[&>a]:flex [&>a]:items-center [&>a]:min-h-[2rem] [&>a]:gap-[10px] [&>a]:text-[0.8125rem] [&>a]:text-icon3 [&>a]:py-[6px] [&>a]:px-[0.75rem] [&>a]:w-full [&>a]:rounded-lg [&>a]:justify-center',
-        '[&_svg]:w-[1rem] [&_svg]:h-[1rem] [&_svg]:text-icon3/60',
-        '[&>a:hover]:bg-surface4 [&>a:hover]:text-icon5 [&>a:hover_svg]:text-icon3',
+        '[&>a]:flex [&>a]:items-center [&>a]:min-h-[2rem] [&>a]:gap-[10px] [&>a]:text-[0.8125rem] [&>a]:text-neutral3 [&>a]:py-[6px] [&>a]:px-[0.75rem] [&>a]:w-full [&>a]:rounded-lg [&>a]:justify-center',
+        '[&_svg]:w-[1rem] [&_svg]:h-[1rem] [&_svg]:text-neutral3/60',
+        '[&>a:hover]:bg-surface4 [&>a:hover]:text-neutral5 [&>a:hover_svg]:text-neutral3',
         {
-          '[&>a]:text-icon5 [&>a]:bg-surface3': isActive,
-          '[&_svg]:text-icon5': isActive,
+          '[&>a]:text-neutral5 [&>a]:bg-surface3': isActive,
+          '[&_svg]:text-neutral5': isActive,
           '[&>a]:justify-start ': !isCollapsed,
-          '[&_svg]:text-icon3': isCollapsed,
+          '[&_svg]:text-neutral3': isCollapsed,
           '[&>a]:rounded-md [&>a]:my-[0.5rem] [&>a]:bg-accent1/75 [&>a:hover]:bg-accent1/85 [&>a]:text-black [&>a:hover]:text-black':
             isFeatured,
           '[&_svg]:text-black/75 [&>a:hover_svg]:text-black': isFeatured,
@@ -62,7 +62,7 @@ export function MainSidebarNavLink({
                   {isCollapsed ? <VisuallyHidden>{link.name}</VisuallyHidden> : link.name} {children}
                 </Link>
               </TooltipTrigger>
-              <TooltipContent side="right" align="center" className="bg-border1 text-icon6 ml-[1rem]">
+              <TooltipContent side="right" align="center" className="bg-border1 text-neutral6 ml-[1rem]">
                 {link.tooltipMsg ? (
                   <>
                     {isCollapsed && `${link.name} | `} {link.tooltipMsg}

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
@@ -47,9 +47,9 @@ export function MainSidebarRoot({ children, className }: MainSidebarRootProps) {
             <button
               onClick={toggleSidebar}
               className={cn(
-                'inline-flex w-auto items-center text-icon3 h-[2rem] px-[0.75rem] rounded-md ml-auto',
+                'inline-flex w-auto items-center text-neutral3 h-[2rem] px-[0.75rem] rounded-md ml-auto',
                 'hover:bg-surface4',
-                '[&_svg]:w-[1rem] [&_svg]:h-[1rem] [&_svg]:text-icon3',
+                '[&_svg]:w-[1rem] [&_svg]:h-[1rem] [&_svg]:text-neutral3',
                 {
                   'ml-auto': !isCollapsed,
                 },

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof MainSidebar> = {
           <div className="flex h-[500px] bg-surface1 border border-border1 rounded-lg overflow-hidden">
             <Story />
             <div className="flex-1 p-4">
-              <p className="text-icon5">Main content area</p>
+              <p className="text-neutral5">Main content area</p>
             </div>
           </div>
         </MainSidebarProvider>

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -160,7 +160,7 @@ const COMPONENTS: Components = {
     </a>
   ),
   blockquote: ({ children, ...props }) => (
-    <blockquote className="border-l-2 border-icon6 pl-4" {...props}>
+    <blockquote className="border-l-2 border-neutral6 pl-4" {...props}>
       {children}
     </blockquote>
   ),
@@ -198,13 +198,13 @@ const COMPONENTS: Components = {
     </li>
   ),
   table: ({ children, ...props }) => (
-    <table className="w-full border-collapse overflow-y-auto rounded-md border border-icon6/20" {...props}>
+    <table className="w-full border-collapse overflow-y-auto rounded-md border border-neutral6/20" {...props}>
       {children}
     </table>
   ),
   th: ({ children, ...props }) => (
     <th
-      className="border border-icon6/20 px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right"
+      className="border border-neutral6/20 px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right"
       {...props}
     >
       {children}
@@ -212,7 +212,7 @@ const COMPONENTS: Components = {
   ),
   td: ({ children, ...props }) => (
     <td
-      className="border border-icon6/20 px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right"
+      className="border border-neutral6/20 px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right"
       {...props}
     >
       {children}
@@ -228,7 +228,7 @@ const COMPONENTS: Components = {
       {children}
     </p>
   ),
-  hr: ({ ...props }) => <hr className="border-icon6/20" {...props} />,
+  hr: ({ ...props }) => <hr className="border-neutral6/20" {...props} />,
 };
 
 export default MarkdownRenderer;

--- a/packages/playground-ui/src/ds/components/Notification/notification.tsx
+++ b/packages/playground-ui/src/ds/components/Notification/notification.tsx
@@ -43,7 +43,7 @@ export function Notification({
   return (
     <div
       className={cn(
-        'grid grid-cols-[1fr_auto] gap-[0.5rem] rounded-lg bg-white/5 p-[1.5rem] py-[1rem] text-[0.875rem] text-icon3 items-center',
+        'grid grid-cols-[1fr_auto] gap-[0.5rem] rounded-lg bg-white/5 p-[1.5rem] py-[1rem] text-[0.875rem] text-neutral3 items-center',
         {
           'bg-red-900/10 border border-red-900': type === 'error',
         },

--- a/packages/playground-ui/src/ds/components/PageHeader/page-header.tsx
+++ b/packages/playground-ui/src/ds/components/PageHeader/page-header.tsx
@@ -16,8 +16,8 @@ export function PageHeader({ title, description, icon, className }: PageHeaderPr
     <header className={clsx('grid gap-2 pt-8 pb-8', className)}>
       <h1
         className={clsx(
-          'text-icon6 text-xl font-normal flex items-center gap-2',
-          '[&>svg]:w-6 [&>svg]:h-6 [&>svg]:text-icon3',
+          'text-neutral6 text-xl font-normal flex items-center gap-2',
+          '[&>svg]:w-6 [&>svg]:h-6 [&>svg]:text-neutral3',
           {
             'bg-surface4 w-60 max-w-[50%] rounded-md animate-pulse': titleIsLoading,
           },
@@ -33,7 +33,7 @@ export function PageHeader({ title, description, icon, className }: PageHeaderPr
       </h1>
       {description && (
         <p
-          className={clsx('text-icon4 text-sm m-0', {
+          className={clsx('text-neutral4 text-sm m-0', {
             'bg-surface4 w-[40rem] max-w-[80%] rounded-md animate-pulse': descriptionIsLoading,
           })}
         >

--- a/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
@@ -27,7 +27,7 @@ export const Default: Story = {
         <div className="grid gap-4">
           <div className="space-y-2">
             <h4 className="font-medium leading-none">Dimensions</h4>
-            <p className="text-sm text-icon3">Set the dimensions for the layer.</p>
+            <p className="text-sm text-neutral3">Set the dimensions for the layer.</p>
           </div>
           <div className="grid gap-2">
             <div className="grid grid-cols-3 items-center gap-4">
@@ -57,7 +57,7 @@ export const WithIconTrigger: Story = {
         <div className="grid gap-4">
           <div className="space-y-2">
             <h4 className="font-medium leading-none">Settings</h4>
-            <p className="text-sm text-icon3">Manage your preferences.</p>
+            <p className="text-sm text-neutral3">Manage your preferences.</p>
           </div>
         </div>
       </PopoverContent>
@@ -124,7 +124,7 @@ export const SimpleText: Story = {
         <Button variant="ghost">?</Button>
       </PopoverTrigger>
       <PopoverContent className="w-60">
-        <p className="text-sm text-icon5">This is helpful information about the feature.</p>
+        <p className="text-sm text-neutral5">This is helpful information about the feature.</p>
       </PopoverContent>
     </Popover>
   ),

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={clsx(
-        'z-50 w-72 rounded-md border bg-surface3 text-icon5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 w-72 rounded-md border bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className && /\bp-\S+/.test(className) ? false : `p-4`,
         className,
       )}

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
@@ -79,21 +79,21 @@ export const WithDescriptions: Story = {
         <RadioGroupItem value="startup" id="startup" className="mt-1" />
         <div className="grid gap-1">
           <Label htmlFor="startup">Startup</Label>
-          <p className="text-xs text-icon3">Best for small teams just getting started</p>
+          <p className="text-xs text-neutral3">Best for small teams just getting started</p>
         </div>
       </div>
       <div className="flex items-start space-x-2">
         <RadioGroupItem value="business" id="business" className="mt-1" />
         <div className="grid gap-1">
           <Label htmlFor="business">Business</Label>
-          <p className="text-xs text-icon3">For growing companies with advanced needs</p>
+          <p className="text-xs text-neutral3">For growing companies with advanced needs</p>
         </div>
       </div>
       <div className="flex items-start space-x-2">
         <RadioGroupItem value="enterprise" id="enterprise" className="mt-1" />
         <div className="grid gap-1">
           <Label htmlFor="enterprise">Enterprise</Label>
-          <p className="text-xs text-icon3">For large organizations requiring customization</p>
+          <p className="text-xs text-neutral3">For large organizations requiring customization</p>
         </div>
       </div>
     </RadioGroup>

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
@@ -20,7 +20,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        'aspect-square h-4 w-4 rounded-full border border-icon6 text-icon6 disabled:cursor-not-allowed disabled:opacity-50',
+        'aspect-square h-4 w-4 rounded-full border border-neutral6 text-neutral6 disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
     <ScrollArea className="h-[200px] w-[300px] rounded-md border border-border1 p-4">
       <div className="space-y-4">
         {Array.from({ length: 20 }).map((_, i) => (
-          <p key={i} className="text-sm text-icon5">
+          <p key={i} className="text-sm text-neutral5">
             Item {i + 1} - Lorem ipsum dolor sit amet
           </p>
         ))}
@@ -32,7 +32,7 @@ export const WithMaxHeight: Story = {
     <ScrollArea maxHeight="150px" className="w-[300px] rounded-md border border-border1 p-4">
       <div className="space-y-4">
         {Array.from({ length: 15 }).map((_, i) => (
-          <p key={i} className="text-sm text-icon5">
+          <p key={i} className="text-sm text-neutral5">
             Line {i + 1}
           </p>
         ))}
@@ -47,7 +47,7 @@ export const HorizontalScroll: Story = {
       <div className="flex gap-4 w-[800px]">
         {Array.from({ length: 20 }).map((_, i) => (
           <div key={i} className="h-16 w-16 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
-            <span className="text-sm text-icon5">{i + 1}</span>
+            <span className="text-sm text-neutral5">{i + 1}</span>
           </div>
         ))}
       </div>
@@ -58,7 +58,7 @@ export const HorizontalScroll: Story = {
 export const CodeBlock: Story = {
   render: () => (
     <ScrollArea className="h-[200px] w-[400px] rounded-md border border-border1 bg-surface2">
-      <pre className="p-4 text-sm font-mono text-icon5">
+      <pre className="p-4 text-sm font-mono text-neutral5">
         {`function example() {
   const data = fetchData();
 
@@ -98,7 +98,7 @@ export const ChatMessages: Story = {
       <div className="space-y-4">
         {Array.from({ length: 10 }).map((_, i) => (
           <div key={i} className={`p-3 rounded-lg ${i % 2 === 0 ? 'bg-surface3 ml-8' : 'bg-surface4 mr-8'}`}>
-            <p className="text-sm text-icon5">
+            <p className="text-sm text-neutral5">
               {i % 2 === 0
                 ? 'This is a user message with some content'
                 : 'This is an assistant response with helpful information'}

--- a/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
         <div className="flex gap-4 p-4 w-[1000px]">
           {Array.from({ length: 20 }).map((_, i) => (
             <div key={i} className="h-16 w-24 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
-              <span className="text-sm text-icon5">Item {i + 1}</span>
+              <span className="text-sm text-neutral5">Item {i + 1}</span>
             </div>
           ))}
         </div>
@@ -47,8 +47,8 @@ export const CardGallery: Story = {
               key={i}
               className="h-32 w-48 shrink-0 rounded-lg bg-surface3 border border-border1 p-4 flex flex-col justify-between"
             >
-              <span className="text-sm font-medium text-icon6">Card {i + 1}</span>
-              <span className="text-xs text-icon3">Description text</span>
+              <span className="text-sm font-medium text-neutral6">Card {i + 1}</span>
+              <span className="text-xs text-neutral3">Description text</span>
             </div>
           ))}
         </div>
@@ -64,7 +64,7 @@ export const FastScroll: Story = {
         <div className="flex gap-2 p-2 w-[1200px]">
           {Array.from({ length: 30 }).map((_, i) => (
             <div key={i} className="h-12 w-12 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
-              <span className="text-xs text-icon5">{i + 1}</span>
+              <span className="text-xs text-neutral5">{i + 1}</span>
             </div>
           ))}
         </div>
@@ -80,7 +80,7 @@ export const SlowScroll: Story = {
         <div className="flex gap-2 p-2 w-[1000px]">
           {Array.from({ length: 25 }).map((_, i) => (
             <div key={i} className="h-12 w-12 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
-              <span className="text-xs text-icon5">{i + 1}</span>
+              <span className="text-xs text-neutral5">{i + 1}</span>
             </div>
           ))}
         </div>
@@ -108,7 +108,7 @@ export const Badges: Story = {
             'Next.js',
             'Tailwind',
           ].map(tech => (
-            <span key={tech} className="shrink-0 px-3 py-1 text-xs rounded-full bg-surface4 text-icon5">
+            <span key={tech} className="shrink-0 px-3 py-1 text-xs rounded-full bg-surface4 text-neutral5">
               {tech}
             </span>
           ))}

--- a/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.tsx
@@ -116,7 +116,7 @@ export const ScrollableContainer = ({
         onMouseUp={onStopScrolling}
         onTouchEnd={onStopScrolling}
         onTouchCancel={onStopScrolling}
-        className="bg-surface4 text-icon3 border-surface5 hover:border-icon3 fixed z-10 flex items-center justify-center rounded-lg border text-2xl hover:text-white"
+        className="bg-surface4 text-neutral3 border-surface5 hover:border-neutral3 fixed z-10 flex items-center justify-center rounded-lg border text-2xl hover:text-white"
         style={{
           ...styles,
           left:

--- a/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
@@ -90,7 +90,7 @@ const InteractiveSearchDemo = () => {
       {results.length > 0 && (
         <ul className="bg-surface3 rounded-md p-2 space-y-1">
           {results.map(result => (
-            <li key={result} className="text-sm text-icon5 p-1">
+            <li key={result} className="text-sm text-neutral5 p-1">
               {result}
             </li>
           ))}

--- a/packages/playground-ui/src/ds/components/Searchbar/searchbar.tsx
+++ b/packages/playground-ui/src/ds/components/Searchbar/searchbar.tsx
@@ -47,7 +47,7 @@ export const Searchbar = ({ onSearch, label, placeholder, debounceMs = 300 }: Se
 
   return (
     <div className="focus-within:outline focus-within:outline-accent1 -outline-offset-2 border-sm border-icon-3 flex h-8 w-full items-center gap-2 overflow-hidden rounded-lg pl-2 pr-1">
-      <SearchIcon className="text-icon3 h-4 w-4" />
+      <SearchIcon className="text-neutral3 h-4 w-4" />
 
       <div className="flex-1">
         <label htmlFor={id} className="sr-only">

--- a/packages/playground-ui/src/ds/components/Section/section-heading.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section-heading.tsx
@@ -13,7 +13,7 @@ export function SectionHeading({ headingLevel = 'h2', children, className }: Sec
   return (
     <HeadingTag
       className={cn(
-        'flex items-center gap-[0.5em] text-[0.9375rem] font-bold text-icon4',
+        'flex items-center gap-[0.5em] text-[0.9375rem] font-bold text-neutral4',
         '[&>svg]:w-[1.2em] [&>svg]:h-[1.2em] [&>svg]:opacity-50',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Section/section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
         <Section.Heading>Section Title</Section.Heading>
       </Section.Header>
       <div className="p-4 rounded-md border border-border1 bg-surface2">
-        <p className="text-sm text-icon5">Section content goes here</p>
+        <p className="text-sm text-neutral5">Section content goes here</p>
       </div>
     </Section>
   ),
@@ -39,7 +39,7 @@ export const WithAction: Story = {
         </Button>
       </Section.Header>
       <div className="p-4 rounded-md border border-border1 bg-surface2">
-        <p className="text-sm text-icon5">List of agents would go here</p>
+        <p className="text-sm text-neutral5">List of agents would go here</p>
       </div>
     </Section>
   ),
@@ -56,16 +56,16 @@ export const ConfigurationSection: Story = {
       </Section.Header>
       <div className="space-y-3 p-4 rounded-md border border-border1 bg-surface2">
         <div className="flex justify-between">
-          <span className="text-sm text-icon3">Model</span>
-          <span className="text-sm text-icon6">GPT-4</span>
+          <span className="text-sm text-neutral3">Model</span>
+          <span className="text-sm text-neutral6">GPT-4</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-sm text-icon3">Temperature</span>
-          <span className="text-sm text-icon6">0.7</span>
+          <span className="text-sm text-neutral3">Temperature</span>
+          <span className="text-sm text-neutral6">0.7</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-sm text-icon3">Max Tokens</span>
-          <span className="text-sm text-icon6">4096</span>
+          <span className="text-sm text-neutral3">Max Tokens</span>
+          <span className="text-sm text-neutral6">4096</span>
         </div>
       </div>
     </Section>
@@ -80,7 +80,7 @@ export const MultipleSections: Story = {
           <Section.Heading>General</Section.Heading>
         </Section.Header>
         <div className="p-4 rounded-md border border-border1 bg-surface2">
-          <p className="text-sm text-icon5">General settings content</p>
+          <p className="text-sm text-neutral5">General settings content</p>
         </div>
       </Section>
       <Section>
@@ -88,7 +88,7 @@ export const MultipleSections: Story = {
           <Section.Heading>Advanced</Section.Heading>
         </Section.Header>
         <div className="p-4 rounded-md border border-border1 bg-surface2">
-          <p className="text-sm text-icon5">Advanced settings content</p>
+          <p className="text-sm text-neutral5">Advanced settings content</p>
         </div>
       </Section>
     </div>

--- a/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
@@ -23,7 +23,7 @@ export const Default: Story = {
           <Section.Heading>Section One</Section.Heading>
         </Section.Header>
         <div className="p-4 rounded-md border border-border1 bg-surface2">
-          <p className="text-sm text-icon5">First section content</p>
+          <p className="text-sm text-neutral5">First section content</p>
         </div>
       </Section>
       <Section>
@@ -31,7 +31,7 @@ export const Default: Story = {
           <Section.Heading>Section Two</Section.Heading>
         </Section.Header>
         <div className="p-4 rounded-md border border-border1 bg-surface2">
-          <p className="text-sm text-icon5">Second section content</p>
+          <p className="text-sm text-neutral5">Second section content</p>
         </div>
       </Section>
       <Section>
@@ -39,7 +39,7 @@ export const Default: Story = {
           <Section.Heading>Section Three</Section.Heading>
         </Section.Header>
         <div className="p-4 rounded-md border border-border1 bg-surface2">
-          <p className="text-sm text-icon5">Third section content</p>
+          <p className="text-sm text-neutral5">Third section content</p>
         </div>
       </Section>
     </Sections>
@@ -58,12 +58,12 @@ export const SettingsPage: Story = {
         </Section.Header>
         <div className="space-y-3 p-4 rounded-md border border-border1 bg-surface2">
           <div className="flex justify-between">
-            <span className="text-sm text-icon3">Name</span>
-            <span className="text-sm text-icon6">John Doe</span>
+            <span className="text-sm text-neutral3">Name</span>
+            <span className="text-sm text-neutral6">John Doe</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-sm text-icon3">Email</span>
-            <span className="text-sm text-icon6">john@example.com</span>
+            <span className="text-sm text-neutral3">Email</span>
+            <span className="text-sm text-neutral6">john@example.com</span>
           </div>
         </div>
       </Section>
@@ -73,12 +73,12 @@ export const SettingsPage: Story = {
         </Section.Header>
         <div className="space-y-3 p-4 rounded-md border border-border1 bg-surface2">
           <div className="flex justify-between">
-            <span className="text-sm text-icon3">Email notifications</span>
-            <span className="text-sm text-icon6">Enabled</span>
+            <span className="text-sm text-neutral3">Email notifications</span>
+            <span className="text-sm text-neutral6">Enabled</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-sm text-icon3">Push notifications</span>
-            <span className="text-sm text-icon6">Disabled</span>
+            <span className="text-sm text-neutral3">Push notifications</span>
+            <span className="text-sm text-neutral6">Disabled</span>
           </div>
         </div>
       </Section>
@@ -101,13 +101,13 @@ export const DocumentationSections: Story = {
         <Section.Header>
           <Section.Heading>Overview</Section.Heading>
         </Section.Header>
-        <p className="text-sm text-icon5">This section provides an overview of the feature and its capabilities.</p>
+        <p className="text-sm text-neutral5">This section provides an overview of the feature and its capabilities.</p>
       </Section>
       <Section>
         <Section.Header>
           <Section.Heading>Installation</Section.Heading>
         </Section.Header>
-        <pre className="p-4 rounded-md bg-surface2 text-sm font-mono text-icon5 overflow-x-auto">
+        <pre className="p-4 rounded-md bg-surface2 text-sm font-mono text-neutral5 overflow-x-auto">
           npm install @mastra/core
         </pre>
       </Section>
@@ -115,7 +115,7 @@ export const DocumentationSections: Story = {
         <Section.Header>
           <Section.Heading>Usage</Section.Heading>
         </Section.Header>
-        <pre className="p-4 rounded-md bg-surface2 text-sm font-mono text-icon5 overflow-x-auto">
+        <pre className="p-4 rounded-md bg-surface2 text-sm font-mono text-neutral5 overflow-x-auto">
           {`import { Mastra } from '@mastra/core';
 
 const mastra = new Mastra({

--- a/packages/playground-ui/src/ds/components/Select/select.tsx
+++ b/packages/playground-ui/src/ds/components/Select/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between rounded-md border border-surface4 bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-icon3 disabled:cursor-not-allowed disabled:opacity-50',
+      'flex h-9 w-full items-center justify-between rounded-md border border-surface4 bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-neutral3 disabled:cursor-not-allowed disabled:opacity-50',
       className,
     )}
     {...props}
@@ -38,7 +38,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 min-w-[8rem] max-h-dropdown-max-height overflow-y-auto overflow-x-hidden rounded-md border bg-surface3 text-icon5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 min-w-[8rem] max-h-dropdown-max-height overflow-y-auto overflow-x-hidden rounded-md border bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -67,7 +67,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-icon5 text-sm focus:bg-surface5 focus:text-icon5 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-neutral5 text-sm focus:bg-surface5 focus:text-neutral5 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/packages/playground-ui/src/ds/components/SelectElement/select.tsx
+++ b/packages/playground-ui/src/ds/components/SelectElement/select.tsx
@@ -17,7 +17,7 @@ export function ElementSelect({ name, onChange, value, options, placeholder }: S
       <SelectContent>
         {(options || []).map((option, idx) => (
           <SelectItem key={option} value={`${idx}`}>
-            <div className="flex items-center gap-2 [&>svg]:w-[1.2em] [&>svg]:h-[1.2em] [&>svg]:text-icon3">
+            <div className="flex items-center gap-2 [&>svg]:w-[1.2em] [&>svg]:h-[1.2em] [&>svg]:text-neutral3">
               {option}
             </div>
           </SelectItem>

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog-code-section.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog-code-section.tsx
@@ -65,9 +65,9 @@ export function SideDialogCodeSection({ codeStr = '', title, icon, simplified = 
         </ButtonsGroup>
       </Section.Header>
       {codeStr && (
-        <div className="bg-black/20 p-[1rem] overflow-hidden rounded-xl border border-white/10 text-icon4 text-[0.875rem] break-all">
+        <div className="bg-black/20 p-[1rem] overflow-hidden rounded-xl border border-white/10 text-neutral4 text-[0.875rem] break-all">
           {simplified ? (
-            <div className="text-icon4 font-mono break-all px-[0.5rem]">
+            <div className="text-neutral4 font-mono break-all px-[0.5rem]">
               <pre className="text-wrap">{codeStr}</pre>
             </div>
           ) : (

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog-heading.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog-heading.tsx
@@ -12,7 +12,7 @@ export function SideDialogHeading({ children, className, as = 'h1' }: SideDialog
   return (
     <HeadingTag
       className={cn(
-        'flex items-start text-icon4 text-[1.125rem] font-semibold gap-[.5rem]',
+        'flex items-start text-neutral4 text-[1.125rem] font-semibold gap-[.5rem]',
         '[&>svg]:w-[1.25em] [&>svg]:h-[1.25em] [&>svg]:shrink-0 [&>svg]:mt-[.2em] [&>svg]:opacity-70',
         {
           'text-[1.125rem]': as === 'h1',

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog-nav.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog-nav.tsx
@@ -21,7 +21,7 @@ export function SideDialogNav({ onNext, onPrevious, className }: SideDialogNavPr
     <div
       className={cn(
         'flex items-center gap-[1rem]',
-        '[&_svg]:w-[1.1em] [&_svg]:h-[1.1em] [&_svg]:text-icon3',
+        '[&_svg]:w-[1.1em] [&_svg]:h-[1.1em] [&_svg]:text-neutral3',
         className,
       )}
     >

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog-root.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog-root.tsx
@@ -56,8 +56,8 @@ export function SideDialogRoot({
             <Dialog.Close asChild>
               <button
                 className={cn(
-                  'flex appearance-none items-center justify-center rounded-bl-lg h-[3.5rem] w-[3.5rem] absolute top-0 left-[-3.5rem] bg-surface2 text-icon4 border-l border-b border-border2',
-                  'hover:surface5 hover:text-icon5',
+                  'flex appearance-none items-center justify-center rounded-bl-lg h-[3.5rem] w-[3.5rem] absolute top-0 left-[-3.5rem] bg-surface2 text-neutral4 border-l border-b border-border2',
+                  'hover:surface5 hover:text-neutral5',
                 )}
                 aria-label="Close"
               >

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog-top.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog-top.tsx
@@ -9,7 +9,7 @@ export function SideDialogTop({ children, className }: SideDialogTopProps) {
   return (
     <div
       className={cn(
-        `flex h-[3.5rem] items-center text-icon5 text-[.875rem] pl-[1.5rem] relative gap-[1rem]`,
+        `flex h-[3.5rem] items-center text-neutral5 text-[.875rem] pl-[1.5rem] relative gap-[1rem]`,
         '[&:after]:content-[""] [&:after]:absolute [&:after]:left-[1.5rem] [&:after]:right-[1.5rem] [&:after]:bottom-0 [&:after]:border-b [&:after]:border-border1',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
@@ -43,8 +43,8 @@ const SideDialogDemo = ({
         </SideDialog.Top>
         <SideDialog.Content>
           <div className="p-6">
-            <p className="text-icon5">This is the side dialog content area.</p>
-            <p className="text-icon3 mt-2">You can put any content here.</p>
+            <p className="text-neutral5">This is the side dialog content area.</p>
+            <p className="text-neutral3 mt-2">You can put any content here.</p>
           </div>
         </SideDialog.Content>
       </SideDialog>
@@ -84,15 +84,15 @@ const SideDialogWithCodeDemo = () => {
         <SideDialog.Content>
           <div className="p-6 space-y-6">
             <div>
-              <h3 className="text-sm font-medium text-icon6 mb-2">Configuration</h3>
+              <h3 className="text-sm font-medium text-neutral6 mb-2">Configuration</h3>
               <div className="space-y-2">
                 <div className="flex justify-between text-sm">
-                  <span className="text-icon3">Model</span>
-                  <span className="text-icon5">GPT-4</span>
+                  <span className="text-neutral3">Model</span>
+                  <span className="text-neutral5">GPT-4</span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-icon3">Temperature</span>
-                  <span className="text-icon5">0.7</span>
+                  <span className="text-neutral3">Temperature</span>
+                  <span className="text-neutral5">0.7</span>
                 </div>
               </div>
             </div>
@@ -130,8 +130,8 @@ const ConfirmationDialogDemo = () => {
       >
         <SideDialog.Content>
           <div className="p-6 flex flex-col items-center justify-center h-full">
-            <h3 className="text-lg font-medium text-icon6 mb-2">Confirm deletion?</h3>
-            <p className="text-sm text-icon3 mb-6 text-center">
+            <h3 className="text-lg font-medium text-neutral6 mb-2">Confirm deletion?</h3>
+            <p className="text-sm text-neutral3 mb-6 text-center">
               This action cannot be undone. The agent will be permanently deleted.
             </p>
             <div className="flex gap-2">

--- a/packages/playground-ui/src/ds/components/Slider/slider.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Slider/slider.stories.tsx
@@ -69,8 +69,8 @@ export const WithLabel: Story = {
   render: () => (
     <div className="flex flex-col gap-2 w-[250px]">
       <div className="flex justify-between">
-        <span className="text-sm text-icon5">Volume</span>
-        <span className="text-sm text-icon3">50%</span>
+        <span className="text-sm text-neutral5">Volume</span>
+        <span className="text-sm text-neutral3">50%</span>
       </div>
       <Slider defaultValue={[50]} max={100} step={1} />
     </div>

--- a/packages/playground-ui/src/ds/components/Slider/slider.tsx
+++ b/packages/playground-ui/src/ds/components/Slider/slider.tsx
@@ -12,10 +12,10 @@ const Slider = React.forwardRef<
     className={cn('relative flex w-full touch-none select-none items-center', className)}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-icon6/20">
-      <SliderPrimitive.Range className="absolute h-full bg-icon6/50" />
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-neutral6/20">
+      <SliderPrimitive.Range className="absolute h-full bg-neutral6/50" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-icon6/50 bg-white shadow transition-colors disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-neutral6/50 bg-white shadow transition-colors disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
@@ -54,7 +54,7 @@ export const Large: Story = {
 
 export const InButton: Story = {
   render: () => (
-    <button className="flex items-center gap-2 px-4 py-2 bg-surface2 border border-border1 rounded-md text-icon6">
+    <button className="flex items-center gap-2 px-4 py-2 bg-surface2 border border-border1 rounded-md text-neutral6">
       <Spinner className="h-4 w-4" />
       Loading...
     </button>

--- a/packages/playground-ui/src/ds/components/Steps/process-step-list-item.tsx
+++ b/packages/playground-ui/src/ds/components/Steps/process-step-list-item.tsx
@@ -22,9 +22,9 @@ export function ProcessStepListItem({ stepId, step, isActive, position }: Proces
       })}
     >
       <div className="grid grid-cols-[auto_1fr] gap-[.5rem]">
-        <span className="text-[0.875rem] text-icon5 min-w-[1.5rem] flex justify-end">{position}.</span>
+        <span className="text-[0.875rem] text-neutral5 min-w-[1.5rem] flex justify-end">{position}.</span>
         <div>
-          <h4 className="text-[0.875rem] text-icon5">{formatStepTitle(stepId)}</h4>
+          <h4 className="text-[0.875rem] text-neutral5">{formatStepTitle(stepId)}</h4>
           {step.description && <p className="text-[0.875rem] -mt-[0.125rem]">{step.description}</p>}
         </div>
       </div>

--- a/packages/playground-ui/src/ds/components/Steps/process-step-progress-bar.tsx
+++ b/packages/playground-ui/src/ds/components/Steps/process-step-progress-bar.tsx
@@ -23,7 +23,7 @@ export function ProcessStepProgressBar({ steps }: ProcessStepProgressBarProps) {
             >
               <div
                 className={cn(
-                  'w-[2rem] h-[2rem] rounded-full flex items-center justify-center self-center absolute right-0 translate-x-[50%] bg-surface3 z-10 text-icon3 font-bold text-[0.75rem]',
+                  'w-[2rem] h-[2rem] rounded-full flex items-center justify-center self-center absolute right-0 translate-x-[50%] bg-surface3 z-10 text-neutral3 font-bold text-[0.75rem]',
                   {
                     'border border-gray-500 border-dashed': step.status === 'pending',
                     '[&>svg]:text-surface4 [&>svg]:w-[1.1rem] [&>svg]:h-[1.1rem]': step.status !== 'running',
@@ -38,7 +38,7 @@ export function ProcessStepProgressBar({ steps }: ProcessStepProgressBarProps) {
           );
         })}
       </div>
-      <div className="text-xs text-icon3 text-center">
+      <div className="text-xs text-neutral3 text-center">
         {completedSteps} of {totalSteps} steps completed
       </div>
     </div>

--- a/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
@@ -78,7 +78,7 @@ export const WithDescription: Story = {
     <div className="flex items-start justify-between gap-4 w-[350px]">
       <div className="flex flex-col gap-1">
         <Label htmlFor="dark-mode">Dark mode</Label>
-        <span className="text-xs text-icon3">Switch to a darker color scheme</span>
+        <span className="text-xs text-neutral3">Switch to a darker color scheme</span>
       </div>
       <Switch id="dark-mode" />
     </div>

--- a/packages/playground-ui/src/ds/components/Table/Cells.tsx
+++ b/packages/playground-ui/src/ds/components/Table/Cells.tsx
@@ -13,7 +13,7 @@ export interface CellProps extends React.TdHTMLAttributes<HTMLTableCellElement> 
 
 export const Cell = ({ className, children, ...props }: CellProps) => {
   return (
-    <td className={clsx('text-icon5 first:pl-5 last:pr-5', className)} {...props}>
+    <td className={clsx('text-neutral5 first:pl-5 last:pr-5', className)} {...props}>
       <div className={clsx('flex h-full w-full shrink-0 items-center')}>{children}</div>
     </td>
   );
@@ -39,7 +39,7 @@ export const DateTimeCell = ({ dateTime, ...props }: DateTimeCellProps) => {
   return (
     <Cell {...props}>
       <div className="shrink-0">
-        <Txt as="span" variant="ui-sm" className="text-icon3">
+        <Txt as="span" variant="ui-sm" className="text-neutral3">
           {day}
         </Txt>{' '}
         <Txt as="span" variant="ui-md">
@@ -62,17 +62,17 @@ export const EntryCell = ({ name, description, icon, meta, ...props }: EntryCell
     <Cell {...props}>
       <div className="flex items-center gap-[14px]">
         {icon && (
-          <Icon size="lg" className="text-icon5">
+          <Icon size="lg" className="text-neutral5">
             {icon}
           </Icon>
         )}
 
         <div className="flex flex-col gap-0">
-          <Txt as="span" variant="ui-md" className="text-icon6 font-medium !leading-tight">
+          <Txt as="span" variant="ui-md" className="text-neutral6 font-medium !leading-tight">
             {name}
           </Txt>
           {description && (
-            <Txt as="span" variant="ui-xs" className="text-icon3 w-full max-w-[300px] truncate !leading-tight">
+            <Txt as="span" variant="ui-xs" className="text-neutral3 w-full max-w-[300px] truncate !leading-tight">
               {description}
             </Txt>
           )}

--- a/packages/playground-ui/src/ds/components/Table/Table.tsx
+++ b/packages/playground-ui/src/ds/components/Table/Table.tsx
@@ -43,7 +43,7 @@ export const Th = ({ className, children, ...props }: ThProps) => {
   return (
     <th
       className={clsx(
-        'text-icon3 text-ui-sm h-full whitespace-nowrap text-left font-normal uppercase first:pl-5 last:pr-5',
+        'text-neutral3 text-ui-sm h-full whitespace-nowrap text-left font-normal uppercase first:pl-5 last:pr-5',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -16,16 +16,17 @@ export const TabList = ({ children, variant = 'default', className }: TabListPro
           {
             // variant: default
             'text-[0.9375rem]': variant === 'default',
-            '[&>button]:py-[0.5rem] [&>button]:px-[1.5rem] [&>button]:font-normal [&>button]:text-icon3 [&>button]:flex-1 [&>button]:border-b [&>button]:border-border1':
+            '[&>button]:py-[0.5rem] [&>button]:px-[1.5rem] [&>button]:font-normal [&>button]:text-neutral3 [&>button]:flex-1 [&>button]:border-b [&>button]:border-border1':
               variant === 'default',
-            '[&>button[data-state=active]]:text-icon5 [&>button[data-state=active]]:transition-colors [&>button[data-state=active]]:duration-200 [&>button[data-state=active]]:border-icon3':
+            '[&>button[data-state=active]]:text-neutral5 [&>button[data-state=active]]:transition-colors [&>button[data-state=active]]:duration-200 [&>button[data-state=active]]:border-neutral3':
               variant === 'default',
             // variant: buttons
             'border border-border1 flex justify-stretch rounded-md overflow-hidden text-[0.875rem] min-h-[2.5rem]':
               variant === 'buttons',
-            '[&>button]:flex-1 [&>button]:py-[0.5rem] [&>button]:px-[1rem] [&>button]:text-icon3':
+            '[&>button]:flex-1 [&>button]:py-[0.5rem] [&>button]:px-[1rem] [&>button]:text-neutral3':
               variant === 'buttons',
-            '[&>button[data-state=active]]:text-icon5 [&>button[data-state=active]]:bg-[#222]': variant === 'buttons',
+            '[&>button[data-state=active]]:text-neutral5 [&>button[data-state=active]]:bg-[#222]':
+              variant === 'buttons',
           },
           className,
         )}

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -15,7 +15,7 @@ export const Tab = ({ children, value, onClick, onClose, className }: TabProps) 
     <RadixTabs.Trigger
       value={value}
       className={cn(
-        'text-xs p-3 text-icon3 data-[state=active]:text-icon5 data-[state=active]:border-b-2 whitespace-nowrap flex-shrink-0 flex items-center justify-center gap-1.5',
+        'text-xs p-3 text-neutral3 data-[state=active]:text-neutral5 data-[state=active]:border-b-2 whitespace-nowrap flex-shrink-0 flex items-center justify-center gap-1.5',
         className,
       )}
       onClick={onClick}

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
@@ -25,13 +25,13 @@ export const Default: Story = {
         <Tab value="tab3">Settings</Tab>
       </TabList>
       <TabContent value="tab1">
-        <div className="p-4 text-icon5">Overview content goes here</div>
+        <div className="p-4 text-neutral5">Overview content goes here</div>
       </TabContent>
       <TabContent value="tab2">
-        <div className="p-4 text-icon5">Details content goes here</div>
+        <div className="p-4 text-neutral5">Details content goes here</div>
       </TabContent>
       <TabContent value="tab3">
-        <div className="p-4 text-icon5">Settings content goes here</div>
+        <div className="p-4 text-neutral5">Settings content goes here</div>
       </TabContent>
     </Tabs>
   ),
@@ -46,13 +46,13 @@ export const ButtonsVariant: Story = {
         <Tab value="output">Output</Tab>
       </TabList>
       <TabContent value="code">
-        <div className="p-4 text-icon5 font-mono text-sm">const hello = world;</div>
+        <div className="p-4 text-neutral5 font-mono text-sm">const hello = world;</div>
       </TabContent>
       <TabContent value="preview">
-        <div className="p-4 text-icon5">Preview content</div>
+        <div className="p-4 text-neutral5">Preview content</div>
       </TabContent>
       <TabContent value="output">
-        <div className="p-4 text-icon5">Output content</div>
+        <div className="p-4 text-neutral5">Output content</div>
       </TabContent>
     </Tabs>
   ),
@@ -66,10 +66,10 @@ export const TwoTabs: Story = {
         <Tab value="output">Output</Tab>
       </TabList>
       <TabContent value="input">
-        <div className="p-4 text-icon5">Input content</div>
+        <div className="p-4 text-neutral5">Input content</div>
       </TabContent>
       <TabContent value="output">
-        <div className="p-4 text-icon5">Output content</div>
+        <div className="p-4 text-neutral5">Output content</div>
       </TabContent>
     </Tabs>
   ),
@@ -86,19 +86,19 @@ export const ManyTabs: Story = {
         <Tab value="tab5">Tab 5</Tab>
       </TabList>
       <TabContent value="tab1">
-        <div className="p-4 text-icon5">Content 1</div>
+        <div className="p-4 text-neutral5">Content 1</div>
       </TabContent>
       <TabContent value="tab2">
-        <div className="p-4 text-icon5">Content 2</div>
+        <div className="p-4 text-neutral5">Content 2</div>
       </TabContent>
       <TabContent value="tab3">
-        <div className="p-4 text-icon5">Content 3</div>
+        <div className="p-4 text-neutral5">Content 3</div>
       </TabContent>
       <TabContent value="tab4">
-        <div className="p-4 text-icon5">Content 4</div>
+        <div className="p-4 text-neutral5">Content 4</div>
       </TabContent>
       <TabContent value="tab5">
-        <div className="p-4 text-icon5">Content 5</div>
+        <div className="p-4 text-neutral5">Content 5</div>
       </TabContent>
     </Tabs>
   ),
@@ -119,13 +119,13 @@ export const WithClosableTabs: Story = {
         </Tab>
       </TabList>
       <TabContent value="file1">
-        <div className="p-4 text-icon5">index.ts content</div>
+        <div className="p-4 text-neutral5">index.ts content</div>
       </TabContent>
       <TabContent value="file2">
-        <div className="p-4 text-icon5">utils.ts content</div>
+        <div className="p-4 text-neutral5">utils.ts content</div>
       </TabContent>
       <TabContent value="file3">
-        <div className="p-4 text-icon5">types.ts content</div>
+        <div className="p-4 text-neutral5">types.ts content</div>
       </TabContent>
     </Tabs>
   ),

--- a/packages/playground-ui/src/ds/components/Text/text-and-icon.tsx
+++ b/packages/playground-ui/src/ds/components/Text/text-and-icon.tsx
@@ -9,7 +9,7 @@ export function TextAndIcon({ children, className }: TextAndIconProps) {
   return (
     <span
       className={cn(
-        'flex items-center gap-[0.5em] text-icon4 text-[0.875rem]',
+        'flex items-center gap-[0.5em] text-neutral4 text-[0.875rem]',
         '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:opacity-50 [&_svg]:flex-shrink-0',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
@@ -20,17 +20,17 @@ export const Default: Story = {
         <ThreadList>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5">New conversation</span>
+              <span className="text-neutral5">New conversation</span>
             </ThreadLink>
           </ThreadItem>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5">Help with code review</span>
+              <span className="text-neutral5">Help with code review</span>
             </ThreadLink>
           </ThreadItem>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5">API integration question</span>
+              <span className="text-neutral5">API integration question</span>
             </ThreadLink>
           </ThreadItem>
         </ThreadList>
@@ -46,17 +46,17 @@ export const WithActiveThread: Story = {
         <ThreadList>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5">Previous chat</span>
+              <span className="text-neutral5">Previous chat</span>
             </ThreadLink>
           </ThreadItem>
           <ThreadItem isActive>
             <ThreadLink href="#">
-              <span className="text-icon5">Current conversation</span>
+              <span className="text-neutral5">Current conversation</span>
             </ThreadLink>
           </ThreadItem>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5">Another chat</span>
+              <span className="text-neutral5">Another chat</span>
             </ThreadLink>
           </ThreadItem>
         </ThreadList>
@@ -72,19 +72,19 @@ export const WithDeleteButtons: Story = {
         <ThreadList>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">Debugging session</span>
+              <span className="text-neutral5 truncate">Debugging session</span>
             </ThreadLink>
             <ThreadDeleteButton onClick={() => console.log('Delete thread 1')} />
           </ThreadItem>
           <ThreadItem isActive>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">Feature discussion</span>
+              <span className="text-neutral5 truncate">Feature discussion</span>
             </ThreadLink>
             <ThreadDeleteButton onClick={() => console.log('Delete thread 2')} />
           </ThreadItem>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">Code review feedback</span>
+              <span className="text-neutral5 truncate">Code review feedback</span>
             </ThreadLink>
             <ThreadDeleteButton onClick={() => console.log('Delete thread 3')} />
           </ThreadItem>
@@ -101,7 +101,7 @@ export const LongThreadNames: Story = {
         <ThreadList>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">
+              <span className="text-neutral5 truncate">
                 This is a very long thread name that should be truncated when displayed
               </span>
             </ThreadLink>
@@ -109,7 +109,9 @@ export const LongThreadNames: Story = {
           </ThreadItem>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">Another extremely long conversation title that exceeds width</span>
+              <span className="text-neutral5 truncate">
+                Another extremely long conversation title that exceeds width
+              </span>
             </ThreadLink>
             <ThreadDeleteButton onClick={() => console.log('Delete')} />
           </ThreadItem>
@@ -137,7 +139,7 @@ export const ManyThreads: Story = {
           {Array.from({ length: 10 }, (_, i) => (
             <ThreadItem key={i} isActive={i === 2}>
               <ThreadLink href="#">
-                <span className="text-icon5">Conversation {i + 1}</span>
+                <span className="text-neutral5">Conversation {i + 1}</span>
               </ThreadLink>
               <ThreadDeleteButton onClick={() => console.log(`Delete thread ${i + 1}`)} />
             </ThreadItem>
@@ -155,22 +157,22 @@ export const WithTimestamps: Story = {
         <ThreadList>
           <ThreadItem isActive>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">Current discussion</span>
-              <span className="text-xs text-icon3">Just now</span>
+              <span className="text-neutral5 truncate">Current discussion</span>
+              <span className="text-xs text-neutral3">Just now</span>
             </ThreadLink>
             <ThreadDeleteButton onClick={() => console.log('Delete')} />
           </ThreadItem>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">API design review</span>
-              <span className="text-xs text-icon3">2 hours ago</span>
+              <span className="text-neutral5 truncate">API design review</span>
+              <span className="text-xs text-neutral3">2 hours ago</span>
             </ThreadLink>
             <ThreadDeleteButton onClick={() => console.log('Delete')} />
           </ThreadItem>
           <ThreadItem>
             <ThreadLink href="#">
-              <span className="text-icon5 truncate">Bug investigation</span>
-              <span className="text-xs text-icon3">Yesterday</span>
+              <span className="text-neutral5 truncate">Bug investigation</span>
+              <span className="text-xs text-neutral3">Yesterday</span>
             </ThreadLink>
             <ThreadDeleteButton onClick={() => console.log('Delete')} />
           </ThreadItem>

--- a/packages/playground-ui/src/ds/components/Threads/threads.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.tsx
@@ -73,7 +73,7 @@ export const ThreadDeleteButton = ({ onClick }: ThreadDeleteButtonProps) => {
       onClick={onClick}
     >
       <Icon>
-        <X aria-label="delete thread" className="text-icon3" />
+        <X aria-label="delete thread" className="text-neutral3" />
       </Icon>
     </Button>
   );

--- a/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
@@ -40,7 +40,7 @@ export const WithIcon: Story = {
     <Tooltip>
       <TooltipTrigger asChild>
         <button className="p-1 rounded hover:bg-surface2">
-          <Info className="h-4 w-4 text-icon3" />
+          <Info className="h-4 w-4 text-neutral3" />
         </button>
       </TooltipTrigger>
       <TooltipContent>

--- a/packages/playground-ui/src/ds/components/Tooltip/tooltip.tsx
+++ b/packages/playground-ui/src/ds/components/Tooltip/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 overflow-hidden rounded-md bg-icon6 px-3 py-1.5 text-xs text-surface2 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 overflow-hidden rounded-md bg-neutral6 px-3 py-1.5 text-xs text-surface2 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/icons/icons.stories.tsx
+++ b/packages/playground-ui/src/ds/icons/icons.stories.tsx
@@ -107,10 +107,10 @@ const IconGrid = ({ size = 'default' }: { size?: 'sm' | 'default' | 'lg' }) => (
         key={name}
         className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg hover:bg-surface4 transition-colors"
       >
-        <Icon size={size} className="text-icon5">
+        <Icon size={size} className="text-neutral5">
           <IconComponent />
         </Icon>
-        <span className="text-xs text-icon3 text-center">{name.replace('Icon', '')}</span>
+        <span className="text-xs text-neutral3 text-center">{name.replace('Icon', '')}</span>
       </div>
     ))}
   </div>
@@ -144,22 +144,22 @@ export const IconSizes: Story = {
   render: () => (
     <div className="flex items-end gap-8">
       <div className="flex flex-col items-center gap-2">
-        <Icon size="sm" className="text-icon5">
+        <Icon size="sm" className="text-neutral5">
           <AgentIcon />
         </Icon>
-        <span className="text-xs text-icon3">Small</span>
+        <span className="text-xs text-neutral3">Small</span>
       </div>
       <div className="flex flex-col items-center gap-2">
-        <Icon size="default" className="text-icon5">
+        <Icon size="default" className="text-neutral5">
           <AgentIcon />
         </Icon>
-        <span className="text-xs text-icon3">Default</span>
+        <span className="text-xs text-neutral3">Default</span>
       </div>
       <div className="flex flex-col items-center gap-2">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <AgentIcon />
         </Icon>
-        <span className="text-xs text-icon3">Large</span>
+        <span className="text-xs text-neutral3">Large</span>
       </div>
     </div>
   ),
@@ -168,13 +168,13 @@ export const IconSizes: Story = {
 export const IconColors: Story = {
   render: () => (
     <div className="flex gap-4">
-      <Icon className="text-icon3">
+      <Icon className="text-neutral3">
         <AgentIcon />
       </Icon>
-      <Icon className="text-icon5">
+      <Icon className="text-neutral5">
         <AgentIcon />
       </Icon>
-      <Icon className="text-icon6">
+      <Icon className="text-neutral6">
         <AgentIcon />
       </Icon>
       <Icon className="text-accent1">
@@ -194,22 +194,22 @@ export const AgentIcons: Story = {
   render: () => (
     <div className="flex gap-4">
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <AgentIcon />
         </Icon>
-        <span className="text-xs text-icon3">Agent</span>
+        <span className="text-xs text-neutral3">Agent</span>
       </div>
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <AgentCoinIcon />
         </Icon>
-        <span className="text-xs text-icon3">AgentCoin</span>
+        <span className="text-xs text-neutral3">AgentCoin</span>
       </div>
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <AgentNetworkCoinIcon />
         </Icon>
-        <span className="text-xs text-icon3">AgentNetworkCoin</span>
+        <span className="text-xs text-neutral3">AgentNetworkCoin</span>
       </div>
     </div>
   ),
@@ -219,16 +219,16 @@ export const WorkflowIcons: Story = {
   render: () => (
     <div className="flex gap-4">
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <WorkflowIcon />
         </Icon>
-        <span className="text-xs text-icon3">Workflow</span>
+        <span className="text-xs text-neutral3">Workflow</span>
       </div>
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <WorkflowCoinIcon />
         </Icon>
-        <span className="text-xs text-icon3">WorkflowCoin</span>
+        <span className="text-xs text-neutral3">WorkflowCoin</span>
       </div>
     </div>
   ),
@@ -238,16 +238,16 @@ export const ToolIcons: Story = {
   render: () => (
     <div className="flex gap-4">
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <ToolsIcon />
         </Icon>
-        <span className="text-xs text-icon3">Tools</span>
+        <span className="text-xs text-neutral3">Tools</span>
       </div>
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <ToolCoinIcon />
         </Icon>
-        <span className="text-xs text-icon3">ToolCoin</span>
+        <span className="text-xs text-neutral3">ToolCoin</span>
       </div>
     </div>
   ),
@@ -257,28 +257,28 @@ export const BrandIcons: Story = {
   render: () => (
     <div className="flex gap-4">
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <GithubIcon />
         </Icon>
-        <span className="text-xs text-icon3">Github</span>
+        <span className="text-xs text-neutral3">Github</span>
       </div>
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <GithubCoinIcon />
         </Icon>
-        <span className="text-xs text-icon3">GithubCoin</span>
+        <span className="text-xs text-neutral3">GithubCoin</span>
       </div>
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <GoogleIcon />
         </Icon>
-        <span className="text-xs text-icon3">Google</span>
+        <span className="text-xs text-neutral3">Google</span>
       </div>
       <div className="flex flex-col items-center gap-2 p-3 bg-surface3 rounded-lg">
-        <Icon size="lg" className="text-icon5">
+        <Icon size="lg" className="text-neutral5">
           <OpenAIIcon />
         </Icon>
-        <span className="text-xs text-icon3">OpenAI</span>
+        <span className="text-xs text-neutral3">OpenAI</span>
       </div>
     </div>
   ),

--- a/packages/playground-ui/src/ds/tokens/colors.ts
+++ b/packages/playground-ui/src/ds/tokens/colors.ts
@@ -20,12 +20,12 @@ export const Colors = {
   accent3Darker: '#14141a',
   accent5Darker: '#14161a',
   accent6Darker: '#1a1a14',
-  icon1: '#5C5C5C',
-  icon2: '#707070',
-  icon3: '#939393',
-  icon4: '#A9A9A9',
-  icon5: '#E6E6E6',
-  icon6: '#FFFFFF',
+  neutral1: '#5C5C5C',
+  neutral2: '#707070',
+  neutral3: '#939393',
+  neutral4: '#A9A9A9',
+  neutral5: '#E6E6E6',
+  neutral6: '#FFFFFF',
 };
 
 export const BorderColors = {

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
@@ -53,7 +53,7 @@ export const AttachFileDialog = ({ onOpenChange, open }: AttachFileDialogProps) 
 
         <form onSubmit={handleSubmit} className="flex flex-row items-end gap-4">
           <div className="w-full space-y-1">
-            <Label htmlFor="url-attachment" className="text-icon3 text-ui-md">
+            <Label htmlFor="url-attachment" className="text-neutral3 text-ui-md">
               Public URL
             </Label>
             <Input
@@ -75,12 +75,12 @@ export const AttachFileDialog = ({ onOpenChange, open }: AttachFileDialogProps) 
         <hr className="my-2 border-sm border-border1" />
 
         <div className="space-y-2">
-          <Txt variant="ui-md" className="text-icon3">
+          <Txt variant="ui-md" className="text-neutral3">
             Or from your computer
           </Txt>
           <button
             onClick={addFilInputAttachment}
-            className="w-full h-40 border-sm border-border1 rounded-lg text-icon3 border-dashed flex flex-col items-center justify-center gap-2 hover:bg-surface2 active:bg-surface3"
+            className="w-full h-40 border-sm border-border1 rounded-lg text-neutral3 border-dashed flex flex-col items-center justify-center gap-2 hover:bg-surface2 active:bg-surface3"
           >
             <CloudUpload className="size-12" />
             <Txt variant="header-md">Add a local file</Txt>

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
@@ -100,7 +100,7 @@ export const TxtEntry = ({ data }: TxtEntryProps) => {
   return (
     <>
       <button onClick={() => setOpen(true)} className={ctaClassName} type="button">
-        <FileText className="text-icon3" />
+        <FileText className="text-neutral3" />
       </button>
       <TxtPreviewDialog data={formattedContent} open={open} onOpenChange={setOpen} />
     </>

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attachment.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attachment.tsx
@@ -101,7 +101,7 @@ const AttachmentRemove = () => {
     <AttachmentPrimitive.Remove asChild>
       <TooltipIconButton
         tooltip="Remove file"
-        className="absolute -right-3 -top-3 text-icon3 hover:text-icon6 rounded-full bg-surface1 hover:bg-surface2 rounded-full p-1"
+        className="absolute -right-3 -top-3 text-neutral3 hover:text-neutral6 rounded-full bg-surface1 hover:bg-surface2 rounded-full p-1"
         side="top"
       >
         <Icon>

--- a/packages/playground-ui/src/lib/ai-ui/memory-search.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/memory-search.tsx
@@ -226,7 +226,7 @@ export const MemorySearch = ({
   return (
     <div className={cn('flex flex-col h-full', className)} ref={dropdownRef}>
       <div className="relative shrink-0">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-icon3" />
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-neutral3" />
         <Input
           type="text"
           value={query}
@@ -253,13 +253,13 @@ export const MemorySearch = ({
             </div>
           ) : isSearching && results.length === 0 ? (
             <div className="p-4 text-center">
-              <Txt variant="ui-sm" className="text-icon3">
+              <Txt variant="ui-sm" className="text-neutral3">
                 Searching...
               </Txt>
             </div>
           ) : results.length === 0 ? (
             <div className="p-4 text-center">
-              <Txt variant="ui-sm" className="text-icon3">
+              <Txt variant="ui-sm" className="text-neutral3">
                 No results found for "{query}"
               </Txt>
             </div>
@@ -281,7 +281,7 @@ export const MemorySearch = ({
                         {result.context.before.map((msg, idx) => (
                           <div key={idx} className="flex items-start gap-2">
                             <span className="font-medium">{msg.role}:</span>
-                            <span className="text-icon3">{truncateContent(msg.content, 50)}</span>
+                            <span className="text-neutral3">{truncateContent(msg.content, 50)}</span>
                           </div>
                         ))}
                       </div>
@@ -301,7 +301,7 @@ export const MemorySearch = ({
                           >
                             {result.role}
                           </span>
-                          <Txt variant="ui-xs" className="text-icon3">
+                          <Txt variant="ui-xs" className="text-neutral3">
                             {formatRelativeTime(new Date(result.createdAt))}
                           </Txt>
                           {result.threadTitle && (
@@ -310,7 +310,7 @@ export const MemorySearch = ({
                                 variant="ui-xs"
                                 className={cn(
                                   'truncate max-w-[150px]',
-                                  result.threadId !== currentThreadId ? 'text-blue-400 font-medium' : 'text-icon3',
+                                  result.threadId !== currentThreadId ? 'text-blue-400 font-medium' : 'text-neutral3',
                                 )}
                                 title={result.threadTitle}
                               >
@@ -322,7 +322,7 @@ export const MemorySearch = ({
                             </div>
                           )}
                         </div>
-                        <Txt variant="ui-sm" className="text-icon5 break-words">
+                        <Txt variant="ui-sm" className="text-neutral5 break-words">
                           {truncateContent(result.content)}
                         </Txt>
                       </div>
@@ -334,7 +334,7 @@ export const MemorySearch = ({
                         {result.context.after.map((msg, idx) => (
                           <div key={idx} className="flex items-start gap-2">
                             <span className="font-medium">{msg.role}:</span>
-                            <span className="text-icon3">{truncateContent(msg.content, 50)}</span>
+                            <span className="text-neutral3">{truncateContent(msg.content, 50)}</span>
                           </div>
                         ))}
                       </div>

--- a/packages/playground-ui/src/lib/ai-ui/messages/assistant-message.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/assistant-message.tsx
@@ -40,7 +40,7 @@ export const AssistantMessage = ({ hasModelList }: AssistantMessageProps) => {
 
   return (
     <MessagePrimitive.Root className="max-w-full" data-message-id={messageId}>
-      <div className="text-icon6 text-ui-lg leading-ui-lg">
+      <div className="text-neutral6 text-ui-lg leading-ui-lg">
         <MessagePrimitive.Parts
           components={{
             Text: ErrorAwareText,
@@ -89,7 +89,7 @@ const AssistantActionBar = () => {
         </ActionBarPrimitive.StopSpeaking>
       </MessagePrimitive.If>
       <ActionBarPrimitive.Copy asChild>
-        <TooltipIconButton tooltip="Copy" className="bg-transparent text-icon3 hover:text-icon6">
+        <TooltipIconButton tooltip="Copy" className="bg-transparent text-neutral3 hover:text-neutral6">
           <MessagePrimitive.If copied>
             <CheckIcon />
           </MessagePrimitive.If>

--- a/packages/playground-ui/src/lib/ai-ui/messages/markdown-text.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/markdown-text.tsx
@@ -116,7 +116,7 @@ const ImageWithFallback = ({ alt, src, ...rest }: ImgHTMLAttributes<HTMLImageEle
           d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
         />
       </svg>
-      <p className="text-xs italic text-icon3 -mt-[0.625rem] mb-[0.625rem]">Image link is broken</p>
+      <p className="text-xs italic text-neutral3 -mt-[0.625rem] mb-[0.625rem]">Image link is broken</p>
     </div>
   ) : (
     <img
@@ -192,7 +192,7 @@ const defaultComponents = memoizeMarkdownComponents({
   ),
   p: ({ className, ...props }) => <p className={cn('leading-7 first:mt-0 last:mb-0', className)} {...props} />,
   a: ({ className, ...props }) => (
-    <a className={cn('text-icon6 font-medium underline underline-offset-4', className)} {...props} />
+    <a className={cn('text-neutral6 font-medium underline underline-offset-4', className)} {...props} />
   ),
   blockquote: ({ className, ...props }) => (
     <blockquote className={cn('border-l-2 pl-6 italic', className)} {...props} />

--- a/packages/playground-ui/src/lib/ai-ui/messages/reasoning.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/reasoning.tsx
@@ -19,7 +19,7 @@ export const Reasoning = ({ text }: ReasoningMessagePart) => {
 
       {!isCollapsed ? (
         <div className="rounded-lg bg-surface4 p-2 border-sm border-border-1">
-          <pre className="whitespace-pre-wrap text-ui-sm leading-ui-sm text-icon6">{text}</pre>
+          <pre className="whitespace-pre-wrap text-ui-sm leading-ui-sm text-neutral6">{text}</pre>
         </div>
       ) : null}
     </div>

--- a/packages/playground-ui/src/lib/ai-ui/messages/user-messages.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/user-messages.tsx
@@ -43,7 +43,7 @@ export const UserMessage = () => {
   return (
     <MessagePrimitive.Root className="w-full flex items-end pb-4 flex-col" data-message-id={messageId}>
       {/* <UserActionBar /> */}
-      <div className="max-w-[366px] px-5 py-3 text-icon6 text-ui-lg leading-ui-lg rounded-lg bg-surface3">
+      <div className="max-w-[366px] px-5 py-3 text-neutral6 text-ui-lg leading-ui-lg rounded-lg bg-surface3">
         <MessagePrimitive.Parts
           components={{
             File: p => {

--- a/packages/playground-ui/src/lib/ai-ui/thread.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/thread.tsx
@@ -107,7 +107,7 @@ const Composer = ({ hasMemory, agentId }: ComposerProps) => {
           <ComposerPrimitive.Input asChild className="w-full">
             <textarea
               ref={textareaRef}
-              className="text-ui-lg leading-ui-lg placeholder:text-icon3 text-icon6 bg-transparent focus:outline-none resize-none outline-none"
+              className="text-ui-lg leading-ui-lg placeholder:text-neutral3 text-neutral6 bg-transparent focus:outline-none resize-none outline-none"
               autoFocus={document.activeElement === document.body}
               placeholder="Enter your message..."
               name=""
@@ -192,12 +192,12 @@ const EditComposer = () => {
 
       <div>
         <ComposerPrimitive.Cancel asChild>
-          <button className="bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-icon3 hover:text-icon6">
+          <button className="bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
             Cancel
           </button>
         </ComposerPrimitive.Cancel>
         <ComposerPrimitive.Send asChild>
-          <button className="bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-icon3 hover:text-icon6">
+          <button className="bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
             Send
           </button>
         </ComposerPrimitive.Send>

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/loading-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/loading-badge.tsx
@@ -6,7 +6,7 @@ import { Colors } from '@/ds/tokens';
 export const LoadingBadge = () => {
   return (
     <BadgeWrapper
-      icon={<Spinner color={Colors.icon3} />}
+      icon={<Spinner color={Colors.neutral3} />}
       title={<Skeleton className="ml-2 w-12 h-2" />}
       collapsible={false}
     />

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
@@ -33,14 +33,14 @@ const NetworkChoiceMetadata = ({ selectionReason, open, onOpenChange, input }: N
 
         <div className="space-y-4 p-4 border-t-sm border-border1">
           <div className="space-y-2">
-            <Txt className="text-icon3">Selection Reason</Txt>
-            <div className="text-icon6 text-ui-md">{selectionReason}</div>
+            <Txt className="text-neutral3">Selection Reason</Txt>
+            <div className="text-neutral6 text-ui-md">{selectionReason}</div>
           </div>
 
           {inputSlot && (
             <div className="space-y-2">
-              <Txt className="text-icon3">Input</Txt>
-              <div className="text-icon6 text-ui-md">{inputSlot}</div>
+              <Txt className="text-neutral3">Input</Txt>
+              <div className="text-neutral6 text-ui-md">{inputSlot}</div>
             </div>
           )}
         </div>
@@ -62,7 +62,7 @@ export const NetworkChoiceMetadataDialogTrigger = ({
   return (
     <>
       <TooltipIconButton tooltip="Show selection reason" side="top" onClick={() => setIsOpen(s => !s)}>
-        <Share2 className="text-icon3 size-5" />
+        <Share2 className="text-neutral3 size-5" />
       </TooltipIconButton>
 
       <NetworkChoiceMetadata

--- a/packages/playground-ui/src/lib/form/components/array-wrapper.tsx
+++ b/packages/playground-ui/src/lib/form/components/array-wrapper.tsx
@@ -10,7 +10,7 @@ export const ArrayWrapper: React.FC<ArrayWrapperProps> = ({ label, children, onA
   return (
     <div>
       <div className="flex gap-2 justify-between">
-        <Txt as="h3" variant="ui-sm" className="text-icon3 pb-2 flex items-center gap-1">
+        <Txt as="h3" variant="ui-sm" className="text-neutral3 pb-2 flex items-center gap-1">
           <Icon size="sm">
             <Brackets />
           </Icon>
@@ -24,7 +24,7 @@ export const ArrayWrapper: React.FC<ArrayWrapperProps> = ({ label, children, onA
               <button
                 onClick={onAddItem}
                 type="button"
-                className="text-icon3 bg-surface3 rounded-md p-1 hover:bg-surface4 hover:text-icon6 h-icon-sm w-icon-sm"
+                className="text-neutral3 bg-surface3 rounded-md p-1 hover:bg-surface4 hover:text-neutral6 h-icon-sm w-icon-sm"
               >
                 <Icon size="sm">
                   <PlusIcon />

--- a/packages/playground-ui/src/lib/form/components/boolean-field.tsx
+++ b/packages/playground-ui/src/lib/form/components/boolean-field.tsx
@@ -20,7 +20,7 @@ export const BooleanField: React.FC<AutoFormFieldProps> = ({ field, label, id, i
       defaultChecked={field.default}
       disabled={inputProps.disabled || inputProps.readOnly}
     />
-    <Txt as="label" variant="ui-sm" className="text-icon3" htmlFor={id}>
+    <Txt as="label" variant="ui-sm" className="text-neutral3" htmlFor={id}>
       {label}
       {field.required && <span className="text-accent2"> *</span>}
     </Txt>

--- a/packages/playground-ui/src/lib/form/components/field-wrapper.tsx
+++ b/packages/playground-ui/src/lib/form/components/field-wrapper.tsx
@@ -11,7 +11,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({ label, children, id,
   return (
     <div className="pb-4 last:pb-0">
       {!isDisabled && (
-        <Txt as="label" variant="ui-sm" className="text-icon3 pb-1 block" htmlFor={id}>
+        <Txt as="label" variant="ui-sm" className="text-neutral3 pb-1 block" htmlFor={id}>
           {label}
           {field.required && <span className="text-accent2"> *</span>}
         </Txt>
@@ -20,7 +20,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({ label, children, id,
       {children}
 
       {field.fieldConfig?.description && (
-        <Txt as="p" variant="ui-sm" className="text-icon6">
+        <Txt as="p" variant="ui-sm" className="text-neutral6">
           {field.fieldConfig.description}
         </Txt>
       )}

--- a/packages/playground-ui/src/lib/form/components/object-wrapper.tsx
+++ b/packages/playground-ui/src/lib/form/components/object-wrapper.tsx
@@ -14,7 +14,7 @@ export const ObjectWrapper: React.FC<ObjectWrapperProps> = ({ label, children })
     <div className="">
       <div className="flex items-center">
         {hasLabel && (
-          <Txt as="h3" variant="ui-sm" className="text-icon3 flex items-center gap-1 pb-2">
+          <Txt as="h3" variant="ui-sm" className="text-neutral3 flex items-center gap-1 pb-2">
             <Icon size="sm">
               <Braces />
             </Icon>

--- a/packages/playground/src/domains/workflows/workflow-layout.tsx
+++ b/packages/playground/src/domains/workflows/workflow-layout.tsx
@@ -34,7 +34,7 @@ export const WorkflowLayout = ({ children }: { children: React.ReactNode }) => {
         </Header>
         <MainContentContent isCentered={true}>
           <div className="flex flex-col items-center justify-center h-full">
-            <Txt variant="ui-md" className="text-icon6 text-center">
+            <Txt variant="ui-md" className="text-neutral6 text-center">
               No workflow ID provided
             </Txt>
           </div>

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -66,7 +66,7 @@
     @apply border-border1;
   }
   body {
-    @apply bg-surface1 text-icon6;
+    @apply bg-surface1 text-neutral6;
   }
   html {
     scrollbar-color: var(--color-thumb) var(--color-track);
@@ -84,7 +84,7 @@
 }
 
 .react-flow__controls-button {
-  @apply !text-icon5 !bg-surface2 !border-none;
+  @apply !text-neutral5 !bg-surface2 !border-none;
 }
 
 .scorerListItem:has(+ .expanded) {


### PR DESCRIPTION
The `icon1-6` color tokens were misleadingly named - they're actually a general grayscale used for text, borders, and backgrounds throughout the UI, not just icons.

Renamed to `neutral1-6` for better semantic clarity:

```ts
// Before
text-icon3  // confusing - is this for icons?

// After  
text-neutral3  // clear - it's a neutral gray
```

Token values unchanged:
- `neutral1`: #5C5C5C
- `neutral2`: #707070  
- `neutral3`: #939393
- `neutral4`: #A9A9A9
- `neutral5`: #E6E6E6
- `neutral6`: #FFFFFF

Updated 150+ files across playground-ui and playground packages.

🤖 Generated with [Claude Code](https://claude.ai/code)