### PR TITLE
fix(observability): llm span metadata inheritance

### DIFF
--- a/.changeset/fifty-bananas-bathe.md
+++ b/.changeset/fifty-bananas-bathe.md
@@ -1,0 +1,9 @@
+---
+'@mastra/observability': patch
+---
+
+feat(tracing): implement metadata inheritance for child spans
+
+- Updated the BaseSpan constructor to inherit metadata from parent spans when not explicitly provided, merging values if both exist.
+- Added tests to verify that child spans correctly inherit and can override metadata from their parent spans.
+- Enhanced existing tests to ensure proper metadata propagation in tracing scenarios.

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -365,7 +365,6 @@ describe('Span', () => {
       const workflowSpan = agentSpan.createChildSpan({
         type: SpanType.WORKFLOW_RUN,
         name: 'workflow',
-        metadata: { workflowVersion: 'v2' },
         attributes: {},
       });
 
@@ -375,8 +374,7 @@ describe('Span', () => {
         attributes: { model: 'gpt-4' },
       });
 
-      // LLM span should have metadata from both agent and workflow
-      expect(llmSpan.metadata).toEqual({ userId: 'user-123', workflowVersion: 'v2' });
+      expect(llmSpan.metadata).toEqual({ userId: 'user-123' });
 
       agentSpan.end();
     });

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -154,9 +154,7 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     this.attributes = deepClean(options.attributes, this.deepCleanOptions) || ({} as SpanTypeMap[TType]);
     // Metadata - inherit from parent if not explicitly provided, merge if both exist
     this.metadata = deepClean(
-      options.parent?.metadata || options.metadata
-        ? { ...options.parent?.metadata, ...options.metadata }
-        : undefined,
+      options.parent?.metadata || options.metadata ? { ...options.parent?.metadata, ...options.metadata } : undefined,
       this.deepCleanOptions,
     );
     if (options.requestContext && options.requestContext.size() > 0) {

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -152,7 +152,13 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     this.name = options.name;
     this.type = options.type;
     this.attributes = deepClean(options.attributes, this.deepCleanOptions) || ({} as SpanTypeMap[TType]);
-    this.metadata = deepClean(options.metadata, this.deepCleanOptions);
+    // Metadata - inherit from parent if not explicitly provided, merge if both exist
+    this.metadata = deepClean(
+      options.parent?.metadata || options.metadata
+        ? { ...options.parent?.metadata, ...options.metadata }
+        : undefined,
+      this.deepCleanOptions,
+    );
     if (options.requestContext && options.requestContext.size() > 0) {
       this.requestContext = deepClean(options.requestContext.all, this.deepCleanOptions);
     }

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -1704,8 +1704,11 @@ describe('Tracing', () => {
         },
       });
 
-      // This child should NOT have extracted metadata
-      expect(childSpanNoContext.metadata).toBeUndefined();
+      // This child should inherit metadata from parent (even without requestContext)
+      expect(childSpanNoContext.metadata).toEqual({
+        userId: 'user-123',
+        sessionId: 'session-456',
+      });
       expect(childSpanNoContext.traceState).toEqual(rootSpan.traceState);
 
       rootSpan.end();


### PR DESCRIPTION
## Description

This PR implements metadata inheritance for child spans in the Mastra observability system. Previously, child spans did not inherit metadata from their parent spans, requiring explicit metadata to be passed at each level. With this change, metadata automatically propagates through the span hierarchy, similar to how entityType, entityId, and entityName are already inherited.

A key use case for this feature is tracking token consumption by user or tenant. By setting userId or tenantId in the root span's metadata, all child spans (including MODEL_GENERATION spans that track token usage) automatically inherit these identifiers. This enables:

  - Analyzing token consumption per user or tenant
  - Cost attribution and billing based on metadata attributes
  - Usage monitoring and quota enforcement at the user/tenant level

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/10230
https://github.com/mastra-ai/mastra/pull/11914

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child spans now inherit metadata from parent spans and merge values, with child values taking precedence for overlaps.

* **Tests**
  * Added comprehensive tests covering metadata inheritance, overrides, merging, and propagation across nested span hierarchies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->