### PR TITLE
chore: update changeset slash commands to use CLI

### DIFF
--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -1,22 +1,34 @@
 # Changeset
 
-Create a changeset in `.changeset`, ensuring the naming convention for the changeset file is inline with other changesets in the `.changeset` folder.
+Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
 
-The frontmatter of the changeset file should include the package names being changed, along with the type of version bump for each package:
+## CLI Usage
 
-```yaml
----
-'package-name': 'type-of-bump'
----
+```bash
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
 ```
 
-Where `type-of-bump` is one of the following:
+**Arguments:**
+
+- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"` - The changeset message (required)
+- `--major @scope/pkg` - Packages that should have a major version bump
+- `--minor @scope/pkg` - Packages that should have a minor version bump
+- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+
+**Notes:**
+
+- The CLI auto-detects changed packages from git and defaults them to `patch` bumps
+- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor @mastra/cli`
+
+## Version Bump Types
 
 - `patch` - Bugfixes with backward-compatible changes
 - `minor` - New features with backward-compatible changes
 - `major` - Breaking changes that are not backward-compatible
 
-The body of the changeset should follow these guidelines:
+## Message Guidelines
 
 - The target audience are developers
 - Write short, direct sentences that anyone can understand. Avoid commit messages, technical jargon, and acronyms. Use action-oriented verbs (Added, Fixed, Improved, Deprecated, Removed)
@@ -26,4 +38,4 @@ The body of the changeset should follow these guidelines:
 - If the change is a breaking change or is adding a new feature, ensure that a code example is provided. This code example should show the public API usage (the before and after). Do not show code examples of internal implementation details.
 - Keep the formatting easy-to-read and scannable. If necessary, use bullet points or multiple paragraphs (Use **bold** text as the heading for these sections, do not use markdown headings).
 - For larger, more substantial changes, also answer the "Why" behind the changes
-- Check that the description inside the changeset file only applies to the packages listed in the frontmatter. Do not allow descriptions that mention changes to packages not listed in the frontmatter. In these cases, you must create a separate changeset file for those packages.
+- If changes span multiple packages with different purposes, run the CLI multiple times to create separate changesets for each logical group of changes.

--- a/.cursor/commands/changeset.md
+++ b/.cursor/commands/changeset.md
@@ -1,22 +1,34 @@
 # Changeset
 
-Create a changeset in `.changeset`, ensuring the naming convention for the changeset file is inline with other changesets in the `.changeset` folder.
+Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
 
-The frontmatter of the changeset file should include the package names being changed, along with the type of version bump for each package:
+## CLI Usage
 
-```yaml
----
-'package-name': 'type-of-bump'
----
+```bash
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
 ```
 
-Where `type-of-bump` is one of the following:
+**Arguments:**
+
+- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"` - The changeset message (required)
+- `--major @scope/pkg` - Packages that should have a major version bump
+- `--minor @scope/pkg` - Packages that should have a minor version bump
+- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+
+**Notes:**
+
+- The CLI auto-detects changed packages from git and defaults them to `patch` bumps
+- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor @mastra/cli`
+
+## Version Bump Types
 
 - `patch` - Bugfixes with backward-compatible changes
 - `minor` - New features with backward-compatible changes
 - `major` - Breaking changes that are not backward-compatible
 
-The body of the changeset should follow these guidelines:
+## Message Guidelines
 
 - The target audience are developers
 - Write short, direct sentences that anyone can understand. Avoid commit messages, technical jargon, and acronyms. Use action-oriented verbs (Added, Fixed, Improved, Deprecated, Removed)
@@ -26,4 +38,4 @@ The body of the changeset should follow these guidelines:
 - If the change is a breaking change or is adding a new feature, ensure that a code example is provided. This code example should show the public API usage (the before and after). Do not show code examples of internal implementation details.
 - Keep the formatting easy-to-read and scannable. If necessary, use bullet points or multiple paragraphs (Use **bold** text as the heading for these sections, do not use markdown headings).
 - For larger, more substantial changes, also answer the "Why" behind the changes
-- Check that the description inside the changeset file only applies to the packages listed in the frontmatter. Do not allow descriptions that mention changes to packages not listed in the frontmatter. In these cases, you must create a separate changeset file for those packages.
+- If changes span multiple packages with different purposes, run the CLI multiple times to create separate changesets for each logical group of changes.

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -2,25 +2,29 @@
 
 The user will issue this command. You will need to do two things.
 
-## Create a changeset file
+## Create a changeset using the CLI
 
-Create a changeset in `.changeset`, ensuring the naming convention for the changeset file is inline with other changesets in the `.changeset` folder.
+Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
 
-The frontmatter of the changeset file should include the package names being changed, along with the type of version bump for each package:
-
-```yaml
----
-'package-name': 'type-of-bump'
----
+```bash
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
 ```
 
