### PR TITLE
refactor(playground-ui): convert spacing tokens from px to rem

### DIFF
--- a/.changeset/spacing-tokens-rem.md
+++ b/.changeset/spacing-tokens-rem.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Converted spacing design tokens from pixels to REM units for better accessibility. Spacing now scales with the user's browser font size settings. All existing Tailwind spacing classes (`p-4`, `gap-2`, `m-8`, etc.) continue to work unchanged.

--- a/packages/playground-ui/src/ds/tokens/spacings.ts
+++ b/packages/playground-ui/src/ds/tokens/spacings.ts
@@ -1,5 +1,45 @@
 export const Spacings = {
-  sm: '2px',
-  md: '4px',
-  lg: '8px',
-};
+  // Base scale (REM-based, matching Tailwind convention)
+  '0': '0rem',
+  px: '0.0625rem', // 1px
+  '0.5': '0.125rem', // 2px
+  '1': '0.25rem', // 4px
+  '1.5': '0.375rem', // 6px
+  '2': '0.5rem', // 8px
+  '2.5': '0.625rem', // 10px
+  '3': '0.75rem', // 12px
+  '3.5': '0.875rem', // 14px
+  '4': '1rem', // 16px
+  '5': '1.25rem', // 20px
+  '6': '1.5rem', // 24px
+  '7': '1.75rem', // 28px
+  '8': '2rem', // 32px
+  '9': '2.25rem', // 36px
+  '10': '2.5rem', // 40px
+  '11': '2.75rem', // 44px
+  '12': '3rem', // 48px
+  '14': '3.5rem', // 56px
+  '16': '4rem', // 64px
+  '20': '5rem', // 80px
+  '24': '6rem', // 96px
+  '28': '7rem', // 112px
+  '32': '8rem', // 128px
+  '36': '9rem', // 144px
+  '40': '10rem', // 160px
+  '44': '11rem', // 176px
+  '48': '12rem', // 192px
+  '52': '13rem', // 208px
+  '56': '14rem', // 224px
+  '60': '15rem', // 240px
+  '64': '16rem', // 256px
+  '72': '18rem', // 288px
+  '80': '20rem', // 320px
+  '96': '24rem', // 384px
+
+  // Legacy aliases for backwards compatibility
+  sm: '0.125rem', // 2px (was sm: '2px')
+  md: '0.25rem', // 4px (was md: '4px')
+  lg: '0.5rem', // 8px (was lg: '8px')
+} as const;
+
+export type Spacing = keyof typeof Spacings;

--- a/packages/playground-ui/tailwind.config.ts
+++ b/packages/playground-ui/tailwind.config.ts
@@ -16,6 +16,7 @@ export default {
         '2xl': '1400px',
       },
     },
+    spacing: Spacings,
     extend: {
       screens: {
         '3xl': '1900px',
@@ -29,15 +30,6 @@ export default {
       },
       borderRadius: {
         ...BorderRadius,
-      },
-      padding: {
-        ...Spacings,
-      },
-      margin: {
-        ...Spacings,
-      },
-      gap: {
-        ...Spacings,
       },
       height: {
         ...Sizes,


### PR DESCRIPTION
Converted the spacing design tokens in playground-ui from pixel values to REM units.

This improves accessibility since spacing now scales with the user's browser font size. The Tailwind config now uses a centralized spacing configuration instead of separate padding, margin, and gap entries.

All existing classes like p-4, gap-2, m-8 continue to work unchanged - they just use REM values now (e.g., p-4 = 1rem instead of 16px).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Converted spacing design tokens from pixels to REM units to improve accessibility and enable responsive scaling with browser font size settings.
  * Expanded the spacing scale with additional granular values for improved design flexibility.
  * All existing Tailwind spacing classes remain fully functional with backward compatibility maintained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->