### PR TITLE
feat: implement workflow node comment persistence

### DIFF
--- a/packages/playground-ui/src/domains/workflow-builder/components/builder-toolbar.tsx
+++ b/packages/playground-ui/src/domains/workflow-builder/components/builder-toolbar.tsx
@@ -84,7 +84,13 @@ export function BuilderToolbar({ className, onShowShortcuts }: BuilderToolbarPro
 
     try {
       // Serialize the graph to workflow definition format
-      const { stepGraph, steps } = serializeGraph(nodes, edges);
+      const { stepGraph, steps, nodeComments } = serializeGraph(nodes, edges);
+
+      // Build metadata with node comments (only include if there are comments)
+      const metadata =
+        Object.keys(nodeComments).length > 0
+          ? { nodeComments }
+          : undefined;
 
       await updateWorkflowDefinition.mutateAsync({
         id: workflowId,
@@ -95,6 +101,7 @@ export function BuilderToolbar({ className, onShowShortcuts }: BuilderToolbarPro
         stateSchema: Object.keys(stateSchema).length > 0 ? stateSchema : undefined,
         stepGraph,
         steps,
+        metadata,
       });
 
       setDirty(false);

--- a/packages/playground-ui/src/domains/workflow-builder/components/nodes/base-node.tsx
+++ b/packages/playground-ui/src/domains/workflow-builder/components/nodes/base-node.tsx
@@ -25,6 +25,8 @@ export interface BaseNodeProps {
   quickAddExcludeTypes?: BuilderNodeType[];
   /** Comment/annotation for this node */
   comment?: string;
+  /** Whether to show the comment button (defaults to true) */
+  showComment?: boolean;
 }
 
 export function BaseNode({
@@ -38,6 +40,7 @@ export function BaseNode({
   showQuickAdd = true,
   quickAddExcludeTypes = [],
   comment,
+  showComment = true,
 }: BaseNodeProps) {
   const deleteNode = useWorkflowBuilderStore(state => state.deleteNode);
   const addConnectedNode = useWorkflowBuilderStore(state => state.addConnectedNode);
@@ -182,7 +185,7 @@ export function BaseNode({
         {hasStepResult && <StepStatusOverlay stepId={id} position="top-right" />}
 
         {/* Node comment */}
-        <NodeComment nodeId={id} comment={comment} position="top" />
+        {showComment && <NodeComment nodeId={id} comment={comment} position="top" />}
 
         {children}
       </div>

--- a/packages/playground-ui/src/domains/workflow-builder/components/nodes/condition-node.tsx
+++ b/packages/playground-ui/src/domains/workflow-builder/components/nodes/condition-node.tsx
@@ -22,7 +22,7 @@ export const ConditionNode = memo(function ConditionNode({
       accentColor={CONDITION_COLOR}
       bottomHandleCount={Math.max(totalHandles, 2)}
       quickAddExcludeTypes={['trigger']}
-      comment={data.comment}
+      showComment={false}
     >
       <div className="p-3">
         <div className="flex items-center gap-2 mb-2">

--- a/packages/playground-ui/src/domains/workflow-builder/components/nodes/foreach-node.tsx
+++ b/packages/playground-ui/src/domains/workflow-builder/components/nodes/foreach-node.tsx
@@ -18,7 +18,7 @@ export const ForeachNode = memo(function ForeachNode({
       selected={selected}
       accentColor={FOREACH_COLOR}
       quickAddExcludeTypes={['trigger']}
-      comment={data.comment}
+      showComment={false}
     >
       <div className="p-3">
         <div className="flex items-center gap-2 mb-2">

--- a/packages/playground-ui/src/domains/workflow-builder/components/nodes/loop-node.tsx
+++ b/packages/playground-ui/src/domains/workflow-builder/components/nodes/loop-node.tsx
@@ -16,7 +16,7 @@ export const LoopNode = memo(function LoopNode({ id, data, selected }: NodeProps
       selected={selected}
       accentColor={LOOP_COLOR}
       quickAddExcludeTypes={['trigger']}
-      comment={data.comment}
+      showComment={false}
     >
       <div className="p-3">
         <div className="flex items-center gap-2 mb-2">

--- a/packages/playground-ui/src/domains/workflow-builder/components/nodes/parallel-node.tsx
+++ b/packages/playground-ui/src/domains/workflow-builder/components/nodes/parallel-node.tsx
@@ -21,7 +21,7 @@ export const ParallelNode = memo(function ParallelNode({
       accentColor={PARALLEL_COLOR}
       bottomHandleCount={branchCount}
       quickAddExcludeTypes={['trigger']}
-      comment={data.comment}
+      showComment={false}
     >
       <div className="p-3">
         <div className="flex items-center gap-2 mb-2">

--- a/packages/playground-ui/src/domains/workflow-builder/components/nodes/tool-node.tsx
+++ b/packages/playground-ui/src/domains/workflow-builder/components/nodes/tool-node.tsx
@@ -3,6 +3,7 @@ import type { Node, NodeProps } from '@xyflow/react';
 import { Wrench } from 'lucide-react';
 import { BaseNode } from './base-node';
 import { Badge } from '@/ds/components/Badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { ToolNodeData } from '../../types';
 
 const TOOL_COLOR = '#a855f7'; // purple-500
@@ -31,7 +32,18 @@ export const ToolNode = memo(function ToolNode({ id, data, selected }: NodeProps
         </div>
 
         {data.toolId ? (
-          <div className="text-xs text-icon4 bg-surface2 rounded px-2 py-1 font-mono">{data.toolId}</div>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="text-xs text-icon4 bg-surface2 rounded px-2 py-1 font-mono truncate cursor-default">
+                  {data.toolId}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-xs">
+                <p className="font-mono text-xs break-all">{data.toolId}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ) : (
           <div className="text-xs text-amber-500 bg-amber-500/10 rounded px-2 py-1">No tool selected</div>
         )}

--- a/packages/playground-ui/src/domains/workflow-builder/utils/serialize.ts
+++ b/packages/playground-ui/src/domains/workflow-builder/utils/serialize.ts
@@ -35,6 +35,8 @@ export interface SerializeOptions {
 export interface SerializedGraph {
   stepGraph: DefinitionStepFlowEntry[];
   steps: Record<string, DeclarativeStepDefinition>;
+  /** Map of node IDs to their comments (for persistence in workflow metadata) */
+  nodeComments: Record<string, string>;
 }
 
 /**
@@ -45,7 +47,15 @@ export function serializeGraph(nodes: BuilderNode[], edges: BuilderEdge[]): Seri
   // Build steps object from non-trigger nodes
   const steps: Record<string, DeclarativeStepDefinition> = {};
 
+  // Collect comments from all nodes
+  const nodeComments: Record<string, string> = {};
+
   for (const node of nodes) {
+    // Collect comment if present
+    if (node.data.comment) {
+      nodeComments[node.id] = node.data.comment;
+    }
+
     // Skip types that don't have step definitions (handled in stepGraph only)
     if (node.data.type === 'trigger') continue;
     if (node.data.type === 'condition') continue;
@@ -64,7 +74,7 @@ export function serializeGraph(nodes: BuilderNode[], edges: BuilderEdge[]): Seri
   // Build stepGraph by traversing from trigger
   const stepGraph = buildStepGraph(nodes, edges);
 
-  return { stepGraph, steps };
+  return { stepGraph, steps, nodeComments };
 }
 
 /**


### PR DESCRIPTION
## Description

Implements full comment persistence for workflow nodes using workflow metadata storage. Comments are now saved and restored across save/load cycles for all node types that support it. Additionally, comments are hidden from flow control nodes (loop, foreach, parallel, condition) where persistence isn't possible due to core type limitations, and long tool names now truncate with a tooltip.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Code refactoring

## Implementation Details

**Comment Persistence**: Comments stored in `workflow.metadata.nodeComments` as a node ID → comment text map.

**Supported Nodes**: Trigger, Agent, Tool, Workflow, Transform, Suspend, Sleep (fully persistent). Loop, Foreach, Parallel, Condition (UI hidden until core type changes support ID fields).

**UI Improvements**: Added text truncation and tooltip for long tool names in Tool Step nodes.

## Checklist

- [x] Tested comment save/load cycle on supported node types
- [x] Verified comment buttons hidden on flow control nodes