### PR TITLE
Fixed missing peer dependency warnings for @mastra/datadog observability exporter

### DIFF
--- a/.changeset/fix-datadog-peer-deps.md
+++ b/.changeset/fix-datadog-peer-deps.md
@@ -8,7 +8,5 @@ Added `@openfeature/core` and `@openfeature/server-sdk` as optional peer depende
 
 **Troubleshooting documentation added:**
 
-- Missing `@openfeature/core` dependency warnings
-- Native module ABI mismatch errors (Node.js version compatibility)
-- Version resolution issues with `@mastra/observability`
+- Native module ABI mismatch errors (Node.js version compatibility with `dd-trace`)
 - Bundler externals configuration for `dd-trace` and native modules

--- a/.changeset/fix-datadog-peer-deps.md
+++ b/.changeset/fix-datadog-peer-deps.md
@@ -1,0 +1,14 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed missing peer dependency warnings for `@openfeature/core` and `@openfeature/server-sdk`
+
+Added `@openfeature/core` and `@openfeature/server-sdk` as optional peer dependencies to resolve warnings that occur during installation. These are transitive dependencies from `dd-trace` and are now properly declared.
+
+**Troubleshooting documentation added:**
+
+- Missing `@openfeature/core` dependency warnings
+- Native module ABI mismatch errors (Node.js version compatibility)
+- Version resolution issues with `@mastra/observability`
+- Bundler externals configuration for `dd-trace` and native modules

--- a/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
@@ -133,6 +133,83 @@ Mastra span types are automatically mapped to Datadog LLMObs span kinds:
 
 Other/future Mastra span types will default to 'task' when mapped unless specified.
 
+## Troubleshooting
+
+### Missing `@openfeature/core` dependency
+
+If you see warnings about missing `@openfeature/core` or `@openfeature/server-sdk` dependencies, these are optional peer dependencies from `dd-trace`. You can safely ignore these warnings, or install them explicitly:
+
+```bash npm2yarn
+npm install @openfeature/core @openfeature/server-sdk
+```
+
+### Native module ABI mismatch
+
+If you see errors like:
+
+```
+Error: No native build was found for runtime=node abi=137 platform=linuxglibc arch=x64
+```
+
+This indicates a Node.js version compatibility issue with `dd-trace`'s native modules. These native modules are **optional** and provide performance monitoring features.
+
+**Solutions:**
+
+1. **Use Node.js 22.x**: The `@mastra/datadog` package requires Node.js >=22.13.0. Native modules have the best compatibility with Node.js 22.x.
+
+2. **Ignore native module warnings**: The native modules (`@datadog/native-metrics`, `@datadog/native-appsec`, etc.) are optional. If they fail to load, core tracing functionality still works.
+
+3. **Set environment variable**: You can suppress native module warnings:
+   ```bash
+   DD_TRACE_DISABLED_INSTRUMENTATIONS=native-metrics
+   ```
+
+### Version resolution issues
+
+If you encounter version mismatch errors with `@mastra/observability`, add this override to your `package.json`:
+
+```json title="package.json"
+{
+  "overrides": {
+    "@mastra/datadog": {
+      "@mastra/observability": "1.0.0-beta.10"
+    }
+  }
+}
+```
+
+For pnpm users:
+
+```json title="package.json"
+{
+  "pnpm": {
+    "overrides": {
+      "@mastra/observability": "1.0.0-beta.10"
+    }
+  }
+}
+```
+
+### Bundler externals configuration
+
+When using bundlers like esbuild, webpack, or the Mastra CLI bundler, you may need to mark `dd-trace` and its dependencies as external:
+
+```typescript title="mastra.config.ts"
+export default {
+  bundler: {
+    externals: [
+      "dd-trace",
+      "@openfeature/core",
+      "@openfeature/server-sdk",
+      "@datadog/native-metrics",
+      "@datadog/native-appsec",
+      "@datadog/native-iast-taint-tracking",
+      "@datadog/pprof",
+    ],
+  },
+};
+```
+
 ## Related
 
 - [Tracing Overview](/docs/v1/observability/tracing/overview)

--- a/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
@@ -135,14 +135,6 @@ Other/future Mastra span types will default to 'task' when mapped unless specifi
 
 ## Troubleshooting
 
-### Missing `@openfeature/core` dependency
-
-If you see warnings about missing `@openfeature/core` or `@openfeature/server-sdk` dependencies, these are optional peer dependencies from `dd-trace`. You can safely ignore these warnings, or install them explicitly:
-
-```bash
-pnpm add @openfeature/core @openfeature/server-sdk
-```
-
 ### Native module ABI mismatch
 
 If you see errors like:
@@ -155,40 +147,9 @@ This indicates a Node.js version compatibility issue with `dd-trace`'s native mo
 
 **Solutions:**
 
