### PR TITLE
docs(evals): clarify when judge runs in custom scorers

### DIFF
--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -35,6 +35,8 @@ Each step can use either **functions** or **prompt objects** (LLM-based evaluati
 - Natural language understanding tasks
 - Nuanced context evaluation
 
+**What “prompt object” means:** Instead of a function, the step is an object with `description` + `createPrompt` (and `outputSchema` for `preprocess`/`analyze`). That object tells Mastra to run the judge LLM for the step and store the structured output in `results.<step>StepResult`.
+
 You can mix and match approaches within a single scorer - for example, use a function for preprocessing data and an LLM for analyzing quality.
 
 ### Initializing a Scorer
@@ -60,6 +62,49 @@ const glutenCheckerScorer = createScorer({
 ```
 
 The judge configuration is only needed if you plan to use prompt objects in any step. Individual steps can override this default configuration with their own judge settings.
+
+If all steps are function-based, the judge is never called and there is no judge output. To see LLM output, define at least one step as a prompt object and read the corresponding step result (for example, `results.analyzeStepResult`).
+
+#### Minimal judge example (prompt object)
+
+This example uses a prompt object in `analyze`, so the judge runs and its structured output is available as `results.analyzeStepResult`.
+
+```typescript
+import { createScorer } from "@mastra/core/evals";
+import { z } from "zod";
+
+const quoteSourcesScorer = createScorer({
+  id: "quote-sources",
+  description: "Check if the response includes sources",
+  judge: {
+    model: "openai/gpt-4.1-nano",
+    instructions: "You are a strict evaluator.",
+  },
+})
+  .analyze({
+    description: "Detect whether sources are present",
+    outputSchema: z.object({
+      hasSources: z.boolean(),
+      sources: z.array(z.string()),
+    }),
+    createPrompt: ({ run }) => `
+Does the response contain sources? Extract them as a list.
+
+Response:
+${run.output}
+`,
+  })
+  .generateScore(({ results }) => (results.analyzeStepResult.hasSources ? 1 : 0));
+
+// Run the scorer and inspect judge output
+const result = await quoteSourcesScorer.run({
+  input: "What is the capital of France?",
+  output: "Paris is the capital of France [1]. Source: [1] Wikipedia",
+});
+
+console.log(result.score);              // 1
+console.log(result.analyzeStepResult);  // { hasSources: true, sources: ["Wikipedia"] }
+```
 
 #### Agent Type for Agent Evaluation
 
@@ -400,8 +445,6 @@ Provides human-readable explanations for the score using another LLM call.
 
 The reason generation step creates explanations that help users understand why a particular score was assigned, using both the boolean result and the specific gluten sources identified by the analysis step.
 
-````
-
 ## High gluten-free example
 
 ```typescript title="src/example-high-gluten-free.ts"
@@ -413,7 +456,7 @@ const result = await glutenCheckerScorer.run({
 console.log('Score:', result.score);
 console.log('Gluten sources:', result.analyzeStepResult.glutenSources);
 console.log('Reason:', result.reason);
-````
+```
 
 ### High gluten-free output
 

--- a/docs/src/content/en/reference/evals/create-scorer.mdx
+++ b/docs/src/content/en/reference/evals/create-scorer.mdx
@@ -13,6 +13,8 @@ Mastra provides a unified `createScorer` factory that allows you to define custo
 
 Use the `createScorer` factory to define your scorer with a name, description, and optional judge configuration. Then chain step methods to build your evaluation pipeline. You must provide at least a `generateScore` step.
 
+**Prompt object steps** are step configurations expressed as objects with `description` + `createPrompt` (and `outputSchema` for `preprocess`/`analyze`). These steps invoke the judge LLM. **Function steps** are plain functions and never call the judge.
+
 ```typescript
 import { createScorer } from "@mastra/core/evals";
 
@@ -99,6 +101,10 @@ This function returns a scorer builder that you can chain step methods onto. See
     },
   ]}
 />
+
+The judge only runs for steps defined as **prompt objects** (`preprocess`, `analyze`, `generateScore`, `generateReason` in prompt mode). If you use function steps only, the judge is never called and there is no LLM output to inspect. In that case, any score/reason must be produced by your functions.
+
+When a prompt-object step runs, its structured LLM output is stored in the corresponding result field (`preprocessStepResult`, `analyzeStepResult`, or the value consumed by `calculateScore` in `generateScore`).
 
 ## Type Safety
 


### PR DESCRIPTION
## Summary

- Clarify that the `judge` config only runs for **prompt-object** steps, not function steps
- Define "prompt object" terminology explicitly in the docs
- Add minimal example showing prompt-object usage and how to inspect judge output via `results.analyzeStepResult`
- Fix broken code fence in existing example

## Context

Addresses user confusion in #11931 where someone configured a `judge` but only used a function in `generateScore`, so the LLM was never called. The docs now clearly explain:
1. Judge only runs for prompt-object steps
2. Function steps bypass the judge entirely
3. To see LLM output, use a prompt object and read `results.<step>StepResult`

Fixes #11931

## Test plan

- [x] Verify docs render correctly locally
- [x] Review examples are syntactically correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified prompt object definitions and their role in custom scorers
  * Added practical examples demonstrating scorer configuration with prompt-based steps
  * Explained how the judge LLM processes prompt objects and stores results
  * Documented the distinction between prompt-based and function-based scoring approaches

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->