### PR TITLE
refactor(playground-ui): replace clsx with cn utility

### DIFF
--- a/.changeset/replace-clsx-with-cn-utility.md
+++ b/.changeset/replace-clsx-with-cn-utility.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Replaced direct `clsx` imports with the `cn` utility across all components for consistent Tailwind class merging.

--- a/packages/playground-ui/src/domains/agents/components/agent-advanced-settings.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-advanced-settings.tsx
@@ -73,7 +73,7 @@ export const AgentAdvancedSettings = () => {
     }
   };
 
-  const collapsibleClassName = 'rounded-lg border-sm border-border1 bg-surface3 overflow-clip';
+  const collapsibleClassName = 'rounded-lg border border-border1 bg-surface3 overflow-clip';
   const collapsibleTriggerClassName =
     'text-neutral3 text-ui-lg font-medium flex items-center gap-2 w-full p-[10px] justify-between';
   const collapsibleContentClassName = 'bg-surface2 p-[10px] @container/collapsible';

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-information.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-information.tsx
@@ -130,7 +130,7 @@ export const AgentInformationTabLayout = ({ children, agentId }: AgentInformatio
   });
 
   return (
-    <div className="flex-1 overflow-hidden border-t-sm border-border1 flex flex-col">
+    <div className="flex-1 overflow-hidden border-t border-border1 flex flex-col">
       <Tabs defaultTab="overview" value={selectedTab} onValueChange={handleTabChange}>
         {children}
       </Tabs>

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-instructions-enhancer.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-instructions-enhancer.tsx
@@ -38,7 +38,7 @@ export const PromptEnhancer = ({ agentId }: { agentId: string }) => {
       )}
 
       <div className="space-y-2">