-Where `type-of-bump` is one of the following:
+**Arguments:**
+
+- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"` - The changeset message (required)
+- `--major @scope/pkg` - Packages that should have a major version bump
+- `--minor @scope/pkg` - Packages that should have a minor version bump
+- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+
+**Version bump types:**
 
 - `patch` - Bugfixes with backward-compatible changes
 - `minor` - New features with backward-compatible changes
 - `major` - Breaking changes that are not backward-compatible
 
-The body of the changeset should follow these guidelines:
+**Message guidelines:**
 
 - The target audience are developers
 - Write short, direct sentences that anyone can understand. Avoid commit messages, technical jargon, and acronyms. Use action-oriented verbs (Added, Fixed, Improved, Deprecated, Removed)
@@ -30,7 +34,7 @@ The body of the changeset should follow these guidelines:
 - If the change is a breaking change or is adding a new feature, ensure that a code example is provided. This code example should show the public API usage (the before and after). Do not show code examples of internal implementation details.
 - Keep the formatting easy-to-read and scannable. If necessary, use bullet points or multiple paragraphs (Use **bold** text as the heading for these sections, do not use markdown headings).
 - For larger, more substantial changes, also answer the "Why" behind the changes
-- Check that the description inside the changeset file only applies to the packages listed in the frontmatter. Do not allow descriptions that mention changes to packages not listed in the frontmatter. In these cases, you must create a separate changeset file for those packages.
+- If changes span multiple packages with different purposes, run the CLI multiple times to create separate changesets for each logical group of changes.
 
 ## Open a PR using the GitHub CLI
 

--- a/.github/prompts/changeset.prompt.md
+++ b/.github/prompts/changeset.prompt.md
@@ -1,10 +1,13 @@
-# PR
+---
+agent: agent
+description: Create a changeset for version bumps
+---
 
-The user will issue this command. You will need to do two things.
-
-## Create a changeset using the CLI
+# Changeset
 
 Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
+
+## CLI Usage
 
 ```bash
 pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
@@ -18,13 +21,19 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 - `--minor @scope/pkg` - Packages that should have a minor version bump
 - `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
 
-**Version bump types:**
+**Notes:**
+
+- The CLI auto-detects changed packages from git and defaults them to `patch` bumps
+- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor @mastra/cli`
+
+## Version Bump Types
 
 - `patch` - Bugfixes with backward-compatible changes
 - `minor` - New features with backward-compatible changes
 - `major` - Breaking changes that are not backward-compatible
 
-**Message guidelines:**
+## Message Guidelines
 
 - The target audience are developers
 - Write short, direct sentences that anyone can understand. Avoid commit messages, technical jargon, and acronyms. Use action-oriented verbs (Added, Fixed, Improved, Deprecated, Removed)
@@ -35,13 +44,3 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 - Keep the formatting easy-to-read and scannable. If necessary, use bullet points or multiple paragraphs (Use **bold** text as the heading for these sections, do not use markdown headings).
 - For larger, more substantial changes, also answer the "Why" behind the changes
 - If changes span multiple packages with different purposes, run the CLI multiple times to create separate changesets for each logical group of changes.
-
-## Open a PR using the GitHub CLI
-
-Use gh cli to open a PR for the current branch in the user's browser. Do not open it directly, use the web option that opens it in the browser so the user can edit the title/description if needed.
-
-Add a descriptive/concise title, use conventional commits in the title (e.g. "fix: title here" or "feat(pkg-name): title here").
-
-Add a concise, humble PR description without flowery or overly verbose language.
-Keep it casual/friendly but get to the point. Show simple code examples before/after for fixes, or just after examples for new features.
-Do not add lists or headings. Keep it simple and to the point.

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -1,3 +1,8 @@
+---
+agent: agent
+description: Create a changeset and open a pull request
+---
+
 # PR
 
 The user will issue this command. You will need to do two things.


### PR DESCRIPTION
The changeset CLI already supports non-interactive mode via `-s` (skipPrompt) and `-m` (message) flags. This updates all the slash commands (.claude, .cursor, .github/prompts) to use the CLI instead of manually creating changeset files.

Example usage:
```bash
pnpm changeset -s -m "Fixed validation bug" --patch @mastra/core
```

This lets Claude create changesets programmatically without interactive prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changeset creation workflow to use CLI-based approach with automatic package detection.
  * Added comprehensive Arguments section detailing available flags and options.
  * Enhanced Message Guidelines with improved guidance on tone, clarity, and formatting.
  * Introduced Version Bump Types section clarifying patch, minor, and major semantics.
  * Added support for creating separate changesets when changes span multiple packages with different purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->