-1. **Use Node.js 22.x**: The `@mastra/datadog` package requires Node.js >=22.13.0. Native modules have the best compatibility with Node.js 22.x.
+1. **Use Node.js 22.x**: Native modules have the best compatibility with Node.js 22.x.
 
 2. **Ignore native module warnings**: The native modules (`@datadog/native-metrics`, `@datadog/native-appsec`, etc.) are optional. If they fail to load, core tracing functionality still works.
-
-3. **Set environment variable**: You can suppress native module warnings:
-   ```bash
-   DD_TRACE_DISABLED_INSTRUMENTATIONS=native-metrics
-   ```
-
-### Version resolution issues
-
-If you encounter version mismatch errors with `@mastra/observability`, add this override to your `package.json`:
-
-```json title="package.json"
-{
-  "overrides": {
-    "@mastra/datadog": {
-      "@mastra/observability": "1.0.0-beta.10"
-    }
-  }
-}
-```
-
-For pnpm users:
-
-```json title="package.json"
-{
-  "pnpm": {
-    "overrides": {
-      "@mastra/observability": "1.0.0-beta.10"
-    }
-  }
-}
-```
 
 ### Bundler externals configuration
 
@@ -199,8 +160,6 @@ export default {
   bundler: {
     externals: [
       "dd-trace",
-      "@openfeature/core",
-      "@openfeature/server-sdk",
       "@datadog/native-metrics",
       "@datadog/native-appsec",
       "@datadog/native-iast-taint-tracking",

--- a/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
@@ -139,8 +139,8 @@ Other/future Mastra span types will default to 'task' when mapped unless specifi
 
 If you see warnings about missing `@openfeature/core` or `@openfeature/server-sdk` dependencies, these are optional peer dependencies from `dd-trace`. You can safely ignore these warnings, or install them explicitly:
 
-```bash npm2yarn
-npm install @openfeature/core @openfeature/server-sdk
+```bash
+pnpm add @openfeature/core @openfeature/server-sdk
 ```
 
 ### Native module ABI mismatch

--- a/observability/datadog/README.md
+++ b/observability/datadog/README.md
@@ -117,11 +117,11 @@ When using bundlers, mark `dd-trace` and native modules as external:
 export default {
   bundler: {
     externals: [
-      "dd-trace",
-      "@datadog/native-metrics",
-      "@datadog/native-appsec",
-      "@datadog/native-iast-taint-tracking",
-      "@datadog/pprof",
+      'dd-trace',
+      '@datadog/native-metrics',
+      '@datadog/native-appsec',
+      '@datadog/native-iast-taint-tracking',
+      '@datadog/pprof',
     ],
   },
 };

--- a/observability/datadog/README.md
+++ b/observability/datadog/README.md
@@ -10,6 +10,7 @@ pnpm add @mastra/datadog
 
 ## Requirements
 
+- **Node.js >=22.13.0** (Node.js 22.x recommended for best native module compatibility)
 - Datadog account with LLM Observability enabled
 - Datadog API key (available in your Datadog account settings)
 
@@ -97,6 +98,58 @@ All unmapped span types (including `MODEL_CHUNK`, `GENERIC`, etc., and future sp
 - **Metadata as tags**: Span metadata is flattened into searchable Datadog tags
 - **Error tracking**: Error spans include error tags with message, ID, and category
 - **Parent/child hierarchy**: Spans are emitted parent-first to preserve trace trees in Datadog
+
+## Troubleshooting
+
+### Missing `@openfeature/core` dependency
+
+If you see warnings about missing `@openfeature/core` or `@openfeature/server-sdk`, these are optional peer dependencies from `dd-trace`. You can ignore the warnings or install them:
+
+```bash
+pnpm add @openfeature/core @openfeature/server-sdk
+```
+
+### Native module ABI errors
+
+If you see errors like `No native build was found for runtime=node abi=137`:
+
+1. **Use Node.js 22.x** - Native modules have best compatibility with Node.js 22.x
+2. **Ignore the warnings** - Native modules are optional; core tracing still works without them
+
+### Version resolution issues
+
+If you encounter version conflicts with `@mastra/observability`, add this to your `package.json`:
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "@mastra/observability": "1.0.0-beta.10"
+    }
+  }
+}
+```
+
+### Bundler configuration
+
+When using bundlers, mark `dd-trace` and native modules as external:
+
+```typescript
+// mastra.config.ts
+export default {
+  bundler: {
+    externals: [
+      "dd-trace",
+      "@openfeature/core",
+      "@openfeature/server-sdk",
+      "@datadog/native-metrics",
+      "@datadog/native-appsec",
+      "@datadog/native-iast-taint-tracking",
+      "@datadog/pprof",
+    ],
+  },
+};
+```
 
 ## License
 

--- a/observability/datadog/README.md
+++ b/observability/datadog/README.md
@@ -10,7 +10,7 @@ pnpm add @mastra/datadog
 
 ## Requirements
 
-- **Node.js >=22.13.0** (Node.js 22.x recommended for best native module compatibility)
+- **Node.js >=22.13.0** (Node.js 22.x recommended; `dd-trace` native modules ship prebuilt binaries for this ABI)
 - Datadog account with LLM Observability enabled
 - Datadog API key (available in your Datadog account settings)
 
@@ -105,8 +105,12 @@ All unmapped span types (including `MODEL_CHUNK`, `GENERIC`, etc., and future sp
 
 If you see errors like `No native build was found for runtime=node abi=137`:
 
-1. **Use Node.js 22.x** - Native modules have best compatibility with Node.js 22.x
-2. **Ignore the warnings** - Native modules are optional; core tracing still works without them
+These are non-blocking warnings. The `dd-trace` native modules (`@datadog/native-metrics`, etc.) are **optional** and provide performance monitoring features. Core tracing works without them.
+
+**Options:**
+
+1. **Use Node.js 22.x** - Prebuilt binaries for `dd-trace` native modules target Node.js 22 (ABI 127/131). Newer Node.js versions have different ABIs.
+2. **Ignore the errors** - These are warnings, not fatal errors. LLM observability tracing functions normally without native modules.
 
 ### Bundler configuration
 

--- a/observability/datadog/README.md
+++ b/observability/datadog/README.md
@@ -101,34 +101,12 @@ All unmapped span types (including `MODEL_CHUNK`, `GENERIC`, etc., and future sp
 
 ## Troubleshooting
 
-### Missing `@openfeature/core` dependency
-
-If you see warnings about missing `@openfeature/core` or `@openfeature/server-sdk`, these are optional peer dependencies from `dd-trace`. You can ignore the warnings or install them:
-
-```bash
-pnpm add @openfeature/core @openfeature/server-sdk
-```
-
 ### Native module ABI errors
 
 If you see errors like `No native build was found for runtime=node abi=137`:
 
 1. **Use Node.js 22.x** - Native modules have best compatibility with Node.js 22.x
 2. **Ignore the warnings** - Native modules are optional; core tracing still works without them
-
-### Version resolution issues
-
-If you encounter version conflicts with `@mastra/observability`, add this to your `package.json`:
-
-```json
-{
-  "pnpm": {
-    "overrides": {
-      "@mastra/observability": "1.0.0-beta.10"
-    }
-  }
-}
-```
 
 ### Bundler configuration
 
@@ -140,8 +118,6 @@ export default {
   bundler: {
     externals: [
       "dd-trace",
-      "@openfeature/core",
-      "@openfeature/server-sdk",
       "@datadog/native-metrics",
       "@datadog/native-appsec",
       "@datadog/native-iast-taint-tracking",

--- a/observability/datadog/package.json
+++ b/observability/datadog/package.json
@@ -48,7 +48,17 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@openfeature/core": "^1.7.0",
+    "@openfeature/server-sdk": "^1.18.0"
+  },
+  "peerDependenciesMeta": {
+    "@openfeature/core": {
+      "optional": true
+    },
+    "@openfeature/server-sdk": {
+      "optional": true
+    }
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1091,6 +1091,12 @@ importers:
       '@mastra/observability':
         specifier: workspace:*
         version: link:../mastra
+      '@openfeature/core':
+        specifier: ^1.7.0
+        version: 1.9.1
+      '@openfeature/server-sdk':
+        specifier: ^1.18.0
+        version: 1.18.0(@openfeature/core@1.9.1)
       dd-trace:
         specifier: ^5.0.0
         version: 5.81.0(@openfeature/core@1.9.1)(@openfeature/server-sdk@1.18.0(@openfeature/core@1.9.1))
@@ -23023,13 +23029,11 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openfeature/core@1.9.1':
-    optional: true
+  '@openfeature/core@1.9.1': {}
 
   '@openfeature/server-sdk@1.18.0(@openfeature/core@1.9.1)':
     dependencies:
       '@openfeature/core': 1.9.1
-    optional: true
 
   '@openrouter/ai-sdk-provider@0.4.6(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
## Description

Fixed missing peer dependency warnings for `@openfeature/core` and `@openfeature/server-sdk`

Added `@openfeature/core` and `@openfeature/server-sdk` as optional peer dependencies to resolve warnings that occur during installation. These are transitive dependencies from `dd-trace` and are now properly declared.

**Troubleshooting documentation added:**

- Native module ABI mismatch errors (Node.js version compatibility with `dd-trace`)
- Bundler externals configuration for `dd-trace` and native modules

## Related Issue(s)

Fixes #11934

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved peer dependency warnings for the Datadog exporter by declaring tracing-related packages as optional peers.

* **Documentation**
  * Added troubleshooting for native module ABI mismatches and Node.js version guidance.
  * Provided bundler externals configuration examples for Datadog tracing.
  * Linked additional Datadog LLM observability resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->