-        <div className="rounded-md bg-[#1a1a1a] p-1 font-mono">
+        <div className="rounded-md bg-surface4 p-1 font-mono">
           <CodeMirror
             value={prompt}
             editable={true}

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -208,7 +208,7 @@ export const AgentMetadataToolList = ({ tools, agentId }: AgentMetadataToolListP
       {tools.map(tool => (
         <AgentMetadataListItem key={tool.id}>
           <Link href={paths.agentToolLink(agentId, tool.id)} data-testid="tool-badge">
-            <Badge icon={<ToolsIcon className="text-[#ECB047]" />}>{tool.id}</Badge>
+            <Badge icon={<ToolsIcon className="text-accent6" />}>{tool.id}</Badge>
           </Link>
         </AgentMetadataListItem>
       ))}

--- a/packages/playground-ui/src/domains/agents/components/agent-settings.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-settings.tsx
@@ -14,8 +14,8 @@ import { Txt } from '@/ds/components/Txt/Txt';
 
 import { AgentAdvancedSettings } from './agent-advanced-settings';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/ds/components/Tooltip';
-import clsx from 'clsx';
 import { Checkbox } from '@/ds/components/Checkbox';
+import { cn } from '@/lib/utils';
 import { useAgent } from '../hooks/use-agent';
 import { useMemory } from '@/domains/memory/hooks/use-memory';
 import { Skeleton } from '@/ds/components/Skeleton';
@@ -32,7 +32,7 @@ const NetworkCheckbox = ({ hasMemory, hasSubAgents }: { hasMemory: boolean; hasS
     <div className="flex items-center gap-2">
       <RadioGroupItem value="network" id="network" className="text-neutral6" disabled={!isNetworkAvailable} />
       <Label
-        className={clsx('text-neutral6 text-ui-md', !isNetworkAvailable && '!text-neutral3 cursor-not-allowed')}
+        className={cn('text-neutral6 text-ui-md', !isNetworkAvailable && '!text-neutral3 cursor-not-allowed')}
         htmlFor="network"
       >
         Network

--- a/packages/playground-ui/src/domains/configuration/components/header-list-form.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/header-list-form.tsx
@@ -24,7 +24,7 @@ export const HeaderListForm = ({ headers, onAddHeader, onRemoveHeader }: HeaderL
         Headers
       </Txt>
 
-      <div className="bg-surface4 rounded-lg p-4 border-sm border-border2 space-y-4">
+      <div className="bg-surface4 rounded-lg p-4 border border-border2 space-y-4">
         {headers.length > 0 && (
           <ul className="space-y-4">
             {headers.map((header, index) => (

--- a/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
@@ -174,7 +174,7 @@ const ToolEntry = ({ tool, serverId }: { tool: McpToolInfo; serverId: string }) 
   return (
     <Entity onClick={() => linkRef.current?.click()}>
       <EntityIcon>
-        <ToolIconComponent className="group-hover/entity:text-[#ECB047]" />
+        <ToolIconComponent className="group-hover/entity:text-accent6" />
       </EntityIcon>
 
       <EntityContent>

--- a/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/MCPDetail.tsx
@@ -81,7 +81,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
 
         <div className="flex flex-col gap-4">
           {/* HTTP Stream */}
-          <div className="rounded-lg border-sm border-border1 bg-surface3 p-4">
+          <div className="rounded-lg border border-border1 bg-surface3 p-4">
             <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">HTTP</span>}>
               Regular HTTP Endpoint
             </Badge>
@@ -97,7 +97,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
           </div>
 
           {/* SSE */}
-          <div className="rounded-lg border-sm border-border1 bg-surface3 p-4">
+          <div className="rounded-lg border border-border1 bg-surface3 p-4">
             <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">SSE</span>}>
               Server-Sent Events
             </Badge>
@@ -113,7 +113,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
           </div>
 
           {/* Command Line */}
-          <div className="rounded-lg border-sm border-border1 bg-surface3 p-4">
+          <div className="rounded-lg border border-border1 bg-surface3 p-4">
             <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">CLI</span>}>Command Line</Badge>
 
             <Txt className="text-neutral3 pt-1 pb-2">Use for local command-line access via npx and mcp-remote.</Txt>
@@ -128,7 +128,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
         </div>
       </div>
 
-      <div className="h-full overflow-y-scroll border-l-sm border-border1">
+      <div className="h-full overflow-y-scroll border-l border-border1">
         <McpToolList server={server} />
       </div>
     </MainContentContent>

--- a/packages/playground-ui/src/domains/observability/components/timeline-timing-col.tsx
+++ b/packages/playground-ui/src/domains/observability/components/timeline-timing-col.tsx
@@ -64,7 +64,7 @@ export function TimelineTimingCol({
       </HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
-          className="z-[100] w-auto max-w-[25rem] rounded-md bg-[#222] p-[.5rem] px-[1rem] pr-[1.5rem] text-[.75rem] text-neutral5 text-center border border-border1"
+          className="z-[100] w-auto max-w-[25rem] rounded-md bg-surface4 p-[.5rem] px-[1rem] pr-[1.5rem] text-[.75rem] text-neutral5 text-center border border-border1"
           sideOffset={5}
           side="top"
         >

--- a/packages/playground-ui/src/domains/tools/components/ToolExecutor.tsx
+++ b/packages/playground-ui/src/domains/tools/components/ToolExecutor.tsx
@@ -34,7 +34,7 @@ const ToolExecutor = ({
 
   return (
     <MainContentContent hasLeftServiceColumn={true} className="relative">
-      <div className="bg-surface2 border-r-sm border-border1 w-[20rem]">
+      <div className="bg-surface2 border-r border-border1 w-[20rem]">
         <ToolInformation toolDescription={toolDescription} toolId={toolId} toolType={toolType} />
         <div className="p-5 overflow-y-auto">
           <DynamicForm

--- a/packages/playground-ui/src/domains/tools/components/ToolInformation.tsx
+++ b/packages/playground-ui/src/domains/tools/components/ToolInformation.tsx
@@ -13,7 +13,7 @@ export const ToolInformation = ({ toolDescription, toolId, toolType }: ToolInfor
   const ToolIconComponent = ToolIconMap[toolType || 'tool'];
 
   return (
-    <div className="p-5 border-b-sm border-border1">
+    <div className="p-5 border-b border-border1">
       <div className="text-neutral6 flex gap-2">
         <div>
           <Icon size="lg" className="bg-surface4 rounded-md p-1">

--- a/packages/playground-ui/src/domains/workflows/components/workflow-information.tsx
+++ b/packages/playground-ui/src/domains/workflows/components/workflow-information.tsx
@@ -92,7 +92,7 @@ export function WorkflowInformation({ workflowId, initialRunId }: WorkflowInform
   }
 
   return (
-    <div className="grid grid-rows-[auto_1fr] h-full overflow-y-auto border-l-sm border-border1">
+    <div className="grid grid-rows-[auto_1fr] h-full overflow-y-auto border-l border-border1">
       <EntityHeader icon={<WorkflowIcon />} title={workflow?.name || ''} isLoading={isLoading}>
         <div className="flex items-center gap-2 pt-2">
           <Tooltip>
@@ -118,7 +118,7 @@ export function WorkflowInformation({ workflowId, initialRunId }: WorkflowInform
         </div>
       </EntityHeader>
 
-      <div className="flex-1 overflow-auto border-t-sm border-border1 flex flex-col">
+      <div className="flex-1 overflow-auto border-t border-border1 flex flex-col">
         <Tabs defaultTab="current-run" value={tab} onValueChange={handleTabChange} className="h-full">
           <TabList>
             <Tab value="current-run">Current Run</Tab>

--- a/packages/playground-ui/src/domains/workflows/components/workflow-step-detail.tsx
+++ b/packages/playground-ui/src/domains/workflows/components/workflow-step-detail.tsx
@@ -22,7 +22,7 @@ export function WorkflowStepDetailContent() {
   return (
     <div className="flex flex-col h-full">
       {/* Header with title and close button */}
-      <div className="flex items-center justify-between px-4 py-3 border-b-sm border-border1 bg-surface1">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border1 bg-surface1">
         <div className="flex items-center gap-2">
           {stepDetail.type === 'map-config' && <List className="w-4 h-4" style={{ color: BADGE_COLORS.map }} />}
           {stepDetail.type === 'nested-graph' && (

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-card.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-card.tsx
@@ -12,7 +12,7 @@ export interface WorkflowCardProps {
 export const WorkflowCard = ({ header, children, footer }: WorkflowCardProps) => {
   const [expanded, setExpanded] = useState(false);
   return (
-    <div className="rounded-lg border-sm border-border1 bg-surface4">
+    <div className="rounded-lg border border-border1 bg-surface4">
       <button className="py-1 px-2 flex items-center gap-3 justify-between w-full" onClick={() => setExpanded(s => !s)}>
         <div className="w-full">{header}</div>
         <Icon>
@@ -20,9 +20,9 @@ export const WorkflowCard = ({ header, children, footer }: WorkflowCardProps) =>
         </Icon>
       </button>
       {children && expanded && (
-        <div className="border-t-sm border-border1 max-h-[400px] overflow-y-auto">{children}</div>
+        <div className="border-t border-border1 max-h-[400px] overflow-y-auto">{children}</div>
       )}
-      {footer && <div className="py-1 px-2 border-t-sm border-border1">{footer}</div>}
+      {footer && <div className="py-1 px-2 border-t border-border1">{footer}</div>}
     </div>
   );
 };

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-card.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-card.tsx
@@ -19,9 +19,7 @@ export const WorkflowCard = ({ header, children, footer }: WorkflowCardProps) =>
           <ChevronDownIcon className={cn('text-neutral3 transition-transform -rotate-90', expanded && 'rotate-0')} />
         </Icon>
       </button>
-      {children && expanded && (
-        <div className="border-t border-border1 max-h-[400px] overflow-y-auto">{children}</div>
-      )}
+      {children && expanded && <div className="border-t border-border1 max-h-[400px] overflow-y-auto">{children}</div>}
       {footer && <div className="py-1 px-2 border-t border-border1">{footer}</div>}
     </div>
   );

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -55,7 +55,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
         data-workflow-step-status={previousDisplayStatus}
         data-testid="workflow-condition-node"
         className={cn(
-          'bg-surface3 rounded-lg w-[300px] border-sm border-border1',
+          'bg-surface3 rounded-lg w-[300px] border border-border1',
           previousDisplayStatus === 'success' && nextStep && 'bg-accent1Darker',
           previousDisplayStatus === 'failed' && nextStep && 'bg-accent2Darker',
           previousDisplayStatus === 'tripwire' && nextStep && 'bg-amber-950/40 border-amber-500/30',

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-default-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-default-node.tsx
@@ -79,7 +79,7 @@ export function WorkflowDefaultNode({
         data-workflow-step-status={displayStatus ?? 'idle'}
         data-testid="workflow-default-node"
         className={cn(
-          'bg-surface3 rounded-lg w-[274px] border-sm border-border1',
+          'bg-surface3 rounded-lg w-[274px] border border-border1',
           hasSpecialBadge ? 'pt-0' : 'pt-2',
           displayStatus === 'success' && 'bg-accent1Darker',
           displayStatus === 'failed' && 'bg-accent2Darker',

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-input-data.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-input-data.tsx
@@ -125,7 +125,7 @@ const JSONInput = ({
   return (
     <div className="flex flex-col gap-4">
       {errors.length > 0 && (
-        <div className="border-sm border-accent2 rounded-lg p-2">
+        <div className="border border-accent2 rounded-lg p-2">
           <Txt as="p" variant="ui-md" className="text-accent2 font-semibold">
             {errors.length} errors found
           </Txt>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-nested-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-nested-node.tsx
@@ -80,7 +80,7 @@ export function WorkflowNestedNode({
         data-workflow-node
         data-workflow-step-status={displayStatus}
         className={cn(
-          'bg-surface3 rounded-lg w-[274px] border-sm border-border1',
+          'bg-surface3 rounded-lg w-[274px] border border-border1',
           hasSpecialBadge ? 'pt-0' : 'pt-2',
           displayStatus === 'success' && 'bg-accent1Darker',
           displayStatus === 'failed' && 'bg-accent2Darker',

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -65,8 +65,8 @@ export const WorkflowStepActionBar = ({
 
   const workflowStatus = result?.status ?? runSnapshot?.status;
 
-  const dialogContentClass = 'bg-surface2 rounded-lg border-sm border-border1 max-w-4xl w-full px-0';
-  const dialogTitleClass = 'border-b-sm border-border1 pb-4 px-6';
+  const dialogContentClass = 'bg-surface2 rounded-lg border border-border1 max-w-4xl w-full px-0';
+  const dialogTitleClass = 'border-b border-border1 pb-4 px-6';
 
   const showTimeTravel =
     !withoutTimeTravel && stepKey && !mapConfig && workflowStatus !== 'running' && workflowStatus !== 'paused';
@@ -171,7 +171,7 @@ export const WorkflowStepActionBar = ({
         showDebugMode) && (
         <div
           className={cn(
-            'flex flex-wrap items-center bg-surface4 border-t-sm border-border1 px-2 py-1 gap-2 rounded-b-lg',
+            'flex flex-wrap items-center bg-surface4 border-t border-border1 px-2 py-1 gap-2 rounded-b-lg',
             status === 'success' && 'bg-accent1Dark',
             status === 'failed' && 'bg-accent2Dark',
             status === 'tripwire' && 'bg-amber-900/40 border-amber-500/20',

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -212,9 +212,9 @@ export function WorkflowTrigger({
 
   return (
     <div className="h-full pt-3 overflow-y-auto">
-      <div className="space-y-4 px-5 pb-5 border-b-sm border-border1">
+      <div className="space-y-4 px-5 pb-5 border-b border-border1">
         {isSuspendedSteps && isStreamingWorkflow && (
-          <div className="py-2 px-5 flex items-center gap-2 bg-surface5 -mx-5 -mt-5 border-b-sm border-border1">
+          <div className="py-2 px-5 flex items-center gap-2 bg-surface5 -mx-5 -mt-5 border-b border-border1">
             <Icon>
               <Loader2 className="animate-spin text-neutral6" />
             </Icon>
@@ -324,7 +324,7 @@ export function WorkflowTrigger({
 
         {hasWorkflowActivePaths && (
           <>
-            <hr className="border-border1 border-sm my-5" />
+            <hr className="border-border1 border my-5" />
             <div className="flex flex-col gap-2">
               <Txt variant="ui-xs" className="px-4 text-neutral3">
                 Status
@@ -381,7 +381,7 @@ export function WorkflowTrigger({
       </div>
 
       {result && !isObjectEmpty(result) && (
-        <div className="p-5 border-b-sm border-border1">
+        <div className="p-5 border-b border-border1">
           <WorkflowJsonDialog result={result} />
         </div>
       )}

--- a/packages/playground-ui/src/ds/components/Alert/Alert.tsx
+++ b/packages/playground-ui/src/ds/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@/ds/icons';
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 import { AlertCircle, InfoIcon, TriangleAlert } from 'lucide-react';
 import React from 'react';
 import { Txt, TxtProps } from '../Txt';
@@ -26,7 +26,7 @@ const variantIcons: Record<AlertVariant, React.FC<React.SVGProps<SVGSVGElement>>
 export const Alert = ({ children, variant = 'destructive' }: AlertProps) => {
   const Ico = variantIcons[variant];
   return (
-    <div className={clsx(variantClasses[variant], 'p-2 rounded-md')}>
+    <div className={cn(variantClasses[variant], 'p-2 rounded-md')}>
       <div className="flex items-start gap-2">
         <Icon className="mt-0.5">
           <Ico />

--- a/packages/playground-ui/src/ds/components/Alert/Alert.tsx
+++ b/packages/playground-ui/src/ds/components/Alert/Alert.tsx
@@ -12,9 +12,9 @@ export interface AlertProps {
 }
 
 const variantClasses: Record<AlertVariant, string> = {
-  warning: 'bg-yellow-900/20 border-sm border-yellow-200 text-yellow-200',
-  destructive: 'bg-red-900/20 border-sm border-red-200 text-red-200',
-  info: 'bg-blue-900/20 border-sm border-blue-200 text-blue-200',
+  warning: 'bg-yellow-900/20 border border-yellow-200 text-yellow-200',
+  destructive: 'bg-red-900/20 border border-red-200 text-red-200',
+  info: 'bg-blue-900/20 border border-blue-200 text-blue-200',
 };
 
 const variantIcons: Record<AlertVariant, React.FC<React.SVGProps<SVGSVGElement>>> = {

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
@@ -51,7 +51,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-[#141414] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-surface3 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Avatar/Avatar.tsx
+++ b/packages/playground-ui/src/ds/components/Avatar/Avatar.tsx
@@ -17,7 +17,7 @@ const sizeClasses: Record<AvatarSize, string> = {
 export const Avatar = ({ src, name, size = 'sm' }: AvatarProps) => {
   return (
     <div
-      className={`${sizeClasses[size]} border border-border1 bg-surface-3 shrink-0 overflow-hidden rounded-full flex items-center justify-center`}
+      className={`${sizeClasses[size]} border border-border1 bg-surface3 shrink-0 overflow-hidden rounded-full flex items-center justify-center`}
     >
       {src ? (
         <img src={src} alt={name} className="h-full w-full object-cover" />

--- a/packages/playground-ui/src/ds/components/Avatar/Avatar.tsx
+++ b/packages/playground-ui/src/ds/components/Avatar/Avatar.tsx
@@ -17,7 +17,7 @@ const sizeClasses: Record<AvatarSize, string> = {
 export const Avatar = ({ src, name, size = 'sm' }: AvatarProps) => {
   return (
     <div
-      className={`${sizeClasses[size]} border-sm border-border1 bg-surface-3 shrink-0 overflow-hidden rounded-full flex items-center justify-center`}
+      className={`${sizeClasses[size]} border border-border1 bg-surface-3 shrink-0 overflow-hidden rounded-full flex items-center justify-center`}
     >
       {src ? (
         <img src={src} alt={name} className="h-full w-full object-cover" />

--- a/packages/playground-ui/src/ds/components/Badge/Badge.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
-import clsx from 'clsx';
 import React from 'react';
 
 import { Icon } from '../../icons/Icon';
+import { cn } from '@/lib/utils';
 
 export interface BadgeProps {
   icon?: React.ReactNode;
@@ -20,7 +20,7 @@ const variantClasses = {
 export const Badge = ({ icon, variant = 'default', className, children, ...props }: BadgeProps) => {
   return (
     <div
-      className={clsx(
+      className={cn(
         'font-mono bg-surface4 text-ui-sm gap-md h-badge-default inline-flex items-center rounded-md shrink-0',
         icon ? 'pl-md pr-1.5' : 'px-1.5',
         icon || variant === 'default' ? 'text-neutral5' : variantClasses[variant],

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -1,8 +1,8 @@
-import clsx from 'clsx';
 import React from 'react';
 
 import { Icon } from '../../icons/Icon';
 import { SlashIcon } from '../../icons/SlashIcon';
+import { cn } from '@/lib/utils';
 
 export interface BreadcrumbProps {
   children?: React.ReactNode;
@@ -35,7 +35,7 @@ export const Crumb = ({ className, as, isCurrent, action, ...props }: CrumbProps
       <li className="flex h-full shrink-0 items-center gap-1">
         <Root
           aria-current={isCurrent ? 'page' : undefined}
-          className={clsx(
+          className={cn(
             'text-ui-lg leading-ui-lg font-medium flex items-center gap-2',
             isCurrent ? 'text-white' : 'text-neutral3',
             className,

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx';
 import React from 'react';
+import { cn } from '@/lib/utils';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   as?: React.ElementType;
@@ -30,7 +30,7 @@ export function buttonVariants(options?: { variant?: ButtonProps['variant']; siz
   const variant = options?.variant || 'default';
   const size = options?.size || 'md';
 
-  return clsx(
+  return cn(
     'bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
     variantClasses[variant],
     sizeClasses[size],
@@ -44,7 +44,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Component
         ref={ref}
-        className={clsx(
+        className={cn(
           'bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
           variantClasses[variant],
           sizeClasses[size],

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -31,7 +31,7 @@ export function buttonVariants(options?: { variant?: ButtonProps['variant']; siz
   const size = options?.size || 'md';
 
   return cn(
-    'bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
+    'bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
     variantClasses[variant],
     sizeClasses[size],
   );
@@ -45,7 +45,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <Component
         ref={ref}
         className={cn(
-          'bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
+          'bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
           variantClasses[variant],
           sizeClasses[size],
           className,

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -3,8 +3,8 @@ import { EditorView } from '@codemirror/view';
 import { tags as t } from '@lezer/highlight';
 import { draculaInit } from '@uiw/codemirror-theme-dracula';
 import CodeMirror from '@uiw/react-codemirror';
-import clsx from 'clsx';
 import { HTMLAttributes, useMemo } from 'react';
+import { cn } from '@/lib/utils';
 
 import type { Extension } from '@codemirror/state';
 
@@ -51,7 +51,7 @@ export const CodeEditor = ({ data, value, onChange, showCopyButton = true, class
   const formattedCode = data ? JSON.stringify(data, null, 2) : (value ?? '');
 
   return (
-    <div className={clsx('rounded-md bg-surface4 p-1 font-mono relative', className)} {...props}>
+    <div className={cn('rounded-md bg-surface4 p-1 font-mono relative', className)} {...props}>
       {showCopyButton && <CopyButton content={formattedCode} className="absolute top-2 right-2 z-20" />}
       <CodeMirror
         value={formattedCode}

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -3,7 +3,6 @@ import { X } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
-import clsx from 'clsx';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -68,7 +67,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={clsx('text-lg font-semibold leading-none tracking-tight', className)}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
     {...props}
   />
 ));

--- a/packages/playground-ui/src/ds/components/Entity/Entity.tsx
+++ b/packages/playground-ui/src/ds/components/Entity/Entity.tsx
@@ -20,7 +20,7 @@ export const Entity = ({ children, className, onClick }: EntityProps) => {
         }
       }}
       className={cn(
-        'flex gap-3 group/entity bg-surface3 rounded-lg border-sm border-border1 py-3 px-4',
+        'flex gap-3 group/entity bg-surface3 rounded-lg border border-border1 py-3 px-4',
         onClick && 'cursor-pointer hover:bg-surface4 transition-all',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Entity/Entity.tsx
+++ b/packages/playground-ui/src/ds/components/Entity/Entity.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@/ds/icons';
 import { Txt } from '../Txt';
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 
 export interface EntityProps {
   children: React.ReactNode;
@@ -19,7 +19,7 @@ export const Entity = ({ children, className, onClick }: EntityProps) => {
           onClick?.();
         }
       }}
-      className={clsx(
+      className={cn(
         'flex gap-3 group/entity bg-surface3 rounded-lg border-sm border-border1 py-3 px-4',
         onClick && 'cursor-pointer hover:bg-surface4 transition-all',
         className,
@@ -33,7 +33,7 @@ export const Entity = ({ children, className, onClick }: EntityProps) => {
 
 export const EntityIcon = ({ children, className }: EntityProps) => {
   return (
-    <Icon size="lg" className={clsx('text-neutral3 mt-1', className)}>
+    <Icon size="lg" className={cn('text-neutral3 mt-1', className)}>
       {children}
     </Icon>
   );
@@ -41,7 +41,7 @@ export const EntityIcon = ({ children, className }: EntityProps) => {
 
 export const EntityName = ({ children, className }: EntityProps) => {
   return (
-    <Txt as="p" variant="ui-lg" className={clsx('text-neutral6 font-medium', className)}>
+    <Txt as="p" variant="ui-lg" className={cn('text-neutral6 font-medium', className)}>
       {children}
     </Txt>
   );
@@ -49,7 +49,7 @@ export const EntityName = ({ children, className }: EntityProps) => {
 
 export const EntityDescription = ({ children, className }: EntityProps) => {
   return (
-    <Txt as="p" variant="ui-sm" className={clsx('text-neutral3', className)}>
+    <Txt as="p" variant="ui-sm" className={cn('text-neutral3', className)}>
       {children}
     </Txt>
   );

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list-entry.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list-entry.tsx
@@ -19,7 +19,7 @@ export function EntryListEntry({ entry, isSelected, onClick, children, columns }
   return (
     <li
       className={cn(
-        'border-t text-[#ccc] border-border1 last:border-b-0 text-[0.875rem]',
+        'border-t text-neutral5 border-border1 last:border-b-0 text-[0.875rem]',
         '[&:last-child>button]:rounded-b-lg',
         {
           'bg-surface5': isSelected,

--- a/packages/playground-ui/src/ds/components/FormFields/input-field.tsx
+++ b/packages/playground-ui/src/ds/components/FormFields/input-field.tsx
@@ -59,12 +59,12 @@ export function InputField({
         name={name}
         value={value}
         className={cn(
-          'flex grow items-center cursor-pointer text-[0.875rem] text-[rgba(255,255,255,0.8)] border border-[rgba(255,255,255,0.15)] leading-none rounded-lg bg-transparent min-h-[2.5rem] px-[0.75rem] py-[0.5rem] w-full',
+          'flex grow items-center cursor-pointer text-[0.875rem] text-neutral5 border border-border1 leading-none rounded-lg bg-transparent min-h-[2.5rem] px-[0.75rem] py-[0.5rem] w-full',
           'focus:outline-none focus:shadow-[inset_0_0_0_1px_#18fb6f]',
           'placeholder:text-neutral3 placeholder:text-[.8125rem]',
           {
             'cursor-not-allowed opacity-50': disabled,
-            'border-red-800 focus:border-[rgba(255,255,255,0.15)]': error || errorMsg,
+            'border-red-800 focus:border-border1': error || errorMsg,
           },
         )}
         data-testid={testId}

--- a/packages/playground-ui/src/ds/components/FormFields/select-field.tsx
+++ b/packages/playground-ui/src/ds/components/FormFields/select-field.tsx
@@ -49,7 +49,7 @@ export function SelectField({
         <SelectTrigger
           id="select-dataset"
           className={cn(
-            'w-full border border-[rgba(255,255,255,0.15)] rounded-lg min-h-[2.5rem] min-w-[5rem] gap-[0.5rem]',
+            'w-full border border-border1 rounded-lg min-h-[2.5rem] min-w-[5rem] gap-[0.5rem]',
             'focus:outline-none focus:shadow-[inset_0_0_0_1px_rgba(24,251,111,0.75)]',
           )}
         >

--- a/packages/playground-ui/src/ds/components/Header/Header.tsx
+++ b/packages/playground-ui/src/ds/components/Header/Header.tsx
@@ -12,7 +12,7 @@ export const Header = ({ children, border = true }: HeaderProps) => {
   return (
     <header
       className={cn('h-header-default z-50 flex w-full items-center gap-[18px] bg-transparent px-5', {
-        'border-b-sm border-border1': border,
+        'border-b border-border1': border,
       })}
     >
       {children}

--- a/packages/playground-ui/src/ds/components/Header/Header.tsx
+++ b/packages/playground-ui/src/ds/components/Header/Header.tsx
@@ -1,7 +1,7 @@
-import clsx from 'clsx';
 import React from 'react';
 
 import { Txt } from '../Txt';
+import { cn } from '@/lib/utils';
 
 export interface HeaderProps {
   children?: React.ReactNode;
@@ -11,7 +11,7 @@ export interface HeaderProps {
 export const Header = ({ children, border = true }: HeaderProps) => {
   return (
     <header
-      className={clsx('h-header-default z-50 flex w-full items-center gap-[18px] bg-transparent px-5', {
+      className={cn('h-header-default z-50 flex w-full items-center gap-[18px] bg-transparent px-5', {
         'border-b-sm border-border1': border,
       })}
     >

--- a/packages/playground-ui/src/ds/components/Input/input.tsx
+++ b/packages/playground-ui/src/ds/components/Input/input.tsx
@@ -2,7 +2,7 @@ import { cva } from 'class-variance-authority';
 import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 
 const inputVariants = cva(
   'flex w-full text-neutral6 rounded-lg border bg-transparent shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
@@ -36,7 +36,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <input
         type={type}
-        className={clsx(className, inputVariants({ variant, customSize, className }))}
+        className={cn(className, inputVariants({ variant, customSize, className }))}
         data-testid={testId}
         ref={ref}
         {...props}

--- a/packages/playground-ui/src/ds/components/Input/input.tsx
+++ b/packages/playground-ui/src/ds/components/Input/input.tsx
@@ -9,8 +9,8 @@ const inputVariants = cva(
   {
     variants: {
       variant: {
-        default: 'border-sm border-border1 placeholder:text-neutral3',
-        filled: 'border-sm bg-inputFill border-border1 placeholder:text-neutral3',
+        default: 'border border-border1 placeholder:text-neutral3',
+        filled: 'border bg-inputFill border-border1 placeholder:text-neutral3',
         unstyled: 'border-0 bg-transparent placeholder:text-neutral3',
       },
       customSize: {

--- a/packages/playground-ui/src/ds/components/Kbd/kbd.tsx
+++ b/packages/playground-ui/src/ds/components/Kbd/kbd.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 
 export type KbdProps = {
   children: React.ReactNode;
@@ -12,5 +12,5 @@ const themeClasses: Record<NonNullable<KbdProps['theme']>, string> = {
 
 export const Kbd = ({ children, theme = 'dark' }: KbdProps) => {
   const themeClass = themeClasses[theme];
-  return <kbd className={clsx('border-sm rounded-md px-1 py-0.5 font-mono', themeClass)}>{children}</kbd>;
+  return <kbd className={cn('border-sm rounded-md px-1 py-0.5 font-mono', themeClass)}>{children}</kbd>;
 };

--- a/packages/playground-ui/src/ds/components/Kbd/kbd.tsx
+++ b/packages/playground-ui/src/ds/components/Kbd/kbd.tsx
@@ -12,5 +12,5 @@ const themeClasses: Record<NonNullable<KbdProps['theme']>, string> = {
 
 export const Kbd = ({ children, theme = 'dark' }: KbdProps) => {
   const themeClass = themeClasses[theme];
-  return <kbd className={cn('border-sm rounded-md px-1 py-0.5 font-mono', themeClass)}>{children}</kbd>;
+  return <kbd className={cn('border rounded-md px-1 py-0.5 font-mono', themeClass)}>{children}</kbd>;
 };

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
@@ -71,7 +71,7 @@ export function KeyValueList({ data, LinkComponent, className, labelsAreHidden, 
             <dd
               className={cn(
                 'flex flex-wrap gap-[.5rem] py-[0.25rem] min-h-[2.25rem] text-[0.875rem] items-center text-neutral5 text-wrap',
-                '[&>a]:text-neutral5 [&>a]:max-w-full [&>a]:w-auto truncate [&>a]:bg-[#222] [&>a]:transition-colors [&>a]:flex [&>a]:items-center [&>a]:gap-[0.5rem] [&>a]:pt-[0.15rem] [&>a]:pb-[0.2rem] [&>a]:px-[.5rem] [&>a]:rounded-md [&>a]:text-[0.875rem] [&>a]:min-h-[1.75rem] [&>a]:leading-0 ',
+                '[&>a]:text-neutral5 [&>a]:max-w-full [&>a]:w-auto truncate [&>a]:bg-surface4 [&>a]:transition-colors [&>a]:flex [&>a]:items-center [&>a]:gap-[0.5rem] [&>a]:pt-[0.15rem] [&>a]:pb-[0.2rem] [&>a]:px-[.5rem] [&>a]:rounded-md [&>a]:text-[0.875rem] [&>a]:min-h-[1.75rem] [&>a]:leading-0 ',
                 '[&>a:hover]:text-neutral6 [&>a:hover]:bg-surface6',
                 '[&>a>svg]:w-[1em] [&>a>svg]:h-[1em] [&>a>svg]:text-neutral3 [&>a>svg]:ml-[-0.5em]',
               )}
@@ -117,7 +117,7 @@ function RelationWrapper({ description, children }: RelationWrapperProps) {
       <HoverCard.Trigger asChild>{children}</HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
-          className="z-[100] w-auto max-w-[15rem] rounded-md bg-[#333] p-[.5rem] px-[1rem] text-[.75rem] text-neutral5 text-center"
+          className="z-[100] w-auto max-w-[15rem] rounded-md bg-surface5 p-[.5rem] px-[1rem] text-[.75rem] text-neutral5 text-center"
           sideOffset={5}
           side="top"
         >

--- a/packages/playground-ui/src/ds/components/Label/label.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.tsx
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority';
 import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 
 const labelVariants = cva('text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70');
 
@@ -11,7 +11,7 @@ const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root ref={ref} className={clsx(labelVariants(), className)} {...props} />
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
 ));
 Label.displayName = LabelPrimitive.Root.displayName;
 

--- a/packages/playground-ui/src/ds/components/PageHeader/page-header.tsx
+++ b/packages/playground-ui/src/ds/components/PageHeader/page-header.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx';
 import React from 'react';
+import { cn } from '@/lib/utils';
 
 export interface PageHeaderProps {
   title?: string | 'loading';
@@ -13,9 +13,9 @@ export function PageHeader({ title, description, icon, className }: PageHeaderPr
   const descriptionIsLoading = description === 'loading';
 
   return (
-    <header className={clsx('grid gap-2 pt-8 pb-8', className)}>
+    <header className={cn('grid gap-2 pt-8 pb-8', className)}>
       <h1
-        className={clsx(
+        className={cn(
           'text-neutral6 text-xl font-normal flex items-center gap-2',
           '[&>svg]:w-6 [&>svg]:h-6 [&>svg]:text-neutral3',
           {
@@ -33,7 +33,7 @@ export function PageHeader({ title, description, icon, className }: PageHeaderPr
       </h1>
       {description && (
         <p
-          className={clsx('text-neutral4 text-sm m-0', {
+          className={cn('text-neutral4 text-sm m-0', {
             'bg-surface4 w-[40rem] max-w-[80%] rounded-md animate-pulse': descriptionIsLoading,
           })}
         >

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -1,7 +1,7 @@
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React from 'react';
 
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 
 const Popover = PopoverPrimitive.Root;
 
@@ -16,7 +16,7 @@ const PopoverContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={clsx(
+      className={cn(
         'z-50 w-72 rounded-md border bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className && /\bp-\S+/.test(className) ? false : `p-4`,
         className,

--- a/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx';
 import React, { useRef, useState, useEffect, useCallback } from 'react';
+import { cn } from '@/lib/utils';
 
 const INDICATOR_WIDTH = 40;
 const INDICATOR_HEIGHT = 150;
@@ -170,7 +170,7 @@ export const ScrollableContainer = ({
   }, []);
 
   return (
-    <div ref={containerRef} className={clsx('relative max-h-full overflow-auto', className)}>
+    <div ref={containerRef} className={cn('relative max-h-full overflow-auto', className)}>
       {children}
       <ScrollIndicator
         isVisible={showLeftIndicator}

--- a/packages/playground-ui/src/ds/components/Searchbar/searchbar.tsx
+++ b/packages/playground-ui/src/ds/components/Searchbar/searchbar.tsx
@@ -46,7 +46,7 @@ export const Searchbar = ({ onSearch, label, placeholder, debounceMs = 300 }: Se
   };
 
   return (
-    <div className="focus-within:outline focus-within:outline-accent1 -outline-offset-2 border-sm border-icon-3 flex h-8 w-full items-center gap-2 overflow-hidden rounded-lg pl-2 pr-1">
+    <div className="focus-within:outline focus-within:outline-accent1 -outline-offset-2 border border-icon-3 flex h-8 w-full items-center gap-2 overflow-hidden rounded-lg pl-2 pr-1">
       <SearchIcon className="text-neutral3 h-4 w-4" />
 
       <div className="flex-1">
@@ -69,5 +69,5 @@ export const Searchbar = ({ onSearch, label, placeholder, debounceMs = 300 }: Se
 };
 
 export const SearchbarWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <div className="px-4 py-2 border-b-sm border-border1">{children}</div>;
+  return <div className="px-4 py-2 border-b border-border1">{children}</div>;
 };

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.tsx
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 
 export type SpinnerProps = {
   color?: string;
@@ -8,7 +8,7 @@ export type SpinnerProps = {
 function Spinner({ color = '#fff', className }: SpinnerProps) {
   return (
     <svg
-      className={clsx('animate-spin duration-700', className)}
+      className={cn('animate-spin duration-700', className)}
       xmlns="http://www.w3.org/2000/svg"
       width="24"
       height="24"

--- a/packages/playground-ui/src/ds/components/Table/Cells.tsx
+++ b/packages/playground-ui/src/ds/components/Table/Cells.tsx
@@ -1,8 +1,8 @@
-import clsx from 'clsx';
 import React from 'react';
 
 import { Icon } from '../../icons/Icon';
 import { Txt } from '../Txt';
+import { cn } from '@/lib/utils';
 
 import { formatDateCell } from './utils';
 
@@ -13,8 +13,8 @@ export interface CellProps extends React.TdHTMLAttributes<HTMLTableCellElement> 
 
 export const Cell = ({ className, children, ...props }: CellProps) => {
   return (
-    <td className={clsx('text-neutral5 first:pl-5 last:pr-5', className)} {...props}>
-      <div className={clsx('flex h-full w-full shrink-0 items-center')}>{children}</div>
+    <td className={cn('text-neutral5 first:pl-5 last:pr-5', className)} {...props}>
+      <div className={cn('flex h-full w-full shrink-0 items-center')}>{children}</div>
     </td>
   );
 };

--- a/packages/playground-ui/src/ds/components/Table/Table.tsx
+++ b/packages/playground-ui/src/ds/components/Table/Table.tsx
@@ -29,7 +29,7 @@ export interface TheadProps {
 export const Thead = ({ className, children }: TheadProps) => {
   return (
     <thead>
-      <tr className={cn('h-table-header border-b-sm border-border1 bg-surface2', className)}>{children}</tr>
+      <tr className={cn('h-table-header border-b border-border1 bg-surface2', className)}>{children}</tr>
     </thead>
   );
 };
@@ -82,7 +82,7 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
     return (
       <tr
         className={cn(
-          'border-b-sm border-border1 hover:bg-surface3 focus:bg-surface3 -outline-offset-2',
+          'border-b border-border1 hover:bg-surface3 focus:bg-surface3 -outline-offset-2',
           selected && 'bg-surface4',
           onClick && 'cursor-pointer',
           className,

--- a/packages/playground-ui/src/ds/components/Table/Table.tsx
+++ b/packages/playground-ui/src/ds/components/Table/Table.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx';
 import React, { forwardRef } from 'react';
+import { cn } from '@/lib/utils';
 
 export interface TableProps {
   className?: string;
@@ -15,7 +15,7 @@ const rowSize = {
 
 export const Table = ({ className, children, size = 'default', style }: TableProps) => {
   return (
-    <table className={clsx('w-full', rowSize[size], className)} style={style}>
+    <table className={cn('w-full', rowSize[size], className)} style={style}>
       {children}
     </table>
   );
@@ -29,7 +29,7 @@ export interface TheadProps {
 export const Thead = ({ className, children }: TheadProps) => {
   return (
     <thead>
-      <tr className={clsx('h-table-header border-b-sm border-border1 bg-surface2', className)}>{children}</tr>
+      <tr className={cn('h-table-header border-b-sm border-border1 bg-surface2', className)}>{children}</tr>
     </thead>
   );
 };
@@ -42,7 +42,7 @@ export interface ThProps extends React.TdHTMLAttributes<HTMLTableCellElement> {
 export const Th = ({ className, children, ...props }: ThProps) => {
   return (
     <th
-      className={clsx(
+      className={cn(
         'text-neutral3 text-ui-sm h-full whitespace-nowrap text-left font-normal uppercase first:pl-5 last:pr-5',
         className,
       )}
@@ -59,7 +59,7 @@ export interface TbodyProps {
 }
 
 export const Tbody = ({ className, children }: TbodyProps) => {
-  return <tbody className={clsx('', className)}>{children}</tbody>;
+  return <tbody className={cn('', className)}>{children}</tbody>;
 };
 
 export interface RowProps {
@@ -81,7 +81,7 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
 
     return (
       <tr
-        className={clsx(
+        className={cn(
           'border-b-sm border-border1 hover:bg-surface3 focus:bg-surface3 -outline-offset-2',
           selected && 'bg-surface4',
           onClick && 'cursor-pointer',

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-list.tsx
@@ -25,7 +25,7 @@ export const TabList = ({ children, variant = 'default', className }: TabListPro
               variant === 'buttons',
             '[&>button]:flex-1 [&>button]:py-[0.5rem] [&>button]:px-[1rem] [&>button]:text-neutral3':
               variant === 'buttons',
-            '[&>button[data-state=active]]:text-neutral5 [&>button[data-state=active]]:bg-[#222]':
+            '[&>button[data-state=active]]:text-neutral5 [&>button[data-state=active]]:bg-surface4':
               variant === 'buttons',
           },
           className,

--- a/packages/playground-ui/src/ds/components/Threads/threads.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/ds/components/Button';
 import { Icon } from '@/ds/icons/Icon';
-import clsx from 'clsx';
 import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { ElementType } from 'react';
 
 export interface ThreadsProps {
@@ -27,7 +27,7 @@ export const ThreadLink = ({ children, as: Component = 'a', href, className, pre
       href={href}
       prefetch={prefetch}
       to={to}
-      className={clsx('text-ui-sm flex h-full w-full flex-col justify-center font-medium cursor-pointer', className)}
+      className={cn('text-ui-sm flex h-full w-full flex-col justify-center font-medium cursor-pointer', className)}
     >
       {children}
     </Component>
@@ -51,7 +51,7 @@ export interface ThreadItemProps {
 export const ThreadItem = ({ children, isActive, className }: ThreadItemProps) => {
   return (
     <li
-      className={clsx(
+      className={cn(
         'border-b-sm border-border1 hover:bg-surface3 group flex h-[54px] items-center justify-between gap-2 px-3 py-2',
         isActive && 'bg-surface4',
         className,

--- a/packages/playground-ui/src/ds/components/Threads/threads.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.tsx
@@ -52,7 +52,7 @@ export const ThreadItem = ({ children, isActive, className }: ThreadItemProps) =
   return (
     <li
       className={cn(
-        'border-b-sm border-border1 hover:bg-surface3 group flex h-[54px] items-center justify-between gap-2 px-3 py-2',
+        'border-b border-border1 hover:bg-surface3 group flex h-[54px] items-center justify-between gap-2 px-3 py-2',
         isActive && 'bg-surface4',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Txt/Txt.tsx
+++ b/packages/playground-ui/src/ds/components/Txt/Txt.tsx
@@ -1,7 +1,7 @@
-import clsx from 'clsx';
 import React from 'react';
 
 import { FontSizes } from '../../tokens';
+import { cn } from '@/lib/utils';
 
 export interface TxtProps extends React.HTMLAttributes<HTMLDivElement | HTMLLabelElement> {
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'label';
@@ -25,5 +25,5 @@ const fonts = {
 };
 
 export const Txt = ({ as: Root = 'p', className, variant = 'ui-md', font, ...props }: TxtProps) => {
-  return <Root className={clsx(variants[variant], font && fonts[font], className)} {...props} />;
+  return <Root className={cn(variants[variant], font && fonts[font], className)} {...props} />;
 };

--- a/packages/playground-ui/src/ds/icons/Icon.tsx
+++ b/packages/playground-ui/src/ds/icons/Icon.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx';
 import React from 'react';
+import { cn } from '@/lib/utils';
 
 export interface IconProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
@@ -14,7 +14,7 @@ const sizes = {
 
 export const Icon = ({ children, className, size = 'default', ...props }: IconProps) => {
   return (
-    <span className={clsx('block', sizes[size], className)} {...props}>
+    <span className={cn('block', sizes[size], className)} {...props}>
       {children}
     </span>
   );

--- a/packages/playground-ui/src/ds/tokens/borders.ts
+++ b/packages/playground-ui/src/ds/tokens/borders.ts
@@ -1,7 +1,3 @@
-export const BorderWidth = {
-  sm: '0.5px',
-};
-
 export const BorderRadius = {
   none: '0px',
   sm: '2px',

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -84,6 +84,7 @@ export * from './lib/framework';
 export { MemorySearch } from './lib/ai-ui/memory-search';
 export * from './domains/conversation/index';
 export * from './lib/errors';
+export { cn } from './lib/utils';
 export * from './lib/ai-ui/tools/tool-fallback';
 export * from './domains/workflows/runs/workflow-run-list';
 export * from './domains/mcps/index';

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
@@ -72,7 +72,7 @@ export const AttachFileDialog = ({ onOpenChange, open }: AttachFileDialogProps) 
           </Button>
         </form>
 
-        <hr className="my-2 border-sm border-border1" />
+        <hr className="my-2 border border-border1" />
 
         <div className="space-y-2">
           <Txt variant="ui-md" className="text-neutral3">
@@ -80,7 +80,7 @@ export const AttachFileDialog = ({ onOpenChange, open }: AttachFileDialogProps) 
           </Txt>
           <button
             onClick={addFilInputAttachment}
-            className="w-full h-40 border-sm border-border1 rounded-lg text-neutral3 border-dashed flex flex-col items-center justify-center gap-2 hover:bg-surface2 active:bg-surface3"
+            className="w-full h-40 border border-border1 rounded-lg text-neutral3 border-dashed flex flex-col items-center justify-center gap-2 hover:bg-surface2 active:bg-surface3"
           >
             <CloudUpload className="size-12" />
             <Txt variant="header-md">Add a local file</Txt>

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attachment.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attachment.tsx
@@ -73,7 +73,7 @@ const AttachmentThumbnail = () => {
           <Tooltip>
             <AttachmentPrimitive.Root>
               <TooltipTrigger asChild>
-                <div className="overflow-hidden size-16 rounded-lg bg-surface3 border-sm border-border1 ">
+                <div className="overflow-hidden size-16 rounded-lg bg-surface3 border border-border1 ">
                   {isImage ? (
                     <ImageEntry src={actualSrc ?? ''} />
                   ) : document?.contentType === 'application/pdf' ? (

--- a/packages/playground-ui/src/lib/ai-ui/messages/reasoning.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/reasoning.tsx
@@ -18,7 +18,7 @@ export const Reasoning = ({ text }: ReasoningMessagePart) => {
       </button>
 
       {!isCollapsed ? (
-        <div className="rounded-lg bg-surface4 p-2 border-sm border-border-1">
+        <div className="rounded-lg bg-surface4 p-2 border border-border-1">
           <pre className="whitespace-pre-wrap text-ui-sm leading-ui-sm text-neutral6">{text}</pre>
         </div>
       ) : null}

--- a/packages/playground-ui/src/lib/ai-ui/thread.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/thread.tsx
@@ -99,7 +99,7 @@ const Composer = ({ hasMemory, agentId }: ComposerProps) => {
         </div>
 
         <div
-          className="bg-surface3 rounded-lg border-sm border-border1 py-4 mt-auto max-w-3xl w-full mx-auto px-4 focus-within:outline focus-within:outline-accent1 -outline-offset-2"
+          className="bg-surface3 rounded-lg border border-border1 py-4 mt-auto max-w-3xl w-full mx-auto px-4 focus-within:outline focus-within:outline-accent1 -outline-offset-2"
           onClick={() => {
             textareaRef.current?.focus();
           }}
@@ -168,7 +168,7 @@ const ComposerAction = () => {
           <TooltipIconButton
             tooltip="Send"
             variant="default"
-            className="rounded-full border-sm border-border1 bg-surface5"
+            className="rounded-full border border-border1 bg-surface5"
           >
             <ArrowUp className="h-6 w-6 text-neutral3 hover:text-neutral6" />
           </TooltipIconButton>
@@ -192,12 +192,12 @@ const EditComposer = () => {
 
       <div>
         <ComposerPrimitive.Cancel asChild>
-          <button className="bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
+          <button className="bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
             Cancel
           </button>
         </ComposerPrimitive.Cancel>
         <ComposerPrimitive.Send asChild>
-          <button className="bg-surface2 border-sm border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
+          <button className="bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-button-md gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
             Send
           </button>
         </ComposerPrimitive.Send>

--- a/packages/playground-ui/src/lib/ai-ui/thread.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/thread.tsx
@@ -142,7 +142,7 @@ const SpeechInput = ({ agentId }: { agentId?: string }) => {
       className="rounded-full"
       onClick={() => (isListening ? stop() : start())}
     >
-      {isListening ? <CircleStopIcon /> : <Mic className="h-6 w-6 text-[#898989] hover:text-[#fff]" />}
+      {isListening ? <CircleStopIcon /> : <Mic className="h-6 w-6 text-neutral3 hover:text-neutral6" />}
     </TooltipIconButton>
   );
 };
@@ -158,7 +158,7 @@ const ComposerAction = () => {
         className="rounded-full"
         onClick={() => setIsAddAttachmentDialogOpen(true)}
       >
-        <PlusIcon className="h-6 w-6 text-[#898989] hover:text-[#fff]" />
+        <PlusIcon className="h-6 w-6 text-neutral3 hover:text-neutral6" />
       </TooltipIconButton>
 
       <AttachFileDialog open={isAddAttachmentDialogOpen} onOpenChange={setIsAddAttachmentDialogOpen} />
@@ -168,9 +168,9 @@ const ComposerAction = () => {
           <TooltipIconButton
             tooltip="Send"
             variant="default"
-            className="rounded-full border-sm border-[#363636] bg-[#292929]"
+            className="rounded-full border-sm border-border1 bg-surface5"
           >
-            <ArrowUp className="h-6 w-6 text-[#898989] hover:text-[#fff]" />
+            <ArrowUp className="h-6 w-6 text-neutral3 hover:text-neutral6" />
           </TooltipIconButton>
         </ComposerPrimitive.Send>
       </ThreadPrimitive.If>

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
@@ -25,13 +25,13 @@ const NetworkChoiceMetadata = ({ selectionReason, open, onOpenChange, input }: N
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="border-border1 border-sm bg-surface3 p-0 gap-0">
+      <DialogContent className="border-border1 border bg-surface3 p-0 gap-0">
         <DialogHeader className="p-4">
           <DialogTitle>Agent Network Metadata</DialogTitle>
           <DialogDescription>View the metadata of the agent's network choice.</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 p-4 border-t-sm border-border1">
+        <div className="space-y-4 p-4 border-t border-border1">
           <div className="space-y-2">
             <Txt className="text-neutral3">Selection Reason</Txt>
             <div className="text-neutral6 text-ui-md">{selectionReason}</div>

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/tool-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/tool-badge.tsx
@@ -61,7 +61,7 @@ export const ToolBadge = ({
   return (
     <BadgeWrapper
       data-testid="tool-badge"
-      icon={<ToolsIcon className="text-[#ECB047]" />}
+      icon={<ToolsIcon className="text-accent6" />}
       title={toolName}
       extraInfo={
         metadata?.mode === 'network' && (

--- a/packages/playground-ui/src/lib/resize/separator.tsx
+++ b/packages/playground-ui/src/lib/resize/separator.tsx
@@ -1,10 +1,10 @@
-import clsx from 'clsx';
 import { Separator } from 'react-resizable-panels';
+import { cn } from '@/lib/utils';
 
 export const PanelSeparator = () => {
   return (
     <Separator
-      className={clsx(
+      className={cn(
         'w-1.5 bg-surface3',
         "[&[data-separator='hover']]:!bg-surface4",
         "[&[data-separator='active']]:!bg-surface5",

--- a/packages/playground-ui/src/lib/toast.tsx
+++ b/packages/playground-ui/src/lib/toast.tsx
@@ -15,7 +15,7 @@ const defaultOptions: ExternalToast = {
   unstyled: true,
   classNames: {
     toast:
-      'bg-[#0F0F0F] w-full backdrop-accent h-auto rounded-lg gap-2 border border p-4 flex items-start justify-between rounded-lg pointer-events-auto',
+      'bg-surface2 w-full backdrop-accent h-auto rounded-lg gap-2 border border p-4 flex items-start justify-between rounded-lg pointer-events-auto',
     title: 'text-white font-semibold text-xs mb-1 -mt-1',
     description: '!text-text text-sm !font-light',
     cancelButton:

--- a/packages/playground-ui/src/lib/tw-merge-config.ts
+++ b/packages/playground-ui/src/lib/tw-merge-config.ts
@@ -3,8 +3,10 @@ import * as Tokens from '../ds/tokens';
 
 const colorKeys = Object.keys({ ...Tokens.Colors, ...Tokens.BorderColors });
 const spacingKeys = Object.keys(Tokens.Spacings);
+const fontSizeKeys = Object.keys(Tokens.FontSizes);
 const lineHeightKeys = Object.keys(Tokens.LineHeights);
 const borderRadiusKeys = Object.keys(Tokens.BorderRadius);
+const sizeKeys = Object.keys(Tokens.Sizes);
 
 export const twMerge = extendTailwindMerge({
   extend: {
@@ -13,6 +15,16 @@ export const twMerge = extendTailwindMerge({
       spacing: spacingKeys,
       radius: borderRadiusKeys,
       leading: lineHeightKeys,
+    },
+    classGroups: {
+      'font-size': [{ text: fontSizeKeys }],
+      h: [{ h: sizeKeys }],
+      w: [{ w: sizeKeys }],
+      size: [{ size: sizeKeys }],
+      'min-h': [{ 'min-h': sizeKeys }],
+      'min-w': [{ 'min-w': sizeKeys }],
+      'max-h': [{ 'max-h': sizeKeys }],
+      'max-w': [{ 'max-w': sizeKeys }],
     },
   },
 });

--- a/packages/playground-ui/src/lib/tw-merge-config.ts
+++ b/packages/playground-ui/src/lib/tw-merge-config.ts
@@ -1,0 +1,29 @@
+import { extendTailwindMerge } from 'tailwind-merge';
+import * as Tokens from '../ds/tokens';
+
+const colorKeys = Object.keys({ ...Tokens.Colors, ...Tokens.BorderColors });
+const spacingKeys = Object.keys(Tokens.Spacings);
+const fontSizeKeys = Object.keys(Tokens.FontSizes);
+const lineHeightKeys = Object.keys(Tokens.LineHeights);
+const borderRadiusKeys = Object.keys(Tokens.BorderRadius);
+const borderWidthKeys = Object.keys(Tokens.BorderWidth);
+const sizeKeys = Object.keys(Tokens.Sizes);
+
+export const twMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      color: colorKeys,
+      spacing: spacingKeys,
+      radius: borderRadiusKeys,
+      leading: lineHeightKeys,
+    },
+    classGroups: {
+      'font-size': [{ text: fontSizeKeys }],
+      'border-w': [{ border: borderWidthKeys }],
+      h: [{ h: sizeKeys }],
+      w: [{ w: sizeKeys }],
+      'max-h': [{ 'max-h': sizeKeys }],
+      'max-w': [{ 'max-w': sizeKeys }],
+    },
+  },
+});

--- a/packages/playground-ui/src/lib/tw-merge-config.ts
+++ b/packages/playground-ui/src/lib/tw-merge-config.ts
@@ -3,11 +3,8 @@ import * as Tokens from '../ds/tokens';
 
 const colorKeys = Object.keys({ ...Tokens.Colors, ...Tokens.BorderColors });
 const spacingKeys = Object.keys(Tokens.Spacings);
-const fontSizeKeys = Object.keys(Tokens.FontSizes);
 const lineHeightKeys = Object.keys(Tokens.LineHeights);
 const borderRadiusKeys = Object.keys(Tokens.BorderRadius);
-const borderWidthKeys = Object.keys(Tokens.BorderWidth);
-const sizeKeys = Object.keys(Tokens.Sizes);
 
 export const twMerge = extendTailwindMerge({
   extend: {
@@ -16,14 +13,6 @@ export const twMerge = extendTailwindMerge({
       spacing: spacingKeys,
       radius: borderRadiusKeys,
       leading: lineHeightKeys,
-    },
-    classGroups: {
-      'font-size': [{ text: fontSizeKeys }],
-      'border-w': [{ border: borderWidthKeys }],
-      h: [{ h: sizeKeys }],
-      w: [{ w: sizeKeys }],
-      'max-h': [{ 'max-h': sizeKeys }],
-      'max-w': [{ 'max-w': sizeKeys }],
     },
   },
 });

--- a/packages/playground-ui/src/lib/utils.ts
+++ b/packages/playground-ui/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { twMerge } from './tw-merge-config';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/packages/playground-ui/tailwind.config.ts
+++ b/packages/playground-ui/tailwind.config.ts
@@ -1,14 +1,6 @@
 import type { Config } from 'tailwindcss';
 import defaultFont from 'tailwindcss/defaultTheme';
-import {
-  FontSizes,
-  LineHeights,
-  BorderColors,
-  Colors,
-  BorderRadius,
-  Spacings,
-  Sizes,
-} from './src/ds/tokens';
+import { FontSizes, LineHeights, BorderColors, Colors, BorderRadius, Spacings, Sizes } from './src/ds/tokens';
 import animate from 'tailwindcss-animate';
 import assistantUi from '@assistant-ui/react-ui/tailwindcss';
 import containerQueries from '@tailwindcss/container-queries';

--- a/packages/playground-ui/tailwind.config.ts
+++ b/packages/playground-ui/tailwind.config.ts
@@ -6,7 +6,6 @@ import {
   BorderColors,
   Colors,
   BorderRadius,
-  BorderWidth,
   Spacings,
   Sizes,
 } from './src/ds/tokens';
@@ -38,9 +37,6 @@ export default {
       },
       borderRadius: {
         ...BorderRadius,
-      },
-      borderWidth: {
-        ...BorderWidth,
       },
       padding: {
         ...Spacings,

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -12,7 +12,7 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
             <MainSidebarProvider>
               <AppSidebar />
             </MainSidebarProvider>
-            <div className="bg-surface2 my-3 mr-3 rounded-lg border-sm border-border1 overflow-y-auto">{children}</div>
+            <div className="bg-surface2 my-3 mr-3 rounded-lg border border-border1 overflow-y-auto">{children}</div>
           </div>
         </TooltipProvider>
       </ThemeProvider>

--- a/packages/playground/src/domains/agents/tool-list.tsx
+++ b/packages/playground/src/domains/agents/tool-list.tsx
@@ -30,7 +30,7 @@ const ToolEntity = ({ tool, agentId }: ToolEntityProps) => {
   return (
     <Entity onClick={() => linkRef.current?.click()}>
       <EntityIcon>
-        <ToolsIcon className="group-hover/entity:text-[#ECB047]" />
+        <ToolsIcon className="group-hover/entity:text-accent6" />
       </EntityIcon>
       <EntityContent>
         <EntityName>

--- a/packages/playground/src/lib/utils.ts
+++ b/packages/playground/src/lib/utils.ts
@@ -1,8 +1,1 @@
-import { clsx } from 'clsx';
-import type { ClassValue } from 'clsx';
-
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from '@mastra/playground-ui';

--- a/packages/playground/src/pages/settings/index.tsx
+++ b/packages/playground/src/pages/settings/index.tsx
@@ -24,7 +24,7 @@ export const StudioSettingsPage = () => {
       </Header>
       <MainContentContent>
         <div className="p-5">
-          <div className="max-w-2xl p-5 w-full bg-surface3 border-sm border-border1 rounded-lg">
+          <div className="max-w-2xl p-5 w-full bg-surface3 border border-border1 rounded-lg">
             <StudioConfigForm initialConfig={{ baseUrl, headers }} />
           </div>
         </div>


### PR DESCRIPTION
Replaced all direct `clsx` imports with the `cn` utility in playground-ui components.

The `cn` utility wraps `clsx` with `twMerge` for better Tailwind class conflict resolution. This makes class handling consistent across all 22 components.

Before:
```tsx
import clsx from 'clsx';
className={clsx('bg-surface4', className)}
```

After:
```tsx
import { cn } from '@/lib/utils';
className={cn('bg-surface4', className)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new EntityContent component for flexible content composition.

* **Style**
  * Standardized border thicknesses and replaced hard-coded colors with theme tokens.
  * Refreshed hover states, badge/icon colors, toast and card backgrounds, and various component backgrounds for improved contrast and cohesion.

* **Chores**
  * Centralized class-name handling and Tailwind merge configuration for consistent styling behavior and class merging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->