### PR TITLE
Add `hideInput` and `hideOutput` options to `TracingOptions` for protecting sensitive data in traces.

### DIFF
--- a/.changeset/add-hide-input-output-tracing-options.md
+++ b/.changeset/add-hide-input-output-tracing-options.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': minor
+'@mastra/observability': minor
+---
+
+Add `hideInput` and `hideOutput` options to `TracingOptions` for protecting sensitive data in traces.
+
+When set to `true`, these options hide input/output data from all spans in a trace, including child spans. This is useful for protecting sensitive information from being logged to observability platforms.
+
+```typescript
+const agent = mastra.getAgent('myAgent');
+await agent.generate('Process this sensitive data', {
+  tracingOptions: {
+    hideInput: true,  // Input will be hidden from all spans
+    hideOutput: true, // Output will be hidden from all spans
+  },
+});
+```
+
+The options can be used independently (hide only input or only output) or together. The settings are propagated to all child spans via `TraceState`, ensuring consistent behavior across the entire trace.
+
+Fixes #10888

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -495,6 +495,61 @@ const result = await agent.generate({
 - **Priority levels**: `"priority-high"`, `"priority-low"`
 - **Experiments**: `"experiment-v1"`, `"control-group"`, `"treatment-a"`
 
+### Hiding Sensitive Input/Output
+
+When processing sensitive data, you may want to prevent input and output values from being logged to your observability platforms. Use `hideInput` and `hideOutput` in `tracingOptions` to exclude this data from all spans in a trace:
+
+```ts
+// Hide input data (e.g., user credentials, PII)
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Process this sensitive data" }],
+  tracingOptions: {
+    hideInput: true, // Input will be hidden from all spans
+  },
+});
+
+// Hide output data (e.g., generated secrets, confidential results)
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Generate API keys" }],
+  tracingOptions: {
+    hideOutput: true, // Output will be hidden from all spans
+  },
+});
+
+// Hide both input and output
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Handle confidential request" }],
+  tracingOptions: {
+    hideInput: true,
+    hideOutput: true,
+  },
+});
+```
+
+#### How It Works
+
+- **Trace-wide effect**: When set on the root span, these options apply to all child spans in the trace (tool calls, model generations, etc.)
+- **Export-time filtering**: The data is still available internally during execution but is excluded when spans are exported to observability platforms
+- **Combinable with other options**: You can use `hideInput`/`hideOutput` alongside `tags`, `metadata`, and other `tracingOptions`
+
+```ts
+const result = await agent.generate({
+  messages: [{ role: "user", content: "Sensitive operation" }],
+  tracingOptions: {
+    hideInput: true,
+    hideOutput: true,
+    tags: ["sensitive-operation", "pii-handling"],
+    metadata: { operationType: "credential-processing" },
+  },
+});
+```
+
+:::tip
+
+For more granular control over sensitive data, consider using the [Sensitive Data Filter](/docs/v1/observability/tracing/processors/sensitive-data-filter) processor, which can redact specific fields (like passwords, tokens, and keys) while preserving the rest of the input/output.
+
+:::
+
 #### Child Spans and Metadata Extraction
 
 When creating child spans within tools or workflow steps, you can pass the `requestContext` parameter to enable metadata extraction:

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -580,6 +580,18 @@ interface TracingOptions {
    * Note: Tags are only applied to the root span of a trace.
    */
   tags?: string[];
+
+  /**
+   * When true, input data will be hidden from all spans in this trace.
+   * Useful for protecting sensitive data from being logged.
+   */
+  hideInput?: boolean;
+
+  /**
+   * When true, output data will be hidden from all spans in this trace.
+   * Useful for protecting sensitive data from being logged.
+   */
+  hideOutput?: boolean;
 }
 ```
 

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -316,12 +316,18 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     // Merge: configured + additional
     const allKeys = [...configuredKeys, ...additionalKeys];
 
-    if (allKeys.length === 0) {
-      return undefined; // No metadata extraction needed
+    const hideInput = tracingOptions?.hideInput;
+    const hideOutput = tracingOptions?.hideOutput;
+
+    // Return undefined if no TraceState properties are needed
+    if (allKeys.length === 0 && !hideInput && !hideOutput) {
+      return undefined;
     }
 
     return {
       requestContextKeys: allKeys,
+      ...(hideInput !== undefined && { hideInput }),
+      ...(hideOutput !== undefined && { hideOutput }),
     };
   }
 

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -239,6 +239,10 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
 
   /** Returns a lightweight span ready for export */
   public exportSpan(includeInternalSpans?: boolean): ExportedSpan<TType> {
+    // Check if input/output should be hidden based on traceState
+    const hideInput = this.traceState?.hideInput ?? false;
+    const hideOutput = this.traceState?.hideOutput ?? false;
+
     return {
       id: this.id,
       traceId: this.traceId,
@@ -251,8 +255,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
       metadata: this.metadata,
       startTime: this.startTime,
       endTime: this.endTime,
-      input: this.input,
-      output: this.output,
+      input: hideInput ? undefined : this.input,
+      output: hideOutput ? undefined : this.output,
       errorInfo: this.errorInfo,
       isEvent: this.isEvent,
       isRootSpan: this.isRootSpan,

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -841,6 +841,14 @@ export interface TraceState {
    * with the per-request requestContextKeys.
    */
   requestContextKeys: string[];
+  /**
+   * When true, input data will be hidden from all spans in this trace.
+   */
+  hideInput?: boolean;
+  /**
+   * When true, output data will be hidden from all spans in this trace.
+   */
+  hideOutput?: boolean;
 }
 
 /**
@@ -871,6 +879,16 @@ export interface TracingOptions {
    * Note: Tags are only applied to the root span of a trace.
    */
   tags?: string[];
+  /**
+   * When true, input data will be hidden from all spans in this trace.
+   * Useful for protecting sensitive data from being logged.
+   */
+  hideInput?: boolean;
+  /**
+   * When true, output data will be hidden from all spans in this trace.
+   * Useful for protecting sensitive data from being logged.
+   */
+  hideOutput?: boolean;
 }
 
 export interface SpanIds {


### PR DESCRIPTION
## Description

Add `hideInput` and `hideOutput` options to `TracingOptions` for protecting sensitive data in traces.

When set to `true`, these options hide input/output data from all spans in a trace, including child spans. This is useful for protecting sensitive information from being logged to observability platforms.

```typescript
const agent = mastra.getAgent('myAgent');
await agent.generate('Process this sensitive data', {
  tracingOptions: {
    hideInput: true,  // Input will be hidden from all spans
    hideOutput: true, // Output will be hidden from all spans
  },
});
```

The options can be used independently (hide only input or only output) or together. The settings are propagated to all child spans via `TraceState`, ensuring consistent behavior across the entire trace.

Fixes #10888


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hideInput and hideOutput options to redact sensitive data from traces. Options can be used independently or together and automatically propagate to all child spans.

* **Documentation**
  * Added comprehensive documentation with usage examples showing how to configure and use the new data protection options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->